### PR TITLE
Move provider-archive under crates/ directory

### DIFF
--- a/.github/workflows/provider-archive.yml
+++ b/.github/workflows/provider-archive.yml
@@ -1,0 +1,39 @@
+name: PROVIDER-ARCHIVE
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "crates/provider-archive/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "crates/provider-archive/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./crates/provider-archive
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/provider-archive_release.yml
+++ b/.github/workflows/provider-archive_release.yml
@@ -1,0 +1,62 @@
+name: PROVIDER-ARCHIVE_RELEASE
+
+on:
+  push:
+    tags:
+      - 'provider-archive-v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./crates/provider-archive
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}
+
+  release:
+    depends-on: [cargo_check, clippy_check]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ target/
 *.creds
 *.jwt
 *.nk
+
+# Ignore par and parJEEzy files
+*.par
+*.par.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,6 +2048,17 @@ dependencies = [
 [[package]]
 name = "provider-archive"
 version = "0.4.0"
+dependencies = [
+ "data-encoding",
+ "flate2",
+ "ring",
+ "tar",
+ "wascap",
+]
+
+[[package]]
+name = "provider-archive"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c05c0a204e6cc14b5a4a585ab20fa15ab757de28b833dd32750a65cd2749ebd"
 dependencies = [
@@ -3374,7 +3385,7 @@ dependencies = [
  "log",
  "nats 0.8.6",
  "nkeys 0.1.0",
- "provider-archive",
+ "provider-archive 0.4.0",
  "redis",
  "reqwest",
  "rmp-serde",
@@ -3506,7 +3517,7 @@ dependencies = [
  "oci-distribution",
  "once_cell",
  "parking_lot",
- "provider-archive",
+ "provider-archive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.3",
  "reqwest",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ ctor = "0.1.16"
 futures = "0.3.6"
 nats = "0.8.6"
 crossbeam-channel = "0.5.1"
-provider-archive = "0.4.0"
+provider-archive = { path = "crates/provider-archive", version = "0.4.0" }
 redis = "0.19.0"
 reqwest = { version = "0.11", features = ["json"]}
 rmp-serde = "0.15.4"
@@ -75,6 +75,7 @@ members = [
     "crates/wasmcloud-host",
     "crates/wasmcloud-control-interface",
     "crates/auth-nats-account",
+    "crates/provider-archive",
     "samples/bench-actor",
     "samples/bencher",
 ]

--- a/crates/provider-archive/Cargo.toml
+++ b/crates/provider-archive/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "provider-archive"
+version = "0.4.0"
+authors = ["wasmCloud Team"]
+edition = "2018"
+description = "Library for reading and writing wasmCloud capability provider archive files"
+license = "Apache-2.0"
+homepage = "https://github.com/wasmcloud/provider-archive"
+documentation = "https://docs.rs/provider-archive"
+readme = "README.md"
+keywords = ["jwt", "zip", "archive", "security", "wasmcloud"]
+categories = ["cryptography", "authentication", "wasm"]
+
+[dependencies]
+wascap = "0.6.0"
+data-encoding = "2.3.1"
+ring = "0.16"
+tar = "0.4.30"
+flate2 = "1.0.19"

--- a/crates/provider-archive/README.md
+++ b/crates/provider-archive/README.md
@@ -1,0 +1,60 @@
+![Rust build](https://github.com/wascc/provider-archive/workflows/Rust/badge.svg)
+[![crates.io](https://img.shields.io/crates/v/provider-archive.svg)](https://crates.io/crates/provider-archive)
+![license](https://img.shields.io/crates/l/provider-archive.svg)&nbsp;
+[![documentation](https://docs.rs/provider-archive/badge.svg)](https://docs.rs/provider-archive)
+
+# Provider Archive
+Until the [WASI](https://wasi.dev) specification includes robust networking support _and_ the available WebAssembly tooling (**wasm3** , **wasmtime**, etc) supports this WASI specification, _and_ the Rust compiler is able to generate the right set of WASI imports when compiling "regular" socket code ... our support for portable capability providers will be limited.
+
+In the absence of useful portable capability providers, we need the ability to store, retrieve, and schedule _native_ capability providers. A native capability provider is an FFI plugin stored in a binary file that is specific to a particular CPU architecture and Operating System. The issue with these binary files (_shared object_ files on linux) is that we cannot embed secure claims JWTs in these like we can in WebAssembly files. With actors, we use these signed tokens to get a verifiable, globally unique public key (identity) as well as a hash of the associated file to verify that the file has not been tampered with since being signed.
+
+To give us the ability to store, retrieve, schedule, and _sign_ capability providers, we need a **Provider Archive** (PAR). This is a simple TAR file that contains a signed JWT, as well as a binary file for each of the supported OS/CPU combinations.
+
+## Provider Archive File Format
+Each provider archive file contains a root `claims.jwt` file that holds a signed set of claims (see appendix). Also in the root directory of the archive are binary files containing the bytes of the native capability provider plugin with a filename of the format `[arch]-[os].bin`.
+
+The following is an example of the contents of a provider archive file:
+
+```
++ provider_archive.tar
+|
++---- claims.jwt
+|
+|---- x86_64-linux.bin
+|---- aarch64-linux.bin
+|---- x86_64-macos.bin
+`---- aarch64-ios.bin
+```
+
+Until we gain the ability to create network-capable WASI modules that can support robust capability provider functionality (like DB clients, web servers, raw TCP or UDP control, etc), Gantry will be storing and retrieving **par** files for each capability provider.
+
+## Appendix A - Architecture values
+The following is a list of some of the possible architectures (_NOTE_ not all of these architectures may be supported by the waSCC host):
+
+* x86
+* x86_64
+* arm
+* aarch64
+* mips
+* mips64
+
+## Appendix B - Operating System Values
+The following is a list of some of the possible operating systems (_NOTE_ not all of these operating systems may be supported by the waSCC host):
+
+* linux
+* macos
+* ios
+* freebsd
+* android
+* windows
+
+## Appendix C - JSON Web Token Claims
+The following is a list of the custom claims that will appear in the `wascap` section beneath the standard JWT fields. This is the same nesting style used by actor claims when embedded into a WebAssembly file:
+
+* `hashes` - This is a map where the key is an `[arch]-[os]` string and the value is the hash for that particular file. Having these hashes inside the signed token means we can verify that the plugin binaries have not been tampered with.
+* `name` - Friendly name of the capability provider.
+* `vendor` - A vendor string helping to identify the provider (e.g. `Redis` or `Cassandra` or `PostgreSQL` etc). This is an information-only field and is not used as any kind of key or unique identifier.
+* `capid` - The capability contract ID (e.g. `wascc:messaging` or `wascc:keyvalue`, etc). Note that the plugin itself is required to expose this information to the runtime when it receives the "query descriptor" message. This value is to allow processes other than the waSCC runtime (e.g. Gantry) to interrogate the core metadata.
+* `version` - Friendly version string
+* `revision` - A monotonically increasing revision value. This value will be used to retrieve / store version-specific files.
+

--- a/crates/provider-archive/src/archive.rs
+++ b/crates/provider-archive/src/archive.rs
@@ -1,0 +1,630 @@
+use crate::Result;
+use data_encoding::HEXUPPER;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use ring::digest::{Context, Digest, SHA256};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::{copy, Cursor, Read};
+use std::path::PathBuf;
+use wascap::jwt::{CapabilityProvider, Claims};
+use wascap::prelude::KeyPair;
+
+const CLAIMS_JWT_FILE: &str = "claims.jwt";
+
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+
+/// A provider archive is a specialized ZIP file that contains a set of embedded and signed claims
+/// (a .JWT file) as well as a list of binary files, one plugin library for each supported
+/// target architecture and OS combination
+pub struct ProviderArchive {
+    libraries: HashMap<String, Vec<u8>>,
+    capid: String,
+    name: String,
+    vendor: String,
+    rev: Option<i32>,
+    ver: Option<String>,
+    claims: Option<Claims<CapabilityProvider>>,
+}
+
+impl ProviderArchive {
+    /// Creates a new provider archive in memory, to which native library files can be added.
+    pub fn new(
+        capid: &str,
+        name: &str,
+        vendor: &str,
+        rev: Option<i32>,
+        ver: Option<String>,
+    ) -> ProviderArchive {
+        ProviderArchive {
+            libraries: HashMap::new(),
+            capid: capid.to_string(),
+            name: name.to_string(),
+            vendor: vendor.to_string(),
+            rev,
+            ver,
+            claims: None,
+        }
+    }
+
+    /// Adds a native library file (.so, .dylib, .dll) to the archive for a given target string
+    pub fn add_library(&mut self, target: &str, input: &[u8]) -> Result<()> {
+        self.libraries.insert(target.to_string(), input.to_vec());
+
+        Ok(())
+    }
+
+    /// Gets the list of architecture/OS targets within the archive
+    pub fn targets(&self) -> Vec<String> {
+        self.libraries.keys().cloned().collect()
+    }
+
+    /// Retrieves the raw bytes for a given target
+    pub fn target_bytes(&self, target: &str) -> Option<Vec<u8>> {
+        self.libraries.get(target).cloned()
+    }
+
+    /// Returns the embedded claims associated with this archive. Note that claims are not available
+    /// while building a new archive. They are only available after the archive has been written
+    /// or if the archive was loaded from an existing file
+    pub fn claims(&self) -> Option<Claims<CapabilityProvider>> {
+        self.claims.clone()
+    }
+
+    /// Attempts to read a Provider Archive (PAR) file's bytes to analyze and verify its contents. The embedded claims
+    /// in this archive will be validated, and the file hashes contained in those claims will be compared and
+    /// verified against hashes computed at load time. This prevents the contents of the archive from being modified
+    /// without the embedded claims being re-signed
+    pub fn try_load(input: &[u8]) -> Result<ProviderArchive> {
+        let mut libraries = HashMap::new();
+
+        if input.len() < 2 {
+            return Err("Not enough bytes to be a valid PAR file".into());
+        }
+
+        let mut par = tar::Archive::new(if input[0..2] == GZIP_MAGIC {
+            Box::new(GzDecoder::new(input)) as Box<dyn Read>
+        } else {
+            Box::new(Cursor::new(input)) as Box<dyn Read>
+        });
+
+        let mut c: Option<Claims<CapabilityProvider>> = None;
+
+        let entries = par.entries()?;
+
+        for f in entries {
+            let mut file = f.unwrap();
+            let mut bytes = Vec::new();
+            copy(&mut file, &mut bytes)?;
+            let target = PathBuf::from(file.path()?)
+                .file_stem()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string();
+            if target == "claims" {
+                c = Some(Claims::<CapabilityProvider>::decode(&std::str::from_utf8(
+                    &bytes,
+                )?)?);
+            } else {
+                libraries.insert(target.to_string(), bytes.to_vec());
+            }
+        }
+
+        if c == None || libraries.len() < 1 {
+            // we need at least claims.jwt and one plugin binary
+            libraries.clear();
+            return Err(
+                "Not enough files found in provider archive. Is this a complete archive?".into(),
+            );
+        }
+
+        if let Some(ref cl) = c {
+            let metadata = cl.metadata.as_ref().unwrap();
+            let name = cl.name();
+            let capid = metadata.capid.to_string();
+            let vendor = metadata.vendor.to_string();
+            let rev = metadata.rev;
+            let ver = metadata.ver.clone();
+
+            validate_hashes(&libraries, c.as_ref().unwrap())?;
+
+            Ok(ProviderArchive {
+                libraries,
+                capid,
+                name,
+                vendor,
+                rev,
+                ver,
+                claims: c,
+            })
+        } else {
+            Err("No claims found embedded in provider archive.".into())
+        }
+    }
+
+    /// Generates a Provider Archive (PAR) file with all of the library files and a signed set of claims in an embedded JWT
+    pub fn write(
+        &mut self,
+        destination: &str,
+        issuer: &KeyPair,
+        subject: &KeyPair,
+        compress_par: bool,
+    ) -> Result<()> {
+        let file = File::create(if compress_par && !destination.ends_with(".gz") {
+            format!("{}.gz", destination)
+        } else {
+            destination.to_string()
+        })?;
+
+        let mut par = tar::Builder::new(if compress_par {
+            Box::new(GzEncoder::new(file, Compression::best())) as Box<dyn Write>
+        } else {
+            Box::new(file) as Box<dyn Write>
+        });
+
+        let claims = Claims::<CapabilityProvider>::new(
+            self.name.to_string(),
+            issuer.public_key(),
+            subject.public_key(),
+            self.capid.to_string(),
+            self.vendor.to_string(),
+            self.rev.clone(),
+            self.ver.clone(),
+            generate_hashes(&self.libraries),
+        );
+        self.claims = Some(claims.clone());
+
+        let claims_file = claims.encode(&issuer)?;
+
+        let mut header = tar::Header::new_gnu();
+        header.set_path(CLAIMS_JWT_FILE)?;
+        header.set_size(claims_file.as_bytes().len() as u64);
+        header.set_cksum();
+        par.append_data(&mut header, CLAIMS_JWT_FILE, Cursor::new(claims_file))?;
+
+        for (tgt, lib) in self.libraries.iter() {
+            let mut header = tar::Header::new_gnu();
+            let path = format!("{}.bin", tgt);
+            header.set_path(path.to_string())?;
+            header.set_size(lib.len() as u64);
+            header.set_cksum();
+            par.append_data(&mut header, path.to_string(), Cursor::new(lib))?;
+        }
+
+        // Completes the process of packing a .par archive
+        par.into_inner()?;
+
+        Ok(())
+    }
+}
+
+fn validate_hashes(
+    libraries: &HashMap<String, Vec<u8>>,
+    claims: &Claims<CapabilityProvider>,
+) -> Result<()> {
+    let file_hashes = claims.metadata.as_ref().unwrap().target_hashes.clone();
+
+    for (tgt, library) in libraries.iter() {
+        let file_hash = file_hashes.get(tgt).cloned().unwrap();
+        let check_hash = hash_bytes(&library);
+        if file_hash != check_hash {
+            return Err(format!("File hash and verify hash do not match for '{}'", tgt).into());
+        }
+    }
+    Ok(())
+}
+
+fn generate_hashes(libraries: &HashMap<String, Vec<u8>>) -> HashMap<String, String> {
+    let mut hm = HashMap::new();
+    for (target, lib) in libraries.iter() {
+        let hash = hash_bytes(lib);
+        hm.insert(target.to_string(), hash);
+    }
+
+    hm
+}
+
+fn hash_bytes(bytes: &[u8]) -> String {
+    let digest = sha256_digest(bytes).unwrap();
+    HEXUPPER.encode(digest.as_ref())
+}
+
+fn sha256_digest<R: Read>(mut reader: R) -> Result<Digest> {
+    let mut context = Context::new(&SHA256);
+    let mut buffer = [0; 1024];
+
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        context.update(&buffer[..count]);
+    }
+
+    Ok(context.finish())
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ProviderArchive;
+    use crate::Result;
+    use flate2::read::GzDecoder;
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::fs::File;
+    use std::io::prelude::*;
+    use std::io::Read;
+    use wascap::prelude::KeyPair;
+
+    fn compress(par: &[u8]) -> Result<Vec<u8>> {
+        let mut e = GzEncoder::new(Vec::new(), Compression::best());
+        e.write_all(par).unwrap();
+        e.finish().map_err(|e| e.into())
+    }
+
+    fn decompress(par: &[u8]) -> Result<Vec<u8>> {
+        let mut d = GzDecoder::new(par);
+        let mut buf = Vec::new();
+        d.read_to_end(&mut buf)?;
+
+        Ok(buf)
+    }
+
+    #[test]
+    fn write_par() -> Result<()> {
+        let mut arch = ProviderArchive::new(
+            "wascc:testing",
+            "Testing",
+            "waSCC",
+            Some(1),
+            Some("0.0.1".to_string()),
+        );
+        arch.add_library("aarch64-linux", b"blahblah")?;
+
+        let issuer = KeyPair::new_account();
+        let subject = KeyPair::new_service();
+
+        arch.write("./writetest.par", &issuer, &subject, false)?;
+
+        let _ = std::fs::remove_file("./writetest.par");
+        Ok(())
+    }
+
+    #[test]
+    fn error_on_no_providers() -> Result<()> {
+        let mut arch = ProviderArchive::new(
+            "wascc:testing",
+            "Testing",
+            "waSCC",
+            Some(2),
+            Some("0.0.2".to_string()),
+        );
+
+        let issuer = KeyPair::new_account();
+        let subject = KeyPair::new_service();
+
+        arch.write("./shoulderr.par", &issuer, &subject, false)?;
+
+        let mut buf2 = Vec::new();
+        let mut f2 = File::open("./shoulderr.par")?;
+        f2.read_to_end(&mut buf2)?;
+
+        let arch2 = ProviderArchive::try_load(&buf2);
+
+        match arch2 {
+            Ok(_notok) => panic!("Loading an archive without any libraries should fail"),
+            Err(_e) => (),
+        }
+
+        let _ = std::fs::remove_file("./shoulderr.par");
+        Ok(())
+    }
+
+    #[test]
+    fn round_trip() -> Result<()> {
+        // Build an archive in memory the way a CLI wrapper might...
+        let mut arch = ProviderArchive::new(
+            "wascc:testing",
+            "Testing",
+            "waSCC",
+            Some(3),
+            Some("0.0.3".to_string()),
+        );
+        arch.add_library("aarch64-linux", b"blahblah")?;
+        arch.add_library("x86_64-linux", b"bloobloo")?;
+        arch.add_library("x86_64-macos", b"blarblar")?;
+
+        let issuer = KeyPair::new_account();
+        let subject = KeyPair::new_service();
+
+        // Generate the .par file with embedded claims.jwt file (needs a service and an account key)
+        arch.write("./firstarchive.par", &issuer, &subject, false)?;
+
+        let mut buf2 = Vec::new();
+        let mut f2 = File::open("./firstarchive.par")?;
+        f2.read_to_end(&mut buf2)?;
+
+        // Make sure the file we wrote can be read back in with no data loss
+        let mut arch2 = ProviderArchive::try_load(&buf2)?;
+        assert_eq!(arch.capid, arch2.capid);
+        assert_eq!(
+            arch.libraries[&"aarch64-linux".to_string()],
+            arch2.libraries[&"aarch64-linux".to_string()]
+        );
+        assert_eq!(arch.claims().unwrap().subject, subject.public_key());
+
+        // Another common task - read an existing archive and add another library file to it
+        arch2.add_library("mips-linux", b"bluhbluh")?;
+        arch2.write("./secondarchive.par", &issuer, &subject, false)?;
+
+        let mut buf3 = Vec::new();
+        let mut f3 = File::open("./secondarchive.par")?;
+        f3.read_to_end(&mut buf3)?;
+
+        // Make sure the re-written/modified archive looks the way we expect
+        let arch3 = ProviderArchive::try_load(&buf3)?;
+        assert_eq!(arch3.capid, arch2.capid);
+        assert_eq!(
+            arch3.libraries[&"aarch64-linux".to_string()],
+            arch2.libraries[&"aarch64-linux".to_string()]
+        );
+        assert_eq!(arch3.claims().unwrap().subject, subject.public_key());
+        assert_eq!(arch3.targets().len(), 4);
+
+        let _ = std::fs::remove_file("./firstarchive.par");
+        let _ = std::fs::remove_file("./secondarchive.par");
+
+        Ok(())
+    }
+
+    #[test]
+    fn compression_roundtrip() -> Result<()> {
+        let mut arch = ProviderArchive::new(
+            "wascc:testing",
+            "Testing",
+            "waSCC",
+            Some(4),
+            Some("0.0.4".to_string()),
+        );
+        arch.add_library("aarch64-linux", b"heylookimaraspberrypi")?;
+        arch.add_library("x86_64-linux", b"system76")?;
+        arch.add_library("x86_64-macos", b"16inchmacbookpro")?;
+
+        let issuer = KeyPair::new_account();
+        let subject = KeyPair::new_service();
+
+        let filename = "computers";
+
+        arch.write(&format!("{}.par", filename), &issuer, &subject, false)?;
+
+        let mut buf2 = Vec::new();
+        let mut f2 = File::open(&format!("{}.par", filename))?;
+        f2.read_to_end(&mut buf2)?;
+
+        let compressed = compress(&buf2)?;
+        let mut file = File::create(&format!("{}.par.gz", filename))?;
+        file.write_all(&compressed)?;
+
+        let mut buf3 = Vec::new();
+        let mut f3 = File::open(&format!("{}.par.gz", filename))?;
+        f3.read_to_end(&mut buf3)?;
+
+        // Make sure the file we wrote compressed can be read back in with no data loss
+        let arch2 = ProviderArchive::try_load(&buf3)?;
+        assert_eq!(arch.capid, arch2.capid);
+        assert_eq!(
+            arch.libraries[&"aarch64-linux".to_string()],
+            arch2.libraries[&"aarch64-linux".to_string()]
+        );
+        assert_eq!(arch.claims().unwrap().subject, subject.public_key());
+
+        let _ = std::fs::remove_file(&format!("{}.par", filename));
+        let _ = std::fs::remove_file(&format!("{}.par.gz", filename));
+        Ok(())
+    }
+
+    #[test]
+    fn valid_decompression() -> Result<()> {
+        let mut arch = ProviderArchive::new(
+            "wascc:testing",
+            "Testing",
+            "waSCC",
+            Some(5),
+            Some("0.0.5".to_string()),
+        );
+        arch.add_library("aarch64-linux", b"cool-linux")?;
+        arch.add_library("x86_64-linux", b"linux")?;
+        arch.add_library("x86_64-macos", b"macos")?;
+
+        let issuer = KeyPair::new_account();
+        let subject = KeyPair::new_service();
+
+        let filename = "operatingsystem";
+
+        arch.write(&format!("{}.par", filename), &issuer, &subject, false)?;
+
+        let mut buf2 = Vec::new();
+        let mut f2 = File::open(&format!("{}.par", filename))?;
+        f2.read_to_end(&mut buf2)?;
+
+        let compressed = compress(&buf2)?;
+        let mut file = File::create(&format!("{}.par.gz", filename))?;
+        file.write_all(&compressed)?;
+
+        let mut buf3 = Vec::new();
+        let mut f3 = File::open(&format!("{}.par.gz", filename))?;
+        f3.read_to_end(&mut buf3)?;
+
+        let decompressed = decompress(&buf3)?;
+
+        assert_eq!(buf2, decompressed);
+
+        let _ = std::fs::remove_file(&format!("{}.par", filename));
+        let _ = std::fs::remove_file(&format!("{}.par.gz", filename));
+        Ok(())
+    }
+
+    #[test]
+    fn valid_write_compressed() -> Result<()> {
+        let mut arch = ProviderArchive::new(
+            "wascc:testing",
+            "Testing",
+            "waSCC",
+            Some(6),
+            Some("0.0.6".to_string()),
+        );
+        arch.add_library("x86_64-linux", b"linux")?;
+        arch.add_library("arm-macos", b"macos")?;
+        arch.add_library("mips64-freebsd", b"freebsd")?;
+
+        let filename = "multi-os";
+
+        let issuer = KeyPair::new_account();
+        let subject = KeyPair::new_service();
+
+        arch.write(&format!("{}.par", filename), &issuer, &subject, true)?;
+
+        let mut buf = Vec::new();
+        let mut f = File::open(format!("{}.par.gz", filename))?;
+        f.read_to_end(&mut buf)?;
+
+        let arch2 = ProviderArchive::try_load(&buf)?;
+
+        assert_eq!(
+            arch.libraries[&"x86_64-linux".to_string()],
+            arch2.libraries[&"x86_64-linux".to_string()]
+        );
+        assert_eq!(
+            arch.libraries[&"arm-macos".to_string()],
+            arch2.libraries[&"arm-macos".to_string()]
+        );
+        assert_eq!(
+            arch.libraries[&"mips64-freebsd".to_string()],
+            arch2.libraries[&"mips64-freebsd".to_string()]
+        );
+        assert_eq!(arch.claims(), arch2.claims());
+
+        let _ = std::fs::remove_file(format!("{}.par", filename));
+        let _ = std::fs::remove_file(format!("{}.par.gz", filename));
+
+        Ok(())
+    }
+
+    #[test]
+    fn valid_write_compressed_with_suffix() -> Result<()> {
+        let mut arch = ProviderArchive::new(
+            "wascc:testing",
+            "Testing",
+            "waSCC",
+            Some(7),
+            Some("0.0.7".to_string()),
+        );
+        arch.add_library("x86_64-linux", b"linux")?;
+        arch.add_library("arm-macos", b"macos")?;
+        arch.add_library("mips64-freebsd", b"freebsd")?;
+
+        let filename = "suffix-test";
+
+        let issuer = KeyPair::new_account();
+        let subject = KeyPair::new_service();
+
+        // the gz suffix is explicitly provided to write
+        arch.write(&format!("{}.par.gz", filename), &issuer, &subject, true)?;
+
+        let mut buf = Vec::new();
+        let mut f = File::open(format!("{}.par.gz", filename))?;
+        f.read_to_end(&mut buf)?;
+
+        let arch2 = ProviderArchive::try_load(&buf)?;
+
+        assert_eq!(
+            arch.libraries[&"x86_64-linux".to_string()],
+            arch2.libraries[&"x86_64-linux".to_string()]
+        );
+        assert_eq!(
+            arch.libraries[&"arm-macos".to_string()],
+            arch2.libraries[&"arm-macos".to_string()]
+        );
+        assert_eq!(
+            arch.libraries[&"mips64-freebsd".to_string()],
+            arch2.libraries[&"mips64-freebsd".to_string()]
+        );
+        assert_eq!(arch.claims(), arch2.claims());
+
+        let _ = std::fs::remove_file(format!("{}.par", filename));
+        let _ = std::fs::remove_file(format!("{}.par.gz", filename));
+
+        Ok(())
+    }
+
+    #[test]
+    fn preserved_claims() -> Result<()> {
+        // Build an archive in memory the way a CLI wrapper might...
+        let capid = "wascc:testing";
+        let name = "Testing";
+        let vendor = "waSCC";
+        let rev = 8;
+        let ver = "0.0.8".to_string();
+        let mut arch = ProviderArchive::new(capid, name, vendor, Some(rev), Some(ver.clone()));
+        arch.add_library("aarch64-linux", b"blahblah")?;
+        arch.add_library("x86_64-linux", b"bloobloo")?;
+        arch.add_library("x86_64-macos", b"blarblar")?;
+
+        let issuer = KeyPair::new_account();
+        let subject = KeyPair::new_service();
+
+        arch.write("./original.par.gz", &issuer, &subject, true)?;
+
+        let mut buf2 = Vec::new();
+        let mut f2 = File::open("./original.par.gz")?;
+        f2.read_to_end(&mut buf2)?;
+
+        // Make sure the file we wrote can be read back in with no claims loss
+        let mut arch2 = ProviderArchive::try_load(&buf2)?;
+
+        assert_eq!(arch.capid, arch2.capid);
+        assert_eq!(
+            arch.libraries[&"aarch64-linux".to_string()],
+            arch2.libraries[&"aarch64-linux".to_string()]
+        );
+        assert_eq!(arch2.claims().unwrap().subject, subject.public_key());
+        assert_eq!(arch2.claims().unwrap().issuer, issuer.public_key());
+        assert_eq!(arch2.claims().unwrap().name(), name);
+        assert_eq!(arch2.claims().unwrap().metadata.unwrap().ver.unwrap(), ver);
+        assert_eq!(arch2.claims().unwrap().metadata.unwrap().rev.unwrap(), rev);
+        assert_eq!(arch2.claims().unwrap().metadata.unwrap().vendor, vendor);
+        assert_eq!(arch2.claims().unwrap().metadata.unwrap().capid, capid);
+
+        // Another common task - read an existing archive and add another library file to it
+        arch2.add_library("mips-linux", b"bluhbluh")?;
+        arch2.write("./linuxadded.par.gz", &issuer, &subject, true)?;
+
+        let mut buf3 = Vec::new();
+        let mut f3 = File::open("./linuxadded.par.gz")?;
+        f3.read_to_end(&mut buf3)?;
+
+        // Make sure the re-written/modified archive looks the way we expect
+        let arch3 = ProviderArchive::try_load(&buf3)?;
+        assert_eq!(arch3.capid, arch2.capid);
+        assert_eq!(
+            arch3.libraries[&"aarch64-linux".to_string()],
+            arch2.libraries[&"aarch64-linux".to_string()]
+        );
+        assert_eq!(arch3.claims().unwrap().subject, subject.public_key());
+        assert_eq!(arch3.claims().unwrap().issuer, issuer.public_key());
+        assert_eq!(arch3.claims().unwrap().name(), name);
+        assert_eq!(arch3.claims().unwrap().metadata.unwrap().ver.unwrap(), ver);
+        assert_eq!(arch3.claims().unwrap().metadata.unwrap().rev.unwrap(), rev);
+        assert_eq!(arch3.claims().unwrap().metadata.unwrap().vendor, vendor);
+        assert_eq!(arch3.claims().unwrap().metadata.unwrap().capid, capid);
+        assert_eq!(arch3.targets().len(), 4);
+
+        let _ = std::fs::remove_file("./original.par.gz");
+        let _ = std::fs::remove_file("./linuxadded.par.gz");
+
+        Ok(())
+    }
+}

--- a/crates/provider-archive/src/lib.rs
+++ b/crates/provider-archive/src/lib.rs
@@ -1,0 +1,4 @@
+mod archive;
+
+pub type Result<T> = ::std::result::Result<T, Box<dyn std::error::Error + Sync + Send>>;
+pub use archive::ProviderArchive;

--- a/samples/bench-actor/Cargo.toml
+++ b/samples/bench-actor/Cargo.toml
@@ -14,7 +14,7 @@ wasmcloud-actor-http-server = {version = "0.1.0", features = ["guest"] }
 serde = {version = "1.0.123", features = ["derive"]}
 serde_json = "1.0.62"
 
-[profile.release]
+# [profile.release]
 # Optimize for small code size
-opt-level = "s"
-lto = true
+# opt-level = "s"
+# lto = true


### PR DESCRIPTION
This PR fixes https://github.com/wasmCloud/provider-archive/issues/14

The files from the provider-archive repo have been straight copied over, merging the two repository histories is proving to be difficult so I'm submitting this for the time being as a draft PR. 