### PR TITLE
fix(host): use named fields when publishing link definitions

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -3573,7 +3573,7 @@ impl Host {
         )
         .await?;
 
-        let msgp = rmp_serde::to_vec(ld).context("failed to encode link definition")?;
+        let msgp = rmp_serde::to_vec_named(ld).context("failed to encode link definition")?;
         let lattice_prefix = &self.host_config.lattice_prefix;
         self.prov_rpc_nats
             .publish_with_headers(
@@ -3623,7 +3623,7 @@ impl Host {
         )
         .await?;
 
-        let msgp = rmp_serde::to_vec(ld).context("failed to encode link definition")?;
+        let msgp = rmp_serde::to_vec_named(ld).context("failed to encode link definition")?;
         let lattice_prefix = &self.host_config.lattice_prefix;
         self.prov_rpc_nats
             .publish_with_headers(


### PR DESCRIPTION
## Feature or Problem
When serializing link definitions to be published to providers, the host omits field names. This PR adds names to the serialized data, so providers which don't interpret the fields in the same order (e.g. non-Rust providers) can successfully deserialize the data

## Release Information
Next

## Consumer Impact
This should allow Go providers to run with the new hsot

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Before:
```
[#2] Received on "wasmbus.rpc.default.VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M.default.linkdefs.put"
�MCTI7WLWX62WZQ2J2HRDFCH3VXZLC2G7YKR4TLUVYGIAHXLVTTBSY7M3�VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5Mdefaultwasmcloud:httpserveraddress0.0.0.0:8082
```

After:
```
[#3] Received on "wasmbus.rpc.default.VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M.default.linkdefs.put"
actor_id�MCTI7WLWX62WZQ2J2HRDFCH3VXZLC2G7YKR4TLUVYGIAHXLVTTBSY7M3provider_id�VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5Mlink_namedefaultcontract_idwasmcloud:httpservervaluesaddress0.0.0.0:8082
```