### PR TITLE
fix(wasmbus): properly format actors_started claims

### DIFF
--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -83,7 +83,7 @@ pub fn actors_started(
         "image_ref": image_ref.as_ref(),
         "annotations": annotations,
         "host_id": host_id.as_ref(),
-        "claims": claims,
+        "claims": format_actor_claims(claims),
         "count": count.into(),
     })
 }


### PR DESCRIPTION
## Feature or Problem
This PR serializes actor claims on `actors_started` events in the same format as `actor_started`.

## Related Issues
Fixes e2e tests in https://github.com/wasmCloud/wadm/pull/171

## Release Information
v0.78.0-rc10

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
