### PR TITLE
Feat/policy service

### DIFF
--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -16,6 +16,9 @@ pub mod bindle;
 /// OCI artifact fetching
 pub mod oci;
 
+/// wasmCloud policy service
+pub mod policy;
+
 /// Provider archive functionality
 mod par;
 

--- a/crates/host/src/policy.rs
+++ b/crates/host/src/policy.rs
@@ -42,7 +42,7 @@ pub struct RequestSource {
     #[serde(rename = "expiresAt")]
     pub expires_at: Option<u64>,
     /// Whether the claims have expired already. This is included in case the policy server is fulfilled by an actor, which cannot access the system clock
-    pub expired: Option<bool>,
+    pub expired: bool,
 }
 
 /// Relevant information about the actor that is being invoked, or the actor or provider that is
@@ -155,7 +155,7 @@ impl From<jwt::Claims<jwt::Actor>> for RequestSource {
             issuer: Some(claims.issuer),
             issued_on: Some(claims.issued_at.to_string()),
             expires_at: claims.expires,
-            expired: claims.expires.map(is_expired),
+            expired: claims.expires.map(is_expired).unwrap_or_default(),
         }
     }
 }
@@ -170,7 +170,7 @@ impl From<jwt::Claims<jwt::CapabilityProvider>> for RequestSource {
             issuer: Some(claims.issuer),
             issued_on: Some(claims.issued_at.to_string()),
             expires_at: claims.expires,
-            expired: claims.expires.map(is_expired),
+            expired: claims.expires.map(is_expired).unwrap_or_default(),
         }
     }
 }

--- a/crates/host/src/policy.rs
+++ b/crates/host/src/policy.rs
@@ -21,6 +21,7 @@ use wascap::jwt;
 /// Relevant information about the actor or provider making an invocation. This struct is empty for
 /// policy decisions related to starting actors or providers. All fields are optional for backwards-compatibility
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Hash)]
+// TODO: convert to an enum where variants use relevant fields, then remove the above comment about backwards-compatibility
 pub struct RequestSource {
     /// The public key of the actor or provider
     #[serde(rename = "publicKey")]
@@ -48,6 +49,7 @@ pub struct RequestSource {
 /// Relevant information about the actor that is being invoked, or the actor or provider that is
 /// being started. All fields are optional for backwards-compatibility
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Hash)]
+// TODO: convert to an enum where variants use relevant fields, then remove the above comment about backwards-compatibility
 pub struct RequestTarget {
     /// The public key of the actor or provider
     #[serde(rename = "publicKey")]
@@ -229,8 +231,8 @@ impl Manager {
             host_info,
             policy_topic,
             policy_timeout: policy_timeout.unwrap_or(DEFAULT_POLICY_TIMEOUT),
-            decision_cache: Arc::new(RwLock::new(HashMap::new())),
-            request_to_key: Arc::new(RwLock::new(HashMap::new())),
+            decision_cache: Arc::default(),
+            request_to_key: Arc::default(),
             policy_changes: policy_changes_abort,
         };
         let manager = Arc::new(manager);
@@ -254,7 +256,7 @@ impl Manager {
             });
         }
 
-        Ok(Arc::clone(&manager))
+        Ok(manager)
     }
 
     /// Constructs a

--- a/crates/host/src/policy.rs
+++ b/crates/host/src/policy.rs
@@ -1,0 +1,354 @@
+use core::time::Duration;
+
+use std::collections::{hash_map, HashMap};
+use std::hash::Hash;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Context;
+use futures::{
+    stream::{AbortHandle, Abortable},
+    StreamExt,
+};
+use serde::{Deserialize, Serialize, Serializer};
+use tokio::spawn;
+use tokio::sync::RwLock;
+use tracing::{debug, error, instrument, trace, warn};
+use ulid::Ulid;
+use uuid::Uuid;
+use wascap::jwt;
+
+/// Relevant information about the actor or provider making an invocation. This struct is empty for
+/// policy decisions related to starting actors or providers. All fields are optional for backwards-compatibility
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Hash)]
+pub struct RequestSource {
+    /// The public key of the actor or provider
+    #[serde(rename = "publicKey")]
+    pub public_key: Option<String>,
+    /// The contract ID of the provider, or None if the source is an actor
+    #[serde(rename = "contractId")]
+    pub contract_id: Option<String>,
+    /// The link name of the provider, or None if the source is an actor
+    #[serde(rename = "linkName")]
+    pub link_name: Option<String>,
+    /// The list of capabilities of the actor, or None if the source is a provider
+    pub capabilities: Vec<String>,
+    /// The issuer of the source's claims
+    pub issuer: Option<String>,
+    /// The time the claims were signed
+    #[serde(rename = "issuedOn")]
+    pub issued_on: Option<String>,
+    /// The time the claims expire, if any
+    #[serde(rename = "expiresAt")]
+    pub expires_at: Option<u64>,
+    /// Whether the claims have expired already. This is included in case the policy server is fulfilled by an actor, which cannot access the system clock
+    pub expired: Option<bool>,
+}
+
+/// Relevant information about the actor that is being invoked, or the actor or provider that is
+/// being started. All fields are optional for backwards-compatibility
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Hash)]
+pub struct RequestTarget {
+    /// The public key of the actor or provider
+    #[serde(rename = "publicKey")]
+    pub public_key: Option<String>,
+    /// The issuer of the target's claims
+    pub issuer: Option<String>,
+    /// The contract ID of the provider, or None if the target is an actor
+    #[serde(rename = "contractId")]
+    pub contract_id: Option<String>,
+    /// The link name of the provider, or None if the target is an actor
+    #[serde(rename = "linkName")]
+    pub link_name: Option<String>,
+}
+
+/// Relevant information about the host that is receiving the invocation, or starting the actor or provider
+#[derive(Clone, Debug, Serialize)]
+pub struct HostInfo {
+    /// The public key of the host
+    #[serde(rename = "publicKey")]
+    pub public_key: String,
+    /// The ID of the lattice the host is running in
+    #[serde(rename = "latticeId")]
+    pub lattice_id: String,
+    /// The labels associated with the host
+    pub labels: HashMap<String, String>,
+    /// The host's list of issuers it will accept invocations from
+    #[serde(rename = "clusterIssuers")]
+    pub cluster_issuers: Vec<String>,
+}
+
+/// The action being requested
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Hash)]
+pub enum Action {
+    /// The host is checking whether it may invoke the target actor
+    #[serde(rename = "perform_invocation")]
+    PerformInvocation,
+    /// The host is checking whether it may start the target actor
+    #[serde(rename = "start_actor")]
+    StartActor,
+    /// The host is checking whether it may start the target provider
+    #[serde(rename = "start_provider")]
+    StartProvider,
+}
+
+/// A request for a policy decision
+#[derive(Serialize)]
+struct Request {
+    /// a unique request id. This value is returned in the response
+    #[serde(rename = "requestId")]
+    request_id: String,
+    // Use a custom serializer to handle the case where the source is None
+    #[serde(serialize_with = "serialize_source")]
+    source: Option<RequestSource>,
+    target: RequestTarget,
+    host: HostInfo,
+    action: Action,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+struct RequestKey {
+    source: RequestSource,
+    target: RequestTarget,
+    action: Action,
+}
+
+/// A policy decision response
+#[derive(Clone, Debug, Deserialize)]
+pub struct Response {
+    /// The request id copied from the request
+    #[serde(rename = "requestId")]
+    pub request_id: String,
+    /// Whether the request is permitted
+    pub permitted: bool,
+    /// An optional error explaining why the request was denied. Suitable for logging
+    pub message: Option<String>,
+}
+
+/// Policy services expect a source on all requests, even though no data is relevant for the start
+/// actions. When source is None, we still serialize an (empty) object
+fn serialize_source<S>(source: &Option<RequestSource>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match source {
+        Some(source) => source.serialize(serializer),
+        None => RequestSource::default().serialize(serializer),
+    }
+}
+
+fn is_expired(expires: u64) -> bool {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards") // SAFETY: now() should always be greater than UNIX_EPOCH
+        .as_secs()
+        > expires
+}
+
+impl From<jwt::Claims<jwt::Actor>> for RequestSource {
+    fn from(claims: jwt::Claims<jwt::Actor>) -> Self {
+        RequestSource {
+            public_key: Some(claims.subject),
+            contract_id: None,
+            link_name: None,
+            capabilities: claims.metadata.and_then(|m| m.caps).unwrap_or_default(),
+            issuer: Some(claims.issuer),
+            issued_on: Some(claims.issued_at.to_string()),
+            expires_at: claims.expires,
+            expired: claims.expires.map(is_expired),
+        }
+    }
+}
+
+impl From<jwt::Claims<jwt::CapabilityProvider>> for RequestSource {
+    fn from(claims: jwt::Claims<jwt::CapabilityProvider>) -> Self {
+        RequestSource {
+            public_key: Some(claims.subject),
+            contract_id: claims.metadata.map(|m| m.capid),
+            link_name: None, // Unfortunately, since claims don't include a link name, we can't populate this
+            capabilities: vec![],
+            issuer: Some(claims.issuer),
+            issued_on: Some(claims.issued_at.to_string()),
+            expires_at: claims.expires,
+            expired: claims.expires.map(is_expired),
+        }
+    }
+}
+
+impl From<jwt::Claims<jwt::Actor>> for RequestTarget {
+    fn from(claims: jwt::Claims<jwt::Actor>) -> Self {
+        RequestTarget {
+            public_key: Some(claims.subject),
+            issuer: Some(claims.issuer),
+            contract_id: None,
+            link_name: None,
+        }
+    }
+}
+
+impl From<jwt::Claims<jwt::CapabilityProvider>> for RequestTarget {
+    fn from(claims: jwt::Claims<jwt::CapabilityProvider>) -> Self {
+        RequestTarget {
+            public_key: Some(claims.subject),
+            issuer: Some(claims.issuer),
+            contract_id: claims.metadata.map(|m| m.capid),
+            link_name: None, // Unfortunately, since claims don't include a link name, we can't populate this
+        }
+    }
+}
+
+/// Encapsulates making requests for policy decisions, and receiving updated decisions
+#[derive(Debug)]
+pub struct Manager {
+    nats: async_nats::Client,
+    host_info: HostInfo,
+    policy_topic: Option<String>,
+    policy_timeout: Duration,
+    decision_cache: Arc<RwLock<HashMap<RequestKey, Response>>>,
+    request_to_key: Arc<RwLock<HashMap<String, RequestKey>>>,
+    /// An abort handle for the policy changes subscription
+    pub policy_changes: AbortHandle,
+}
+
+impl Manager {
+    /// Construct a new policy manager. Can fail if policy_changes_topic is set but we fail to subscribe to it
+    #[instrument(skip(nats))]
+    pub async fn new(
+        nats: async_nats::Client,
+        host_info: HostInfo,
+        policy_topic: Option<String>,
+        policy_timeout: Option<Duration>,
+        policy_changes_topic: Option<String>,
+    ) -> anyhow::Result<Arc<Self>> {
+        const DEFAULT_POLICY_TIMEOUT: Duration = Duration::from_secs(1);
+
+        let (policy_changes_abort, policy_changes_abort_reg) = AbortHandle::new_pair();
+
+        let manager = Manager {
+            nats: nats.clone(),
+            host_info,
+            policy_topic,
+            policy_timeout: policy_timeout.unwrap_or(DEFAULT_POLICY_TIMEOUT),
+            decision_cache: Arc::new(RwLock::new(HashMap::new())),
+            request_to_key: Arc::new(RwLock::new(HashMap::new())),
+            policy_changes: policy_changes_abort,
+        };
+        let manager = Arc::new(manager);
+
+        if let Some(policy_changes_topic) = policy_changes_topic {
+            let policy_changes = nats
+                .subscribe(policy_changes_topic)
+                .await
+                .context("failed to subscribe to policy changes")?;
+
+            let _policy_changes = spawn({
+                let manager = Arc::clone(&manager);
+                Abortable::new(policy_changes, policy_changes_abort_reg).for_each(move |msg| {
+                    let manager = Arc::clone(&manager);
+                    async move {
+                        if let Err(e) = manager.override_decision(msg).await {
+                            error!("failed to process policy decision override: {}", e);
+                        }
+                    }
+                })
+            });
+        }
+
+        Ok(Arc::clone(&manager))
+    }
+
+    /// Constructs a
+    #[instrument(skip(self))]
+    pub async fn evaluate_action(
+        &self,
+        source: Option<RequestSource>,
+        target: RequestTarget,
+        action: Action,
+    ) -> anyhow::Result<Response> {
+        let cache_key = RequestKey {
+            source: source.clone().unwrap_or_default(),
+            target: target.clone(),
+            action: action.clone(),
+        };
+        let mut decision_cache = self.decision_cache.write().await;
+        match decision_cache.entry(cache_key.clone()) {
+            hash_map::Entry::Occupied(entry) => {
+                let entry = entry.get();
+                trace!(?cache_key, ?entry, "using cached policy decision");
+                Ok(entry.clone())
+            }
+            hash_map::Entry::Vacant(entry) => {
+                let request_id = Uuid::from_u128(Ulid::new().into()).to_string();
+                let decision = if let Some(policy_topic) = self.policy_topic.clone() {
+                    trace!(?cache_key, "requesting policy decision");
+                    let payload = serde_json::to_vec(&Request {
+                        request_id: request_id.clone(),
+                        source,
+                        target,
+                        host: self.host_info.clone(),
+                        action,
+                    })
+                    .context("failed to serialize policy request")?;
+                    let request = async_nats::Request::new()
+                        .payload(payload.into())
+                        .timeout(Some(self.policy_timeout));
+                    let res = self
+                        .nats
+                        .send_request(policy_topic, request)
+                        .await
+                        .context("policy request failed")?;
+                    serde_json::from_slice::<Response>(&res.payload)
+                        .context("failed to deserialize policy response")?
+                } else {
+                    trace!(
+                        ?cache_key,
+                        "no policy topic configured, defaulting to permitted"
+                    );
+                    // default to permitted if no policy topic is configured
+                    Response {
+                        request_id: request_id.clone(),
+                        permitted: true,
+                        message: None,
+                    }
+                };
+                entry.insert(decision.clone()); // cache policy decision
+                let mut request_to_key = self.request_to_key.write().await;
+                request_to_key.insert(request_id, cache_key); // cache request id -> decision key
+                Ok(decision)
+            }
+        }
+    }
+
+    #[instrument(skip(self))]
+    async fn override_decision(&self, msg: async_nats::Message) -> anyhow::Result<()> {
+        let Response {
+            request_id,
+            permitted,
+            message,
+        } = serde_json::from_slice(&msg.payload)
+            .context("failed to deserialize policy decision override")?;
+
+        debug!(request_id, "received policy decision override");
+
+        let mut decision_cache = self.decision_cache.write().await;
+        let request_to_key = self.request_to_key.read().await;
+
+        if let Some(key) = request_to_key.get(&request_id) {
+            decision_cache.insert(
+                key.clone(),
+                Response {
+                    request_id: request_id.clone(),
+                    permitted,
+                    message,
+                },
+            );
+        } else {
+            warn!(
+                request_id,
+                "received policy decision override for unknown request id"
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -63,6 +63,19 @@ pub struct Host {
     pub config_service_enabled: bool,
     /// configuration for OpenTelemetry tracing
     pub otel_config: OtelConfig,
+    /// configuration for wasmCloud policy service
+    pub policy_service_config: PolicyService,
+}
+
+/// Configuration for wasmCloud policy service
+#[derive(Clone, Debug, Default)]
+pub struct PolicyService {
+    /// The topic to request policy decisions on
+    pub policy_topic: Option<String>,
+    /// An optional topic to receive updated policy decisions on
+    pub policy_changes_topic: Option<String>,
+    /// The timeout for policy requests
+    pub policy_timeout_ms: Option<Duration>,
 }
 
 impl Default for Host {
@@ -97,6 +110,7 @@ impl Default for Host {
             log_level: LogLevel::Info,
             config_service_enabled: false,
             otel_config: OtelConfig::default(),
+            policy_service_config: PolicyService::default(),
         }
     }
 }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -3592,6 +3592,11 @@ impl Host {
             (Operation::Delete, Some("CLAIMS"), Some(pubkey)) => {
                 self.process_claims_delete(pubkey, value).await
             }
+            (operation, Some("REFMAP"), id) => {
+                // TODO: process REFMAP entries
+                debug!(?operation, id, "ignoring REFMAP entry");
+                Ok(())
+            }
             _ => {
                 error!(
                     bucket,

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,11 +227,7 @@ struct Args {
     oci_password: Option<String>,
 
     /// Specifies which exporter to use for traces. Only "otlp" is supported at this time
-    #[clap(
-        long = "otel-traces-exporter",
-        env = "OTEL_TRACES_EXPORTER",
-        default_value = "otlp"
-    )]
+    #[clap(long = "otel-traces-exporter", env = "OTEL_TRACES_EXPORTER")]
     otel_traces_exporter: Option<String>,
 
     /// Specifies the endpoint to use for the OTLP exporter

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -921,14 +921,14 @@ expected: {expected_labels:?}"#
     } = ctl_client
         .get_claims()
         .await
-        .map_err(|e| anyhow!(e).context("failed to query claims"))?;
+        .map_err(|e| anyhow!(e).context("failed to query claims via host"))?;
     claims_from_host.sort_by(|a, b| a.get("sub").unwrap().cmp(b.get("sub").unwrap()));
     ensure!(claims_from_host.len() == 8); // 4 providers, 4 actors
 
     let mut links_from_host = ctl_client
         .query_links()
         .await
-        .map_err(|e| anyhow!(e).context("failed to query claims"))?
+        .map_err(|e| anyhow!(e).context("failed to query links via host"))?
         .links;
     links_from_host.sort_by(|a, b| match a.actor_id.cmp(&b.actor_id) {
         std::cmp::Ordering::Equal => match a.provider_id.cmp(&b.provider_id) {
@@ -952,13 +952,13 @@ expected: {expected_labels:?}"#
     } = ctl_client
         .get_claims()
         .await
-        .map_err(|e| anyhow!(e).context("failed to query claims"))?;
+        .map_err(|e| anyhow!(e).context("failed to query claims via bucket"))?;
     claims_from_bucket.sort_by(|a, b| a.get("sub").unwrap().cmp(b.get("sub").unwrap()));
 
     let mut links_from_bucket = ctl_client
         .query_links()
         .await
-        .map_err(|e| anyhow!(e).context("failed to query claims"))?
+        .map_err(|e| anyhow!(e).context("failed to query links via bucket"))?
         .links;
     links_from_bucket.sort_by(|a, b| match a.actor_id.cmp(&b.actor_id) {
         std::cmp::Ordering::Equal => match a.provider_id.cmp(&b.provider_id) {


### PR DESCRIPTION
## Feature or Problem

This PR:
- caches actor and provider claim updates from the lattice data KV bucket subscription in memory, removing the need to do full table scans of the bucket
  - Note: awkward typing of wascap's `jwt::Claims` makes it difficult to unify these right now
- adds a `PolicyManager`, which:
  - makes requests on `WASMCLOUD_POLICY_TOPIC` when starting an actor/provider or when an actor receives an invocation
    - caches decisions made, so (in general) only one request is needed
  - listens on `WASMCLOUD_POLICY_CHANGES_TOPIC` for updates to invalidate previous policy decisions

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/480

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
We probably _should_ set up an integration test that exercises the same logic as I manually tested below, but I'd like to get this reviewed ASAP

### Manual Verification
I set up a custom reply on the policy topic to permit/deny requests. I tested:
- starting actors
- starting providers
- invoking actors
- overriding a cached decision by publishing on the `CHANGES` topic