### PR TITLE
build(nix): update dependencies

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-linux:
+  build-bin:
     strategy:
       matrix:
         config:
@@ -19,6 +19,16 @@ jobs:
           test-bin: nix shell --inputs-from . 'nixpkgs#qemu' -c qemu-aarch64 ./result/bin/wasmcloud --version
           test-oci: docker load < ./result
           # TODO: Run aarch64 binary within OCI
+
+        - target: aarch64-apple-darwin
+          install-path: /bin/wasmcloud
+          test-bin: file ./result/bin/wasmcloud
+          test-oci: docker load < ./result
+
+        - target: x86_64-apple-darwin
+          install-path: /bin/wasmcloud
+          test-bin: file ./result/bin/wasmcloud
+          test-oci: docker load < ./result
 
         - target: x86_64-pc-windows-gnu
           install-path: /bin/wasmcloud.exe
@@ -50,38 +60,9 @@ jobs:
         package: wasmcloud-${{ matrix.config.target }}-oci
     - run: ${{ matrix.config.test-oci }}
 
-  build-mac:
-    strategy:
-      matrix:
-        config:
-        - target: aarch64-apple-darwin
-          test: file ./result/bin/wasmcloud
-          # TODO: Run aarch64 binary on host system and via OCI
-
-        - target: x86_64-apple-darwin
-          test: ./result/bin/wasmcloud --version
-
-    name: wasmcloud-${{ matrix.config.target }}
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - uses: ./.github/actions/install-nix
-      with: 
-        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - uses: ./.github/actions/build-nix
-      with:
-        package: wasmcloud-${{ matrix.config.target }}
-        install-path: /bin/wasmcloud
-    - run: ${{ matrix.config.test-bin }}
-    - uses: ./.github/actions/build-nix
-      with:
-        package: wasmcloud-${{ matrix.config.target }}-oci
-    - run: ${{ matrix.platform.test-oci }}
-    # TODO: Test OCI on Mac
-
   build-lipo:
     name: wasmcloud-universal-darwin
-    needs: build-mac
+    needs: build-bin
     runs-on: macos-12
     steps:
     - uses: actions/download-artifact@v3
@@ -90,6 +71,8 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: wasmcloud-x86_64-apple-darwin
+    - run: chmod +x ./wasmcloud-x86_64-apple-darwin
+    - run: ./wasmcloud-x86_64-apple-darwin --version
     - run: lipo -create ./wasmcloud-aarch64-apple-darwin ./wasmcloud-x86_64-apple-darwin -output ./wasmcloud-universal-darwin
     - run: chmod +x ./wasmcloud-universal-darwin
     - run: ./wasmcloud-universal-darwin --version
@@ -100,7 +83,7 @@ jobs:
 
   test-windows:
     runs-on: windows-2022
-    needs: build-linux
+    needs: build-bin
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/flake.lock
+++ b/flake.lock
@@ -583,6 +583,22 @@
         "type": "github"
       }
     },
+    "macos-sdk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656095854,
+        "narHash": "sha256-Bksziu35r3/t7qNl6P/LXc/UZDF1zbXCMMvEarPFGUs=",
+        "owner": "hexops-graveyard",
+        "repo": "sdk-macos-12.0",
+        "rev": "14613b4917c7059dad8f3789f55bb13a2548f83d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hexops-graveyard",
+        "repo": "sdk-macos-12.0",
+        "type": "github"
+      }
+    },
     "nix-filter": {
       "locked": {
         "lastModified": 1687178632,
@@ -825,6 +841,7 @@
         "crane": "crane",
         "fenix": "fenix",
         "flake-utils": "flake-utils",
+        "macos-sdk": "macos-sdk",
         "nix-filter": "nix-filter",
         "nix-log": "nix-log",
         "nixlib": "nixlib_3",
@@ -832,11 +849,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1692781236,
-        "narHash": "sha256-yVLgQX6tLNGCUxIvafIb8hVYAUlzxT23Xfn4kXPtzeY=",
+        "lastModified": 1693327678,
+        "narHash": "sha256-UQoH8G4uOWXPsgD7v30kbIOBkq15T4yk6XlTZt9of+8=",
         "owner": "rvolosatovs",
         "repo": "nixify",
-        "rev": "a195c4f8c33bad8cd8d614ab616229a743f936f2",
+        "rev": "8c5e4e0183fbd09c811fa5ff8a36cd62ef601a95",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -108,22 +108,24 @@
 
               buildInputs =
                 buildInputs
-                ++ optionals stdenv.hostPlatform.isDarwin [
+                ++ optionals (pkgs.stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isDarwin) [
                   pkgs.darwin.apple_sdk.frameworks.Security
                   pkgs.libiconv
-                ];
-
-              depsBuildBuild =
-                depsBuildBuild
-                ++ optionals stdenv.hostPlatform.isDarwin [
-                  darwin.apple_sdk.frameworks.CoreFoundation
-                  libiconv
+                  pkgs.xcbuild.xcrun
                 ];
 
               nativeBuildInputs =
                 nativeBuildInputs
                 ++ [
                   pkgs.protobuf # prost build dependency
+                ];
+            }
+            // optionalAttrs (args ? cargoArtifacts) {
+              depsBuildBuild =
+                depsBuildBuild
+                ++ optionals (pkgs.stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isDarwin) [
+                  darwin.apple_sdk.frameworks.CoreFoundation
+                  libiconv
                 ];
 
               nativeCheckInputs =
@@ -132,12 +134,11 @@
                   pkgs.nats-server
                   pkgs.redis
                 ];
-            }
-            // optionalAttrs (args ? cargoArtifacts && stdenv.hostPlatform.isDarwin) {
-              # See https://github.com/nextest-rs/nextest/issues/267
+
               preCheck =
                 preCheck
-                + ''
+                # See https://github.com/nextest-rs/nextest/issues/267
+                + optionalString (pkgs.stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isDarwin) ''
                   export DYLD_FALLBACK_LIBRARY_PATH=$(rustc --print sysroot)/lib
                 '';
             };


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This makes sure that `aarch64-darwin` binaries are runnable out-of-the-box and we now build Mac binaries on Linux

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

https://github.com/rvolosatovs/nixify/pull/148
https://github.com/bytecodealliance/wit-deps/pull/49

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
```
$ unzip wasmcloud-universal-darwin.zip 
Archive:  wasmcloud-universal-darwin.zip
  inflating: wasmcloud-universal-darwin  
administrator@administrators-Mac-mini ~ % chmod +x wasmcloud-universal-darwin
administrator@administrators-Mac-mini ~ % ./wasmcloud-universal-darwin 
OTEL exporter endpoint not set, defaulting to 'http://localhost:55681/v1/traces'
Error: failed to initialize host

Caused by:
    0: failed to establish NATS control server connection
    1: failed to connect to NATS
    2: Connection refused (os error 61)
    3: Connection refused (os error 61)
administrator@administrators-Mac-mini ~ % file ./wasmcloud-universal-darwin
./wasmcloud-universal-darwin: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
./wasmcloud-universal-darwin (for architecture x86_64):	Mach-O 64-bit executable x86_64
./wasmcloud-universal-darwin (for architecture arm64):	Mach-O 64-bit executable arm64
administrator@administrators-Mac-mini ~ % otool -L ./wasmcloud-universal-darwin
./wasmcloud-universal-darwin (architecture x86_64):
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60157.30.13)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1853.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.0.0)
./wasmcloud-universal-darwin (architecture arm64):
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60157.30.13)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1853.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.0.0)
```