### PR TITLE
fix: format error messages with variable substitution

### DIFF
--- a/examples/echo/main.rs
+++ b/examples/echo/main.rs
@@ -23,7 +23,9 @@ async fn host_call(
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     const WASM: &str = env!("CARGO_CDYLIB_FILE_ACTOR_ECHO_MODULE");
-    let wasm = fs::read(WASM).await.context("failed to read `{WASM}`")?;
+    let wasm = fs::read(WASM)
+        .await
+        .with_context(|| format!("failed to read `{WASM}`"))?;
 
     let issuer = KeyPair::new_account();
     let module = KeyPair::new_module();

--- a/src/actor/component.rs
+++ b/src/actor/component.rs
@@ -141,7 +141,7 @@ impl Component {
         instance
             .call(operation, payload)
             .await
-            .context("failed to call operation `{operation}` on module")
+            .with_context(|| format!("failed to call operation `{operation}` on module"))
     }
 }
 

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -111,11 +111,11 @@ impl Actor {
             Actor::Module(module) => module
                 .call(operation, payload.map(Into::into).unwrap_or(vec![]))
                 .await
-                .context("failed to call operation `{operation}` on module"),
+                .with_context(|| format!("failed to call operation `{operation}` on module")),
             Actor::Component(component) => component
                 .call(operation, payload)
                 .await
-                .context("failed to call operation `{operation}` on component"),
+                .with_context(|| format!("failed to call operation `{operation}` on component")),
         }
     }
 }

--- a/src/actor/module/mod.rs
+++ b/src/actor/module/mod.rs
@@ -183,7 +183,7 @@ impl Module {
         } = instance
             .call(operation, payload)
             .await
-            .context("failed to call operation `{operation}` on module")?;
+            .with_context(|| format!("failed to call operation `{operation}` on module"))?;
         ensure!(code == 1, "operation failed with exit code `{code}`");
         if !console_log.is_empty() {
             trace!(?console_log);


### PR DESCRIPTION
## Feature or Problem

Some of the error message context invocations are missing formatting directives in `main`, that is fixed in this PR

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
