### PR TITLE
Adopt Restricted profile recommendations as default securityContext for wasmcloud-chart containers

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -113,8 +113,8 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  runAsUser: 10000
-  runAsGroup: 10000
+  runAsUser: 1000
+  runAsGroup: 1000
   runAsNonRoot: true
   allowPrivilegeEscalation: false
   capabilities:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -113,7 +113,6 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-securityContext:
   runAsUser: 10000
   runAsGroup: 10000
   runAsNonRoot: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -113,13 +113,16 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  runAsUser: 10000
+  runAsGroup: 10000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - "ALL"
+  seccompProfile:
+    type: "RuntimeDefault"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Feature or Problem

It was pointed out in #978 that the defaults we have in our chart's `values.yaml` for securityContext that gets configured for the both of the containers included in the Chart does not meet the recommendations from a security standpoint.

This PR adds a set of defaults that meets the [Restricted profile as outlined in Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/).

## Related Issues

https://github.com/wasmCloud/wasmCloud/issues/978

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing

I've tested this locally against a [KinD cluster running 1.27.3 (latest available KinD version)](https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0), and from review the [`1.28` changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md), it did not appear anything had changed in a material way that would impact this set of configuration.

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
