### PR TITLE
Switch docker image to debian-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,3 +36,23 @@ USER user:user
 
 ENTRYPOINT ["/usr/local/bin/wasmcloud"]
 CMD ["-V"]
+
+# Sometimes you want to be able to debug the cluster connectivity,
+# or the http/redis capability providers. Build and upload this target with:
+#
+#   docker build --target debug -t wasmcloud/wasmcloud:0.18.2-debug .
+#   docker push wasmcloud/wasmcloud:0.18.2-debug
+#
+FROM final as debug
+USER root
+RUN apt-get update && apt-get install -y \
+    curl \
+    redis && \
+    curl -sSL https://github.com/nats-io/natscli/releases/download/0.0.25/nats-0.0.25-amd64.deb -o nats-0.0.25-amd64.deb && \
+    dpkg -i nats-0.0.25-amd64.deb && \
+    rm -rf nats-0.0.25-amd64.deb /var/lib/apt/lists/* \
+    ;
+USER user:user
+
+# Make docker build use the `final` target by default.
+FROM final

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,38 @@
-FROM rust:alpine as builder
-
+FROM rust:slim-buster as builder
 WORKDIR /build
-RUN apk add --no-cache clang clang-dev libressl-dev ca-certificates musl-dev llvm-dev clang-libs
-
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    clang \
+    libclang-dev \
+    libssl-dev \
+    llvm-dev \
+    pkg-config \
+    ;
 COPY Cargo.toml .
 COPY Cargo.lock .
 COPY ./src ./src
 COPY ./crates ./crates
 COPY ./samples ./samples
-
-RUN adduser \    
-    --disabled-password \    
-    --gecos "" \    
-    --home "/nonexistent" \    
-    --shell "/sbin/nologin" \    
-    --no-create-home \    
-    --uid "10001" \    
-    "user"
-
 ENV RUSTFLAGS=-Ctarget-feature=-crt-static
 RUN cargo build --release
 
-FROM scratch
-
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/group /etc/group
-
-COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
-COPY --from=builder /lib/libssl.so.48 /lib/libssl.so.48
-COPY --from=builder /lib/libcrypto.so.46 /lib/libcrypto.so.46
-COPY --from=builder /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
-COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
-
-COPY --from=builder /build/target/release/wasmcloud /usr/local/bin/
-
+FROM debian:buster-slim as final
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libssl-dev && \
+    rm -rf /var/lib/apt/lists/* \
+    ;
+COPY --from=builder /build/target/release/wasmcloud /usr/local/bin/wasmcloud
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "10001" \
+    "user" \
+    ;
 USER user:user
+
 ENTRYPOINT ["/usr/local/bin/wasmcloud"]
 CMD ["-V"]


### PR DESCRIPTION
@StuartHarris can take most of the credit for this (I just added the debug layer).

The from-scratch image did not have certificates in the right place, so it couldn't pull actors from `eu.gcr.io/wasmcloud-k8s-demo/todo-backend:0.2`.
Alpine's libc is also not capable of loading capability provider .so files.

When setting up a kubernetes cluster, we had a few problems connecting to redis and nats, and our http capability provider would sometimes not come up correctly. I have added a `debug` target that includes the utilities needed to debug these things.

I was also thinking that it would be nice to have a `test` target, that runs some sanity integration checks (spin up a wasmcloud with a manifest and check that it works)

This has been pushed to `eu.gcr.io/wasmcloud-k8s-demo/wasmcloud:0.18.2` and `eu.gcr.io/wasmcloud-k8s-demo/wasmcloud:0.18.2-debug` and tested as part of https://github.com/redbadger/wasmcloud-k8s-demo