### PR TITLE
Initial attempt at some deterministic tests. No worky

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmcloud"
-version = "0.15.0"
-authors = ["wasmCloud Team"]
+version = "0.16.0"
+authors = ["wasmcloud Team"]
 edition = "2018"
 default-run = "wasmcloud"
 license-file = "LICENSE"
@@ -38,7 +38,7 @@ wapc = { version = "0.10.1" }
 log = "0.4.11"
 env_logger = "0.8.2"
 anyhow = "1.0.34"
-wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.15.0" }
+wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.16.0" }
 actix-rt = "1.1.1"
 nats = "0.8.6"
 structopt = "0.3.21"
@@ -61,6 +61,8 @@ wasmcloud-actor-http-server = "0.1.0"
 ctor = "0.1.16"
 wascap = "0.6.0"
 futures = "0.3.6"
+crossbeam = "0.8.0"
+crossbeam-channel = "0.5.0"
 
 [workspace]
 members = [

--- a/crates/nats-kvcache/.gitignore
+++ b/crates/nats-kvcache/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+Cargo.lock
+.idea

--- a/crates/nats-kvcache/Cargo.toml
+++ b/crates/nats-kvcache/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "wasmcloud-nats-kvcache"
+version = "0.4.1"
+authors = ["wasmCloud Team"]
+edition = "2018"
+license-file = "LICENSE.txt"
+description = "A key-value capability provider for wasmCloud that replicates data changes over NATS"
+repository = "https://github.com/wasmcloud/capability-providers"
+documentation = "https://wasmcloud.com"
+readme = "README.md"
+keywords = [
+    "cache",
+    "nats",
+    "keyvalue",
+    "webassembly",
+    "wasmcloud"    
+]
+categories = [
+    "wasm", "api-bindings",
+]
+
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# Enable if the provider will be statically compiled into a host
+static_plugin = []
+
+[dependencies]
+wasmcloud-actor-keyvalue = "0.2.0"
+wasmcloud-actor-core = "0.2.0"
+nats = "0.8.6"
+wascc-codec = "0.9.0"
+wascap = "0.5.1"
+env_logger = "0.8.2"
+uuid = { version = "0.8.1", features = ["v4"] }
+lazy_static = "1.4.0"
+log = "0.4.11"
+eventsourcing = "0.1.5"
+eventsourcing-derive = "0.1.3"
+serde = { version = "1.0.118", features = ["derive"]}
+crossbeam = "0.8.0"
+crossbeam-channel = "0.5.0"

--- a/crates/nats-kvcache/LICENSE.txt
+++ b/crates/nats-kvcache/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/nats-kvcache/README.md
+++ b/crates/nats-kvcache/README.md
@@ -1,0 +1,31 @@
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-nats-kvcache.svg)](https://crates.io/crates/wasmcloud-nats-kvcache)
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/NATS-KVCACHE/badge.svg)
+![license](https://img.shields.io/crates/l/wasmcloud-nats-kvcache.svg)
+[![documentation](https://docs.rs/wasmcloud-nats-kvcache/badge.svg)](https://docs.rs/wasmcloud-nats-kvcache)
+
+# wasmCloud Key-Value Provider (NATS Distributed Key-Value Cache)
+
+This is an _in-memory_ key-value cache that is distributed by replicating state changes across a specific set of
+NATS topics. It is understood that in the "bare NATS" version of this provider, message loss can potentially happen
+and thus the cache values can potentially diverge from host to host.
+
+## CAUTION ⚠️
+
+It is recommended that this key-value store be used in development, debugging, and R&D purposes only and you
+not use this for a production distributed cache unless periodic node divergence is an acceptable use case (for example, you re-query
+data upon cache misses or time-delayed/heartbeat reconciliation is acceptable). This provider will attempt to use high water marks + event sourcing to reconcile global state, but that system is not infallible.
+
+As per the `wasmcloud:keyvalue` contract, all values (except for atomics) stored by this provider are treated as strings. `Sets` are treated as sets of strings, etc. Atomic values _cannot guarantee_ global atomicity. Increments and decrements will be done relative to the currently known (local) value at the time, which means concurrent, distributed so-called "atomic" updates can result in inconsistent values.
+
+Also note that caches are _not isolated per actor_. This is not a multi-tenant cache. If two different actors bound to the same named link instance
+of this provider request the same key, they will get the same value. If you need to segment distributed caches, do so by providing different
+link names during start-up.
+
+This provider will take the configuration received from the _first linked actor_ and use that data to connect to NATS. All subsequent attempts
+to provide link configuration will be ignored in order to satisfy the "idempotent provider" requirement. If no NATS connection string information is provided during the initial link configuration, then this provider will effectively perform like a single, standalone in-memory cache and not replicate or subscribe to any state changes.
+
+## ANOTHER WARNING ⚠️
+
+Do not rely on this provider to return meaningful data in response to mutation operations. For example, the atomic add operation, by contract, returns
+an integer that should represent the new value. For optimization purposes, this provider will return the default (empty) version of all responses. This
+is based on the notion that when you are setting data in this distributed cache, you are not interested in immediately retrieving the value.

--- a/crates/nats-kvcache/src/events.rs
+++ b/crates/nats-kvcache/src/events.rs
@@ -1,0 +1,163 @@
+use std::error::Error;
+
+use eventsourcing::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::kvcache::KeyValueStore;
+
+pub(crate) const DOMAIN_VERSION: &str = "1.0";
+
+#[derive(Serialize, Deserialize, Debug, Clone, Event)]
+#[event_type_version(DOMAIN_VERSION)]
+#[event_source("events://github.com/wasmCloud/capability-providers/rust/nats-keyvalue")]
+/// Indicates an event that has occurred on a distributed cache. In all of the variants of this event, the first parameter is always the key
+pub enum CacheEvent {
+    AtomicAdd(String, i32),
+    KeyDelete(String),
+    ScalarSet(String, String),
+    ListClear(String),
+    ListPush(String, String),
+    ListRemoveItem(String, String),
+    SetAdd(String, String),
+    SetRemoveItem(String, String),
+}
+
+#[doc(hidden)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CacheEventWrapper {
+    pub origin_id: String,
+    pub event: CacheEvent,
+}
+
+pub(crate) enum CacheCommand {}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CacheData {
+    history: Vec<CacheEvent>,
+    cache: KeyValueStore,
+}
+
+impl CacheData {
+    pub fn new(cache: KeyValueStore) -> Self {
+        CacheData {
+            history: vec![],
+            cache,
+        }
+    }
+
+    pub fn history(&self) -> Vec<CacheEvent> {
+        self.history.clone()
+    }
+
+    pub fn get(&self, key: &str) -> Result<Option<String>, Box<dyn Error>> {
+        if self.cache.exists(key)? {
+            Ok(Some(self.cache.get(key)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn list_range(
+        &self,
+        key: &str,
+        start: i32,
+        stop: i32,
+    ) -> Result<Vec<String>, Box<dyn Error>> {
+        self.cache.lrange(key, start, stop)
+    }
+
+    pub fn exists(&self, key: &str) -> Result<bool, Box<dyn Error>> {
+        self.cache.exists(key)
+    }
+
+    pub fn set_union(&self, keys: Vec<String>) -> Result<Vec<String>, Box<dyn Error>> {
+        self.cache.sunion(keys)
+    }
+
+    pub fn set_intersect(&self, keys: Vec<String>) -> Result<Vec<String>, Box<dyn Error>> {
+        self.cache.sinter(keys)
+    }
+
+    pub fn set_query(&self, key: &str) -> Result<Vec<String>, Box<dyn Error>> {
+        self.cache.smembers(key.to_string())
+    }
+
+    pub fn atomic_add(
+        &mut self,
+        key: &str,
+        value: &i32,
+    ) -> ::std::result::Result<(), Box<dyn Error>> {
+        self.cache.incr(key, *value).map(|_| ())
+    }
+
+    pub fn key_delete(&mut self, key: &str) -> Result<(), Box<dyn Error>> {
+        self.cache.del(key)
+    }
+
+    pub fn set_scalar(&mut self, key: &str, value: &str) -> Result<(), Box<dyn Error>> {
+        self.cache.set(key, value.to_string())
+    }
+
+    pub fn list_clear(&mut self, key: &str) -> Result<(), Box<dyn Error>> {
+        self.cache.del(key)
+    }
+
+    pub fn list_push(&mut self, key: &str, value: &str) -> Result<(), Box<dyn Error>> {
+        self.cache.lpush(key, value.to_string()).map(|_| ())
+    }
+
+    pub fn list_remove(&mut self, key: &str, value: &str) -> Result<(), Box<dyn Error>> {
+        self.cache.lrem(key, value.to_string()).map(|_| ())
+    }
+
+    pub fn set_add(&mut self, key: &str, value: &str) -> Result<(), Box<dyn Error>> {
+        self.cache.sadd(key, value.to_string()).map(|_| ())
+    }
+
+    pub fn set_remove(&mut self, key: &str, value: &str) -> Result<(), Box<dyn Error>> {
+        self.cache.srem(key, value.to_string()).map(|_| ())
+    }
+
+    pub fn log_event(&mut self, evt: CacheEvent) {
+        self.history.push(evt);
+    }
+}
+
+impl AggregateState for CacheData {
+    fn generation(&self) -> u64 {
+        self.history.len() as u64
+    }
+}
+
+pub(crate) struct Cache;
+impl Aggregate for Cache {
+    type Event = CacheEvent;
+    type Command = CacheCommand;
+    type State = CacheData;
+
+    fn apply_event(state: &Self::State, evt: &Self::Event) -> eventsourcing::Result<Self::State> {
+        let mut state = state.clone();
+        match evt {
+            CacheEvent::AtomicAdd(key, value) => state.atomic_add(key, value),
+            CacheEvent::KeyDelete(key) => state.key_delete(key),
+            CacheEvent::ScalarSet(key, value) => state.set_scalar(key, value),
+            CacheEvent::ListClear(key) => state.list_clear(key),
+            CacheEvent::ListPush(key, value) => state.list_push(key, value),
+            CacheEvent::ListRemoveItem(key, value) => state.list_remove(key, value),
+            CacheEvent::SetAdd(key, value) => state.set_add(key, value),
+            CacheEvent::SetRemoveItem(key, value) => state.set_remove(key, value),
+        }
+        .map_err(|e| eventsourcing::Error {
+            kind: eventsourcing::Kind::StoreFailure(format!("{}", e)),
+        })?;
+        state.log_event(evt.clone());
+        Ok(state)
+    }
+
+    fn handle_command(
+        _state: &Self::State,
+        _cmd: &Self::Command,
+    ) -> eventsourcing::Result<Vec<Self::Event>> {
+        todo!()
+    }
+}

--- a/crates/nats-kvcache/src/kvcache.rs
+++ b/crates/nats-kvcache/src/kvcache.rs
@@ -1,0 +1,299 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::error::Error;
+use std::result::Result;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum KeyValueItem {
+    Atomic(i32),
+    Scalar(String),
+    List(Vec<String>),
+    Set(HashSet<String>),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct KeyValueStore {
+    items: HashMap<String, KeyValueItem>,
+}
+
+impl KeyValueStore {
+    pub fn new() -> Self {
+        KeyValueStore {
+            items: HashMap::new(),
+        }
+    }
+
+    pub fn incr(&mut self, key: &str, value: i32) -> Result<i32, Box<dyn Error>> {
+        let mut orig = 0;
+        self.items
+            .entry(key.to_string())
+            .and_modify(|v| {
+                if let KeyValueItem::Atomic(ref x) = v {
+                    orig = *x;
+                    *v = KeyValueItem::Atomic(x + value);
+                }
+            })
+            .or_insert(KeyValueItem::Atomic(value));
+        Ok(orig + value)
+    }
+
+    pub fn del(&mut self, key: &str) -> Result<(), Box<dyn Error>> {
+        self.items.remove(key);
+        Ok(())
+    }
+
+    pub fn exists(&self, key: &str) -> Result<bool, Box<dyn Error>> {
+        Ok(self.items.contains_key(key))
+    }
+
+    pub fn get(&self, key: &str) -> Result<String, Box<dyn Error>> {
+        self.items.get(key).map_or_else(
+            || Err("No such key".into()),
+            |v| {
+                if let KeyValueItem::Scalar(ref s) = v {
+                    Ok(s.clone())
+                } else if let KeyValueItem::Atomic(x) = v {
+                    Ok(x.to_string())
+                } else {
+                    Err("Attempt to fetch non-scalar as a scalar".into())
+                }
+            },
+        )
+    }
+
+    pub fn lrange(&self, key: &str, start: i32, stop: i32) -> Result<Vec<String>, Box<dyn Error>> {
+        let start = start.max(0);
+        self.items.get(key).map_or_else(
+            || Ok(vec![]),
+            |v| {
+                if let KeyValueItem::List(l) = v {
+                    let stop = stop.min(l.len() as _);
+                    Ok(l.as_slice()[start as _..stop as _].to_vec())
+                } else {
+                    Err("Attempt to fetch non-list".into())
+                }
+            },
+        )
+    }
+
+    pub fn lpush(&mut self, key: &str, value: String) -> Result<i32, Box<dyn Error>> {
+        let mut len = 1;
+        self.items
+            .entry(key.to_string())
+            .and_modify(|v| {
+                if let KeyValueItem::List(ref l) = v {
+                    let mut list = Vec::new();
+                    list.extend_from_slice(&l);
+                    list.push(value.clone());
+                    len = list.len();
+                    *v = KeyValueItem::List(list);
+                }
+            })
+            .or_insert_with(|| KeyValueItem::List(vec![value]));
+        Ok(len as _)
+    }
+
+    pub fn set(&mut self, key: &str, value: String) -> Result<(), Box<dyn Error>> {
+        self.items
+            .entry(key.to_string())
+            .and_modify(|v| {
+                if let KeyValueItem::Scalar(_) = v {
+                    *v = KeyValueItem::Scalar(value.clone());
+                }
+            })
+            .or_insert(KeyValueItem::Scalar(value));
+        Ok(())
+    }
+
+    pub fn lrem(&mut self, key: &str, value: String) -> Result<i32, Box<dyn Error>> {
+        let mut len: i32 = 0;
+        self.items.entry(key.to_string()).and_modify(|v| {
+            if let KeyValueItem::List(ref l) = v {
+                let list: Vec<String> = l
+                    .iter()
+                    .filter(|i| **i != value)
+                    .map(|v| v.into())
+                    .collect();
+                len = list.len() as _;
+                *v = KeyValueItem::List(list);
+            }
+        });
+        Ok(len)
+    }
+
+    pub fn sadd(&mut self, key: &str, value: String) -> Result<i32, Box<dyn Error>> {
+        let mut len: i32 = 1;
+        self.items
+            .entry(key.to_string())
+            .and_modify(|v| {
+                if let KeyValueItem::Set(ref mut s) = v {
+                    s.insert(value.clone());
+                    len = s.len() as _;
+                }
+            })
+            .or_insert_with(|| new_set(value));
+        Ok(len)
+    }
+
+    pub fn srem(&mut self, key: &str, value: String) -> Result<i32, Box<dyn Error>> {
+        let mut len: i32 = 0;
+        self.items
+            .entry(key.to_string())
+            .and_modify(|v| {
+                if let KeyValueItem::Set(ref mut s) = v {
+                    s.remove(&value);
+                    len = s.len() as _;
+                }
+            })
+            .or_insert_with(|| KeyValueItem::Set(HashSet::new()));
+        Ok(len)
+    }
+
+    pub fn sunion(&self, keys: Vec<String>) -> Result<Vec<String>, Box<dyn Error>> {
+        let union = self
+            .items
+            .iter()
+            .filter_map(|(k, v)| {
+                if keys.contains(k) {
+                    if let KeyValueItem::Set(s) = v {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .fold(HashSet::new(), |acc, x| acc.union(&x).cloned().collect());
+
+        Ok(union.iter().cloned().collect())
+    }
+
+    pub fn sinter(&self, keys: Vec<String>) -> Result<Vec<String>, Box<dyn Error>> {
+        let sets: Vec<HashSet<String>> = self
+            .items
+            .iter()
+            .filter_map(|(k, v)| {
+                if keys.contains(k) {
+                    if let KeyValueItem::Set(s) = v {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let set1 = &sets[0];
+        let inter = set1
+            .iter()
+            .filter(|k| sets.as_slice().iter().all(|s| s.contains(*k)));
+        Ok(inter.cloned().collect())
+    }
+
+    pub fn smembers(&self, key: String) -> Result<Vec<String>, Box<dyn Error>> {
+        self.items.get(&key).map_or_else(
+            || Ok(vec![]),
+            |v| {
+                if let KeyValueItem::Set(ref s) = v {
+                    Ok(s.iter().cloned().collect())
+                } else {
+                    Err(format!("attempt to query non-set '{}'", key).into())
+                }
+            },
+        )
+    }
+}
+
+fn new_set(value: String) -> KeyValueItem {
+    let mut x = HashSet::new();
+    x.insert(value);
+    KeyValueItem::Set(x)
+}
+
+#[cfg(test)]
+mod test {
+    use super::KeyValueStore;
+
+    fn gen_store() -> KeyValueStore {
+        let mut store = KeyValueStore::new();
+        store.sadd("test", "bob".to_string()).unwrap();
+        store.sadd("test", "alice".to_string()).unwrap();
+        store.sadd("test", "dave".to_string()).unwrap();
+        store.sadd("test2", "bob".to_string()).unwrap();
+        store.sadd("test2", "dave".to_string()).unwrap();
+
+        store.lpush("list1", "first".to_string()).unwrap();
+        store.lpush("list1", "second".to_string()).unwrap();
+        store.lpush("list1", "third".to_string()).unwrap();
+
+        store.incr("counter", 5).unwrap();
+
+        store.set("setkey", "setval".to_string()).unwrap();
+        store
+    }
+
+    #[test]
+    fn test_intersect() {
+        let store = gen_store();
+
+        let inter = store
+            .sinter(vec!["test".to_string(), "test2".to_string()])
+            .unwrap();
+        assert!(inter.contains(&String::from("bob")));
+        assert!(inter.contains(&String::from("dave")));
+        assert_eq!(false, inter.contains(&String::from("alice")));
+    }
+
+    #[test]
+    fn test_union() {
+        let store = gen_store();
+
+        let union = store
+            .sunion(vec!["test".to_string(), "test2".to_string()])
+            .unwrap();
+        assert_eq!(3, union.len());
+    }
+
+    #[test]
+    fn test_get_set() {
+        let store = gen_store();
+
+        assert_eq!("setval".to_string(), store.get("setkey").unwrap());
+    }
+
+    #[test]
+    fn test_list() {
+        let store = gen_store();
+        assert_eq!(
+            vec!["first", "second", "third"],
+            store.lrange("list1", 0, 100).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_incr() {
+        let mut store = gen_store();
+
+        let a = store.incr("counter", 1).unwrap();
+        let b = store.incr("counter", 1).unwrap();
+        let c = store.incr("counter", -3).unwrap();
+
+        assert_eq!(a, 6);
+        assert_eq!(b, 7);
+        assert_eq!(c, 4);
+    }
+
+    #[test]
+    fn test_exists_and_del() {
+        let mut store = gen_store();
+
+        store.set("thenumber", "42".to_string()).unwrap();
+        assert!(store.exists("thenumber").unwrap());
+        store.del("thenumber").unwrap();
+        assert_eq!(false, store.exists("thenumber").unwrap());
+        store.set("thenumber", "41".to_string()).unwrap();
+        assert!(store.exists("thenumber").unwrap());
+    }
+}

--- a/crates/nats-kvcache/src/lib.rs
+++ b/crates/nats-kvcache/src/lib.rs
@@ -1,0 +1,612 @@
+//! # NATS Key Value Cache
+//!
+//! A simple distributed cache that exposes a `wasmcloud:keyvalue` capability provider
+//! contract. All state changes are replicated over NATS in the form of events that are
+//! then reconstituted by other nodes to build state. Replays can be requested with high
+//! watermark values in order to reload/synchronize state for joining or lagging nodes.
+//!
+//! ## Protocol
+//!
+//! | Subject Pattern | Usage |
+//! |---|---|
+//! | {root}.events | Subscribed to by all running providers. Each event received on this subject is processed by an aggregate to update local state |
+//! | {root}.replay.req | Queue subscribed by all running providers. In response to a request, a provider will stream responses to the requester |
+//!
+//! When a requester sends a request, they will send it with a high watermark (`hwm`). This indicates the offset from zero of the latest message
+//! the requester has received. In response, the provider that handled the request will first send a [ReplayRequestAck] back on the reply
+//! subject, indicating the local (handling provider) `hwm` and the `hwm` sent by the requester. Subtracting these two will tell the
+//! requester how many more messages to receive on that reply subject, one for each event the requester has not received.
+//!
+//! As an example, assume the requester has a high watermark of 12, and the handling provider has a high watermark of 15. The requester will
+//! first receive a [ReplayRequestAck] indicating how many subsequent events to expect in reply, followed then by `n` [CacheEvent]s.
+
+mod events;
+mod kvcache;
+
+pub use events::CacheEvent;
+
+#[macro_use]
+extern crate eventsourcing_derive;
+
+extern crate eventsourcing;
+
+extern crate wasmcloud_actor_core as core;
+extern crate wasmcloud_actor_keyvalue as keyvalue;
+#[macro_use]
+extern crate wascc_codec as codec;
+#[macro_use]
+extern crate log;
+use crossbeam_channel::{select, tick, Receiver, Sender};
+
+use codec::capabilities::{
+    CapabilityProvider, Dispatcher, NullDispatcher, OP_GET_CAPABILITY_DESCRIPTOR,
+};
+use codec::core::{OP_BIND_ACTOR, OP_HEALTH_REQUEST, OP_REMOVE_ACTOR};
+use codec::SYSTEM_ACTOR;
+use core::{CapabilityConfiguration, HealthCheckResponse};
+use events::{Cache, CacheData, CacheEventWrapper};
+use eventsourcing::Aggregate;
+use keyvalue::{
+    deserialize, serialize, AddArgs, AddResponse, ClearArgs, DelArgs, DelResponse, GetArgs,
+    GetResponse, KeyExistsArgs, ListItemDeleteArgs, ListRangeResponse, ListResponse, PushArgs,
+    RangeArgs, SetAddArgs, SetArgs, SetIntersectionArgs, SetOperationResponse, SetQueryArgs,
+    SetQueryResponse, SetRemoveArgs, SetResponse, SetUnionArgs,
+};
+use kvcache::KeyValueStore;
+use std::{
+    collections::HashMap,
+    error::Error,
+    sync::{Arc, RwLock},
+    thread,
+    time::Duration,
+};
+use uuid::Uuid;
+use wascap::prelude::KeyPair;
+
+type MessageHandlerResult = Result<Vec<u8>, Box<dyn Error + Send + Sync + 'static>>;
+
+#[doc(hidden)]
+#[cfg(not(feature = "static_plugin"))]
+capability_provider!(NatsReplicatedKVProvider, NatsReplicatedKVProvider::new);
+
+const NATS_URL_CONFIG_KEY: &str = "NATS_URL";
+const CLIENT_SEED_CONFIG_KEY: &str = "CLIENT_SEED";
+const CLIENT_JWT_CONFIG_KEY: &str = "CLIENT_JWT";
+const STATE_REPL_SUBJECT_KEY: &str = "STATE_REPL_SUBJECT";
+const STATE_REPLAY_SUBJECT_KEY: &str = "REPLAY_REQ_SUBJECT";
+const HEARTBEAT_KEY: &str = "REPLAY_HEARTBEAT_SECS";
+
+const DEFAULT_STATE_REPL_SUBJECT: &str = "lattice.state.events";
+const DEFAULT_REPLAY_REQ_SUBJECT: &str = "lattice.state.replay";
+const DEFAULT_REPLAY_HEARTBEAT_SECONDS: &str = "60";
+
+/// An instance of a `wasmcloud:keyvalue` capability provider that replicates changes to the
+/// cache by means of pub/sub over a NATS message broker
+#[derive(Clone)]
+pub struct NatsReplicatedKVProvider {
+    dispatcher: Arc<RwLock<Box<dyn Dispatcher>>>,
+    cache: Arc<RwLock<CacheData>>,
+    nc: Arc<RwLock<Option<nats::Connection>>>,
+    event_subject: Arc<RwLock<String>>,
+    id: String,
+    terminator: Arc<RwLock<Option<Sender<bool>>>>,
+}
+
+impl Default for NatsReplicatedKVProvider {
+    fn default() -> Self {
+        match env_logger::try_init() {
+            Ok(_) => {}
+            Err(_) => {}
+        };
+        NatsReplicatedKVProvider {
+            dispatcher: Arc::new(RwLock::new(Box::new(NullDispatcher::new()))),
+            cache: Arc::new(RwLock::new(CacheData::new(KeyValueStore::new()))),
+            nc: Arc::new(RwLock::new(None)),
+            event_subject: Arc::new(RwLock::new("".to_string())),
+            id: Uuid::new_v4().to_string(),
+            terminator: Arc::new(RwLock::new(None)),
+        }
+    }
+}
+
+impl NatsReplicatedKVProvider {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn configure(&self, config: CapabilityConfiguration) -> MessageHandlerResult {
+        if config.values.contains_key(NATS_URL_CONFIG_KEY) {
+            match self.initialize_connection(config.values) {
+                Ok(_) => {
+                    info!("KV cache configured for {}", config.module);
+                    Ok(vec![])
+                }
+                Err(e) => {
+                    error!("Failed to configure KV cache for {}: {}", config.module, e);
+                    Err(e)
+                }
+            }
+        } else {
+            info!("No NATS URL present, falling back to standalone/isolated KV cache");
+            Ok(vec![])
+        }
+    }
+
+    fn remove_actor(&self, _config: CapabilityConfiguration) -> MessageHandlerResult {
+        let mut lock = self.nc.write().unwrap();
+        if let Some(nc) = lock.take() {
+            nc.close();
+        }
+        Ok(vec![])
+    }
+
+    fn initialize_connection(
+        &self,
+        values: HashMap<String, String>,
+    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+        let default_subject = DEFAULT_STATE_REPL_SUBJECT.to_string();
+        let subject = values
+            .get(STATE_REPL_SUBJECT_KEY)
+            .unwrap_or(&default_subject)
+            .to_string();
+        *self.event_subject.write().unwrap() = subject.to_string();
+
+        let default_replay_req_subject = DEFAULT_REPLAY_REQ_SUBJECT.to_string();
+        let replay_req_subject = values
+            .get(STATE_REPLAY_SUBJECT_KEY)
+            .unwrap_or(&default_replay_req_subject)
+            .to_string();
+
+        let cache = self.cache.clone();
+        let cache2 = self.cache.clone();
+        let cache3 = self.cache.clone();
+        // TODO: get authentication information from the values map
+        let nc = nats_connection_from_values(values.clone())?;
+        let origin = self.id.to_string();
+        nc.subscribe(&subject)?.with_handler(move |msg| {
+            let evt: CacheEventWrapper = deserialize(&msg.data).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Deserialization failure: {}", e),
+                )
+            })?;
+            if evt.origin_id != origin {
+                let _ = handle_state_event(&evt.event, cache.clone());
+            }
+            Ok(())
+        });
+
+        regenerate_cache_from_replay(&nc, cache2.clone(), &replay_req_subject)?;
+
+        nc.queue_subscribe(&replay_req_subject, &replay_req_subject)?
+            .with_handler(move |msg| process_replay_request(msg, cache3.clone()));
+
+        let nc2 = nc.clone();
+        let mut lock = self.nc.write().unwrap();
+        *lock = Some(nc);
+
+        let delay = Duration::from_secs(
+            values
+                .get(HEARTBEAT_KEY)
+                .unwrap_or(&DEFAULT_REPLAY_HEARTBEAT_SECONDS.to_string())
+                .parse()
+                .unwrap(),
+        );
+        let c = cache2.clone();
+        let conn = nc2.clone();
+
+        let (term_s, term_r): (Sender<bool>, Receiver<bool>) = crossbeam_channel::bounded(1);
+        {
+            let mut lock = self.terminator.write().unwrap();
+            *lock = Some(term_s);
+        }
+
+        thread::spawn(move || {
+            let ticker = tick(delay);
+            loop {
+                select! {
+                    recv(ticker) -> _ =>  {
+                        let _ = regenerate_cache_from_replay(&conn, c.clone(), &replay_req_subject);
+                    }
+                    recv(term_r) -> _ => break,
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    fn health(&self) -> MessageHandlerResult {
+        let bytes = serialize(HealthCheckResponse {
+            healthy: true,
+            message: "".to_string(),
+        })?;
+        Ok(bytes)
+    }
+
+    fn add(&self, _actor: &str, req: AddArgs) -> MessageHandlerResult {
+        let evt = CacheEvent::AtomicAdd(req.key, req.value);
+        handle_state_event(&evt, self.cache.clone())?;
+        publish_state_event(
+            &self.id,
+            &self.event_subject.read().unwrap(),
+            &evt,
+            self.nc.clone(),
+        )?;
+        let bytes = serialize(AddResponse::default())?;
+
+        Ok(bytes)
+    }
+
+    fn del(&self, _actor: &str, req: DelArgs) -> MessageHandlerResult {
+        let evt = CacheEvent::KeyDelete(req.key);
+        handle_state_event(&evt, self.cache.clone())?;
+        publish_state_event(
+            &self.id,
+            &self.event_subject.read().unwrap(),
+            &evt,
+            self.nc.clone(),
+        )?;
+        let bytes = serialize(DelResponse::default())?;
+        Ok(bytes)
+    }
+
+    fn get(&self, _actor: &str, req: GetArgs) -> MessageHandlerResult {
+        println!("CLAIMS GET");
+        let res = {
+            let lock = self.cache.read().unwrap();
+            lock.get(&req.key)
+        };
+
+        let resp = match res {
+            Ok(v) if v.is_some() => GetResponse {
+                value: v.unwrap(),
+                exists: true,
+            },
+            Ok(_v) => GetResponse {
+                value: "".to_string(),
+                exists: false,
+            },
+            Err(e) => return Err(format!("Failed to retrieve value {}", e).into()),
+        };
+        println!("{:?}", resp);
+        Ok(serialize(resp)?)
+    }
+
+    fn list_clear(&self, _actor: &str, req: ClearArgs) -> MessageHandlerResult {
+        let evt = CacheEvent::ListClear(req.key);
+        handle_state_event(&evt, self.cache.clone())?;
+        publish_state_event(
+            &self.id,
+            &self.event_subject.read().unwrap(),
+            &evt,
+            self.nc.clone(),
+        )?;
+        let bytes = serialize(DelResponse::default())?;
+        Ok(bytes)
+    }
+
+    fn list_range(&self, _actor: &str, req: RangeArgs) -> MessageHandlerResult {
+        let resp = match self
+            .cache
+            .read()
+            .unwrap()
+            .list_range(&req.key, req.start, req.stop)
+        {
+            Ok(v) => v,
+            Err(e) => return Err(format!("Failed to get list range: {}", e).into()),
+        };
+        Ok(serialize(ListRangeResponse { values: resp })?)
+    }
+
+    fn list_push(&self, _actor: &str, req: PushArgs) -> MessageHandlerResult {
+        let evt = CacheEvent::ListPush(req.key, req.value);
+        handle_state_event(&evt, self.cache.clone())?;
+        publish_state_event(
+            &self.id,
+            &self.event_subject.read().unwrap(),
+            &evt,
+            self.nc.clone(),
+        )?;
+        Ok(serialize(ListResponse::default())?)
+    }
+
+    fn set(&self, _actor: &str, req: SetArgs) -> MessageHandlerResult {
+        let evt = CacheEvent::ScalarSet(req.key, req.value);
+        handle_state_event(&evt, self.cache.clone())?;
+        publish_state_event(
+            &self.id,
+            &self.event_subject.read().unwrap(),
+            &evt,
+            self.nc.clone(),
+        )?;
+        Ok(serialize(SetResponse::default())?)
+    }
+
+    fn list_del_item(&self, _actor: &str, req: ListItemDeleteArgs) -> MessageHandlerResult {
+        let evt = CacheEvent::ListRemoveItem(req.key, req.value);
+        handle_state_event(&evt, self.cache.clone())?;
+        publish_state_event(
+            &self.id,
+            &self.event_subject.read().unwrap(),
+            &evt,
+            self.nc.clone(),
+        )?;
+        Ok(serialize(ListResponse::default())?)
+    }
+
+    fn set_add(&self, _actor: &str, req: SetAddArgs) -> MessageHandlerResult {
+        let evt = CacheEvent::SetAdd(req.key, req.value);
+        handle_state_event(&evt, self.cache.clone())?;
+        publish_state_event(
+            &self.id,
+            &self.event_subject.read().unwrap(),
+            &evt,
+            self.nc.clone(),
+        )?;
+        Ok(serialize(SetOperationResponse::default())?)
+    }
+
+    fn set_remove(&self, _actor: &str, req: SetRemoveArgs) -> MessageHandlerResult {
+        let evt = CacheEvent::SetRemoveItem(req.key, req.value);
+        handle_state_event(&evt, self.cache.clone())?;
+        publish_state_event(
+            &self.id,
+            &self.event_subject.read().unwrap(),
+            &evt,
+            self.nc.clone(),
+        )?;
+        Ok(serialize(SetOperationResponse::default())?)
+    }
+
+    fn set_union(&self, _actor: &str, req: SetUnionArgs) -> MessageHandlerResult {
+        let resp = match self.cache.read().unwrap().set_union(req.keys) {
+            Ok(v) => v,
+            Err(e) => return Err(format!("Failed to perform set untion: {}", e).into()),
+        };
+        Ok(serialize(SetQueryResponse { values: resp })?)
+    }
+
+    fn set_intersect(&self, _actor: &str, req: SetIntersectionArgs) -> MessageHandlerResult {
+        let resp = match self.cache.read().unwrap().set_intersect(req.keys) {
+            Ok(v) => v,
+            Err(e) => return Err(format!("Failed to perform set intersect: {}", e).into()),
+        };
+        Ok(serialize(SetQueryResponse { values: resp })?)
+    }
+
+    fn set_query(&self, _actor: &str, req: SetQueryArgs) -> MessageHandlerResult {
+        let resp = match self.cache.read().unwrap().set_query(&req.key) {
+            Ok(v) => v,
+            Err(e) => return Err(format!("Failed to query set members: {}", e).into()),
+        };
+        Ok(serialize(SetQueryResponse { values: resp })?)
+    }
+
+    fn exists(&self, _actor: &str, req: KeyExistsArgs) -> MessageHandlerResult {
+        let resp = match self.cache.read().unwrap().exists(&req.key) {
+            Ok(b) => b,
+            Err(e) => return Err(format!("Unable to determine key existence: {}", e).into()),
+        };
+        Ok(serialize(GetResponse {
+            value: "".to_string(),
+            exists: resp,
+        })?)
+    }
+}
+
+fn nats_connection_from_values(
+    values: HashMap<String, String>,
+) -> Result<nats::Connection, Box<dyn std::error::Error + Sync + Send>> {
+    let nats_url = match values.get(NATS_URL_CONFIG_KEY) {
+        Some(v) => v,
+        None => "nats://0.0.0.0:4222",
+    }
+    .to_string();
+    let mut opts = if let Some(seed) = values.get(CLIENT_SEED_CONFIG_KEY) {
+        let jwt = values
+            .get(CLIENT_JWT_CONFIG_KEY)
+            .unwrap_or(&"".to_string())
+            .to_string();
+        let kp = KeyPair::from_seed(seed)?;
+        nats::Options::with_jwt(
+            move || Ok(jwt.to_string()),
+            move |nonce| kp.sign(nonce).unwrap(),
+        )
+    } else {
+        nats::Options::new()
+    };
+    opts = opts.with_name("wasmCloud KV Cache Provider");
+    opts.connect(&nats_url)
+        .map_err(|e| format!("NATS connection failure:{}", e).into())
+}
+
+fn process_replay_request(
+    msg: nats::Message,
+    cache: Arc<RwLock<CacheData>>,
+) -> Result<(), std::io::Error> {
+    let req: ReplayRequest =
+        deserialize(&msg.data).map_err(|e| gen_std_io_error(&format!("{}", e)))?;
+    let history = cache.read().unwrap().history();
+
+    let ack = ack_from_request(req.hwm, history.len());
+    msg.respond(&serialize(&ack).map_err(|e| gen_std_io_error(&format!("{}", e)))?)?;
+    let start = history.len() - ack.events_to_expect as usize;
+    let end = history.len();
+    for i in start..end {
+        let evt = history[i].clone();
+        msg.respond(&serialize(evt).map_err(|e| gen_std_io_error(&format!("{}", e)))?)?;
+    }
+    Ok(())
+}
+
+fn gen_std_io_error(msg: &str) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Other, msg)
+}
+
+fn regenerate_cache_from_replay(
+    nc: &nats::Connection,
+    cache: Arc<RwLock<CacheData>>,
+    replay_req_subject: &str,
+) -> Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    let sub = nc.request_multi(
+        replay_req_subject,
+        serialize(ReplayRequest {
+            hwm: cache.read().unwrap().history().len() as u64,
+        })?,
+    )?;
+
+    let first = sub.next_timeout(Duration::from_secs(2));
+    if first.is_err() {
+        return Ok(()); // No one is listening for replay requests. That's not necessarily fatal
+    }
+    let first = first.unwrap();
+
+    let ack: ReplayRequestAck = deserialize(&first.data)?;
+    for _i in 0..ack.events_to_expect {
+        if let Ok(msg) = sub.next_timeout(Duration::from_secs(1)) {
+            let evt: CacheEvent = deserialize(&msg.data)?;
+            if let Err(e) = handle_state_event(&evt, cache.clone()) {
+                error!(
+                    "Failed processing cache state event: {}. Cache should be considered invalid.",
+                    e
+                );
+            }
+        } else {
+            error!("Did not receive an expected state replication reply. Cache should now be considered invalid.");
+        }
+    }
+    Ok(())
+}
+
+// Receive an inbound event, which just modifies our internal state
+fn handle_state_event(
+    evt: &CacheEvent,
+    cache: Arc<RwLock<CacheData>>,
+) -> Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    let new_state = {
+        let state = cache.read().unwrap();
+        Cache::apply_event(&state, &evt)
+    }?;
+
+    let mut lock = cache.write().unwrap();
+    *lock = new_state;
+
+    Ok(())
+}
+
+fn publish_state_event(
+    origin: &str,
+    subject: &str,
+    evt: &CacheEvent,
+    nc: Arc<RwLock<Option<nats::Connection>>>,
+) -> Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    if let Some(ref conn) = *nc.read().unwrap() {
+        let wrapper = CacheEventWrapper {
+            origin_id: origin.to_string(),
+            event: evt.clone(),
+        };
+        conn.publish(subject, serialize(wrapper)?)?;
+    }
+    Ok(())
+}
+
+impl CapabilityProvider for NatsReplicatedKVProvider {
+    fn configure_dispatch(
+        &self,
+        dispatcher: Box<dyn Dispatcher>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        trace!("Dispatcher received.");
+        let mut lock = self.dispatcher.write().unwrap();
+        *lock = dispatcher;
+
+        Ok(())
+    }
+
+    fn handle_call(
+        &self,
+        actor: &str,
+        op: &str,
+        msg: &[u8],
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        trace!("Received host call from {}, operation - {}", actor, op);
+
+        match op {
+            OP_BIND_ACTOR if actor == SYSTEM_ACTOR => self.configure(deserialize(msg)?),
+            OP_REMOVE_ACTOR if actor == SYSTEM_ACTOR => self.remove_actor(deserialize(msg)?),
+            OP_HEALTH_REQUEST if actor == SYSTEM_ACTOR => self.health(),
+            OP_GET_CAPABILITY_DESCRIPTOR if actor == SYSTEM_ACTOR => Ok(vec![]), // Descriptors are no longer used
+            keyvalue::OP_ADD => self.add(actor, deserialize(msg)?),
+            keyvalue::OP_DEL => self.del(actor, deserialize(msg)?),
+            keyvalue::OP_GET => self.get(actor, deserialize(msg)?),
+            keyvalue::OP_CLEAR => self.list_clear(actor, deserialize(msg)?),
+            keyvalue::OP_RANGE => self.list_range(actor, deserialize(msg)?),
+            keyvalue::OP_PUSH => self.list_push(actor, deserialize(msg)?),
+            keyvalue::OP_SET => self.set(actor, deserialize(msg)?),
+            keyvalue::OP_LIST_DEL => self.list_del_item(actor, deserialize(msg)?),
+            keyvalue::OP_SET_ADD => self.set_add(actor, deserialize(msg)?),
+            keyvalue::OP_SET_REMOVE => self.set_remove(actor, deserialize(msg)?),
+            keyvalue::OP_SET_UNION => self.set_union(actor, deserialize(msg)?),
+            keyvalue::OP_SET_INTERSECT => self.set_intersect(actor, deserialize(msg)?),
+            keyvalue::OP_SET_QUERY => self.set_query(actor, deserialize(msg)?),
+            keyvalue::OP_KEY_EXISTS => self.exists(actor, deserialize(msg)?),
+            _ => Err("bad dispatch".into()),
+        }
+    }
+
+    fn stop(&self) {
+        /*{
+            let mut lock = self.terminator.write().unwrap();
+            if let Some(t) = lock.as_mut() {
+                let _ = t.send(true);
+            }
+        } */
+        /*
+        let mut lock = self.nc.write().unwrap();
+        if let Some(nc) = lock.take() {
+            nc.close();
+        } */
+    }
+}
+
+fn ack_from_request(req_hwm: u64, history_len: usize) -> ReplayRequestAck {
+    let diff = history_len as i64 - req_hwm as i64;
+    if diff <= 0 {
+        ReplayRequestAck {
+            events_to_expect: 0,
+        }
+    } else {
+        ReplayRequestAck {
+            events_to_expect: diff as u64,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayRequest {
+    pub hwm: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReplayRequestAck {
+    pub events_to_expect: u64,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{ack_from_request, ReplayRequestAck};
+
+    #[test]
+    fn watermark_diffing() {
+        // scenario:
+        // requester sends hwm of 12 (local history length)
+        // handler has hwm of 15 (local history length)
+        // need 3 as the `events_to_expect` field.
+        assert_eq!(
+            ReplayRequestAck {
+                events_to_expect: 3
+            },
+            ack_from_request(12, 15)
+        );
+    }
+}

--- a/crates/nats-kvcache/tests/integration.rs
+++ b/crates/nats-kvcache/tests/integration.rs
@@ -1,0 +1,157 @@
+// *** This test requires a running NATS server
+
+use std::{collections::HashMap, time::Duration};
+
+use wascc_codec::{capabilities::CapabilityProvider, core::OP_BIND_ACTOR};
+use wasmcloud_actor_core::{deserialize, serialize, CapabilityConfiguration};
+use wasmcloud_actor_keyvalue::{
+    AddArgs, GetArgs, GetResponse, SetAddArgs, SetQueryArgs, SetQueryResponse, OP_ADD, OP_GET,
+    OP_SET_ADD, OP_SET_QUERY,
+};
+use wasmcloud_nats_kvcache::NatsReplicatedKVProvider;
+
+#[test]
+fn steadystate_and_replay() {
+    let prov_a = NatsReplicatedKVProvider::new();
+    let prov_b = NatsReplicatedKVProvider::new();
+
+    let r = prov_a.handle_call(
+        "system",
+        OP_BIND_ACTOR,
+        &serialize(capability_config()).unwrap(),
+    );
+    let r2 = prov_b.handle_call(
+        "system",
+        OP_BIND_ACTOR,
+        &serialize(capability_config()).unwrap(),
+    );
+    assert!(r.is_ok());
+    assert!(r2.is_ok());
+
+    // let A handle a cache-mutating event
+    let _ = prov_a.handle_call(
+        "system",
+        OP_ADD,
+        &serialize(AddArgs {
+            key: "val1".to_string(),
+            value: 14,
+        })
+        .unwrap(),
+    );
+
+    ::std::thread::sleep(Duration::from_millis(500)); // allow time to replicate
+
+    let ga = GetArgs {
+        key: "val1".to_string(),
+    };
+    let q = prov_b
+        .handle_call("system", OP_GET, &serialize(&ga).unwrap())
+        .unwrap();
+    let g: GetResponse = deserialize(&q).unwrap();
+    let q2 = prov_a
+        .handle_call("system", OP_GET, &serialize(&ga).unwrap())
+        .unwrap();
+    let g2: GetResponse = deserialize(&q2).unwrap();
+    assert_eq!(g.value, "14");
+    assert_eq!(g.exists, true);
+    assert_eq!(g2.value, "14");
+    assert_eq!(g2.exists, true);
+
+    let _ = prov_b.handle_call(
+        "system",
+        OP_SET_ADD,
+        &serialize(SetAddArgs {
+            key: "set_one".to_string(),
+            value: "smurf".to_string(),
+        })
+        .unwrap(),
+    );
+    let _ = prov_b.handle_call(
+        "system",
+        OP_SET_ADD,
+        &serialize(SetAddArgs {
+            key: "set_one".to_string(),
+            value: "gargamel".to_string(),
+        })
+        .unwrap(),
+    );
+
+    std::thread::sleep(Duration::from_millis(500)); // allow time for replication
+
+    let res = prov_a
+        .handle_call(
+            "system",
+            OP_SET_QUERY,
+            &serialize(SetQueryArgs {
+                key: "set_one".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+    let setresp: SetQueryResponse = deserialize(&res).unwrap();
+    assert!(setresp.values.contains(&"smurf".to_string()));
+    assert!(setresp.values.contains(&"gargamel".to_string()));
+
+    // ***
+    // Create a third provider and bring it up
+    // ***
+    // Ensure that it automatically acquires the cluster state from
+    // one of the two existing providers
+
+    let prov_c = NatsReplicatedKVProvider::new();
+
+    let _ = prov_c
+        .handle_call(
+            "system",
+            OP_BIND_ACTOR,
+            &serialize(capability_config()).unwrap(),
+        )
+        .unwrap();
+
+    std::thread::sleep(Duration::from_secs(1)); // allow time for restore from replay
+
+    let res = prov_c
+        .handle_call(
+            "system",
+            OP_SET_QUERY,
+            &serialize(SetQueryArgs {
+                key: "set_one".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+    let setresp: SetQueryResponse = deserialize(&res).unwrap();
+    assert!(setresp.values.contains(&"smurf".to_string()));
+    assert!(setresp.values.contains(&"gargamel".to_string()));
+    let ga = GetArgs {
+        key: "val1".to_string(),
+    };
+    let q = prov_c
+        .handle_call("system", OP_GET, &serialize(&ga).unwrap())
+        .unwrap();
+    let g: GetResponse = deserialize(&q).unwrap();
+    assert_eq!(g.value, "14");
+    assert_eq!(g.exists, true);
+}
+
+fn capability_config() -> CapabilityConfiguration {
+    CapabilityConfiguration {
+        module: "test".to_string(), // because of the nature of this provider, the module (actor ID) doesn't matter
+        values: config_values(),
+    }
+}
+
+fn config_values() -> HashMap<String, String> {
+    let mut hm = HashMap::new();
+    hm.insert("NATS_URL".to_string(), "nats://0.0.0.0:4222".to_string());
+    hm.insert(
+        "STATE_REPL_SUBJECT".to_string(),
+        "itest.lattice.state.events".to_string(),
+    );
+    hm.insert(
+        "REPLAY_REQ_SUBJECT".to_string(),
+        "itest.lattice.state.replay".to_string(),
+    );
+
+    hm
+}

--- a/crates/wasmcloud-host/Cargo.toml
+++ b/crates/wasmcloud-host/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "wasmcloud-host"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
-repository = "https://github.com/wasmCloud/wasmCloud"
+repository = "https://github.com/wasmcloud/wasmcloud"
 description = "A secure, distributed, WebAssembly actor model runtime for the cloud, edge, and everything in between"
 license = "Apache-2.0"
 documentation = "https://docs.rs/wasmcloud-host"
@@ -47,7 +47,7 @@ chrono = "0.4.19"
 envmnt = "0.8.4"
 nats = "0.8.6"
 wasmcloud-actor-keyvalue = "0.2.0"
-wasmcloud-nats-kvcache = "0.4.0"
+wasmcloud-nats-kvcache = { version = "0.4.1", path = "../nats-kvcache" }
 wasmcloud-control-interface = { path = "../wasmcloud-control-interface", version = "0.1.0" }
 
 wasm3-provider = { version = "0.0.2", optional = true}

--- a/crates/wasmcloud-host/src/capability/extras.rs
+++ b/crates/wasmcloud-host/src/capability/extras.rs
@@ -1,4 +1,4 @@
-// A default implementation of the "wascc:extras" provider that is always included
+// A default implementation of the "wasmcloud:extras" provider that is always included
 // with the host runtime. This provides functionality for generating random numbers,
 // generating a guid, and generating a sequence number... things that a standalone
 // WASM module cannot do.
@@ -43,7 +43,7 @@ impl Default for ExtrasCapabilityProvider {
     }
 }
 
-pub(crate) const CAPABILITY_ID: &str = "wascc:extras";
+pub(crate) const CAPABILITY_ID: &str = "wasmcloud:extras";
 
 impl ExtrasCapabilityProvider {
     fn generate_guid(

--- a/crates/wasmcloud-host/src/capability/native_host.rs
+++ b/crates/wasmcloud-host/src/capability/native_host.rs
@@ -294,7 +294,7 @@ mod test {
             WasmCloudEntity::Actor(SYSTEM_ACTOR.to_string()),
             WasmCloudEntity::Capability {
                 id: "VDHPKGFKDI34Y4RN4PWWZHRYZ6373HYRSNNEM4UTDLLOGO5B37TSVREP".to_string(),
-                contract_id: "wascc:extras".to_string(),
+                contract_id: "wasmcloud:extras".to_string(),
                 link_name: "default".to_string(),
             },
             OP_REQUEST_GUID,

--- a/crates/wasmcloud-host/src/control_interface/events.rs
+++ b/crates/wasmcloud-host/src/control_interface/events.rs
@@ -50,6 +50,11 @@ pub enum ControlEvent {
         link_name: String,
         provider_id: String,
     },
+    LinkEstablished {
+        contract_id: String,
+        link_name: String,
+        provider_id: String,
+    },
     Heartbeat {
         claims: Vec<wascap::jwt::Claims<wascap::jwt::Actor>>,
         entities: HashMap<String, RunState>,

--- a/crates/wasmcloud-host/src/host_controller/hc_actor.rs
+++ b/crates/wasmcloud-host/src/host_controller/hc_actor.rs
@@ -370,7 +370,7 @@ impl Handler<Initialize> for HostController {
         let claims = crate::capability::extras::get_claims();
         let pk = claims.subject;
 
-        // Start wascc:extras
+        // Start wasmcloud:extras
         let extras = SyncArbiter::start(1, NativeCapabilityHost::new);
         let claims = crate::capability::extras::get_claims();
         let ex = ExtrasCapabilityProvider::default();

--- a/crates/wasmcloud-host/src/lib.rs
+++ b/crates/wasmcloud-host/src/lib.rs
@@ -1,9 +1,10 @@
-//! # wasmCloud Host
+#![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/52050279?s=200&v=4")]
+//! # wasmcloud Host
 //!
-//! [wasmCloud](https://wasmcloud.com) is a secure, distributed actor platform with an autonomous mesh network built
+//! [wasmcloud](https://wasmcloud.com) is a secure, distributed actor platform with an autonomous mesh network built
 //! for bridging disparate and far-flung infrastructure.
 //!
-//! By default a wasmCloud host will start in offline mode and only allow "local" scheduling of actors
+//! By default a wasmcloud host will start in offline mode and only allow "local" scheduling of actors
 //! and capabilities. If you choose to opt-in to the lattice, you can use NATS as a message broker to
 //! provide the infrastructure for wasmCloud's self-forming, self-healing network. If you then want
 //! even more power, you can choose to override the capability provider used for managing the shared
@@ -17,7 +18,8 @@
 //! take a look at the documentation and tutorials at [wasmcloud.dev](https://wasmcloud.dev).
 //!
 //! # Example
-//! The following example creates a new wasmCloud host in the default standalone (no lattice) mode. It
+//!
+//! The following example creates a new wasmcloud host in the default standalone (no lattice) mode. It
 //! then loads an actor that simply echoes back incoming HTTP requests as outbound HTTP responses.
 //! The HTTP server capability provider is loaded so that the actor can receive web requests.
 //! Note that the link definition (configuration of the link between the actor and the

--- a/crates/wasmcloud-host/src/messagebus/latticecache_client.rs
+++ b/crates/wasmcloud-host/src/messagebus/latticecache_client.rs
@@ -161,6 +161,7 @@ impl LatticeCacheClient {
         actor_id: &str,
         claims: Claims<wascap::jwt::Actor>,
     ) -> Result<()> {
+        println!("LC CLAIMS PUT: {:?}", claims);
         // KV context: KEY is {prefix}:claims_{actor_id}
         // value is claims JSON
         let key = prefix(&format!("claims_{}", actor_id));
@@ -195,17 +196,21 @@ impl LatticeCacheClient {
 
     /// Retrieves the claims, if they exist, belonging to a given actor ID
     pub async fn get_claims(&self, actor_id: &str) -> Result<Option<Claims<wascap::jwt::Actor>>> {
+        println!("LC CLAIMS GET: {}", actor_id);
         // KV context: KEY is {prefix}:claims_{actor_id}
         // value is claims JSON
         let key = prefix(&format!("claims_{}", actor_id));
         let args = GetArgs { key };
         let inv = self.invocation_for_provider(OP_GET, &serialize(&args)?);
         let get_r: GetResponse = invoke_as(&self.provider, inv).await?;
+        println!("HEYO");
 
         if get_r.exists {
             let c: Claims<wascap::jwt::Actor> = serde_json::from_str(&get_r.value)?;
+            println!("WIN");
             Ok(Some(c))
         } else {
+            println!("LOSE");
             Ok(None)
         }
     }
@@ -411,6 +416,7 @@ async fn invoke_as<'de, T: Deserialize<'de>>(
     inv: Invocation,
 ) -> Result<T> {
     let inv_r = target.send(inv).await?;
+    println!("INV_R: {:?}", inv_r);
     if let Some(e) = inv_r.error {
         let s = format!("Lattice cache client invocation failure: {}", e);
         error!("{}", s);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,15 +1,22 @@
 use actix_rt::time::delay_for;
+use crossbeam_channel::{Receiver, Sender};
 use provider_archive::ProviderArchive;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::time::Duration;
-use wasmcloud_host::{Actor, Host, HostBuilder, NativeCapability, Result};
+use wasmcloud_host::{Actor, ControlEvent, Host, HostBuilder, NativeCapability, Result};
 
 pub const REDIS_OCI: &str = "wasmcloud.azurecr.io/redis:0.11.1";
+pub const REDIS_KEY: &str = "VAZVC4RX54J2NVCMCW7BPCAHGGG5XZXDBXFUMDUXGESTMQEJLC3YVZWB";
+
 pub const HTTPSRV_OCI: &str = "wasmcloud.azurecr.io/httpserver:0.11.1";
+pub const HTTPSRV_KEY: &str = "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M";
+
 pub const NATS_OCI: &str = "wasmcloud.azurecr.io/nats:0.10.1";
 pub const KVCOUNTER_OCI: &str = "wasmcloud.azurecr.io/kvcounter:0.2.0";
+
+pub const KVCOUNTER_KEY: &str = "MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E";
 
 pub async fn await_actor_count(
     h: &Host,
@@ -62,57 +69,107 @@ pub async fn await_provider_count(
     Ok(())
 }
 
-pub async fn gen_kvcounter_host(
-    web_port: u32,
-    lattice_rpc: Option<nats::asynk::Connection>,
-    lattice_control: Option<nats::asynk::Connection>,
-) -> Result<Host> {
-    let mut h = HostBuilder::new();
-    if let Some(rpc) = lattice_rpc {
-        h = h.with_rpc_client(rpc);
-    }
-    if let Some(cplane) = lattice_control {
-        h = h.with_control_client(cplane);
-    }
-    let h = h.build();
+pub async fn gen_kvcounter_host(h: &Host, web_port: u32, collector: &EventCollector) -> Result<()> {
+    let timeout = Duration::from_secs(4); // this can take long because of OCI downloads
+                                          /*    if let Some(rpc) = lattice_rpc {
+                                              h = h.with_rpc_client(rpc);
+                                          }
+                                          if let Some(cplane) = lattice_control {
+                                              h = h.with_control_client(cplane);
+                                          } */
+
     h.start().await?;
+    assert!(collector.wait_for(|e| *e == ControlEvent::HostStarted, timeout)?);
 
-    let kvcounter = Actor::from_file("./tests/modules/kvcounter.wasm")?;
-    let kvcounter_key = kvcounter.public_key();
-    h.start_actor(kvcounter).await?;
-    await_actor_count(&h, 1, Duration::from_millis(50), 3).await?;
+    //let kvcounter = Actor::from_file("./tests/modules/kvcounter.wasm")?;
+    h.start_actor_from_registry(KVCOUNTER_OCI).await?;
 
-    let arc = par_from_file("./tests/modules/redis.par.gz")?;
-    let arc2 = par_from_file("./tests/modules/httpserver.par.gz")?;
-
-    let redis = NativeCapability::from_archive(&arc, None)?;
-    let websrv = NativeCapability::from_archive(&arc2, None)?;
-
-    let redis_id = arc.claims().unwrap().subject;
-    let websrv_id = arc2.claims().unwrap().subject;
+    assert!(collector.wait_for(
+        |e| *e
+            == ControlEvent::ActorStarted {
+                actor: KVCOUNTER_KEY.to_string(),
+                image_ref: Some(KVCOUNTER_OCI.to_string())
+            },
+        timeout
+    )?);
 
     let mut values: HashMap<String, String> = HashMap::new();
     values.insert("URL".to_string(), "redis://127.0.0.1:6379".to_string());
 
     let mut webvalues: HashMap<String, String> = HashMap::new();
     webvalues.insert("PORT".to_string(), format!("{}", web_port));
-    h.start_native_capability(redis).await?;
-    h.start_native_capability(websrv).await?;
-    await_provider_count(&h, 4, Duration::from_millis(50), 3).await?; // 2 providers plus wascc:extras
-    h.set_link(&kvcounter_key, "wasmcloud:keyvalue", None, redis_id, values)
-        .await?;
 
+    //let arc = par_from_file("./tests/modules/redis.par.gz")?;
+    h.start_capability_from_registry(REDIS_OCI, None).await?;
+    //let arc2 = par_from_file("./tests/modules/httpserver.par.gz")?;
+    h.start_capability_from_registry(HTTPSRV_OCI, None).await?;
+
+    //let redis = NativeCapability::from_archive(&arc, None)?;
+    //let websrv = NativeCapability::from_archive(&arc2, None)?;
+
+    assert!(collector.wait_for(
+        |e| *e
+            == ControlEvent::ProviderStarted {
+                contract_id: "wasmcloud:keyvalue".to_string(),
+                image_ref: Some(REDIS_OCI.to_string()),
+                link_name: "default".to_string(),
+                provider_id: REDIS_KEY.to_string()
+            },
+        timeout
+    )?);
+
+    assert!(collector.wait_for(
+        |e| *e
+            == ControlEvent::ProviderStarted {
+                contract_id: "wasmcloud:httpserver".to_string(),
+                image_ref: Some(HTTPSRV_OCI.to_string()),
+                link_name: "default".to_string(),
+                provider_id: HTTPSRV_KEY.to_string()
+            },
+        timeout
+    )?);
+
+    println!("HERE");
+    //await_provider_count(&h, 4, Duration::from_millis(50), 3).await?; // 2 providers plus wasmcloud:extras
     h.set_link(
-        &kvcounter_key,
+        KVCOUNTER_KEY,
+        "wasmcloud:keyvalue",
+        None,
+        REDIS_KEY.to_string(),
+        values,
+    )
+    .await?;
+    assert!(collector.wait_for(
+        |e| *e
+            == ControlEvent::LinkEstablished {
+                contract_id: "wasmcloud:keyvalue".to_string(),
+                link_name: "default".to_string(),
+                provider_id: REDIS_KEY.to_string()
+            },
+        timeout
+    )?);
+
+    println!("HERE2");
+    h.set_link(
+        KVCOUNTER_KEY,
         "wasmcloud:httpserver",
         None,
-        websrv_id,
+        HTTPSRV_KEY.to_string(),
         webvalues,
     )
     .await?;
-    delay_for(Duration::from_millis(75)).await; // give the web server enough time to fire up
 
-    Ok(h)
+    assert!(collector.wait_for(
+        |e| *e
+            == ControlEvent::LinkEstablished {
+                contract_id: "wasmcloud:httpserver".to_string(),
+                link_name: "default".to_string(),
+                provider_id: HTTPSRV_KEY.to_string()
+            },
+        timeout
+    )?);
+
+    Ok(())
 }
 
 pub fn par_from_file(file: &str) -> Result<ProviderArchive> {
@@ -120,4 +177,31 @@ pub fn par_from_file(file: &str) -> Result<ProviderArchive> {
     let mut buf = Vec::new();
     f.read_to_end(&mut buf)?;
     ProviderArchive::try_load(&buf)
+}
+
+pub struct EventCollector {
+    receiver: Receiver<ControlEvent>,
+}
+
+impl EventCollector {
+    pub fn new(receiver: Receiver<ControlEvent>) -> Self {
+        EventCollector { receiver }
+    }
+
+    pub fn wait_for(
+        &self,
+        pred: impl Fn(&ControlEvent) -> bool,
+        timeout: Duration,
+    ) -> Result<bool> {
+        match self.receiver.recv_timeout(timeout) {
+            Ok(ref e) => match pred(e) {
+                true => Ok(true),
+                false => {
+                    println!("Event collector predicate failed, received {:?}", e);
+                    Ok(false)
+                }
+            },
+            Err(e) => Err(format!("Event collector expectation failed: {}", e).into()),
+        }
+    }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -14,6 +14,7 @@ fn init() {
     let _ = ::std::fs::remove_dir_all(path);
 }
 
+/*
 #[actix_rt::test]
 async fn empty_host_has_two_providers() {
     let res = no_lattice::empty_host_has_two_providers().await;
@@ -30,7 +31,7 @@ async fn start_and_execute_echo() {
         println!("{}", e);
     }
     assert!(res.is_ok());
-}
+} */
 
 #[actix_rt::test]
 async fn kvcounter_basic() {
@@ -40,6 +41,7 @@ async fn kvcounter_basic() {
     }
     assert!(res.is_ok());
 }
+/*
 
 #[actix_rt::test]
 async fn kvcounter_start_stop() {
@@ -125,3 +127,4 @@ async fn control_calltest() {
     }
     assert!(res.is_ok());
 }
+ */


### PR DESCRIPTION
Here's the output I get (that's important to the test) near the bottom:

```
PUB: ProviderStarted { contract_id: "wasmcloud:httpserver", link_name: "default", provider_id: "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M", image_ref: Some("wasmcloud.azurecr.io/httpserver:0.11.1") }
HERE
EF1
EF1.5
EF1.8 - "MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E"
LC CLAIMS GET: MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E
CLAIMS GET
GetResponse { value: "{\"jti\":\"pLpmPddt9tBhIn1Rd7He2p\",\"iat\":1612814292,\"iss\":\"ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW\",\"sub\":\"MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E\",\"wascap\":{\"name\":\"Key Value Counter\",\"hash\":\"635DF3BB755B4A63A33A80A2E386685CA97F684C9427BB8F9025D9DAE71514FC\",\"tags\":[],\"caps\":[\"wasmcloud:keyvalue\",\"wasmcloud:httpserver\"],\"rev\":2,\"ver\":\"0.2.0\",\"prov\":false}}", exists: true }
Event collector expectation failed: timed out waiting on receive operation
thread 'kvcounter_basic' panicked at 'assertion failed: res.is_ok()', tests/lib.rs:42:5
```

Ignore the `SEGV` for now, I think that might be happening as a result of the bad test failure. What's currently bugging me is that attempting to get the claims during the local link enforcement check is hanging with the kvprovider native host not returning.