### PR TITLE
Make Host Sendable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ wapc = { version = "0.10.1" }
 log = "0.4.11"
 env_logger = "0.8.2"
 anyhow = "1.0.34"
-wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.15.3" }
+wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.15.4" }
 actix-rt = "1.1.1"
 nats = "0.8.6"
 structopt = "0.3.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "0.15.4"
+version = "0.15.5"
 authors = ["wasmcloud Team"]
 edition = "2018"
 default-run = "wasmcloud"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ wapc = { version = "0.10.1" }
 log = "0.4.11"
 env_logger = "0.8.2"
 anyhow = "1.0.34"
-wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.15.4" }
+wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.15.5" }
 actix-rt = "1.1.1"
 nats = "0.8.6"
 structopt = "0.3.21"

--- a/crates/wasmcloud-host/Cargo.toml
+++ b/crates/wasmcloud-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.15.3"
+version = "0.15.4"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/crates/wasmcloud-host/Cargo.toml
+++ b/crates/wasmcloud-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.15.4"
+version = "0.15.5"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"


### PR DESCRIPTION
Fixes an issue where the Host struct was not Send because of leftover and unnecessary use of Refcells