### PR TITLE
fix(wash-cli): use valid host and public keys for wash call

### DIFF
--- a/crates/wash-cli/src/call.rs
+++ b/crates/wash-cli/src/call.rs
@@ -91,11 +91,8 @@ fn print_test_results(results: &[TestResult]) {
     writeln!(&mut stdout).unwrap();
 }
 
-/// fake key (not a real public key)  used to construct origin for invoking actors
-const WASH_ORIGIN_KEY: &str = "__WASH__";
-
 /// hostname used for actor invocations
-const WASH_HOST_ID: &str = "NwashHostCallerId000000000000000000000000000000000000000";
+const WASH_HOST_ID: &str = "NAWASHVALZUZPZNXPIF6HGQ4OMJYLXQ4B2WZZ5AMBCXKWEQPYXDOIWMA"; // "a wash val" :)
 
 #[derive(Debug, Args, Clone)]
 #[clap(name = "call")]
@@ -245,7 +242,7 @@ pub async fn handle_call(
     let InvocationResponse { msg, .. } = client
         .send_timeout(
             WasmCloudEntity {
-                public_key: WASH_ORIGIN_KEY.to_string(),
+                public_key: actor_id.to_string(), // This is "wrong" in the sense that an actor shouldn't be calling itself, but it ensures the receiving host has both the origin and target public keys in its claims
                 ..Default::default()
             },
             WasmCloudEntity {


### PR DESCRIPTION
## Feature or Problem
There were two issues with `wash call` and the host. This fixes both of them:
- an invalid host ID. The replacement is a real nkey with a vanity prefix
- an invalid public key on the `origin` of the `Invocation`. The replacement is to use the target's public key, which is provided by the user and assumed to be valid. This is "wrong", but allows the host to look up both public keys (the same key) in its claims

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/852

## Release Information
Next

## Consumer Impact
`wash call` works again 🙂 

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
```
./target/debug/wasmcloud --log-level debug --allow-file-load --cluster-seed SCAGNV7ILF26UE4OIIHBZFK5WRB6NWWWA5ZPHHBQOZ3QX4UGOG24QWZSRA
2023-11-10T18:57:10.223596Z DEBUG handle_scale_actor_task:start_actor: wasmcloud_host::wasmbus: starting new actor actor_ref="wasmcloud.azurecr.io/echo:0.3.8" max=Some(1)
2023-11-10T18:57:10.224602Z DEBUG process_claims_put: wasmcloud_host::wasmbus: process claim entry put pubkey="MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"
2023-11-10T18:57:10.224794Z  INFO handle_scale_actor_task:start_actor: wasmcloud_host::wasmbus: actor started actor_ref="wasmcloud.azurecr.io/echo:0.3.8"
```

```
./target/debug/wash call --cluster-seed SCAGNV7ILF26UE4OIIHBZFK5WRB6NWWWA5ZPHHBQOZ3QX4UGOG24QWZSRA MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5 HttpServer.HandleRequest '{"method": "GET", "path": "/", "body": "", "queryString":"","header":{}}'

Call response (raw): ��statusCode�Ȧheader��body�7{"body":[],"method":"GET","path":"/","query_string":""}
```