### PR TITLE
Release 0.16.0 for wasmcloud-host and wasmcloud binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "0.15.5"
+version = "0.16.0"
 authors = ["wasmcloud Team"]
 edition = "2018"
 default-run = "wasmcloud"
@@ -39,7 +39,7 @@ log = "0.4.11"
 env_logger = "0.8.2"
 anyhow = "1.0.34"
 actix-rt = "2.1.0"
-wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.15.5" }
+wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.16.0" }
 nats = "0.8.6"
 structopt = "0.3.21"
 nkeys = "0.1.0"

--- a/crates/wasmcloud-host/Cargo.toml
+++ b/crates/wasmcloud-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.15.6"
+version = "0.16.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/samples/bencher/Cargo.toml
+++ b/samples/bencher/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasmcloud-host = { path = "../../crates/wasmcloud-host", version="0.15.4" }
+wasmcloud-host = { path = "../../crates/wasmcloud-host", version="0.16.0" }
 actix-rt = "2.1.0"
 wasmcloud-actor-core = "0.2.0"
 wasmcloud-actor-http-server = "0.1.0"


### PR DESCRIPTION
Minor bump as actix-rt 2.1.0 / actix 0.11.0 / tokio 1.0 is a breaking change for developers depending on the `wasmcloud-host` crate.