### PR TITLE
build: default to a Debian-based OCI image

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -204,7 +204,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
 
     - run: |
-        nix run -L .#build-wasmcloud-oci wasmcloud
+        nix run -L .#build-wasmcloud-oci-debian wasmcloud
         nix profile install --inputs-from . 'nixpkgs#buildah'
 
     - name: Push commit rev
@@ -264,22 +264,6 @@ jobs:
 
     - run: chmod +x ./wasmcloud-*
 
-    - uses: actions/download-artifact@v3
-      with:
-        name: wasmcloud-aarch64-apple-darwin-oci
-    - uses: actions/download-artifact@v3
-      with:
-        name: wasmcloud-aarch64-unknown-linux-musl-oci
-    - uses: actions/download-artifact@v3
-      with:
-        name: wasmcloud-x86_64-pc-windows-gnu-oci
-    - uses: actions/download-artifact@v3
-      with:
-        name: wasmcloud-x86_64-apple-darwin-oci
-    - uses: actions/download-artifact@v3
-      with:
-        name: wasmcloud-x86_64-unknown-linux-musl-oci
-
     - uses: softprops/action-gh-release@v1
       with:
         draft: true
@@ -287,13 +271,8 @@ jobs:
         generate_release_notes: true
         files: |
           wasmcloud-aarch64-apple-darwin
-          wasmcloud-aarch64-apple-darwin-oci
           wasmcloud-aarch64-unknown-linux-musl
-          wasmcloud-aarch64-unknown-linux-musl-oci
           wasmcloud-universal-darwin
           wasmcloud-x86_64-apple-darwin
-          wasmcloud-x86_64-apple-darwin-oci
           wasmcloud-x86_64-pc-windows-gnu
-          wasmcloud-x86_64-pc-windows-gnu-oci
           wasmcloud-x86_64-unknown-linux-musl
-          wasmcloud-x86_64-unknown-linux-musl-oci


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Default to a Debian-based OCI image, since currently-released capability providers are dynamically linked to glibc

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

Closes #614 
Closes #618 
https://github.com/wasmCloud/capability-providers/issues/265

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
```
$ nats-server -js
$ docker run --rm -it --network host rvolosatovs/wasmcloud:0.78.0-rc3
$ wash start provider wasmcloud.azurecr.io/httpserver:0.19.1
```

https://github.com/rvolosatovs/wasmCloud/actions/runs/6063571716