### PR TITLE
chore: upgrade vendored wasmtime-component-macro bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,17 +2659,6 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
-dependencies = [
- "bitflags 1.3.2",
- "memchr",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
@@ -4548,11 +4537,11 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 1.0.109",
+ "syn 2.0.37",
  "tracing",
  "tracing-subscriber",
- "wasmtime-wit-bindgen 11.0.2",
- "wit-parser 0.8.0",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4720,8 +4709,8 @@ dependencies = [
  "quote",
  "syn 2.0.37",
  "wasmtime-component-util",
- "wasmtime-wit-bindgen 13.0.0",
- "wit-parser 0.11.1",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4965,17 +4954,6 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "11.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed98de4b3e68b1abe60f0dc59ecd74b757d70a39459d500a727a8cab3311bbb"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser 0.8.0",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62003d48822f89cc393e93643366ddbee1766779c0874353b8ba2ede4679fbf9"
@@ -4983,7 +4961,7 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap 2.0.0",
- "wit-parser 0.11.1",
+ "wit-parser",
 ]
 
 [[package]]
@@ -5294,7 +5272,7 @@ checksum = "7f0371c47784e7559efb422f74473e395b49f7101725584e2673657e0b4fc104"
 dependencies = [
  "anyhow",
  "wit-component",
- "wit-parser 0.11.1",
+ "wit-parser",
 ]
 
 [[package]]
@@ -5351,36 +5329,20 @@ dependencies = [
  "wasm-encoder 0.33.1",
  "wasm-metadata",
  "wasmparser 0.113.3",
- "wit-parser 0.11.1",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.8.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6daec9f093dbaea0e94043eeb92ece327bbbe70c86b1f41aca9bbfefd7f050f0"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 1.9.3",
- "log",
- "pulldown-cmark 0.8.0",
- "semver",
- "unicode-xid",
- "url",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcd022610436a1873e60bfdd9b407763f2404adf7d1cb57912c7ae4059e57a5"
+checksum = "a39edca9abb16309def3843af73b58d47d243fe33a9ceee572446bcc57556b9a"
 dependencies = [
  "anyhow",
  "id-arena",
  "indexmap 2.0.0",
  "log",
- "pulldown-cmark 0.9.3",
+ "pulldown-cmark",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ wasmcloud-tracing = { version = "*", path = "./crates/tracing" }
 wasmparser = { version = "0.113", default-features = false }
 wasmtime = { version = "13", default-features = false }
 wasmtime-wasi = { version = "13", default-features = false }
-wasmtime-wit-bindgen = { version = "11", default-features = false }
+wasmtime-wit-bindgen = { version = "13", default-features = false }
 wit-bindgen = { version = "0.12", default-features = false }
 wit-component = { version = "0.14", default-features = false }
-wit-parser = { version = "0.8", default-features = false }
+wit-parser = { version = "0.11.3", default-features = false }

--- a/crates/provider-wit-bindgen/Cargo.toml
+++ b/crates/provider-wit-bindgen/Cargo.toml
@@ -21,10 +21,7 @@ heck = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 serde = { workspace = true }
-# This version of syn is required due to current version of wasmtime_component_macro that
-# has been vendored in this crate. It can be upgraded when the macros themselves update
-# (see: src/vendor/wasmtime_component_macro.rs)
-syn = { version = "1", features = [ "parsing", "full", "visit-mut", "extra-traits" ] }
+syn = { version = "2", features = [ "parsing", "full", "visit-mut", "extra-traits" ] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [ "fmt", "env-filter" ] }
 wasmtime-wit-bindgen = { workspace = true }

--- a/crates/provider-wit-bindgen/src/lib.rs
+++ b/crates/provider-wit-bindgen/src/lib.rs
@@ -47,7 +47,7 @@ use syn::{
     punctuated::Punctuated,
     visit_mut::{visit_item_mut, VisitMut},
     FnArg, Item, ItemMod, ItemStruct, ItemType, LitStr, PathSegment, ReturnType, Token, TraitItem,
-    TraitItemMethod,
+    TraitItemFn,
 };
 
 /// Rust module name that is used by wit-bindgen to generate all the modules
@@ -317,7 +317,7 @@ impl WitFunctionLatticeTranslationStrategy {
     fn translate_import_fn_for_lattice(
         &self,
         wit_iface_path: WitInterfacePath,
-        trait_method: &TraitItemMethod,
+        trait_method: &TraitItemFn,
         struct_lookup: &StructLookup,
         type_lookup: &TypeLookup,
     ) -> anyhow::Result<(WitInterfacePath, LatticeMethod)> {
@@ -382,7 +382,7 @@ impl WitFunctionLatticeTranslationStrategy {
     fn translate_import_fn_via_first_arg(
         wit_iface_path: WitInterfacePath,
         lattice_method_name: LitStr,
-        trait_method: &TraitItemMethod,
+        trait_method: &TraitItemFn,
         _struct_lookup: &StructLookup,
         _type_lookup: &TypeLookup,
     ) -> anyhow::Result<(WitInterfacePath, LatticeMethod)> {
@@ -436,7 +436,7 @@ impl WitFunctionLatticeTranslationStrategy {
     fn translate_import_fn_via_bundled_args(
         wit_iface_name: WitInterfacePath,
         lattice_method_name: LitStr,
-        trait_method: &TraitItemMethod,
+        trait_method: &TraitItemFn,
         struct_lookup: &StructLookup,
         type_lookup: &TypeLookup,
     ) -> anyhow::Result<(WitInterfacePath, LatticeMethod)> {
@@ -1250,7 +1250,7 @@ struct WitBindgenOutputVisitor {
     type_lookup: TypeLookup,
 
     /// Functions in traits that we'll have to stub eventually
-    import_trait_methods: HashMap<WitInterfacePath, Vec<TraitItemMethod>>,
+    import_trait_methods: HashMap<WitInterfacePath, Vec<TraitItemFn>>,
 }
 
 impl WitBindgenOutputVisitor {
@@ -1448,7 +1448,7 @@ impl VisitMut for WitBindgenOutputVisitor {
                 // which means the function calls & arguments must be converted to serializable objects to be received
                 if t.ident == HOST_IMPORTS_TRAIT_NAME {
                     for ti in t.items.iter_mut() {
-                        if let TraitItem::Method(tim) = ti {
+                        if let TraitItem::Fn(tim) = ti {
                             // Prune the &self argument
                             let mut trimmed = tim.clone();
                             trimmed.sig.inputs = <Punctuated<FnArg, Token![,]>>::from_iter(
@@ -1609,7 +1609,7 @@ struct LatticeMethod {
 fn build_lattice_methods_by_wit_interface(
     struct_lookup: &StructLookup,
     type_lookup: &TypeLookup,
-    map: &HashMap<WitInterfacePath, Vec<TraitItemMethod>>,
+    map: &HashMap<WitInterfacePath, Vec<TraitItemFn>>,
     bindgen_cfg: &ProviderBindgenConfig,
 ) -> anyhow::Result<HashMap<WitInterfacePath, Vec<LatticeMethod>>> {
     let mut methods_by_name: HashMap<WitInterfacePath, Vec<LatticeMethod>> = HashMap::new();

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -1252,6 +1252,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -2050,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
 dependencies = [
  "bitflags 1.3.2",
  "memchr",
@@ -3686,7 +3687,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 1.0.109",
+ "syn 2.0.37",
  "tracing",
  "tracing-subscriber",
  "wasmtime-wit-bindgen",
@@ -3721,12 +3722,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "11.0.2"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed98de4b3e68b1abe60f0dc59ecd74b757d70a39459d500a727a8cab3311bbb"
+checksum = "62003d48822f89cc393e93643366ddbee1766779c0874353b8ba2ede4679fbf9"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
+ "indexmap 2.0.0",
  "wit-parser",
 ]
 
@@ -3916,16 +3918,18 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.8.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6daec9f093dbaea0e94043eeb92ece327bbbe70c86b1f41aca9bbfefd7f050f0"
+checksum = "a39edca9abb16309def3843af73b58d47d243fe33a9ceee572446bcc57556b9a"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "log",
  "pulldown-cmark",
  "semver",
+ "serde",
+ "serde_json",
  "unicode-xid",
  "url",
 ]


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Update vendored `wasmtime-component-macro` and related deps used by `provider-wit-bindgen`.

We're also able to remove our dependency on the older version of `syn` as newer versions of `wasmtime-component-macro` have upgraded.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

Consumers are able to use latest & greatest features of `wasmtime-component-macro`, if desired.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
