### PR TITLE
Remove wascc related artifacts from previous life and fix few more cosmetics issues

### DIFF
--- a/crates/wasmcloud-control-interface/codegen.yaml
+++ b/crates/wasmcloud-control-interface/codegen.yaml
@@ -1,4 +1,4 @@
-schema: https://raw.githubusercontent.com/wascc/schemas/main/control_interface.widl
+schema: https://raw.githubusercontent.com/wasmCloud/actor-interfaces/main/schemas/control_interface.widl
 generates:
   src/generated/ctliface.rs:
     package: widl-codegen/language/rust

--- a/crates/wasmcloud-control-interface/src/broker.rs
+++ b/crates/wasmcloud-control-interface/src/broker.rs
@@ -64,7 +64,7 @@ pub mod commands {
 pub mod queries {
     use super::prefix;
 
-    pub fn linkdefinitions(nsprefix: &Option<String>) -> String {
+    pub fn link_definitions(nsprefix: &Option<String>) -> String {
         format!("{}.get.links", prefix(nsprefix))
     }
 

--- a/crates/wasmcloud-control-interface/src/generated/ctliface.rs
+++ b/crates/wasmcloud-control-interface/src/generated/ctliface.rs
@@ -1,5 +1,4 @@
-extern crate rmp_serde as rmps;
-use rmps::{Deserializer, Serializer};
+use rmp_serde::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 

--- a/crates/wasmcloud-control-interface/src/inv.rs
+++ b/crates/wasmcloud-control-interface/src/inv.rs
@@ -20,12 +20,12 @@ use wascap::prelude::KeyPair;
 
 const URL_SCHEME: &str = "wasmbus";
 
-/// An immutable representation of an invocation within waSCC
+/// An immutable representation of an invocation within wasmcloud
 #[derive(Debug, Clone, Serialize, Deserialize)]
 
 pub struct Invocation {
-    pub origin: WasccEntity,
-    pub target: WasccEntity,
+    pub origin: Entity,
+    pub target: Entity,
     pub operation: String,
     pub msg: Vec<u8>,
     pub id: String,
@@ -39,8 +39,8 @@ impl Invocation {
     /// so an invocation requires a reference to the host (signing) key
     pub fn new(
         hostkey: &KeyPair,
-        origin: WasccEntity,
-        target: WasccEntity,
+        origin: Entity,
+        target: Entity,
         op: &str,
         msg: Vec<u8>,
     ) -> Invocation {
@@ -77,7 +77,7 @@ pub struct InvocationResponse {
 /// Represents an entity within the host runtime that can be the source
 /// or target of an invocation
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, Hash)]
-pub enum WasccEntity {
+pub enum Entity {
     Actor(String),
     Capability {
         id: String,
@@ -86,12 +86,12 @@ pub enum WasccEntity {
     },
 }
 
-impl WasccEntity {
+impl Entity {
     /// The URL of the entity
     pub fn url(&self) -> String {
         match self {
-            WasccEntity::Actor(pk) => format!("{}://{}", URL_SCHEME, pk),
-            WasccEntity::Capability {
+            Entity::Actor(pk) => format!("{}://{}", URL_SCHEME, pk),
+            Entity::Capability {
                 id,
                 contract_id,
                 link_name,

--- a/crates/wasmcloud-control-interface/src/lib.rs
+++ b/crates/wasmcloud-control-interface/src/lib.rs
@@ -6,7 +6,7 @@ pub use crate::generated::ctliface::*;
 use actix_rt::time::delay_for;
 use futures::stream::StreamExt;
 use futures::TryStreamExt;
-use inv::WasccEntity;
+use inv::Entity;
 pub use inv::{Invocation, InvocationResponse};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -144,8 +144,8 @@ impl Client {
         let subject = broker::rpc::call_actor(&self.nsprefix, target_id);
         let bytes = crate::generated::ctliface::serialize(Invocation::new(
             &self.key,
-            WasccEntity::Actor("system".to_string()),
-            WasccEntity::Actor(target_id.to_string()),
+            Entity::Actor("system".to_string()),
+            Entity::Actor(target_id.to_string()),
             operation,
             data.to_vec(),
         ))?;

--- a/crates/wasmcloud-host/README.md
+++ b/crates/wasmcloud-host/README.md
@@ -36,7 +36,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::time::Duration;
 use actix_rt::time::delay_for;
-extern crate reqwest;
+use reqwest;
 
 const WEB_PORT: u32 = 8080;
 

--- a/crates/wasmcloud-host/src/capability/extras.rs
+++ b/crates/wasmcloud-host/src/capability/extras.rs
@@ -6,11 +6,7 @@
 use crate::generated::core::HealthResponse;
 use crate::generated::extras::{GeneratorRequest, GeneratorResult};
 use crate::messagebus::handlers::OP_HEALTH_REQUEST;
-extern crate wasmcloud_provider_core as codec;
 
-use codec::capabilities::{CapabilityProvider, Dispatcher, NullDispatcher};
-use codec::core::OP_BIND_ACTOR;
-use codec::{deserialize, serialize};
 use std::error::Error;
 use std::sync::{Arc, RwLock};
 use std::{
@@ -19,6 +15,9 @@ use std::{
 };
 use uuid::Uuid;
 use wascap::jwt::Claims;
+use wasmcloud_provider_core::capabilities::{CapabilityProvider, Dispatcher, NullDispatcher};
+use wasmcloud_provider_core::core::OP_BIND_ACTOR;
+use wasmcloud_provider_core::{deserialize, serialize};
 
 pub(crate) const OP_REQUEST_GUID: &str = "RequestGuid";
 pub(crate) const OP_REQUEST_RANDOM: &str = "RequestRandom";
@@ -104,7 +103,7 @@ impl ExtrasCapabilityProvider {
 impl CapabilityProvider for ExtrasCapabilityProvider {
     fn configure_dispatch(
         &self,
-        dispatcher: Box<dyn codec::capabilities::Dispatcher>,
+        dispatcher: Box<dyn Dispatcher>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         trace!("Dispatcher received.");
         let mut lock = self.dispatcher.write().unwrap();

--- a/crates/wasmcloud-host/src/capability/native.rs
+++ b/crates/wasmcloud-host/src/capability/native.rs
@@ -1,8 +1,7 @@
 use crate::{Host, Result};
 use provider_archive::ProviderArchive;
 use wascap::jwt::Claims;
-extern crate wasmcloud_provider_core as codec;
-use codec::capabilities::CapabilityProvider;
+use wasmcloud_provider_core::capabilities::CapabilityProvider;
 
 /// Represents a native capability provider compiled as a shared object library.
 /// These plugins are OS- and architecture-specific, so they will be `.so` files on Linux, `.dylib`
@@ -25,6 +24,7 @@ impl NativeCapability {
         if archive.claims().is_none() {
             return Err("No claims found in provider archive file".into());
         }
+
         let link = normalize_link_name(link_target_name.unwrap_or_else(|| "default".to_string()));
 
         let target = Host::native_target();
@@ -45,7 +45,7 @@ impl NativeCapability {
     }
 
     /// This function is to be used for _capability embedding_. If you are building a custom
-    /// waSCC host and have a fixed set of capabilities that you want to always be available
+    /// wasmcloud host and have a fixed set of capabilities that you want to always be available
     /// to actors, then you can declare a dependency on the capability provider, enable
     /// the `static_plugin` feature, and provide an instance of that provider. Be sure to check
     /// that the provider supports capability embedding. You must also provide a set of valid

--- a/crates/wasmcloud-host/src/capability/native_host.rs
+++ b/crates/wasmcloud-host/src/capability/native_host.rs
@@ -14,8 +14,7 @@ use libloading::{Library, Symbol};
 use std::env::temp_dir;
 use std::fs::File;
 use wascap::prelude::KeyPair;
-extern crate wasmcloud_provider_core as codec;
-use codec::capabilities::CapabilityProvider;
+use wasmcloud_provider_core::capabilities::CapabilityProvider;
 
 #[derive(Message)]
 #[rtype(result = "Result<WasmCloudEntity>")]

--- a/crates/wasmcloud-host/src/control_interface/ctlactor.rs
+++ b/crates/wasmcloud-host/src/control_interface/ctlactor.rs
@@ -102,7 +102,7 @@ impl Handler<NatsMessage> for ControlInterface {
             async move {
                 if subject == queries::host_inventory(&prefix, &host) {
                     handle_host_inventory_query(&host, &msg).await
-                } else if subject == queries::linkdefinitions(&prefix) {
+                } else if subject == queries::link_definitions(&prefix) {
                     handle_linkdefs_query(&host, &msg).await
                 } else if subject == queries::claims(&prefix) {
                     handle_claims_query(&host, &msg).await
@@ -152,7 +152,7 @@ impl Handler<Initialize> for ControlInterface {
         let prefix = Some(self.ns_prefix.to_string());
 
         self.subscribers.insert(
-            queries::linkdefinitions(&prefix),
+            queries::link_definitions(&prefix),
             NatsSubscriber::default().start(),
         );
         self.subscribers.insert(
@@ -162,7 +162,7 @@ impl Handler<Initialize> for ControlInterface {
         self.subscribers
             .insert(queries::claims(&prefix), NatsSubscriber::default().start());
         self.subscribers.insert(
-            queries::linkdefinitions(&prefix),
+            queries::link_definitions(&prefix),
             NatsSubscriber::default().start(),
         );
         self.subscribers.insert(

--- a/crates/wasmcloud-host/src/dispatch.rs
+++ b/crates/wasmcloud-host/src/dispatch.rs
@@ -4,7 +4,6 @@ use crate::{
     errors::{self, ErrorKind},
     messagebus::LookupAlias,
 };
-extern crate wasmcloud_provider_core as codec;
 use crate::{Result, SYSTEM_ACTOR};
 use actix::dev::{MessageResponse, ResponseChannel};
 use actix::prelude::*;
@@ -18,14 +17,15 @@ use std::error::Error;
 use std::io::Read;
 use uuid::Uuid;
 use wascap::prelude::{Claims, KeyPair};
+use wasmcloud_provider_core as codec;
 
 pub(crate) const URL_SCHEME: &str = "wasmbus";
 
-pub const CONFIG_WASCC_CLAIMS_ISSUER: &str = "__wascc_issuer";
-pub const CONFIG_WASCC_CLAIMS_CAPABILITIES: &str = "__wascc_capabilities";
-pub const CONFIG_WASCC_CLAIMS_NAME: &str = "__wascc_name";
-pub const CONFIG_WASCC_CLAIMS_EXPIRES: &str = "__wascc_expires";
-pub const CONFIG_WASCC_CLAIMS_TAGS: &str = "__wascc_tags";
+pub const CONFIG_WASMCLOUD_CLAIMS_ISSUER: &str = "__wasmcloud_issuer";
+pub const CONFIG_WASMCLOUD_CLAIMS_CAPABILITIES: &str = "__wasmcloud_capabilities";
+pub const CONFIG_WASMCLOUD_CLAIMS_NAME: &str = "__wasmcloud_name";
+pub const CONFIG_WASMCLOUD_CLAIMS_EXPIRES: &str = "__wasmcloud_expires";
+pub const CONFIG_WASMCLOUD_CLAIMS_TAGS: &str = "__wasmcloud_tags";
 
 pub const OP_HALT: &str = "__halt";
 
@@ -453,11 +453,11 @@ pub(crate) fn gen_config_invocation(
 ) -> Invocation {
     let mut values = values;
     values.insert(
-        CONFIG_WASCC_CLAIMS_ISSUER.to_string(),
+        CONFIG_WASMCLOUD_CLAIMS_ISSUER.to_string(),
         claims.issuer.to_string(),
     );
     values.insert(
-        CONFIG_WASCC_CLAIMS_CAPABILITIES.to_string(),
+        CONFIG_WASMCLOUD_CLAIMS_CAPABILITIES.to_string(),
         claims
             .metadata
             .as_ref()
@@ -467,13 +467,13 @@ pub(crate) fn gen_config_invocation(
             .unwrap_or(&Vec::new())
             .join(","),
     );
-    values.insert(CONFIG_WASCC_CLAIMS_NAME.to_string(), claims.name());
+    values.insert(CONFIG_WASMCLOUD_CLAIMS_NAME.to_string(), claims.name());
     values.insert(
-        CONFIG_WASCC_CLAIMS_EXPIRES.to_string(),
+        CONFIG_WASMCLOUD_CLAIMS_EXPIRES.to_string(),
         claims.expires.unwrap_or(0).to_string(),
     );
     values.insert(
-        CONFIG_WASCC_CLAIMS_TAGS.to_string(),
+        CONFIG_WASMCLOUD_CLAIMS_TAGS.to_string(),
         claims
             .metadata
             .as_ref()

--- a/crates/wasmcloud-host/src/errors.rs
+++ b/crates/wasmcloud-host/src/errors.rs
@@ -42,7 +42,7 @@ impl StdError for Error {
             ErrorKind::Wascap(_) => "Embedded JWT Failure",
             ErrorKind::Authorization(_) => "Module authorization failure",
             ErrorKind::CapabilityProvider(_) => "Capability provider failure",
-            ErrorKind::MiscHost(_) => "waSCC Host error",
+            ErrorKind::MiscHost(_) => "Wasmcloud Host error",
             ErrorKind::Plugin(_) => "Plugin error",
             ErrorKind::Middleware(_) => "Middleware error",
             ErrorKind::Serialization(_) => "Serialization failure",
@@ -80,7 +80,7 @@ impl fmt::Display for Error {
             ErrorKind::CapabilityProvider(ref err) => {
                 write!(f, "Capability provider error: {}", err)
             }
-            ErrorKind::MiscHost(ref err) => write!(f, "waSCC Host Error: {}", err),
+            ErrorKind::MiscHost(ref err) => write!(f, "Wasmcloud Host Error: {}", err),
             ErrorKind::Plugin(ref err) => write!(f, "Plugin error: {}", err),
             ErrorKind::Middleware(ref err) => write!(f, "Middleware error: {}", err),
             ErrorKind::Serialization(ref err) => write!(f, "Serialization failure: {}", err),

--- a/crates/wasmcloud-host/src/generated/core.rs
+++ b/crates/wasmcloud-host/src/generated/core.rs
@@ -1,5 +1,4 @@
-extern crate rmp_serde as rmps;
-use rmps::{Deserializer, Serializer};
+use rmp_serde::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 

--- a/crates/wasmcloud-host/src/generated/extras.rs
+++ b/crates/wasmcloud-host/src/generated/extras.rs
@@ -1,5 +1,3 @@
-extern crate rmp_serde as rmps;
-
 use serde::{Deserialize, Serialize};
 
 extern crate log;

--- a/crates/wasmcloud-host/src/lib.rs
+++ b/crates/wasmcloud-host/src/lib.rs
@@ -31,7 +31,7 @@
 //! use std::error::Error;
 //! use std::time::Duration;
 //! use actix_rt::time::delay_for;
-//! extern crate reqwest;
+//! use reqwest;
 //!
 //! const WEB_PORT: u32 = 8080;
 //!

--- a/crates/wasmcloud-host/src/messagebus/utils.rs
+++ b/crates/wasmcloud-host/src/messagebus/utils.rs
@@ -1,6 +1,6 @@
 use crate::dispatch::{
-    CONFIG_WASCC_CLAIMS_CAPABILITIES, CONFIG_WASCC_CLAIMS_EXPIRES, CONFIG_WASCC_CLAIMS_ISSUER,
-    CONFIG_WASCC_CLAIMS_NAME, CONFIG_WASCC_CLAIMS_TAGS,
+    CONFIG_WASMCLOUD_CLAIMS_CAPABILITIES, CONFIG_WASMCLOUD_CLAIMS_EXPIRES,
+    CONFIG_WASMCLOUD_CLAIMS_ISSUER, CONFIG_WASMCLOUD_CLAIMS_NAME, CONFIG_WASMCLOUD_CLAIMS_TAGS,
 };
 
 use crate::messagebus::OP_BIND_ACTOR;
@@ -23,11 +23,11 @@ pub(crate) fn generate_link_invocation_and_call(
     // the source actor
     let mut values = values;
     values.insert(
-        CONFIG_WASCC_CLAIMS_ISSUER.to_string(),
+        CONFIG_WASMCLOUD_CLAIMS_ISSUER.to_string(),
         claims.issuer.to_string(),
     );
     values.insert(
-        CONFIG_WASCC_CLAIMS_CAPABILITIES.to_string(),
+        CONFIG_WASMCLOUD_CLAIMS_CAPABILITIES.to_string(),
         claims
             .metadata
             .as_ref()
@@ -37,13 +37,13 @@ pub(crate) fn generate_link_invocation_and_call(
             .unwrap_or(&Vec::new())
             .join(","),
     );
-    values.insert(CONFIG_WASCC_CLAIMS_NAME.to_string(), claims.name());
+    values.insert(CONFIG_WASMCLOUD_CLAIMS_NAME.to_string(), claims.name());
     values.insert(
-        CONFIG_WASCC_CLAIMS_EXPIRES.to_string(),
+        CONFIG_WASMCLOUD_CLAIMS_EXPIRES.to_string(),
         claims.expires.unwrap_or(0).to_string(),
     );
     values.insert(
-        CONFIG_WASCC_CLAIMS_TAGS.to_string(),
+        CONFIG_WASMCLOUD_CLAIMS_TAGS.to_string(),
         claims
             .metadata
             .as_ref()

--- a/crates/wasmcloud-host/src/middleware/mod.rs
+++ b/crates/wasmcloud-host/src/middleware/mod.rs
@@ -5,7 +5,7 @@ use crate::Result;
 
 pub(crate) use runner::*;
 
-/// The trait that must be implemented by all waSCC middleware. Each time an actor or
+/// The trait that must be implemented by all middleware. Each time an actor or
 /// capability provider is invoked, each middleware in the chain will get a chance to
 /// react to the input Invocation. Middleware is cloned on a 1:1 basis with each
 /// potential target. Because each of the target types invokes in single-threaded fashion,

--- a/crates/wasmcloud-host/src/oci.rs
+++ b/crates/wasmcloud-host/src/oci.rs
@@ -69,7 +69,7 @@ fn cached_file(img: &str) -> PathBuf {
     let path = temp_dir();
     let path = path.join("wasmcloud_ocicache");
     let _ = ::std::fs::create_dir_all(&path);
-    // should produce a file like wascc_azurecr_io_kvcounter_v1.bin
+    // should produce a file like wasmcloud_azurecr_io_kvcounter_v1.bin
     let img = img.replace(":", "_");
     let img = img.replace("/", "_");
     let img = img.replace(".", "_");

--- a/crates/wasmcloud-provider-core/src/lib.rs
+++ b/crates/wasmcloud-provider-core/src/lib.rs
@@ -79,8 +79,7 @@
 
 pub use capabilities::*;
 
-extern crate rmp_serde as rmps;
-use rmps::{Deserializer, Serializer};
+use rmp_serde::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 

--- a/samples/bench-actor/src/lib.rs
+++ b/samples/bench-actor/src/lib.rs
@@ -1,10 +1,9 @@
-extern crate wapc_guest as guest;
 use actor::deserialize;
 use serde::{Deserialize, Serialize};
 use wasmcloud_actor_core as actor;
 use wasmcloud_actor_http_server as http;
 
-use guest::prelude::*;
+use wapc_guest::prelude::*;
 
 #[no_mangle]
 pub fn wapc_init() {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -98,7 +98,7 @@ pub async fn gen_kvcounter_host(
     webvalues.insert("PORT".to_string(), format!("{}", web_port));
     h.start_native_capability(redis).await?;
     h.start_native_capability(websrv).await?;
-    await_provider_count(&h, 4, Duration::from_millis(50), 3).await?; // 2 providers plus wascc:extras
+    await_provider_count(&h, 4, Duration::from_millis(50), 3).await?; // 2 providers plus wasmcloud:extras
     h.set_link(&kvcounter_key, "wasmcloud:keyvalue", None, redis_id, values)
         .await?;
 

--- a/tests/control.rs
+++ b/tests/control.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(debug_assertions, allow(dead_code, unused_imports))]
+
 use crate::common::{
     await_actor_count, await_provider_count, par_from_file, HTTPSRV_OCI, KVCOUNTER_OCI, NATS_OCI,
     REDIS_OCI,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod common;
 mod control;
 mod no_lattice;

--- a/tests/no_lattice.rs
+++ b/tests/no_lattice.rs
@@ -184,7 +184,7 @@ pub async fn kvcounter_start_stop() -> Result<()> {
 
     let websrv = NativeCapability::from_archive(&arc2, None)?;
     h.start_native_capability(websrv).await?;
-    await_provider_count(&h, 4, Duration::from_millis(50), 3).await?; // 2 providers plus wascc:extras + kvcache
+    await_provider_count(&h, 4, Duration::from_millis(50), 3).await?; // 2 providers plus wasmcloud:extras + kvcache
     delay_for(Duration::from_millis(300)).await; // give web server enough time to start
 
     let resp2 = reqwest::get(&url).await?;
@@ -249,7 +249,7 @@ pub async fn kvcounter_link_first() -> Result<()> {
     // for each.
     h.start_native_capability(redis).await?;
     h.start_native_capability(websrv).await?;
-    await_provider_count(&h, 4, Duration::from_millis(50), 3).await?; // 2 providers plus wascc:extras
+    await_provider_count(&h, 4, Duration::from_millis(50), 3).await?; // 2 providers plus wasmcloud:extras
     delay_for(Duration::from_millis(150)).await;
 
     let key = uuid::Uuid::new_v4().to_string();

--- a/tests/with_lattice.rs
+++ b/tests/with_lattice.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(debug_assertions, allow(dead_code, unused_imports))]
+
 use crate::common::{await_actor_count, await_provider_count, par_from_file, REDIS_OCI};
 use actix_rt::time::delay_for;
 use provider_archive::ProviderArchive;


### PR DESCRIPTION
This PR:
* Removes Wascc artifacts from previous writes
* Renames `linkdefinitions` to `link_definitions` to match naming convention with other methods
* Removes `extern crate` declaration except for log crate since 2018 edition is used
* Adds `#![cfg_attr(debug_assertions, allow(dead_code, unused_imports))]` to test modules `controls.rs` and `with_lattice.rs` modules to suppress linting warnings
* Renames  https://raw.githubusercontent.com/wascc/schemas/main/control_interface.widl to https://raw.githubusercontent.com/wasmCloud/actor-interfaces/main/schemas/control_interface.widl