### PR TITLE
Allow specified list of HTTP connections for OCI interaction

### DIFF
--- a/crates/wasmcloud-host/src/control_interface/ctlactor.rs
+++ b/crates/wasmcloud-host/src/control_interface/ctlactor.rs
@@ -26,7 +26,7 @@ pub struct Initialize {
 #[derive(Clone, Debug, Default)]
 pub struct ControlOptions {
     pub oci_allow_latest: bool,
-    pub oci_allow_insecure: bool,
+    pub oci_allowed_insecure: Vec<String>,
     pub host_labels: HashMap<String, String>,
     pub max_actors: u16,    // Currently unused
     pub max_providers: u16, // Currently unused
@@ -96,7 +96,7 @@ impl Handler<NatsMessage> for ControlInterface {
         let msg = msg.msg;
         let subject = msg.subject.to_string();
         let allow_latest = self.options.oci_allow_latest;
-        let allow_insecure = self.options.oci_allow_insecure;
+        let allowed_insecure = self.options.oci_allowed_insecure.clone();
         let nc = self.client.clone();
         Box::pin(
             async move {
@@ -111,13 +111,13 @@ impl Handler<NatsMessage> for ControlInterface {
                 } else if subject == actor_auction_subject(&prefix) {
                     handle_actor_auction(&host, &msg).await
                 } else if subject == commands::start_actor(&prefix, &host) {
-                    handle_start_actor(&host, &msg, allow_latest, allow_insecure).await
+                    handle_start_actor(&host, &msg, allow_latest, &allowed_insecure).await
                 } else if subject == commands::update_actor(&prefix, &host) {
-                    handle_update_actor(&host, &msg, allow_insecure).await
+                    handle_update_actor(&host, &msg, &allowed_insecure).await
                 } else if subject == commands::stop_provider(&prefix, &host) {
                     handle_stop_provider(&host, &msg).await
                 } else if subject == commands::start_provider(&prefix, &host) {
-                    handle_start_provider(&host, &msg, allow_latest, allow_insecure).await
+                    handle_start_provider(&host, &msg, allow_latest, &allowed_insecure).await
                 } else if subject == commands::stop_actor(&prefix, &host) {
                     handle_stop_actor(&host, &msg).await
                 } else if subject == queries::hosts(&prefix) {

--- a/crates/wasmcloud-host/src/host_controller/hc_actor.rs
+++ b/crates/wasmcloud-host/src/host_controller/hc_actor.rs
@@ -402,7 +402,7 @@ impl Handler<Initialize> for HostController {
                 let (nativecache, claims) = create_cache_provider(
                     msg.lattice_cache_provider.clone(),
                     msg.allow_latest,
-                    msg.allow_insecure,
+                    &msg.allowed_insecure,
                 )
                 .await;
                 let init = crate::capability::native_host::Initialize {
@@ -666,10 +666,10 @@ async fn initialize_provider(
 async fn create_cache_provider(
     provider_ref: Option<String>,
     allow_latest: bool,
-    allow_insecure: bool,
+    allowed_insecure: &Vec<String>,
 ) -> (NativeCapability, Claims<wascap::jwt::CapabilityProvider>) {
     if let Some(s) = provider_ref {
-        let par = crate::oci::fetch_provider_archive(&s, allow_latest, allow_insecure)
+        let par = crate::oci::fetch_provider_archive(&s, allow_latest, allowed_insecure)
             .await
             .unwrap();
         (

--- a/crates/wasmcloud-host/src/host_controller/mod.rs
+++ b/crates/wasmcloud-host/src/host_controller/mod.rs
@@ -34,7 +34,7 @@ pub(crate) struct Initialize {
     pub kp: KeyPair,
     pub allow_live_updates: bool,
     pub allow_latest: bool,
-    pub allow_insecure: bool,
+    pub allowed_insecure: Vec<String>,
     pub lattice_cache_provider: Option<String>,
     pub strict_update_check: bool,
 }

--- a/crates/wasmcloud-host/src/manifest.rs
+++ b/crates/wasmcloud-host/src/manifest.rs
@@ -82,7 +82,7 @@ impl HostManifest {
 pub(crate) async fn generate_actor_start_messages(
     manifest: &HostManifest,
     allow_latest: bool,
-    allow_insecure: bool,
+    allowed_insecure: &Vec<String>,
 ) -> Vec<StartActor> {
     let mut v = Vec::new();
     for actor_ref in &manifest.actors {
@@ -97,7 +97,7 @@ pub(crate) async fn generate_actor_start_messages(
             }
         } else {
             // load actor from OCI
-            if let Ok(a) = fetch_oci_bytes(&actor_ref, allow_latest, allow_insecure)
+            if let Ok(a) = fetch_oci_bytes(&actor_ref, allow_latest, allowed_insecure)
                 .await
                 .and_then(|bytes| crate::Actor::from_slice(&bytes))
             {
@@ -114,7 +114,7 @@ pub(crate) async fn generate_actor_start_messages(
 pub(crate) async fn generate_provider_start_messages(
     manifest: &HostManifest,
     allow_latest: bool,
-    allow_insecure: bool,
+    allowed_insecure: &Vec<String>,
 ) -> Vec<StartProvider> {
     let mut v = Vec::new();
     for cap in &manifest.capabilities {
@@ -132,7 +132,7 @@ pub(crate) async fn generate_provider_start_messages(
             }
         } else {
             // read PAR from OCI
-            if let Ok(prov) = fetch_oci_bytes(&cap.image_ref, allow_latest, allow_insecure)
+            if let Ok(prov) = fetch_oci_bytes(&cap.image_ref, allow_latest, allowed_insecure)
                 .await
                 .and_then(|bytes| ProviderArchive::try_load(&bytes))
                 .and_then(|par| NativeCapability::from_archive(&par, cap.link_name.clone()))

--- a/src/wasmcloud.rs
+++ b/src/wasmcloud.rs
@@ -66,6 +66,10 @@ struct Cli {
     /// Disables strict comparison of live updated actor claims
     #[structopt(long = "disable-strict-update-check")]
     disable_strict_update_check: bool,
+
+    /// Allows the use of HTTP registry connections to these registries
+    #[structopt(long = "allowed-insecure")]
+    allowed_insecure: Vec<String>,
 }
 
 #[actix_rt::main]
@@ -100,6 +104,9 @@ async fn main() -> Result<()> {
     }
     if cli.disable_strict_update_check {
         host_builder = host_builder.disable_strict_update_check();
+    }
+    if !cli.allowed_insecure.is_empty() {
+        host_builder = host_builder.oci_allow_insecure(cli.allowed_insecure);
     }
 
     let host = host_builder.build();


### PR DESCRIPTION
Fixes #63

My solution here ended up allowing for the user instantiating the host to provide a list of registries that are allowed for insecure (HTTP) connections. This option is valid regardless of authentication scheme. This way, instantiating a host with a host builder now can include the option:
```
host_builder = host_builder.oci_allow_insecure(vec!["localhost:5000"]);
```
to allow for insecure connections to a local registry, but then to use HTTPS for all other connections. The intended use of this is to let users define specific registries for testing / development purposes that they can connect via HTTP.