### PR TITLE
Fix/drop prov rpc

### DIFF
--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -32,14 +32,6 @@ pub struct Host {
     pub rpc_key: Option<Arc<KeyPair>>,
     /// Whether to require TLS for RPC connection
     pub rpc_tls: bool,
-    /// NATS URL to pass to providers for RPC
-    pub prov_rpc_nats_url: Url,
-    /// Authentication JWT for Provider RPC connection, must be specified with prov_rpc_seed
-    pub prov_rpc_jwt: Option<String>,
-    /// Authentication key pair for Provider RPC connection, must be specified with prov_rpc_jwt
-    pub prov_rpc_key: Option<Arc<KeyPair>>,
-    /// Whether to require TLS for Provider RPC connection
-    pub prov_rpc_tls: bool,
     /// The lattice the host belongs to
     pub lattice_prefix: String,
     /// The domain to use for host Jetstream operations
@@ -96,11 +88,6 @@ impl Default for Host {
             rpc_jwt: None,
             rpc_key: None,
             rpc_tls: false,
-            prov_rpc_nats_url: Url::parse("nats://localhost:4222")
-                .expect("failed to parse Provider RPC NATS URL"),
-            prov_rpc_jwt: None,
-            prov_rpc_key: None,
-            prov_rpc_tls: false,
             lattice_prefix: "default".to_string(),
             js_domain: None,
             labels: HashMap::default(),

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -491,7 +491,7 @@ async fn wasmbus() -> anyhow::Result<()> {
     )
     .context("failed to connect to NATS")?;
 
-    // FIXME: we should be using separate NATS clients for CTL, RPC, and PROV_RPC
+    // FIXME: we should be using separate NATS clients for CTL and RPC
 
     let (
         (component_redis_server, component_stop_redis_tx, component_redis_url),
@@ -525,7 +525,6 @@ async fn wasmbus() -> anyhow::Result<()> {
     let (host, shutdown) = Host::new(HostConfig {
         ctl_nats_url: ctl_nats_url.clone(),
         rpc_nats_url: ctl_nats_url.clone(),
-        prov_rpc_nats_url: ctl_nats_url.clone(),
         lattice_prefix: TEST_PREFIX.to_string(),
         js_domain: None,
         labels: HashMap::from([("label1".into(), "value1".into())]),
@@ -544,7 +543,6 @@ async fn wasmbus() -> anyhow::Result<()> {
     let (host_two, shutdown_two) = Host::new(HostConfig {
         ctl_nats_url: ctl_nats_url.clone(),
         rpc_nats_url: ctl_nats_url.clone(),
-        prov_rpc_nats_url: ctl_nats_url.clone(),
         lattice_prefix: TEST_PREFIX.to_string(),
         labels: HashMap::from([("label1".into(), "value1".into())]),
         cluster_key: Some(Arc::clone(&cluster_key_two)),


### PR DESCRIPTION
## Feature or Problem
~~Leaving in draft for now, since we should remove support from wash first: https://github.com/wasmCloud/wash/pull/929~~

The host supports separate `rpc` and `prov_rpc` NATS connections. The intent was to separate untrusted providers from snooping on traffic they shouldn't have access to. However, in practice this doesn't work, since the host only sends a single NATS URL to the provider in `HostDatata`. The host has been sending `prov_rpc`, but the host subscribes to RPC traffic on `rpc`, which means if two separate URLs/servers were used, providers and hosts wouldn't be able to communicate. Since this doesn't work today, let's just remove support for separate connections.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
v0.80, since this is technically a breaking change (though I expect no users to be relying on it)

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
