### PR TITLE
Initial implementation of actor update functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,11 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 wapc = { version = "0.10.1" }
 log = "0.4.11"
-env_logger = "0.7.1"
-anyhow = "1.0.33"
+env_logger = "0.8.2"
+anyhow = "1.0.34"
 wasmcloud-host = { path = "crates/wasmcloud-host" }
 actix-rt = "1.1.1"
-nats = "0.8.5"
+nats = "0.8.6"
 
 [dev-dependencies]
 rmp-serde = "0.14.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ wascc-httpsrv = { git = "https://github.com/wascc/capability-providers", branch 
 wascc-redis = { git = "https://github.com/wascc/capability-providers", branch = "main", features = ["static_plugin"] }
 control-interface = { path = "./crates/control-interface"}
 ctor = "0.1.16"
+wascap = "0.5.1"
+futures = "0.3.6"
 
 [workspace]
 members = [

--- a/crates/control-interface/src/generated/ctliface.rs
+++ b/crates/control-interface/src/generated/ctliface.rs
@@ -1,7 +1,6 @@
 extern crate rmp_serde as rmps;
-use rmps::{Deserializer, Serializer};
+
 use serde::{Deserialize, Serialize};
-use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
 pub struct ProviderAuctionRequest {

--- a/crates/wasmcloud-host/src/actors/actor_host.rs
+++ b/crates/wasmcloud-host/src/actors/actor_host.rs
@@ -1,16 +1,15 @@
 use crate::actors::WasccActor;
 use crate::control_interface::ctlactor::{ControlInterface, PublishEvent};
-use crate::control_interface::events::TerminationReason;
+
 use crate::dispatch::{Invocation, InvocationResponse, WasccEntity};
 use crate::hlreg::HostLocalSystemService;
-use crate::messagebus::{
-    AdvertiseClaims, EnforceLocalActorLinks, MessageBus, PutClaims, Subscribe,
-};
+use crate::messagebus::{AdvertiseClaims, MessageBus, PutClaims, Subscribe};
 use crate::middleware::{run_actor_post_invoke, run_actor_pre_invoke, Middleware};
 use crate::{ControlEvent, Result};
 use actix::prelude::*;
 use futures::executor::block_on;
-use wapc::{WapcHost, WasiParams};
+use wapc::WapcHost;
+use wascap::jwt::TokenValidation;
 use wascap::prelude::{Claims, KeyPair};
 
 #[derive(Default)]
@@ -24,113 +23,284 @@ struct State {
     mw_chain: Vec<Box<dyn Middleware>>,
     image_ref: Option<String>,
     host_id: String,
+    seed: String,
+    can_update: bool,
 }
 
 #[derive(Message)]
 #[rtype(result = "Result<()>")]
 pub(crate) struct Initialize {
     pub actor_bytes: Vec<u8>,
-    pub wasi: Option<WasiParams>,
+    //pub wasi: Option<WasiParams>, Disabling WASI support in actors for now
     pub mw_chain: Vec<Box<dyn Middleware>>,
     pub signing_seed: String,
     pub image_ref: Option<String>,
     pub host_id: String,
+    pub can_update: bool,
+}
+
+#[derive(Message)]
+#[rtype(result = "Result<()>")]
+pub(crate) struct LiveUpdate {
+    pub actor_bytes: Vec<u8>,
+    pub image_ref: String,
+}
+
+impl Handler<LiveUpdate> for ActorHost {
+    type Result = Result<()>;
+
+    fn handle(&mut self, msg: LiveUpdate, ctx: &mut Self::Context) -> Self::Result {
+        if self.state.is_none() {
+            return Err("Attempted to live update an actor with no existing state".into());
+        }
+        if !self.state.as_ref().unwrap().can_update {
+            error!(
+                "Rejecting attempt to update actor {} - live updates disabled",
+                msg.image_ref
+            );
+            return Err("Attempt to live update actor denied. Runtime updates for this actor are not enabled".into());
+        }
+        if self
+            .state
+            .as_ref()
+            .unwrap()
+            .image_ref
+            .as_ref()
+            .unwrap_or(&"".to_string())
+            .to_string()
+            != msg.image_ref
+        {
+            error!("Live updated targeted at this actor but the image ref does not match");
+            return Err(
+                "Image reference for live update actor does not match running actor".into(),
+            );
+        }
+
+        let actor = WasccActor::from_slice(&msg.actor_bytes)?;
+        let new_claims = actor.claims();
+        // Validate that this update is one that we will allow to take place
+        validate_update(&new_claims, &self.state.as_ref().unwrap().claims)?;
+        let old_revision = self
+            .state
+            .as_ref()
+            .unwrap()
+            .claims
+            .metadata
+            .as_ref()
+            .unwrap_or(&wascap::jwt::Actor::default())
+            .rev
+            .unwrap_or(0) as u32;
+        let new_revision = new_claims
+            .metadata
+            .as_ref()
+            .unwrap_or(&wascap::jwt::Actor::default())
+            .rev
+            .unwrap_or(0) as u32;
+        let pe = PublishEvent {
+            event: ControlEvent::ActorUpdateBegan {
+                actor: actor.public_key(),
+                old_revision,
+                new_revision,
+            },
+        };
+        ControlInterface::from_hostlocal_registry(&self.state.as_ref().unwrap().host_id)
+            .do_send(pe);
+        // Essentially re-starting the actor with a new set of bytes
+        let init = Initialize {
+            actor_bytes: msg.actor_bytes,
+            mw_chain: self.state.as_ref().unwrap().mw_chain.clone(),
+            signing_seed: self.state.as_ref().unwrap().seed.clone(),
+            image_ref: Some(msg.image_ref),
+            host_id: self.state.as_ref().unwrap().host_id.to_string(),
+            can_update: true,
+        };
+        let host_id = init.host_id.to_string();
+        let actor = perform_initialization(self, ctx, init);
+        match actor {
+            Ok(a) => {
+                ControlInterface::from_hostlocal_registry(&host_id).do_send(PublishEvent {
+                    event: ControlEvent::ActorUpdateCompleted {
+                        actor: a,
+                        old_revision,
+                        new_revision,
+                    },
+                });
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
 }
 
 impl Handler<Initialize> for ActorHost {
     type Result = Result<()>;
 
     fn handle(&mut self, msg: Initialize, ctx: &mut Self::Context) -> Self::Result {
-        let buf = msg.actor_bytes.clone();
-        let actor = WasccActor::from_slice(&buf)?;
-
-        #[cfg(feature = "wasmtime")]
-        let engine = wasmtime_provider::WasmtimeEngineProvider::new(&buf, msg.wasi);
-        #[cfg(feature = "wasm3")]
-        let engine = wasm3_provider::Wasm3EngineProvider::new(&buf);
-
-        let c = actor.token.claims.clone();
-        let c2 = c.clone();
-        let c3 = c.clone(); // TODO: I can't believe I have to do this to make the [censored] borrow checker happy
-        let seed = msg.signing_seed.to_string();
-
-        let guest = WapcHost::new(Box::new(engine), move |_id, bd, ns, op, payload| {
-            crate::dispatch::wapc_host_callback(
-                KeyPair::from_seed(&seed).unwrap(),
-                c2.clone(),
-                bd,
-                ns,
-                op,
-                payload,
-            )
-        });
-
-        match guest {
-            Ok(g) => {
-                let c = c3.clone();
-                let entity = WasccEntity::Actor(c.subject.to_string());
-                let b = MessageBus::from_hostlocal_registry(&msg.host_id);
-                let b2 = b.clone();
-                let b3 = b.clone(); // DAMN YOU BORROW CHECKER
-                let recipient = ctx.address().clone().recipient();
+        let image_ref = msg.image_ref.clone();
+        let actor = perform_initialization(self, ctx, msg);
+        match actor {
+            Ok(a) => {
+                let pe = PublishEvent {
+                    event: ControlEvent::ActorStarted {
+                        actor: a.to_string(),
+                        image_ref,
+                    },
+                };
+                let host_id = self.state.as_ref().unwrap().host_id.to_string();
                 let _ = block_on(async move {
-                    b.send(Subscribe {
-                        interest: entity,
-                        subscriber: recipient,
-                    })
-                    .await
-                });
-                let pc = AdvertiseClaims { claims: c.clone() };
-                let r = block_on(async move {
-                    if let Err(e) = b2.send(pc).await {
-                        error!("Actor failed to advertise claims to bus: {}", e);
-                        ctx.stop();
-                        Err("Failed to advertise bus claims".into())
-                    } else {
-                        Ok(())
-                    }
-                });
-                if r.is_err() {
-                    return r;
-                }
-                let host_id = msg.host_id.to_string();
-                let hid = msg.host_id.to_string();
-                let imgref = msg.image_ref.clone();
-                let subject = c.subject.to_string();
-                let _ = block_on(async move {
-                    let pe = PublishEvent {
-                        event: ControlEvent::ActorStarted {
-                            actor: subject.to_string(),
-                            image_ref: imgref.clone(),
-                        },
-                    };
                     let cp = ControlInterface::from_hostlocal_registry(&host_id);
                     let _ = cp.send(pe).await;
                 });
-
-                self.state = Some(State {
-                    guest_module: g,
-                    claims: c.clone(),
-                    mw_chain: msg.mw_chain,
-                    image_ref: msg.image_ref,
-                    host_id: hid,
-                });
-                info!(
-                    "Actor {} initialized",
-                    &self.state.as_ref().unwrap().claims.subject
-                );
                 Ok(())
             }
-            Err(_e) => {
-                error!(
-                    "Failed to create a WebAssembly host for actor {}",
-                    actor.token.claims.subject
-                );
+            Err(e) => Err(e),
+        }
+    }
+}
+
+fn perform_initialization(
+    me: &mut ActorHost,
+    ctx: &mut SyncContext<ActorHost>,
+    msg: Initialize,
+) -> Result<String> {
+    let buf = msg.actor_bytes.clone();
+    let actor = WasccActor::from_slice(&buf)?;
+    let c = actor.token.claims.clone();
+    let jwt = actor.token.jwt.to_string();
+
+    // Ensure that the JWT we found on this actor is valid, not expired, can be used,
+    // has a verified signature, etc.
+    let tv = wascap::jwt::validate_token::<wascap::jwt::Actor>(&jwt)?;
+    assert_validation_result(&tv)?;
+
+    #[cfg(feature = "wasmtime")]
+    let engine = wasmtime_provider::WasmtimeEngineProvider::new(&buf, None);
+    #[cfg(feature = "wasm3")]
+    let engine = wasm3_provider::Wasm3EngineProvider::new(&buf);
+
+    let c2 = c.clone();
+    let c3 = c.clone(); // TODO: I can't believe I have to do this to make the [censored] borrow checker happy
+    let seed = msg.signing_seed.to_string();
+
+    let guest = WapcHost::new(Box::new(engine), move |_id, bd, ns, op, payload| {
+        crate::dispatch::wapc_host_callback(
+            KeyPair::from_seed(&seed).unwrap(),
+            c2.clone(),
+            bd,
+            ns,
+            op,
+            payload,
+        )
+    });
+
+    match guest {
+        Ok(g) => {
+            let c = c3.clone();
+            let entity = WasccEntity::Actor(c.subject.to_string());
+            let b = MessageBus::from_hostlocal_registry(&msg.host_id);
+            let b2 = b.clone();
+            let recipient = ctx.address().clone().recipient();
+            let _ = block_on(async move {
+                b.send(Subscribe {
+                    interest: entity,
+                    subscriber: recipient,
+                })
+                .await
+            });
+            if !advertise_claims(&c, &b2) {
                 ctx.stop();
-                Err("Failed to create a raw WebAssembly host".into())
+                return Err("Failed to advertise claims to message bus".into());
+            }
+            let hid = msg.host_id.to_string();
+
+            me.state = Some(State {
+                guest_module: g,
+                claims: c.clone(),
+                mw_chain: msg.mw_chain,
+                image_ref: msg.image_ref,
+                host_id: hid,
+                seed: msg.signing_seed,
+                can_update: msg.can_update,
+            });
+            info!(
+                "Actor {} initialized",
+                &me.state.as_ref().unwrap().claims.subject
+            );
+            Ok(c.subject.to_string())
+        }
+        Err(_e) => {
+            error!(
+                "Failed to create a WebAssembly host for actor {}",
+                actor.token.claims.subject
+            );
+            ctx.stop();
+            Err("Failed to create a raw WebAssembly host".into())
+        }
+    }
+}
+
+fn advertise_claims(c: &Claims<wascap::jwt::Actor>, bus: &Addr<MessageBus>) -> bool {
+    let pc = AdvertiseClaims { claims: c.clone() };
+    block_on(async move {
+        if let Err(e) = bus.send(pc).await {
+            error!("Actor failed to advertise claims to bus: {}", e);
+            false
+        } else {
+            true
+        }
+    })
+}
+
+fn assert_validation_result(tv: &TokenValidation) -> Result<()> {
+    if tv.cannot_use_yet {
+        error!(
+            "Claims validation failure: Cannot be used {}",
+            tv.not_before_human
+        );
+        Err("Actor claims cannot be used yet".into())
+    } else if tv.expired {
+        error!("Claims validation failure: Expired {}", tv.expires_human);
+        Err("Actor claims have expired".into())
+    } else if !tv.signature_valid {
+        Err("Actor claims token has invalid signature".into())
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_update(
+    new_claims: &Claims<wascap::jwt::Actor>,
+    old_claims: &Claims<wascap::jwt::Actor>,
+) -> Result<u32> {
+    if let Some(ref new_md) = new_claims.metadata {
+        if let Some(ref old_md) = old_claims.metadata {
+            if new_claims.subject != old_claims.subject {
+                error!(
+                    "Rejecting attempt to replace actor {} with actor {} - PKs do not match",
+                    old_claims.subject, new_claims.subject
+                );
+                return Err(
+                    "Public keys of old actor and new actor do not match. Update denied.".into(),
+                );
+            }
+            if new_md.rev.unwrap_or(0) <= old_md.rev.unwrap_or(0) {
+                return Err(
+                    "Cannot live update if the new module is not a higher revision number".into(),
+                );
+            }
+            if new_md.caps.as_ref().unwrap_or(&vec![]).len()
+                > old_md.caps.as_ref().unwrap_or(&vec![]).len()
+            {
+                warn!("Live update warning: new actor has more claims than the previous revision.");
             }
         }
     }
+    Ok(new_claims
+        .metadata
+        .as_ref()
+        .unwrap_or(&wascap::jwt::Actor::default())
+        .rev
+        .unwrap_or(0) as u32)
 }
 
 impl Actor for ActorHost {

--- a/crates/wasmcloud-host/src/actors/mod.rs
+++ b/crates/wasmcloud-host/src/actors/mod.rs
@@ -1,5 +1,5 @@
 mod actor_host;
 mod wascc_actor;
 
-pub(crate) use actor_host::{ActorHost, Initialize};
+pub(crate) use actor_host::{ActorHost, Initialize, LiveUpdate};
 pub(crate) use wascc_actor::WasccActor;

--- a/crates/wasmcloud-host/src/capability/native_host.rs
+++ b/crates/wasmcloud-host/src/capability/native_host.rs
@@ -1,6 +1,6 @@
 use crate::capability::native::NativeCapability;
 use crate::control_interface::ctlactor::{ControlInterface, PublishEvent};
-use crate::control_interface::events::TerminationReason;
+
 use crate::dispatch::{Invocation, InvocationResponse, ProviderDispatcher, WasccEntity};
 use crate::hlreg::HostLocalSystemService;
 use crate::messagebus::{EnforceLocalProviderLinks, MessageBus, Subscribe};
@@ -58,12 +58,12 @@ impl Actor for NativeCapabilityHost {
             //warn!("Stopped a provider host that had no state. Something might be amiss, askew, or perchance awry");
             return;
         }
-        let mut state = self.state.as_mut().unwrap();
+        let state = self.state.as_mut().unwrap();
 
         state.plugin.stop(); // Tell the provider to clean up, dispose of resources, stop threads, etc
         if let Some(l) = state.library.take() {
             let r = l.close();
-            if let Err(e) = r {
+            if let Err(_e) = r {
                 //
             }
         }
@@ -253,17 +253,6 @@ fn extrude(
         Ok((Some(library), plugin))
     } else {
         Ok((None, cap.plugin.clone().unwrap()))
-    }
-}
-
-fn get_descriptor(plugin: &Box<dyn CapabilityProvider>) -> Result<CapabilityDescriptor> {
-    if let Ok(v) = plugin.handle_call(SYSTEM_ACTOR, OP_GET_CAPABILITY_DESCRIPTOR, &[]) {
-        match crate::generated::core::deserialize::<CapabilityDescriptor>(&v) {
-            Ok(c) => Ok(c),
-            Err(e) => Err(format!("Failed to deserialize descriptor: {}", e).into()),
-        }
-    } else {
-        Err("Failed to invoke GetCapabilityDescriptor".into())
     }
 }
 

--- a/crates/wasmcloud-host/src/generated/extras.rs
+++ b/crates/wasmcloud-host/src/generated/extras.rs
@@ -1,7 +1,6 @@
 extern crate rmp_serde as rmps;
-use rmps::{Deserializer, Serializer};
+
 use serde::{Deserialize, Serialize};
-use std::io::Cursor;
 
 extern crate log;
 

--- a/crates/wasmcloud-host/src/hlreg.rs
+++ b/crates/wasmcloud-host/src/hlreg.rs
@@ -38,8 +38,3 @@ pub(crate) trait HostLocalSystemService: SystemService {
         })
     }
 }
-
-pub(crate) fn purge() {
-    let mut sreg = SREG.lock();
-    sreg.clear();
-}

--- a/crates/wasmcloud-host/src/host.rs
+++ b/crates/wasmcloud-host/src/host.rs
@@ -1,4 +1,7 @@
-use crate::messagebus::{AdvertiseLink, MessageBus};
+use crate::{
+    messagebus::{AdvertiseLink, MessageBus},
+    InvocationResponse,
+};
 
 use actix::prelude::*;
 
@@ -301,8 +304,13 @@ impl Host {
             msg.to_vec(),
         );
         let b = MessageBus::from_hostlocal_registry(&self.id.borrow());
-        let ir = b.send(inv).await?;
-        Ok(ir.msg)
+        let ir: InvocationResponse = b.send(inv).await?;
+
+        if let Some(e) = ir.error {
+            Err(format!("Invocation failure: {}", e).into())
+        } else {
+            Ok(ir.msg)
+        }
     }
 
     pub async fn set_link(

--- a/crates/wasmcloud-host/src/host_controller/mod.rs
+++ b/crates/wasmcloud-host/src/host_controller/mod.rs
@@ -1,4 +1,4 @@
-use crate::actors::WasccActor;
+use crate::actors::{ActorHost, WasccActor};
 use crate::auth::Authorizer;
 use crate::messagebus::rpc_client::LinkDefinition;
 use crate::{NativeCapability, Result};
@@ -30,6 +30,7 @@ pub(crate) struct Initialize {
     pub labels: HashMap<String, String>,
     pub auth: Box<dyn Authorizer>,
     pub kp: KeyPair,
+    pub allow_live_updates: bool,
 }
 
 #[derive(Message)]
@@ -77,6 +78,12 @@ pub(crate) struct QueryActorRunning {
 pub(crate) struct QueryProviderRunning {
     pub provider_ref: String,
     pub link_name: String,
+}
+
+#[derive(Message)]
+#[rtype(result = "Option<Addr<ActorHost>>")]
+pub(crate) struct GetRunningActor {
+    pub actor_id: String,
 }
 
 #[derive(Message)]

--- a/crates/wasmcloud-host/src/manifest.rs
+++ b/crates/wasmcloud-host/src/manifest.rs
@@ -191,7 +191,7 @@ mod test {
                     link_name: Some("default".to_string()),
                 },
             ],
-            links: vec![linkEntry {
+            links: vec![LinkEntry {
                 actor: "a".to_string(),
                 contract_id: "wascc:one".to_string(),
                 provider_id: "Vxxxone".to_string(),

--- a/crates/wasmcloud-host/src/messagebus/nats_subscriber.rs
+++ b/crates/wasmcloud-host/src/messagebus/nats_subscriber.rs
@@ -1,4 +1,3 @@
-use crate::{InvocationResponse, WasccEntity};
 use actix::prelude::*;
 use futures::StreamExt;
 
@@ -24,7 +23,6 @@ pub(crate) struct NatsSubscriber {
 
 struct SubscriberState {
     receiver: Recipient<NatsMessage>,
-    subject: String,
 }
 
 impl Actor for NatsSubscriber {
@@ -43,7 +41,6 @@ impl Handler<Initialize> for NatsSubscriber {
     fn handle(&mut self, msg: Initialize, _ctx: &mut Self::Context) -> Self::Result {
         let state = SubscriberState {
             receiver: msg.receiver,
-            subject: msg.subject.to_string(),
         };
         self.state = Some(state);
         let nc = msg.nc;

--- a/crates/wasmcloud-host/src/messagebus/rpc_client.rs
+++ b/crates/wasmcloud-host/src/messagebus/rpc_client.rs
@@ -1,18 +1,15 @@
 use crate::generated::core::{deserialize, serialize};
 use crate::hlreg::HostLocalSystemService;
-use crate::host_controller::{CheckLink, HostController};
+use crate::host_controller::HostController;
 use crate::messagebus::rpc_subscription::{claims_subject, invoke_subject, links_subject};
-use crate::messagebus::{
-    AdvertiseClaims, AdvertiseLink, EnforceLocalActorLinks, EnforceLocalProviderLinks, MessageBus,
-    PutClaims, PutLink,
-};
+use crate::messagebus::{AdvertiseClaims, AdvertiseLink, MessageBus, PutClaims, PutLink};
 use crate::Result;
 use crate::{Invocation, InvocationResponse};
 use actix::prelude::*;
-use futures::{StreamExt, TryFutureExt};
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Arc;
+
 use std::time::Duration;
 
 #[derive(Message)]
@@ -170,11 +167,11 @@ impl Handler<LinkInbound> for RpcClient {
     fn handle(&mut self, msg: LinkInbound, _ctx: &mut Self::Context) -> Self::Result {
         trace!("Received notification of link definition lattice-wide publication");
         let target = self.bus.clone().unwrap();
-        let hc = HostController::from_hostlocal_registry(self.host_id.as_ref().unwrap());
+        let _hc = HostController::from_hostlocal_registry(self.host_id.as_ref().unwrap());
         if let Some(link) = msg.link {
             Box::pin(
                 async move {
-                    let ld = link.clone();
+                    let _ld = link.clone();
                     let _ = target
                         .send(PutLink {
                             link_name: link.link_name,

--- a/crates/wasmcloud-host/src/messagebus/utils.rs
+++ b/crates/wasmcloud-host/src/messagebus/utils.rs
@@ -2,7 +2,7 @@ use crate::dispatch::{
     CONFIG_WASCC_CLAIMS_CAPABILITIES, CONFIG_WASCC_CLAIMS_EXPIRES, CONFIG_WASCC_CLAIMS_ISSUER,
     CONFIG_WASCC_CLAIMS_NAME, CONFIG_WASCC_CLAIMS_TAGS,
 };
-use crate::messagebus::AdvertiseLink;
+
 use crate::messagebus::OP_BIND_ACTOR;
 use crate::{Invocation, WasccEntity, SYSTEM_ACTOR};
 use actix::prelude::*;

--- a/crates/wasmcloud-host/src/middleware/runner.rs
+++ b/crates/wasmcloud-host/src/middleware/runner.rs
@@ -3,48 +3,6 @@ use crate::middleware::Middleware;
 use crate::Result;
 use actix::Recipient;
 
-/// Execute a full chain of middleware, terminating at a capability provider
-pub(crate) async fn invoke_capability(
-    middlewares: &[Box<dyn Middleware>],
-    inv: Invocation,
-    target: Recipient<Invocation>,
-) -> Result<InvocationResponse> {
-    // PRE
-    if let Err(e) = run_capability_pre_invoke(&inv, &middlewares) {
-        error!("Middleware pre-invoke failure: {}", e);
-        return Err(e);
-    } else {
-        match target.send(inv.clone()).await {
-            Ok(ir) => {
-                // POST
-                run_capability_post_invoke(ir, middlewares)
-            }
-            Err(_e) => Err("Actor mailbox failure during middleware execution".into()),
-        }
-    }
-}
-
-/// Execute a full chain of middleware, termianting at an actor
-pub(crate) async fn invoke_actor(
-    middlewares: &[Box<dyn Middleware>],
-    inv: Invocation,
-    target: Recipient<Invocation>,
-) -> Result<InvocationResponse> {
-    // PRE
-    if let Err(e) = run_actor_pre_invoke(&inv, middlewares) {
-        error!("Middleware pre-invoke failure: {}", e);
-        return Err(e);
-    } else {
-        match target.send(inv.clone()).await {
-            Ok(ir) => {
-                // POST
-                run_actor_post_invoke(ir, middlewares)
-            }
-            Err(_e) => Err("Actor mailbox failure during middleware execution".into()),
-        }
-    }
-}
-
 /// Executes a chain of pre-invoke handlers for a capability
 pub(crate) fn run_capability_pre_invoke(
     inv: &Invocation,

--- a/src/wasmcloud.rs
+++ b/src/wasmcloud.rs
@@ -19,6 +19,7 @@ async fn main() -> Result<()> {
     let host = HostBuilder::new()
         .with_rpc_client(nc_rpc)
         .with_control_client(nc_control)
+        .enable_live_updates()
         .build();
     match host.start().await {
         Ok(_) => {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -24,7 +24,7 @@ pub async fn await_actor_count(
                     break;
                 }
             }
-            Err(e) => {
+            Err(_e) => {
                 if attempt > max_attempts {
                     return Err("Exceeded max attempts".into());
                 }
@@ -49,7 +49,7 @@ pub async fn await_provider_count(
                     break;
                 }
             }
-            Err(e) => {
+            Err(_e) => {
                 if attempt > max_attempts {
                     return Err("Exceeded max attempts".into());
                 }

--- a/tests/no_lattice.rs
+++ b/tests/no_lattice.rs
@@ -1,5 +1,6 @@
 use crate::common::{await_actor_count, await_provider_count, gen_kvcounter_host, par_from_file};
 use crate::generated::http::{deserialize, serialize, Request, Response};
+use actix_rt::time::delay_for;
 use std::collections::HashMap;
 use std::time::Duration;
 use wasmcloud_host::Result;
@@ -86,7 +87,7 @@ pub async fn kvcounter_start_stop() -> Result<()> {
         .await?;
     await_provider_count(&h, 2, Duration::from_millis(50), 3).await?;
 
-    ::std::thread::sleep(Duration::from_millis(50)); // give the web server enough time to let go of the port
+    delay_for(Duration::from_millis(50)); // give the web server enough time to let go of the port
 
     let websrv = NativeCapability::from_archive(&arc2, None)?;
     h.start_native_capability(websrv).await?;

--- a/tests/with_lattice.rs
+++ b/tests/with_lattice.rs
@@ -1,4 +1,4 @@
-use crate::common::{await_actor_count, await_provider_count, gen_kvcounter_host, par_from_file};
+use crate::common::{await_actor_count, await_provider_count, par_from_file};
 use actix_rt::time::delay_for;
 use provider_archive::ProviderArchive;
 use std::collections::HashMap;


### PR DESCRIPTION
There's no integration test (yet) for the live update stuff because we need our own local OCI (check out the corresponding issue #31 ) that we can populate with multiple test modules. Right now the integration test for updating actors live requires us to replace an actor with that same actor's image from an OCI, and I can't mess up the public OCI with test signing keys, etc.

All the goodies should be here, however.

Also note that the host builder now has an option for enabling live updates. They will be _disabled_ by default.