### PR TITLE
ci: publish latest tag

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -232,7 +232,16 @@ jobs:
         docker run ghcr.io/${{ steps.ctx.outputs.package }}:${{ steps.ctx.outputs.version }} wasmcloud --version
         docker run wasmcloud.azurecr.io/${{ steps.ctx.outputs.package }}:${{ steps.ctx.outputs.version }} wasmcloud --version
 
-  # TODO: Push `latest`
+    - name: Push latest tag
+      if: startswith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')
+      run: |
+        buildah manifest push --storage-driver=vfs --all --format 'v2s2' wasmcloud docker://${{ steps.ctx.outputs.package }}:latest
+        buildah manifest push --storage-driver=vfs --all --format 'v2s2' wasmcloud docker://ghcr.io/${{ steps.ctx.outputs.package }}:latest
+        buildah manifest push --storage-driver=vfs --all --format 'v2s2' wasmcloud docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.package }}:latest
+
+        docker run ${{ steps.ctx.outputs.package }}:latest wasmcloud --version
+        docker run ghcr.io/${{ steps.ctx.outputs.package }}:latest wasmcloud --version
+        docker run wasmcloud.azurecr.io/${{ steps.ctx.outputs.package }}:latest wasmcloud --version
 
   release:
     if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push'


### PR DESCRIPTION
## Feature or Problem
I had a sad:
```
docker run wasmcloud/wasmcloud:latest
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
wasmcloud 0.18.2
```
