### PR TITLE
fix: deprecate HOST_ label prefix in favor of WASMCLOUD_HOST_

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1752,14 +1752,22 @@ impl Host {
         labels.extend(config.labels.clone().into_iter());
         let existing_labels: HashSet<String> = labels.keys().cloned().collect();
         labels.extend(env::vars().filter_map(|(key, value)| {
-            let key = key.strip_prefix("HOST_")?;
-            if existing_labels.contains(key) {
+            let mut key = key;
+            if key.starts_with("HOST_") {
+                warn!("labels set via HOST_ environment variables are deprecated and will be removed in a future version. Please use WASMCLOUD_HOST_ as the prefix instead");
+                key = key.strip_prefix("HOST_")?.to_string();
+            } else if key.starts_with("WASMCLOUD_HOST_") {
+                key = key.strip_prefix("WASMCLOUD_HOST_")?.to_string();
+            } else {
+                return None;
+            }
+            if existing_labels.contains(&key) {
                 warn!(
                     ?key,
-                    "label provided via HOST_ environment variable will override existing label"
+                    "label provided via environment variable will override existing label"
                 );
             }
-            Some((key.to_string(), value))
+            Some((key, value))
         }));
         let friendly_name =
             Self::generate_friendly_name().context("failed to generate friendly name")?;

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1752,15 +1752,14 @@ impl Host {
         labels.extend(config.labels.clone().into_iter());
         let existing_labels: HashSet<String> = labels.keys().cloned().collect();
         labels.extend(env::vars().filter_map(|(key, value)| {
-            let mut key = key;
-            if key.starts_with("HOST_") {
+            let key = if key.starts_with("HOST_") {
                 warn!("labels set via HOST_ environment variables are deprecated and will be removed in a future version. Please use WASMCLOUD_HOST_ as the prefix instead");
-                key = key.strip_prefix("HOST_")?.to_string();
+                key.strip_prefix("HOST_")?.to_string()
             } else if key.starts_with("WASMCLOUD_HOST_") {
-                key = key.strip_prefix("WASMCLOUD_HOST_")?.to_string();
+                key.strip_prefix("WASMCLOUD_HOST_")?.to_string()
             } else {
                 return None;
-            }
+            };
             if existing_labels.contains(&key) {
                 warn!(
                     ?key,


### PR DESCRIPTION
## Feature or Problem
This updates the expected env var prefix for host labels from `HOST_` to `WASMCLOUD_HOST_` (and deprecates the former)

## Related Issues
Related to https://github.com/wasmCloud/wasmcloud-otp/issues/637

## Release Information
Next

## Consumer Impact
Nothing for now, but eventually we will remove support for `HOST_` prefixes. That will solve the interaction with Nix/any other system which uses this prefix, and will break old scripts, so we'll have to wait a while before doing that.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tested manually:

```
HOST_foo=bar ./target/debug/wasmcloud
2023-10-06T20:36:13.821866Z  WARN new: wasmcloud_host::wasmbus: labels set via HOST_ environment variables are deprecated. Please use WASMCLOUD_HOST_ as the prefix instead
2023-10-06T20:36:13.824337Z  INFO async_nats::options: event: connected
2023-10-06T20:36:13.824537Z  INFO async_nats::options: event: connected
2023-10-06T20:36:13.824572Z  INFO async_nats::options: event: connected
2023-10-06T20:36:13.825910Z  INFO new:create_lattice_metadata_bucket{bucket="LATTICEDATA_default"}: wasmcloud_host::wasmbus: lattice metadata bucket LATTICEDATA_default already exists. Skipping creation.
2023-10-06T20:36:13.826630Z  INFO new: wasmcloud_host::wasmbus: wasmCloud host started host_id="NBNYEOGQ662A6DTI5SPMKRM2A3OCLAKQNGBMYUBGHJZFFEBJOOKPKMYQ"
```

```
{"specversion":"1.0","id":"018b06b4-7d82-df17-97b5-24001e0e60f2","type":"com.wasmcloud.lattice.host_started","source":"NBNYEOGQ662A6DTI5SPMKRM2A3OCLAKQNGBMYUBGHJZFFEBJOOKPKMYQ","datacontenttype":"application/json","time":"2023-10-06T20:36:13.826494Z","data":{"friendly_name":"fragrant-water-0798","labels":{"foo":"bar","hostcore.arch":"aarch64","hostcore.os":"macos","hostcore.osfamily":"unix"},"uptime_seconds":0,"version":"0.79.0"}}
```

```
WASMCLOUD_HOST_foo=bar ./target/debug/wasmcloud
2023-10-06T20:36:30.342730Z  INFO async_nats::options: event: connected
2023-10-06T20:36:30.342937Z  INFO async_nats::options: event: connected
2023-10-06T20:36:30.342992Z  INFO async_nats::options: event: connected
2023-10-06T20:36:30.344348Z  INFO new:create_lattice_metadata_bucket{bucket="LATTICEDATA_default"}: wasmcloud_host::wasmbus: lattice metadata bucket LATTICEDATA_default already exists. Skipping creation.
2023-10-06T20:36:30.345073Z  INFO new: wasmcloud_host::wasmbus: wasmCloud host started host_id="NC5FUPVYJZDLR5ZMSYVRLQ2EIBTMRXHTPG6QGGKNDYGKWRYJAZC2JFYD"
```

```
{"specversion":"1.0","id":"018b06b4-be08-e4ec-9092-b72cf939c193","type":"com.wasmcloud.lattice.host_started","source":"NC5FUPVYJZDLR5ZMSYVRLQ2EIBTMRXHTPG6QGGKNDYGKWRYJAZC2JFYD","datacontenttype":"application/json","time":"2023-10-06T20:36:30.344940Z","data":{"friendly_name":"ancient-meadow-1564","labels":{"foo":"bar","hostcore.arch":"aarch64","hostcore.os":"macos","hostcore.osfamily":"unix"},"uptime_seconds":0,"version":"0.79.0"}}
```