### PR TITLE
chore(OWNERS): Add final list of initial org maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,8 @@
-# wasmCloud is maintained by
+# wasmCloud Org maintainers
 
 @autodidaddict
 @brooksmtownsend
 @thomastaylor312
 @liamrandall
 @stevelr
-
-# Supported and co-maintained by
-
-liam@cosmonic.com
+@jordan-rash


### PR DESCRIPTION
@autodidaddict, @brooksmtownsend, @LiamRandall, @stevelr, @jordan-rash This PR will not be merged until you have all approved this PR to indicate your agreement to be org maintainers. I double checked with people, but an official approval is important here.

For those in the community, this initial list of org maintainers is based on people who are currently acting in this role. From here on out, all org maintainers must be added or step down as defined in the [governance doc](https://github.com/wasmCloud/wasmCloud/blob/main/GOVERNANCE.md#wasmcloud-org-maintainers)