### PR TITLE
Bump wasmcloud-host version for wasmtime-provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["wasmcloud Team"]
 edition = "2018"
 default-run = "wasmcloud"
@@ -46,7 +46,7 @@ log = "0.4.11"
 env_logger = "0.8.2"
 anyhow = "1.0.34"
 actix-rt = "2.1.0"
-wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.18.0", default-features = false }
+wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.18.1", default-features = false }
 nats = "0.8.6"
 structopt = "0.3.21"
 nkeys = "0.1.0"

--- a/crates/wasmcloud-host/Cargo.toml
+++ b/crates/wasmcloud-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/samples/bencher/Cargo.toml
+++ b/samples/bencher/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasmcloud-host = { path = "../../crates/wasmcloud-host", version="0.18.0" }
+wasmcloud-host = { path = "../../crates/wasmcloud-host", version="0.18.1" }
 actix-rt = "2.1.0"
 wasmcloud-actor-core = "0.2.0"
 wasmcloud-actor-http-server = "0.1.0"


### PR DESCRIPTION
With the latest patch from @matthewtgilbride, I wanted to bump the wasmcloud-host version a patch version so that developers on the M1 chip can use our crate + binary with the `wasmtime` provider.