### PR TITLE
Update cargo lock, ensure git recognizes it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3367,6 +3367,7 @@ version = "0.18.1"
 dependencies = [
  "actix-rt",
  "anyhow",
+ "crossbeam-channel",
  "ctor",
  "env_logger 0.8.3",
  "futures",
@@ -3470,9 +3471,11 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "actix-rt",
+ "chrono",
+ "crossbeam-channel",
  "data-encoding",
  "futures",
  "log",


### PR DESCRIPTION
With just a simple `cargo build`, `Cargo.lock` updates to the point where `cargo publish` will succeed. I assume that this was due to an outstanding pull request that didn't yet pull in the changes to the `.gitignore`, so no changes have been made.