### PR TITLE
chore: add ci-maintainers to Nix-related paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,11 +5,11 @@
 .github @wasmCloud/ci-maintainers
 
 # nix
-.github/actions/build-nix @rvolosatovs
-.github/actions/install-nix @rvolosatovs
-.github/workflows/nix.yml @rvolosatovs
-flake.* @rvolosatovs
-garnix.yaml @rvolosatovs
+.github/actions/build-nix @wasmCloud/ci-maintainers
+.github/actions/install-nix @wasmCloud/ci-maintainers
+.github/workflows/nix.yml @wasmCloud/ci-maintainers
+flake.* @wasmCloud/ci-maintainers
+garnix.yaml @wasmCloud/ci-maintainers
 
 # host-related code
 crates/actor @wasmCloud/host-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 
 # .github CI
 .github @wasmCloud/ci-maintainers
+.github/CODEOWNERS @wasmCloud/org-maintainers
 
 # nix
 .github/actions/build-nix @wasmCloud/ci-maintainers


### PR DESCRIPTION
This way if Roman goes on vacation others can still review and enable auto-merge for changes against these paths :)