### PR TITLE
fix(host): Flushes NATS clients on host stop

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1863,7 +1863,21 @@ impl Host {
                 }),
             )
             .await
-            .context("failed to publish stop event")
+            .context("failed to publish stop event")?;
+            // Before we exit, make sure to flush all messages or we may lose some that we've
+            // thought were sent (like the host_stopped event)
+            host.ctl_nats
+                .flush()
+                .await
+                .context("failed to flush ctl client")?;
+            host.rpc_nats
+                .flush()
+                .await
+                .context("failed to flush rpc client")?;
+            host.prov_rpc_nats
+                .flush()
+                .await
+                .context("failed to flush prov rpc client")
         }))
     }
 


### PR DESCRIPTION
Without this, sending responses to things like a host stop command or publishing the host stop event can fail as we don't ensure all messages in the NATS client queue have been sent