### PR TITLE
Adding more detail to host inventory and API queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["wasmcloud Team"]
 edition = "2018"
 default-run = "wasmcloud"
@@ -46,7 +46,7 @@ log = "0.4.11"
 env_logger = "0.8.2"
 anyhow = "1.0.34"
 actix-rt = "2.1.0"
-wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.17.0", default-features = false }
+wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.18.0", default-features = false }
 nats = "0.8.6"
 structopt = "0.3.21"
 nkeys = "0.1.0"

--- a/crates/wasmcloud-control-interface/Cargo.toml
+++ b/crates/wasmcloud-control-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/crates/wasmcloud-control-interface/src/generated/ctliface.rs
+++ b/crates/wasmcloud-control-interface/src/generated/ctliface.rs
@@ -189,10 +189,12 @@ pub struct ActorDescription {
     #[serde(rename = "id")]
     pub id: String,
     #[serde(rename = "image_ref")]
-    pub image_ref: Option<String>,
+    pub image_refs: Vec<String>,
     #[serde(rename = "name")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(rename = "revision")]
+    pub revision: i32,
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
@@ -202,10 +204,12 @@ pub struct ProviderDescription {
     #[serde(rename = "link_name")]
     pub link_name: String,
     #[serde(rename = "image_ref")]
-    pub image_ref: Option<String>,
+    pub image_refs: Vec<String>,
     #[serde(rename = "name")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(rename = "revision")]
+    pub revision: i32,
 }
 
 /// The standard function for serializing codec structs into a format that can be

--- a/crates/wasmcloud-control-interface/src/generated/ctliface.rs
+++ b/crates/wasmcloud-control-interface/src/generated/ctliface.rs
@@ -188,7 +188,8 @@ pub struct HostInventory {
 pub struct ActorDescription {
     #[serde(rename = "id")]
     pub id: String,
-    #[serde(rename = "image_ref")]
+    #[serde(rename = "image_refs")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub image_refs: Vec<String>,
     #[serde(rename = "name")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -203,7 +204,8 @@ pub struct ProviderDescription {
     pub id: String,
     #[serde(rename = "link_name")]
     pub link_name: String,
-    #[serde(rename = "image_ref")]
+    #[serde(rename = "image_refs")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub image_refs: Vec<String>,
     #[serde(rename = "name")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/wasmcloud-host/Cargo.toml
+++ b/crates/wasmcloud-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -44,7 +44,7 @@ wapc = "0.10.1"
 wascap = "0.6.0"
 serde_bytes = "0.11.5"
 wasmcloud-actor-keyvalue = "0.2.0"
-wasmcloud-control-interface = { path = "../wasmcloud-control-interface", version = "0.2.1" }
+wasmcloud-control-interface = { path = "../wasmcloud-control-interface", version = "0.3.0" }
 
 wasm3-provider = { version = "0.0.2", optional = true}
 wasmtime-provider = { version = "0.0.2" , optional = true}

--- a/crates/wasmcloud-host/src/actors/actor_host.rs
+++ b/crates/wasmcloud-host/src/actors/actor_host.rs
@@ -1,7 +1,10 @@
 use std::collections::{hash_map::Entry, HashMap};
 
-use crate::control_interface::ctlactor::{ControlInterface, PublishEvent};
-use crate::{actors::WasmCloudActor, capability::native_host::GetName};
+use crate::{actors::WasmCloudActor, capability::native_host::GetIdentity};
+use crate::{
+    capability::native_host::IdentityResponse,
+    control_interface::ctlactor::{ControlInterface, PublishEvent},
+};
 
 use crate::dispatch::OP_HALT;
 use crate::dispatch::{Invocation, InvocationResponse, WasmCloudEntity};
@@ -52,11 +55,21 @@ pub(crate) struct LiveUpdate {
     pub image_ref: Option<String>,
 }
 
-impl Handler<GetName> for ActorHost {
-    type Result = String;
+impl Handler<GetIdentity> for ActorHost {
+    type Result = IdentityResponse;
 
-    fn handle(&mut self, _msg: GetName, _ctx: &mut Self::Context) -> Self::Result {
-        self.state.as_ref().unwrap().claims.name()
+    fn handle(&mut self, _msg: GetIdentity, _ctx: &mut Self::Context) -> Self::Result {
+        let state = self.state.as_ref().unwrap();
+
+        IdentityResponse {
+            name: state.claims.name(),
+            revision: state
+                .claims
+                .metadata
+                .as_ref()
+                .map(|md| md.rev.unwrap_or(0))
+                .unwrap_or(0),
+        }
     }
 }
 

--- a/crates/wasmcloud-host/src/control_interface/handlers.rs
+++ b/crates/wasmcloud-host/src/control_interface/handlers.rs
@@ -162,8 +162,9 @@ pub(crate) async fn handle_host_inventory_query(host: &str, msg: &nats::asynk::M
                 .map(|ps| ProviderDescription {
                     id: ps.id.to_string(),
                     link_name: ps.link_name.to_string(),
-                    image_ref: ps.image_ref.clone(),
+                    image_refs: ps.image_refs.clone(),
                     name: ps.name.clone(),
+                    revision: ps.revision,
                 })
                 .collect();
             inv.actors = hi
@@ -171,8 +172,9 @@ pub(crate) async fn handle_host_inventory_query(host: &str, msg: &nats::asynk::M
                 .iter()
                 .map(|a| ActorDescription {
                     id: a.id.to_string(),
-                    image_ref: a.image_ref.clone(),
+                    image_refs: a.image_refs.clone(),
                     name: a.name.clone(),
+                    revision: a.revision,
                 })
                 .collect();
             inv.labels = hi.labels;

--- a/crates/wasmcloud-host/src/host_controller/mod.rs
+++ b/crates/wasmcloud-host/src/host_controller/mod.rs
@@ -129,16 +129,18 @@ pub(crate) struct HostInventory {
 #[derive(Default, Debug, Clone, PartialEq)]
 pub(crate) struct ActorSummary {
     pub id: String,
-    pub image_ref: Option<String>,
+    pub image_refs: Vec<String>,
     pub name: Option<String>,
+    pub revision: i32,
 }
 
 #[derive(Default, Debug, Clone, PartialEq)]
 pub(crate) struct ProviderSummary {
     pub id: String,
-    pub image_ref: Option<String>,
+    pub image_refs: Vec<String>,
     pub link_name: String,
     pub name: Option<String>,
+    pub revision: i32,
 }
 
 impl<A, M> MessageResponse<A, M> for HostInventory

--- a/crates/wasmcloud-host/src/messagebus/handlers.rs
+++ b/crates/wasmcloud-host/src/messagebus/handlers.rs
@@ -232,7 +232,7 @@ impl Handler<QueryActors> for MessageBus {
                 .subscribers
                 .keys()
                 .filter_map(|k| match k {
-                    WasmCloudEntity::Actor(s) => Some(s.to_string()),
+                    WasmCloudEntity::Actor(s) => Some(WasmCloudEntity::Actor(s.clone())),
                     WasmCloudEntity::Capability { .. } => None,
                 })
                 .collect(),
@@ -439,7 +439,7 @@ impl Handler<QueryProviders> for MessageBus {
                 .subscribers
                 .keys()
                 .filter_map(|k| match k {
-                    WasmCloudEntity::Capability { id, .. } => Some(id.to_string()),
+                    c @ WasmCloudEntity::Capability { .. } => Some(c.clone()),
                     _ => None,
                 })
                 .collect(),

--- a/crates/wasmcloud-host/src/messagebus/mod.rs
+++ b/crates/wasmcloud-host/src/messagebus/mod.rs
@@ -61,7 +61,7 @@ pub struct LinkDefinition {
 }
 
 pub struct QueryResponse {
-    pub results: Vec<String>,
+    pub results: Vec<WasmCloudEntity>,
 }
 
 impl<A, M> MessageResponse<A, M> for QueryResponse

--- a/samples/bencher/Cargo.toml
+++ b/samples/bencher/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasmcloud-host = { path = "../../crates/wasmcloud-host", version="0.17.0" }
+wasmcloud-host = { path = "../../crates/wasmcloud-host", version="0.18.0" }
 actix-rt = "2.1.0"
 wasmcloud-actor-core = "0.2.0"
 wasmcloud-actor-http-server = "0.1.0"

--- a/schemas/control_interface.widl
+++ b/schemas/control_interface.widl
@@ -126,14 +126,16 @@ type HostInventory {
 type ActorDescription {
     id: string
     "If there is a corresponding OCI image reference for this actor it will be in this field"
-    image_ref: string?
+    image_refs: [string]
     name: string?
+    revision: i32
 }
 
 type ProviderDescription {
     id: string
     link_name: string
     "If there is a corresponding OCI image reference for this provider it will be in this field"
-    image_ref: string?
+    image_refs: [string]
     name: string?
+    revision: i32
 }

--- a/tests/control.rs
+++ b/tests/control.rs
@@ -124,8 +124,9 @@ pub(crate) async fn basics() -> Result<()> {
     println!("Got host inventory: {:?}", inv);
     //assert_eq!(3, inv.providers.len());
     assert_eq!(1, inv.actors.len());
-    assert_eq!(inv.actors[0].image_ref, Some(KVCOUNTER_OCI.to_string()));
+    assert_eq!(inv.actors[0].image_refs, vec![KVCOUNTER_OCI.to_string()]);
     assert_eq!(inv.actors[0].name, Some("Key Value Counter".to_string()));
+    assert_eq!(inv.actors[0].revision, 2);
     assert_eq!(4, inv.labels.len()); // each host gets 3 built-in labels
     assert_eq!(inv.host_id, hosts[0].id);
     h.stop().await;


### PR DESCRIPTION
* Host inventory (lattice) query now includes:
  * revision number of actor and provider _currently running in the host_ (e.g. not retrieved from cache)
  * vector of OCI references (was previously a single OCI ref, which could've been inaccurate)
* Host API has changed:
  *  `providers()` function now returns a Vec of 3-tuples `(public_key, contract_id, link_name)` - was previously just public key