### PR TITLE
Added `call_context` to HostInvocations and additional `call_with_context` functions

### DIFF
--- a/examples/echo/main.rs
+++ b/examples/echo/main.rs
@@ -13,6 +13,7 @@ async fn host_call(
     claims: jwt::Claims<jwt::Actor>,
     binding: String,
     invocation: HostInvocation,
+    _call_context: Option<Vec<u8>>,
 ) -> anyhow::Result<Option<[u8; 0]>> {
     bail!(
         "cannot execute `{invocation:?}` within binding `{binding}` for actor `{}`",

--- a/src/actor/module/wasmbus.rs
+++ b/src/actor/module/wasmbus.rs
@@ -255,7 +255,9 @@ async fn host_call(
     match trace_span!("Handle::handle")
         .in_scope(|| {
             let ctx = store.data();
-            ctx.wasmbus.handler.handle(ctx.claims, bd, invocation)
+            ctx.wasmbus
+                .handler
+                .handle(ctx.claims, bd, invocation, &store.data().call_context)
         })
         .await
     {

--- a/src/capability/logging/discard.rs
+++ b/src/capability/logging/discard.rs
@@ -16,6 +16,7 @@ impl Handle<Invocation> for Logging {
         _: &jwt::Claims<jwt::Actor>,
         _: String,
         _: Invocation,
+        _: &Option<Vec<u8>>,
     ) -> Result<Option<Vec<u8>>> {
         Ok(None)
     }

--- a/src/capability/logging/log.rs
+++ b/src/capability/logging/log.rs
@@ -58,6 +58,7 @@ impl<T: Log> Handle<Invocation> for Logging<T> {
         claims: &jwt::Claims<jwt::Actor>,
         _binding: String,
         invocation: Invocation,
+        _call_context: &Option<Vec<u8>>,
     ) -> Result<Option<Vec<u8>>> {
         match invocation {
             Invocation::WriteLog { level, text } => {

--- a/src/capability/numbergen/rand.rs
+++ b/src/capability/numbergen/rand.rs
@@ -39,6 +39,7 @@ where
         claims: &jwt::Claims<jwt::Actor>,
         _binding: String,
         invocation: Invocation,
+        _call_context: &Option<Vec<u8>>,
     ) -> Result<Option<Vec<u8>>> {
         match invocation {
             Invocation::GenerateGuid => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ async fn host_call(
     claims: jwt::Claims<jwt::Actor>,
     binding: String,
     invocation: HostInvocation,
+    _call_context: Option<Vec<u8>>,
 ) -> anyhow::Result<Option<[u8; 0]>> {
     bail!(
         "cannot execute `{invocation:?}` within binding `{binding}` for actor `{}`",

--- a/tests/actor_compat.rs
+++ b/tests/actor_compat.rs
@@ -14,10 +14,12 @@ async fn host_call(
         operation,
         payload,
     }: HostInvocation,
+    call_context: Option<Vec<u8>>,
 ) -> anyhow::Result<Option<&'static str>> {
     assert_eq!(namespace, "FoobarHost");
     assert_eq!(operation, "Foobar.Foo");
     assert_eq!(payload, None);
+    assert_eq!(call_context, None);
     Ok(Some("foo"))
 }
 

--- a/tests/actor_http_log_rng.rs
+++ b/tests/actor_http_log_rng.rs
@@ -30,6 +30,7 @@ async fn host_call(
     claims: jwt::Claims<jwt::Actor>,
     binding: String,
     invocation: HostInvocation,
+    _call_context: Option<Vec<u8>>,
 ) -> anyhow::Result<Option<[u8; 0]>> {
     bail!(
         "cannot execute `{invocation:?}` within binding `{binding}` for actor `{}`",


### PR DESCRIPTION
## Feature or Problem
This PR adds an additional parameter to the component and module `call` functions, with another function head called `call_with_context`, and another parameter `HostInvocation` struct called `call_context`, which is an optional byte vector. Host implementers can use to add additional context onto invocations which will be propagated the entire length of the call.

The original problem this addresses is the fact that there was no way to propagate a parent span ID through a system in order to construct a full trace from the host side. I'd be happy to entertain different naming schemes for the context, different API strategies instead of a `call` and `call_with_context` function, etc. I decided to implement first to show a glimpse at what needed to be done so we can discuss.

## Related Issues


## Release Information
`next`

## Consumer Impact
Consumers of this crate won't need to change their code as the `call_with_context` functions are pure additions.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
None

### Acceptance or Integration
None

### Manual Verification
I used this git branch in order to test https://github.com/wasmCloud/wasmcloud-otp/pull/594 which is a full implementation of adding a `call_context` with a span context and then reconstituting the trace context on the other end

![image](https://user-images.githubusercontent.com/12040685/228333443-ce00075e-7015-4007-959e-7e1fad5dfcf2.png)

