### PR TITLE
Add pipeline for validating and publishing the wasmcloud helm chart

### DIFF
--- a/.github/workflows/wasmcloud-chart.yml
+++ b/.github/workflows/wasmcloud-chart.yml
@@ -1,0 +1,83 @@
+name: wasmcloud-chart
+
+env:
+  HELM_VERSION: v3.13.1
+
+on:
+  push:
+    tags:
+      - 'chart-v[0-9].[0-9]+.[0-9]+'
+  pull_request:
+    paths:
+      - 'chart/**'
+      - '.github/workflows/wasmcloud-chart.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.5
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      # Used by helm chart-testing below
+      - name: Set up Python
+        uses: actions/setup-python@v4.7.1
+        with:
+          python-version: '3.12.0'
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+        with:
+          version: v3.9.0
+          yamllint_version: 1.32.0
+          yamale_version: 4.0.4
+
+      - name: Run chart-testing (lint)
+        run: |
+          ct lint --charts chart/ --validate-maintainers=false
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.8.0
+
+      - name: Run chart-testing (install)
+        run: ct install --charts chart/
+
+  publish:
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/chart-v') }}
+    runs-on: ubuntu-22.04
+    needs: validate
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.5
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Package
+        run: |
+          helm package chart -d .helm-charts
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish
+        run: |
+          for chart in .helm-charts/*; do
+            if [ -z "${chart:-}" ]; then
+              break
+            fi
+            helm push "${chart}" "oci://ghcr.io/${{ github.repository_owner }}"
+          done

--- a/.github/workflows/wasmcloud-chart.yml
+++ b/.github/workflows/wasmcloud-chart.yml
@@ -48,7 +48,7 @@ jobs:
         run: ct install --charts chart/
 
   publish:
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/chart-v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/chart-v') }}
     runs-on: ubuntu-22.04
     needs: validate
     permissions:

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: wasmcloud-host
+name: wasmcloud-chart
 description: A Helm chart for running wasmCloud hosts on Kubernetes
 
 keywords:


### PR DESCRIPTION
## Feature or Problem

Adds a pipeline that validates the helm chart (added in #788) and (on `chart-vX.X.X` push) publishes the helm chart to `ghcr.io/wasmcloud/wasmcloud-chart`.

## Related Issues

#684

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
