### PR TITLE
Control interface start actor and provider now acknowledge prior to downloading OCI bytes

### DIFF
--- a/crates/control-interface/src/generated/ctliface.rs
+++ b/crates/control-interface/src/generated/ctliface.rs
@@ -55,8 +55,6 @@ pub struct StartActorAck {
     pub host_id: String,
     #[serde(rename = "actor_ref")]
     pub actor_ref: String,
-    #[serde(rename = "actor_id")]
-    pub actor_id: String,
     #[serde(rename = "failure")]
     pub failure: Option<String>,
 }
@@ -77,8 +75,6 @@ pub struct StartProviderAck {
     pub host_id: String,
     #[serde(rename = "provider_ref")]
     pub provider_ref: String,
-    #[serde(rename = "provider_id")]
-    pub provider_id: String,
     #[serde(rename = "failure")]
     pub failure: Option<String>,
 }

--- a/crates/wasmcloud-host/src/control_interface/handlers.rs
+++ b/crates/wasmcloud-host/src/control_interface/handlers.rs
@@ -276,7 +276,9 @@ pub(crate) async fn handle_start_actor(
             let _ = msg.respond(&serialize(ack).unwrap()).await;
             return;
         }
-        Ok(_) => {} // all good to start
+        Ok(_) => {
+            let _ = msg.respond(&serialize(ack).unwrap()).await;
+        } // all good to start
         Err(_) => {
             let f = "Failed to query host controller for running actor".to_string();
             error!("{}", f);
@@ -290,8 +292,6 @@ pub(crate) async fn handle_start_actor(
     if let Err(e) = bytes {
         let f = format!("Failed to retrieve actor image from OCI registry: {}", e);
         error!("{}", f);
-        ack.failure = Some(f);
-        let _ = msg.respond(&serialize(ack).unwrap()).await;
         return;
     }
     let bytes = bytes.unwrap();
@@ -303,13 +303,9 @@ pub(crate) async fn handle_start_actor(
             e
         );
         error!("{}", f);
-        ack.failure = Some(f);
-        let _ = msg.respond(&serialize(ack).unwrap()).await;
         return;
     }
     let actor = actor.unwrap();
-
-    let actor_id = actor.public_key();
 
     let r = hc
         .send(StartActor {
@@ -320,16 +316,8 @@ pub(crate) async fn handle_start_actor(
     if let Err(_e) = r {
         let f = "Host controller did not acknowledge start actor message".to_string();
         error!("{}", f);
-        ack.failure = Some(f);
-        let _ = msg.respond(&serialize(ack).unwrap()).await;
         return;
     }
-    // Acknowledge the message
-    ack.actor_ref = cmd.actor_ref;
-    ack.actor_id = actor_id;
-    ack.failure = None;
-
-    let _ = msg.respond(&serialize(ack).unwrap()).await;
 }
 
 pub(crate) async fn handle_stop_provider(host: &str, msg: &nats::asynk::Message) {
@@ -428,7 +416,9 @@ pub(crate) async fn handle_start_provider(
             let _ = msg.respond(&serialize(ack).unwrap()).await;
             return;
         }
-        Ok(_) => {}
+        Ok(_) => {
+            let _ = msg.respond(&serialize(ack).unwrap()).await;
+        }
         Err(_) => {
             let f = "Failed to query host controller for running providers".to_string();
             error!("{}", f);
@@ -446,8 +436,6 @@ pub(crate) async fn handle_start_provider(
             e
         );
         error!("{}", f);
-        ack.failure = Some(f);
-        let _ = msg.respond(&serialize(ack).unwrap()).await;
         return;
     }
     let par = par.unwrap();
@@ -459,8 +447,6 @@ pub(crate) async fn handle_start_provider(
             e
         );
         error!("{}", f);
-        ack.failure = Some(f);
-        let _ = msg.respond(&serialize(ack).unwrap()).await;
         return;
     }
     let cap = cap.unwrap();
@@ -475,15 +461,8 @@ pub(crate) async fn handle_start_provider(
     if let Err(_e) = r {
         let f = "Host controller failed to acknowledge start provider command".to_string();
         error!("{}", f);
-        let _ = msg.respond(&serialize(ack).unwrap()).await;
         return;
     }
-
-    ack.provider_ref = cmd.provider_ref;
-    ack.provider_id = provider_id;
-
-    // Acknowledge the command
-    let _ = msg.respond(&serialize(ack).unwrap()).await;
 }
 
 pub(crate) async fn handle_stop_actor(host: &str, msg: &nats::asynk::Message) {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -109,7 +109,6 @@ async fn redis_kvcache() {
 //    assert!(res.is_ok());
 //}
 
-
 #[actix_rt::test]
 async fn control_auctions() {
     let res = control::auctions().await;

--- a/tests/with_lattice.rs
+++ b/tests/with_lattice.rs
@@ -38,8 +38,11 @@ pub(crate) async fn distributed_echo() -> Result<()> {
     await_actor_count(&host_a, 1, Duration::from_millis(50), 3).await?;
 
     let arc = par_from_file("./tests/modules/libwascc_httpsrv.par.gz").unwrap();
-    let websrv = NativeCapability::from_instance(wascc_httpsrv::HttpServerProvider::new(),
-      None, arc.claims().clone().unwrap())?;
+    let websrv = NativeCapability::from_instance(
+        wascc_httpsrv::HttpServerProvider::new(),
+        None,
+        arc.claims().clone().unwrap(),
+    )?;
 
     // ** NOTE - we should be able to start host B in any order because when the cache client starts
     // it should request a replay of cache events and therefore get the existing claims, links,


### PR DESCRIPTION
The new behavior of the wasmCloud control interface is that the `StartActor` and `StartProvider` commands will now be acknowledged as early as possible, either if a validation failure is detected or immediately _before_ the OCI bytes are downloaded.

This has a downstream effect of requiring that any consumer of the control interface must monitor the control event stream in order to determine if an actor or provider did successfully complete the startup process.