### PR TITLE
wasmcloud-host 0.15.6: upgrade oci-distribution dependency to 0.6, completing tokio 1.x/actix 2 migration

### DIFF
--- a/crates/wasmcloud-host/Cargo.toml
+++ b/crates/wasmcloud-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.15.5"
+version = "0.15.6"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -18,19 +18,18 @@ wasmtime = ["wasmtime-provider"]
 wasm3 = ["wasm3-provider"]
 
 [dependencies]
-actix = "0.11.0-beta.3"
+actix = "0.11"
 actix-rt = "2.1.0"
 chrono = "0.4.19"
 crossbeam-channel = "0.5.0"
 data-encoding = "2.3.1"
-envmnt = "0.8.4"
-futures = "0.3.6"
+envmnt = "0.9"
+futures = "0.3"
 lazy_static = "1.4.0"
 libloading = "0.7.0"
 log = "0.4.11"
 nats = "0.8.6"
-# the 0.6.0 crate will work when it's released (very soon?), but Cargo.toml still says 0.5.0 so we have to pull from git
-oci-distribution = { git = "https://github.com/deislabs/krustlet" }
+oci-distribution = "0.6"
 once_cell = "1.5.2"
 parking_lot = "0.11.1"
 provider-archive ="0.4.0"
@@ -43,7 +42,6 @@ serde_yaml = "0.8.14"
 uuid = {version = "0.8", features  = ["serde", "v4"]}
 wapc = "0.10.1"
 wascap = "0.6.0"
-tokio = { version = "0.3.5", features = ["rt"] }
 serde_bytes = "0.11.5"
 wasmcloud-actor-keyvalue = "0.2.0"
 wasmcloud-control-interface = { path = "../wasmcloud-control-interface", version = "0.2.1" }


### PR DESCRIPTION
wasmcloud-host 0.15.6
Upgrade oci-distribution dependency to 0.6, completing the tokio 1.x/actix 2 migration. 
Upgrade actix from 0.11-beta to 0.11