### PR TITLE
Chore/migrate helm chart

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: wasmcloud-host
+description: A Helm chart for running wasmCloud hosts on Kubernetes
+
+keywords:
+  - wasm
+  - Wasm
+  - wasmCloud
+  - wasmcloud
+
+home: https://wasmcloud.com
+sources:
+  - https://github.com/wasmCloud/wasmcloud-otp
+icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasmcloud-logo.png
+
+type: application
+
+# Note: Ensure you bump this `version` field in a separate PR than what you plan
+# to tag as the updated wasmCloud version. To be safe, bump and release wasmCloud
+# in one PR, then open a new PR updating this `version` and `appVersion`.
+version: 0.6.11
+
+appVersion: "0.63.1"

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,97 @@
+# wasmCloud Host Helm Chart
+
+A Helm Chart for installing and scaling wasmCloud hosts inside of Kubernetes.
+
+## Overview
+
+In keeping with our goal of "compatible with, but not dependent on," this Helm chart provides an
+option to users who would like to run wasmCloud hosts inside of pods on Kubernetes. Please note this
+is not the required or recommended way for completely new development, but is meant to be used as a
+way to bridge those already running things in Kubernetes with the new work being done in wasmCloud!
+If you are trying something completely net new, running your hosts in Kubernetes might not be your
+best option.
+
+### Limitations
+
+This chart is purely meant for creating a pool of scalable hosts and not for running your whole
+lattice. Ideally, the main NATS server and the place you'll be controlling your lattice from will
+likely be outside of Kubernetes. If you'd like to run everything inside of Kubernetes, we'd
+recommend deploying your main NATS server with another chart.
+
+## Running the chart
+
+The chart is available in a hosted Helm repository. To add the repository, run the following:
+
+```console
+$ helm repo add wasmcloud https://wasmcloud.github.io/wasmcloud-otp/
+```
+
+Then you can install the chart:
+
+```console
+$ helm install <RELEASE_NAME> wasmcloud/wasmcloud-host
+```
+
+This will get you up and going with a wasmCloud Host and NATS server so you can kick the tires and
+try things out. In order to access the dashboard and NATS, you'll need to forward the ports locally
+(using the `RELEASE_NAME` you chose above as the `RELEASE_NAME` below)
+
+```console
+# In one terminal
+$ kubectl port-forward deployment/${RELEASE_NAME} 4000
+
+# In a second terminal
+$ kubectl port-forward deployment/${RELEASE_NAME} 4222
+```
+
+### Configuration
+
+For a full list of configuration options, see the documented `values.yaml` file.
+
+#### Production usage
+
+By default, the chart ships with a standalone NATS server and a `Service` that could be exposed
+through a `LoadBalancer` or `Ingress`. However, this is not meant for production usage. Currently, 2
+main deployment methods are supported: leaf node and external NATS server
+
+##### Leaf Node
+
+This option allows you to run a small NATS [leaf
+node](https://docs.nats.io/nats-server/configuration/leafnodes) alongside the wasmCloud Host. This
+is a common deployment practice when connecting with something like [NGS](https://synadia.com/ngs).
+To use this method, you'll need to set `nats.leafnode.enabled` to `true`. Additionally, you'll need
+to set the following values on the command line or in a values file:
+
+| Value                       | Purpose                                                                                                                                                                 |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nats.leafnode.clusterURL`  | The URL of the NATS cluster to connect to                                                                                                                               |
+| `nats.leafnode.credentials` | The credentials for connecting to the NATS cluster. If passing on the command line, we recommend using `--set-file`                                                     |
+| `nats.jetstreamDomain`      | The JetStream domain to use for distributing cache data. If you are using domains, you will also need to set a different domain for `.wasmcloud.config.jetstreamDomain` |
+
+##### External NATS Server
+
+If you'd like to connect directly to a NATS server instead, you can disable the NATS sidecare
+container by setting `nats.enabled` to `false`. You can then set the various config options
+available under `wasmcloud.config` to use your NATS server with the credentials you have generated
+for the host. Please see the `values.yaml` documentation as well as the [wasmCloud Host
+documentation](https://wasmcloud.dev/reference/host-runtime/host_configure/) for more detailed
+information.
+
+##### Scaling the hosts
+
+If you have deployed the host using one of the production options, it can be scaled as high as you'd
+like. The number of hosts can be scaled by setting `replicaCount` to the desired number or by using
+`kubectl scale`
+
+#### Kubernetes Applier Support
+
+This chart comes with built in support for the [Kubernetes Applier provider and
+actor](https://github.com/cosmonic/kubernetes-applier). To enable support so that any applier
+provider running on these nodes automatically gets the necessary credentials, set
+`wasmcloud.enableApplierSupport` to `true`. Note that this will force usage of a pod
+`ServiceAccount`.
+
+If using the architecture described in the [applier
+documentation](https://github.com/cosmonic/kubernetes-applier/tree/main/service-applier#requirements-for-hosts-running-in-kubernetes)
+that uses router nodes, you can use the `wasmcloud.customLabels` map to set the custom labels needed
+for those hosts (such as `wasmcloud.dev/route-to: "true"`)

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. You can access the wasmCloud dashboard with the following steps:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "wasmcloud_host.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "wasmcloud_host.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "wasmcloud_host.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "wasmcloud_host.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:$CONTAINER_PORT to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME $CONTAINER_PORT
+{{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "wasmcloud_host.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "wasmcloud_host.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "wasmcloud_host.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "wasmcloud_host.labels" -}}
+helm.sh/chart: {{ include "wasmcloud_host.chart" . }}
+{{ include "wasmcloud_host.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "wasmcloud_host.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wasmcloud_host.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "wasmcloud_host.serviceAccountName" -}}
+{{- if or .Values.serviceAccount.create .Values.wasmcloud.enableApplierSupport }}
+{{- default (include "wasmcloud_host.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,236 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wasmcloud_host.fullname" . }}
+  labels:
+    {{- include "wasmcloud_host.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "wasmcloud_host.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "wasmcloud_host.selectorLabels" . | nindent 8 }}
+        {{- if .Values.wasmcloud.customLabels }}
+        {{- toYaml .Values.wasmcloud.customLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "wasmcloud_host.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.wasmcloud.image.repository }}:{{ .Values.wasmcloud.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.wasmcloud.image.pullPolicy }}
+          env: 
+            - name: WASMCLOUD_RPC_HOST
+              value: {{ .Values.wasmcloud.config.rpcNatsHost | quote }}
+            - name: WASMCLOUD_RPC_PORT
+              value: {{ .Values.wasmcloud.config.rpcNatsPort | quote }}
+            - name: WASMCLOUD_PROV_RPC_HOST
+              value: {{ .Values.wasmcloud.config.providerNatsHost | quote }}
+            - name: WASMCLOUD_PROV_RPC_PORT
+              value: {{ .Values.wasmcloud.config.providerNatsPort | quote }}
+            - name: WASMCLOUD_CTL_HOST
+              value: {{ .Values.wasmcloud.config.controlNatsHost | quote }}
+            - name: WASMCLOUD_CTL_PORT
+              value: {{ .Values.wasmcloud.config.controlNatsPort | quote }}
+            {{- if .Values.wasmcloud.config.controlTopicPrefix }}
+            - name: WASMCLOUD_CTL_TOPIC_PREFIX
+              value: {{ .Values.wasmcloud.config.controlTopicPrefix | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.clusterIssuers }}
+            - name: WASMCLOUD_CLUSTER_ISSUERS
+              value: {{ .Values.wasmcloud.config.clusterIssuers | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.clusterSeed }}
+            - name: WASMCLOUD_CLUSTER_SEED
+              value: {{ .Values.wasmcloud.config.clusterSeed | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.hostKey }}
+            - name: WASMCLOUD_HOST_KEY
+              value: {{ .Values.wasmcloud.config.hostKey | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.rpcJWT }}
+            - name: WASMCLOUD_RPC_JWT
+              value: {{ .Values.wasmcloud.config.rpcJWT | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.rpcTimeout }}
+            - name: WASMCLOUD_RPC_TIMEOUT_MS
+              value: {{ .Values.wasmcloud.config.rpcTimeout | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.providerRpcJWT }}
+            - name: WASMCLOUD_PROV_RPC_JWT
+              value: {{ .Values.wasmcloud.config.providerRpcJWT | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.providerRpcTimeout }}
+            - name: WASMCLOUD_PROV_RPC_TIMEOUT_MS
+              value: {{ .Values.wasmcloud.config.providerRpcTimeout | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.ctlJWT }}
+            - name: WASMCLOUD_CTL_JWT
+              value: {{ .Values.wasmcloud.config.ctlJWT | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.providerShutdownDelay }}
+            - name: WASMCLOUD_PROV_SHUTDOWN_DELAY_MS
+              value: {{ .Values.wasmcloud.config.providerShutdownDelay | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.latticePrefix }}
+            - name: WASMCLOUD_LATTICE_PREFIX
+              value: {{ .Values.wasmcloud.config.latticePrefix | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.jetstreamDomain }}
+            - name: WASMCLOUD_JS_DOMAIN
+              value: {{ .Values.wasmcloud.config.jetstreamDomain | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.logging.structuredLoggingEnabled }}
+            - name: WASMCLOUD_STRUCTURED_LOGGING_ENABLED
+              value: {{ .Values.wasmcloud.config.logging.structuredLoggingEnabled | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.logging.logLevel }}
+            - name: WASMCLOUD_STRUCTURED_LOG_LEVEL
+              value: {{ .Values.wasmcloud.config.logging.logLevel | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.otel.exporter }}
+            - name: OTEL_TRACES_EXPORTER
+              value: {{ .Values.wasmcloud.config.otel.exporter | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.otel.endpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.wasmcloud.config.otel.endpoint | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.registry.url }}
+            - name: OCI_REGISTRY
+              value: {{ .Values.wasmcloud.config.registry.url | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.registry.username }}
+            - name: OCI_REGISTRY_USER
+              value: {{ .Values.wasmcloud.config.registry.username | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.registry.password }}
+            - name: OCI_REGISTRY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wasmcloud_host.fullname" . }}
+                  key: registryPassword
+            {{- end }}
+            {{- if .Values.wasmcloud.config.hostSeed }}
+            - name: WASMCLOUD_HOST_SEED
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wasmcloud_host.fullname" . }}
+                  key: hostSeed
+            {{- end }}
+            {{- if .Values.wasmcloud.config.rpcSeed }}
+            - name: WASMCLOUD_RPC_SEED
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wasmcloud_host.fullname" . }}
+                  key: rpcSeed
+            {{- end }}
+            {{- if .Values.wasmcloud.config.providerRpcSeed }}
+            - name: WASMCLOUD_PROV_RPC_SEED
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wasmcloud_host.fullname" . }}
+                  key: providerRpcSeed
+            {{- end }}
+            {{- if .Values.wasmcloud.config.ctlSeed }}
+            - name: WASMCLOUD_CTL_SEED
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wasmcloud_host.fullname" . }}
+                  key: ctlSeed
+            {{- end }}
+            {{- if .Values.wasmcloud.config.ociAllowedInsecure }}
+            - name: WASMCLOUD_OCI_ALLOWED_INSECURE
+              value: {{ .Values.wasmcloud.config.ociAllowedInsecure | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.ociAllowLatest }}
+            - name: WASMCLOUD_OCI_ALLOW_LATEST
+              value: {{ .Values.wasmcloud.config.ociAllowLatest | quote }}
+            {{- end }}
+            {{- range $k, $v := .Values.wasmcloud.config.hostLabels }}
+            - name: HOST_{{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          ports:
+            - name: washboard
+              containerPort: 4000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/livez
+              port: washboard
+          readinessProbe:
+            httpGet:
+              path: /api/readyz
+              port: washboard
+          resources:
+            {{- toYaml .Values.wasmcloud.resources | nindent 12 }}
+        {{- if .Values.nats.enabled }}
+        - name: nats
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.nats.image.repository }}:{{ .Values.nats.image.tag }}"
+          imagePullPolicy: {{ .Values.nats.image.pullPolicy }}
+          args:
+            - "-js"
+            {{- if .Values.nats.leafnode.enabled }}
+            - "-c"
+            - "/nats/nats.conf"
+            {{- end }}
+          ports:
+            - name: client
+              containerPort: 4222
+            - name: clustering
+              containerPort: 6222
+            - name: management
+              containerPort: 8222
+          {{- if .Values.nats.leafnode.enabled }}
+          volumeMounts:
+            - name: leafnode-config
+              mountPath: /nats/nats.conf
+              subPath: nats.conf
+              readOnly: true
+            - name: leafnode-creds
+              mountPath: /nats/nats.creds
+              subPath: nats.creds
+              readOnly: true
+          {{- end }}
+          resources:
+            {{- toYaml .Values.nats.resources | nindent 12 }}
+        {{- end }}
+      {{- if .Values.nats.leafnode.enabled }}
+      volumes:
+        - name: leafnode-config
+          configMap:
+            name: {{ include "wasmcloud_host.fullname" . }}
+        - name: leafnode-creds
+          secret:
+            secretName: {{ include "wasmcloud_host.fullname" . }}-nats
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/templates/leafnode.yaml
+++ b/chart/templates/leafnode.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.nats.leafnode.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wasmcloud_host.fullname" . }}
+  labels:
+    {{- include "wasmcloud_host.labels" . | nindent 4 }}
+data:
+  nats.conf: |-
+    {{ if .Values.nats.jetstreamDomain -}}
+    jetstream {
+      domain: {{ .Values.nats.jetstreamDomain }}
+    }
+    {{- end }}
+    leafnodes {
+      remotes = [
+        {
+          url: {{ .Values.nats.leafnode.clusterURL | quote }}
+          credentials: "/nats/nats.creds"
+        },
+      ]
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wasmcloud_host.fullname" . }}-nats
+  labels:
+    {{- include "wasmcloud_host.labels" . | nindent 4 }}
+data:
+  nats.creds: |-
+    {{ required "Credentials are required for a leafnode" .Values.nats.leafnode.credentials | b64enc }}
+{{- end }}

--- a/chart/templates/role-binding.yaml
+++ b/chart/templates/role-binding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.wasmcloud.enableApplierSupport -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "wasmcloud_host.name" . }}-service-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "wasmcloud_host.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "wasmcloud_host.name" . }}-service-manager
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.wasmcloud.enableApplierSupport -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "wasmcloud_host.name" . }}-service-manager
+rules:
+- apiGroups: [""] 
+  resources: ["services"]
+  verbs: ["get", "create", "update", "delete", "patch"]
+{{- end }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,0 +1,24 @@
+{{- if or .Values.wasmcloud.config.hostSeed .Values.wasmcloud.config.rpcSeed .Values.wasmcloud.config.providerRpcSeed .Values.wasmcloud.config.ctlSeed .Values.wasmcloud.config.registry.password -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wasmcloud_host.fullname" . }}
+  labels:
+    {{- include "wasmcloud_host.labels" . | nindent 4 }}
+data:
+  {{- if .Values.wasmcloud.config.hostSeed }}
+  hostSeed: {{ .Values.wasmcloud.config.hostSeed | b64enc }}
+  {{- end }}
+  {{- if .Values.wasmcloud.config.rpcSeed }}
+  rpcSeed: {{ .Values.wasmcloud.config.rpcSeed | b64enc }}
+  {{- end }}
+  {{- if .Values.wasmcloud.config.providerRpcSeed }}
+  providerRpcSeed: {{ .Values.wasmcloud.config.providerRpcSeed | b64enc }}
+  {{- end }}
+  {{- if .Values.wasmcloud.config.ctlSeed }}
+  ctlSeed: {{ .Values.wasmcloud.config.ctlSeed | b64enc }}
+  {{- end }}
+  {{- if .Values.wasmcloud.config.registry.password }}
+  registryPassword: {{ .Values.wasmcloud.config.registry.password | b64enc }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.useService -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wasmcloud_host.fullname" . }}
+  labels:
+    {{- include "wasmcloud_host.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.washboardPort }}
+      targetPort: washboard
+      protocol: TCP
+      name: washboard
+    {{- if .Values.nats.enabled }}
+    - port: {{ .Values.service.natsPort }}
+      targetPort: client
+      name: client
+    {{- end }}
+  selector:
+    {{- include "wasmcloud_host.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if or .Values.serviceAccount.create .Values.wasmcloud.enableApplierSupport -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wasmcloud_host.serviceAccountName" . }}
+  labels:
+    {{- include "wasmcloud_host.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,125 @@
+replicaCount: 1
+
+wasmcloud:
+  # Config options for the wasmCloud Host. See
+  # https://wasmcloud.dev/reference/host-runtime/host_configure/ for full details
+  config:
+    rpcNatsHost: 127.0.0.1
+    rpcNatsPort: 4222
+    providerNatsHost: 127.0.0.1
+    providerNatsPort: 4222
+    controlNatsHost: 127.0.0.1
+    controlNatsPort: 4222
+    controlTopicPrefix: ""
+    clusterIssuers: ""
+    clusterSeed: ""
+    hostKey: ""
+    latticePrefix: ""
+    rpcJWT: ""
+    rpcTimeout: ""
+    providerRpcJWT: ""
+    providerRpcTimeout: ""
+    ctlJWT: ""
+    providerShutdownDelay: ""
+    hostSeed: ""
+    rpcSeed: ""
+    providerRpcSeed: ""
+    ctlSeed: ""
+    jetstreamDomain: ""
+    logging:
+      structuredLoggingEnabled: false
+      logLevel: ""
+    otel:
+      exporter: ""
+      endpoint: ""
+    ociAllowedInsecure: ""
+    ociAllowLatest: false
+    # Sets the username and password for use with a private registry
+    registry:
+      url: ""
+      username: ""
+      password: ""
+    # A map of key value pairs to use as wasmCloud Host labels. These map to environment variable
+    # names, so the `.` character is not allowed
+    hostLabels:
+      kubernetes: "true"
+  # Enables support for the Kubernetes Applier provider. Essentially, this generates a role and role
+  # binding for the pod service account that allows it to get, create, update, delete, and patch
+  # service resources if you start the kubernetes applier on one of these hosts. Enabling this
+  # option enables service account creation
+  enableApplierSupport: false
+  # Extra labels to attach to the pod template for each host. Meant for use with things like the
+  # Service Applier actor, which requires specific labels in order to route to those pods
+  customLabels: {}
+  image:
+    repository: wasmcloud/wasmcloud_host
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  resources: {}
+
+nats:
+  # Enables the nats container (enabled by default). This can be disabled if you'd like to connect
+  # to another in-cluster NATS cluster
+  enabled: true
+  # The jetstream domain to use for distributed cache data. You'll likely need this if running in
+  # production. This is different than the domain used for the host
+  jetstreamDomain: ""
+  leafnode:
+    # Sets the nats container to operate in leafnode mode
+    enabled: false
+    # The NATS cluster to connect to. Defaults to NGS
+    clusterURL: "nats-leaf://connect.ngs.global"
+    # Credentials to use
+    credentials: ""
+
+  image:
+    repository: nats
+    pullPolicy: IfNotPresent
+    # NOTE: The alpine image is required if you are doing leafnode configuration. Otherwise the base
+    # nats image is missing the root certificates needed for validation
+    tag: "2.9-alpine"
+  resources: {}
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  washboardPort: 4000
+  natsPort: 8080
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Whether or not to expose the host and its NATS server as a service. This defaults to true for ease
+# of "kick the tires" use. For real deployments, this should likely be turned off
+useService: true


### PR DESCRIPTION
## Feature or Problem

Enables the installation of Rust-based wasmCloud host via `helm`.

## Related Issues

#684 

## Release Information

## Consumer Impact

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
