### PR TITLE
chore(wash-cli): remove `wasmbus_rpc` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5888,8 +5888,9 @@ dependencies = [
  "warp-embed",
  "wascap 0.12.0",
  "wash-lib",
- "wasmbus-rpc 0.15.0",
  "wasmcloud-control-interface 0.31.0",
+ "wasmcloud-core",
+ "wasmcloud-provider-sdk",
  "wasmcloud-test-util",
  "weld-codegen",
  "which",
@@ -6197,43 +6198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmbus-rpc"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17417841089a43a945a31ddfcc0062704a97625fb7ecbfbe91df043d930f05a"
-dependencies = [
- "async-nats 0.31.0",
- "async-trait",
- "atty",
- "base64 0.13.1",
- "bytes",
- "cfg-if",
- "data-encoding",
- "futures",
- "lazy_static",
- "minicbor 0.17.1",
- "minicbor-ser",
- "nkeys",
- "once_cell",
- "rmp-serde",
- "serde",
- "serde_bytes",
- "serde_json",
- "sha2 0.10.8",
- "thiserror",
- "time",
- "tokio",
- "toml 0.5.11",
- "tracing",
- "tracing-futures",
- "tracing-subscriber",
- "uuid 1.5.0",
- "wascap 0.11.2",
- "wasmbus-macros",
- "weld-codegen",
-]
-
-[[package]]
 name = "wasmcloud"
 version = "0.80.0"
 dependencies = [
@@ -6465,7 +6429,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc 0.14.0",
+ "wasmbus-rpc",
  "weld-codegen",
 ]
 
@@ -6567,7 +6531,7 @@ dependencies = [
  "termcolor",
  "tokio",
  "toml 0.7.8",
- "wasmbus-rpc 0.14.0",
+ "wasmbus-rpc",
  "wasmcloud-interface-testing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,6 @@ wash-lib = { version = "0", path = "./crates/wash-lib", default-features = false
 wasi-common = { version = "14", git = "https://github.com/rvolosatovs/wasmtime", branch = "release-14.0.0", default-features = false }
 wasm-encoder = { version = "0.36", default-features = false }
 wasm-gen = { version = "0.1", default-features = false }
-wasmbus-rpc = { version = "0.15", default-features = false }
 wasmcloud-actor = { version = "0", path = "./crates/actor", default-features = false }
 wasmcloud-actor-macros = { version = "0", path = "./crates/actor/macros", default-features = false }
 wasmcloud-compat = { version = "0", path = "./crates/compat", default-features = false }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -59,8 +59,9 @@ warp = { workspace = true }
 warp-embed = { workspace = true }
 wascap = { workspace = true }
 wash-lib = { workspace = true, features = ["cli", "parser", "nats", "start"] }
-wasmbus-rpc = { workspace = true }
 wasmcloud-control-interface = { workspace = true }
+wasmcloud-core = { workspace = true }
+wasmcloud-provider-sdk = { workspace = true }
 wasmcloud-test-util = { workspace = true }
 weld-codegen = { workspace = true, features = ["wasmbus"] }
 which = { workspace = true }

--- a/crates/wash-cli/src/util.rs
+++ b/crates/wash-cli/src/util.rs
@@ -27,9 +27,9 @@ pub fn default_timeout_ms() -> u64 {
 
 /// Transform a json string (e.g. "{"hello": "world"}") into msgpack bytes
 pub fn json_str_to_msgpack_bytes(payload: &str) -> Result<Vec<u8>> {
-    let json = serde_json::from_str::<serde_json::Value>(payload)?;
-    let payload = rmp_serde::to_vec_named(&json)?;
-    Ok(payload)
+    let json: serde_json::Value =
+        serde_json::from_str(payload).context("failed to encode string as JSON")?;
+    rmp_serde::to_vec_named(&json).context("failed to encode JSON as msgpack")
 }
 
 use once_cell::sync::OnceCell;

--- a/crates/wash-cli/src/util.rs
+++ b/crates/wash-cli/src/util.rs
@@ -28,7 +28,7 @@ pub fn default_timeout_ms() -> u64 {
 /// Transform a json string (e.g. "{"hello": "world"}") into msgpack bytes
 pub fn json_str_to_msgpack_bytes(payload: &str) -> Result<Vec<u8>> {
     let json = serde_json::from_str::<serde_json::Value>(payload)?;
-    let payload = wasmbus_rpc::common::serialize(&json)?;
+    let payload = rmp_serde::to_vec_named(&json)?;
     Ok(payload)
 }
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Replace `wasmbus_rpc` by `wasmcloud_core` and `wasmcloud_provider_sdk`

This is the last occurence of usage of `wasmbus_rpc` within the root workspace. Only providers left (e.g. #745 )

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

#641

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
