### PR TITLE
fix(ci): add wash-lib to list of crates possible to release

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -483,6 +483,7 @@ jobs:
         - provider-archive
         - wascap
         - wash-cli
+        - wash-lib
 
     if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
     needs: cargo


### PR DESCRIPTION
I was about to release wash-lib v0.13.0, and realized this was missing