### PR TITLE
Add arm64 and amd64 packaging

### DIFF
--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -1,0 +1,34 @@
+name: Package
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.ref }}
+      PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_API_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install dependencies
+        run: apt-get update -q -y;
+             apt-get install -y \
+              libssl-dev \
+              pkg-config \
+              libclang-dev
+      - name: Compile wasmCloud
+        run: cargo build --release
+      - name: Install NFPM
+        run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/nfpm.sh | sh
+      - name: Package amd64 (Debian)
+        run: ./bin/nfpm pkg --packager deb -f build/nfpm.amd64.yaml
+      - name: Package amd64 (RPM)
+        run: ./bin/nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
+      - name: Push amd64 (Debian)
+        run: curl -F "package[distro_version_id]=190" -F "package[package_file]=@$(ls wasmcloud_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+      - name: Push x86_64 (RPM)
+        run: curl -F "package[distro_version_id]=204" -F "package[package_file]=@$(ls wasmcloud-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json

--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -1,4 +1,4 @@
-name: Package
+name: Release - amd64
 
 on:
   push:

--- a/.github/workflows/release_arm64.yml
+++ b/.github/workflows/release_arm64.yml
@@ -1,0 +1,49 @@
+name: Release - arm64
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_HTTP_DEBUG: true
+  VERSION: ${{ github.ref }}
+  PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_API_TOKEN }}
+
+jobs:
+  armv7_job:
+    runs-on: ubuntu-20.04
+    name: Build on ubuntu-20.04 aarch64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@v2.0.7
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          shell: /bin/bash
+          dockerRunArgs: |
+            --volume "${PWD}/artifacts:/artifacts"
+          install: |
+            apt-get update -q -y
+            apt-get install -y \
+              curl \
+              gcc-aarch64-linux-gnu \
+              libssl-dev \
+              pkg-config \
+              llvm \
+              libclang-dev
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+          run: |
+            source $HOME/.cargo/env
+            cargo build --release --target-dir /artifacts/
+            ls -l /artifacts/release
+
+      - name: Package armv7
+        run: |
+            curl -sfL https://install.goreleaser.com/github.com/goreleaser/nfpm.sh | sh
+            ./bin/nfpm pkg --packager deb -f build/nfpm.arm64.yaml
+            ./bin/nfpm pkg --packager rpm -f build/nfpm.arm64.yaml
+            ls -l "${PWD}/artifacts"
+            curl -F "package[distro_version_id]=190" -F "package[package_file]=@$(ls ${PWD}/wasmcloud_*_arm64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+            curl -F "package[distro_version_id]=204" -F "package[package_file]=@$(ls ${PWD}/wasmcloud-*.aarch64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json

--- a/build/nfpm.amd64.yaml
+++ b/build/nfpm.amd64.yaml
@@ -1,0 +1,16 @@
+# NFPM: check https://nfpm.goreleaser.com/configuration for detailed usage
+# wasmCloud cli [arm64]
+
+name: wasmcloud
+arch: amd64
+platform: linux
+version: ${VERSION}
+section: default
+priority: extra
+maintainer: Bill Young <bill@byoung.io>
+description: wasmcloud
+vendor: wasmCloud
+homepage: https://wascc.dev
+license: Apache-2.0
+files:
+  target/release/wasmcloud: "/usr/local/bin/wasmcloud"

--- a/build/nfpm.arm64.yaml
+++ b/build/nfpm.arm64.yaml
@@ -1,0 +1,16 @@
+# NFPM: check https://nfpm.goreleaser.com/configuration for detailed usage
+# wasmCloud cli [arm64]
+
+name: wasmcloud
+arch: arm64
+platform: linux
+version: ${VERSION}
+section: default
+priority: extra
+maintainer: Bill Young <bill@byoung.io>
+description: wasmcloud
+vendor: wasmCloud
+homepage: https://wascc.dev
+license: Apache-2.0
+files:
+  artifacts/release/wasmcloud: "/usr/local/bin/wasmcloud"


### PR DESCRIPTION
This PR adds `amd64` and `arm64` packaging for `wasmCloud`

Each workflow will compile and package its respective architecture, and push the resulting `deb/rpm` files to Package Cloud

**Notes:**

- The current implementation of `arm64` compiling and packaging is a placeholder until we move to a self-hosted github action runner.