### PR TITLE
ci: add merge_group event trigger to support merge queue

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,7 @@ name: docker
 
 on:
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,7 @@ name: nix
 
 on:
   pull_request:
+  merge_group:
   push:
 
 concurrency:

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -2,6 +2,7 @@ name: wasmCloud
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
     - main
@@ -172,7 +173,7 @@ jobs:
     permissions:
       packages: write
     needs: build-bin
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: ./.github/actions/install-nix


### PR DESCRIPTION
## Feature or Problem
This enables our workflows on the `merge_group` event, which is used by [the merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions). Once this is validated, we can enable a merge queue to prevent issues caused by merging PRs which work independently but cause issues when integrated together

## Related Issues
https://github.com/wasmCloud/wasmCloud/issues/424