### PR TITLE
Bump wasmcloud-host/wasmtime-provider to 0.0.3

### DIFF
--- a/crates/wasmcloud-host/Cargo.toml
+++ b/crates/wasmcloud-host/Cargo.toml
@@ -47,7 +47,7 @@ wasmcloud-actor-keyvalue = "0.2.0"
 wasmcloud-control-interface = { path = "../wasmcloud-control-interface", version = "0.3.0" }
 
 wasm3-provider = { version = "0.0.2", optional = true}
-wasmtime-provider = { version = "0.0.2" , optional = true}
+wasmtime-provider = { version = "0.0.3" , optional = true}
 
 [dependencies.wasmcloud-provider-core]
 #path = "../wasmcloud-provider-core"


### PR DESCRIPTION
This change should enable installing using the wasmtime feature on Apple M1 hosts.