### PR TITLE
Release/wash cli v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4945,7 +4945,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.22.0"
+version = "0.23.0"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) CLI tool"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.13.0"
+version = "0.14.0"
 categories = ["wasm", "wasmcloud"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]


### PR DESCRIPTION
Minor bumps for both since there have been breaking changes:
- bumps to dependencies in wash-lib (e.g. wadm)
- updates to `--context` semantics in wash-cli