### PR TITLE
refactor(wascap): use `OnceLock` to remove `once-cell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4127,7 +4127,6 @@ dependencies = [
  "log",
  "nkeys",
  "nuid 0.4.1",
- "once_cell",
  "ring 0.17.5",
  "serde",
  "serde_json",

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -3393,7 +3393,6 @@ dependencies = [
  "log",
  "nkeys 0.3.2",
  "nuid 0.4.1",
- "once_cell",
  "ring 0.17.4",
  "serde",
  "serde_json",

--- a/crates/wascap/Cargo.toml
+++ b/crates/wascap/Cargo.toml
@@ -19,7 +19,6 @@ humantime = { workspace = true }
 log = { workspace = true }
 nkeys = { workspace = true }
 nuid = { workspace = true }
-once_cell = { workspace = true }
 ring = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/crates/wascap/src/caps.rs
+++ b/crates/wascap/src/caps.rs
@@ -1,8 +1,7 @@
 //! A set of standard names for capabilities that can be provided by a host
 
 use std::collections::HashMap;
-
-use once_cell::sync::Lazy;
+use std::sync::OnceLock;
 
 pub const BLOB: &str = "wasmcloud:blobstore";
 pub const HTTP_CLIENT: &str = "wasmcloud:httpclient";
@@ -13,21 +12,25 @@ pub const EVENTSTREAMS: &str = "wasmcloud:eventstreams";
 pub const NUMBERGEN: &str = "wasmcloud:builtin:numbergen";
 pub const LOGGING: &str = "wasmcloud:builtin:logging";
 
-static CAPABILITY_NAMES: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
-    let mut m = HashMap::new();
-    m.insert(MESSAGING, "Messaging");
-    m.insert(KEY_VALUE, "K/V Store");
-    m.insert(HTTP_SERVER, "HTTP Server");
-    m.insert(HTTP_CLIENT, "HTTP Client");
-    m.insert(BLOB, "Blob Store");
-    m.insert(EVENTSTREAMS, "Event Streams");
-    m.insert(NUMBERGEN, "Number Generation");
-    m.insert(LOGGING, "Logging");
-    m
-});
+static CAPABILITY_NAMES: OnceLock<HashMap<&str, &str>> = OnceLock::new();
+
+fn get_capability_names() -> &'static HashMap<&'static str, &'static str> {
+    CAPABILITY_NAMES.get_or_init(|| {
+        HashMap::from([
+            (MESSAGING, "Messaging"),
+            (KEY_VALUE, "K/V Store"),
+            (HTTP_SERVER, "HTTP Server"),
+            (HTTP_CLIENT, "HTTP Client"),
+            (BLOB, "Blob Store"),
+            (EVENTSTREAMS, "Event Streams"),
+            (NUMBERGEN, "Number Generation"),
+            (LOGGING, "Logging"),
+        ])
+    })
+}
 
 pub fn capability_name(cap: &str) -> String {
-    CAPABILITY_NAMES
+    get_capability_names()
         .get(cap)
         .map_or(cap.to_string(), |item| item.to_string())
 }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit removes the use of `once-cell` in favor of `std::sync::OnceLock`

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
