### PR TITLE
chore: update Cargo.lock

### DIFF
--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -3396,7 +3396,7 @@ dependencies = [
  "ring 0.17.4",
  "serde",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.33.2",
  "wasm-gen",
  "wasmparser 0.113.3",
 ]
@@ -3418,7 +3418,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.29.0",
  "wasm-gen",
  "wasmparser 0.107.0",
 ]
@@ -3500,6 +3500,15 @@ name = "wasm-encoder"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34180c89672b3e4825c3a8db4b61a674f1447afd5fe2445b2d22c3d8b6ea086c"
 dependencies = [
  "leb128",
 ]


### PR DESCRIPTION
## Feature or Problem
This syncs Cargo.lock. It not being in sync was making switching branches annoying