### PR TITLE
Initial commit of code that invokes the benchmark actor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ futures = "0.3.6"
 members = [
     "crates/wasmcloud-host",
     "samples/bench-actor",
+    "samples/bencher",
     "crates/wasmcloud-control-interface"
 ]
 

--- a/samples/bench-actor/Makefile
+++ b/samples/bench-actor/Makefile
@@ -1,10 +1,10 @@
 COLOR ?= always # Valid COLOR options: {always, auto, never}
 CARGO = cargo --color $(COLOR)
-TARGET = target/wasm32-unknown-unknown
+TARGET = ../../target/wasm32-unknown-unknown
 DEBUG = $(TARGET)/debug
 RELEASE = $(TARGET)/release
 KEYDIR ?= .keys
-VERSION = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+VERSION = "0.1.0"
 
 .PHONY: all build check clean doc test update
 

--- a/samples/bencher/Cargo.toml
+++ b/samples/bencher/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bencher"
+version = "0.1.0"
+authors = ["wasmcloud team"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+wasmcloud-host = "0.15.0"
+actix-rt = "1.1.1"
+wasmcloud-actor-core = "0.2.0"
+wasmcloud-actor-http-server = "0.1.0"
+serde = { version = "1.0.123", features = ["derive"]}
+serde_json = "1.0.62"

--- a/samples/bencher/README.md
+++ b/samples/bencher/README.md
@@ -1,0 +1,8 @@
+# Bencher
+
+Runs a tight loop of 10,000 iterations on an actor that makes no host capability requests. The benchmark actor performs
+a de-serialization of the HTTP request, and a de-serialization of the body, and then performs a serialization of the HTTP
+response after performing a few match calculations. This simulates (roughly) the kind of work being done by actors without
+taking a latency loss for capability use.
+
+You will need to `make release` in the bench actor's directory. You will also want to run the `release` version o this binary or use `cargo run --release`. This makes a _huge_ difference (a factor of 100, usually) in the performance of the benchmark test.

--- a/samples/bencher/src/main.rs
+++ b/samples/bencher/src/main.rs
@@ -10,7 +10,15 @@ use wasmcloud_host::{Actor, HostBuilder};
 async fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
     let h = HostBuilder::new().build();
     h.start().await?;
-    let echo = Actor::from_file("../../target/wasm32-unknown-unknown/release/bench_actor_s.wasm")?;
+    let echo = match Actor::from_file(
+        "../../target/wasm32-unknown-unknown/release/bench_actor_s.wasm",
+    ) {
+        Ok(e) => e,
+        Err(e) => {
+            println!("Unable to locate bench_actor_s.wasm. Please run 'make release' in samples/bench-actor/");
+            return Err(e);
+        }
+    };
     let actor_id = echo.public_key();
     h.start_actor(echo).await?;
 

--- a/samples/bencher/src/main.rs
+++ b/samples/bencher/src/main.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::error::Error;
+use std::time::Instant;
+use wasmcloud_actor_core::serialize;
+use wasmcloud_actor_http_server as http;
+use wasmcloud_host::{Actor, HostBuilder};
+
+#[actix_rt::main]
+async fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
+    let h = HostBuilder::new().build();
+    h.start().await?;
+    let echo = Actor::from_file("../../target/wasm32-unknown-unknown/release/bench_actor_s.wasm")?;
+    let actor_id = echo.public_key();
+    h.start_actor(echo).await?;
+
+    let data = Data {
+        field1: 21.5,
+        field2: 30,
+        field3: "testing".to_string(),
+    };
+    let payload = serialize(http::Request {
+        method: "GET".to_string(),
+        path: "/test".to_string(),
+        query_string: "".to_string(),
+        header: HashMap::new(),
+        body: serialize(&data)?, // this is msgpack encoding inside an HTTP body.
+    })?;
+
+    let now = Instant::now();
+    for _i in 0..10_000 {
+        h.call_actor(&actor_id, "HandleRequest", &payload).await?;
+    }
+    let done = now.elapsed().as_secs();
+    println!(
+        "10,000 iterations took {}s, {}/iteration",
+        done,
+        done as f64 / 10_000 as f64
+    );
+
+    Ok(())
+}
+
+// Copy this struct into whatever benchmark test is invoking this actor
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct Data {
+    pub field1: f64,
+    pub field2: u32,
+    pub field3: String,
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -99,7 +99,7 @@ async fn redis_kvcache() {
 
 //#[actix_rt::test]
 //async fn control_basics() {
-//    let res = control::basics().await;
+//let res = control::basics().await;
 //    if let Err(ref e) = res {
 //        println!("{}", e);
 //    } else {


### PR DESCRIPTION
Make sure you run the `bencher` binary/project in release mode, otherwise you get the super-slow parsing/interpreting behavior on the wasm files.