### PR TITLE
Normalizing Native Capability link names

### DIFF
--- a/crates/wasmcloud-host/src/capability/native.rs
+++ b/crates/wasmcloud-host/src/capability/native.rs
@@ -24,7 +24,7 @@ impl NativeCapability {
         if archive.claims().is_none() {
             return Err("No claims found in provider archive file".into());
         }
-        let link = link_target_name.unwrap_or("default".to_string());
+        let link = normalize_link_name(link_target_name.unwrap_or("default".to_string()));
 
         let target = Host::native_target();
 
@@ -55,7 +55,7 @@ impl NativeCapability {
         claims: Claims<wascap::jwt::CapabilityProvider>,
     ) -> Result<Self> {
         let b: Box<dyn CapabilityProvider> = Box::new(instance);
-        let link = link_target_name.unwrap_or("default".to_string());
+        let link = normalize_link_name(link_target_name.unwrap_or("default".to_string()));
 
         Ok(NativeCapability {
             plugin: Some(b),
@@ -68,5 +68,14 @@ impl NativeCapability {
     /// Returns the unique ID (public key/subject) of the capability provider
     pub fn id(&self) -> String {
         self.claims.subject.to_string()
+    }
+}
+
+/// Helper function to unwrap link name. Returns link name if exists and non-empty, "default" otherwise
+pub(crate) fn normalize_link_name(link_name: String) -> String {
+    if link_name.trim().is_empty() {
+        "default".to_string()
+    } else {
+        link_name
     }
 }

--- a/crates/wasmcloud-host/src/capability/native_host.rs
+++ b/crates/wasmcloud-host/src/capability/native_host.rs
@@ -1,4 +1,4 @@
-use crate::capability::native::NativeCapability;
+use crate::capability::native::{normalize_link_name, NativeCapability};
 use crate::control_interface::ctlactor::{ControlInterface, PublishEvent};
 
 use crate::dispatch::{Invocation, InvocationResponse, ProviderDispatcher, WasmCloudEntity};
@@ -96,6 +96,7 @@ impl Handler<Initialize> for NativeCapabilityHost {
 
         let b = MessageBus::from_hostlocal_registry(&state.kp.public_key());
         let b2 = b.clone();
+        let link_name = normalize_link_name(state.cap.link_name.to_string());
         let entity = WasmCloudEntity::Capability {
             id: state.cap.claims.subject.to_string(),
             contract_id: state
@@ -106,7 +107,7 @@ impl Handler<Initialize> for NativeCapabilityHost {
                 .unwrap()
                 .capid
                 .to_string(),
-            link_name: state.cap.link_name.to_string(),
+            link_name: link_name.to_string(),
         };
 
         let nativedispatch = ProviderDispatcher::new(
@@ -139,7 +140,7 @@ impl Handler<Initialize> for NativeCapabilityHost {
         });
         let epl = EnforceLocalProviderLinks {
             provider_id: state.cap.claims.subject.to_string(),
-            link_name: state.cap.link_name.to_string(),
+            link_name: link_name.to_string(),
         };
         let _ = block_on(async move {
             // If the target provider for any known links involving this provider
@@ -149,7 +150,7 @@ impl Handler<Initialize> for NativeCapabilityHost {
         let cp = ControlInterface::from_hostlocal_registry(&state.kp.public_key());
         cp.do_send(PublishEvent {
             event: ControlEvent::ProviderStarted {
-                link_name: state.cap.link_name.to_string(),
+                link_name,
                 provider_id: state.cap.claims.subject.to_string(),
                 contract_id: state
                     .cap

--- a/crates/wasmcloud-host/src/dispatch.rs
+++ b/crates/wasmcloud-host/src/dispatch.rs
@@ -318,6 +318,12 @@ pub(crate) fn wapc_host_callback(
         operation
     );
 
+    let link_name = if link_name.trim().is_empty() {
+        // Some actor SDKs may not specify a link field by default
+        "default"
+    } else {
+        link_name
+    };
     // Look up the public key of the provider bound to the origin actor
     // for the given capability contract ID.
     let bus = MessageBus::from_hostlocal_registry(&kp.public_key());
@@ -362,17 +368,11 @@ fn invocation_from_callback(
     provider_id: &str,
     payload: &[u8],
 ) -> Invocation {
-    let link_name = if bd.trim().is_empty() {
-        // Some actor SDKs may not specify a link field by default
-        "default".to_string()
-    } else {
-        bd.to_string()
-    };
     let target = if ns.len() == 56 && ns.starts_with("M") {
         WasmCloudEntity::Actor(ns.to_string())
     } else {
         WasmCloudEntity::Capability {
-            link_name,
+            link_name: bd.to_string(),
             contract_id: ns.to_string(),
             id: provider_id.to_string(),
         }


### PR DESCRIPTION
Fixes #68

`link_name` is littered across the project (162 results in 16 files) so I've attempted to do this in the most efficient way possible. I tackled two main areas of issue when creating links across wasmCloud:
1. Starting a capability provider with a link name of `""`
  Tackled with `normalize_link_name` within the `capability` module. Feasibly, we could surround every occurrence of `link_name` with this function, but I see less value in that if we stop the irregular naming at the source. (If this is desired, `normalize_link_name` could be moved to a common `util` module, and I can do that refactor brute-force 😄 
2. Starting a native capability host (e.g. accessing a capability from within an actor) with a link name of `""`
  This functionality was actually already present, just at a later point in the callstack. I moved that logic up so that an actor invoking a provider can't make the mistake of invoking a provider on the link `""`