### PR TITLE
style: rename most instances of lattice and wasmbus to host

### DIFF
--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -4,10 +4,10 @@
 #![warn(missing_docs)]
 #![forbid(clippy::unwrap_used)]
 
-/// local lattice
+/// local host
 pub mod local;
 
-/// wasmbus lattice
+/// wasmbus host
 pub mod wasmbus;
 
 /// bindle artifact fetching
@@ -19,8 +19,8 @@ pub mod oci;
 /// Provider archive functionality
 mod par;
 
-pub use local::{Lattice as LocalLattice, LatticeConfig as LocalLatticeConfig};
-pub use wasmbus::{Lattice as WasmbusLattice, LatticeConfig as WasmbusLatticeConfig};
+pub use local::{Host as LocalHost, HostConfig as LocalHostConfig};
+pub use wasmbus::{Host as WasmbusHost, HostConfig as WasmbusHostConfig};
 
 pub use url;
 

--- a/crates/host/src/local/config.rs
+++ b/crates/host/src/local/config.rs
@@ -6,10 +6,10 @@ use std::env;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use url::Url;
 
-/// Declarative local lattice configuration
+/// Declarative local host configuration
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct Lattice {
+pub struct Host {
     /// Actor definitions
     #[serde(default)]
     pub actors: HashMap<String, Actor>,
@@ -128,10 +128,10 @@ addr = "[::]:5000"
 
     #[test]
     fn parse() -> anyhow::Result<()> {
-        let config: Lattice = toml::from_str(CONFIG).context("failed to parse config")?;
+        let config: Host = toml::from_str(CONFIG).context("failed to parse config")?;
         assert_eq!(
             config,
-            Lattice {
+            Host {
                 actors: HashMap::from([
                     (
                         "http-parser".into(),

--- a/crates/host/src/local/mod.rs
+++ b/crates/host/src/local/mod.rs
@@ -1,9 +1,8 @@
-/// Local lattice configuration
+/// Local host configuration
 pub mod config;
 
 pub use config::{
-    Actor as ActorConfig, Lattice as LatticeConfig, Link as LinkConfig,
-    TcpSocket as TcpSocketConfig,
+    Actor as ActorConfig, Host as HostConfig, Link as LinkConfig, TcpSocket as TcpSocketConfig,
 };
 
 use crate::socket_pair;
@@ -234,21 +233,21 @@ impl Actor {
     }
 }
 
-/// Local lattice
+/// Local host
 #[derive(Debug)]
-pub struct Lattice {
+pub struct Host {
     #[allow(unused)] // TODO: Use and remove
     actors: Arc<RwLock<HashMap<String, Actor>>>,
     state: State,
 }
 
-/// Local lattice state
+/// Local host state
 #[derive(Debug, Default)]
 pub struct State {
     tcp_listeners: HashMap<String, AbortHandle>,
 }
 
-impl Drop for Lattice {
+impl Drop for Host {
     fn drop(&mut self) {
         for abort in self.state.tcp_listeners.values() {
             abort.abort();
@@ -299,10 +298,10 @@ async fn handle_tcp_stream(
     .context("failed to execute chain")
 }
 
-impl Lattice {
-    /// Construct a new [Lattice]
+impl Host {
+    /// Construct a new [Host]
     #[instrument]
-    pub async fn new(LatticeConfig { actors, links }: LatticeConfig) -> anyhow::Result<Self> {
+    pub async fn new(HostConfig { actors, links }: HostConfig) -> anyhow::Result<Self> {
         // TODO: Configure
         let rt = Runtime::builder()
             .build()

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-/// Wasmbus lattice configuration
-pub struct Lattice {
+/// wasmCloud Host configuration
+pub struct Host {
     /// URL to connect to
     pub url: Url,
     /// Optional host seed
@@ -12,7 +12,7 @@ pub struct Lattice {
     pub cluster_seed: Option<String>,
 }
 
-impl Default for Lattice {
+impl Default for Host {
     fn default() -> Self {
         Self {
             url: Url::parse("nats://localhost:4222").expect("failed to parse URL"),

--- a/examples/rust/http-axum/tests/local.rs
+++ b/examples/rust/http-axum/tests/local.rs
@@ -6,7 +6,7 @@ use std::net::{Ipv6Addr, TcpListener};
 use anyhow::Context;
 use tokio::process::Command;
 use tracing_subscriber::prelude::*;
-use wasmcloud_host::local::{ActorConfig, Lattice, LatticeConfig, LinkConfig, TcpSocketConfig};
+use wasmcloud_host::local::{ActorConfig, Host, HostConfig, LinkConfig, TcpSocketConfig};
 use wasmcloud_host::url::Url;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -45,7 +45,7 @@ async fn local() -> anyhow::Result<()> {
         env!("CARGO_TARGET_TMPDIR")
     ))
     .expect("failed to parse Wasm path");
-    let _lattice = Lattice::new(LatticeConfig {
+    let _host = Host::new(HostConfig {
         actors: HashMap::from([("server".into(), ActorConfig { url })]),
         links: vec![LinkConfig::Tcp {
             socket: TcpSocketConfig {
@@ -55,7 +55,7 @@ async fn local() -> anyhow::Result<()> {
         }],
     })
     .await
-    .context("failed to initialize lattice")?;
+    .context("failed to initialize host")?;
 
     eprintln!("sending a GET request on port `{port}`");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::{self, Context};
 use clap::Parser;
 use tokio::{select, signal};
 use tracing_subscriber::prelude::*;
-use wasmcloud_host::WasmbusLatticeConfig;
+use wasmcloud_host::WasmbusHostConfig;
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
@@ -23,13 +23,13 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let (lattice, shutdown) = wasmcloud_host::WasmbusLattice::new(WasmbusLatticeConfig::default())
+    let (host, shutdown) = wasmcloud_host::WasmbusHost::new(WasmbusHostConfig::default())
         .await
-        .context("failed to initialize `wasmbus` lattice")?;
+        .context("failed to initialize host")?;
     select! {
         sig = signal::ctrl_c() => sig.context("failed to wait for Ctrl-C")?,
-        _ = lattice.stopped() => {},
+        _ = host.stopped() => {},
     };
-    shutdown.await.context("failed to shutdown lattice")?;
+    shutdown.await.context("failed to shutdown host")?;
     Ok(())
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use anyhow::Context;
 use tracing_subscriber::prelude::*;
-use wasmcloud_host::local::{ActorConfig, Lattice, LatticeConfig, LinkConfig, TcpSocketConfig};
+use wasmcloud_host::local::{ActorConfig, Host, HostConfig, LinkConfig, TcpSocketConfig};
 use wasmcloud_host::url::Url;
 
 fn wasm_url(path: impl AsRef<Path>) -> Url {
@@ -12,7 +12,7 @@ fn wasm_url(path: impl AsRef<Path>) -> Url {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "skip local lattice test by default"]
+#[ignore = "skip local host test by default"]
 async fn local() -> anyhow::Result<()> {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().pretty().without_time())
@@ -29,7 +29,7 @@ async fn local() -> anyhow::Result<()> {
         .context("failed to query listener local address")?
         .port();
 
-    let _lattice = Lattice::new(LatticeConfig {
+    let _host = Host::new(HostConfig {
         actors: HashMap::from([
             (
                 "logging".into(),


### PR DESCRIPTION
## Feature or Problem
There were several instances where we referred to "wasmbus" or "lattice" where I think "host" is the more appropriate term. I was getting confused so I replaced most of these with "host"

## Related Issues
N/A

## Release Information
Next

## Consumer Impact
N/A

## Testing
No additional testing performed