### PR TITLE
feat: add claims and link query functionality

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -56,8 +56,6 @@ use wasmcloud_runtime::capability::{messaging, Bus, KeyValueReadWrite, Messaging
 use wasmcloud_runtime::{ActorInstancePool, Runtime};
 
 const SUCCESS: &str = r#"{"accepted":true,"error":""}"#;
-const CLAIMS_PREFIX: &str = "CLAIMS_";
-const LINKDEF_PREFIX: &str = "LINKDEF_";
 
 #[derive(Debug)]
 struct Queue {
@@ -2184,14 +2182,14 @@ impl Host {
             claims: Vec<StoredClaims>,
         }
 
-        let claims: Vec<StoredClaims> = self.scan_latticedata(CLAIMS_PREFIX).await?;
+        let claims: Vec<StoredClaims> = self.scan_latticedata("CLAIMS_").await?;
         let resp = ClaimsResponse { claims };
         Ok(serde_json::to_vec(&resp)?.into())
     }
 
     #[instrument(skip(self))]
     async fn handle_links(&self) -> anyhow::Result<Bytes> {
-        let links: Vec<LinkDefinition> = self.scan_latticedata(LINKDEF_PREFIX).await?;
+        let links: Vec<LinkDefinition> = self.scan_latticedata("LINKDEF_").await?;
         let resp = LinkDefinitionList { links };
         Ok(serde_json::to_vec(&resp)?.into())
     }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2200,30 +2200,36 @@ impl Host {
         &self,
         key_prefix: &str,
     ) -> anyhow::Result<Vec<T>> {
-        let filtered_keys = self
+        self
             .data
             .keys()
             .await
             .context("failed to scan lattice data keys")?
+            .map_err(|e| anyhow!(e).context("failed to read lattice data stream"))
             .try_filter(|key| futures::future::ready(key.starts_with(key_prefix)))
-            .try_collect::<Vec<String>>()
-            .await
-            .context("failed to collect lattice data keys")?;
+            .and_then(|key| async move {
+                let maybe_bytes = self.data.get(&key).await?; // if we get an error here, we do want to fail
 
-        let futs = filtered_keys.into_iter().map(|key| self.data.get(key));
-        let list: Vec<T> = futures::future::join_all(futs)
-            .await
-            .into_iter()
-            .filter_map(|resp| {
-                // TODO: we should probably handle when we get an error from NATS or encountering
-                // malformed data in the bucket entries https://github.com/wasmCloud/wasmCloud/issues/509
-                resp.ok()
-                    .and_then(|bytes| bytes)
-                    .and_then(|bytes| serde_json::from_slice::<T>(&bytes).ok())
+                match maybe_bytes {
+                    None => {
+                        // this isn't the responsibility of the host, so warn and continue
+                        warn!(key, "latticedata entry was empty. Data may have been deleted during processing");
+                        anyhow::Ok(None)
+                    }
+                    Some(bytes) => {
+                        if let Ok(t) = serde_json::from_slice::<T>(&bytes) {
+                            anyhow::Ok(Some(t))
+                        } else {
+                            // this isn't the responsibility of the host, so warn and continue
+                            warn!(key, "failed to deserialize latticedata entry");
+                            anyhow::Ok(None)
+                        }
+                    }
+                }
             })
-            .collect();
-
-        Ok(list)
+            .try_filter_map(|v| futures::future::ready(Ok(v)))
+            .try_collect::<Vec<T>>()
+            .await
     }
 
     #[instrument(skip(self, payload))]

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -31,7 +31,7 @@ use cloudevents::{EventBuilder, EventBuilderV10};
 use futures::stream::{AbortHandle, Abortable};
 use futures::{stream, try_join, FutureExt, Stream, StreamExt, TryStreamExt};
 use nkeys::{KeyPair, KeyPairType};
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use time::format_description::well_known::Rfc3339;
@@ -48,14 +48,16 @@ use uuid::Uuid;
 use wascap::jwt;
 use wasmcloud_control_interface::{
     ActorAuctionAck, ActorAuctionRequest, ActorDescription, HostInventory, LinkDefinition,
-    ProviderAuctionRequest, ProviderDescription, RemoveLinkDefinitionRequest, ScaleActorCommand,
-    StartActorCommand, StartProviderCommand, StopActorCommand, StopHostCommand,
+    LinkDefinitionList, ProviderAuctionRequest, ProviderDescription, RemoveLinkDefinitionRequest,
+    ScaleActorCommand, StartActorCommand, StartProviderCommand, StopActorCommand, StopHostCommand,
     StopProviderCommand, UpdateActorCommand,
 };
 use wasmcloud_runtime::capability::{messaging, Bus, KeyValueReadWrite, Messaging};
 use wasmcloud_runtime::{ActorInstancePool, Runtime};
 
 const SUCCESS: &str = r#"{"accepted":true,"error":""}"#;
+const CLAIMS_PREFIX: &str = "CLAIMS_";
+const LINKDEF_PREFIX: &str = "LINKDEF_";
 
 #[derive(Debug)]
 struct Queue {
@@ -1623,6 +1625,9 @@ impl Host {
 
         let actor = self.fetch_actor(&actor_ref).await?;
         let claims = actor.claims().context("claims missing")?;
+        self.store_claims(claims.clone())
+            .await
+            .context("failed to store claims")?;
 
         let annotations = annotations.map(|annotations| annotations.into_iter().collect());
         let Some(count) = NonZeroUsize::new(count.into()) else {
@@ -1799,6 +1804,9 @@ impl Host {
         let new_claims = new_actor
             .claims()
             .context("claims missing from new actor")?;
+        self.store_claims(new_claims.clone())
+            .await
+            .context("failed to store claims")?;
         let old_claims = actor
             .pool
             .claims()
@@ -1851,6 +1859,9 @@ impl Host {
             crate::fetch_provider(provider_ref, link_name, &self.host_config.oci_opts)
                 .await
                 .context("failed to fetch provider")?;
+        self.store_claims(claims.clone())
+            .await
+            .context("failed to store claims")?;
 
         let annotations = annotations.map(|annotations| annotations.into_iter().collect());
         let mut providers = self.providers.write().await;
@@ -2164,16 +2175,55 @@ impl Host {
         Ok(buf.into())
     }
 
-    #[allow(unused)] // TODO: Remove once implemented
-    #[instrument(skip(self, payload))]
-    async fn handle_claims(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
-        bail!("TODO")
+    #[instrument(skip(self))]
+    async fn handle_claims(&self) -> anyhow::Result<Bytes> {
+        // TODO: update control interface client to have a more specific type definition for
+        // GetClaimsResponse, so we can re-use it here. Currently it's Vec<HashMap<String, String>>
+        #[derive(Serialize)]
+        struct ClaimsResponse {
+            claims: Vec<StoredClaims>,
+        }
+
+        let claims: Vec<StoredClaims> = self.scan_latticedata(CLAIMS_PREFIX).await?;
+        let resp = ClaimsResponse { claims };
+        Ok(serde_json::to_vec(&resp)?.into())
     }
 
-    #[allow(unused)] // TODO: Remove once implemented
-    #[instrument(skip(self, payload))]
-    async fn handle_links(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
-        bail!("TODO")
+    #[instrument(skip(self))]
+    async fn handle_links(&self) -> anyhow::Result<Bytes> {
+        let links: Vec<LinkDefinition> = self.scan_latticedata(LINKDEF_PREFIX).await?;
+        let resp = LinkDefinitionList { links };
+        Ok(serde_json::to_vec(&resp)?.into())
+    }
+
+    async fn scan_latticedata<T: DeserializeOwned>(
+        &self,
+        key_prefix: &str,
+    ) -> anyhow::Result<Vec<T>> {
+        let filtered_keys = self
+            .data
+            .keys()
+            .await
+            .context("failed to scan lattice data keys")?
+            .try_filter(|key| futures::future::ready(key.starts_with(key_prefix)))
+            .try_collect::<Vec<String>>()
+            .await
+            .context("failed to collect lattice data keys")?;
+
+        let futs = filtered_keys.into_iter().map(|key| self.data.get(key));
+        let list: Vec<T> = futures::future::join_all(futs)
+            .await
+            .into_iter()
+            .filter_map(|resp| {
+                // TODO: we should probably handle when we get an error from NATS or encountering
+                // malformed data in the bucket entries https://github.com/wasmCloud/wasmCloud/issues/509
+                resp.ok()
+                    .and_then(|bytes| bytes)
+                    .and_then(|bytes| serde_json::from_slice::<T>(&bytes).ok())
+            })
+            .collect();
+
+        Ok(list)
     }
 
     #[instrument(skip(self, payload))]
@@ -2309,10 +2359,8 @@ impl Host {
             (Some("get"), Some(host_id), Some("inv"), None) => {
                 self.handle_inventory(payload, host_id).await.map(Some)
             }
-            (Some("get"), Some("claims"), None, None) => {
-                self.handle_claims(payload).await.map(Some)
-            }
-            (Some("get"), Some("links"), None, None) => self.handle_links(payload).await.map(Some),
+            (Some("get"), Some("claims"), None, None) => self.handle_claims().await.map(Some),
+            (Some("get"), Some("links"), None, None) => self.handle_links().await.map(Some),
             (Some("linkdefs"), Some("put"), None, None) => {
                 self.handle_linkdef_put(payload).await.map(Some)
             }
@@ -2353,6 +2401,24 @@ impl Host {
             }
             _ => {}
         }
+    }
+
+    async fn store_claims<T>(&self, claims: T) -> anyhow::Result<()>
+    where
+        T: TryInto<StoredClaims, Error = anyhow::Error>,
+    {
+        let stored_claims: StoredClaims = claims.try_into()?;
+        let key = format!("CLAIMS_{}", stored_claims.subject);
+
+        let bytes = serde_json::to_vec(&stored_claims)
+            .map_err(anyhow::Error::from)
+            .context("failed to serialize claims")?
+            .into();
+        self.data
+            .put(key, bytes)
+            .await
+            .context("failed to put claims")?;
+        Ok(())
     }
 
     #[instrument(skip(self, id, value))]
@@ -2486,6 +2552,14 @@ impl Host {
             (Operation::Delete, Some("LINKDEF"), Some(id)) => {
                 self.process_linkdef_delete(id, value).await
             }
+            (Operation::Put, Some("CLAIMS"), Some(_pubkey)) => {
+                // TODO https://github.com/wasmCloud/wasmCloud/issues/507
+                Ok(())
+            }
+            (Operation::Delete, Some("CLAIMS"), Some(_pubkey)) => {
+                // TODO https://github.com/wasmCloud/wasmCloud/issues/507
+                Ok(())
+            }
             _ => {
                 error!(
                     bucket,
@@ -2502,5 +2576,77 @@ impl Host {
         if let Err(error) = &res {
             warn!(?error, ?operation, bucket, "failed to process entry");
         }
+    }
+}
+
+// TODO: use a better format https://github.com/wasmCloud/wasmCloud/issues/508
+#[derive(Serialize, Deserialize)]
+struct StoredClaims {
+    call_alias: String,
+    #[serde(rename = "caps")]
+    capabilities: String,
+    contract_id: String,
+    #[serde(rename = "iss")]
+    issuer: String,
+    name: String,
+    #[serde(rename = "rev")]
+    revision: String,
+    #[serde(rename = "sub")]
+    subject: String,
+    tags: String,
+    version: String,
+}
+
+impl TryFrom<jwt::Claims<jwt::Actor>> for StoredClaims {
+    type Error = anyhow::Error;
+
+    fn try_from(claims: jwt::Claims<jwt::Actor>) -> Result<Self, Self::Error> {
+        let jwt::Claims {
+            issuer,
+            subject,
+            metadata,
+            ..
+        } = claims;
+
+        let metadata = metadata.context("no metadata found on provider claims")?;
+
+        Ok(StoredClaims {
+            call_alias: metadata.call_alias.unwrap_or_default(),
+            capabilities: metadata.caps.unwrap_or_default().join(","),
+            contract_id: String::new(), // actors don't have a contract_id
+            issuer,
+            name: metadata.name.unwrap_or_default(),
+            revision: metadata.rev.unwrap_or_default().to_string(),
+            subject,
+            tags: metadata.tags.unwrap_or_default().join(","),
+            version: metadata.ver.unwrap_or_default(),
+        })
+    }
+}
+
+impl TryFrom<jwt::Claims<jwt::CapabilityProvider>> for StoredClaims {
+    type Error = anyhow::Error;
+
+    fn try_from(claims: jwt::Claims<jwt::CapabilityProvider>) -> Result<Self, Self::Error> {
+        let jwt::Claims {
+            issuer,
+            subject,
+            metadata,
+            ..
+        } = claims;
+
+        let metadata = metadata.context("no metadata found on provider claims")?;
+
+        Ok(StoredClaims {
+            call_alias: String::new(),   // providers don't have a call alias
+            capabilities: String::new(), // providers don't have a capabilities list
+            contract_id: metadata.capid,
+            issuer,
+            name: metadata.name.unwrap_or_default(),
+            revision: metadata.rev.unwrap_or_default().to_string(),
+            subject,
+            tags: String::new(), // providers don't have tags
+            version: metadata.ver.unwrap_or_default(),
+        })
     }
 }

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -548,7 +548,7 @@ expected: {expected_labels:?}"#
         .await
         .map_err(|e| anyhow!(e).context("failed to query claims"))?
         .claims;
-    claims_from_host.sort_by(|a, b| a.get("sub").unwrap().cmp(&b.get("sub").unwrap()));
+    claims_from_host.sort_by(|a, b| a.get("sub").unwrap().cmp(b.get("sub").unwrap()));
 
     ensure!(claims_from_host.len() == 4); // 3 providers, 1 actor
 
@@ -579,7 +579,7 @@ expected: {expected_labels:?}"#
         .await
         .map_err(|e| anyhow!(e).context("failed to query claims"))?
         .claims;
-    claims_from_bucket.sort_by(|a, b| a.get("sub").unwrap().cmp(&b.get("sub").unwrap()));
+    claims_from_bucket.sort_by(|a, b| a.get("sub").unwrap().cmp(b.get("sub").unwrap()));
 
     let mut links_from_bucket = ctl_client
         .query_links()


### PR DESCRIPTION
## Feature or Problem
This PR:
- stores actor and provider claims when they are started
- adds the ability to query claims and links via the host

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/492 and https://github.com/wasmCloud/wasmCloud/issues/481

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
The host will now respond accurately to requests on `wasmbus.ctl.{lattice_prefix}.get.claims` and `.get.links`

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
I added tests to `tests/wamsbus.rs` to confirm that the hosts responds to requests for links and claims with the correct data, and also that the data returned is exactly what the control interface client returns when querying the latticedata bucket directly

### Manual Verification
I also did manual testing with `wash get claims/links` and `nats req ...`