### PR TITLE
fix(logs): allow debug and trace logs in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ clap = { workspace = true, features = [
     "usage",
 ] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
-tracing = { workspace = true, features = ["release_max_level_info"] }
+tracing = { workspace = true } # TODO: revisit the 'release_max_level_info' feature https://github.com/wasmCloud/wasmCloud/issues/468
 tracing-subscriber = { workspace = true, features = [
     "ansi",
     "env-filter",


### PR DESCRIPTION
## Feature or Problem
This removes a feature from the tracing crate, allowing higher log verbosity than info for release builds

Allowing users to specify debug/trace-level logs is important for debugging release builds. The size of the debug build is prohibitively large in some environments where viewing debug/trace logs is still helpful