### PR TITLE
add provider ref to start ack

### DIFF
--- a/crates/wasmcloud-host/src/control_interface/handlers.rs
+++ b/crates/wasmcloud-host/src/control_interface/handlers.rs
@@ -247,12 +247,12 @@ pub(crate) async fn handle_start_actor(
     allow_latest: bool,
     allowed_insecure: &[String],
 ) {
-    let cmd = deserialize::<StartActorCommand>(&msg.data);
     let mut ack = StartActorAck {
         host_id: host.to_string(),
         ..Default::default()
     };
 
+    let cmd = deserialize::<StartActorCommand>(&msg.data);
     if let Err(e) = cmd {
         let f = format!("Bad StartActor command received: {}", e);
         error!("{}", f);
@@ -404,6 +404,8 @@ pub(crate) async fn handle_start_provider(
         return;
     }
     let cmd = cmd.unwrap();
+    ack.provider_ref = cmd.provider_ref.to_string();
+
     let hc = HostController::from_hostlocal_registry(host);
 
     let res = hc

--- a/tests/no_lattice.rs
+++ b/tests/no_lattice.rs
@@ -42,7 +42,7 @@ pub async fn start_and_stop_actor() -> Result<()> {
     let buf = serialize(&request)?;
     println!("{}", buf.len());
     let res = h.call_actor(&actor_id, "HandleRequest", &buf).await;
-    assert!(true, res.is_err()); // We should not still be able to call this actor
+    assert!(res.is_err()); // We should not still be able to call this actor
 
     Ok(())
 }


### PR DESCRIPTION
fixes #106 

This PR adds the provider OCI reference to the acknowledgement JSON from `wash ctl start provider` (also moved a line in the start actor function to match).

Also fixes an integration test which was just asserting true :-)