### PR TITLE
Feat/wadm js domain

### DIFF
--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -369,7 +369,7 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
             host: nats_host.clone(),
             port: nats_port,
             store_dir: std::env::temp_dir().join(format!("wash-jetstream-{nats_port}")),
-            js_domain: wasmcloud_opts.wasmcloud_js_domain.clone(),
+            js_domain: cmd.nats_opts.nats_js_domain,
             remote_url: cmd.nats_opts.nats_remote_url,
             credentials: cmd.nats_opts.nats_credsfile.clone(),
             websocket_port: cmd.nats_opts.nats_websocket_port,

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -301,6 +301,9 @@ pub struct WadmOpts {
 
     #[clap(long = "disable-wadm")]
     pub disable_wadm: bool,
+
+    #[clap(long = "wadm-js-domain", env = "WADM_JS_DOMAIN")]
+    pub wadm_js_domain: Option<String>,
 }
 
 pub async fn handle_command(command: UpCommand, output_kind: OutputKind) -> Result<CommandOutput> {
@@ -398,7 +401,7 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
         spinner.update_spinner_message(" Starting wadm ...".to_string());
         let config = WadmConfig {
             structured_logging: wasmcloud_opts.enable_structured_logging,
-            js_domain: cmd.nats_opts.nats_js_domain.clone(),
+            js_domain: cmd.wadm_opts.wadm_js_domain.clone(),
             nats_server_url: nats_listen_address.clone(),
             nats_credsfile: cmd.nats_opts.nats_credsfile,
         };

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -70,11 +70,7 @@ pub struct NatsOpts {
     pub nats_credsfile: Option<PathBuf>,
 
     /// Optional remote URL of existing NATS infrastructure to extend.
-    #[clap(
-        long = "nats-remote-url",
-        env = "NATS_REMOTE_URL",
-        requires = "nats_credsfile"
-    )]
+    #[clap(long = "nats-remote-url", env = "NATS_REMOTE_URL")]
     pub nats_remote_url: Option<String>,
 
     /// If a connection can't be established, exit and don't start a NATS server. Will be ignored if a remote_url and credsfile are specified
@@ -354,9 +350,8 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
 
     // Avoid downloading + starting NATS if the user already runs their own server and we can connect.
     let should_run_nats = !cmd.nats_opts.connect_only && nats_client.is_err();
-    // Ignore connect_only if this server has a remote and credsfile as we have to start a leafnode in that scenario
-    let supplied_remote_credentials =
-        cmd.nats_opts.nats_remote_url.is_some() && cmd.nats_opts.nats_credsfile.is_some();
+    // Ignore connect_only if this server has a remote as we have to start a leafnode in that scenario
+    let supplied_remote_credentials = cmd.nats_opts.nats_remote_url.is_some();
 
     let nats_bin = if should_run_nats || supplied_remote_credentials {
         // Download NATS if not already installed

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -200,22 +200,28 @@ impl NatsConfig {
     where
         P: AsRef<Path>,
     {
-        let leafnode_section = match (self.remote_url, self.credentials) {
-            (Some(url), Some(creds)) => format!(
+        let leafnode_section = if let Some(url) = self.remote_url {
+            let url_line = format!(r#"url: "{url}""#);
+            let creds_line = self
+                .credentials
+                .as_ref()
+                .map(|c| format!("credentials: {c:?}"))
+                .unwrap_or_default();
+
+            format!(
                 r#"
 leafnodes {{
     remotes = [
         {{
-            url: "{}"
-            credentials: {:?}
+            {url_line}
+            {creds_line}
         }}
     ]
 }}
                 "#,
-                url,
-                creds.to_string_lossy()
-            ),
-            _ => "".to_owned(),
+            )
+        } else {
+            "".to_owned()
         };
         let websocket_section = match self.websocket_port {
             Some(port) => format!(


### PR DESCRIPTION
## Feature or Problem
This adds a `--wadm-js-domain` option to wash. In doing this, I fixed two bugs:
- the NATS server was being configured with the `--wasmcloud-js-domain`, effectively ignoring the `--nats-js-domain` option
- the `--remote-nats-url` option required `--nats-credsfile`, but anonymous connections from a leaf node to a remote should be allowed

Note that while this PR opens more options, it also creates an opportunity for a new footgun, i.e. specifying incompatible JS domains. For example, this will not work out of the box:

```
wash up --wasmcloud-js-domain wasmcloud-domain --nats-js-domain nats-domain --wadm-js-domain wadm-domain
```

If wash starts a single NATS server with the `nats-domain`, then jetstream traffic on `wasmcloud-domain` and `wadm-domain` will fail, causing the host and wadm processes to exit. Since these are advanced options and there are use cases where the above is valid (NATS leafs vs remotes), I'm okay with this change, but it increases the need for documentation. 

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/854

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tested e2e with a full leaf+remote setup:

Set up `core.conf`:
```
jetstream {
    domain=core
    store_dir="/var/folders/h0/s_qctf2x2pd00wr6ldk0jppw0000gn/T/wash-jetstream-4224"
}

leafnodes {
  port: 7422
}
```

Start core server:
```
nats-server -js -p 4224 --config core.conf
```

Start leaf node, wasmCloud host, and wadm, where:
- the leaf node is running on the `leaf-domain`, pointed at the remote
- the host's js domain is `core` (the remote)
- wadm's js domain is `leaf-domain`
```
./target/debug/wash up --nats-remote-url nats://127.0.0.1:7422 --nats-js-domain leaf-domain --wasmcloud-js-domain core --wadm-js-domain leaf-domain --log-level debug
🏃 Running in interactive mode.
🎛️  If you enabled --nats-websocket-port, start the dashboard by executing `wash ui`
🚪 Press `CTRL+c` at any time to exit
2023-11-10T21:16:26.449314Z DEBUG new: wasmcloud_host::wasmbus: adding cluster key to cluster issuers cluster_pub_key="CB4Q2TMWPB5O5PQERDQNIIPP5FIGVCCQEN3CLFYQ2TP2O4CGJN2GC7RB"
2023-11-10T21:16:26.449438Z DEBUG new: wasmcloud_host::wasmbus: connecting to NATS control server ctl_nats_url="nats://127.0.0.1:4222"
2023-11-10T21:16:26.449469Z DEBUG new: wasmcloud_host::wasmbus: connecting to NATS RPC server rpc_nats_url="nats://127.0.0.1:4222"
2023-11-10T21:16:26.449477Z DEBUG new: wasmcloud_host::wasmbus: connecting to NATS Provider RPC server prov_rpc_nats_url="nats://127.0.0.1:4222"
2023-11-10T21:16:26.451612Z  INFO async_nats::options: event: connected
2023-11-10T21:16:26.451684Z  INFO async_nats::options: event: connected
2023-11-10T21:16:26.451703Z  INFO async_nats::options: event: connected
2023-11-10T21:16:26.454768Z  INFO new:create_lattice_metadata_bucket{bucket="LATTICEDATA_default"}: wasmcloud_host::wasmbus: created lattice metadata bucket LATTICEDATA_default with 1 replica
2023-11-10T21:16:26.455885Z  INFO new: wasmcloud_host::wasmbus: wasmCloud host started host_id="NA4OKKRIU2SJMINMQ6N3C7YRLAZXRO4J36FBMIQUD4BQCKOQGAPBALUF"
```

Then we see the host successfully created its bucket on the `core` domain:
```
nats stream ls --domain core -a
╭─────────────────────────────────────────────────────────────────────────────────────────────╮
│                                           Streams                                           │
├────────────────────────┬─────────────┬─────────────────────┬──────────┬──────┬──────────────┤
│ Name                   │ Description │ Created             │ Messages │ Size │ Last Message │
├────────────────────────┼─────────────┼─────────────────────┼──────────┼──────┼──────────────┤
│ KV_LATTICEDATA_default │             │ 2023-11-10 14:16:26 │ 0        │ 0 B  │ never        │
╰────────────────────────┴─────────────┴─────────────────────┴──────────┴──────┴──────────────╯
```

And wadm successfully created its streams on `leaf-domain`:
```
nats stream ls --domain leaf-domain -a
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                           Streams                                                                            │
├───────────────────┬──────────────────────────────────────────────────────────────────────────────────┬─────────────────────┬──────────┬───────┬──────────────┤
│ Name              │ Description                                                                      │ Created             │ Messages │ Size  │ Last Message │
├───────────────────┼──────────────────────────────────────────────────────────────────────────────────┼─────────────────────┼──────────┼───────┼──────────────┤
│ KV_wadm_manifests │                                                                                  │ 2023-11-10 14:16:26 │ 0        │ 0 B   │ never        │
│ KV_wadm_state     │                                                                                  │ 2023-11-10 14:16:26 │ 0        │ 0 B   │ never        │
│ wadm_commands     │ A stream that stores all commands for wadm                                       │ 2023-11-10 14:16:26 │ 0        │ 0 B   │ never        │
│ wadm_events       │ A stream that stores all events coming in on the wasmbus.evt topics in a cluster │ 2023-11-10 14:16:26 │ 0        │ 0 B   │ never        │
│ wadm_notify       │ A stream for capturing all notification events for wadm                          │ 2023-11-10 14:16:26 │ 0        │ 0 B   │ never        │
│ wadm_status       │ A stream that stores all status updates for wadm applications                    │ 2023-11-10 14:16:26 │ 0        │ 0 B   │ never        │
│ wadm_mirror       │ A stream that publishes all events to the same stream                            │ 2023-11-10 14:16:26 │ 1        │ 472 B │ 2.84s        │
╰───────────────────┴──────────────────────────────────────────────────────────────────────────────────┴─────────────────────┴──────────┴───────┴──────────────╯
```