### PR TITLE
fix(ci): remove duplicated path

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -376,7 +376,7 @@ jobs:
     - run: |
         for dir in ./artifacts/wasmcloud-*; do
           target=${dir#./artifacts/wasmcloud-}
-          for bin in ${dir}/wasmcloud-${target}/bin/*; do
+          for bin in ${dir}/bin/*; do
             chmod +x ${bin}
             case "$bin" in
               *.exe)


### PR DESCRIPTION
I'm not 100% confident in this, but it seems `${dir}/wasmcloud-${target}/` effectively doubles up on `wasmcloud-${target}`:

https://github.com/wasmCloud/wasmCloud/actions/runs/6738319353/job/18318008734