### PR TITLE
added stale.yaml for closing old issues

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,11 +1,12 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 90
+daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned # Pinned issues should stick around
   - security # Security issues need to be resolved
+  - roadmap # Issue is captured on the wasmCloud roadmap and won't be lost
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned # Pinned issues should stick around
+  - security # Security issues need to be resolved
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. If this 
+  has been closed too eagerly, please feel free to tag a maintainer so we can
+  keep working on the issue. Thank you for contributing to wasmCloud!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
## Feature or Problem
This PR adds a `stale.yaml` definition which marks issues as stale after 90 days, and closes them after 7 days with a `wontfix` label. I plan to take this definition and replicate it across the other wasmCloud repositories, so please leave comments here and then I can copy/paste around.

## Related Issues
All the stale ones

## Release Information
N/A