### PR TITLE
Implemented codeowners for automatic PR review

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,0 +1,5 @@
+# wasmcloud team members
+* @autodidaddict @brooksmtownsend @ChrisRx @billyoung
+
+# wasmcloud devops
+/.github/actions @billyoung @brooksmtownsend


### PR DESCRIPTION
With this file commited to `main`, all of the wasmcloud team members should be requested for a review when a PR is created. Additionally, if the file only involves GitHub actions, we primarily request @billyoung and I've added myself as a secondary.