### PR TITLE
Add manual trigger to gitpod workflow

### DIFF
--- a/.github/workflows/gitpod_docker.yml
+++ b/.github/workflows/gitpod_docker.yml
@@ -1,5 +1,6 @@
 name: Build Gitpod Docker Artifact
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
We will need this when we release a new binary version of the `wash` or `wasmcloud` tools.  It will be manually triggerable in the UI.