### PR TITLE
fix(host): ignore empty responses

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -623,7 +623,11 @@ impl KeyValueReadWrite for Handler {
                 },
             )
             .await?;
-        rmp_serde::from_slice(&res).context("failed to decode response")
+        if res.is_empty() {
+            Ok(())
+        } else {
+            rmp_serde::from_slice(&res).context("failed to decode response")
+        }
     }
 
     #[instrument]
@@ -741,7 +745,11 @@ impl Messaging for Handler {
                 },
             )
             .await?;
-        rmp_serde::from_slice(&res).context("failed to decode response")
+        if res.is_empty() {
+            Ok(())
+        } else {
+            rmp_serde::from_slice(&res).context("failed to decode response")
+        }
     }
 }
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

It appears that providers using `wasmcloud-provider-sdk` differ from the ones using `wasmbus-rpc` in that the latter return an empty response on RPCs that do not define a response, whereas the former encodes `()`. Account for both.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
