### PR TITLE
fix(docs): update helm chart install to use artifacthub

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -20,26 +20,37 @@ recommend deploying your main NATS server with another chart.
 
 ## Running the chart
 
-The chart is available in a hosted Helm repository. To add the repository, run the following:
+You can install the chart via [the `wasmcloud-chart` package on ArtifactHub][artifacthub-wasmcloud]:
 
 ```console
-$ helm repo add wasmcloud https://wasmcloud.github.io/wasmcloud-otp/
+$ helm install wasmcloud oci://ghcr.io/wasmcloud/wasmcloud-chart --version 0.7.0
 ```
 
-Then you can install the chart:
-
-```console
-$ helm install <RELEASE_NAME> wasmcloud/wasmcloud-host
-```
+> [!NOTE]
+>
+> You can replace `wasmcloud` with whatever you'd like to call your instantiation
+> of the helm chart.
+>
+> Version `0.7.0` of the helm chart (released Nov 9th, 2023) deploys version [`v0.80.0`][wasmcloud-v0.80.0] of the host by default.
+>
+> To change the version of the wasmcloud host that is deployed, set `wasmcloud.image.tag` in [`values.yaml`][values-yaml] to the
+> [docker image tag][wasmcloud-docker-tags] you'd like to deploy instead.
 
 This will get you up and going with a wasmCloud Host and NATS server so you can kick the tires and
-try things out. In order to access the dashboard and NATS, you'll need to forward the ports locally
+try things out.
+
+In order to access the dashboard and NATS, you'll need to forward the ports locally
 (using the `RELEASE_NAME` you chose above as the `RELEASE_NAME` below)
 
 ```console
 # In a second terminal
 $ kubectl port-forward deployment/${RELEASE_NAME} 4222
 ```
+
+[artifacthub-wasmcloud]: https://artifacthub.io/packages/helm/wasmcloud-chart/wasmcloud-chart
+[wasmcloud-v0.80.0]: https://github.com/wasmCloud/wasmCloud/tree/v0.80.0
+[wasmcloud-docker-tags]: https://hub.docker.com/r/wasmcloud/wasmcloud/tags
+[values-yaml]: ./values.yaml
 
 ### Configuration
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

While the official wasmcloud Helm chart was recently updated and published to ArtifactHub, the README was still referencing the old OTP host's Helm chart.

This commit updates the helm chart README to use recent Helm install instructions that are posted to the ArtifactHub page, and also reference that page so users can find the listing.


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
