### PR TITLE
Commit cargo lock to main repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "actix-rt",
  "anyhow",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-host"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "actix",
  "actix-rt",


### PR DESCRIPTION
Same deal as https://github.com/wasmCloud/wash/pull/128 here, apparently the Cargo.lock was committed in a different PR so the file is dirty when `cargo publish` would run (I tested with `--dry-run` before this time :P)