### PR TITLE
Strict claims update checking for actors

### DIFF
--- a/crates/wasmcloud-host/src/host_controller/hc_actor.rs
+++ b/crates/wasmcloud-host/src/host_controller/hc_actor.rs
@@ -39,6 +39,7 @@ pub struct HostController {
     image_refs: HashMap<String, String>,
     started: Instant,
     allow_live_updates: bool,
+    strict_update_check: bool,
 }
 
 impl Default for HostController {
@@ -53,6 +54,7 @@ impl Default for HostController {
             image_refs: HashMap::new(),
             started: Instant::now(),
             allow_live_updates: false,
+            strict_update_check: true,
         }
     }
 }
@@ -330,6 +332,7 @@ impl Handler<Initialize> for HostController {
         self.providers.insert(key, extras); // can't let this provider go out of scope, or the actix actor will stop
         self.kp = Some(msg.kp);
         self.allow_live_updates = msg.allow_live_updates;
+        self.strict_update_check = msg.strict_update_check;
         info!(
             "Host controller initialized - {} (Hot Updating - {})",
             host_id, self.allow_live_updates
@@ -367,6 +370,7 @@ impl Handler<StartActor> for HostController {
             image_ref: msg.image_ref.clone(),
             host_id: self.kp.as_ref().unwrap().public_key(),
             can_update: self.allow_live_updates,
+            strict_update_check: self.strict_update_check,
         };
 
         let new_actor = SyncArbiter::start(1, move || ActorHost::default());

--- a/crates/wasmcloud-host/src/host_controller/mod.rs
+++ b/crates/wasmcloud-host/src/host_controller/mod.rs
@@ -32,6 +32,7 @@ pub(crate) struct Initialize {
     pub auth: Box<dyn Authorizer>,
     pub kp: KeyPair,
     pub allow_live_updates: bool,
+    pub strict_update_check: bool,
 }
 
 #[derive(Message)]


### PR DESCRIPTION
Fixes #35 

By default, wasmcloud hosts (and actors) will enforce a `strict_updates_check` flag, which requires actors that live update to retain the same claims list as the original actor. 

For example:
["wascc:keyvalue", "wascc:http_server"] -> ["wascc:keyvalue", "wascc:http_server"] is valid
["wascc:keyvalue", "wascc:http_server"] -> ["wascc:keyvalue", "wascc:http_server", "wascc:blockchain"] is invalid
["wascc:keyvalue", "wascc:http_server"] -> ["wascc:keyvalue"] is invalid
["wascc:keyvalue"] -> ["wascc:http_server"] is invalid
etc...

If `strict_updates_check` is false, then an update will be allowed with a warning message. 