### PR TITLE
Ensure live update of actor puts new OCI reference

### DIFF
--- a/crates/wasmcloud-control-interface/src/generated/ctliface.rs
+++ b/crates/wasmcloud-control-interface/src/generated/ctliface.rs
@@ -189,7 +189,6 @@ pub struct ActorDescription {
     #[serde(rename = "id")]
     pub id: String,
     #[serde(rename = "image_refs")]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub image_refs: Vec<String>,
     #[serde(rename = "name")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -205,7 +204,6 @@ pub struct ProviderDescription {
     #[serde(rename = "link_name")]
     pub link_name: String,
     #[serde(rename = "image_refs")]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub image_refs: Vec<String>,
     #[serde(rename = "name")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/wasmcloud-host/src/host_controller/hc_actor.rs
+++ b/crates/wasmcloud-host/src/host_controller/hc_actor.rs
@@ -659,6 +659,22 @@ impl Handler<StartProvider> for HostController {
     }
 }
 
+impl Handler<PutOciReference> for HostController {
+    type Result = ResponseActFuture<Self, bool>;
+
+    fn handle(&mut self, msg: PutOciReference, _ctx: &mut Context<Self>) -> Self::Result {
+        let lc = self.latticecache.clone().unwrap();
+        Box::pin(
+            async move {
+                lc.put_oci_mapping(&msg.oci_ref, &msg.public_key)
+                    .await
+                    .is_ok()
+            }
+            .into_actor(self),
+        )
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn initialize_provider(
     provider: NativeCapability,

--- a/crates/wasmcloud-host/src/host_controller/mod.rs
+++ b/crates/wasmcloud-host/src/host_controller/mod.rs
@@ -105,6 +105,13 @@ pub(crate) struct QueryHostInventory;
 
 #[derive(Message)]
 #[rtype(result = "bool")]
+pub(crate) struct PutOciReference {
+    pub oci_ref: String,
+    pub public_key: String,
+}
+
+#[derive(Message)]
+#[rtype(result = "bool")]
 pub(crate) struct AuctionProvider {
     pub constraints: HashMap<String, String>,
     pub provider_ref: String,

--- a/tests/control.rs
+++ b/tests/control.rs
@@ -232,8 +232,8 @@ pub(crate) async fn multiple_ocirefs() -> Result<()> {
         actix_rt::time::sleep(Duration::from_millis(1000)).await;
     }
 
+    // Ensure oci references exist over control interface
     let inv = ctl_client.get_host_inventory(&hosts[0].id).await?;
-
     assert_eq!(1, inv.actors.len());
     assert_eq!(2, inv.actors[0].image_refs.len());
     assert!(inv.actors[0].image_refs.contains(&ECHO_0_2_0.to_string()));
@@ -242,6 +242,13 @@ pub(crate) async fn multiple_ocirefs() -> Result<()> {
     assert_eq!(inv.actors[0].revision, 2);
     assert_eq!(4, inv.labels.len()); // each host gets 3 built-in labels
     assert_eq!(inv.host_id, hosts[0].id);
+
+    // Ensure oci references exist on host API
+    let oci_refs = h.oci_references().await?;
+    assert!(oci_refs.contains_key(ECHO_0_2_0));
+    assert_eq!(oci_refs.get(ECHO_0_2_0).unwrap(), ECHO_PKEY);
+    assert!(oci_refs.contains_key(ECHO_0_2_1));
+    assert_eq!(oci_refs.get(ECHO_0_2_1).unwrap(), ECHO_PKEY);
     h.stop().await;
 
     Ok(())

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -43,6 +43,15 @@ async fn live_update() {
 }
 
 #[actix_rt::test]
+async fn multiple_ocirefs() {
+    let res = control::multiple_ocirefs().await;
+    if let Err(ref e) = res {
+        println!("{}", e);
+    }
+    assert!(res.is_ok());
+}
+
+#[actix_rt::test]
 async fn actor_to_actor_call_alias() {
     let res = no_lattice::actor_to_actor_call_alias().await;
     if let Err(ref e) = res {

--- a/tests/no_lattice.rs
+++ b/tests/no_lattice.rs
@@ -340,7 +340,6 @@ pub async fn extras_provider() -> Result<()> {
     let h = HostBuilder::new().build();
     h.start().await?;
     // Start extras actor
-    //TODO(brooksmtownsend): replace this with the real extras
     let extras = Actor::from_file("./tests/modules/extras.wasm")?;
     let extras_id = extras.public_key();
     h.start_actor(extras).await?;


### PR DESCRIPTION
Fixes #156 

A few notes:
1. My suggestion to skip serializing the field if the Vec is empty fails to deserialize (exactly as the documentation says) so I removed it
2. I added a test to ensure we don't regress in the future, which tests both `ctl` and host API