### PR TITLE
fix(ci): use wash Dockerfile

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -344,7 +344,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
-        file: "Dockerfile.wash"
+        file: "./crates/wash-cli/Dockerfile"
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/amd64,linux/arm64
         push: ${{ github.repository == 'wasmCloud/wasmCloud' }}


### PR DESCRIPTION
## Feature or Problem
I noticed the OCI build [references a file that doesn't exist](https://github.com/wasmCloud/wasmCloud/actions/runs/6698481609/job/18201730394), so I updated the workflow 