### PR TITLE
[FEATURE] wash keys clarity, renames, and error handling

### DIFF
--- a/crates/wash-cli/src/keys.rs
+++ b/crates/wash-cli/src/keys.rs
@@ -59,12 +59,9 @@ pub fn keytype_parser(keytype: &str) -> Result<KeyPairType> {
     match keytype.to_lowercase().as_str() {
         "account" => Ok(KeyPairType::Account),
         "user" => Ok(KeyPairType::User),
-        "module" => Ok(KeyPairType::Module),
-        "actor" => Ok(KeyPairType::Module),
-        "service" => Ok(KeyPairType::Service),
-        "provider" => Ok(KeyPairType::Service),
-        "server" => Ok(KeyPairType::Server),
-        "host" => Ok(KeyPairType::Server),
+        "module" | "actor" => Ok(KeyPairType::Module),
+        "service" | "provider" => Ok(KeyPairType::Service),
+        "server" | "host" => Ok(KeyPairType::Server),
         "operator" => Ok(KeyPairType::Operator),
         "cluster" => Ok(KeyPairType::Cluster),
         _ => Err(anyhow::anyhow!(

--- a/crates/wash-cli/tests/wash_keys.rs
+++ b/crates/wash-cli/tests/wash_keys.rs
@@ -23,7 +23,8 @@ fn integration_keys_gen_basic() {
 #[test]
 fn integration_keys_gen_comprehensive() {
     let key_gen_types = [
-        "account", "user", "module", "service", "server", "operator", "cluster",
+        "account", "user", "module", "actor", "service", "provider", "server", "host", "operator",
+        "cluster",
     ];
 
     key_gen_types.iter().for_each(|cmd| {


### PR DESCRIPTION
## Feature or Problem
There is a problem with `wash keys` in that it always defaults to a module key, when that's not great behavior. The `keytype` arg appears to default to module even if the input is invalid, but we should error out if invalid input is inserted.

## Related Issues
#863 


## Release Information
v0.79.0

## Consumer Impact
improves correctness of `wash keys gen <keytype>` command

## Testing

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows


### Acceptance or Integration
- updated [test_gen_comprehensive](https://github.com/ahmedtadde/wasmCloud/blob/69db9efcf9d8352bd3a85caea45422162d883f32/crates/wash-cli/src/keys.rs#L272)
- updated [test_invalid_keytype_input](https://github.com/ahmedtadde/wasmCloud/blob/69db9efcf9d8352bd3a85caea45422162d883f32/crates/wash-cli/src/keys.rs#L303)
- updated [integration_keys_gen_comprehensive](https://github.com/ahmedtadde/wasmCloud/blob/69db9efcf9d8352bd3a85caea45422162d883f32/crates/wash-cli/tests/wash_keys.rs#L24)
