### PR TITLE
fix(ci): fix syntax in release script

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -386,11 +386,11 @@ jobs:
               *.exe)
                 name="${bin#.exe}"
                 mkdir -p ${name}
-                do mv ${bin} ./${name}/${bin#.exe}-${target}.exe
+                mv ${bin} ./${name}/${bin#.exe}-${target}.exe
               ;;
               *)
                 mkdir -p ${bin}
-                do mv ${bin} ./${bin}/${bin}-${target}
+                mv ${bin} ./${bin}/${bin}-${target}
               ;;
             esac
           done


### PR DESCRIPTION
Don't do.

There was a syntax error in this script preventing host releases: https://github.com/wasmCloud/wasmCloud/actions/runs/6737821381/job/18316486221