### PR TITLE
Adding support for manifest loading to the wasmcloud binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "0.15.2"
+version = "0.15.3"
 authors = ["wasmcloud Team"]
 edition = "2018"
 default-run = "wasmcloud"
@@ -76,7 +76,3 @@ members = [
 [[bin]]
 name = "wasmcloud"
 path = "src/wasmcloud.rs"
-
-[[bin]]
-name = "wasmcloud-lite"
-path = "src/wasmcloud-lite.rs"

--- a/codegen.yaml
+++ b/codegen.yaml
@@ -1,5 +1,0 @@
-schema: ../schemas/http.widl
-generates:
-  tests/generated/http.rs:
-    package: widl-codegen/language/rust
-    visitorClass: ModuleVisitor

--- a/src/wasmcloud-lite.rs
+++ b/src/wasmcloud-lite.rs
@@ -1,7 +1,0 @@
-/// A version of the binary host that uses the inproc bus for
-/// local testing and development w/out a lattice connection
-
-fn main() -> anyhow::Result<()> {
-    println!("TBD");
-    Ok(())
-}


### PR DESCRIPTION
Assuming this PR is approved and merged and everything passes, we will need to release the 0.15.3 binary to address this gap.