### PR TITLE
fix(tests): avoid saving data when starting local redis instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 .vscode/
 /tests/fixtures
 /tmp/
-dump.rdb
 host_config.json
 node_modules
 target/


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Up until now, Redis has generated dump files which can be loaded depending on configuration of the local redis server. The files (by default `dump.rdb` get created when tests are run, and are gitignored)

This commit avoids generating dump files by disabling save *and* randomizes the file names that are generated by embedding the port to avoid overlaps.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
