### PR TITLE
fix: change expected host label prefix to remove collision with WASMCLOUD_HOST_SEED

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-host"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "0.79.0"
+version = "0.79.1"
 description = "wasmCloud host runtime"
 
 authors.workspace = true

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.79.0"
+version = "0.79.1"
 description = "wasmCloud host library"
 
 authors.workspace = true

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1776,10 +1776,10 @@ impl Host {
         let existing_labels: HashSet<String> = labels.keys().cloned().collect();
         labels.extend(env::vars().filter_map(|(key, value)| {
             let key = if key.starts_with("HOST_") {
-                warn!("labels set via HOST_ environment variables are deprecated and will be removed in a future version. Please use WASMCLOUD_HOST_ as the prefix instead");
+                warn!("labels set via HOST_ environment variables are deprecated and will be removed in a future version. Please use WASMCLOUD_LABEL_ as the prefix instead");
                 key.strip_prefix("HOST_")?.to_string()
-            } else if key.starts_with("WASMCLOUD_HOST_") {
-                key.strip_prefix("WASMCLOUD_HOST_")?.to_string()
+            } else if key.starts_with("WASMCLOUD_LABEL_") {
+                key.strip_prefix("WASMCLOUD_LABEL_")?.to_string()
             } else {
                 return None;
             };


### PR DESCRIPTION
## Feature or Problem
In https://github.com/wasmCloud/wasmCloud/pull/731, we renamed the expected prefix from `HOST_` to `WASMCLOUD_HOST_`. Unfortunately, this collides with the existing `WASMCLOUD_HOST_SEED` argument, and results in hosts which have a seed specified via env var gaining a `SEED=XXXXXXXX` label

Note: while "seed" makes this sound like it could be a security vulnerability, the host's ID keypair is not used in the signing/verifying of invocations or other security-related functionality.

## Release Information
v0.79.1