### PR TITLE
[BUG] wash claims sign allows empty versions and revisions

### DIFF
--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -3182,7 +3182,7 @@ dependencies = [
  "serde_json",
  "wasm-encoder 0.36.1",
  "wasm-gen",
- "wasmparser 0.115.0",
+ "wasmparser 0.116.0",
 ]
 
 [[package]]
@@ -3564,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.115.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
+checksum = "53290b1276c5c2d47d694fb1a920538c01f51690e7e261acbe1d10c5fc306ea1"
 dependencies = [
  "indexmap 2.0.2",
  "semver",

--- a/crates/wash-cli/tests/wash_claims.rs
+++ b/crates/wash-cli/tests/wash_claims.rs
@@ -97,9 +97,6 @@ fn integration_claims_sign() {
         .output()
         .expect("faile to run sign command");
     assert!(!sign_echo.status.success());
-    assert!(String::from_utf8(sign_echo.stderr)
-        .expect("Failed to convert stderr bytes to String")
-        .contains("revision (--rev) must be specified for signing"));
 
     let sign_echo = wash()
         .args([
@@ -125,9 +122,6 @@ fn integration_claims_sign() {
         .output()
         .expect("faile to run sign command");
     assert!(!sign_echo.status.success());
-    assert!(String::from_utf8(sign_echo.stderr)
-        .expect("Failed to convert stderr bytes to String")
-        .contains("version (--ver) must be specified for signing"));
 
     let sign_echo = wash()
         .args([
@@ -153,9 +147,6 @@ fn integration_claims_sign() {
         .output()
         .expect("faile to run sign command");
     assert!(!sign_echo.status.success());
-    assert!(String::from_utf8(sign_echo.stderr)
-        .expect("Failed to convert stderr bytes to String")
-        .contains("revision (--rev) and version (--ver) must be specified for signing"));
 
     remove_dir_all(sign_dir).unwrap();
 }

--- a/crates/wash-cli/tests/wash_claims.rs
+++ b/crates/wash-cli/tests/wash_claims.rs
@@ -48,6 +48,10 @@ fn integration_claims_sign() {
             echo.to_str().unwrap(),
             "--name",
             "EchoSigned",
+            "--ver",
+            "0.1.0",
+            "--rev",
+            "1",
             "--http_server",
             "--issuer",
             ISSUER,
@@ -67,6 +71,91 @@ fn integration_claims_sign() {
             signed_wasm_path.to_str().unwrap()
         )
     );
+
+    // signing should fail when revision or/and version are not provided
+    let sign_echo = wash()
+        .args([
+            "claims",
+            "sign",
+            echo.to_str().unwrap(),
+            "--name",
+            "EchoSigned",
+            "--ver",
+            "0.1.0",
+            // "--rev",
+            // "1",
+            "--http_server",
+            "--issuer",
+            ISSUER,
+            "--subject",
+            SUBJECT,
+            "--disable-keygen",
+            "--destination",
+            signed_wasm_path.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("faile to run sign command");
+    assert!(!sign_echo.status.success());
+    assert!(String::from_utf8(sign_echo.stderr)
+        .expect("Failed to convert stderr bytes to String")
+        .contains("revision (--rev) must be specified for signing"));
+
+    let sign_echo = wash()
+        .args([
+            "claims",
+            "sign",
+            echo.to_str().unwrap(),
+            "--name",
+            "EchoSigned",
+            // "--ver",
+            // "0.1.0",
+            "--rev",
+            "1",
+            "--http_server",
+            "--issuer",
+            ISSUER,
+            "--subject",
+            SUBJECT,
+            "--disable-keygen",
+            "--destination",
+            signed_wasm_path.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("faile to run sign command");
+    assert!(!sign_echo.status.success());
+    assert!(String::from_utf8(sign_echo.stderr)
+        .expect("Failed to convert stderr bytes to String")
+        .contains("version (--ver) must be specified for signing"));
+
+    let sign_echo = wash()
+        .args([
+            "claims",
+            "sign",
+            echo.to_str().unwrap(),
+            "--name",
+            "EchoSigned",
+            // "--ver",
+            // "0.1.0",
+            // "--rev",
+            // "1",
+            "--http_server",
+            "--issuer",
+            ISSUER,
+            "--subject",
+            SUBJECT,
+            "--disable-keygen",
+            "--destination",
+            signed_wasm_path.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("faile to run sign command");
+    assert!(!sign_echo.status.success());
+    assert!(String::from_utf8(sign_echo.stderr)
+        .expect("Failed to convert stderr bytes to String")
+        .contains("revision (--rev) and version (--ver) must be specified for signing"));
 
     remove_dir_all(sign_dir).unwrap();
 }
@@ -289,6 +378,10 @@ fn integration_claims_call_alias() {
             logger.to_str().unwrap(),
             "--name",
             "Logger",
+            "-v",
+            "0.1.0",
+            "-r",
+            "1",
             "-l",
             "-q",
             "--issuer",
@@ -332,7 +425,8 @@ fn integration_claims_call_alias() {
         "capabilities": ["HTTP Server", "Logging"],
         "expires": "never",
         "tags": "None",
-        "version": "None",
+        "version": "0.1.0",
+        "revision": 1,
         "call_alias": "wasmcloud/logger_onedotzero"
     });
 

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -177,9 +177,8 @@ fn sign_actor_wasm(
         destination: Some(destination),
         metadata: ActorMetadata {
             name: common_config.name.clone(),
-            ver: Some(common_config.version.to_string()),
-            //NOTE(Ahmed Tadde): sign_file requires a revision, using 1 as default
-            rev: Some(1),
+            ver: common_config.version.to_string(),
+            rev: common_config.revision,
             custom_caps: actor_config.claims.clone(),
             call_alias: actor_config.call_alias.clone(),
             issuer: signing_config.issuer,
@@ -697,6 +696,7 @@ world downstream {
                 &CommonConfig {
                     name: "test".into(),
                     version: Version::parse("0.1.0")?,
+                    revision: 0,
                     path: project_dir.path().into(),
                     wasm_bin_name: Some("test.wasm".into()),
                 },

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -178,6 +178,8 @@ fn sign_actor_wasm(
         metadata: ActorMetadata {
             name: common_config.name.clone(),
             ver: Some(common_config.version.to_string()),
+            //NOTE(Ahmed Tadde): sign_file requires a revision, using 1 as default
+            rev: Some(1),
             custom_caps: actor_config.claims.clone(),
             call_alias: actor_config.call_alias.clone(),
             issuer: signing_config.issuer,

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -588,6 +588,18 @@ pub fn sign_file(cmd: SignCommand, output_kind: OutputKind) -> Result<CommandOut
         bail!("Capability providers cannot provide multiple capabilities at once.");
     }
 
+    if cmd.metadata.rev.is_none() && cmd.metadata.ver.is_none() {
+        bail!("revision (--rev) and version (--ver) must be specified for signing.");
+    }
+
+    if cmd.metadata.rev.is_none() {
+        bail!("revision (--rev) must be specified for signing.");
+    }
+
+    if cmd.metadata.ver.is_none() {
+        bail!("version (--ver) must be specified for signing.");
+    }
+
     let signed = sign_buffer_with_claims(
         cmd.metadata.name.clone(),
         &buf,

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -266,10 +266,10 @@ pub struct ActorMetadata {
     pub provider: bool,
     /// Revision number
     #[clap(short = 'r', long = "rev")]
-    pub rev: Option<i32>,
+    pub rev: i32,
     /// Human-readable version string
     #[clap(short = 'v', long = "ver")]
-    pub ver: Option<String>,
+    pub ver: String,
     /// Developer or human friendly unique alias used for invoking an actor, consisting of lowercase alphanumeric characters, underscores '_' and slashes '/'
     #[clap(short = 'a', long = "call-alias")]
     pub call_alias: Option<String>,
@@ -410,8 +410,8 @@ fn generate_actor(actor: ActorMetadata, output_kind: OutputKind) -> Result<Comma
         days_from_now_to_jwt_time(actor.common.expires_in_days),
         days_from_now_to_jwt_time(actor.common.not_before_days),
         actor.provider,
-        actor.rev,
-        actor.ver.clone(),
+        Some(actor.rev),
+        Some(actor.ver.clone()),
         sanitize_alias(actor.call_alias)?,
     );
 
@@ -588,18 +588,6 @@ pub fn sign_file(cmd: SignCommand, output_kind: OutputKind) -> Result<CommandOut
         bail!("Capability providers cannot provide multiple capabilities at once.");
     }
 
-    if cmd.metadata.rev.is_none() && cmd.metadata.ver.is_none() {
-        bail!("revision (--rev) and version (--ver) must be specified for signing.");
-    }
-
-    if cmd.metadata.rev.is_none() {
-        bail!("revision (--rev) must be specified for signing.");
-    }
-
-    if cmd.metadata.ver.is_none() {
-        bail!("version (--ver) must be specified for signing.");
-    }
-
     let signed = sign_buffer_with_claims(
         cmd.metadata.name.clone(),
         &buf,
@@ -610,8 +598,8 @@ pub fn sign_file(cmd: SignCommand, output_kind: OutputKind) -> Result<CommandOut
         caps_list.clone(),
         cmd.metadata.tags.clone(),
         cmd.metadata.provider,
-        cmd.metadata.rev,
-        cmd.metadata.ver.clone(),
+        Some(cmd.metadata.rev),
+        Some(cmd.metadata.ver.clone()),
         sanitize_alias(cmd.metadata.call_alias)?,
     )?;
 
@@ -930,8 +918,8 @@ mod test {
                 assert!(!metadata.tags.is_empty());
                 assert_eq!(metadata.tags[0], "testtag");
                 assert!(metadata.provider);
-                assert_eq!(metadata.rev.unwrap(), 2);
-                assert_eq!(metadata.ver.unwrap(), "0.0.1");
+                assert_eq!(metadata.rev, 2);
+                assert_eq!(metadata.ver, "0.0.1");
             }
             cmd => panic!("claims constructed incorrect command: {:?}", cmd),
         }
@@ -998,8 +986,8 @@ mod test {
                 assert!(!metadata.tags.is_empty());
                 assert_eq!(metadata.tags[0], "testtag");
                 assert!(metadata.provider);
-                assert_eq!(metadata.rev.unwrap(), 2);
-                assert_eq!(metadata.ver.unwrap(), "0.0.1");
+                assert_eq!(metadata.rev, 2);
+                assert_eq!(metadata.ver, "0.0.1");
             }
             cmd => panic!("claims constructed incorrect command: {:?}", cmd),
         }
@@ -1147,8 +1135,8 @@ mod test {
                 assert_eq!(custom_caps[0], "test:custom");
                 assert!(!tags.is_empty());
                 assert_eq!(tags[0], "testtag");
-                assert_eq!(rev.unwrap(), 2);
-                assert_eq!(ver.unwrap(), "0.0.1");
+                assert_eq!(rev, 2);
+                assert_eq!(ver, "0.0.1");
             }
             cmd => panic!("claims constructed incorrect command: {:?}", cmd),
         }

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -211,6 +211,8 @@ pub struct CommonConfig {
     pub name: String,
     /// Semantic version of the project.
     pub version: Version,
+    /// Monotonically increasing revision number
+    pub revision: i32,
     /// Path to the project directory to determine where built and signed artifacts should be
     pub path: PathBuf,
     /// Expected name of the wasm module binary that will be generated
@@ -271,6 +273,10 @@ struct RawProjectConfig {
 
     /// Semantic version of the project.
     pub version: Option<Version>,
+
+    /// Monotonically increasing revision number.
+    #[serde(default)]
+    pub revision: i32,
 
     pub actor: Option<RawActorConfig>,
     pub provider: Option<RawProviderConfig>,
@@ -375,6 +381,7 @@ impl RawProjectConfig {
         project_path: PathBuf,
         name: Option<String>,
         version: Option<Version>,
+        revision: i32,
     ) -> Result<CommonConfig> {
         let cargo_toml_path = project_path.join("Cargo.toml");
         if !cargo_toml_path.is_file() {
@@ -413,6 +420,7 @@ impl RawProjectConfig {
         Ok(CommonConfig {
             name,
             version,
+            revision,
             path: project_path,
             wasm_bin_name,
         })
@@ -462,6 +470,7 @@ impl RawProjectConfig {
                     project_path.clone(),
                     self.name.clone(),
                     self.version.clone(),
+                    self.revision,
                 ) {
                     // Successfully built with cargo information
                     Ok(cfg) => Ok(cfg),
@@ -470,6 +479,7 @@ impl RawProjectConfig {
                     Err(_) if self.name.is_some() && self.version.is_some() => Ok(CommonConfig {
                         name: self.name.unwrap(),
                         version: self.version.unwrap(),
+                        revision: self.revision,
                         path: project_path,
                         wasm_bin_name: None,
                     }),
@@ -487,6 +497,7 @@ impl RawProjectConfig {
                 version: self
                     .version
                     .ok_or_else(|| anyhow!("Missing version in wasmcloud.toml"))?,
+                revision: self.revision,
                 path: project_path,
                 wasm_bin_name: None,
             }),

--- a/crates/wash-lib/tests/parser/files/rust_actor_with_revision.toml
+++ b/crates/wash-lib/tests/parser/files/rust_actor_with_revision.toml
@@ -1,0 +1,18 @@
+language = "rust"
+type = "actor"
+name = "testactor"
+version = "0.1.0"
+revision = 666
+
+[actor]
+claims = ["wasmcloud:httpserver"]
+registry = "localhost:8080"
+push_insecure = false
+key_directory = "./keys"
+filename = "testactor.wasm"
+wasm_target = "wasm32-unknown-unknown"
+call_alias = "testactor"
+
+[rust]
+cargo_path = "./cargo"
+target_path = "./target"

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -85,6 +85,7 @@ fn rust_actor_with_revision() {
             wasi_preview2_adapter_path: None,
             wasm_target: WasmTarget::CoreModule,
             wit_world: None,
+            ..ActorConfig::default()
         })
     );
 

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -8,7 +8,6 @@ use wash_lib::parser::{
 };
 
 #[test]
-/// When given a specific toml file's path, it should parse the file and return a ProjectConfig.
 fn rust_actor() {
     let result = get_config(
         Some(PathBuf::from("./tests/parser/files/rust_actor.toml")),
@@ -45,6 +44,56 @@ fn rust_actor() {
         CommonConfig {
             name: "testactor".to_string(),
             version: Version::parse("0.1.0").unwrap(),
+            revision: 0,
+            path: PathBuf::from("./tests/parser/files/")
+                .canonicalize()
+                .unwrap(),
+            wasm_bin_name: None,
+        }
+    );
+}
+
+#[test]
+/// When given a specific toml file's path, it should parse the file and return a ProjectConfig.
+fn rust_actor_with_revision() {
+    let result = get_config(
+        Some(PathBuf::from(
+            "./tests/parser/files/rust_actor_with_revision.toml",
+        )),
+        None,
+    );
+
+    let config = assert_ok!(result);
+
+    assert_eq!(
+        config.language,
+        LanguageConfig::Rust(RustConfig {
+            cargo_path: Some("./cargo".into()),
+            target_path: Some("./target".into())
+        })
+    );
+
+    assert_eq!(
+        config.project_type,
+        TypeConfig::Actor(ActorConfig {
+            claims: vec!["wasmcloud:httpserver".to_string()],
+            registry: Some("localhost:8080".to_string()),
+            push_insecure: false,
+            key_directory: PathBuf::from("./keys"),
+            filename: Some("testactor.wasm".to_string()),
+            call_alias: Some("testactor".to_string()),
+            wasi_preview2_adapter_path: None,
+            wasm_target: WasmTarget::CoreModule,
+            wit_world: None,
+        })
+    );
+
+    assert_eq!(
+        config.common,
+        CommonConfig {
+            name: "testactor".to_string(),
+            version: Version::parse("0.1.0").unwrap(),
+            revision: 666,
             path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
@@ -91,6 +140,7 @@ fn tinygo_actor_module() {
         CommonConfig {
             name: "testactor".to_string(),
             version: Version::parse("0.1.0").unwrap(),
+            revision: 0,
             path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
@@ -305,6 +355,7 @@ fn minimal_rust_actor() {
             path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
+            revision: 0,
             wasm_bin_name: None,
         }
     )
@@ -352,6 +403,7 @@ fn cargo_toml_actor() {
             path: PathBuf::from("./tests/parser/files/withcargotoml")
                 .canonicalize()
                 .unwrap(),
+            revision: 0,
             wasm_bin_name: None,
         }
     )


### PR DESCRIPTION
## Feature or Problem
Currently, when signing an actor with wash, the version (--ver) and revision (--rev) args are not required. This will lead to claims that are missing some important information.

## Related Issues

[859](https://github.com/wasmCloud/wasmCloud/issues/861)

## Release Information
v0.79.0

## Consumer Impact
stricter `wash claims sign` cmd that ultimately improves the metadata output of `wash inspect`

## Testing

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Acceptance or Integration
updated integration tests [integration_claims_sign](https://github.com/ahmedtadde/wash/blob/0939a7d4b1c8c229386baedccbaef9f3621071c6/tests/integration_claims.rs#L12), [integration_claims_call_alias](https://github.com/ahmedtadde/wash/blob/21f9f2f4d751e29e88fd8990ef9014a310ed425a/tests/integration_claims.rs#L328)
