### PR TITLE
feat(wash-cli): add --label option to wash up

### DIFF
--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -233,7 +233,8 @@ pub struct WasmcloudOpts {
     )]
     pub enable_structured_logging: bool,
 
-    #[clap(short = 'l', long = "label")]
+    /// A label to apply to the host, in the form of `key=value`. This flag can be repeated to supply multiple labels
+    #[clap(short = 'l', long = "label", alias = "labels")]
     pub label: Option<Vec<String>>,
 
     /// Controls the verbosity of JSON structured logs from the wasmCloud host


### PR DESCRIPTION
## Feature or Problem
The host added support for setting labels via `--label` and `WASMCLOUD_LABEL_XXXX` in https://github.com/wasmCloud/wasmCloud/pull/706. This adds `--label` support to `wash up`

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/856

## Release Information
Next

## Consumer Impact
Yay

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
```
./target/debug/wash up --label foobar --label baz=qux

invalid label format `foobar`. Expected `key=value`
```

```
./target/debug/wash up --label foo=bar --label baz=qux
```
```
[#12] Received on "wasmbus.evt.default"
{"specversion":"1.0","id":"018bbb2a-146b-8cab-c466-fdeccc416696","type":"com.wasmcloud.lattice.host_stopped","source":"NB3Q76LIMMFFCWP5Q62E4MWPQ7UNFDWUKGPGNDL532GCTZ5Z5VEAK2KQ","datacontenttype":"application/json","time":"2023-11-10T21:36:19.051304Z","data":{"labels":{"baz":"qux","foo":"bar","hostcore.arch":"aarch64","hostcore.os":"macos","hostcore.osfamily":"unix"}}}
```