### PR TITLE
Update deb pkg

### DIFF
--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -23,9 +23,7 @@ jobs:
           export VERSION=$(echo $REF | cut -d/ -f3)
           ./bin/nfpm pkg --packager deb -f build/nfpm.amd64.yaml
           ./bin/nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
-      - name: Push amd64 (Ubuntu 19.04)
-        run: curl -F "package[distro_version_id]=203" -F "package[package_file]=@$(ls wasmcloud_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
-      - name: Push amd64 (Ubuntu 20.04)
-        run: curl -F "package[distro_version_id]=210" -F "package[package_file]=@$(ls wasmcloud_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+      - name: Push amd64 (deb)
+        run: curl -F "package[distro_version_id]=35" -F "package[package_file]=@$(ls wasmcloud_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
       - name: Push x86_64 (Fedora 32)
         run: curl -F "package[distro_version_id]=216" -F "package[package_file]=@$(ls wasmcloud-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json

--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -18,7 +18,7 @@ jobs:
         run: cargo build --release
       - name: Install NFPM
         run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/nfpm.sh | sh
-      - name: Package amd64 (Debian)
+      - name: Package amd64
         run: |
           export VERSION=$(echo $REF | cut -d/ -f3)
           ./bin/nfpm pkg --packager deb -f build/nfpm.amd64.yaml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,34 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo_check:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Check fmt
+      run: cargo fmt -- --check
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test -- --test-threads=1
     - name: Check fmt
       run: cargo fmt -- --check
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      nats:
+        image: nats
+        ports:
+          - 6222:6222
+          - 4222:4222
+          - 8222:8222
+
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+
     steps:
     - uses: actions/checkout@v2
     - name: Build

--- a/build/nfpm.arm64.yaml
+++ b/build/nfpm.arm64.yaml
@@ -12,5 +12,6 @@ description: wasmcloud
 vendor: wasmCloud
 homepage: https://wascc.dev
 license: Apache-2.0
-files:
-  artifacts/release/wasmcloud: "/usr/local/bin/wasmcloud"
+contents:
+  - src: artifacts/release/wasmcloud
+    dst: /usr/local/bin/wasmcloud


### PR DESCRIPTION
Removes specific distribution id's from the push to package cloud.

Distribution ID 35 will allow any debian based distribution:
```
    {
      "display_name": "Any deb-based distribution.",
      "index_name": "any",
      "versions": [
        {
          "id": 35,
          "display_name": "Any version.",
          "index_name": "any",
          "version_number": null
        }
      ]
    }
```