### PR TITLE
docs(*): Adds contributing and governance docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,281 @@
 # Contributing Guide
 
-THIS GUIDE IS UNDER CONSTRUCTION
+wasmCloud projects accept contributions via GitHub pull requests. This document outlines the process
+to help get your contribution accepted.
 
-This document describes the requirements for committing to the wasmCloud project.
+## Table of Contents
 
-## Pull Request Management
+  - [Reporting a Security Issue](#reporting-a-security-issue)
+  - [Sign Your Work](#sign-your-work)
+  - [Support Channels](#support-channels)
+  - [Semantic Versioning](#semantic-versioning)
+  - [Issues](#issues)
+    - [Issue Types](#issue-types)
+    - [Issue Lifecycle](#issue-lifecycle)
+  - [Proposing an Idea](#proposing-an-idea)
+  - [How to Contribute Code](#how-to-contribute-code)
+  - [Pull Requests](#pull-requests)
+    - [PR Lifecycle](#pr-lifecycle)
+      - [Documentation PRs](#documentation-prs)
+  - [Labels](#labels)
+    - [Common](#common)
+    - [Issue Specific](#issue-specific)
+    - [PR Specific](#pr-specific)
 
-All code that is contributed to wasmCloud must go through the Pull Request (PR) process. To
-contribute a PR, fork this project, create a new branch, make changes on that branch, and then use
-GitHub to open a pull request with your changes.
+## Reporting a Security Issue
 
-Every PR must be reviewed by at least one Core Maintainer of the project. Once a PR has been marked
-"Approved" by a Core Maintainer (and no other core maintainer has an open "Rejected" vote), the PR
-may be merged. While it is fine for non-maintainers to contribute their own code reviews, those
-reviews do not satisfy the above requirement.
+Most of the time, when you find a bug in wasmCloud, it should be reported using GitHub issues. However,
+if you are reporting a _security vulnerability_, please follow the guidelines outlined in our
+[security process](SECURITY.md)
 
-## Signoffs
+## Sign Your Work
 
-All code in this and every other repository must satisfy the Developer Certificate of Origin (DCO) signoff rules. To achieve this, just use the `-s` flag in your git commit. This is a requirement of the wasmCloud project being a part of the Cloud Native Computing Foundation.
+The sign-off is a simple line at the end of the explanation for a commit. All commits needs to be
+signed. Your signature certifies that you wrote the patch or otherwise have the right to contribute
+the material. The rules are pretty simple, if you can certify the below (from
+[developercertificate.org](https://developercertificate.org/)):
 
+```
+Developer Certificate of Origin
+Version 1.1
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+Developer's Certificate of Origin 1.1
+By making a contribution to this project, I certify that:
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@example.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you set your `user.name` and `user.email` git configs, you can sign your commit automatically
+with `git commit -s`.
+
+Note: If your git config information is set properly then viewing the `git log` information for your
+ commit will look something like this:
+
+```
+Author: Joe Smith <joe.smith@example.com>
+Date:   Thu Feb 2 11:41:15 2018 -0800
+    Update README
+    Signed-off-by: Joe Smith <joe.smith@example.com>
+```
+
+Notice the `Author` and `Signed-off-by` lines match. If they don't your PR will be rejected by the
+automated DCO check.
+
+## Support Channels
+
+Whether you are a user or contributor, official support channels include:
+
+- The GitHub Issues in each subproject repository
+- [Slack](https://slack.wasmcloud.com/)
+  - Please note that Slack is meant for help in discussing specific problems or asyncronous
+    debugging/help. If you are reporting a specific bug, please do so it in GitHub Issues
+
+Before opening a new issue or submitting a new pull request, it's helpful to search the project -
+it's likely that another user has already reported the issue you're facing, or it's a known issue
+that we're already aware of. It is also worth asking on the Slack channels.
+
+<!-- NOTE: As the project matures, we may want to add a section about creating project milestones in GH that we adhere to -->
+
+## Semantic Versioning
+
+If you are not familiar with SemVer (the standard), [give it a quick read](https://semver.org/). We
+follow SemVer with a high degree of rigor. 
+
+As a pre-1.0 project, we are likely to have breaking changes on each release. However, these changes
+must be _clearly documented_ in the release notes for each release. Once we release a 1.0 version of
+wasmCloud, we will maintain a strong commitment to backward compatibility. All of our changes to
+protocols and formats will be backward compatible from one minor release to the next. No features,
+flags, commands, or APIs will be removed or substantially modified without a major version release
+(unless absolutely needed to fix a security issue). This often means that we have to tell people
+"no" or "wait" in order to preserve backward compatibility.
+
+## Issues
+
+Issues are used as the primary method for tracking anything to do with a wasmCloud project.
+
+### Issue Types
+
+There are 5 types of issues (each with their own corresponding [label](#labels)) in any wasmCloud
+project:
+
+- `question`: These are support or functionality inquiries that we want to have a record of for
+  future reference. Generally these are questions that are too complex or large to store in the
+  Slack channel or have particular interest to the community as a whole. Depending on the
+  discussion, these can turn into `feature` or `bug` issues.
+- `enhancement`: These track specific feature requests and ideas until they are complete. They can
+  evolve from an [ADR](#proposing-an-idea) or can be submitted individually depending on the size.
+- `bug`: These track bugs with the code
+- `documentation`: These track problems with the documentation (i.e. missing or incomplete)
+
+### Issue Lifecycle
+
+The issue lifecycle is mainly driven by the project and org maintainers, but is good information for
+those contributing to wasmCloud projects. All issue types follow the same general lifecycle.
+Differences are noted below.
+
+1. Issue creation
+2. Triage
+    - A maintainer or contributor will apply the proper labels for the issue. This includes labels
+      for priority, type, and metadata (such as `good first issue`). The only issue priority we will
+      be tracking is whether or not the issue is "critical." If additional levels are needed in the
+      future, we will add them.
+    - (If needed) Clean up the title to succinctly and clearly state the issue.
+3. Discussion
+    - Issues that are labeled `enhancement` must write an Architectural Decision Record (ADR) (see
+      [Proposing an Idea](#proposing-an-idea)). Smaller quality-of-life enhancements are exempt. The
+      decision about which enhancements are exempt are left to the decision of project maintainers
+    - Issues that are labeled as `enhancement` or `bug` should be connected to the PR that resolves
+      it once it is opened (see [How to Contribute Code](#how-to-contribute-code)).
+    - Whoever is working on an `enhancement` or `bug` issue (whether a maintainer or someone from
+      the community), should either assign the issue to themself or make a comment in the issue
+      saying that they are taking it.
+    - `question` issues should stay open until resolved or if they have not been active for more
+      than 30 days. This will help keep the issue queue to a manageable size and reduce noise.
+      Should the issue need to stay open, the `keep open` label can be added.
+4. Issue closure/resolution
+
+## Proposing an Idea
+
+Before proposing a new idea to a wasmCloud project, please make sure to write up an [Architectural
+Decision Record](https://wasmcloud.github.io/adr/). An Architectural Decision Record is a design
+document that describes a new feature for a wasmCloud project. The proposal should provide a concise
+technical specification and rationale for the feature. 
+
+It is also worth considering vetting your idea with the community via Slack. Vetting an idea
+publicly before going as far as writing a proposal is meant to save the potential author time.
+
+ADRs are submitted to the [wasmcloud/adr repository](https://github.com/wasmCloud/adr/tree/gh-pages)
+(submitted against the `gh-pages` branch). See
+[ADR0000](https://wasmcloud.github.io/adr/0000-use-markdown-architectural-decision-records.html) for
+a the specific structure chosen and the [provided
+template](https://wasmcloud.github.io/adr/template.html) to write your own
+
+After your proposal has been approved, you can go ahead and get started implementing it!
+
+## How to Contribute Code
+
+1. Identify or create the related issue. If you're proposing a larger change to wasmCloud, see
+   [Proposing an Idea](#proposing-an-idea).
+2. Fork the desired repo; develop and test your code changes.
+3. Submit a pull request, making sure to sign your work and link the related issue.
+
+In general, most repos in the wasmCloud project have linters and other coding standards to follow.
+Those standards should be followed when you contribute your code.
+
+## Pull Requests
+
+Like any good open source project, we use Pull Requests (PRs) to track code changes.
+
+### PR Lifecycle
+
+1. PR creation
+    - We more than welcome PRs that are currently in progress. They are a great way to keep track of
+      important work that is in-flight, but useful for others to see. If a PR is a work in progress,
+      it **must** be prefaced with "WIP: [title]". Once the PR is ready for review, remove "WIP"
+      from the title.
+    - It is preferred, but not required, to have a PR tied to a specific issue. There can be
+      circumstances where if it is a quick fix then an issue might be overkill. The details provided
+      in the PR description would suffice in this case.
+2. Triage
+    - The maintainer in charge of triaging will apply the proper labels for the issue. This should
+      include at least a `bug` or `feature` label once all labels are applied. See the [Labels
+      section](#labels) for full details on the definitions of labels.
+3. Assigning reviews
+    - Reviewers will either be autoassigned using a CODEOWNERS file or by maintainers of the repo
+      when they triage PRs, maintainers will review them as schedule permits. The maintainer who
+      takes the issue should self-request a review.
+    - PRs from a community member with that are any larger than 10-ish lines requires 2 review
+      approvals from maintainers before it can be merged. For contributions from contributors and
+      maintainers, 2 reviews are only required if the PR is large, or if the first maintainer
+      requests a second review. These size and review requirements are implemented per the judgement
+      of the maintainers. In the future, we may adopt a more standardized approach
+4. Reviewing/Discussion
+    - All reviews will be completed using GitHub review tool.
+    - A "Comment" review should be used when there are questions about the code that should be
+      answered, but that don't involve code changes. This type of review does not count as approval.
+    - A "Changes Requested" review indicates that changes to the code need to be made before they
+      will be merged.
+    - Reviewers should update labels as needed (such as `breaking`, if the PR contains a breaking
+      change)
+    - If a comment is a nit, it should be prefaced with the text `Nit:` to indicate to the submitter
+      that addressing this comment is optional
+5. Address comments by answering questions or changing code
+6. LGTM (Looks good to me)
+    - Once a Reviewer has completed a review and the code looks ready to merge, an "Approve" review
+      is used to signal to the contributor and to other maintainers that you have reviewed the code
+      and feel that it is ready to be merged.
+7. Merge or close
+    - PRs should stay open until merged or if they have not been active for more than 30 days. This
+      will help keep the PR queue to a manageable size and reduce noise. Should the PR need to stay
+      open (like in the case of a WIP), the `keep open` label can be added.
+    - If the owner of the PR is a maintainer, that user **must** merge their own PRs or explicitly
+      request another maintainer do that for them.
+    - If the owner of a PR is _not_ a maintainer, any maintainer may merge the PR. As a rule of
+      thumb, we usually recommend one of the reviewers be the one to merge the PR, but this is not
+      required
+
+#### Documentation PRs
+
+Documentation PRs will follow the same lifecycle as other PRs. They will also be labeled with the
+`documentation` label. For documentation, special attention will be paid to spelling, grammar, and
+clarity (whereas those things don't matter *as* much for comments in code).
+
+## Labels
+
+The following tables define all label types used for wasmCloud projects. This does not preclude
+individual projects from having additional labels, but all wasmCloud projects will have the same
+base labels. The labels below are split up by category
+
+### Common
+
+| Label           | Description                                                                                                                            |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `bug`           | Marks an issue as a bug or a PR as a bugfix                                                                                            |
+| `critical`      | Marks an issue or PR as critical. This means that addressing the PR or issue is top priority and must be addressed as soon as possible |
+| `documentation` | Indicates the issue or PR is a documentation change                                                                                    |
+| `enhancement`   | Marks the issue as a feature request or a PR as a feature implementation                                                               |
+| `keep open`     | Denotes that the issue or PR should be kept open past 30 days of inactivity                                                            |
+| `refactor`      | Indicates that the issue is a code refactor and is not fixing a bug or adding additional functionality                                 |
+
+### Issue Specific
+
+| Label              | Description                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------- |
+| `help wanted`      | Marks an issue needs help from the community to solve                                           |
+| `proposal`         | Marks an issue as a proposal                                                                    |
+| `question`         | Marks an issue as a support request or question                                                 |
+| `good first issue` | Marks an issue as a good starter issue for someone new to the project                           |
+| `wontfix`          | Marks an issue as discussed and will not be implemented (or accepted in the case of a proposal) |
+
+### PR Specific
+
+| Label      | Description                                               |
+| ---------- | --------------------------------------------------------- |
+| `breaking` | Indicates a PR has breaking changes (such as API changes) |

--- a/CONTRIBUTION_LADDER.md
+++ b/CONTRIBUTION_LADDER.md
@@ -1,0 +1,122 @@
+# Contribution Ladder
+
+---
+  - [Community Member](#community-member)
+  - [Contributor](#contributor)
+    - [How to become a contributor](#how-to-become-a-contributor)
+  - [Project Maintainer](#project-maintainer)
+    - [How to become a maintainer](#how-to-become-a-maintainer)
+    - [Other types of maintainers](#other-types-of-maintainers)
+  - [Org Maintainers](#org-maintainers)
+    - [How to become an org maintainer](#how-to-become-an-org-maintainer)
+  - [Emeritus Maintainers](#emeritus-maintainers)
+---
+
+A contribution ladder is a document that defines the "ladder to climb" to become a maintainer of one
+or more wasmCloud projects. You will need to gain people's trust, demonstrate your competence and
+understanding, and meet the requirements of the role.
+
+## Community Member
+
+Everyone is a community member! :tada: You've read this far so you are already ahead.
+
+Here are some ideas for how you can be more involved and participate in the community:
+
+* Comment on an issue that you’re interested in.
+* Submit a pull request to fix an issue.
+* Report a bug.
+* Share an actor/provider you made and your experience with it
+* Come chat with us in [Slack](https://slack.wasmcloud.com/).
+
+As a community member you must follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Contributor
+
+You can be a contributor to multiple wasmCloud repositories. This role will be assigned basic
+privileges on the wasmCloud respositories where they are contributors. Contributors have the
+following capabilities:
+
+* Have issues and pull requests assigned to them
+* Apply labels, milestones and projects
+* [Mark issues as
+  duplicates](https://help.github.com/en/articles/about-duplicate-issues-and-pull-requests)
+* Close, reopen, and assign issues and pull requests
+
+They must agree to and follow our [Contributing Guide](CONTRIBUTING.md)
+
+### How to become a contributor
+
+To become a contributor, the maintainers of the project would like to see you:
+
+* Comment on issues with your experiences and opinions.
+* Add your comments and reviews on pull requests.
+* Contribute pull requests.
+* Open issues with bugs, experience reports, and questions.
+
+Contributors and maintainers will do their best to watch for community members who may make good
+contributors. But don’t be shy, if you feel that this is you, please reach out to one or more of the
+contributors or maintainers.
+
+## Project Maintainer
+
+Project Maintainers are members who are maintainers of specific wasmCloud projects with extra
+capabilities:
+
+* Be a Code Owner and have reviews automatically requested.
+* Review pull requests.
+* Merge pull requests.
+
+Maintainers also have additional responsibilities beyond just merging code:
+
+* Help foster a safe and welcoming environment for all project participants. This will include
+  understanding and enforcing our [Code of Conduct](CODE_OF_CONDUCT.md).
+* Organize and promote pull request reviews, e.g. prompting community members, contributors, and
+  other maintainers to review.
+* Triage issues, e.g. adding labels, promoting discussions, finalizing decisions.
+* Help organize our weekly meetings, e.g. schedule, organize and execute agenda.
+* Make project-level technical decisions in conjunction with other maintainers
+
+They must agree to and follow the [Reviewing Guide](CONTRIBUTING.md#reviewing) found in our
+Contributing Guide.
+
+### How to become a maintainer
+
+To become a maintainer, we would like you to see you be an effective contributor, and show that you
+can do some of the things maintainers do. Maintainers will do their best to regularly discuss
+promoting contributors. But don’t be shy, if you feel that this is you, please reach out to one or
+more of the maintainers.
+
+### Other types of maintainers
+
+We know that not all people want to manage code in a project! To that end, we also recognize that
+some maintainers/contributors may also want to take on a "community management" role. A community
+managment maintainer will have other types of responsibilities:
+
+* Managing Slack and other communication channels
+* Planning community meetups/events
+* Coordinating additional developer meetings
+* Managing/reviewing blog posts
+* Assisting, as desired, with branding/messaging/CNCF communicating
+
+## Org Maintainers
+
+Org maintainers are maintainers with extra [responsibilities](https://youtu.be/b23wrRfy7SM):
+
+* Help manage org level permissions and access
+* Serve as a tiebreaker in the case of any ties among other wasmCloud projects
+* In most cases, should be involved as a project maintainer for at least one of the wasmCloud
+  projects
+* Decide with other org maintainers on the overall direction of wasmCloud 
+
+### How to become an org maintainer
+
+It isn't expected that all maintainers will need or want to move up to org maintainer. If you are a
+maintainer, and find yourself often asking an admin to do certain tasks for you and you would like
+to help out with administrative tasks or decisions, please reach out to one or more of the org
+maintainers.
+
+## Emeritus Maintainers
+
+Any maintainer (org or project) who withdraws from active maintainership will be designated an
+Emeritus Maintainer as a thank you for their contributions. They have no responsibilities but remain
+permanently "on the record" as former maintainers unless they request to be removed.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,126 @@
+# wasmCloud Governance
+
+The following document outlines how the wasmCloud project governance operates.
+
+  - [The wasmCloud Project](#the-wasmcloud-project)
+  - [Maintainers Structure](#maintainers-structure)
+    - [wasmCloud Org Maintainers](#wasmcloud-org-maintainers)
+  - [Decision Making at the wasmCloud org level](#decision-making-at-the-wasmcloud-org-level)
+  - [Decision Making at the wasmCloud project level](#decision-making-at-the-wasmcloud-project-level)
+  - [Code of Conduct](#code-of-conduct)
+  - [DCO and Licenses](#dco-and-licenses)
+
+## The wasmCloud Project
+
+The wasmCloud project is made up of several codebases and services with different release cycles. A
+list of these projects can be found [here](https://github.com/orgs/wasmCloud/repositories).
+
+## Maintainers Structure
+
+There are two levels of maintainers for wasmCloud. The wasmCloud org maintainers oversee the overall
+project and its health. Project maintainers focus on a single codebase, a group of related
+codebases, a service (e.g., a website), or project to support the other projects (e.g., marketing or
+community management). For example, the provider maintainers manage the capability providers
+repository. See the [Contributor Ladder](./CONTRIBUTION_LADDER.md) for more detailed information on
+responsibilities.
+
+<!-- TODO: We should choose a canonical communication mechanism (like a mailing list) an require -->
+
+### wasmCloud Org Maintainers
+
+The wasmCloud Org maintainers are responsible for:
+
+* Maintaining the mission, vision, values, and scope of the project
+* Refining the governance and charter as needed
+* Making project level decisions
+* Resolving escalated project decisions when the subteam responsible is blocked
+* Managing the wasmCloud brand
+* Controlling access to wasmCloud assets such as source repositories, hosting, project calendars
+* Handling code of conduct violations
+* Deciding what sub-groups are part of the wasmCloud project
+* Overseeing the resolution and disclosure of security issues
+* Managing financial decisions related to the project
+
+Changes to org maintainers use the following:
+
+* There will be between 3 and 9 people.
+* Any project maintainer of any active (non-archived) wasmCloud organization project is eligible for
+  a position as an org maintainer.
+* An org maintainer may step down by emailing the org maintainers or contacting them through Slack
+* Org maintainers MUST remain active on the project. If they are unresponsive for > 3 months they
+  will lose org maintainership unless a
+  [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other org
+  maintainers agrees to extend the period to be greater than 3 months
+* When there is an opening for a new org maintainer, any person who has made a contribution to any
+  repo under the wasmCloud GitHub org may nominate a suitable project maintainer of an active
+  project as a replacement by contacting the current org maintainers
+  * The nomination period will be three weeks starting the day after an org maintainer opening
+    becomes available
+* Org maintainers must vote for a nominated maintainer and the vote must pass with a
+  [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote).
+* When an org maintainer steps down, they become an emeritus maintainer
+
+Once an org maintainer is elected, they remain a maintainer until stepping down (or, in rare cases,
+are removed). Voting for new maintainers occurs when necessary to fill vacancies. Any existing
+project maintainer is eligible to become an org maintainer.
+
+## Decision Making at the wasmCloud org level
+
+When maintainers need to make decisions there are two ways decisions are made, unless described
+elsewhere.
+
+The default decision making process is
+[lazy-consensus](http://communitymgt.wikia.com/wiki/Lazy_consensus). This means that any decision is
+considered supported by the team making it as long as no one objects. Silence on any consensus
+decision is implicit agreement and equivalent to explicit agreement. Explicit agreement may be
+stated at will.
+
+When a consensus cannot be found a maintainer can call for a
+[majority](https://en.wikipedia.org/wiki/Majority) vote on a decision.
+
+Many of the day-to-day project maintenance can be done by a lazy consensus model. But the following
+items must be called to vote:
+
+* Enforcing a CoC violation (super majority)
+* Removing a maintainer for any reason other than inactivity (super majority)
+* Changing the governance rules (this document) (super majority)
+* Licensing and intellectual property changes (including new logos, wordmarks) (simple majority)
+* Adding, archiving, or removing subprojects (simple majority)
+* Utilizing wasmCloud/CNCF money for anything CNCF deems "not cheap and easy" (simple majority)
+
+Other decisions may, but do not need to be, called out and put up for decision at any time and by
+anyone. By default, any decisions called to a vote will be for a _simple majority_ vote.
+
+## Decision Making at the wasmCloud project level
+
+Project maintainers are free to set their own decision making processes in most cases. As with org
+level decisions, the default decision making process is
+[lazy-consensus](http://communitymgt.wikia.com/wiki/Lazy_consensus). This means that any decision is
+considered supported by the team making it as long as no one objects. Silence on any consensus
+decision is implicit agreement and equivalent to explicit agreement. Explicit agreement may be
+stated at will.
+
+Decisions pertaining to day-to-day operations (such as agreeing on ADRs or when to release) can be
+done with a [simple majority](https://en.wikipedia.org/wiki/Majority) vote. However, it is
+recommended to make sure and have a vote from all interested parties. For example, if you have 2
+maintainers from company X and 1 from company Y, you should have at least 1 vote from both company X
+and company Y
+
+## Code of Conduct
+
+The code of conduct is overseen by the wasmCloud org maintainers. Possible code of conduct
+violations should be sent to the org maintainers <!-- TODO: Update this to a mailing list once we
+have one  -->
+
+If the possible violation is against one of the org maintainers that member will be recused from
+voting on the issue. Such issues must be escalated to the appropriate CNCF contact, and CNCF may
+choose to intervene.
+
+## DCO and Licenses
+
+The following licenses and contributor agreements will be used for wasmCloud projects:
+
+* [Apache 2.0](https://opensource.org/licenses/Apache-2.0) for code
+* [Creative Commons Attribution 4.0 International Public
+  License](https://creativecommons.org/licenses/by/4.0/legalcode) for documentation
+* [Developer Certificate of Origin](https://developercertificate.org/) for new contributions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,119 @@
+# wasmCloud Security Process and Policy
+
+This document provides the details on the wasmCloud security policy and details the processes
+surrounding security handling including a how to guide on reporting a security vulnerability for
+anything within the wasmCloud organization.
+
+  - [Report A Vulnerability](#report-a-vulnerability)
+    - [When To Send A Report](#when-to-send-a-report)
+    - [When Not To Send A Report](#when-not-to-send-a-report)
+    - [Security Vulnerability Response](#security-vulnerability-response)
+    - [Public Disclosure](#public-disclosure)
+  - [Security Team Membership](#security-team-membership)
+    - [Responsibilities](#responsibilities)
+    - [Membership](#membership)
+  - [Patch and Release Team](#patch-and-release-team)
+  - [Disclosures](#disclosures)
+
+## Report A Vulnerability
+
+We’re extremely grateful for security researchers and users who report vulnerabilities to the
+wasmCloud community. All reports are thoroughly investigated by a set of wasmCloud maintainers.
+
+To make a report please email the private security list at security@wasmcloud.com with the details.
+
+The list of people on the security list is below: 
+
+| Name            | GitHub Handle    |
+| --------------- | ---------------- |
+| Kevin Hoffman   | @autodidaddict   |
+| Brooks Townsend | @brooksmtownsend |
+| Taylor Thomas   | @thomastaylor312 |
+| Liam Randall    | @LiamRandall     |
+
+<!-- TODO: In the future, we may want to offer the possibility of encrypting the email using one of our GPG keys -->
+
+### When To Send A Report
+
+You think you have found a vulnerability in a wasmCloud project or a dependency of a wasmCloud
+project. This can be any of the repositories on the [wasmCloud GitHub
+organization](https://github.com/wasmCloud).
+
+### When Not To Send A Report
+
+* If a vulnerability has been found in an application deployed to a wasmCloud host
+* For guidance on securing wasmCloud, please see the [documentation](https://wasmcloud.dev) or ask
+  in one of the [Slack channels](https://slack.wasmcloud.com/)
+* You are looking for help applying security updates
+
+### Security Vulnerability Response
+
+Each report will be reviewed and receipt acknowledged within 3 business days. This will set off the
+security review process detailed below.
+
+Any vulnerability information shared with the security team stays within the wasmCloud project and
+will not be shared with others unless it is necessary to fix the issue. Information is shared only
+on a need to know basis.
+
+We ask that vulnerability reporter(s) act in good faith by not disclosing the issue to others. And
+we strive to act in good faith by acting swiftly, and by justly crediting the vulnerability
+reporter(s) in writing.
+
+As the security issue moves through triage, identification, and release the reporter of the security
+vulnerability will be notified. Additional questions about the vulnerability may also be asked of
+the reporter.
+
+### Public Disclosure
+
+A public disclosure of security vulnerabilities is released alongside release updates or details
+that fix the vulnerability. We try to fully disclose vulnerabilities once a mitigation strategy is
+available. Our goal is to perform a release and public disclosure quickly and in a timetable that
+works well for users. For example, a release may be ready on a Friday but for the sake of users may
+be delayed to a Monday.
+
+CVEs will be assigned to vulnerabilities. Due to the process and time it takes to obtain a CVE ID,
+disclosures may happen first. In this case, once the ID has been assigned the disclosure will be
+updated.
+
+If the vulnerability reporter would like their name and details shared as part of the disclosure
+process we are happy to. We will ask permission and for the way the reporter would like to be
+identified. We appreciate vulnerability reports and would like to credit reporters if they would
+like the credit.
+
+## Security Team Membership
+
+The security team is made up of a subset of the wasmCloud project maintainers who are willing and
+able to respond to vulnerability reports.
+
+### Responsibilities
+
+* Members MUST be active project maintainers on active (non-deprecated) wasmCloud projects.
+* Members SHOULD engage in each reported vulnerability, at a minimum to make sure it is being
+  handled
+* Members MUST keep the vulnerability details private and only share on a need to know basis
+
+### Membership
+
+New members are required to be active maintainers of wasmCloud projects who are willing to perform
+the responsibilities outlined above. The security team is a subset of the maintainers. Members can
+step down at any time and may join at any time.
+
+From time to time, wasmCloud projects are deprecated. If at any time a security team member is found
+to be no longer be an active maintainer on active wasmCloud projects, this individual will be
+removed from the security team.
+
+## Patch and Release Team
+
+When a vulnerability comes in and is acknowledged, a team - including maintainers of the wasmCloud
+project affected - will assembled to patch the vulnerability, release an update, and publish the
+vulnerability disclosure. This may expand beyond the security team as needed but will stay within
+the pool of wasmCloud project maintainers.
+
+## Disclosures
+
+Vulnerability disclosures are published as security advisories in the relevant project repos. The
+disclosures will contain an overview, details about the vulnerability, a fix for the vulnerability
+that will typically be an update, and optionally a workaround if one is available.
+
+Disclosures will be published on the same day as a release fixing the vulnerability after the
+release is published and the release notes will contain a link to the published advisory.


### PR DESCRIPTION
This PR introduces a full rework of our contributing doc and introduces a new
contributor ladder document to clearly explain how someone can become a
maintainer of a wasmcloud project. If approved and merged, there will be follow
up work to make sure the proper labels are defined everywhere

This also contains a governance document. I kept this as lightweight as possible
while still adding some process. If merged, we will need to officially designate
a set of org maintainers to bootstrap the process. As part of governance, I also
added a documented security process for how we handle reported vulnerabilities.
Please let me know if there are other people we should add to the security list.

Please note: These documents draw heavily (read: were copy and modified) from the
[Helm](https://helm.sh) and [Porter](https://getporter.org/) projects as I helped create the Helm documents and am
inspired by the process the Porter project adopted. I just want to acknowledge
their source and thank those projects for their previous efforts