### PR TITLE
chore: emit more clear start message

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1906,10 +1906,6 @@ impl Host {
             actor_claims: Arc::default(),
             provider_claims: Arc::default(),
         };
-        host.publish_event("host_started", start_evt)
-            .await
-            .context("failed to publish start event")?;
-        info!("host {} started", host.host_key.public_key());
 
         let host = Arc::new(host);
         let queue = spawn({
@@ -1958,6 +1954,15 @@ impl Host {
                 }
             })
         });
+
+        host.publish_event("host_started", start_evt)
+            .await
+            .context("failed to publish start event")?;
+        info!(
+            host_id = host.host_key.public_key(),
+            "wasmCloud host started"
+        );
+
         Ok((Arc::clone(&host), async move {
             heartbeat_abort.abort();
             queue_abort.abort();


### PR DESCRIPTION
## Feature or Problem
In https://github.com/wasmCloud/wash/pull/759 we updated the wash integration tests to look for "host" and "started" to confirm the host was up, since the host currently emits `host {ID} started`. This updates the host to emit `wasmCloud host started` and sets the host ID as a field on the event

## Related Issues
Requirement for https://github.com/wasmCloud/wash/issues/761

## Release Information
Next

## Consumer Impact
N/A

## Testing

### Manual Verification
Ran locally. Before:

```
2023-09-02T18:48:46.543474Z  INFO new: wasmcloud_host::wasmbus: host ND76IOUWEMSJ7J7564KOMDJQFDCZ2ELSEJXGEQAKEGJNWJE7IWCHYGMX started
```

After:
```
2023-09-02T18:49:16.871191Z  INFO new: wasmcloud_host::wasmbus: wasmCloud host started host_id="NDSF5YY6QIJBG263XY7744JUCQT3OVBC6ROHXC3YAMJTZO7FENWDGGAX"
```