### PR TITLE
Make inv mod public for control_interface imports

### DIFF
--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod broker;
 mod generated;
-mod inv;
+pub mod inv;
 
 pub use crate::generated::ctliface::*;
 use actix_rt::time::delay_for;


### PR DESCRIPTION
Currently, consumers of the `control_interface` crate will be unable to use the `InvocationResponse` type as the struct is hidden behind a private module. If the `InvocationResponse` type is imported from `wasmcloud-host`, Rust interprets them as two different structs with the same name. This PR just adds the `pub` keyword to the `inv` module which makes those types public