### PR TITLE
chore: replace error field name with err

### DIFF
--- a/crates/core/src/chunking.rs
+++ b/crates/core/src/chunking.rs
@@ -79,10 +79,10 @@ impl ChunkEndpoint {
         obj.read_to_end(&mut result)
             .await
             .context("failed to read chunked stream")?;
-        if let Err(e) = store.delete(inv_id).await {
+        if let Err(err) = store.delete(inv_id).await {
             // not deleting will be a non-fatal error for the receiver,
             // if all the bytes have been received
-            error!(invocation_id = %inv_id, error = %e, "failed to delete chunks");
+            error!(invocation_id = %inv_id, %err, "failed to delete chunks");
         }
         Ok(result)
     }

--- a/crates/providers/http-server/src/lib.rs
+++ b/crates/providers/http-server/src/lib.rs
@@ -274,16 +274,16 @@ impl HttpServerCore {
                 // for tls server yet. Waiting on https://github.com/seanmonstar/warp/pull/717
                 // attempt to bind to the address
                 .bind_with_graceful_shutdown(addr, async move {
-                    if let Err(e) = shutdown_rx.recv_async().await {
-                        error!(error = %e, "shutting down httpserver listener");
+                    if let Err(err) = shutdown_rx.recv_async().await {
+                        error!(%err, "shutting down httpserver listener");
                     }
                 });
             handle.spawn(fut)
         } else {
             let (_, fut) = server
                 .try_bind_with_graceful_shutdown(addr, async move {
-                    if let Err(e) = shutdown_rx.recv_async().await {
-                        error!(error = %e, "shutting down httpserver listener");
+                    if let Err(err) = shutdown_rx.recv_async().await {
+                        error!(%err, "shutting down httpserver listener");
                     }
                 })
                 .map_err(|e| {


### PR DESCRIPTION
There's a bug somewhere in the tracing/opentelemetry/collector stack where certain configurations don't play nicely with error events/logs which include `error` as a field. It seems `error` always gets set to `true`, regardless of whether the tracing information had other contents. Renaming this field to `err` is a workaround so error messages make it through to tracing tools