### PR TITLE
fix: do not proxy env vars from host to providers

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1922,6 +1922,7 @@ impl Host {
                 "spawn provider process"
             );
             let mut child = process::Command::new(&path)
+                .env_clear()
                 .stdin(Stdio::piped())
                 .kill_on_drop(true)
                 .spawn()


### PR DESCRIPTION
## Feature or Problem
Providers should not implicitly receive environment variables from the host, since this is a security risk. Values providers need should be passed via `HostData`

Note this means we need to add `OTEL_TRACES_EXPORTER` and `OTEL_EXPORTER_OTLP_ENDPOINT` to `HostData`, which I've filed in https://github.com/wasmCloud/wasmCloud/issues/523

## Related Issues
N/A

## Release Information
Next

## Consumer Impact
As we rewrite providers, we should remove uses of `std::env::var`, since these values will now be empty

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I started the host with an env var, launched a provider, inspected the env vars the child process had, and confirmed the host's var was not proxied to the provider