### PR TITLE
Windows debugging

### DIFF
--- a/crates/wasmcloud-host/src/capability/native_host.rs
+++ b/crates/wasmcloud-host/src/capability/native_host.rs
@@ -262,7 +262,8 @@ fn extrude(
             #[cfg(not(target_os = "linux"))]
             unsafe { Library::new(&path)? }
         } else if cfg!(target_os = "windows") {
-            unsafe { ::libloading::os::windows::Library::load_with_flags(&path, 0x1000)? }.into()
+            // Must be opened with PAGE_EXECUTE_READWRITE | PAGE_NOCACHE on windows
+            unsafe { ::libloading::os::windows::Library::load_with_flags(&path, 0x40 | 0x200)? }.into()
         } else {
             unsafe { Library::new(&path)? }
         };
@@ -277,7 +278,7 @@ fn extrude(
                     return Err(Box::new(e));
                 }
             };
-            debug!("got constructor");
+            debug!("got constructor (status access violation incoming)");
             let boxed_raw = constructor();
             debug!("got boxed raw");
 


### PR DESCRIPTION
This PR was created in an attempt to further debug the Windows issues that we are running into for wasmcloud.

TL;DR: use WSL

Re: #60, the libloading library automatically appends `.dll` which I confirmed in their documentation, so we have to extract the provider with the `.dll` extension or windows machines will not be able to work.

Refactored the libloading section to have a linux, windows, and "other" section for loading capability providers. I was able to discover that the `.dll` section is not required so long as you use the `libloading::os::windows` module for the library loading portion. I was not able to resolve https://github.com/wasmCloud/wasmCloud/issues/59, and windows still can segfault upon initialization of the capability provider. I was able to confirm with `dumpbin` that the downloaded httpserver provider (I'm running the echo example) does export `__capability_provider_create`, but regardless the code panics with a `LoadLibraryExW` error. From what I can read, this is due to missing shared libraries elsewhere on my system, but as far as I know I have a well functioning Windows development environment. 

I've used `depends` to try and track down the shared module that is failing, however my `depends` lists hundreds of missing `.dll`s.

I've used ProcessMonitor to track syscalls for the wasmcloud program, but I can't find anything out of the ordinary other than a failure to `CreateFileMapping`. I've attempted to open the library with the specified protections, but unfortunately this doesn't fix the issue. 

Here's my current error:
```
[2021-03-30T18:14:31Z DEBUG] GetProcAddress { source: Os { code: 126, kind: Other, message: "The specified module could not be found." } }
[2021-03-30T18:14:31Z ERROR] Failed to extract plugin from provider: GetProcAddress failed
```

Interested if anyone else on windows can reproduce, if you have `nats-server` and I stole the manifest for the program from https://github.com/wasmCloud/examples/blob/main/echo/manifest.yaml

Reference:
https://docs.microsoft.com/en-us/windows/win32/memory/memory-protection-constants
https://docs.rs/libloading/0.7.0/libloading/os/windows/struct.Library.html