### PR TITLE
Pinned wasmcloud-host to version for cargo publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ wapc = { version = "0.10.1" }
 log = "0.4.11"
 env_logger = "0.8.2"
 anyhow = "1.0.34"
-wasmcloud-host = { path = "crates/wasmcloud-host" }
+wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.15.0" }
 actix-rt = "1.1.1"
 nats = "0.8.6"
 structopt = "0.3.21"


### PR DESCRIPTION
`cargo publish --dry-run` succeeds now, so we can release the binary