### PR TITLE
chore(github): CODEOWNERS are host maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Project Maintainers and Contributors
+* @wasmCloud/host-maintainers @wasmCloud/host-contributors
+

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,0 @@
-# wasmCloud Org maintainers
-
-@autodidaddict
-@brooksmtownsend
-@thomastaylor312
-@liamrandall
-@stevelr
-@jordan-rash
-@connorsmith256


### PR DESCRIPTION
Now that this repository contains the wasmCloud host SDK, the owners list should match this.