### PR TITLE
Added badges and CLOmonitor information

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,13 +2,14 @@
 
 The following document outlines how the wasmCloud project governance operates.
 
-  - [The wasmCloud Project](#the-wasmcloud-project)
-  - [Maintainers Structure](#maintainers-structure)
-    - [wasmCloud Org Maintainers](#wasmcloud-org-maintainers)
-  - [Decision Making at the wasmCloud org level](#decision-making-at-the-wasmcloud-org-level)
-  - [Decision Making at the wasmCloud project level](#decision-making-at-the-wasmcloud-project-level)
-  - [Code of Conduct](#code-of-conduct)
-  - [DCO and Licenses](#dco-and-licenses)
+- [The wasmCloud Project](#the-wasmcloud-project)
+- [Maintainers Structure](#maintainers-structure)
+  - [wasmCloud Org Maintainers](#wasmcloud-org-maintainers)
+- [Decision Making at the wasmCloud org level](#decision-making-at-the-wasmcloud-org-level)
+- [Decision Making at the wasmCloud project level](#decision-making-at-the-wasmcloud-project-level)
+- [Code of Conduct](#code-of-conduct)
+- [DCO and Licenses](#dco-and-licenses)
+- [Pull Requests and Reviews](#pull-requests)
 
 ## The wasmCloud Project
 
@@ -30,35 +31,35 @@ responsibilities.
 
 The wasmCloud Org maintainers are responsible for:
 
-* Maintaining the mission, vision, values, and scope of the project
-* Refining the governance and charter as needed
-* Making project level decisions
-* Resolving escalated project decisions when the subteam responsible is blocked
-* Managing the wasmCloud brand
-* Controlling access to wasmCloud assets such as source repositories, hosting, project calendars
-* Handling code of conduct violations
-* Deciding what sub-groups are part of the wasmCloud project
-* Overseeing the resolution and disclosure of security issues
-* Managing financial decisions related to the project
+- Maintaining the mission, vision, values, and scope of the project
+- Refining the governance and charter as needed
+- Making project level decisions
+- Resolving escalated project decisions when the subteam responsible is blocked
+- Managing the wasmCloud brand
+- Controlling access to wasmCloud assets such as source repositories, hosting, project calendars
+- Handling code of conduct violations
+- Deciding what sub-groups are part of the wasmCloud project
+- Overseeing the resolution and disclosure of security issues
+- Managing financial decisions related to the project
 
 Changes to org maintainers use the following:
 
-* There will be between 3 and 9 people.
-* Any project maintainer of any active (non-archived) wasmCloud organization project is eligible for
+- There will be between 3 and 9 people.
+- Any project maintainer of any active (non-archived) wasmCloud organization project is eligible for
   a position as an org maintainer.
-* An org maintainer may step down by emailing the org maintainers or contacting them through Slack
-* Org maintainers MUST remain active on the project. If they are unresponsive for > 3 months they
+- An org maintainer may step down by emailing the org maintainers or contacting them through Slack
+- Org maintainers MUST remain active on the project. If they are unresponsive for > 3 months they
   will lose org maintainership unless a
   [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other org
   maintainers agrees to extend the period to be greater than 3 months
-* When there is an opening for a new org maintainer, any person who has made a contribution to any
+- When there is an opening for a new org maintainer, any person who has made a contribution to any
   repo under the wasmCloud GitHub org may nominate a suitable project maintainer of an active
   project as a replacement by contacting the current org maintainers
-  * The nomination period will be three weeks starting the day after an org maintainer opening
+  - The nomination period will be three weeks starting the day after an org maintainer opening
     becomes available
-* Org maintainers must vote for a nominated maintainer and the vote must pass with a
+- Org maintainers must vote for a nominated maintainer and the vote must pass with a
   [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote).
-* When an org maintainer steps down, they become an emeritus maintainer
+- When an org maintainer steps down, they become an emeritus maintainer
 
 Once an org maintainer is elected, they remain a maintainer until stepping down (or, in rare cases,
 are removed). Voting for new maintainers occurs when necessary to fill vacancies. Any existing
@@ -81,12 +82,12 @@ When a consensus cannot be found a maintainer can call for a
 Many of the day-to-day project maintenance can be done by a lazy consensus model. But the following
 items must be called to vote:
 
-* Enforcing a CoC violation (super majority)
-* Removing a maintainer for any reason other than inactivity (super majority)
-* Changing the governance rules (this document) (super majority)
-* Licensing and intellectual property changes (including new logos, wordmarks) (simple majority)
-* Adding, archiving, or removing subprojects (simple majority)
-* Utilizing wasmCloud/CNCF money for anything CNCF deems "not cheap and easy" (simple majority)
+- Enforcing a CoC violation (super majority)
+- Removing a maintainer for any reason other than inactivity (super majority)
+- Changing the governance rules (this document) (super majority)
+- Licensing and intellectual property changes (including new logos, wordmarks) (simple majority)
+- Adding, archiving, or removing subprojects (simple majority)
+- Utilizing wasmCloud/CNCF money for anything CNCF deems "not cheap and easy" (simple majority)
 
 Other decisions may, but do not need to be, called out and put up for decision at any time and by
 anyone. By default, any decisions called to a vote will be for a _simple majority_ vote.
@@ -120,7 +121,18 @@ choose to intervene.
 
 The following licenses and contributor agreements will be used for wasmCloud projects:
 
-* [Apache 2.0](https://opensource.org/licenses/Apache-2.0) for code
-* [Creative Commons Attribution 4.0 International Public
+- [Apache 2.0](https://opensource.org/licenses/Apache-2.0) for code
+- [Creative Commons Attribution 4.0 International Public
   License](https://creativecommons.org/licenses/by/4.0/legalcode) for documentation
-* [Developer Certificate of Origin](https://developercertificate.org/) for new contributions
+- [Developer Certificate of Origin](https://developercertificate.org/) for new contributions
+
+## Pull Requests and Reviews
+
+Pull requests are reviewed by maintainers and community members. Maintainers are responsible for
+triaging pull requests and ensuring that they are reviewed. Maintainers are also responsible for
+ensuring that the pull request is reviewed by the appropriate people. For example, a pull request
+that changes the website should be reviewed by the website maintainers. Each pull request
+in the wasmCloud organization will be required to pass appropriate checks, and these checks
+are decided at the project level.
+
+Additional information about contributing guidelines can be found in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 [![CNCF sandbox project](https://img.shields.io/website?label=CNCF%20Sandbox%20Project&url=https://landscape.cncf.io/?selected=wasm-cloud)](https://landscape.cncf.io/?selected=wasm-cloud)
 [![Stars](https://img.shields.io/github/stars/wasmcloud?color=gold&label=wasmCloud%20Org%20Stars)](https://github.com/wasmcloud/)
 ![Powered by WebAssembly](https://img.shields.io/badge/powered%20by-WebAssembly-orange.svg)<br />
-[![reddit](https://img.shields.io/reddit/subreddit-subscribers/wasmcloud?style=social)](https://reddit.com/r/wasmcloud)
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6363/badge)](https://bestpractices.coreinfrastructure.org/projects/6363)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wasmcloud/wasmcloud/badge)](https://securityscorecards.dev/viewer/?uri=github.com/wasmcloud/wasmcloud)
+[![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/wasm-cloud/badge)](https://clomonitor.io/projects/cncf/wasm-cloud)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B40030%2Fgit%40github.com%3AwasmCloud%2FwasmCloud.git.svg?type=small)](https://app.fossa.com/projects/custom%2B40030%2Fgit%40github.com%3AwasmCloud%2FwasmCloud.git?ref=badge_small)
 [![twitter](https://img.shields.io/twitter/follow/wasmcloud?style=social)](https://twitter.com/wasmcloud)
 [![youtube subscribers](https://img.shields.io/youtube/channel/subscribers/UCmZVIWGxkudizD1Z1and5JA?style=social)](https://youtube.com/wasmcloud)
 [![youtube views](https://img.shields.io/youtube/channel/views/UCmZVIWGxkudizD1Z1and5JA?style=social)](https://youtube.com/wasmcloud)
@@ -49,11 +52,25 @@ For even more examples, check out [awesome projects](./awesome-wasmcloud) using 
 
 We have plenty of ideas and things going on in the wasmCloud project. Please check out the [Roadmap doc](https://wasmcloud.com/docs/roadmap) for more information, and the [wasmCloud Roadmap project](https://github.com/orgs/wasmCloud/projects/7/views/3) to see the status of new features.
 
+## Releases
+
+The latest release and changelog can be found on the [releases page](https://github.com/wasmCloud/wasmCloud/releases).
+
 # 🧑‍💻 Contributing
 
 Want to get involved? For more information on how to contribute and our contributor guidelines, check out the [contributing readme](./CONTRIBUTING.md).
 
 # 📚 Other Resources
+
+## Community
+
+### Community Meetings
+
+We host weekly community meetings at 1pm EST on Wednesdays. These community meetings are livestreamed to our Twitter account and to [YouTube](https://www.youtube.com/@wasmCloud/streams). You can find the agenda and notes for each meeting in the [community](https://wasmcloud.com/community) secton of our webste. If you're interested in joining in on the call to demo or take part in the discussion, we have a Zoom link on our [community calendar](https://calendar.google.com/calendar/u/0/embed?src=c_6cm5hud8evuns4pe5ggu3h9qrs@group.calendar.google.com).
+
+### Slack
+
+We host our own [community slack](https://slack.wasmcloud.com) for all community members to join and talk about WebAssembly, wasmCloud, or just general cloud native technology. For those of you who are already on the [CNCF Slack](https://cloud-native.slack.com/), we also have our own channel at [#wasmcloud](https://cloud-native.slack.com/archives/C027YTXEYFL).
 
 ## Reference Documentation
 


### PR DESCRIPTION
This PR simply adds information for https://clomonitor.io/projects/cncf/wasm-cloud to properly locate things we've been doing for a while, and some additional fun badges to keep us accountable.