### PR TITLE
feat: enable updating host labels via the control interface

### DIFF
--- a/crates/control-interface/src/broker.rs
+++ b/crates/control-interface/src/broker.rs
@@ -70,6 +70,22 @@ pub fn clear_config(
     )
 }
 
+pub fn put_label(topic_prefix: &Option<String>, lattice_prefix: &str, host_id: &str) -> String {
+    format!(
+        "{}.labels.{}.put",
+        prefix(topic_prefix, lattice_prefix),
+        host_id
+    )
+}
+
+pub fn delete_label(topic_prefix: &Option<String>, lattice_prefix: &str, host_id: &str) -> String {
+    format!(
+        "{}.labels.{}.del",
+        prefix(topic_prefix, lattice_prefix),
+        host_id
+    )
+}
+
 pub mod commands {
     use super::prefix;
 

--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -511,13 +511,13 @@ impl Client {
     pub async fn put_label(
         &self,
         host_id: &str,
-        label: &str,
+        key: &str,
         value: &str,
     ) -> Result<CtlOperationAck> {
         let subject = broker::put_label(&self.topic_prefix, &self.lattice_prefix, host_id);
         debug!(%subject, "putting label");
         let bytes = json_serialize(HostLabel {
-            label: label.to_string(),
+            key: key.to_string(),
             value: value.to_string(),
         })?;
         match self.request_timeout(subject, bytes, self.timeout).await {
@@ -531,11 +531,11 @@ impl Client {
     /// # Errors
     ///
     /// Will return an error if there is a communication problem with the host
-    pub async fn delete_label(&self, host_id: &str, label: &str) -> Result<CtlOperationAck> {
+    pub async fn delete_label(&self, host_id: &str, key: &str) -> Result<CtlOperationAck> {
         let subject = broker::delete_label(&self.topic_prefix, &self.lattice_prefix, host_id);
         debug!(%subject, "removing label");
         let bytes = json_serialize(HostLabel {
-            label: label.to_string(),
+            key: key.to_string(),
             value: String::new(), // value isn't parsed by the host
         })?;
         match self.request_timeout(subject, bytes, self.timeout).await {

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -421,6 +421,6 @@ pub struct LinkDefinition {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct HostLabel {
-    pub label: String,
+    pub key: String,
     pub value: String,
 }

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -418,3 +418,9 @@ pub struct LinkDefinition {
     pub contract_id: String,
     pub values: LinkSettings,
 }
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct HostLabel {
+    pub label: String,
+    pub value: String,
+}

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -3695,7 +3695,7 @@ impl Host {
 
     #[instrument(level = "trace", skip_all)]
     async fn handle_config_get_one(&self, entity_id: &str, key: &str) -> anyhow::Result<Bytes> {
-        trace!("getting config");
+        trace!(%entity_id, %key, "handling config");
         let json = match self
             .config_data_cache
             .read()
@@ -3721,7 +3721,7 @@ impl Host {
 
     #[instrument(level = "trace", skip(self))]
     async fn handle_config_get(&self, entity_id: &str) -> anyhow::Result<Bytes> {
-        trace!(%entity_id, "getting all config");
+        trace!(%entity_id, "handling all config");
         self.config_data_cache
             .read()
             .await

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -217,11 +217,11 @@ async fn assert_config_put(
 async fn assert_put_label(
     client: &wasmcloud_control_interface::Client,
     host_id: &str,
-    label: &str,
+    key: &str,
     value: &str,
 ) -> anyhow::Result<()> {
     client
-        .put_label(host_id, label, value)
+        .put_label(host_id, key, value)
         .await
         .map(|_| ())
         .map_err(|e| anyhow!(e).context("failed to put label"))
@@ -230,10 +230,10 @@ async fn assert_put_label(
 async fn assert_delete_label(
     client: &wasmcloud_control_interface::Client,
     host_id: &str,
-    label: &str,
+    key: &str,
 ) -> anyhow::Result<()> {
     client
-        .delete_label(host_id, label)
+        .delete_label(host_id, key)
         .await
         .map(|_| ())
         .map_err(|e| anyhow!(e).context("failed to put label"))


### PR DESCRIPTION
## Feature or Problem
This adds two new topics to the host's control interface: `wasmbus.ctl.{lattice_id}.labels.{host_id}.{put/del}`. Publishing on these topics allows users to dynamically adjust the target host's labels

## Related Issues
Relates to https://github.com/wasmCloud/wasmCloud/issues/692

## Release Information
Minor bump to the control interface crate as well as the host. Functionality via wash to be added after both of the former are released

## Consumer Impact
This is a potentially a step in the direction of enabling lame-duck mode on the host (we could use a special label to convey that intent)

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
I exercised put and delete via the wasmbus tests

### Manual Verification
```
wash get hosts -o json | jq -r '.hosts | .[] | .labels'
{
  "hostcore.arch": "aarch64",
  "hostcore.os": "macos",
  "hostcore.osfamily": "unix"
}

nats req wasmbus.ctl.default.labels.NARZ43WTEW56DC3Q42FXIND2WJV5TFVTBYJBJ2T42S5OB2AHIPITDDWW.put '{"label": "foo", "value": "bar"}'

18:31:08 Sending request on "wasmbus.ctl.default.labels.NARZ43WTEW56DC3Q42FXIND2WJV5TFVTBYJBJ2T42S5OB2AHIPITDDWW.put"
18:31:08 Received with rtt 501.459µs
{"accepted":true,"error":""}

wash get hosts -o json | jq -r '.hosts | .[] | .labels'
{
  "foo": "bar",
  "hostcore.arch": "aarch64",
  "hostcore.os": "macos",
  "hostcore.osfamily": "unix"
}

nats req wasmbus.ctl.default.labels.NARZ43WTEW56DC3Q42FXIND2WJV5TFVTBYJBJ2T42S5OB2AHIPITDDWW.del '{"label": "foo"}'

18:31:20 Sending request on "wasmbus.ctl.default.labels.NARZ43WTEW56DC3Q42FXIND2WJV5TFVTBYJBJ2T42S5OB2AHIPITDDWW.del"
18:31:20 Received with rtt 551.917µs
{"accepted":true,"error":""}

wash get hosts -o json | jq -r '.hosts | .[] | .labels'
{
  "hostcore.arch": "aarch64",
  "hostcore.os": "macos",
  "hostcore.osfamily": "unix"
}
```
