### PR TITLE
Implement connection args for RPC/CTL/Prov RPC arguments

### DIFF
--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -8,6 +10,30 @@ use crate::oci::Config as OciConfig;
 pub struct Host {
     /// NATS URL to connect to for control interface connection
     pub ctl_nats_url: Url,
+    /// Authentication JWT for control interface connection, must be specified with ctl_seed
+    pub ctl_jwt: Option<String>,
+    /// Authentication NKEY Seed for control interface connection, must be specified with ctl_jwt
+    pub ctl_seed: Option<String>,
+    /// Whether to require TLS for control interface connection
+    pub ctl_tls: bool,
+    /// NATS URL to connect to for actor RPC
+    pub rpc_nats_url: Url,
+    /// Timeout period for all RPC calls
+    pub rpc_timeout: Duration,
+    /// Authentication JWT for RPC connection, must be specified with rpc_seed
+    pub rpc_jwt: Option<String>,
+    /// Authentication NKEY Seed for RPC connection, must be specified with rpc_jwt
+    pub rpc_seed: Option<String>,
+    /// Whether to require TLS for RPC connection
+    pub rpc_tls: bool,
+    /// NATS URL to pass to providers for RPC
+    pub prov_rpc_nats_url: Url,
+    /// Authentication JWT for Provider RPC connection, must be specified with prov_rpc_seed
+    pub prov_rpc_jwt: Option<String>,
+    /// Authentication NKEY Seed for Provider RPC connection, must be specified with prov_rpc_jwt
+    pub prov_rpc_seed: Option<String>,
+    /// Whether to require TLS for Provider RPC connection
+    pub prov_rpc_tls: bool,
     /// The lattice the host belongs to
     pub lattice_prefix: String,
     /// The domain to use for host Jetstream operations
@@ -29,6 +55,20 @@ impl Default for Host {
         Self {
             ctl_nats_url: Url::parse("nats://localhost:4222")
                 .expect("failed to parse control NATS URL"),
+            ctl_jwt: None,
+            ctl_seed: None,
+            ctl_tls: false,
+            rpc_nats_url: Url::parse("nats://localhost:4222")
+                .expect("failed to parse RPC NATS URL"),
+            rpc_timeout: Duration::from_millis(2000),
+            rpc_jwt: None,
+            rpc_seed: None,
+            rpc_tls: false,
+            prov_rpc_nats_url: Url::parse("nats://localhost:4222")
+                .expect("failed to parse Provider RPC NATS URL"),
+            prov_rpc_jwt: None,
+            prov_rpc_seed: None,
+            prov_rpc_tls: false,
             lattice_prefix: "default".to_string(),
             js_domain: None,
             host_seed: None,

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -16,6 +16,8 @@ pub struct Host {
     pub ctl_seed: Option<String>,
     /// Whether to require TLS for control interface connection
     pub ctl_tls: bool,
+    /// The topic prefix to use for control interface subscriptions, defaults to `wasmbus.ctl`
+    pub ctl_topic_prefix: String,
     /// NATS URL to connect to for actor RPC
     pub rpc_nats_url: Url,
     /// Timeout period for all RPC calls
@@ -58,6 +60,7 @@ impl Default for Host {
             ctl_jwt: None,
             ctl_seed: None,
             ctl_tls: false,
+            ctl_topic_prefix: "wasmbus.ctl".to_string(),
             rpc_nats_url: Url::parse("nats://localhost:4222")
                 .expect("failed to parse RPC NATS URL"),
             rpc_timeout: Duration::from_millis(2000),

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1032,6 +1032,7 @@ impl Host {
             _ => async_nats::ConnectOptions::new(),
         }
         .require_tls(config.rpc_tls)
+        .request_timeout(Some(config.rpc_timeout))
         .connect(config.rpc_nats_url.as_str())
         .await
         .context("failed to connect to NATS RPC server")?;

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -161,19 +161,20 @@ impl Queue {
     #[instrument]
     async fn new(
         nats: &async_nats::Client,
+        topic_prefix: &str,
         lattice_prefix: &str,
         cluster_key: &KeyPair,
         host_key: &KeyPair,
     ) -> anyhow::Result<Self> {
         let host_id = host_key.public_key();
         let (registries, pings, links, queries, auction, commands, inventory) = try_join!(
-            nats.subscribe(format!("wasmbus.ctl.{lattice_prefix}.registries.put",)),
-            nats.subscribe(format!("wasmbus.ctl.{lattice_prefix}.ping.hosts",)),
-            nats.subscribe(format!("wasmbus.ctl.{lattice_prefix}.linkdefs.*",)),
-            nats.subscribe(format!("wasmbus.ctl.{lattice_prefix}.get.*",)),
-            nats.subscribe(format!("wasmbus.ctl.{lattice_prefix}.auction.>",)),
-            nats.subscribe(format!("wasmbus.ctl.{lattice_prefix}.cmd.{host_id}.*",)),
-            nats.subscribe(format!("wasmbus.ctl.{lattice_prefix}.get.{host_id}.inv",)),
+            nats.subscribe(format!("{topic_prefix}.{lattice_prefix}.registries.put",)),
+            nats.subscribe(format!("{topic_prefix}.{lattice_prefix}.ping.hosts",)),
+            nats.subscribe(format!("{topic_prefix}.{lattice_prefix}.linkdefs.*",)),
+            nats.subscribe(format!("{topic_prefix}.{lattice_prefix}.get.*",)),
+            nats.subscribe(format!("{topic_prefix}.{lattice_prefix}.auction.>",)),
+            nats.subscribe(format!("{topic_prefix}.{lattice_prefix}.cmd.{host_id}.*",)),
+            nats.subscribe(format!("{topic_prefix}.{lattice_prefix}.get.{host_id}.inv",)),
         )
         .context("failed to subscribe to queues")?;
         Ok(Self {
@@ -840,10 +841,11 @@ pub struct Host {
     host_config: HostConfig,
     host_key: KeyPair,
     labels: HashMap<String, String>,
-    /// NATS client to use for actor RPC calls
-    rpc_nats: async_nats::Client,
+    ctl_topic_prefix: String,
     /// NATS client to use for control interface subscriptions and jetstream queries
     ctl_nats: async_nats::Client,
+    /// NATS client to use for actor RPC calls
+    rpc_nats: async_nats::Client,
     /// NATS client to use for communicating with capability providers
     prov_rpc_nats: async_nats::Client,
     data: kv::Store,
@@ -1001,9 +1003,15 @@ impl Host {
         .await
         .context("failed to connect to NATS control server")?;
 
-        let queue = Queue::new(&ctl_nats, &config.lattice_prefix, &cluster_key, &host_key)
-            .await
-            .context("failed to initialize queue")?;
+        let queue = Queue::new(
+            &ctl_nats,
+            &config.ctl_topic_prefix,
+            &config.lattice_prefix,
+            &cluster_key,
+            &host_key,
+        )
+        .await
+        .context("failed to initialize queue")?;
         ctl_nats.flush().await.context("failed to flush")?;
 
         debug!(
@@ -1092,12 +1100,13 @@ impl Host {
             event_builder,
             friendly_name,
             heartbeat: heartbeat_abort.clone(),
-            host_config: config,
+            ctl_topic_prefix: config.ctl_topic_prefix.clone(),
             host_key,
             labels,
             ctl_nats,
             rpc_nats,
             prov_rpc_nats,
+            host_config: config,
             data: data.clone(),
             data_watch: data_watch_abort.clone(),
             providers: RwLock::default(),
@@ -2339,7 +2348,14 @@ impl Host {
             ..
         }: async_nats::Message,
     ) {
-        let mut parts = subject.split('.').skip(3); // skip `wasmbus.ctl.{prefix}`
+        // Skip the topic prefix and then the lattice prefix
+        // e.g. `wasmbus.ctl.{prefix}`
+        let mut parts = subject
+            .trim()
+            .trim_start_matches(&self.ctl_topic_prefix)
+            .trim_start_matches('.')
+            .split('.')
+            .skip(1);
         let res = match (parts.next(), parts.next(), parts.next(), parts.next()) {
             (Some("auction"), Some("actor"), None, None) => {
                 self.handle_auction_actor(payload).await.map(Some)

--- a/crates/host/src/wasmbus/nats.rs
+++ b/crates/host/src/wasmbus/nats.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use async_nats::ConnectOptions;
+use nkeys::KeyPair;
+
+/// Given the NATS authentication jwt, seed, and tls requirement, return
+/// the proper [`async_nats::ConnectOptions`] to use for connecting.
+///
+/// Returns an error if only one of JWT or seed is specified, as we cannot
+/// authenticate with only one of them.
+pub(crate) fn connection_options(
+    jwt: Option<&String>,
+    seed: Option<&String>,
+    require_tls: bool,
+) -> Result<ConnectOptions> {
+    match (jwt, seed) {
+        (Some(jwt), Some(seed)) => {
+            let kp = Arc::new(
+                KeyPair::from_seed(seed).context("failed to construct key pair from seed")?,
+            );
+            Ok(ConnectOptions::with_jwt(jwt.to_string(), move |nonce| {
+                let key_pair = kp.clone();
+                async move { key_pair.sign(&nonce).map_err(async_nats::AuthError::new) }
+            }))
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            bail!("cannot authenticate if only one of jwt or seed is specified")
+        }
+        _ => Ok(ConnectOptions::new()),
+    }
+    .map(|opts| opts.require_tls(require_tls))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,9 +80,6 @@ struct Args {
         hide = true
     )]
     allow_file_load: bool,
-    /// Enables IPV6 addressing for wasmCloud hosts
-    #[clap(long = "enable-ipv6", env = "WASMCLOUD_ENABLE_IPV6", hide = true)]
-    enable_ipv6: bool,
     /// Enable JSON structured logging from the wasmCloud host
     #[clap(
         long = "enable-structured-logging",

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ struct Args {
     /// Optional flag to require host communication over TLS with a NATS server for CTL messages
     #[clap(long = "ctl-tls", env = "WASMCLOUD_CTL_TLS", hide = true)]
     ctl_tls: bool,
-    /// A prefix to use for all CTL topics
+    /// Advanced: A prefix to use for all CTL topics
     #[clap(
         long = "ctl-topic-prefix",
         env = "WASMCLOUD_CTL_TOPIC_PREFIX",
@@ -241,6 +241,7 @@ async fn main() -> anyhow::Result<()> {
         ctl_jwt,
         ctl_seed,
         ctl_tls,
+        ctl_topic_prefix,
         rpc_host,
         rpc_port,
         rpc_timeout_ms,
@@ -302,6 +303,7 @@ async fn main() -> anyhow::Result<()> {
         ctl_jwt: ctl_jwt.or_else(|| nats_jwt.clone()),
         ctl_seed: ctl_seed.or_else(|| nats_seed.clone()),
         ctl_tls,
+        ctl_topic_prefix,
         rpc_nats_url,
         rpc_timeout: rpc_timeout_ms,
         rpc_jwt: rpc_jwt.or_else(|| nats_jwt.clone()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,12 @@ struct Args {
     /// NATS server port to connect to
     #[clap(long = "nats-port", default_value_t = 4222, env = "NATS_PORT")]
     nats_port: u16,
+    /// A user JWT to use to authenticate to NATS
+    #[clap(long = "nats-jwt", env = "NATS_JWT", requires = "nats_seed")]
+    nats_jwt: Option<String>,
+    /// A seed nkey to use to authenticate to NATS
+    #[clap(long = "nats-seed", env = "NATS_SEED", requires = "nats_jwt")]
+    nats_seed: Option<String>,
 
     /// The lattice the host belongs to
     #[clap(
@@ -84,71 +90,13 @@ struct Args {
     )]
     enable_structured_logging: bool,
 
-    // TODO: use and implement RPC variables
-    /// An IP address or DNS name to use to connect to NATS for RPC messages, defaults to the value supplied to --nats-host if not supplied
-    #[clap(long = "rpc-host", env = "WASMCLOUD_RPC_HOST", hide = true)]
-    rpc_host: Option<String>,
-    /// A port to use to connect to NATS for RPC messages, defaults to the value supplied to --nats-port if not supplied
-    #[clap(long = "rpc-port", env = "WASMCLOUD_RPC_PORT", hide = true)]
-    rpc_port: Option<u16>,
-    /// A user JWT to use to authenticate to NATS for RPC messages
-    #[clap(
-        long = "rpc-jwt",
-        env = "WASMCLOUD_RPC_JWT",
-        requires = "rpc_seed",
-        hide = true
-    )]
-    rpc_jwt: Option<String>,
-    /// A seed nkey to use to authenticate to NATS for RPC messages
-    #[clap(
-        long = "rpc-seed",
-        env = "WASMCLOUD_RPC_SEED",
-        requires = "rpc_jwt",
-        hide = true
-    )]
-    rpc_seed: Option<String>,
-    /// Timeout in milliseconds for all RPC calls
-    #[clap(long = "rpc-timeout-ms", default_value = "2000", env = "WASMCLOUD_RPC_TIMEOUT_MS", value_parser = parse_duration, hide = true)]
-    rpc_timeout_ms: Duration,
-    /// Optional flag to require host communication over TLS with a NATS server for RPC messages
-    #[clap(long = "rpc-tls", env = "WASMCLOUD_RPC_TLS", hide = true)]
-    rpc_tls: bool,
-
-    // TODO: use and implement PROV RPC variables
-    /// An IP address or DNS name to use to connect to NATS for Provider RPC messages, defaults to the value supplied to --nats-host if not supplied
-    #[clap(long = "prov-rpc-host", env = "WASMCLOUD_PROV_RPC_HOST", hide = true)]
-    prov_rpc_host: Option<String>,
-    /// A port to use to connect to NATS for Provider RPC messages, defaults to the value supplied to --nats-port if not supplied
-    #[clap(long = "prov-rpc-port", env = "WASMCLOUD_PROV_RPC_PORT", hide = true)]
-    prov_rpc_port: Option<u16>,
-    /// A user JWT to use to authenticate to NATS for Provider RPC messages
-    #[clap(
-        long = "prov-rpc-jwt",
-        env = "WASMCLOUD_PROV_RPC_JWT",
-        requires = "prov_rpc_seed",
-        hide = true
-    )]
-    prov_rpc_jwt: Option<String>,
-    /// A seed nkey to use to authenticate to NATS for Provider RPC messages
-    #[clap(
-        long = "prov-rpc-seed",
-        env = "WASMCLOUD_PROV_RPC_SEED",
-        requires = "prov_rpc_jwt",
-        hide = true
-    )]
-    prov_rpc_seed: Option<String>,
-    /// Optional flag to require host communication over TLS with a NATS server for Provider RPC messages
-    #[clap(long = "prov-rpc-tls", env = "WASMCLOUD_PROV_RPC_TLS", hide = true)]
-    prov_rpc_tls: bool,
-
-    // TODO: use and implement CTL variables
     /// An IP address or DNS name to use to connect to NATS for Control Interface (CTL) messages, defaults to the value supplied to --nats-host if not supplied
     #[clap(long = "ctl-host", env = "WASMCLOUD_CTL_HOST", hide = true)]
     ctl_host: Option<String>,
     /// A port to use to connect to NATS for CTL messages, defaults to the value supplied to --nats-port if not supplied
     #[clap(long = "ctl-port", env = "WASMCLOUD_CTL_PORT", hide = true)]
     ctl_port: Option<u16>,
-    /// A user JWT to use to authenticate to NATS for CTL messages
+    /// A user JWT to use to authenticate to NATS for CTL messages, defaults to the value supplied to --nats-jwt if not supplied
     #[clap(
         long = "ctl-jwt",
         env = "WASMCLOUD_CTL_JWT",
@@ -156,7 +104,7 @@ struct Args {
         hide = true
     )]
     ctl_jwt: Option<String>,
-    /// A seed nkey to use to authenticate to NATS for CTL messages
+    /// A seed nkey to use to authenticate to NATS for CTL messages, defaults to the value supplied to --nats-seed if not supplied
     #[clap(
         long = "ctl-seed",
         env = "WASMCLOUD_CTL_SEED",
@@ -175,6 +123,61 @@ struct Args {
         hide = true
     )]
     ctl_topic_prefix: String,
+
+    /// An IP address or DNS name to use to connect to NATS for RPC messages, defaults to the value supplied to --nats-host if not supplied
+    #[clap(long = "rpc-host", env = "WASMCLOUD_RPC_HOST", hide = true)]
+    rpc_host: Option<String>,
+    /// A port to use to connect to NATS for RPC messages, defaults to the value supplied to --nats-port if not supplied
+    #[clap(long = "rpc-port", env = "WASMCLOUD_RPC_PORT", hide = true)]
+    rpc_port: Option<u16>,
+    /// A user JWT to use to authenticate to NATS for RPC messages, defaults to the value supplied to --nats-jwt if not supplied
+    #[clap(
+        long = "rpc-jwt",
+        env = "WASMCLOUD_RPC_JWT",
+        requires = "rpc_seed",
+        hide = true
+    )]
+    rpc_jwt: Option<String>,
+    /// A seed nkey to use to authenticate to NATS for RPC messages, defaults to the value supplied to --nats-seed if not supplied
+    #[clap(
+        long = "rpc-seed",
+        env = "WASMCLOUD_RPC_SEED",
+        requires = "rpc_jwt",
+        hide = true
+    )]
+    rpc_seed: Option<String>,
+    /// Timeout in milliseconds for all RPC calls
+    #[clap(long = "rpc-timeout-ms", default_value = "2000", env = "WASMCLOUD_RPC_TIMEOUT_MS", value_parser = parse_duration, hide = true)]
+    rpc_timeout_ms: Duration,
+    /// Optional flag to require host communication over TLS with a NATS server for RPC messages
+    #[clap(long = "rpc-tls", env = "WASMCLOUD_RPC_TLS", hide = true)]
+    rpc_tls: bool,
+
+    /// An IP address or DNS name to use to connect to NATS for Provider RPC messages, defaults to the value supplied to --nats-host if not supplied
+    #[clap(long = "prov-rpc-host", env = "WASMCLOUD_PROV_RPC_HOST", hide = true)]
+    prov_rpc_host: Option<String>,
+    /// A port to use to connect to NATS for Provider RPC messages, defaults to the value supplied to --nats-port if not supplied
+    #[clap(long = "prov-rpc-port", env = "WASMCLOUD_PROV_RPC_PORT", hide = true)]
+    prov_rpc_port: Option<u16>,
+    /// A user JWT to use to authenticate to NATS for Provider RPC messages, defaults to the value supplied to --nats-jwt if not supplied
+    #[clap(
+        long = "prov-rpc-jwt",
+        env = "WASMCLOUD_PROV_RPC_JWT",
+        requires = "prov_rpc_seed",
+        hide = true
+    )]
+    prov_rpc_jwt: Option<String>,
+    /// A seed nkey to use to authenticate to NATS for Provider RPC messages, defaults to the value supplied to --nats-seed if not supplied
+    #[clap(
+        long = "prov-rpc-seed",
+        env = "WASMCLOUD_PROV_RPC_SEED",
+        requires = "prov_rpc_jwt",
+        hide = true
+    )]
+    prov_rpc_seed: Option<String>,
+    /// Optional flag to require host communication over TLS with a NATS server for Provider RPC messages
+    #[clap(long = "prov-rpc-tls", env = "WASMCLOUD_PROV_RPC_TLS", hide = true)]
+    prov_rpc_tls: bool,
 
     // TODO: use and implement policy
     #[clap(long = "policy-topic", env = "WASMCLOUD_POLICY_TOPIC", hide = true)]
@@ -220,6 +223,8 @@ async fn main() -> anyhow::Result<()> {
         log_level,
         nats_host,
         nats_port,
+        nats_jwt,
+        nats_seed,
         lattice_prefix,
         host_seed,
         cluster_seed,
@@ -294,17 +299,17 @@ async fn main() -> anyhow::Result<()> {
             oci_user,
             oci_password,
         },
-        ctl_jwt,
-        ctl_seed,
+        ctl_jwt: ctl_jwt.or_else(|| nats_jwt.clone()),
+        ctl_seed: ctl_seed.or_else(|| nats_seed.clone()),
         ctl_tls,
         rpc_nats_url,
         rpc_timeout: rpc_timeout_ms,
-        rpc_jwt,
-        rpc_seed,
+        rpc_jwt: rpc_jwt.or_else(|| nats_jwt.clone()),
+        rpc_seed: rpc_seed.or_else(|| nats_seed.clone()),
         rpc_tls,
         prov_rpc_nats_url,
-        prov_rpc_jwt,
-        prov_rpc_seed,
+        prov_rpc_jwt: prov_rpc_jwt.or_else(|| nats_jwt.clone()),
+        prov_rpc_seed: prov_rpc_seed.or_else(|| nats_seed.clone()),
         prov_rpc_tls,
     })
     .await

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -250,7 +250,7 @@ async fn wasmbus() -> anyhow::Result<()> {
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key_two.public_key()]),
         host_seed: Some(host_key.seed().unwrap()),
         provider_shutdown_delay: Some(Duration::from_millis(300)),
-        oci_opts: OciConfig::default(),
+        ..Default::default()
     })
     .await
     .context("failed to initialize host")?;
@@ -258,12 +258,11 @@ async fn wasmbus() -> anyhow::Result<()> {
     let (host_two, shutdown_two) = Host::new(HostConfig {
         ctl_nats_url: ctl_nats_url.clone(),
         lattice_prefix: TEST_PREFIX.to_string(),
-        js_domain: None,
         cluster_seed: Some(cluster_key_two.seed().unwrap()),
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key_two.public_key()]),
         host_seed: Some(host_key_two.seed().unwrap()),
         provider_shutdown_delay: Some(Duration::from_millis(400)),
-        oci_opts: OciConfig::default(),
+        ..Default::default()
     })
     .await
     .context("failed to initialize host two")?;

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -30,7 +30,6 @@ use wasmcloud_control_interface::{
     ActorAuctionAck, ActorDescription, ActorInstance, ClientBuilder, CtlOperationAck,
     Host as HostInfo, HostInventory, ProviderAuctionAck,
 };
-use wasmcloud_host::oci::Config as OciConfig;
 use wasmcloud_host::wasmbus::{Host, HostConfig};
 
 async fn free_port() -> anyhow::Result<u16> {
@@ -244,6 +243,8 @@ async fn wasmbus() -> anyhow::Result<()> {
 
     let (host, shutdown) = Host::new(HostConfig {
         ctl_nats_url: ctl_nats_url.clone(),
+        rpc_nats_url: ctl_nats_url.clone(),
+        prov_rpc_nats_url: ctl_nats_url.clone(),
         lattice_prefix: TEST_PREFIX.to_string(),
         js_domain: None,
         cluster_seed: Some(cluster_key.seed().unwrap()),
@@ -257,6 +258,8 @@ async fn wasmbus() -> anyhow::Result<()> {
 
     let (host_two, shutdown_two) = Host::new(HostConfig {
         ctl_nats_url: ctl_nats_url.clone(),
+        rpc_nats_url: ctl_nats_url.clone(),
+        prov_rpc_nats_url: ctl_nats_url.clone(),
         lattice_prefix: TEST_PREFIX.to_string(),
         cluster_seed: Some(cluster_key_two.seed().unwrap()),
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key_two.public_key()]),


### PR DESCRIPTION
## Feature or Problem
This PR implements all of the connection options for RPC, CTL, and Provider RPC connections. Additionally, it adds support for the control interface topic prefix, which just defaults to `wasmbus.ctl` as before.

I made a few choices + stances in this PR:
1. RPC, CTL, and provider RPC connection arguments are _advanced_ arguments. Therefore, they are hidden by default. (I would support showing these arguments with some kind of --help --advanced flag)
2. RPC, CTL, and provider RPC connection args should fall back on the supplied NATS connection variables if not provided, instead of maintaining a separate all-around NATS connection. This way we're always internally using the correct connection, even if it's using the same parameters.

## Related Issues
Fixes #478 

## Release Information
N/A

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
Modified wasmbus test to use the new connection parameters.

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
