### PR TITLE
Optimizing Gitpod Deployment

### DIFF
--- a/.github/workflows/gitpod_docker.yml
+++ b/.github/workflows/gitpod_docker.yml
@@ -1,4 +1,4 @@
-name: Package
+name: Build Gitpod Docker Artifact
 on:
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          file: '.gitpod.Dockerfile'
           push: true
           tags: |
             ghcr.io/${{ env.REPO_LOWER }}:gitpod

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Package
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.gitpod.Dockerfile'
+        
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Check out the repo
+        uses: actions/checkout@v2
+      - 
+        name: Determine Short SHA
+        run: echo ${{ github.sha }} | tail -c 8 | (read; echo SHORT_SHA=$REPLY) >> $GITHUB_ENV
+      -
+        name: Sanitize Repo Name for Tagging
+        run: echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]' | (read; echo REPO_LOWER=$REPLY) >> $GITHUB_ENV
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - 
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GITHUB_USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - 
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            ghcr.io/${{ env.REPO_LOWER }}:gitpod
+            ghcr.io/${{ env.REPO_LOWER }}:${{ env.SHORT_SHA }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }} 
+      - 
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,13 +26,12 @@ jobs:
       - 
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - 
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v1 
+      -
+        uses: azure/docker-login@v1
         with:
-          registry: ghcr.io
-          username: ${{ secrets.GHA_USERNAME }}
-          password: ${{ secrets.GHA_TOKEN }}
+          login-server: ${{ secrets.AZURECR_PUSH_URL }}
+          username: ${{ secrets.AZURECR_PUSH_USER }}
+          password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
       - 
         name: Build and push
         id: docker_build
@@ -41,10 +40,10 @@ jobs:
           file: '.gitpod.Dockerfile'
           push: true
           tags: |
-            ghcr.io/${{ env.REPO_LOWER }}:gitpod
-            ghcr.io/${{ env.REPO_LOWER }}:${{ env.SHORT_SHA }}
+            ${{ secrets.AZURECR_PUSH_URL }}/${{ env.REPO_LOWER }}_gitpod:latest
+            ${{ secrets.AZURECR_PUSH_URL }}/${{ env.REPO_LOWER }}_gitpod:${{ env.SHORT_SHA }}
           labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }} 
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
       - 
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,8 @@ jobs:
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
-          username: ${{ secrets.GITHUB_USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.GHA_USERNAME }}
+          password: ${{ secrets.GHA_TOKEN }}
       - 
         name: Build and push
         id: docker_build

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,9 +1,5 @@
 FROM gitpod/workspace-full
 
-# Gitpod will not rebuild dev image unless *some* change is made to this Dockerfile.
-# To force a rebuild, simply increase this counter:
-ENV TRIGGER_REBUILD 10
-
 USER gitpod
 
 RUN sudo apt-get update && \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -24,3 +24,4 @@ ENV RUST_LLDB=/usr/bin/lldb-11
 
 RUN rustup component add clippy
 RUN rustup target add wasm32-unknown-unknown
+RUN cargo install wasmcloud wash-cli

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,6 @@
 FROM gitpod/workspace-full
 LABEL maintainer="team@wasmcloud.com"
+LABEL repo="github.com/wasmcloud/wasmcloud"
 
 USER gitpod
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,5 @@
 FROM gitpod/workspace-full
+LABEL maintainer="team@wasmcloud.com"
 
 USER gitpod
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,8 @@
 image: ghcr.io/jordan-rash/wasmcloud:gitpod
 tasks:  
   - name: wasmCloud
-    init: cargo install --path . 
     command: wasmcloud --version
   - name: wash
-    init: cargo install wash-cli --force
     command: wash --version
   - name: nats
     command: nats-server &

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ghcr.io/jordan-rash/wasmcloud:gitpod
+image: wasmcloud.azurecr.com/wasmcloud_gitpod:latest
 tasks:  
   - name: wasmCloud
     command: wasmcloud --version

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,4 @@
-image:
-  file: .gitpod.Dockerfile
+image: ghcr.io/jordan-rash/wasmcloud:gitpod
 tasks:  
   - name: wasmCloud
     init: cargo install --path . 


### PR DESCRIPTION
Working on getting the gitpod deployment up and running a little quicker.  This PR includes a new Action that will build `.gitpod.Dockerfile` any time that it is updated and push it to azurecr.  Additionally, it changes the gitpod configuration to use that image.  This method eliminated the need to install wasmcloud and wash at start time (as it is included in the container).  

I still feel there is a good deal of optimizing that can be done (by not using that gitpod/workspace-full) as the base image, but for now, this seems a good deal faster to me.  

Note: I was NOT able to test this using Azure as I dont have ant access.  I did test is using GHCR.io and it worked well.  