### PR TITLE
ci: build `wasmcloud` for `win64`

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -15,11 +15,19 @@ jobs:
       matrix:
         config:
         - target: aarch64-unknown-linux-musl
+          install-path: /bin/wasmcloud
           test-bin: nix shell --inputs-from . 'nixpkgs#qemu' -c qemu-aarch64 ./result/bin/wasmcloud --version
           test-oci: docker load < ./result
           # TODO: Run aarch64 binary within OCI
 
+        - target: x86_64-pc-windows-gnu
+          install-path: /bin/wasmcloud.exe
+          test-bin: nix shell --inputs-from . 'nixpkgs#wine64' -c wine64 ./result/bin/wasmcloud.exe --version
+          test-oci: docker load < ./result
+          # TODO: Run win64 binary within OCI
+
         - target: x86_64-unknown-linux-musl
+          install-path: /bin/wasmcloud
           test-bin: ./result/bin/wasmcloud --version
           test-oci: |
             docker load < ./result
@@ -35,7 +43,7 @@ jobs:
     - uses: ./.github/actions/build-nix
       with:
         package: wasmcloud-${{ matrix.config.target }}
-        install-path: /bin/wasmcloud
+        install-path: ${{ matrix.config.install-path }}
     - run: ${{ matrix.config.test-bin }}
     - uses: ./.github/actions/build-nix
       with:
@@ -89,6 +97,15 @@ jobs:
       with:
         name: wasmcloud-universal-darwin
         path: wasmcloud-universal-darwin
+
+  test-windows:
+    runs-on: windows-2022
+    needs: build-linux
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: wasmcloud-x86_64-pc-windows-gnu
+    - run: .\wasmcloud-x86_64-pc-windows-gnu --version
 
   cargo:
     strategy:

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,6 @@
 
         targets.armv7-unknown-linux-musleabihf = false;
         targets.wasm32-wasi = false;
-        targets.x86_64-pc-windows-gnu = false;
 
         test.allTargets = true;
         test.workspace = true;


### PR DESCRIPTION
- Build for Windows in CI

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

Extracted from #293

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

- `nix flake check -L` on `x86_64-linux`
- `nix build -L .\#packages.aarch64-darwin.wasmcloud-x86_64-pc-windows-gnu-oci` (remote build on `aarch64-darwin` from `x86_64-linux`)
- `nix build -L .\#packages.x86_64-darwin.wasmcloud-x86_64-pc-windows-gnu-oci` (remote build on `x86_64-darwin` from `x86_64-linux`)
- `nix build -L .\#wasmcloud-x86_64-pc-windows-gnu-oci` (remote build on `x86_64-linux` from `x86_64-linux`)
- etc...



