### PR TITLE
feat: add support for non-default link names

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -349,10 +349,11 @@ impl Handler {
             rmp_serde::to_vec_named(&invocation).context("failed to encode invocation")?;
         let lattice_prefix = &self.lattice_prefix;
         let provider_id = invocation.target.public_key;
+        let link_name = invocation.target.link_name;
         let res = self
             .nats
             .request(
-                format!("wasmbus.rpc.{lattice_prefix}.{provider_id}.default",),
+                format!("wasmbus.rpc.{lattice_prefix}.{provider_id}.{link_name}"),
                 request.into(),
             )
             .await
@@ -413,7 +414,6 @@ impl Bus for Handler {
 
         let nats = self.nats.clone();
         let lattice_prefix = self.lattice_prefix.clone();
-        let provider_id = target.public_key.clone();
         let origin = self.origin.clone();
         let target = target.clone();
         let cluster_key = self.cluster_key.clone();
@@ -430,12 +430,14 @@ impl Bus for Handler {
                 let invocation =
                     Invocation::new(&cluster_key, origin, target, interface_method, request)
                         .map_err(|e| e.to_string())?;
+                let provider_id = &invocation.target.public_key;
+                let link_name = &invocation.target.link_name;
                 let request = rmp_serde::to_vec_named(&invocation)
                     .context("failed to encode invocation")
                     .map_err(|e| e.to_string())?;
                 let res = nats
                     .request(
-                        format!("wasmbus.rpc.{lattice_prefix}.{provider_id}.default"),
+                        format!("wasmbus.rpc.{lattice_prefix}.{provider_id}.{link_name}"),
                         request.into(),
                     )
                     .await


### PR DESCRIPTION
## Feature or Problem
This PR adds support for RPC on non-default link names

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/461

## Release Information
Next

## Consumer Impact
Users can start and interact with providers on non-default link names. Note the discussion in https://github.com/wasmCloud/wasmCloud/issues/461 for why this will currently only work for wasm modules, not components

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
N/A

### Acceptance or Integration
Updated the wasmbus tests

### Manual Verification
N/A