### PR TITLE
Updated crate READMEs, additional build/release actions, increased echo delay

### DIFF
--- a/.github/workflows/control-interface.yml
+++ b/.github/workflows/control-interface.yml
@@ -1,0 +1,39 @@
+name: CONTROL-INTERFACE
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "crates/control-interface/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "crates/control-interface/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./crates/control-interface
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/control-interface_release.yml
+++ b/.github/workflows/control-interface_release.yml
@@ -1,0 +1,62 @@
+name: CONTROL-INTERFACE_RELEASE
+
+on:
+  push:
+    tags:
+    - 'control-interface-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./crates/control-interface
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test -- --test-threads=1
+      run: RUST_LOG=trace cargo test --no-fail-fast --verbose -- --test-threads=1 --nocapture
     - name: Check fmt
       run: cargo fmt -- --check
 

--- a/.github/workflows/wasmcloud-host.yml
+++ b/.github/workflows/wasmcloud-host.yml
@@ -1,0 +1,39 @@
+name: WASMCLOUD-HOST
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "crates/wasmcloud-host/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "crates/wasmcloud-host/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./crates/wasmcloud-host
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/wasmcloud-host_release.yml
+++ b/.github/workflows/wasmcloud-host_release.yml
@@ -1,0 +1,62 @@
+name: WASMCLOUD-HOST_RELEASE
+
+on:
+  push:
+    tags:
+    - 'wasmcloud-host-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./crates/wasmcloud-host
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+        working-directory: ${{ env.working-directory }}

--- a/crates/control-interface/README.md
+++ b/crates/control-interface/README.md
@@ -1,0 +1,8 @@
+![Crates.io](https://img.shields.io/crates/v/control-interface)
+[![Documentation](https://img.shields.io/badge/Docs-Documentation-blue)](https://wasmcloud.dev)
+![Rustdocs](https://docs.rs/wasmcloud-host/badge.svg
+
+# wasmCloud Control Interface
+This library is a convenient API for interacting with the lattice control interface.
+
+The lattice control interface provides a way for clients to interact with the lattice to issue control commands and queries. This interface is a message broker protocol that supports functionality like starting and stopping actors and providers, declaring link definitions, performing function calls on actors, monitoring lattice events, holding auctions to determine scheduling compatibility, and much more.

--- a/crates/wasmcloud-host/README.md
+++ b/crates/wasmcloud-host/README.md
@@ -1,6 +1,81 @@
+![Crates.io](https://img.shields.io/crates/v/wasmcloud-host)
 [![Documentation](https://img.shields.io/badge/Docs-Documentation-blue)](https://wasmcloud.dev)
 ![Rustdocs](https://docs.rs/wasmcloud-host/badge.svg)
 
 # wasmCloud Host
 
-This is a Rust library that exposes all of the functionality of the wasmCloud distributed WebAssembly actor runtime
+[wasmCloud](https://wasmcloud.com) is a secure, distributed actor platform with an autonomous mesh network built
+for bridging disparate and far-flung infrastructure.
+
+By default a wasmCloud host will start in offline mode and only allow "local" scheduling of actors
+and capabilities. If you choose to opt-in to the lattice, you can use NATS as a message broker to
+provide the infrastructure for wasmCloud's self-forming, self-healing network. If you then want
+even more power, you can choose to override the capability provider used for managing the shared
+state within a lattice.
+
+Local development on your workstation is easy and simple by default, and you should only
+incur additional complexity as you move toward resilient, distributed production
+environments.
+
+To start a runtime, simply add actors and capabilities to the host. For more information,
+take a look at the documentation and tutorials at [wasmcloud.dev](https://wasmcloud.dev).
+
+## Example
+The following example creates a new wasmCloud host in the default standalone (no lattice) mode. It
+then loads an actor that simply echoes back incoming HTTP requests as outbound HTTP responses.
+The HTTP server capability provider is loaded so that the actor can receive web requests.
+Note that the link definition (configuration of the link between the actor and the
+capability provider) can be defined _in any order_. The host runtime automatically
+establishes links as soon as all related parties are up and running inside a host or
+a lattice.
+
+```rust
+use wasmcloud_host::{HostBuilder, Actor, NativeCapability};
+use std::collections::HashMap;
+use std::error::Error;
+use std::time::Duration;
+use actix_rt::time::delay_for;
+extern crate reqwest;
+
+const WEB_PORT: u32 = 8080;
+
+#[actix_rt::main]
+async fn main() -> Result<(), Box<dyn Error + Sync +Send>> {
+    let h = HostBuilder::new().build();
+    h.start().await?;
+    let echo = Actor::from_file("../../tests/modules/echo.wasm")?;
+    let actor_id = echo.public_key();
+    h.start_actor(echo).await?;
+
+    // Read a cross-platform provider archive file
+    let arc = par_from_file("../../tests/modules/httpserver.par.gz")?;
+    let websrv = NativeCapability::from_archive(&arc, None)?;
+    let websrv_id = websrv.id();
+
+    let mut webvalues: HashMap<String, String> = HashMap::new();
+    webvalues.insert("PORT".to_string(), format!("{}", WEB_PORT));
+    // Establish a link between the actor and a capability provider
+    h.set_link(
+        &actor_id,
+        "wasmcloud:httpserver",
+        None,
+        websrv_id,
+        webvalues,
+    )
+    .await?;
+    // Start the web server provider (which auto-establishes the link)
+    h.start_native_capability(websrv).await?;
+    // Let the web server start
+    delay_for(Duration::from_millis(500)).await;
+    let url = format!("http://localhost:{}/demo?test=kthxbye", WEB_PORT);
+
+    let resp = reqwest::get(&url).await?;
+    assert!(resp.status().is_success());
+    let v: serde_json::Value = serde_json::from_slice(&resp.bytes().await?)?;
+    assert_eq!("test=kthxbye", v["query_string"].as_str().unwrap());
+
+    Ok(())
+}
+```
+
+For more examples, refer to the integration tests located at the [base of this repository](../../tests)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,7 +5,6 @@ mod no_lattice;
 mod with_lattice;
 
 use std::env::temp_dir;
-use wasmcloud_host::Result;
 
 #[cfg(test)]
 #[ctor::ctor]

--- a/tests/with_lattice.rs
+++ b/tests/with_lattice.rs
@@ -13,7 +13,7 @@ use wasmcloud_host::{Host, Result};
 pub(crate) async fn distributed_echo() -> Result<()> {
     // Set the default kvcache provider to enable NATS-based replication
     // by supplying a NATS URL.
-    delay_for(Duration::from_millis(500)).await;
+    delay_for(Duration::from_millis(5000)).await;
     ::std::env::set_var("KVCACHE_NATS_URL", "0.0.0.0:4222");
 
     let web_port = 32400_u32;
@@ -48,12 +48,12 @@ pub(crate) async fn distributed_echo() -> Result<()> {
     // it should request a replay of cache events and therefore get the existing claims, links,
     // etc.
     host_b.start().await?;
-    delay_for(Duration::from_millis(500)).await;
+    delay_for(Duration::from_millis(5000)).await;
 
     host_b.start_native_capability(websrv).await?;
     // always have to remember that "extras" and kvcache is in the provider list.
     await_provider_count(&host_b, 3, Duration::from_millis(50), 3).await?;
-    delay_for(Duration::from_millis(500)).await;
+    delay_for(Duration::from_millis(5000)).await;
 
     let mut webvalues: HashMap<String, String> = HashMap::new();
     webvalues.insert("PORT".to_string(), format!("{}", web_port));
@@ -73,7 +73,7 @@ pub(crate) async fn distributed_echo() -> Result<()> {
     let resp = reqwest::get(&url).await?;
     assert!(resp.status().is_success());
     assert_eq!(resp.text().await?,
-     "{\"method\":\"GET\",\"path\":\"/foo/bar\",\"query_string\":\"\",\"headers\":{\"accept\":\"*/*\",\"host\":\"localhost:32400\"},\"body\":[]}");
+     "{\"method\":\"GET\",\"path\":\"/foo/bar\",\"query_string\":\"\",\"headers\":{\"host\":\"localhost:32400\",\"accept\":\"*/*\"},\"body\":[]}");
 
     host_a.stop().await;
     host_b.stop().await;


### PR DESCRIPTION
This PR updates the crate READMEs along with build/release actions so we can get them released and used in `wasmCloud` and `wash`.

This test also updates the echo test, primarily increasing the delay durations to make it pass more consistently with the test suite. I've filed #83 to capture our desire to move away from fiddling with delay timers.