### PR TITLE
chore(host): polish tracing and logging levels

### DIFF
--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -125,13 +125,13 @@ impl ResourceRef<'_> {
 }
 
 /// Fetch an actor from a reference.
-#[instrument(skip_all)]
+#[instrument(level = "debug", skip(allow_file_load, registry_config))]
 pub async fn fetch_actor(
-    actor_ref: impl AsRef<str>,
+    actor_ref: &str,
     allow_file_load: bool,
     registry_config: &HashMap<String, RegistryConfig>,
 ) -> anyhow::Result<Vec<u8>> {
-    match ResourceRef::try_from(actor_ref.as_ref())? {
+    match ResourceRef::try_from(actor_ref)? {
         ResourceRef::File(actor_ref) => {
             ensure!(
                 allow_file_load,

--- a/crates/host/src/policy.rs
+++ b/crates/host/src/policy.rs
@@ -260,7 +260,7 @@ impl Manager {
     }
 
     /// Constructs a
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "trace", skip_all)]
     pub async fn evaluate_action(
         &self,
         source: Option<RequestSource>,

--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -228,7 +228,7 @@ pub fn provider_health_check(
     })
 }
 
-#[instrument(level = "debug", skip(event_builder, ctl_nats, data))]
+#[instrument(level = "trace", skip(event_builder, ctl_nats, data))]
 pub(crate) async fn publish(
     event_builder: &EventBuilderV10,
     ctl_nats: &async_nats::Client,

--- a/crates/runtime/src/actor/mod.rs
+++ b/crates/runtime/src/actor/mod.rs
@@ -67,7 +67,7 @@ impl Actor {
     /// # Errors
     ///
     /// Fails if [Component::new] or [Module::new] fails
-    #[instrument(skip(wasm))]
+    #[instrument(level = "trace", skip_all)]
     pub fn new(rt: &Runtime, wasm: impl AsRef<[u8]>) -> Result<Self> {
         let wasm = wasm.as_ref();
         // TODO: Optimize parsing, add functionality to `wascap` to parse from a custom section
@@ -148,7 +148,7 @@ impl Actor {
     /// # Errors
     ///
     /// Fails if instantiation of the underlying module or component fails
-    #[instrument]
+    #[instrument(level = "trace", skip_all)]
     pub async fn instantiate(&self) -> anyhow::Result<Instance> {
         match self {
             Self::Module(module) => module.instantiate().await.map(Instance::Module),
@@ -161,7 +161,7 @@ impl Actor {
     /// # Errors
     ///
     /// Fails if [`Instance::call`] fails
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn call(
         &self,
         operation: impl AsRef<str>,

--- a/crates/runtime/src/actor/module/mod.rs
+++ b/crates/runtime/src/actor/module/mod.rs
@@ -210,7 +210,7 @@ async fn instantiate(
 
 impl Module {
     /// Extracts [Claims](jwt::Claims) from WebAssembly module and compiles it using [Runtime].
-    #[instrument(skip(wasm))]
+    #[instrument(level = "trace", skip_all)]
     pub fn new(rt: &Runtime, wasm: impl AsRef<[u8]>) -> anyhow::Result<Self> {
         let wasm = wasm.as_ref();
         let claims = claims(wasm)?;
@@ -253,7 +253,7 @@ impl Module {
     }
 
     /// Instantiates a [Module] and returns the resulting [Instance].
-    #[instrument]
+    #[instrument(level = "trace", skip_all)]
     pub async fn instantiate(&self) -> anyhow::Result<Instance> {
         instantiate(
             &self.module,
@@ -526,7 +526,7 @@ impl Logging for GuestInstance {
 
 #[async_trait]
 impl IncomingHttp for GuestInstance {
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     async fn handle(
         &self,
         request: http::Request<Box<dyn AsyncRead + Sync + Send + Unpin>>,

--- a/crates/runtime/src/actor/module/wasmbus.rs
+++ b/crates/runtime/src/actor/module/wasmbus.rs
@@ -221,7 +221,7 @@ fn guest_response(
     Ok(())
 }
 
-#[instrument(skip(handler, payload))]
+#[instrument(level = "trace", skip(handler, payload))]
 async fn handle(
     handler: &mut builtin::Handler,
     binding: String,
@@ -276,7 +276,7 @@ async fn handle(
     }
 }
 
-#[instrument(skip(store))]
+#[instrument(level = "trace", skip(store))]
 #[allow(clippy::too_many_arguments)]
 async fn host_call(
     mut store: wasmtime::Caller<'_, super::Ctx>,


### PR DESCRIPTION
## Feature or Problem
🧹 Generally speaking, I went with:
- set instrumentation to trace if it's not useful for day-to-day observability debugging
- used `skip_all` in most places, unless there was a reason to include a field or two on spans
- downgraded many log messages to trace
- kept most logs at debug, unless they occur infrequently
- introduced several log messages at info, to give users a better idea of what the host is doing (e.g. after scaling an actor)
- removed sensitive information from logs
- updated `handle_ctl_message` to gracefully handle more error cases

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Here are some before and after screenshots, when the log level is set to debug:

Scaling up an actor:
Before: 
![Screenshot 2023-11-07 at 17 23 53](https://github.com/wasmCloud/wasmCloud/assets/3869136/22315a56-04e9-47a1-bde5-59f5dd4e473a)
After:
![Screenshot 2023-11-07 at 17 20 28](https://github.com/wasmCloud/wasmCloud/assets/3869136/6cb4219f-ba2d-4947-9bc8-0cb28f60d45e)

Handling an RPC call from a provider:
Before:
![Screenshot 2023-11-07 at 17 24 55](https://github.com/wasmCloud/wasmCloud/assets/3869136/c2d76f39-b9c1-4331-984d-890f736ce107)
After:
![Screenshot 2023-11-07 at 17 30 31](https://github.com/wasmCloud/wasmCloud/assets/3869136/207a7136-162c-4c55-8bc0-02c30ae54809)

Startup logs (deploying a KV app):
Before:
![Screenshot 2023-11-07 at 17 39 40](https://github.com/wasmCloud/wasmCloud/assets/3869136/f7be8e33-1fe7-48f1-95be-2c9e38fcd029)
After:
![Screenshot 2023-11-07 at 17 38 23](https://github.com/wasmCloud/wasmCloud/assets/3869136/755b21ee-0ed0-49db-a1e6-2e65e8c15f62)
