### PR TITLE
fix(ci): fix typo stripping suffix

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -389,7 +389,7 @@ jobs:
               bin=$(basename ${bin_path})
               case "$bin" in
                 *.exe)
-                  name="${bin#.exe}"
+                  name="${bin%.exe}"
                   mv ${bin_path} ./artifacts/${name}/${name}-${target}.exe
                 ;;
                 *)


### PR DESCRIPTION
`#` is for stripping prefixes, but we want to strip the `.exe` suffix, so we need `%`