### PR TITLE
Fix/host errors

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -344,7 +344,7 @@ impl Handler {
         if resp_length > CHUNK_THRESHOLD_BYTES {
             msg = self
                 .chunk_endpoint
-                .get_unchunkified(&invocation_id)
+                .get_unchunkified_response(&invocation_id)
                 .await
                 .context("failed to dechunk response")?;
         } else {
@@ -798,7 +798,7 @@ impl Bus for Handler {
                     .map_err(|e| e.to_string())?;
                 if resp_length > CHUNK_THRESHOLD_BYTES {
                     msg = chunk_endpoint
-                        .get_unchunkified(&invocation_id)
+                        .get_unchunkified_response(&invocation_id)
                         .await
                         .context("failed to dechunk response")
                         .map_err(|e| e.to_string())?;

--- a/crates/runtime/src/actor/module/wasmbus.rs
+++ b/crates/runtime/src/actor/module/wasmbus.rs
@@ -147,8 +147,7 @@ fn write_bytes<T>(
 }
 
 #[instrument(skip(store, err))]
-fn set_host_error(store: &mut wasmtime::Caller<'_, super::Ctx>, err: impl ToString) {
-    let err = err.to_string();
+fn set_host_error(store: &mut wasmtime::Caller<'_, super::Ctx>, err: String) {
     trace!(err, "set host error");
     store.data_mut().wasmbus.host_error = Some(err);
 }
@@ -308,7 +307,7 @@ async fn host_call(
             Ok(wasm::SUCCESS)
         }
         Err(err) => {
-            set_host_error(&mut store, err);
+            set_host_error(&mut store, format!("{err:#}"));
             Ok(wasm::ERROR)
         }
     }


### PR DESCRIPTION
## Feature or Problem
This PR fixes two bugs in the host:
- the host was looking for the wrong object store IDs when parsing chunked invocation responses
- the host was dropping context when writing errors to the guest

## Release Information
v0.78.0-rc5

## Consumer Impact
The host should now be able to receive chunked invocation responses on behalf of actors

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tested e2e manually:

```
wash start actor -x default -p 4222 ghcr.io/connorsmith256/beeg-image:0.1.0
wash start provider -x default -p 4222 wasmcloud.azurecr.io/httpclient:0.8.0
wash start provider -x default -p 4222 wasmcloud.azurecr.io/httpserver:0.19.1
wash link put -x default -p 4222 MBDBBXENIJQ2YOBD4D6HKLGEVDUXTRO3HHLZVNI6LJRUPVOSNZGSKLD6 VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M wasmcloud:httpserver address=0.0.0.0:8080
wash link put -x default -p 4222 MBDBBXENIJQ2YOBD4D6HKLGEVDUXTRO3HHLZVNI6LJRUPVOSNZGSKLD6 VCCVLH4XWGI3SGARFNYKYT2A32SUYA2KVAIV2U2Q34DQA7WWJPFRKIKM wasmcloud:httpclient
```

Then navigated to the browser at `http://127.0.0.1:8080/` and confirmed the large (3MB) image loads successfully