### PR TITLE
Lattice control events receiver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ nkeys = "0.1.0"
 ctor = "0.1.16"
 futures = "0.3.6"
 nats = "0.8.6"
+crossbeam-channel = "0.5.1"
 provider-archive = "0.4.0"
 redis = "0.19.0"
 reqwest = { version = "0.11", features = ["json"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ log = "0.4.11"
 env_logger = "0.8.2"
 anyhow = "1.0.34"
 actix-rt = "2.1.0"
-wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.18.0", default-features = false }
+wasmcloud-host = { path = "crates/wasmcloud-host", version = "0.18.1", default-features = false }
 nats = "0.8.6"
 structopt = "0.3.21"
 nkeys = "0.1.0"
@@ -54,7 +54,7 @@ nkeys = "0.1.0"
 [dev-dependencies]
 ctor = "0.1.16"
 futures = "0.3.6"
-nats = "0.8.5"
+nats = "0.8.6"
 provider-archive = "0.4.0"
 redis = "0.19.0"
 reqwest = { version = "0.11", features = ["json"]}
@@ -66,7 +66,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 wascap = "0.6.0"
 wasmcloud-actor-extras = "0.1.1"
 wasmcloud-actor-http-server = "0.1.1"
-wasmcloud-control-interface = { path = "crates/wasmcloud-control-interface", version = "0.3.0" }
+wasmcloud-control-interface = { path = "crates/wasmcloud-control-interface", version = "0.3.1" }
 
 [workspace]
 members = [

--- a/crates/wasmcloud-control-interface/Cargo.toml
+++ b/crates/wasmcloud-control-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -17,8 +17,10 @@ categories = ["wasm", "api-bindings"]
 [dependencies]
 actix-rt = "2.1.0"
 data-encoding = "2.3.1"
+chrono = "0.4.19"
 futures = "0.3.8"
 log = "0.4.14"
+crossbeam-channel = "0.5.1"
 nats = "0.8.6"
 ring = "0.16.19"
 rmp-serde = "0.15.0"

--- a/crates/wasmcloud-control-interface/src/events.rs
+++ b/crates/wasmcloud-control-interface/src/events.rs
@@ -3,22 +3,27 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
-#[doc(hidden)]
+/// Contains metadata about a control event
 pub struct EventHeader {
+    /// Origin host id
     pub host_origin: String,
+    /// Timestamp in UTC seconds since the epoch
     pub timestamp: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[doc(hidden)]
+/// A published control event including the event itself and
+/// additional metadata
 pub struct PublishedEvent {
+    /// Event object
     pub event: ControlEvent,
+    /// Event metadata
     pub header: EventHeader,
 }
+
 /// Represents an event that may occur on the lattice control plane. All timestamps
 /// are to be considered as Unix timestamps in UTC in seconds since the epoch.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[doc(hidden)]
 pub enum ControlEvent {
     HostStarted,
     HostStopped,
@@ -71,6 +76,7 @@ pub enum TerminationReason {
 }
 
 impl ControlEvent {
+    /// Converts a control event into a published event with additional metadata
     pub fn into_published(self, origin: &str) -> PublishedEvent {
         let header = EventHeader {
             host_origin: origin.to_string(),

--- a/crates/wasmcloud-control-interface/src/lib.rs
+++ b/crates/wasmcloud-control-interface/src/lib.rs
@@ -1,11 +1,16 @@
 pub mod broker;
+pub mod events;
 mod generated;
 mod inv;
 mod sub_stream;
 
+use crate::events::PublishedEvent;
 pub use crate::generated::ctliface::*;
+use crossbeam_channel::{unbounded, Receiver};
+use futures::stream::StreamExt;
 use inv::Entity;
 pub use inv::{Invocation, InvocationResponse};
+use nats::asynk::Connection;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, time::Duration};
 use sub_stream::SubscriptionStream;
@@ -13,8 +18,9 @@ use wascap::prelude::KeyPair;
 
 type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error + Send + Sync>>;
 
+/// Lattice control interface client
 pub struct Client {
-    nc: nats::asynk::Connection,
+    nc: Connection,
     nsprefix: Option<String>,
     timeout: Duration,
     key: KeyPair,
@@ -22,7 +28,7 @@ pub struct Client {
 
 impl Client {
     /// Creates a new lattice control interface client
-    pub fn new(nc: nats::asynk::Connection, nsprefix: Option<String>, timeout: Duration) -> Self {
+    pub fn new(nc: Connection, nsprefix: Option<String>, timeout: Duration) -> Self {
         Client {
             nc,
             nsprefix,
@@ -30,7 +36,6 @@ impl Client {
             key: KeyPair::new_server(),
         }
     }
-
     /// Queries the lattice for all responsive hosts, waiting for the full period specified by _timeout_.
     pub async fn get_hosts(&self, timeout: Duration) -> Result<Vec<Host>> {
         let subject = broker::queries::hosts(&self.nsprefix);
@@ -204,7 +209,7 @@ impl Client {
     /// occurs **before** the new bytes are downloaded. Live-updating an actor can take a long
     /// time and control clients cannot block waiting for a reply that could come several seconds
     /// later. If you need to verify that the actor has been updated, you will want to set up a
-    /// listener for the appropriate **ControlEvent** which will be published on the control events
+    /// listener for the appropriate **PublishedEvent** which will be published on the control events
     /// channel in JSON
     pub async fn update_actor(
         &self,
@@ -311,6 +316,79 @@ impl Client {
             }
             Err(e) => Err(format!("Did not receive claims from lattice: {}", e).into()),
         }
+    }
+
+    /// Returns the receiver end of a channel that subscribes to the lattice control event stream.
+    /// Any [`PublishedEvent`](struct@PublishedEvent)s that are published after this channel is created
+    /// will be added to the receiver channel's buffer, which can be observed or handled if needed.
+    /// See the example for how you could use this receiver to handle events.
+    ///
+    /// # Example
+    /// ```rust
+    /// use wasmcloud_control_interface::Client;
+    /// async {
+    ///   let nc = nats::asynk::connect("0.0.0.0:4222").await.unwrap();
+    ///   let client = Client::new(nc, None, std::time::Duration::from_millis(1000)).await;
+    ///   let receiver = client.events_receiver().await.unwrap();
+    ///   std::thread::spawn(move || loop {
+    ///     if let Ok(evt) = receiver.recv() {
+    ///       println!("Event received: {:?}", evt);
+    ///     } else {
+    ///       // channel is closed
+    ///       break;
+    ///     }
+    ///   });
+    ///   // perform other operations on client
+    ///   client.get_host_inventory("NAEXHW...").await.unwrap();
+    /// };
+    /// ```
+    pub async fn events_receiver(&self) -> Result<Receiver<PublishedEvent>> {
+        self.subscribe_to_event_stream().await
+    }
+
+    /// Returns an iterator of [`PublishedEvent`](struct@PublishedEvent)s that are published to the lattice
+    /// control stream after this function is called. The iterator's `next()` operation will block waiting for
+    /// future events. See the example for how this can be used to handle events.
+    ///
+    /// # Example
+    /// ```rust
+    /// use wasmcloud_control_interface::Client;
+    /// async {
+    ///   let nc = nats::asynk::connect("0.0.0.0:4222").await.unwrap();
+    ///   let client = Client::new(nc, None, std::time::Duration::from_millis(1000)).await;
+    ///   let mut iter = client.events_iter().await.unwrap();
+    ///   std::thread::spawn(move || {
+    ///     while let Some(evt) = iter.next() {
+    ///       println!("Event received: {:?}", evt);
+    ///     }
+    ///     // channel is closed
+    ///   });
+    ///   // perform other operations on client
+    ///   client.get_host_inventory("NAEXHW...").await.unwrap();
+    /// };
+    /// ```
+    pub async fn events_iter(&self) -> Result<crossbeam_channel::IntoIter<PublishedEvent>> {
+        Ok(self.events_receiver().await?.into_iter())
+    }
+
+    /// Subscribes to the lattice control event stream
+    async fn subscribe_to_event_stream(&self) -> Result<Receiver<PublishedEvent>> {
+        let (sender, receiver) = unbounded();
+        let mut sub = self
+            .nc
+            .subscribe(&broker::control_event(&self.nsprefix))
+            .await?;
+        std::thread::spawn(|| async move {
+            loop {
+                if let Some(msg) = &mut sub.next().await {
+                    match deserialize::<PublishedEvent>(&msg.data) {
+                        Ok(evt) => sender.send(evt).unwrap(),
+                        _ => (),
+                    }
+                }
+            }
+        });
+        Ok(receiver)
     }
 }
 

--- a/crates/wasmcloud-control-interface/src/sub_stream.rs
+++ b/crates/wasmcloud-control-interface/src/sub_stream.rs
@@ -2,8 +2,10 @@
 //!
 
 use crate::deserialize;
-use futures::StreamExt;
+pub use crate::events::ControlEvent;
+use futures::stream::StreamExt;
 use log::error;
+use nats::asynk::Subscription;
 use serde::de::DeserializeOwned;
 use std::time::{Duration, Instant};
 
@@ -23,12 +25,12 @@ pub enum SubscriptionNextResult<T: serde::de::DeserializeOwned> {
 /// Stream wrapper for nats subscription
 #[doc(hidden)]
 pub struct SubscriptionStream {
-    sub: nats::asynk::Subscription,
+    sub: Subscription,
 }
 
 impl SubscriptionStream {
     /// Construct stream wrapper for nats async subscription
-    pub fn new(sub: nats::asynk::Subscription) -> SubscriptionStream {
+    pub fn new(sub: Subscription) -> SubscriptionStream {
         SubscriptionStream { sub }
     }
 

--- a/crates/wasmcloud-host/Cargo.toml
+++ b/crates/wasmcloud-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -44,7 +44,7 @@ wapc = "0.10.1"
 wascap = "0.6.0"
 serde_bytes = "0.11.5"
 wasmcloud-actor-keyvalue = "0.2.0"
-wasmcloud-control-interface = { path = "../wasmcloud-control-interface", version = "0.3.0" }
+wasmcloud-control-interface = { path = "../wasmcloud-control-interface", version = "0.3.1" }
 
 wasm3-provider = { version = "0.0.2", optional = true}
 wasmtime-provider = { version = "0.0.3" , optional = true}

--- a/crates/wasmcloud-host/src/actors/actor_host.rs
+++ b/crates/wasmcloud-host/src/actors/actor_host.rs
@@ -12,13 +12,14 @@ use crate::hlreg::HostLocalSystemService;
 use crate::host_controller::{HostController, PutOciReference};
 use crate::messagebus::{AdvertiseClaims, MessageBus, Subscribe};
 use crate::middleware::{run_actor_post_invoke, run_actor_pre_invoke, Middleware};
-use crate::{ControlEvent, Result};
+use crate::Result;
 use actix::prelude::*;
 use futures::executor::block_on;
 use log::info;
 use wapc::WapcHost;
 use wascap::jwt::TokenValidation;
 use wascap::prelude::{Claims, KeyPair};
+use wasmcloud_control_interface::events::ControlEvent;
 
 #[derive(Default)]
 pub(crate) struct ActorHost {

--- a/crates/wasmcloud-host/src/capability/native_host.rs
+++ b/crates/wasmcloud-host/src/capability/native_host.rs
@@ -7,11 +7,12 @@ use crate::dispatch::{Invocation, InvocationResponse, ProviderDispatcher, WasmCl
 use crate::hlreg::HostLocalSystemService;
 use crate::messagebus::{EnforceLocalProviderLinks, MessageBus, Subscribe};
 use crate::middleware::{run_capability_post_invoke, run_capability_pre_invoke, Middleware};
-use crate::{ControlEvent, Result};
+use crate::Result;
 use actix::prelude::*;
 use futures::executor::block_on;
 use libloading::{Library, Symbol};
 use wascap::prelude::KeyPair;
+use wasmcloud_control_interface::events::ControlEvent;
 use wasmcloud_provider_core::capabilities::CapabilityProvider;
 
 #[derive(Message)]

--- a/crates/wasmcloud-host/src/control_interface/ctlactor.rs
+++ b/crates/wasmcloud-host/src/control_interface/ctlactor.rs
@@ -1,9 +1,9 @@
 use crate::hlreg::HostLocalSystemService;
 use crate::messagebus::{NatsMessage, NatsSubscriber};
-use crate::ControlEvent;
 use actix::prelude::*;
 use std::collections::HashMap;
 use wascap::prelude::KeyPair;
+use wasmcloud_control_interface::events::ControlEvent;
 
 #[derive(Default)]
 pub struct ControlInterface {

--- a/crates/wasmcloud-host/src/control_interface/mod.rs
+++ b/crates/wasmcloud-host/src/control_interface/mod.rs
@@ -1,3 +1,2 @@
 pub(crate) mod ctlactor;
-pub mod events;
 mod handlers;

--- a/crates/wasmcloud-host/src/host.rs
+++ b/crates/wasmcloud-host/src/host.rs
@@ -22,12 +22,13 @@ use crate::host_controller::{
 };
 use crate::messagebus::{QueryActors, QueryProviders};
 use crate::oci::fetch_oci_bytes;
-use crate::{ControlEvent, HostManifest, NativeCapability, WasmCloudEntity};
+use crate::{HostManifest, NativeCapability, WasmCloudEntity};
 use crate::{Result, SYSTEM_ACTOR};
 use provider_archive::ProviderArchive;
 use std::time::Duration;
 use std::{collections::HashMap, sync::RwLock};
 use wascap::prelude::{Claims, KeyPair};
+use wasmcloud_control_interface::events::ControlEvent;
 
 /// A host builder provides a convenient, fluid syntax for setting initial configuration
 /// and tuning parameters for a wasmCloud host

--- a/crates/wasmcloud-host/src/host_controller/hc_actor.rs
+++ b/crates/wasmcloud-host/src/host_controller/hc_actor.rs
@@ -1,21 +1,21 @@
 use super::*;
 use crate::capability::extras::ExtrasCapabilityProvider;
 use crate::capability::native_host::NativeCapabilityHost;
+use crate::control_interface::ctlactor::{ControlInterface, PublishEvent};
 use crate::dispatch::Invocation;
 use crate::hlreg::HostLocalSystemService;
+use crate::messagebus::latticecache_client::{CACHE_CONTRACT_ID, CACHE_PROVIDER_LINK_NAME};
+use crate::messagebus::utils::{generate_link_invocation_and_call, system_actor_claims};
 use crate::messagebus::{GetClaims, LatticeCacheClient, MessageBus, SetCacheClient, Unsubscribe};
 use crate::middleware::Middleware;
 use crate::{actors::ActorHost, capability::native_host::GetIdentity};
 use crate::{auth::Authorizer, capability::native_host::IdentityResponse};
 use crate::{NativeCapability, Result, WasmCloudEntity, SYSTEM_ACTOR};
 use std::collections::HashMap;
-
 use std::time::Instant;
-
-use crate::messagebus::latticecache_client::{CACHE_CONTRACT_ID, CACHE_PROVIDER_LINK_NAME};
-use crate::messagebus::utils::{generate_link_invocation_and_call, system_actor_claims};
 use wascap::jwt::Claims;
 use wascap::prelude::KeyPair;
+use wasmcloud_control_interface::events::ControlEvent;
 use wasmcloud_nats_kvcache::NatsReplicatedKVProvider;
 
 #[derive(Debug, PartialEq, Clone, Eq, Hash)]
@@ -327,6 +327,7 @@ impl Handler<StopActor> for HostController {
         trace!("Stopping actor {} per request.", msg.actor_ref);
         let lc = self.latticecache.clone().unwrap();
         let b = MessageBus::from_hostlocal_registry(&self.kp.as_ref().unwrap().public_key());
+        let cp = ControlInterface::from_hostlocal_registry(&self.kp.as_ref().unwrap().public_key());
         Box::pin(
             async move {
                 if let Some(pk) = lc.lookup_oci_mapping(&msg.actor_ref).await.unwrap_or(None) {
@@ -341,6 +342,11 @@ impl Handler<StopActor> for HostController {
                     interest: WasmCloudEntity::Actor(pk.to_string()),
                 });
                 act.actors.remove(&pk);
+                let _ = cp.do_send(PublishEvent {
+                    event: ControlEvent::ActorStopped {
+                        actor: pk.to_string(),
+                    },
+                });
             }),
         )
     }

--- a/crates/wasmcloud-host/src/lib.rs
+++ b/crates/wasmcloud-host/src/lib.rs
@@ -137,7 +137,6 @@ mod oci;
 #[macro_use]
 extern crate log;
 
-pub use crate::control_interface::events::{ControlEvent, EventHeader, PublishedEvent};
 pub use actors::WasmCloudActor;
 pub use auth::{Authorizer, CloneAuthorizer};
 pub use capability::native::NativeCapability;

--- a/crates/wasmcloud-host/src/messagebus/hb.rs
+++ b/crates/wasmcloud-host/src/messagebus/hb.rs
@@ -1,15 +1,15 @@
 use super::MessageBus;
 use crate::control_interface::ctlactor::{ControlInterface, PublishEvent};
-use crate::control_interface::events::RunState;
 use crate::generated::core::{deserialize, serialize, HealthRequest, HealthResponse};
 use crate::hlreg::HostLocalSystemService;
 use crate::messagebus::handlers::OP_HEALTH_REQUEST;
 use crate::Result;
-use crate::{ControlEvent, Invocation, WasmCloudEntity, SYSTEM_ACTOR};
+use crate::{Invocation, WasmCloudEntity, SYSTEM_ACTOR};
 use actix::prelude::*;
 use std::collections::HashMap;
 use std::time::Duration;
 use wascap::prelude::KeyPair;
+use wasmcloud_control_interface::events::{ControlEvent, RunState};
 
 const HEARTBEAT_INTERVAL_ENV_VAR: &str = "HEARTBEAT_INTERVAL_S";
 const DEFAULT_HEARTBEAT_INTERVAL: u16 = 30;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -8,6 +8,8 @@ use wasmcloud_host::{Actor, Host, HostBuilder, NativeCapability, Result};
 pub const REDIS_OCI: &str = "wasmcloud.azurecr.io/redis:0.11.2";
 pub const HTTPSRV_OCI: &str = "wasmcloud.azurecr.io/httpserver:0.12.1";
 pub const KVCOUNTER_OCI: &str = "wasmcloud.azurecr.io/kvcounter:0.2.0";
+pub const ECHO_PKEY: &str = "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5";
+pub const ECHO_OCI: &str = "wasmcloud.azurecr.io/echo:0.2.1";
 #[cfg(test)]
 pub const NATS_OCI: &str = "wasmcloud.azurecr.io/nats:0.10.3";
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -180,6 +180,15 @@ async fn control_calltest() {
 }
 
 #[actix_rt::test]
+async fn monitor_event_stream() {
+    let res = control::monitor_event_stream().await;
+    if let Err(ref e) = res {
+        println!("{}", e);
+    }
+    assert!(res.is_ok());
+}
+
+#[actix_rt::test]
 async fn cant_use_unstarted_host() {
     let res = no_lattice::cant_use_unstarted_host().await;
     if let Err(ref e) = res {


### PR DESCRIPTION
Fixes #140 

This PR adds the method `events_receiver` for `wasmcloud_control_interface`. This method returns an unbounded crossbeam_channel receiver, which can be used to receive `PublishedEvent`s, containing the control event objects for events like `ActorStarted`, `HostStarted`, `ActorStopped`, etc.

I've also included a doctest to show a possible way to handle events, and an integration test to show it in practice. It's important that you don't block the control interface thread waiting for events, so I've shown an `async` and a `thread::spawn` way to avoid that.

This PR also moves the events.rs from the wasmcloud-host control interface module to the control interface. This might technically break the `wasmcloud_host` API, but I don't believe there was a reason to use those events until now.