### PR TITLE
feat: send OTEL config via HostData

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2228,7 +2228,11 @@ impl Host {
                 "invocation_seed": invocation_seed,
                 "js_domain": self.host_config.js_domain,
                 "log_level": self.host_config.log_level.to_string(),
-                "structured_logging": self.host_config.enable_structured_logging
+                "structured_logging": self.host_config.enable_structured_logging,
+                "otel_config": {
+                    "traces_exporter": std::env::var("OTEL_TRACES_EXPORTER").unwrap_or_default(),
+                    "exporter_otlp_endpoint": std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").unwrap_or_default(),
+                }
             }))
             .context("failed to serialize provider data")?;
 

--- a/crates/provider-sdk/src/core.rs
+++ b/crates/provider-sdk/src/core.rs
@@ -66,10 +66,20 @@ pub struct HostData {
     /// The log level providers should log at
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_level: Option<logging::Level>,
+    pub otel_config: Option<OtelConfig>,
 }
 
 /// Environment settings for initializing a capability provider
 pub type HostEnvValues = WitMap<String>;
+
+/// Configuration values for Open Telemetry
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OtelConfig {
+    /// OTEL_TRACES_EXPORTER https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_traces_exporter
+    pub traces_exporter: String,
+    /// OTEL_EXPORTER_OTLP_ENDPOINT https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_endpoint
+    pub exporter_otlp_endpoint: String,
+}
 
 /// RPC message to capability provider
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]


### PR DESCRIPTION
## Feature or Problem
This PR sends tracing config to providers via HostData

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/523

## Release Information
Next

## Consumer Impact
Downstream providers will need to be rebuilt to use the updated parsing logic

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I set up an OTEL exporter and collector manually, started the HTTP server provider built with these changes, and confirmed traces were received when curling the actor's endpoint