### PR TITLE
feat(wash): download washboard assets from releases instead of embedding from source

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -11,7 +11,6 @@ on:
     - Cargo.toml
     - crates/wash-cli/**
     - crates/wash-lib/**
-    - washboard-ui/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,21 +20,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_ui:
-    name: Build UI
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '18.x'
-      - name: npm install
-        run: npm install
-        working-directory: ./washboard-ui
-      - name: npm run build
-        run: npm run build
-        working-directory: ./washboard-ui
-
   unit_tests:
     name: Unit Tests
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5842,6 +5842,7 @@ version = "0.22.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
+ "async-compression",
  "async-nats 0.31.0",
  "atelier_core 0.2.22",
  "bytes",
@@ -5863,6 +5864,7 @@ dependencies = [
  "provider-archive",
  "rand 0.8.5",
  "regex",
+ "reqwest",
  "rmp-serde",
  "rmpv",
  "rust-embed",
@@ -5879,6 +5881,7 @@ dependencies = [
  "term-table",
  "thiserror",
  "tokio",
+ "tokio-tar",
  "toml 0.7.8",
  "url",
  "wadm",

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -16,6 +16,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
+async-compression = { workspace = true, features = ["tokio", "gzip"] }
 async-nats = { workspace = true }
 atelier_core = { workspace = true }
 bytes = { workspace = true }
@@ -36,6 +37,7 @@ oci-distribution = { workspace = true, features = ["rustls-tls"] }
 once_cell = { workspace = true }
 provider-archive = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
 rmp-serde = { workspace = true }
 rmpv = { workspace = true }
 rust-embed = { workspace = true }
@@ -49,6 +51,7 @@ sha2 = { workspace = true }
 term-table = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tokio-tar = { workspace = true }
 toml = { workspace = true }
 url = { workspace = true }
 wadm = { workspace = true }

--- a/crates/wash-cli/src/ui/mod.rs
+++ b/crates/wash-cli/src/ui/mod.rs
@@ -14,13 +14,16 @@ use clap::Parser;
 use tokio_tar::Archive;
 use warp::Filter;
 
-const WASHBOARD_VERSION: &str = "washboard-ui-v0.1.0";
+const DEFAULT_WASHBOARD_VERSION: &str = "v0.1.0";
 
 #[derive(Parser, Debug, Clone)]
 pub struct UiCommand {
     /// Whist port to run the UI on, defaults to 3030
     #[clap(short = 'p', long = "port", default_value = DEFAULT_WASH_UI_PORT)]
     pub port: u16,
+
+    #[clap(short = 'v', long = "version", default_value = DEFAULT_WASHBOARD_VERSION)]
+    pub version: String,
 }
 
 pub async fn handle_command(command: UiCommand, output_kind: OutputKind) -> Result<CommandOutput> {
@@ -30,7 +33,7 @@ pub async fn handle_command(command: UiCommand, output_kind: OutputKind) -> Resu
 }
 
 pub async fn handle_ui(cmd: UiCommand, _output_kind: OutputKind) -> Result<()> {
-    let washboard_assets = ensure_washboard(WASHBOARD_VERSION, downloads_dir()?).await?;
+    let washboard_assets = ensure_washboard(&cmd.version, downloads_dir()?).await?;
     let static_files = warp::fs::dir(washboard_assets);
 
     let cors = warp::cors()
@@ -60,7 +63,7 @@ async fn ensure_washboard(version: &str, base_dir: PathBuf) -> Result<PathBuf> {
 
 async fn download_washboard(version: &str, install_dir: &PathBuf) -> Result<()> {
     let release_url = format!(
-        "https://github.com/wasmCloud/wasmCloud/releases/download/{version}/washboard.tar.gz"
+        "https://github.com/wasmCloud/wasmCloud/releases/download/washboard-ui-{version}/washboard.tar.gz"
     );
 
     // Download tarball

--- a/crates/wash-cli/src/ui/mod.rs
+++ b/crates/wash-cli/src/ui/mod.rs
@@ -1,8 +1,3 @@
-use wash_lib::{
-    cli::{CommandOutput, OutputKind},
-    config::downloads_dir,
-};
-
 mod config;
 pub use config::*;
 
@@ -13,6 +8,10 @@ use async_compression::tokio::bufread::GzipDecoder;
 use clap::Parser;
 use tokio_tar::Archive;
 use warp::Filter;
+use wash_lib::{
+    cli::{CommandOutput, OutputKind},
+    config::downloads_dir,
+};
 
 const DEFAULT_WASHBOARD_VERSION: &str = "v0.1.0";
 


### PR DESCRIPTION
## Feature or Problem
This changes `wash ui` to download the washboard assets from a released version instead of embedding local files, which will enable publishing wash

The version defaults to v0.1.0 for now, but can be specified with `--version`:

```
./target/debug/wash ui --version v0.1.0
Washboard running on http://localhost:3030
Hit CTRL-C to stop
```

@lachieh do we need to allow overriding this behavior for local dev? Or should local dev always be done via `make run-ui`?

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/875

## Release Information
v0.22.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Built and ran locally, and confirmed I could serve the washboard UI