### PR TITLE
fix: allow namespaces with slashes

### DIFF
--- a/crates/actor/src/compat/wasmcloud/bus/host.rs
+++ b/crates/actor/src/compat/wasmcloud/bus/host.rs
@@ -67,13 +67,13 @@ pub fn call_sync(
     match target {
         None => {
             let (namespace, operation) = operation
-                .split_once('/')
+                .rsplit_once('/')
                 .ok_or_else(|| "invalid operation format".to_string())?;
             host_call("", namespace, operation, payload)
         }
         Some(TargetEntity::Link(binding)) => {
             let (namespace, operation) = operation
-                .split_once('/')
+                .rsplit_once('/')
                 .ok_or_else(|| "invalid operation format".to_string())?;
             host_call(
                 binding.as_deref().unwrap_or_default(),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -158,7 +158,7 @@ impl Invocation {
     ) -> anyhow::Result<Invocation> {
         let operation = operation.into();
         let (_, operation) = operation
-            .split_once('/')
+            .rsplit_once('/')
             .context("failed to parse operation")?;
         // TODO: Support per-interface links
         let id = Uuid::from_u128(Ulid::new().into()).to_string();

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -276,7 +276,7 @@ impl Handler {
         let aliases = self.aliases.read().await;
         let operation = operation.into();
         let (package, _) = operation
-            .split_once('/')
+            .rsplit_once('/')
             .context("failed to parse operation")?;
         let inv_target = resolve_target(target, links.get(package), &aliases).await?;
         let needs_chunking = request.len() > CHUNK_THRESHOLD_BYTES;
@@ -722,7 +722,7 @@ impl Bus for Handler {
                 let links = links.read().await;
                 let aliases = aliases.read().await;
                 let (package, _) = operation
-                    .split_once('/')
+                    .rsplit_once('/')
                     .context("failed to parse operation")
                     .map_err(|e| e.to_string())?;
                 let inv_target = resolve_target(target.as_ref(), links.get(package), &aliases)

--- a/crates/runtime/tests/runtime.rs
+++ b/crates/runtime/tests/runtime.rs
@@ -123,8 +123,8 @@ impl capability::Bus for Handler {
             ("", "foobar-component-command-preview2") => Ok(capability::TargetEntity::Actor(
                 capability::ActorIdentifier::Alias("foobar-component-command-preview2".into()),
             )),
-            ("", "unknown") => Ok(capability::TargetEntity::Actor(
-                capability::ActorIdentifier::Alias("unknown".into()),
+            ("", "unknown/alias") => Ok(capability::TargetEntity::Actor(
+                capability::ActorIdentifier::Alias("unknown/alias".into()),
             )),
             _ => panic!("binding `{binding}` namespace `{namespace}` pair not supported"),
         }
@@ -313,10 +313,10 @@ impl capability::Bus for Handler {
                 Some(capability::TargetEntity::Actor(capability::ActorIdentifier::Alias(name))),
                 "test-actors:foobar/actor.foobar" // component invocation
                 | "foobar-component-command-preview2/actor.foobar"  // valid module invocation
-                | "unknown/actor.foobar", // invalid module invocation
-            ) if name == "foobar-component-command-preview2" || name == "unknown" => {
+                | "unknown/alias/actor.foobar", // invalid module invocation
+            ) if name == "foobar-component-command-preview2" || name == "unknown/alias" => {
                 assert_eq!(payload, br#"{"arg":"foo"}"#);
-                if name == "unknown" {
+                if name == "unknown/alias" {
                     bail!("unknown actor call alias")
                 } else {
                     Ok(r#""foobar""#.into())

--- a/tests/actors/rust/builtins-compat-reactor/src/lib.rs
+++ b/tests/actors/rust/builtins-compat-reactor/src/lib.rs
@@ -256,7 +256,7 @@ impl exports::wasmcloud::bus::guest::Guest for Actor {
 
         bus::host::call_sync(
             Some(&TargetEntity::Actor(bus::lattice::ActorIdentifier::Alias(
-                "unknown".into(),
+                "unknown/alias".into(),
             ))),
             "test-actors:foobar/actor.foobar",
             r#"{"arg":"foo"}"#.as_bytes(),

--- a/tests/actors/rust/builtins-component-reactor/src/lib.rs
+++ b/tests/actors/rust/builtins-component-reactor/src/lib.rs
@@ -314,7 +314,7 @@ impl exports::wasi::http::incoming_handler::Guest for Actor {
 
         bus::host::call_sync(
             Some(&TargetEntity::Actor(bus::lattice::ActorIdentifier::Alias(
-                "unknown".into(),
+                "unknown/alias".into(),
             ))),
             "test-actors:foobar/actor.foobar",
             r#"{"arg":"foo"}"#.as_bytes(),

--- a/tests/actors/rust/builtins-module-reactor/src/lib.rs
+++ b/tests/actors/rust/builtins-module-reactor/src/lib.rs
@@ -241,7 +241,7 @@ impl HttpHandler for HttpLogRng {
 
         bus::host::call_sync(
             Some(&TargetEntity::Actor(bus::lattice::ActorIdentifier::Alias(
-                "unknown".into(),
+                "unknown/alias".into(),
             ))),
             // TODO: This should include the package name, i.e. `test-actors:foobar/actor.foobar`
             "actor.foobar",


### PR DESCRIPTION
## Feature or Problem
This PR fixes a bug where we implicitly assumed namespaces wouldn't contain slashes. However, since call aliases can be defined by users, and our own examples include slashes in call aliases, this assumption is violated.

Instead, we assume the operation string `Interface.Method` won't contain slashes, and split from the right

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
0.78.0-rc6

## Consumer Impact
Users can now invoke actors via call aliases that include slashes

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Updated tests to use a call alias with a slash

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Manually tested actor-to-actor calls with aliases which include a slash ([pingpong example](https://github.com/wasmCloud/examples/blob/1670621366866736874d930a411ac8d2a2974af1/actor/actor-to-actor/wadm.yaml))