### PR TITLE
Update packaging

### DIFF
--- a/.github/workflows/release_amd64.yml
+++ b/.github/workflows/release_amd64.yml
@@ -11,6 +11,12 @@ jobs:
     env:
       REF: ${{ github.ref }}
       PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_API_TOKEN }}
+
+    strategy:
+      matrix:
+        # distribution version numbers as supported by packagecloud.io
+        deb: [35, 150, 155, 156, 203, 206, 207, 210, 215, 219]
+        rpm: [140, 141, 146, 194, 204, 205, 209, 216]
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -23,9 +29,8 @@ jobs:
           export VERSION=$(echo $REF | cut -d/ -f3)
           ./bin/nfpm pkg --packager deb -f build/nfpm.amd64.yaml
           ./bin/nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
-      - name: Push amd64 (Ubuntu 19.04)
-        run: curl -F "package[distro_version_id]=203" -F "package[package_file]=@$(ls wasmcloud_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
-      - name: Push amd64 (Ubuntu 20.04)
-        run: curl -F "package[distro_version_id]=210" -F "package[package_file]=@$(ls wasmcloud_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
-      - name: Push x86_64 (Fedora 32)
-        run: curl -F "package[distro_version_id]=216" -F "package[package_file]=@$(ls wasmcloud-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+      - name: Push amd64 (deb)
+        run: curl -F "package[distro_version_id]=${{ matrix.deb }}" -F "package[package_file]=@$(ls wasmcloud_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+      - name: Push x86_64 (rpm)
+        run: curl -F "package[distro_version_id]=${{ matrix.rpm }}" -F "package[package_file]=@$(ls wasmcloud-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+

--- a/.github/workflows/release_arm64.yml
+++ b/.github/workflows/release_arm64.yml
@@ -15,6 +15,13 @@ jobs:
   armv7_job:
     runs-on: ubuntu-20.04
     name: Build on ubuntu-20.04 aarch64
+
+    strategy:
+      matrix:
+        # distribution version numbers as supported by packagecloud.io
+        deb: [35, 150, 155, 156, 203, 206, 207, 210, 215, 219]
+        rpm: [140, 141, 146, 194, 204, 205, 209, 216]
+
     steps:
       - uses: actions/checkout@v2
       - uses: uraimo/run-on-arch-action@v2.0.7
@@ -45,5 +52,5 @@ jobs:
             ./bin/nfpm pkg --packager deb -f build/nfpm.arm64.yaml
             ./bin/nfpm pkg --packager rpm -f build/nfpm.arm64.yaml
             ls -l "${PWD}/artifacts"
-            curl -F "package[distro_version_id]=190" -F "package[package_file]=@$(ls ${PWD}/wasmcloud_*_arm64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
-            curl -F "package[distro_version_id]=204" -F "package[package_file]=@$(ls ${PWD}/wasmcloud-*.aarch64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+            curl -F "package[distro_version_id]=${{ matrix.deb }}" -F "package[package_file]=@$(ls ${PWD}/wasmcloud_*_arm64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json
+            curl -F "package[distro_version_id]=${{ matrix.rpm }}" -F "package[package_file]=@$(ls ${PWD}/wasmcloud-*.aarch64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmCloud/core/packages.json

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,34 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo_check:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Check fmt
+      run: cargo fmt -- --check
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test -- --test-threads=1
     - name: Check fmt
       run: cargo fmt -- --check
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      nats:
+        image: nats
+        ports:
+          - 6222:6222
+          - 4222:4222
+          - 8222:8222
+
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+
     steps:
     - uses: actions/checkout@v2
     - name: Build


### PR DESCRIPTION
This refactors how we manage pushing to many distributions.

Packagecloud uses "distribution version id's" which means in order to support different versions of ubuntu, debian, fedora, etc, we need to push a package with the specific id.

Using the matrix for deb and rpm distribution id's, we can simplify this action considerably. If or when packagecloud adds support for a new distribution, we can simply add the ID to the matrix.