### PR TITLE
chore: reduce verbosity of instrumented functions

### DIFF
--- a/crates/host/src/policy.rs
+++ b/crates/host/src/policy.rs
@@ -260,7 +260,7 @@ impl Manager {
     }
 
     /// Constructs a
-    #[instrument(skip(self))]
+    #[instrument(level = "debug", skip(self))]
     pub async fn evaluate_action(
         &self,
         source: Option<RequestSource>,

--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -228,15 +228,14 @@ pub fn provider_health_check(
     })
 }
 
-#[instrument(skip(event_builder, ctl_nats, name))]
+#[instrument(level = "debug", skip(event_builder, ctl_nats, data))]
 pub(crate) async fn publish(
     event_builder: &EventBuilderV10,
     ctl_nats: &async_nats::Client,
     lattice_prefix: &str,
-    name: impl AsRef<str>,
+    name: &str,
     data: serde_json::Value,
 ) -> anyhow::Result<()> {
-    let name = name.as_ref();
     let name = format!("com.wasmcloud.lattice.{name}");
     let now = OffsetDateTime::now_utc()
         .format(&Rfc3339)

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -240,7 +240,7 @@ struct Handler {
     chunk_endpoint: ChunkEndpoint,
 }
 
-#[instrument]
+#[instrument(level = "debug")]
 async fn resolve_target(
     target: Option<&TargetEntity>,
     links: Option<&HashMap<String, WasmCloudEntity>>,
@@ -272,7 +272,7 @@ async fn resolve_target(
 }
 
 impl Handler {
-    #[instrument(skip(self, operation, request))]
+    #[instrument(level = "debug", skip(self, operation, request))]
     async fn call_operation_with_payload(
         &self,
         target: Option<&TargetEntity>,
@@ -365,7 +365,7 @@ impl Handler {
         }
     }
 
-    #[instrument(skip(self, operation, request))]
+    #[instrument(level = "debug", skip(self, operation, request))]
     async fn call_operation(
         &self,
         target: Option<&TargetEntity>,
@@ -659,7 +659,7 @@ impl Blobstore for Handler {
 
 #[async_trait]
 impl Bus for Handler {
-    #[instrument(skip(self))]
+    #[instrument(level = "debug", skip(self))]
     async fn identify_wasmbus_target(
         &self,
         binding: &str,
@@ -676,7 +676,7 @@ impl Bus for Handler {
         Ok(TargetEntity::Actor(namespace.into()))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(level = "debug", skip(self))]
     async fn set_target(
         &self,
         target: Option<TargetEntity>,
@@ -695,7 +695,7 @@ impl Bus for Handler {
         Ok(())
     }
 
-    #[instrument(skip(self))]
+    #[instrument(level = "debug", skip(self))]
     async fn call(
         &self,
         target: Option<TargetEntity>,
@@ -830,7 +830,7 @@ impl Bus for Handler {
         ))
     }
 
-    #[instrument(skip(self, request))]
+    #[instrument(level = "debug", skip(self, request))]
     async fn call_sync(
         &self,
         target: Option<TargetEntity>,
@@ -979,7 +979,7 @@ impl KeyValueReadWrite for Handler {
 
 #[async_trait]
 impl Logging for Handler {
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn log(
         &self,
         level: logging::Level,
@@ -1129,7 +1129,7 @@ impl Messaging for Handler {
 }
 
 impl ActorInstance {
-    #[instrument(skip(self, msg))]
+    #[instrument(level = "debug", skip(self, msg))]
     async fn handle_invocation(
         &self,
         contract_id: &str,
@@ -1195,7 +1195,7 @@ impl ActorInstance {
         }
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_call(&self, invocation: Invocation) -> anyhow::Result<(Vec<u8>, u64)> {
         debug!(?invocation.origin, ?invocation.target, invocation.operation, "validate actor invocation");
         invocation.validate_antiforgery(&self.valid_issuers)?;
@@ -1298,7 +1298,7 @@ impl ActorInstance {
         }
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_message(&self, message: async_nats::Message) {
         let async_nats::Message {
             ref subject,
@@ -2110,12 +2110,8 @@ impl Host {
         })
     }
 
-    #[instrument(skip(self, name))]
-    async fn publish_event(
-        &self,
-        name: impl AsRef<str>,
-        data: serde_json::Value,
-    ) -> anyhow::Result<()> {
+    #[instrument(level = "debug", skip(self, name))]
+    async fn publish_event(&self, name: &str, data: serde_json::Value) -> anyhow::Result<()> {
         event::publish(
             &self.event_builder,
             &self.ctl_nats,

--- a/crates/provider-sdk/src/rpc_client.rs
+++ b/crates/provider-sdk/src/rpc_client.rs
@@ -267,7 +267,7 @@ impl RpcClient {
 
     /// Send a nats message with no reply-to. Do not wait for a response.
     /// This can be used for general nats messages, not just wasmbus actor/provider messages.
-    #[instrument(level = "debug", skip(self, payload))]
+    #[instrument(level = "trace", skip(self, payload))]
     pub async fn publish(&self, subject: String, payload: Vec<u8>) -> InvocationResult<()> {
         maybe_timeout(
             self.timeout,

--- a/crates/runtime/src/actor/component/mod.rs
+++ b/crates/runtime/src/actor/component/mod.rs
@@ -90,7 +90,7 @@ impl<T> StdioStream<T> {
 
 #[async_trait]
 impl HostInputStream for StdioStream<Box<dyn HostInputStream>> {
-    #[instrument(skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn read(&mut self, size: usize) -> anyhow::Result<(Bytes, StreamState)> {
         match self.0.try_lock().as_deref_mut() {
             Ok(None) => ClosedInputStream.read(size),
@@ -99,7 +99,7 @@ impl HostInputStream for StdioStream<Box<dyn HostInputStream>> {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn skip(&mut self, nelem: usize) -> anyhow::Result<(usize, StreamState)> {
         match self.0.try_lock().as_deref_mut() {
             Ok(None) => ClosedInputStream.skip(nelem),
@@ -108,7 +108,7 @@ impl HostInputStream for StdioStream<Box<dyn HostInputStream>> {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(level = "trace", skip(self))]
     async fn ready(&mut self) -> anyhow::Result<()> {
         if let Some(stream) = self.0.lock().await.as_mut() {
             stream.ready().await
@@ -122,7 +122,7 @@ type OutputStreamResult<T> = Result<T, OutputStreamError>;
 
 #[async_trait]
 impl HostOutputStream for StdioStream<Box<dyn HostOutputStream>> {
-    #[instrument(skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn write(&mut self, bytes: Bytes) -> OutputStreamResult<()> {
         match self.0.try_lock().as_deref_mut() {
             Ok(None) => ClosedOutputStream.write(bytes),
@@ -131,7 +131,7 @@ impl HostOutputStream for StdioStream<Box<dyn HostOutputStream>> {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn write_zeroes(&mut self, nelem: usize) -> OutputStreamResult<()> {
         match self.0.try_lock().as_deref_mut() {
             Ok(None) => ClosedOutputStream.write_zeroes(nelem),
@@ -140,7 +140,7 @@ impl HostOutputStream for StdioStream<Box<dyn HostOutputStream>> {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn flush(&mut self) -> OutputStreamResult<()> {
         match self.0.try_lock().as_deref_mut() {
             Ok(None) => ClosedOutputStream.flush(),
@@ -149,7 +149,7 @@ impl HostOutputStream for StdioStream<Box<dyn HostOutputStream>> {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(level = "trace", skip(self))]
     async fn write_ready(&mut self) -> OutputStreamResult<usize> {
         if let Some(stream) = self.0.lock().await.as_mut() {
             stream.write_ready().await
@@ -271,7 +271,7 @@ impl Component {
     }
 
     /// [Claims](jwt::Claims) associated with this [Component].
-    #[instrument]
+    #[instrument(level = "trace")]
     pub fn claims(&self) -> Option<&jwt::Claims<jwt::Actor>> {
         self.claims.as_ref()
     }
@@ -298,7 +298,7 @@ impl Component {
     }
 
     /// Instantiates a [Component] producing an [Instance] and invokes an operation on it using [Instance::call]
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn call(
         &self,
         operation: impl AsRef<str>,
@@ -493,7 +493,7 @@ pub struct GuestInstance {
 
 impl GuestInstance {
     /// Invoke an operation on a [GuestInstance] producing a result.
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn call(
         &self,
         operation: impl AsRef<str>,

--- a/crates/runtime/src/actor/mod.rs
+++ b/crates/runtime/src/actor/mod.rs
@@ -108,7 +108,7 @@ impl Actor {
     }
 
     /// [Claims](jwt::Claims) associated with this [Actor].
-    #[instrument]
+    #[instrument(level = "trace")]
     pub fn claims(&self) -> Option<&jwt::Claims<jwt::Actor>> {
         match self {
             Self::Module(module) => module.claims(),
@@ -160,7 +160,7 @@ impl Actor {
     /// # Errors
     ///
     /// Fails if [`Instance::call`] fails
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn call(
         &self,
         operation: impl AsRef<str>,
@@ -255,7 +255,7 @@ impl GuestInstance {
     ///
     /// Outermost error represents a failure in calling the actor, innermost - the
     /// application-layer error originating from within the actor itself
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn call(
         &self,
         operation: impl AsRef<str>,
@@ -440,7 +440,7 @@ impl Instance {
     ///
     /// Outermost error represents a failure in calling the actor, innermost - the
     /// application-layer error originating from within the actor itself
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn call(
         &mut self,
         operation: impl AsRef<str>,

--- a/crates/runtime/src/actor/module/mod.rs
+++ b/crates/runtime/src/actor/module/mod.rs
@@ -160,7 +160,7 @@ impl Debug for Module {
 
 impl Module {
     /// [Claims](jwt::Claims) associated with this [Module].
-    #[instrument]
+    #[instrument(level = "trace")]
     pub fn claims(&self) -> Option<&jwt::Claims<jwt::Actor>> {
         self.claims.as_ref()
     }
@@ -258,7 +258,7 @@ impl Module {
     }
 
     /// Instantiate a [Module] producing an [Instance] and invoke an operation on it using [Instance::call]
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn call(
         &self,
         operation: impl AsRef<str>,
@@ -365,7 +365,7 @@ impl Instance {
     }
 
     /// Invoke an operation on an [Instance].
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn call(
         &mut self,
         operation: impl AsRef<str>,
@@ -467,7 +467,7 @@ impl From<Instance> for GuestInstance {
 
 impl GuestInstance {
     /// Invoke an operation on a [GuestInstance].
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn call(
         &self,
         operation: impl AsRef<str>,

--- a/crates/runtime/src/actor/module/wasmbus.rs
+++ b/crates/runtime/src/actor/module/wasmbus.rs
@@ -98,7 +98,7 @@ fn caller_memory<T>(store: &mut wasmtime::Caller<'_, T>) -> wasmtime::Memory {
         .expect("`memory` type is not valid")
 }
 
-#[instrument(skip(store, memory))]
+#[instrument(level = "trace", skip(store, memory))]
 fn read_bytes(
     store: impl wasmtime::AsContext,
     memory: &wasmtime::Memory,
@@ -116,7 +116,7 @@ fn read_bytes(
     Ok(buf)
 }
 
-#[instrument(skip(store, memory))]
+#[instrument(level = "trace", skip(store, memory))]
 fn read_string(
     store: impl wasmtime::AsContext,
     memory: &wasmtime::Memory,
@@ -130,7 +130,7 @@ fn read_string(
     Ok(s)
 }
 
-#[instrument(skip(store, memory, buf))]
+#[instrument(level = "trace", skip(store, memory, buf))]
 fn write_bytes<T>(
     store: &mut wasmtime::Caller<'_, T>,
     memory: &wasmtime::Memory,
@@ -146,20 +146,20 @@ fn write_bytes<T>(
     Ok(())
 }
 
-#[instrument(skip(store, err))]
+#[instrument(level = "trace", skip(store, err))]
 fn set_host_error(store: &mut wasmtime::Caller<'_, super::Ctx>, err: String) {
     trace!(err, "set host error");
     store.data_mut().wasmbus.host_error = Some(err);
 }
 
-#[instrument(skip(store, res))]
+#[instrument(level = "trace", skip(store, res))]
 fn set_host_response(store: &mut wasmtime::Caller<'_, super::Ctx>, res: impl Into<Vec<u8>>) {
     let res = res.into();
     trace!(?res, "set host response");
     store.data_mut().wasmbus.host_response = Some(res);
 }
 
-#[instrument(skip(store))]
+#[instrument(level = "trace", skip(store))]
 fn console_log(
     mut store: wasmtime::Caller<'_, super::Ctx>,
     log_ptr: wasm::ptr,
@@ -173,7 +173,7 @@ fn console_log(
     Ok(())
 }
 
-#[instrument(skip(store))]
+#[instrument(level = "trace", skip(store))]
 fn guest_error(
     mut store: wasmtime::Caller<'_, super::Ctx>,
     err_ptr: wasm::ptr,
@@ -187,7 +187,7 @@ fn guest_error(
     Ok(())
 }
 
-#[instrument(skip(store))]
+#[instrument(level = "trace", skip(store))]
 fn guest_request(
     mut store: wasmtime::Caller<'_, super::Ctx>,
     operation_ptr: wasm::ptr,
@@ -207,7 +207,7 @@ fn guest_request(
         .context("failed to write `__guest_call` payload into guest memory")
 }
 
-#[instrument(skip(store))]
+#[instrument(level = "trace", skip(store))]
 fn guest_response(
     mut store: wasmtime::Caller<'_, super::Ctx>,
     res_ptr: wasm::ptr,
@@ -313,7 +313,7 @@ async fn host_call(
     }
 }
 
-#[instrument(skip(store))]
+#[instrument(level = "trace", skip(store))]
 fn host_error(mut store: wasmtime::Caller<'_, super::Ctx>, err_ptr: wasm::ptr) -> Result<()> {
     let err = store
         .data_mut()
@@ -328,7 +328,7 @@ fn host_error(mut store: wasmtime::Caller<'_, super::Ctx>, err_ptr: wasm::ptr) -
         .context("failed to write `__host_error` error into guest memory")
 }
 
-#[instrument(skip(store))]
+#[instrument(level = "trace", skip(store))]
 fn host_error_len(store: wasmtime::Caller<'_, super::Ctx>) -> wasm::usize {
     let len = store
         .data()
@@ -350,7 +350,7 @@ fn host_error_len(store: wasmtime::Caller<'_, super::Ctx>) -> wasm::usize {
     len
 }
 
-#[instrument(skip(store))]
+#[instrument(level = "trace", skip(store))]
 fn host_response(mut store: wasmtime::Caller<'_, super::Ctx>, res_ptr: wasm::ptr) -> Result<()> {
     let res = store
         .data_mut()
@@ -365,7 +365,7 @@ fn host_response(mut store: wasmtime::Caller<'_, super::Ctx>, res_ptr: wasm::ptr
         .context("failed to write `__host_response` response into guest memory")
 }
 
-#[instrument(skip(store))]
+#[instrument(level = "trace", skip(store))]
 fn host_response_len(store: wasmtime::Caller<'_, super::Ctx>) -> wasm::usize {
     store
         .data()

--- a/crates/runtime/src/capability/builtin.rs
+++ b/crates/runtime/src/capability/builtin.rs
@@ -537,7 +537,7 @@ impl Blobstore for Handler {
 
 #[async_trait]
 impl Bus for Handler {
-    #[instrument]
+    #[instrument(level = "trace")]
     async fn identify_wasmbus_target(
         &self,
         binding: &str,
@@ -591,7 +591,7 @@ impl Bus for Handler {
 
 #[async_trait]
 impl Logging for Handler {
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     async fn log(
         &self,
         level: logging::Level,


### PR DESCRIPTION
## Feature or Problem
This updates many instrumented functions to be at the debug or trace level. As a rule of thumb, I moved runtime internals to trace, and host functions to debug
