### PR TITLE
Implement cluster issuers, log level, provider shutdown, js_domain, and OCI CLI vars

### DIFF
--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::oci::Config as OciConfig;
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 /// wasmCloud Host configuration
 pub struct Host {
@@ -18,6 +20,8 @@ pub struct Host {
     pub cluster_issuers: Option<Vec<String>>,
     /// The amount of time to wait for a provider to gracefully shut down before terminating it
     pub provider_shutdown_delay: Option<std::time::Duration>,
+    /// Configuration for downloading artifacts from OCI registries
+    pub oci_opts: OciConfig,
 }
 
 impl Default for Host {
@@ -31,6 +35,7 @@ impl Default for Host {
             cluster_seed: None,
             cluster_issuers: None,
             provider_shutdown_delay: None,
+            oci_opts: OciConfig::default(),
         }
     }
 }

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -12,6 +12,8 @@ pub struct Host {
     pub host_seed: Option<String>,
     /// The seed key (a printable 256-bit Ed25519 private key) used by this host to sign all invocations
     pub cluster_seed: Option<String>,
+    /// The identity keys (a printable 256-bit Ed25519 public key) that this host should allow invocations from
+    pub cluster_issuers: Option<Vec<String>>,
 }
 
 impl Default for Host {
@@ -22,6 +24,7 @@ impl Default for Host {
             lattice_prefix: "default".to_string(),
             host_seed: None,
             cluster_seed: None,
+            cluster_issuers: None,
         }
     }
 }

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -8,6 +8,8 @@ pub struct Host {
     pub ctl_nats_url: Url,
     /// The lattice the host belongs to
     pub lattice_prefix: String,
+    /// The domain to use for host Jetstream operations
+    pub js_domain: Option<String>,
     /// The seed key (a printable 256-bit Ed25519 private key) used by this host to generate its public key
     pub host_seed: Option<String>,
     /// The seed key (a printable 256-bit Ed25519 private key) used by this host to sign all invocations
@@ -24,6 +26,7 @@ impl Default for Host {
             ctl_nats_url: Url::parse("nats://localhost:4222")
                 .expect("failed to parse control NATS URL"),
             lattice_prefix: "default".to_string(),
+            js_domain: None,
             host_seed: None,
             cluster_seed: None,
             cluster_issuers: None,

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -14,6 +14,8 @@ pub struct Host {
     pub cluster_seed: Option<String>,
     /// The identity keys (a printable 256-bit Ed25519 public key) that this host should allow invocations from
     pub cluster_issuers: Option<Vec<String>>,
+    /// The amount of time to wait for a provider to gracefully shut down before terminating it
+    pub provider_shutdown_delay: Option<std::time::Duration>,
 }
 
 impl Default for Host {
@@ -25,6 +27,7 @@ impl Default for Host {
             host_seed: None,
             cluster_seed: None,
             cluster_issuers: None,
+            provider_shutdown_delay: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,31 +45,22 @@ struct Args {
     #[clap(long = "cluster-seed", env = "WASMCLOUD_CLUSTER_SEED")]
     cluster_seed: Option<String>,
     /// A comma-delimited list of public keys that can be used as issuers on signed invocations
-    #[clap(
-        long = "cluster-issuers",
-        env = "WASMCLOUD_CLUSTER_ISSUERS",
-        hide = true
-    )]
+    #[clap(long = "cluster-issuers", env = "WASMCLOUD_CLUSTER_ISSUERS")]
     cluster_issuers: Option<Vec<String>>,
     /// Delay, in milliseconds, between requesting a provider shut down and forcibly terminating its process
-    #[clap(long = "provider-shutdown-delay", default_value = "300", env = "WASMCLOUD_PROV_SHUTDOWN_DELAY_MS", value_parser = parse_duration, hide = true)]
+    #[clap(long = "provider-shutdown-delay", default_value = "300", env = "WASMCLOUD_PROV_SHUTDOWN_DELAY_MS", value_parser = parse_duration)]
     provider_shutdown_delay: Duration,
     /// Determines whether OCI images tagged latest are allowed to be pulled from OCI registries and started
-    #[clap(long = "allow-latest", env = "WASMCLOUD_OCI_ALLOW_LATEST", hide = true)]
+    #[clap(long = "allow-latest", env = "WASMCLOUD_OCI_ALLOW_LATEST")]
     allow_latest: bool,
     /// A comma-separated list of OCI hosts to which insecure (non-TLS) connections are allowed
-    #[clap(
-        long = "allowed-insecure",
-        env = "WASMCLOUD_OCI_ALLOWED_INSECURE",
-        hide = true
-    )]
+    #[clap(long = "allowed-insecure", env = "WASMCLOUD_OCI_ALLOWED_INSECURE")]
     allowed_insecure: Vec<String>,
-    /// Jetstream domain name, configures a host to properly connect to a NATS supercluster, defaults to `core`
+    /// NATS Jetstream domain name
     #[clap(
         long = "js-domain",
         alias = "wasmcloud-js-domain",
-        env = "WASMCLOUD_JS_DOMAIN",
-        hide = true
+        env = "WASMCLOUD_JS_DOMAIN"
     )]
     js_domain: Option<String>,
     // TODO: use and implement the below args
@@ -202,20 +193,28 @@ struct Args {
     #[clap(long = "policy-timeout-ms", env = "WASMCLOUD_POLICY_TIMEOUT", value_parser = parse_duration, hide = true)]
     policy_timeout_ms: Option<Duration>,
 
-    #[clap(long = "oci-registry", env = "OCI_REGISTRY", hide = true)]
+    /// Used in tandem with `oci_user` and `oci_password` to override credentials for a specific OCI registry.
+    #[clap(
+        long = "oci-registry",
+        env = "OCI_REGISTRY",
+        requires = "oci_user",
+        requires = "oci_password"
+    )]
     oci_registry: Option<String>,
+    /// Username for the OCI registry specified by `oci_registry`.
     #[clap(
         long = "oci-user",
         env = "OCI_REGISTRY_USER",
-        requires = "oci_password",
-        hide = true
+        requires = "oci_registry",
+        requires = "oci_password"
     )]
     oci_user: Option<String>,
+    /// Password for the OCI registry specified by `oci_registry`.
     #[clap(
         long = "oci-password",
         env = "OCI_REGISTRY_PASSWORD",
-        requires = "oci_user",
-        hide = true
+        requires = "oci_registry",
+        requires = "oci_user"
     )]
     oci_password: Option<String>,
 }
@@ -231,6 +230,8 @@ async fn main() -> anyhow::Result<()> {
         cluster_seed,
         cluster_issuers,
         provider_shutdown_delay,
+        allow_latest,
+        allowed_insecure,
         oci_registry,
         oci_user,
         oci_password,

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,6 @@ struct Args {
     /// The seed key (a printable 256-bit Ed25519 private key) used by this host to sign all invocations
     #[clap(long = "cluster-seed", env = "WASMCLOUD_CLUSTER_SEED")]
     cluster_seed: Option<String>,
-    // TODO: use and implement cluster issuers
     /// A comma-delimited list of public keys that can be used as issuers on signed invocations
     #[clap(
         long = "cluster-issuers",
@@ -224,6 +223,7 @@ async fn main() -> anyhow::Result<()> {
         lattice_prefix,
         host_seed,
         cluster_seed,
+        cluster_issuers,
         ..
     } = Args::parse();
 
@@ -243,6 +243,7 @@ async fn main() -> anyhow::Result<()> {
         lattice_prefix,
         host_seed,
         cluster_seed,
+        cluster_issuers,
     })
     .await
     .context("failed to initialize host")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,10 @@ struct Args {
         hide = true
     )]
     cluster_issuers: Option<Vec<String>>,
-    // TODO: use and implement the below args
     /// Delay, in milliseconds, between requesting a provider shut down and forcibly terminating its process
-    #[clap(long = "provider-delay", default_value = "300", env = "WASMCLOUD_PROV_SHUTDOWN_DELAY_MS", value_parser = parse_duration, hide = true)]
-    provider_delay: Duration,
+    #[clap(long = "provider-shutdown-delay", default_value = "300", env = "WASMCLOUD_PROV_SHUTDOWN_DELAY_MS", value_parser = parse_duration, hide = true)]
+    provider_shutdown_delay: Duration,
+    // TODO: use and implement the below args
     /// Determines whether OCI images tagged latest are allowed to be pulled from OCI registries and started
     #[clap(long = "allow-latest", env = "WASMCLOUD_OCI_ALLOW_LATEST", hide = true)]
     allow_latest: bool,
@@ -225,6 +225,7 @@ async fn main() -> anyhow::Result<()> {
         host_seed,
         cluster_seed,
         cluster_issuers,
+        provider_shutdown_delay,
         ..
     } = Args::parse();
 
@@ -245,6 +246,7 @@ async fn main() -> anyhow::Result<()> {
         host_seed,
         cluster_seed,
         cluster_issuers,
+        provider_shutdown_delay: Some(provider_shutdown_delay),
     })
     .await
     .context("failed to initialize host")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,10 +60,16 @@ struct Args {
         env = "WASMCLOUD_OCI_ALLOWED_INSECURE",
         hide = true
     )]
-    allowed_insecure: Option<Vec<String>>,
+    allowed_insecure: Vec<String>,
     /// Jetstream domain name, configures a host to properly connect to a NATS supercluster, defaults to `core`
-    #[clap(long = "wasmcloud-js-domain", env = "WASMCLOUD_JS_DOMAIN", hide = true)]
-    wasmcloud_js_domain: Option<String>,
+    #[clap(
+        long = "js-domain",
+        alias = "wasmcloud-js-domain",
+        env = "WASMCLOUD_JS_DOMAIN",
+        hide = true
+    )]
+    js_domain: Option<String>,
+    // TODO: use and implement the below args
     /// Denotes if a wasmCloud host should issue requests to a config service on startup
     #[clap(
         long = "config-service-enabled",
@@ -226,6 +232,7 @@ async fn main() -> anyhow::Result<()> {
         cluster_seed,
         cluster_issuers,
         provider_shutdown_delay,
+        js_domain,
         ..
     } = Args::parse();
 
@@ -246,6 +253,7 @@ async fn main() -> anyhow::Result<()> {
         host_seed,
         cluster_seed,
         cluster_issuers,
+        js_domain,
         provider_shutdown_delay: Some(provider_shutdown_delay),
     })
     .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,6 +218,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let Args {
+        log_level,
         nats_host,
         nats_port,
         lattice_prefix,
@@ -231,7 +232,7 @@ async fn main() -> anyhow::Result<()> {
         .with(tracing_subscriber::fmt::layer().pretty().without_time())
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn")
+                tracing_subscriber::EnvFilter::new(format!("{log_level},cranelift_codegen=warn"))
             }),
         )
         .init();

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -241,6 +241,7 @@ async fn wasmbus() -> anyhow::Result<()> {
     let (host, shutdown) = Host::new(HostConfig {
         ctl_nats_url: ctl_nats_url.clone(),
         lattice_prefix: TEST_PREFIX.to_string(),
+        js_domain: None,
         cluster_seed: Some(cluster_key.seed().unwrap()),
         cluster_issuers: Some(vec![cluster_key.public_key()]),
         host_seed: Some(host_key.seed().unwrap()),
@@ -271,10 +272,10 @@ async fn wasmbus() -> anyhow::Result<()> {
             [],
         ) => {
             // TODO: Validate `issuer`
-            ensure!(cluster_issuers == Some("TODO".into()));
+            ensure!(cluster_issuers == Some(cluster_key.public_key()));
             ensure!(ctl_host == Some("TODO".into()));
             ensure!(id == host_key.public_key());
-            ensure!(js_domain == Some("TODO".into()));
+            ensure!(js_domain == None);
             ensure!(
                 labels.as_ref() == Some(&expected_labels),
                 r#"invalid labels:

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -244,6 +244,7 @@ async fn wasmbus() -> anyhow::Result<()> {
         cluster_seed: Some(cluster_key.seed().unwrap()),
         cluster_issuers: Some(vec![cluster_key.public_key()]),
         host_seed: Some(host_key.seed().unwrap()),
+        provider_shutdown_delay: Some(Duration::from_millis(300)),
     })
     .await
     .context("failed to initialize host")?;

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -30,6 +30,7 @@ use wasmcloud_control_interface::{
     ActorAuctionAck, ActorDescription, ActorInstance, ClientBuilder, CtlOperationAck,
     Host as HostInfo, HostInventory, ProviderAuctionAck,
 };
+use wasmcloud_host::oci::Config as OciConfig;
 use wasmcloud_host::wasmbus::{Host, HostConfig};
 
 async fn free_port() -> anyhow::Result<u16> {
@@ -246,6 +247,7 @@ async fn wasmbus() -> anyhow::Result<()> {
         cluster_issuers: Some(vec![cluster_key.public_key()]),
         host_seed: Some(host_key.seed().unwrap()),
         provider_shutdown_delay: Some(Duration::from_millis(300)),
+        oci_opts: OciConfig::default(),
     })
     .await
     .context("failed to initialize host")?;

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -242,6 +242,7 @@ async fn wasmbus() -> anyhow::Result<()> {
         ctl_nats_url: ctl_nats_url.clone(),
         lattice_prefix: TEST_PREFIX.to_string(),
         cluster_seed: Some(cluster_key.seed().unwrap()),
+        cluster_issuers: Some(vec![cluster_key.public_key()]),
         host_seed: Some(host_key.seed().unwrap()),
     })
     .await


### PR DESCRIPTION
## Feature or Problem
This PR continues work towards OTP feature parity by using more of the CLI args provided. Specifically, this PR implements using:
1. `cluster_issuers` list by propagating the list as a part of host config. Will need to be utilized in #483 
2. `log_level` by parsing as a `tracing::Level` and passing to the `tracing_subscriber` setup
3. `provider_shutdown_delay` by adding a NATS request to gracefully shutdown the provider with this timeout
4. `allow_latest`, `allowed_insecure`, `oci_registry`, `oci_user`, and `oci_password` by adding an `OciOpts` struct that the `Host` holds as a field and will use for all OCI operations
5. `js_domain` by using the optional domain to create the Jetstream context when accessing the LATTICECACHE KV bucket.

There are still more args to implement, but I'm trying to keep the PRs more organized and only add a few features at a time.

## Related Issues
N/A

## Release Information
N/A

## Consumer Impact
Nothing really quite yet, but you can now run the host with a variety of options 

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
- Validated that log level is parsed properly and affects emitted logs
- Validated that the provider shutdown delay is respected and the message publishes
- Validated that JS domain does properly look for KV buckets in the correct domain (required check for bucket existence in cases where creation of buckets is blocked at the NATS account level)
- Validated that allow_latest, and the 3-tuple of oci_registry, oci_user, and oci_password allow for authenticating to a registry
