### PR TITLE
Adds back owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+# wasmCloud Org maintainers
+
+@autodidaddict
+@brooksmtownsend
+@thomastaylor312
+@liamrandall
+@stevelr
+@jordan-rash
+@connorsmith256


### PR DESCRIPTION
I didn't realize that was the file that we use to indicate who are org maintainers when I merged #281