### PR TITLE
refactor: flatten optional annotations to always be set

### DIFF
--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -38,7 +38,7 @@ fn format_actor_claims(claims: &jwt::Claims<jwt::Actor>) -> serde_json::Value {
 
 pub fn actor_started(
     claims: &jwt::Claims<jwt::Actor>,
-    annotations: &Option<BTreeMap<String, String>>,
+    annotations: &BTreeMap<String, String>,
     instance_id: Uuid,
     image_ref: impl AsRef<str>,
 ) -> serde_json::Value {
@@ -61,7 +61,7 @@ pub fn actor_start_failed(actor_ref: impl AsRef<str>, error: &anyhow::Error) -> 
 
 pub fn actor_stopped(
     claims: &jwt::Claims<jwt::Actor>,
-    annotations: &Option<BTreeMap<String, String>>,
+    annotations: &BTreeMap<String, String>,
     instance_id: Uuid,
 ) -> serde_json::Value {
     json!({
@@ -73,7 +73,7 @@ pub fn actor_stopped(
 
 pub fn actors_started(
     claims: &jwt::Claims<jwt::Actor>,
-    annotations: &Option<BTreeMap<String, String>>,
+    annotations: &BTreeMap<String, String>,
     host_id: impl AsRef<str>,
     count: impl Into<usize>,
     image_ref: impl AsRef<str>,
@@ -90,7 +90,7 @@ pub fn actors_started(
 
 pub fn actors_start_failed(
     claims: &jwt::Claims<jwt::Actor>,
-    annotations: &Option<BTreeMap<String, String>>,
+    annotations: &BTreeMap<String, String>,
     host_id: impl AsRef<str>,
     image_ref: impl AsRef<str>,
     error: &anyhow::Error,
@@ -106,7 +106,7 @@ pub fn actors_start_failed(
 
 pub fn actors_stopped(
     claims: &jwt::Claims<jwt::Actor>,
-    annotations: &Option<BTreeMap<String, String>>,
+    annotations: &BTreeMap<String, String>,
     host_id: impl AsRef<str>,
     count: NonZeroUsize,
     remaining: usize,
@@ -158,7 +158,7 @@ pub fn linkdef_deleted(
 
 pub fn provider_started(
     claims: &jwt::Claims<jwt::CapabilityProvider>,
-    annotations: &Option<BTreeMap<String, String>>,
+    annotations: &BTreeMap<String, String>,
     instance_id: Uuid,
     host_id: impl AsRef<str>,
     image_ref: impl AsRef<str>,
@@ -198,7 +198,7 @@ pub fn provider_start_failed(
 
 pub fn provider_stopped(
     claims: &jwt::Claims<jwt::CapabilityProvider>,
-    annotations: &Option<BTreeMap<String, String>>,
+    annotations: &BTreeMap<String, String>,
     instance_id: Uuid,
     host_id: impl AsRef<str>,
     link_name: impl AsRef<str>,

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -1077,7 +1077,7 @@ expected: {expected_name:?}"#
                 compat_instances.is_empty(),
                 "more than one compat actor instance found"
             );
-            ensure!(annotations == None);
+            ensure!(annotations == Some(HashMap::default()));
             ensure!(Uuid::parse_str(&instance_id).is_ok());
             ensure!(revision == expected_revision.unwrap_or_default());
 
@@ -1109,7 +1109,7 @@ expected: {expected_name:?}"#
                 component_instances.is_empty(),
                 "more than one component actor instance found"
             );
-            ensure!(annotations == None);
+            ensure!(annotations == Some(HashMap::default()));
             ensure!(Uuid::parse_str(&instance_id).is_ok());
             ensure!(revision == expected_revision.unwrap_or_default());
 
@@ -1141,7 +1141,7 @@ expected: {expected_name:?}"#
                 module_instances.is_empty(),
                 "more than one module actor instance found"
             );
-            ensure!(annotations == None);
+            ensure!(annotations == Some(HashMap::default()));
             ensure!(Uuid::parse_str(&instance_id).is_ok());
             ensure!(revision == expected_revision.unwrap_or_default());
 
@@ -1173,7 +1173,7 @@ expected: {expected_name:?}"#
                 foobar_instances.is_empty(),
                 "more than one foobar actor instance found"
             );
-            ensure!(annotations == None);
+            ensure!(annotations == Some(HashMap::default()));
             ensure!(Uuid::parse_str(&instance_id).is_ok());
             ensure!(revision == expected_revision.unwrap_or_default());
         }
@@ -1189,7 +1189,7 @@ expected: {expected_name:?}"#
     ) {
         (Some(blobstore_fs), Some(httpserver), Some(kvredis), []) => {
             // TODO: Validate `constraints`
-            ensure!(blobstore_fs.annotations == None);
+            ensure!(blobstore_fs.annotations == Some(HashMap::new()));
             ensure!(blobstore_fs.id == blobstore_fs_provider_key.public_key());
             ensure!(blobstore_fs.image_ref == Some(blobstore_fs_provider_url.to_string()));
             ensure!(blobstore_fs.contract_id == "wasmcloud:blobstore");
@@ -1198,7 +1198,7 @@ expected: {expected_name:?}"#
             ensure!(blobstore_fs.revision == 0);
 
             // TODO: Validate `constraints`
-            ensure!(httpserver.annotations == None);
+            ensure!(httpserver.annotations == Some(HashMap::new()));
             ensure!(httpserver.id == httpserver_provider_key.public_key());
             ensure!(httpserver.image_ref == Some(httpserver_provider_url.to_string()));
             ensure!(httpserver.contract_id == "wasmcloud:httpserver");
@@ -1207,7 +1207,7 @@ expected: {expected_name:?}"#
             ensure!(httpserver.revision == 0);
 
             // TODO: Validate `constraints`
-            ensure!(kvredis.annotations == None);
+            ensure!(kvredis.annotations == Some(HashMap::new()));
             ensure!(kvredis.id == kvredis_provider_key.public_key());
             ensure!(kvredis.image_ref == Some(kvredis_provider_url.to_string()));
             ensure!(kvredis.contract_id == "wasmcloud:keyvalue");
@@ -1242,7 +1242,7 @@ expected: {expected_labels:?}"#
     match (providers.pop(), providers.as_slice()) {
         (Some(nats), []) => {
             // TODO: Validate `constraints`
-            ensure!(nats.annotations == None);
+            ensure!(nats.annotations == Some(HashMap::new()));
             ensure!(nats.id == nats_provider_key.public_key());
             ensure!(nats.image_ref == Some(nats_provider_url.to_string()));
             ensure!(nats.contract_id == "wasmcloud:messaging");


### PR DESCRIPTION
## Feature or Problem
This PR flattens uses of options for annotations, both for the host's internal `Annotations` type (`BTreeMap<String, String>`) as well as incoming annotations from the control interface client (`HashMap<String, String>`)

This is to avoid cases where e.g. a provider is started via a request where `"annotations" :{}`, but then the user tries to stop the provider via a request where `"annotations": null` (or where `annotations` is omitted entirely)

The host will now treat an omitted annotations field, null annotations, and an empty annotations map on requests the same way

The host will now always emit an empty annotations map in events as well. Since consumers of the events previously had to handle the omitted field, null, or an empty map, this change is backwards-compatible

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
Existing tests still pass

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
