### PR TITLE
Custom lattice prefixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ status = "actively-developed"
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true, features = ["color", "derive", "error-context", "help", "std", "suggestions", "usage"] }
+clap = { workspace = true, features = ["color", "derive", "env", "error-context", "help", "std", "suggestions", "usage"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 tracing = { workspace = true, features = ["release_max_level_info"] }
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "fmt", "json", "std"] }

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -4,18 +4,22 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 /// wasmCloud Host configuration
 pub struct Host {
-    /// URL to connect to
-    pub url: Url,
-    /// Optional host seed
+    /// NATS URL to connect to for control interface connection
+    pub ctl_nats_url: Url,
+    /// The lattice the host belongs to
+    pub lattice_prefix: String,
+    /// The seed key (a printable 256-bit Ed25519 private key) used by this host to generate its public key
     pub host_seed: Option<String>,
-    /// Optional cluster seed
+    /// The seed key (a printable 256-bit Ed25519 private key) used by this host to sign all invocations
     pub cluster_seed: Option<String>,
 }
 
 impl Default for Host {
     fn default() -> Self {
         Self {
-            url: Url::parse("nats://localhost:4222").expect("failed to parse URL"),
+            ctl_nats_url: Url::parse("nats://localhost:4222")
+                .expect("failed to parse control NATS URL"),
+            lattice_prefix: "default".to_string(),
             host_seed: None,
             cluster_seed: None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,15 +4,50 @@ use anyhow::{self, Context};
 use clap::Parser;
 use tokio::{select, signal};
 use tracing_subscriber::prelude::*;
+use wasmcloud_host::url::Url;
 use wasmcloud_host::WasmbusHostConfig;
+
+/// Default NATS server host
+const DEFAULT_NATS_HOST: &str = "localhost";
+/// Default NATS server port
+const DEFAULT_NATS_PORT: &str = "4222";
+/// Default lattice prefix
+const DEFAULT_LATTICE_PREFIX: &str = "default";
+
+/// Env var for NATS server host
+const ENV_NATS_HOST: &str = "NATS_HOST";
+/// Env var for NATS server port
+const ENV_NATS_PORT: &str = "NATS_PORT";
+/// Env var for lattice prefix
+const ENV_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
+/// Env var for host seed
+const ENV_HOST_SEED: &str = "WASMCLOUD_HOST_SEED";
+/// Env var for cluster seed
+const ENV_CLUSTER_SEED: &str = "WASMCLOUD_CLUSTER_SEED";
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
-struct Args;
+struct Args {
+    /// NATS server host to connect to
+    #[clap(long = "nats-host", default_value = DEFAULT_NATS_HOST, env = ENV_NATS_HOST)]
+    pub nats_host: String,
+    /// NATS server port to connect to
+    #[clap(long = "nats-port", default_value = DEFAULT_NATS_PORT, env = ENV_NATS_PORT)]
+    pub nats_port: u16,
+    /// The lattice the host belongs to
+    #[clap(short = 'x', long = "lattice-prefix", default_value = DEFAULT_LATTICE_PREFIX, env = ENV_LATTICE_PREFIX)]
+    pub lattice_prefix: String,
+    /// The seed key (a printable 256-bit Ed25519 private key) used by this host to generate its public key  
+    #[clap(long = "host-seed", env = ENV_HOST_SEED)]
+    pub host_seed: Option<String>,
+    /// The seed key (a printable 256-bit Ed25519 private key) used by this host to sign all invocations
+    #[clap(long = "cluster-seed", env = ENV_CLUSTER_SEED)]
+    pub cluster_seed: Option<String>,
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let Args = Args::parse();
+    let args = Args::parse();
 
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().pretty().without_time())
@@ -23,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let (host, shutdown) = wasmcloud_host::WasmbusHost::new(WasmbusHostConfig::default())
+    let (host, shutdown) = wasmcloud_host::wasmbus::Host::new(args.into())
         .await
         .context("failed to initialize host")?;
     select! {
@@ -32,4 +67,16 @@ async fn main() -> anyhow::Result<()> {
     };
     shutdown.await.context("failed to shutdown host")?;
     Ok(())
+}
+
+impl From<Args> for WasmbusHostConfig {
+    fn from(args: Args) -> Self {
+        Self {
+            ctl_nats_url: Url::parse(&format!("nats://{}:{}", args.nats_host, args.nats_port))
+                .expect("failed to parse ctl_nats_url"),
+            lattice_prefix: args.lattice_prefix,
+            host_seed: args.host_seed,
+            cluster_seed: args.cluster_seed,
+        }
+    }
 }


### PR DESCRIPTION
## Feature or Problem
Note: this PR is based on top of https://github.com/wasmCloud/wasmCloud/pull/431

This PR adds support for setting a custom lattice prefix via args

I also moved a couple other settings into `HostConfig`. If we like this approach, I can easily add support for the rest of the host options.

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/428

## Release Information
Next

## Consumer Impact
Users can now start the host with a `-x foo-bar` and the `lattice_prefix` for incoming/outgoing messages will match

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Acceptance or Integration
I updated the wasmbus test to use a custom prefix

### Manual Verification
I also tested manually with different prefixes and NATS hosts/ports