### PR TITLE
Added logging, allowed manifests support missing fields

### DIFF
--- a/crates/wasmcloud-control-interface/src/lib.rs
+++ b/crates/wasmcloud-control-interface/src/lib.rs
@@ -323,7 +323,7 @@ pub fn serialize<T>(
 where
     T: Serialize,
 {
-    serde_json::to_vec(&item).map_err(|_e| "JSON serialization failure".into())
+    serde_json::to_vec(&item).map_err(|e| format!("JSON serialization failure: {}", e).into())
 }
 
 /// The standard function for de-serializing codec structs from a format suitable
@@ -332,5 +332,5 @@ where
 pub fn deserialize<'de, T: Deserialize<'de>>(
     buf: &'de [u8],
 ) -> ::std::result::Result<T, Box<dyn std::error::Error + Send + Sync>> {
-    serde_json::from_slice(buf).map_err(|_e| "JSON deserialization failure".into())
+    serde_json::from_slice(buf).map_err(|e| format!("JSON deserialization failure: {}", e).into())
 }

--- a/crates/wasmcloud-host/src/control_interface/ctlactor.rs
+++ b/crates/wasmcloud-host/src/control_interface/ctlactor.rs
@@ -87,6 +87,7 @@ impl Handler<NatsMessage> for ControlInterface {
     type Result = ResponseActFuture<Self, ()>;
 
     fn handle(&mut self, msg: NatsMessage, _ctx: &mut Context<Self>) -> Self::Result {
+        trace!("Handling NATS message with subject:{}", msg.msg.subject);
         use super::handlers::*;
         use ::wasmcloud_control_interface::broker::*;
 

--- a/crates/wasmcloud-host/src/dispatch.rs
+++ b/crates/wasmcloud-host/src/dispatch.rs
@@ -14,6 +14,7 @@ use ring::digest::{Context, Digest, SHA256};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
+use std::fmt::Display;
 use std::io::Read;
 use std::string::ToString;
 use uuid::Uuid;
@@ -290,6 +291,12 @@ pub enum WasmCloudEntity {
         contract_id: String,
         link_name: String,
     },
+}
+
+impl Display for WasmCloudEntity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.url())
+    }
 }
 
 impl WasmCloudEntity {

--- a/crates/wasmcloud-host/src/hlreg.rs
+++ b/crates/wasmcloud-host/src/hlreg.rs
@@ -20,6 +20,11 @@ static SREG: Lazy<Mutex<ServiceMap>> = Lazy::new(|| Mutex::new(HashMap::new()));
 /// that implements it
 pub(crate) trait HostLocalSystemService: SystemService {
     fn from_hostlocal_registry(hostid: &str) -> Addr<Self> {
+        trace!(
+            "Requesting HostLocalSystemService with hostid {} ({})",
+            hostid,
+            std::any::type_name::<Self>()
+        );
         let sys = System::current();
         let mut sreg = SREG.lock();
         let reg = sreg.entry(hostid.to_string()).or_insert_with(HashMap::new);

--- a/crates/wasmcloud-host/src/host_controller/hc_actor.rs
+++ b/crates/wasmcloud-host/src/host_controller/hc_actor.rs
@@ -93,6 +93,7 @@ impl Handler<AuctionActor> for HostController {
     // true only if the actor is not running and the host satisfies the indicated
     // constraints.
     fn handle(&mut self, msg: AuctionActor, _ctx: &mut Context<Self>) -> Self::Result {
+        trace!("Received actor auction {}", msg.actor_ref);
         let lc = self.latticecache.clone().unwrap();
         let host_labels = self.host_labels.clone();
         let actor_ref = msg.actor_ref.to_string();
@@ -121,6 +122,7 @@ impl Handler<AuctionProvider> for HostController {
     // only if the provider is not running and the host satisfies the indicated
     // constraints.
     fn handle(&mut self, msg: AuctionProvider, _ctx: &mut Context<Self>) -> Self::Result {
+        trace!("Received provider auction {}", msg.provider_ref);
         let lc = self.latticecache.clone().unwrap();
         let host_labels = self.host_labels.clone();
         let provider_ref = msg.provider_ref.to_string();
@@ -165,6 +167,7 @@ impl Handler<QueryActorRunning> for HostController {
     type Result = ResponseActFuture<Self, bool>;
 
     fn handle(&mut self, msg: QueryActorRunning, _ctx: &mut Context<Self>) -> Self::Result {
+        trace!("Received ActorRunning query {}", msg.actor_ref);
         let lc = self.latticecache.clone().unwrap();
         Box::pin(
             async move {
@@ -186,6 +189,7 @@ impl Handler<GetRunningActor> for HostController {
     type Result = Option<Addr<ActorHost>>;
 
     fn handle(&mut self, msg: GetRunningActor, _ctx: &mut Context<Self>) -> Self::Result {
+        trace!("Getting running actor {}", msg.actor_id);
         self.actors.get(&msg.actor_id).cloned()
     }
 }
@@ -287,6 +291,7 @@ impl Handler<SetLabels> for HostController {
     type Result = ();
 
     fn handle(&mut self, msg: SetLabels, _ctx: &mut Context<Self>) -> Self::Result {
+        trace!("Setting host labels");
         self.host_labels = msg.labels
     }
 }
@@ -366,6 +371,7 @@ impl Handler<Initialize> for HostController {
         self.host_labels = msg.labels.clone();
         self.authorizer = Some(msg.auth.clone());
         let host_id = msg.kp.public_key();
+        trace!("Initializing host controller {}", host_id);
 
         let claims = crate::capability::extras::get_claims();
         let pk = claims.subject;

--- a/crates/wasmcloud-host/src/manifest.rs
+++ b/crates/wasmcloud-host/src/manifest.rs
@@ -14,8 +14,14 @@ pub struct HostManifest {
     #[serde(default)]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub labels: HashMap<String, String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub actors: Vec<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub capabilities: Vec<Capability>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub links: Vec<LinkEntry>,
 }
 

--- a/crates/wasmcloud-host/src/messagebus/nats_subscriber.rs
+++ b/crates/wasmcloud-host/src/messagebus/nats_subscriber.rs
@@ -39,6 +39,7 @@ impl Handler<Initialize> for NatsSubscriber {
     type Result = ResponseActFuture<Self, ()>;
 
     fn handle(&mut self, msg: Initialize, _ctx: &mut Self::Context) -> Self::Result {
+        trace!("Initializing NatsSubscriber for {}", msg.subject);
         let state = SubscriberState {
             receiver: msg.receiver,
         };
@@ -68,8 +69,8 @@ impl Handler<NatsMessage> for NatsSubscriber {
     type Result = ResponseActFuture<Self, ()>;
 
     fn handle(&mut self, msg: NatsMessage, _ctx: &mut Self::Context) -> Self::Result {
-        trace!("NATS subscriber forwarding message");
         let target = self.state.as_ref().unwrap().receiver.clone();
+        trace!("NATS subscriber forwarding message : {}", msg.msg.subject);
         Box::pin(
             async move {
                 if target.send(msg).await.is_err() {


### PR DESCRIPTION
This is mostly a logging PR to help diagnose issues and understand the flow of wasmcloud via trace logging. Some logs don't look valuable, but without them it's confusing to know if anything is happening when you poke at the host.

The large chunk of code changed in CreateSubscription is just logging. There was a lot going on there that failed silently on errors.

Piggybacking onto this PR is support for empty links, actors, and capabilities in manifest files. LMK if I should change any of the message text or back anything out.

- added logging messages
- propagated ser/des error messages  
- implemented Display for WasmCloudEntity
- allowing empty links, capabilities, and actors in manifest