### PR TITLE
fix(host): expose registry as a public module

### DIFF
--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -19,14 +19,14 @@ pub mod oci;
 /// wasmCloud policy service
 pub mod policy;
 
+/// Common registry types
+pub mod registry;
+
 /// Provider archive functionality
 mod par;
 
-/// Common registry types
-mod registry;
-
 pub use local::{Host as LocalHost, HostConfig as LocalHostConfig};
-use registry::Settings as RegistrySettings;
+pub use registry::{Auth as RegistryAuth, Settings as RegistrySettings, Type as RegistryType};
 pub use wasmbus::{Host as WasmbusHost, HostConfig as WasmbusHostConfig};
 
 pub use url;


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
The public function `fetch_*` takes `register::Settings` as a parameter, but the *register module* is not public, so it is now exposed so that `fetch_*` can be called externally.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
