### PR TITLE
Fixed manifest cache behavior for local par files, added log output

### DIFF
--- a/crates/wasmcloud-host/src/actors/actor_host.rs
+++ b/crates/wasmcloud-host/src/actors/actor_host.rs
@@ -375,6 +375,7 @@ impl Handler<Invocation> for ActorHost {
                     }
                 }
                 Err(e) => {
+                    error!("Error invoking actor: {} (from {})", e, msg.target_url());
                     InvocationResponse::error(&msg, &format!("Failed to invoke actor: {}", e))
                 }
             }

--- a/crates/wasmcloud-host/src/capability/native.rs
+++ b/crates/wasmcloud-host/src/capability/native.rs
@@ -1,3 +1,5 @@
+use std::{env::temp_dir, path::PathBuf};
+
 use crate::{Host, Result};
 use provider_archive::ProviderArchive;
 use wascap::jwt::Claims;
@@ -69,6 +71,18 @@ impl NativeCapability {
     /// Returns the unique ID (public key/subject) of the capability provider
     pub fn id(&self) -> String {
         self.claims.subject.to_string()
+    }
+
+    pub fn cache_path(&self) -> PathBuf {
+        let mut path = temp_dir();
+        path.push("wasmcloudcache");
+        path.push(&self.claims.subject);
+        path.push(format!(
+            "{}",
+            self.claims.metadata.as_ref().unwrap().rev.unwrap_or(0)
+        ));
+        path.push(Host::native_target());
+        path
     }
 }
 

--- a/crates/wasmcloud-host/src/capability/native_host.rs
+++ b/crates/wasmcloud-host/src/capability/native_host.rs
@@ -6,13 +6,10 @@ use crate::dispatch::{Invocation, InvocationResponse, ProviderDispatcher, WasmCl
 use crate::hlreg::HostLocalSystemService;
 use crate::messagebus::{EnforceLocalProviderLinks, MessageBus, Subscribe};
 use crate::middleware::{run_capability_post_invoke, run_capability_pre_invoke, Middleware};
-use crate::Host;
 use crate::{ControlEvent, Result};
 use actix::prelude::*;
 use futures::executor::block_on;
 use libloading::{Library, Symbol};
-use std::env::temp_dir;
-use std::fs::File;
 use wascap::prelude::KeyPair;
 extern crate wasmcloud_provider_core as codec;
 use codec::capabilities::CapabilityProvider;
@@ -228,28 +225,32 @@ impl Handler<Invocation> for NativeCapabilityHost {
     }
 }
 
+pub(crate) fn write_provider_to_disk(cap: &NativeCapability) -> Result<()> {
+    if let Some(ref bytes) = cap.native_bytes {
+        use std::io::Write;
+        let path = cap.cache_path();
+        let mut parent_dir = path.clone();
+        parent_dir.pop();
+        std::fs::create_dir_all(parent_dir)?;
+        debug!("Caching provider to {}", path.display());
+        let mut file = std::fs::File::create(&path)?;
+        Ok(file.write_all(&bytes)?)
+    } else {
+        Err("No bytes to cache".into())
+    }
+}
+
 fn extrude(
     cap: &NativeCapability,
 ) -> Result<(Option<Library>, Box<dyn CapabilityProvider + 'static>)> {
-    use std::io::Write;
-    if let Some(ref bytes) = cap.native_bytes {
-        let path = temp_dir();
-        let path = path.join("wasmcloudcache");
-        let path = path.join(&cap.claims.subject);
-        let path = path.join(format!(
-            "{}",
-            cap.claims.metadata.as_ref().unwrap().rev.unwrap_or(0)
-        ));
-        ::std::fs::create_dir_all(&path)?;
-        let target = Host::native_target();
-        let path = path.join(&target);
-        // If this file is already on disk, some other host has probably
-        // created it so don't over-write
-        if !path.exists() {
-            let mut tf = File::create(&path)?;
-            tf.write_all(&bytes)?;
+    if cap.native_bytes.is_some() {
+        let path = cap.cache_path();
+        // If this file is already on disk, don't overwrite
+        if path.exists() {
+            debug!("Using cache at {}", path.display());
+        } else {
+            write_provider_to_disk(cap)?;
         }
-
         #[cfg(target_os = "linux")]
         let library: Library = {
             // On linux the library must be loaded with `RTLD_NOW | RTLD_NODELETE` to fix a SIGSEGV

--- a/crates/wasmcloud-host/src/host.rs
+++ b/crates/wasmcloud-host/src/host.rs
@@ -503,6 +503,10 @@ impl Host {
             let _ = hc.send(msg).await?;
         }
         for msg in crate::manifest::generate_adv_link_messages(&manifest).await {
+            debug!(
+                "Advertising {}:{}:{}",
+                msg.actor, msg.link_name, msg.provider_id
+            );
             let _ = bus.send(msg).await?;
         }
 


### PR DESCRIPTION
Manifests support referencing providers as local files, but wasmcloud-host defers to the cache at `$TEMP/wasmcloudcache` for all cases, even if a local provider has changed on disk. This behavior makes sense for immutable sources, but par files on disk don't make that guarantee. This leads to very difficult-to-troubleshoot behavior when the expectation is that the referenced file is the source of truth, not a previously loaded version.

This PR changes cache behavior when loading a manifest that references local provider archives. It does not affect cache behavior for pars from a registry.

This PR also adds logging for previously silent errors and places that would have made troubleshooting this easier.