### PR TITLE
feat(host): parse labels from args

### DIFF
--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -1,5 +1,6 @@
 use crate::OciConfig;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -43,6 +44,8 @@ pub struct Host {
     pub lattice_prefix: String,
     /// The domain to use for host Jetstream operations
     pub js_domain: Option<String>,
+    /// Labels (key-value pairs) to add to the host
+    pub labels: HashMap<String, String>,
     /// The server key pair used by this host to generate its public key
     pub host_key: Option<Arc<KeyPair>>,
     /// The cluster key pair used by this host to sign all invocations
@@ -100,6 +103,7 @@ impl Default for Host {
             prov_rpc_tls: false,
             lattice_prefix: "default".to_string(),
             js_domain: None,
+            labels: HashMap::default(),
             host_key: None,
             cluster_key: None,
             cluster_issuers: None,

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -462,7 +462,8 @@ async fn wasmbus() -> anyhow::Result<()> {
         ("hostcore.arch".into(), ARCH.into()),
         ("hostcore.os".into(), OS.into()),
         ("hostcore.osfamily".into(), FAMILY.into()),
-        ("path".into(), "test-path".into()),
+        ("label1".into(), "value1".into()),
+        ("PATH".into(), "test-path".into()),
     ]);
 
     let cluster_key = Arc::new(cluster_key);
@@ -473,6 +474,7 @@ async fn wasmbus() -> anyhow::Result<()> {
         prov_rpc_nats_url: ctl_nats_url.clone(),
         lattice_prefix: TEST_PREFIX.to_string(),
         js_domain: None,
+        labels: HashMap::from([("label1".into(), "value1".into())]),
         cluster_key: Some(Arc::clone(&cluster_key)),
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key_two.public_key()]),
         host_key: Some(Arc::clone(&host_key)),
@@ -490,6 +492,7 @@ async fn wasmbus() -> anyhow::Result<()> {
         rpc_nats_url: ctl_nats_url.clone(),
         prov_rpc_nats_url: ctl_nats_url.clone(),
         lattice_prefix: TEST_PREFIX.to_string(),
+        labels: HashMap::from([("label1".into(), "value1".into())]),
         cluster_key: Some(Arc::clone(&cluster_key_two)),
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key_two.public_key()]),
         host_key: Some(Arc::clone(&host_key_two)),


### PR DESCRIPTION
## Feature or Problem
This adds the ability to pass host labels via args to the host, e.g.:

```
./wasmcloud --label cloud=aws -l region=us-east-1
```

```
{"specversion":"1.0","id":"018af29c-45ec-fe01-4c20-f28c5e93d63c","type":"com.wasmcloud.lattice.host_started","source":"NB6UBCPWYG6RSDG2RZVXJPV5TYYJ6ONZPZVUYTVKTIU5SZA34NTIEBL2","datacontenttype":"application/json","time":"2023-10-02T22:57:22.412943Z","data":{"friendly_name":"dark-moon-7391","labels":{"cloud":"true","hostcore.arch":"aarch64","hostcore.os":"macos","hostcore.osfamily":"unix","region":"us-east-1"},"uptime_seconds":0,"version":"0.79.0"}}
```

If a label isn't provided with the right syntax, an error is returned and the host fails to start:
```
./wasmcloud --label foobar
Error: failed to parse labels

Caused by:
    invalid label format `foobar`. Expected `key=value`
```

Note that the existing behavior of specifying labels via `HOST_*` prefixed env vars remains:

```
HOST_cloud=aws ./wasmcloud --label region=us-east-1
```

```
{"specversion":"1.0","id":"018af2b7-638b-a82f-162f-f85ff920b014","type":"com.wasmcloud.lattice.host_started","source":"NCY6QBZMVBZSMICAJ725AUPLMJEUPWPOIHM2DUODAM7FPLZW447AKKRZ","datacontenttype":"application/json","time":"2023-10-02T23:26:59.467221Z","data":{"friendly_name":"autumn-mountain-0504","labels":{"cloud":"aws","hostcore.arch":"aarch64","hostcore.os":"macos","hostcore.osfamily":"unix","region":"us-east-1"},"uptime_seconds":0,"version":"0.79.0"}}
```

If there is a collision between arg-passed labels and env-var labels, a warning is emitted, and the env-var wins (arbitrarily):

```
HOST_cloud=gcp ./wasmcloud --label cloud=aws -l region=us-east-1
2023-10-02T23:28:25.642438Z  WARN new: wasmcloud_host::wasmbus: label provided via HOST_ environment variable will override existing label key="cloud"
```

```
{"specversion":"1.0","id":"018af2b8-b434-cbbe-8f0d-49a61938b22d","type":"com.wasmcloud.lattice.host_started","source":"NACPHDT7OXEFJJUF5T5SEGKIKS7DPOAIFQN3K34GHNAK6PXYXJY5JUPG","datacontenttype":"application/json","time":"2023-10-02T23:28:25.652737Z","data":{"friendly_name":"rough-voice-3220","labels":{"cloud":"gcp","hostcore.arch":"aarch64","hostcore.os":"macos","hostcore.osfamily":"unix","region":"us-east-1"},"uptime_seconds":0,"version":"0.79.0"}}
```

## Related Issues
Relates to https://github.com/wasmCloud/wash/issues/842 (@brooksmtownsend I did the host, now you can do wash 😄 )

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
Added a label to the host config in the integration tests

### Manual Verification
Tested manually (see output above)