### PR TITLE
[FEAT] Actor Autoscaling and scale to zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,12 @@ target/
 # Ignore vscode config
 .vscode/
 
+# Ignore gitpod if you use that
+.gitpod.yml
+
+# Ignore Redis dumps from testing
+dump.rdb
 
 # Ignore Macos files
 .DS_Store
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
- "byteorder 1.4.3",
+ "byteorder 1.5.0",
  "cipher",
 ]
 
@@ -438,9 +438,9 @@ checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -877,7 +877,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
- "byteorder 1.4.3",
+ "byteorder 1.5.0",
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
@@ -1341,7 +1341,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
- "byteorder 1.4.3",
+ "byteorder 1.5.0",
 ]
 
 [[package]]
@@ -1762,9 +1762,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "ittapi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e0d0b7b3b53d92a7e8b80ede3400112a6b8b4c98d1f5b8b16bb787c780582c"
+checksum = "25a5c0b993601cad796222ea076565c5d9f337d35592f8622c753724f06d7271"
 dependencies = [
  "anyhow",
  "ittapi-sys",
@@ -1773,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "ittapi-sys"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f8763c96e54e6d6a0dccc2990d8b5e33e3313aaeae6185921a3f4c1614a77c"
+checksum = "cb7b5e473765060536a660eed127f758cf1a810c73e49063264959c60d1727d9"
 dependencies = [
  "cc",
 ]
@@ -2014,7 +2014,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aad178aad32087b19042ee36dfd450b73f5f934fbfb058b59b198684dfec4c47"
 dependencies = [
- "byteorder 1.4.3",
+ "byteorder 1.5.0",
  "data-encoding",
  "ed25519 2.2.2",
  "ed25519-dalek 2.0.0",
@@ -2946,7 +2946,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
 dependencies = [
- "byteorder 1.4.3",
+ "byteorder 1.5.0",
  "num-traits",
  "paste",
 ]
@@ -2957,7 +2957,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
 dependencies = [
- "byteorder 1.4.3",
+ "byteorder 1.5.0",
  "rmp",
  "serde",
 ]
@@ -4407,11 +4407,12 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.28.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37be05dfc4e1c528be5b9bdf7d0934182abe4a25424fcca0ba7afdb3f2b432e7"
+checksum = "f4befe5c1c3f85e521a835ea4323e0b903702aea0042883416657e51408ef478"
 dependencies = [
  "async-nats",
+ "async-trait",
  "bytes",
  "cloudevents-sdk",
  "data-encoding",
@@ -5227,9 +5228,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4407,9 +4407,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4befe5c1c3f85e521a835ea4323e0b903702aea0042883416657e51408ef478"
+checksum = "b1afe836c6a64bf593db3fcceca9ea23c5f7a53d8a87842be4b7b4efe8a6ca2a"
 dependencies = [
  "async-nats",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,13 +70,8 @@ wascap = { workspace = true }
 wasmcloud-control-interface = { workspace = true }
 
 [workspace]
-members = [
-    "crates/*",
-    "examples/rust/*",
-]
-exclude = [
-    "crates/providers"
-]
+members = ["crates/*", "examples/rust/*"]
+exclude = ["crates/providers"]
 
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
@@ -137,7 +132,7 @@ wasmcloud-actor = { version = "*", path = "./crates/actor" }
 wasmcloud-actor-macros = { version = "*", path = "./crates/actor/macros" }
 wasmcloud-compat = { version = "*", path = "./crates/compat" }
 wasmcloud-component-adapters = { version = "0.2.3" }
-wasmcloud-control-interface = { version = "0.29", default-features = false }
+wasmcloud-control-interface = { version = "0.30", default-features = false }
 wasmcloud-core = { version = "*", path = "./crates/core" }
 wasmcloud-host = { version = "*", path = "./crates/host" }
 wasmcloud-provider-sdk = { version = "*", path = "./crates/provider-sdk", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ wasmcloud-actor = { version = "*", path = "./crates/actor" }
 wasmcloud-actor-macros = { version = "*", path = "./crates/actor/macros" }
 wasmcloud-compat = { version = "*", path = "./crates/compat" }
 wasmcloud-component-adapters = { version = "0.2.3" }
-wasmcloud-control-interface = { version = "0.28", default-features = false }
+wasmcloud-control-interface = { version = "0.29", default-features = false }
 wasmcloud-core = { version = "*", path = "./crates/core" }
 wasmcloud-host = { version = "*", path = "./crates/host" }
 wasmcloud-provider-sdk = { version = "*", path = "./crates/provider-sdk", default-features = false }

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -72,7 +72,7 @@ impl<'a> TryFrom<&'a str> for ResourceRef<'a> {
                     "file" => url
                         .to_file_path()
                         .map(Self::File)
-                        .map_err(|_| anyhow!("failed to convert `{url}` to a file path")),
+                        .map_err(|()| anyhow!("failed to convert `{url}` to a file path")),
                     "bindle" => s
                         .strip_prefix("bindle://")
                         .map(Self::Bindle)

--- a/crates/host/src/local/mod.rs
+++ b/crates/host/src/local/mod.rs
@@ -145,7 +145,7 @@ impl Actor {
             "file" => {
                 let path = url
                     .to_file_path()
-                    .map_err(|_| anyhow!("failed to convert `{url}` to a file path"))?;
+                    .map_err(|()| anyhow!("failed to convert `{url}` to a file path"))?;
                 let buf = fs::read(path).await.context("failed to read actor")?;
                 let actor = wasmcloud_runtime::Actor::new(rt, buf)
                     .context("failed to initialize local actor")?;

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2654,7 +2654,7 @@ impl Host {
                             .instantiate_actor(
                                 claims,
                                 &annotations,
-                                host_id.clone(),
+                                host_id,
                                 &actor_ref,
                                 max,
                                 actor.actor.clone(),
@@ -2674,7 +2674,7 @@ impl Host {
                         .instantiate_actor(
                             claims,
                             &annotations,
-                            host_id.clone(),
+                            host_id,
                             &actor_ref,
                             max,
                             actor.actor.clone(),

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -3599,7 +3599,7 @@ impl Host {
                     .ctl_nats
                     .publish_with_headers(reply.clone(), headers, buf)
                     .err_into::<anyhow::Error>()
-                    .and_then(|_| self.ctl_nats.flush().err_into::<anyhow::Error>())
+                    .and_then(|()| self.ctl_nats.flush().err_into::<anyhow::Error>())
                     .await
                 {
                     error!("failed to publish success in response to `{subject}` request: {e:?}");
@@ -3614,7 +3614,7 @@ impl Host {
                         format!(r#"{{"accepted":false,"error":"{e}"}}"#).into(),
                     )
                     .err_into::<anyhow::Error>()
-                    .and_then(|_| self.ctl_nats.flush().err_into::<anyhow::Error>())
+                    .and_then(|()| self.ctl_nats.flush().err_into::<anyhow::Error>())
                     .await
                 {
                     error!("failed to publish error: {e:?}");

--- a/crates/runtime/src/actor/component/blobstore.rs
+++ b/crates/runtime/src/actor/component/blobstore.rs
@@ -241,7 +241,7 @@ impl blobstore::Host for Ctx {
     #[instrument]
     async fn create_container(&mut self, name: ContainerName) -> anyhow::Result<Result<Container>> {
         match self.handler.create_container(&name).await {
-            Ok(_) => {
+            Ok(()) => {
                 let container = self
                     .table
                     .push_container(name)

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -545,6 +545,7 @@ async fn wasmbus() -> anyhow::Result<()> {
                 uptime_human,
                 uptime_seconds,
                 version,
+                friendly_name,
             }),
             Some(HostInfo {
                 cluster_issuers: cluster_issuers_two,
@@ -577,6 +578,7 @@ expected: {expected_labels:?}"#
             ensure!(uptime_human.unwrap().len() > 0);
             ensure!(uptime_seconds >= 0);
             ensure!(version == Some(env!("CARGO_PKG_VERSION").into()));
+            ensure!(!friendly_name.is_empty());
         }
         (_, _, []) => bail!("not enough hosts in the lattice"),
         _ => bail!("more than two hosts in the lattice"),

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -424,6 +424,9 @@ async fn wasmbus() -> anyhow::Result<()> {
         async_nats::ConnectOptions::new().retry_on_initial_connect()
     }
 
+    // Sometimes NATS completes the server process start but isn't actually ready for connections
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
     let (ctl_nats_client, compat_nats_client, component_nats_client, module_nats_client) =
         try_join!(
             async_nats::connect_with_options(ctl_nats_url.as_str(), default_nats_connect_options()),
@@ -977,7 +980,7 @@ expected: {expected_labels:?}"#
         .await
         .map_err(|e| anyhow!(e).context("failed to query claims via bucket"))?;
     claims_from_bucket.sort_by(|a, b| a.get("sub").unwrap().cmp(b.get("sub").unwrap()));
-    ensure!(claims_from_bucket.len() == 8); // 4 providers, 4 actors
+    ensure!(claims_from_bucket.len() == 9); // 5 providers, 4 actors
 
     let mut links_from_bucket = ctl_client
         .query_links()

--- a/vendor/capability-providers/sqldb-postgres/src/config.rs
+++ b/vendor/capability-providers/sqldb-postgres/src/config.rs
@@ -78,7 +78,7 @@ pub(crate) fn load_config(ld: &LinkDefinition) -> Result<Config, RpcError> {
     if let Some(cj) = ld.values.get("config_b64") {
         config = serde_json::from_slice(
             &base64::decode(cj)
-                .map_err(|_| RpcError::ProviderInit("invalid config_base64 encoding".into()))?,
+                .map_err(|()| RpcError::ProviderInit("invalid config_base64 encoding".into()))?,
         )
         .map_err(|e| RpcError::ProviderInit(format!("invalid json config: {}", e)))?;
     }


### PR DESCRIPTION
## Feature or Problem
This PR features a few prominent changes to the handling of control interface requests, namely `scale`, `start`, and `stop` when it comes to actor components.
**External facing things**
1. Scale and Start now use `max_concurrent` instead of `count` to describe the handling of multiple instances of an individual actor. Per RFC #696, this accurately describes the way we instantiate actors, instantiating on request to handle an invocation and then exiting rather than running a certain number of things.
2. The `ActorInstance` is now the entity that stores an image reference rather than an `Actor`. This functionally doesn't change anything at this time but enables us in the future to consider running different image references of the same actor. We still report the image reference on the host inventory as before and ensure you cannot run duplicate instances. 
3. Requesting to stop an actor with provided annotations will stop that actor entirely and ignore the `count` field.
4. Scaling an actor to 0 will no longer remove that actor, instead it will ensure that the actor has an unbounded level of concurrency. **This is a breaking change and clients like wadm will need to use `stop_actor` instead of scale to 0**
**Internal changes**.
1. Actor instances internal `calls` abortable tasks now streams messages from the RPC topic and handles them concurrently up to the `max` specified when the actor is started/scaled.
2. Any commands that come in on the `la` aka Start actor topic will be immediately proxied into scale commands by adding the requested number to the current number of max instances. This preserves start functionality for now in a nice backwards compatible way.

## Related Issues
Depends on: https://github.com/wasmCloud/control-interface-client/pull/58
RFC: #696 
Fixes #746 

## Release Information
v0.79.0

## Consumer Impact
This PR builds off of v0.30.0 of the wasmCloud control interface client and it makes every choice possible to be backwards compatible with <v0.30.0. Once this is released there should be no required changes on the client side, though some code paths will result in deprecation warnings.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
