### PR TITLE
fix: drop problematic write lock

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -3799,6 +3799,8 @@ impl Host {
 
         let mut links = self.links.write().await;
         links.insert(id.to_string(), ld.clone());
+        // Explicitly drop the lock to avoid deadlock with tasks that lock actors before links
+        drop(links);
         if let Some(actor) = self.actors.read().await.get(actor_id) {
             let mut links = actor.handler.links.write().await;
             links.entry(contract_id.clone()).or_default().insert(
@@ -3857,6 +3859,8 @@ impl Host {
         } = links
             .remove(id)
             .context("attempt to remove a non-existent link")?;
+        // Explicitly drop the lock to avoid deadlock with tasks that lock actors before links
+        drop(links);
         if let Some(actor) = self.actors.read().await.get(actor_id) {
             let mut links = actor.handler.links.write().await;
             if let Some(links) = links.get_mut(contract_id) {

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -3797,10 +3797,7 @@ impl Host {
             "process link definition entry put"
         );
 
-        let mut links = self.links.write().await;
-        links.insert(id.to_string(), ld.clone());
-        // Explicitly drop the lock to avoid deadlock with tasks that lock actors before links
-        drop(links);
+        self.links.write().await.insert(id.to_string(), ld.clone()); // NOTE: this is one statement so the write lock is immediately dropped
         if let Some(actor) = self.actors.read().await.get(actor_id) {
             let mut links = actor.handler.links.write().await;
             links.entry(contract_id.clone()).or_default().insert(
@@ -3845,7 +3842,6 @@ impl Host {
 
         debug!(id, "process link definition entry deletion");
 
-        let mut links = self.links.write().await;
         // NOTE: There is a race condition here, which occurs when `linkdefs.del`
         // is used before `data_watch` task has fully imported the current lattice,
         // but that command is deprecated, so assume it's fine
@@ -3856,11 +3852,12 @@ impl Host {
             ref contract_id,
             ref values,
             ..
-        } = links
+        } = self
+            .links
+            .write() // NOTE: this is one statement so the write lock is immediately dropped
+            .await
             .remove(id)
             .context("attempt to remove a non-existent link")?;
-        // Explicitly drop the lock to avoid deadlock with tasks that lock actors before links
-        drop(links);
         if let Some(actor) = self.actors.read().await.get(actor_id) {
             let mut links = actor.handler.links.write().await;
             if let Some(links) = links.get_mut(contract_id) {


### PR DESCRIPTION
## Feature or Problem
This PR resolves a problematic ordering of locks in our concurrent control interface code. 

After doing some investigation, it looks like the ordering here is problematic. We write lock the actors RwLock and then read links, but during handling a linkdef put we write lock the links and then read lock actors. 
```rust
// handle_scale_actor_task
match (self.actors.write().await.entry(actor_id), requested_max) {
  ...
  (hash_map::Entry::Vacant(entry), max) => {
      // Starting 0 actors makes no logical sense and is interpreted as starting with unbounded concurrency
      self.start_actor(entry, actor, actor_ref, max.flatten(), host_id, annotations)
          .await?;
// a few lines inside start_actor
let links = self.links.read().await;
```
```rust
// process_linkdef_put
let mut links = self.links.write().await;
links.insert(id.to_string(), ld.clone());
if let Some(actor) = self.actors.read().await.get(actor_id) {
```

So the possible deadlock above is we scale an actor and put a link at approximately the same time. We acquire a write lock on the actors RwLock and find the actor hasn't started yet, so we start the actor. At the same time we acquire a write lock on links in order to insert the link, and then the linkdef put waits on the actor read lock to get released. Inside of `start_actor`, we then wait for a read lock on the links. We do a similar ordering inside of the provider start function. This means that any resource that's going to need a read lock on links or actors can no longer work.

So, finally, this PR drops the write locks during `process_linkdef_put` and `process_linkdef_del`. These are the only instances that I could find where we lock things in a mismatched order, but it would be worth a second set of eyes in this highly concurrent handler code.

## Related Issues
N/A

## Release Information
v0.80.0, or can be cherry picked to go in as a patch as v0.79.1.

## Consumer Impact
Consumers issuing many many control interface requests for new actors and links, e.g. consumers of wadm, should see their host no longer fail to publish heartbeats.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
With really large wadm files (20 actors and 60 links) I could trigger this deadlock maybe once every 4 runs. I haven't been able to trigger this deadlock with this code or by running a bunch of continuous bash loops.
