### PR TITLE
Implemented feature flags for wasmcloud binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ exclude = [
 ]
 autotests = false
 
+[features]
+default = ["wasm3"]
+wasmtime = ["wasmcloud-host/wasmtime"]
+wasm3 = ["wasmcloud-host/wasm3"]
+
 [[test]]
 name = "integration"
 path = "tests/lib.rs"
@@ -41,7 +46,7 @@ log = "0.4.11"
 env_logger = "0.8.2"
 anyhow = "1.0.34"
 actix-rt = "2.1.0"
-wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.16.1" }
+wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.16.1", default-features = false }
 nats = "0.8.6"
 structopt = "0.3.21"
 nkeys = "0.1.0"
@@ -71,7 +76,6 @@ members = [
     "samples/bencher",
     "crates/wasmcloud-control-interface"
 ]
-
 
 [[bin]]
 name = "wasmcloud"

--- a/crates/wasmcloud-host/src/actors/actor_host.rs
+++ b/crates/wasmcloud-host/src/actors/actor_host.rs
@@ -11,6 +11,7 @@ use crate::middleware::{run_actor_post_invoke, run_actor_pre_invoke, Middleware}
 use crate::{ControlEvent, Result};
 use actix::prelude::*;
 use futures::executor::block_on;
+use log::info;
 use wapc::WapcHost;
 use wascap::jwt::TokenValidation;
 use wascap::prelude::{Claims, KeyPair};
@@ -172,7 +173,10 @@ fn perform_initialization(
     assert_validation_result(&tv)?;
 
     #[cfg(feature = "wasmtime")]
-    let engine = wasmtime_provider::WasmtimeEngineProvider::new(&buf, None);
+    let engine = {
+        info!("Initializing wasmtime engine");
+        wasmtime_provider::WasmtimeEngineProvider::new(&buf, None)
+    };
     #[cfg(feature = "wasm3")]
     let engine = wasm3_provider::Wasm3EngineProvider::new(&buf);
 

--- a/src/wasmcloud.rs
+++ b/src/wasmcloud.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
     let cli = Cli::from_args();
     let _ = env_logger::Builder::from_env(env_logger::Env::default().filter_or(
         env_logger::DEFAULT_FILTER_ENV,
-        "wasmcloud=info,wasmcloud_host=info",
+        "wasmcloud=info,wasmcloud_host=info,wasmtime_provider=warn",
     ))
     .format_module_path(false)
     .try_init();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -178,4 +178,3 @@ async fn cant_use_unstarted_host() {
     }
     assert!(res.is_ok());
 }
-

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -33,7 +33,6 @@ async fn distributed_unlink_provider() {
     assert!(res.is_ok());
 }
 
-/*
 #[actix_rt::test]
 async fn live_update() {
     let res = control::live_update().await;
@@ -179,4 +178,4 @@ async fn cant_use_unstarted_host() {
     }
     assert!(res.is_ok());
 }
-*/
+


### PR DESCRIPTION
This PR allows you to run the wasmcloud binary with either the `wasm3` or `wasmtime` engine. The default is wasm3, and in order to run with wasmtime you must use the following command:
```
cargo run --features wasmtime --no-default-features
```
In order to enforce a default, as @ChrisRx noted in #56, we have to explicitly remove the default feature in order to use the other engine type. I've adjusted the default log verbosity for the `wasmtime-provider` as in `info` mode you will get a lot of output as wasmtime JITs the actor module, in `debug` mode you get an unusable amount of wasm debug output.

This PR also uncomments our integration tests.