### PR TITLE
fix --rpc-jwt auth mechanism

### DIFF
--- a/src/wasmcloud.rs
+++ b/src/wasmcloud.rs
@@ -182,9 +182,11 @@ async fn nats_connection(
 ) -> Result<nats::asynk::Connection> {
     if let (Some(jwt_file), Some(seed_val)) = (jwt, seed) {
         let kp = nkeys::KeyPair::from_seed(&extract_arg_value(&seed_val)?)?;
+        let jwt_contents = extract_arg_value(&jwt_file)?;
+
         // You must provide the JWT via a closure
         Ok(nats::Options::with_jwt(
-            move || Ok(jwt_file.clone()),
+            move || Ok(jwt_contents.clone()),
             move |nonce| kp.sign(nonce).unwrap(),
         )
         .connect_async(url)


### PR DESCRIPTION
I copy-pasted this into https://github.com/wasmCloud/wash/pull/146 but it turns out it wasn't reading the files.

~If this has been broken for a long time and nobody has noticed then I would actually recommend ripping this mechanism out and just using the .creds files. I would be happy to make a PR for this instead.~ actually maybe not. Turns out if you supply the secrets as environment variables then it works fine, which is what you would be doing in kubernetes-land.