### PR TITLE
Bump Chart.yaml appVersion to 0.80.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,4 +20,4 @@ type: application
 # in one PR, then open a new PR updating this `version` and `appVersion`.
 version: 0.7.0
 
-appVersion: "0.79.1"
+appVersion: "0.80.0"


### PR DESCRIPTION
## Feature or Problem

Since [`v0.80.0`](https://github.com/wasmCloud/wasmCloud/releases/tag/v0.80.0) has been released, let's bump the Chart.yaml to use that instead of `v0.79.1`.

## Related Issues

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
