### PR TITLE
fix(ci): set up buildx after logging into ACR

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -228,12 +228,6 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
       with: 
         cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - name: Set up QEMU
-      if: startsWith(github.ref, 'refs/tags/wash-cli-v') || github.ref == 'refs/heads/main'
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      if: startsWith(github.ref, 'refs/tags/wash-cli-v') || github.ref == 'refs/heads/main'
-      uses: docker/setup-buildx-action@v3
 
     - name: Extract tag context
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
@@ -338,6 +332,16 @@ jobs:
           org.opencontainers.image.version=${{ steps.wash-ctx.outputs.version }}
 
     # Build the docker image
+    # NOTE: order matters, other steps (in particular azure/docker-login)
+    # are capable of messing up the docker buildx configuration
+    #
+    # see: https://github.com/docker/build-push-action/issues/163#issuecomment-918590372
+    - name: Set up QEMU
+      if: startsWith(github.ref, 'refs/tags/wash-cli-v') || github.ref == 'refs/heads/main'
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      if: startsWith(github.ref, 'refs/tags/wash-cli-v') || github.ref == 'refs/heads/main'
+      uses: docker/setup-buildx-action@v3
     - name: Build and push `wash` Docker image
       if: startsWith(github.ref, 'refs/tags/wash-cli-v') || github.ref == 'refs/heads/main'
       id: wash_docker_build


### PR DESCRIPTION
## Feature or Problem
Apparently logging into ACR breaks buildx? So I moved these steps to right before we need them: https://github.com/docker/build-push-action/issues/163#issuecomment-918590372

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
