### PR TITLE
Add cluster issuers verification test

### DIFF
--- a/crates/host/src/bindle.rs
+++ b/crates/host/src/bindle.rs
@@ -196,9 +196,9 @@ pub async fn fetch_actor(
 #[allow(clippy::implicit_hasher)]
 #[allow(clippy::missing_errors_doc)] // TODO: document errors
 pub async fn fetch_provider(
-    creds_override: Option<HashMap<String, String>>,
     bindle_id: impl AsRef<str>,
     link_name: impl AsRef<str>,
+    creds_override: Option<HashMap<String, String>>,
 ) -> anyhow::Result<(PathBuf, jwt::Claims<jwt::CapabilityProvider>)> {
     let bindle_id = bindle_id.as_ref();
     let client = get_client(creds_override, bindle_id)

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -86,7 +86,7 @@ pub async fn fetch_actor(
         ResourceRef::Bindle(actor_ref) => crate::bindle::fetch_actor(None, &actor_ref)
             .await
             .with_context(|| format!("failed to fetch actor under Bindle reference `{actor_ref}`")),
-        ResourceRef::Oci(actor_ref) => crate::oci::fetch_actor(None, &actor_ref, oci_opts)
+        ResourceRef::Oci(actor_ref) => crate::oci::fetch_actor(&actor_ref, None, oci_opts)
             .await
             .with_context(|| format!("failed to fetch actor under OCI reference `{actor_ref}`")),
     }
@@ -104,7 +104,7 @@ pub async fn fetch_provider(
             .await
             .context("failed to read provider"),
         ResourceRef::Bindle(provider_ref) => {
-            crate::bindle::fetch_provider(None, &provider_ref, link_name)
+            crate::bindle::fetch_provider(&provider_ref, link_name, None)
                 .await
                 .with_context(|| {
                     format!("failed to fetch provider under Bindle reference `{provider_ref}`")

--- a/crates/host/src/oci.rs
+++ b/crates/host/src/oci.rs
@@ -162,8 +162,8 @@ async fn cache_oci_image(
 /// Returns an error if either fetching fails or reading the fetched OCI path fails
 #[allow(clippy::implicit_hasher)]
 pub async fn fetch_actor(
-    creds_override: Option<HashMap<String, String>>,
     oci_ref: impl AsRef<str>,
+    creds_override: Option<HashMap<String, String>>,
     host_oci_opts: &Config,
 ) -> anyhow::Result<Vec<u8>> {
     let path = fetch_oci_path(


### PR DESCRIPTION
## Feature or Problem
This PR contains one chore for reordering args, and one addition to the `wasmbus` test which launches a second host instance with a _different_ cluster key in order to verify that we're passing cluster issuers into all the right places. Both of these are requests from @connorsmith256's review of #490 so I just wanted to wrap that up.

## Related Issues
#490 

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
The wasmbus test suite now runs _two_ hosts. I considered adding another test for "multi-host" scenarios but I figured this would be the quickest way to proceed with the logic that we have, and by and large nothing should really be different for running multiple hosts in the same lattice.

### Manual Verification
Ran `cargo nextest run` and, by removing the host cluster issuers from each others list, the test fails with:
```
2023-08-16T20:09:03.196123Z ERROR wasmcloud_provider_sdk::provider: Invocation failed error=Issuer of this invocation is not in list of cluster issuers
[46410] [TRC] 127.0.0.1:60898 - cid:16 - <<- [PUB _INBOX.Z7mQynpFwnxBeVKGPzuS6o 188]
[46410] [TRC] 127.0.0.1:60898 - cid:16 - <<- MSG_PAYLOAD: ["\x85\xa3msg\xc4\x00\xadinvocation_id\xd9$0189fff7-47da-f442-b15d-296770cf8a49\xa5error\xd9[Error when handling invocation: Issuer of this invocation is not in list of cluster issuers\xaecontent_length\x00\xactraceContext\x80"]
[46410] [TRC] [::1]:60876 - cid:6 - ->> [MSG _INBOX.Z7mQynpFwnxBeVKGPzuS6o 16 188]
thread '<unnamed>' panicked at 'failed to publish response: "`wasmcloud:messaging/Messaging.Publish` call failed: Error when handling invocation: Issuer of this invocation is not in list of cluster issuers"', builtins-component-reactor/src/lib.rs:85:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```