### PR TITLE
Propagate allow_file_load, implement structured logging

### DIFF
--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -50,6 +50,12 @@ pub struct Host {
     pub provider_shutdown_delay: Option<std::time::Duration>,
     /// Configuration for downloading artifacts from OCI registries
     pub oci_opts: OciConfig,
+    /// Whether to allow loading actor or provider components from the filesystem
+    pub allow_file_load: bool,
+    // Whether or not structured logging is enabled
+    // pub enable_structured_logging: bool,
+    // Log level to pass to capability providers to use. Should be parsed from a [`tracing::Level`]
+    // pub log_level: String,
 }
 
 impl Default for Host {
@@ -79,6 +85,9 @@ impl Default for Host {
             cluster_issuers: None,
             provider_shutdown_delay: None,
             oci_opts: OciConfig::default(),
+            allow_file_load: false,
+            // enable_structured_logging: false,
+            // log_level: "INFO".to_string(),
         }
     }
 }

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -5,6 +5,7 @@ use url::Url;
 
 use crate::oci::Config as OciConfig;
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 /// wasmCloud Host configuration
 pub struct Host {
@@ -52,10 +53,10 @@ pub struct Host {
     pub oci_opts: OciConfig,
     /// Whether to allow loading actor or provider components from the filesystem
     pub allow_file_load: bool,
-    // Whether or not structured logging is enabled
-    // pub enable_structured_logging: bool,
-    // Log level to pass to capability providers to use. Should be parsed from a [`tracing::Level`]
-    // pub log_level: String,
+    /// Whether or not structured logging is enabled
+    pub enable_structured_logging: bool,
+    /// Log level to pass to capability providers to use. Should be parsed from a [`tracing::Level`]
+    pub log_level: String,
 }
 
 impl Default for Host {
@@ -86,8 +87,8 @@ impl Default for Host {
             provider_shutdown_delay: None,
             oci_opts: OciConfig::default(),
             allow_file_load: false,
-            // enable_structured_logging: false,
-            // log_level: "INFO".to_string(),
+            enable_structured_logging: false,
+            log_level: "info".to_string(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,8 +84,7 @@ struct Args {
     #[clap(
         long = "allow-file-load",
         default_value_t = false,
-        env = "WASMCLOUD_ALLOW_FILE_LOAD",
-        hide = true
+        env = "WASMCLOUD_ALLOW_FILE_LOAD"
     )]
     allow_file_load: bool,
     /// Enable JSON structured logging from the wasmCloud host
@@ -286,6 +285,9 @@ async fn main() -> anyhow::Result<()> {
         prov_rpc_jwt: args.prov_rpc_jwt.or_else(|| args.nats_jwt.clone()),
         prov_rpc_seed: args.prov_rpc_seed.or_else(|| args.nats_seed.clone()),
         prov_rpc_tls: args.prov_rpc_tls,
+        allow_file_load: args.allow_file_load,
+        // log_level: args.log_level.to_string(),
+        // enable_structured_logging: args.enable_structured_logging,
     })
     .await
     .context("failed to initialize host")?;

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -270,6 +270,7 @@ async fn wasmbus() -> anyhow::Result<()> {
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key_two.public_key()]),
         host_seed: Some(host_key.seed().unwrap()),
         provider_shutdown_delay: Some(Duration::from_millis(300)),
+        allow_file_load: true,
         ..Default::default()
     })
     .await
@@ -284,6 +285,7 @@ async fn wasmbus() -> anyhow::Result<()> {
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key_two.public_key()]),
         host_seed: Some(host_key_two.seed().unwrap()),
         provider_shutdown_delay: Some(Duration::from_millis(400)),
+        allow_file_load: true,
         ..Default::default()
     })
     .await


### PR DESCRIPTION
## Feature or Problem
This PR:
1. Propagates and respects the `allow_file_load` parameter
2. Enables structured logging with the `json()` layer, and passes that field and `log_level` to providers as well

Marked as draft for testing with `allow_file_load`, and because I could use some advice on the structured logging and if this is sufficient. I'd also like #506 to merge first 

## Related Issues
N/A

## Release Information
N/A

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)


### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
