### PR TITLE
fix(logging): proxy RUST_LOG to providers

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1197,7 +1197,7 @@ impl ActorInstance {
 
     #[instrument(skip_all)]
     async fn handle_call(&self, invocation: Invocation) -> anyhow::Result<(Vec<u8>, u64)> {
-        debug!(?invocation.origin, ?invocation.target, invocation.operation, "validate actor invocation");
+        trace!(?invocation.origin, ?invocation.target, invocation.operation, "validate actor invocation");
         invocation.validate_antiforgery(&self.valid_issuers)?;
 
         let content_length: usize = invocation
@@ -1211,7 +1211,7 @@ impl ActorInstance {
             invocation.msg
         };
 
-        debug!(?invocation.origin, ?invocation.target, invocation.operation, "handle actor invocation");
+        trace!(?invocation.origin, ?invocation.target, invocation.operation, "handle actor invocation");
 
         let source_public_key = invocation.origin.public_key;
         // actors don't have a contract_id


### PR DESCRIPTION
## Feature or Problem
This PR:
- updates the shared tracing code to allow `RUST_LOG` to override log level directives
- proxies `RUST_LOG` from the host to providers
- removes `log_level` from the host_data, since "current" (legacy) providers built from wasmbus-rpc (not the new SDK, which uses the shared tracing code) [ignores `RUST_LOG` when `log_level` in the host data is set](https://github.com/wasmCloud/weld/blob/main/rpc-rs/src/provider_main.rs#L436)

As a result, a command like `RUST_LOG=debug,hyper=info,async_nats=info ./wasmcloud --log-level debug` will:
- for the host: use debug as the default logging level
  - note that the host internally already sets `async_nats` and `hyper` to info via the shared [tracing crate](https://github.com/wasmCloud/wasmCloud/blob/main/crates/tracing/src/lib.rs#L271)
- for providers: proxy `RUST_LOG=debug,hyper=info,async_nats=info`

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
Next

## Consumer Impact
This should allow operators to significantly reduce the amount of logs generated by legacy providers

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tested e2e manually with `wasmcloud.azurecr.io/httpserver:0.19.0` and `wasmcloud.azurecr.io/nats_messaging:0.17.3`. Logs on startup and upon sending messages to actors respected `RUST_LOG` once more
