### PR TITLE
feat: fill in missing data in host pings and heartbeat messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,6 +4436,7 @@ dependencies = [
  "futures",
  "hex",
  "http",
+ "humantime",
  "names",
  "nkeys",
  "oci-distribution",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ futures = { version = "0.3", default-features = false }
 heck = { version = "0.4.1", default-features = false }
 hex = { version = "0.4", default-features = false }
 http = { version = "0.2", default-features = false }
+humantime = { version = "2.1", default-features = false }
 lazy_static = { version = "1.4", default-features = false }
 log = { version = "0.4", default-features = false }
 names = { version = "0.14", default-features = false }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -24,6 +24,7 @@ cloudevents-sdk = { workspace = true }
 futures = { workspace = true, features = ["async-await", "std"] }
 hex = { workspace = true, features = ["std"] }
 http = { workspace = true }
+humantime = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"] }
 names = { workspace = true }
 nkeys = { workspace = true }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1187,7 +1187,7 @@ impl Host {
             "friendly_name": self.friendly_name,
             "labels": self.labels,
             "providers": providers,
-            "uptime_human": "TODO", // TODO
+            "uptime_human": human_friendly_uptime(uptime),
             "uptime_seconds": uptime.as_secs(),
             "version": env!("CARGO_PKG_VERSION"),
         })
@@ -2309,20 +2309,20 @@ impl Host {
             .clone()
             .unwrap_or_else(|| vec![self.cluster_key.public_key()])
             .join(",");
-        // TODO: Fill in the TODOs
+
         let buf = serde_json::to_vec(&json!({
           "id": self.host_key.public_key(),
           "issuer": self.cluster_key.public_key(),
           "labels": self.labels,
           "friendly_name": self.friendly_name,
           "uptime_seconds": uptime.as_secs(),
-          "uptime_human": "TODO",
+          "uptime_human": human_friendly_uptime(uptime),
           "version": env!("CARGO_PKG_VERSION"),
           "cluster_issuers": cluster_issuers,
           "js_domain": self.host_config.js_domain,
-          "ctl_host": "TODO",
-          "prov_rpc_host": "TODO",
-          "rpc_host": "TODO",
+          "ctl_host": self.host_config.ctl_nats_url.to_string(),
+          "prov_rpc_host": self.host_config.prov_rpc_nats_url.to_string(),
+          "rpc_host": self.host_config.rpc_nats_url.to_string(),
           "lattice_prefix": self.host_config.lattice_prefix,
         }))
         .context("failed to encode reply")?;
@@ -2673,4 +2673,12 @@ impl TryFrom<jwt::Claims<jwt::CapabilityProvider>> for StoredClaims {
             version: metadata.ver.unwrap_or_default(),
         })
     }
+}
+
+fn human_friendly_uptime(uptime: Duration) -> String {
+    // strip sub-seconds, then convert to human-friendly format
+    humantime::format_duration(
+        uptime.saturating_sub(Duration::from_nanos(uptime.subsec_nanos().into())),
+    )
+    .to_string()
 }


### PR DESCRIPTION
## Feature or Problem
This PR populates the `uptime_human` field on heartbeats and host pings. It also populates `ctl_host`, `prov_rpc_host`, `rpc_host` on host pings.

## Related Issues
Resolves #518 

## Release Information
Next

## Consumer Impact
Consumers of heartbeats and host pings get more info, yay

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
I updated the integration test to ping hosts and verify the data that comes back

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
