### PR TITLE
refactor: create bucket explicitly instead of stream

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -670,9 +670,9 @@ async fn create_lattice_metadata_bucket(
                 info!("lattice metadata bucket {bucket} already exists. Skipping creation.");
                 Ok(())
             } else {
-                Err(anyhow!(
-                    "failed to create lattice metadata bucket {bucket}: {err}"
-                ))
+                Err(anyhow!(err).context(format!(
+                    "failed to create lattice metadata bucket '{bucket}'"
+                )))
             }
         }
     }


### PR DESCRIPTION
## Feature or Problem
This PR creates the lattice metadata bucket explicitly, rather than implicitly via a stream. It also gracefully handles errors where the bucket has already been provisioned with custom settings, allowing multiple hosts to run in the same pre-provisioned lattice

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/417

## Release Information
Next

## Consumer Impact
This allows hosts to start in a lattice with pre-provisioned resources, e.g. the lattice metadata bucket

## Testing

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

### Acceptance or Integration
The existing `wasmbus` test covers creating a bucket successfully. I locally edited the code to pre-create a bucket beforehand and verified the host gracefully handles the error from the NATS client. I also tested the error case by attempting to create a bucket with an invalid name. 

### Manual Verification
See above