### PR TITLE
Docs/wash installation instructions

### DIFF
--- a/crates/wascap/README.md
+++ b/crates/wascap/README.md
@@ -10,7 +10,7 @@ The hashes computed with v`0.10.1` and later of wascap are not compatible with t
 
 In the [wasmCloud](https://wasmcloud.dev) host runtime, each actor securely declares the set of capabilities it requires. This library is used to embed, extract, and validate JSON Web Tokens (JWT) containing these capability attestations, as well as the hash of the `wasm` file and a provable issuer for verifying module provenance.
 
-If you want to use the CLI that lets you sign and examine module claims, then you can install the [wash](https://github.com/wasmCloud/wash) CLI and use the `wash claims` set of commands. _Note that earlier versions of `wascap` came with a CLI. This is no longer available and has been supercede by the `wash` CLI._
+If you want to use the CLI that lets you sign and examine module claims, then you can install the [wash](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-cli) CLI and use the `wash claims` set of commands. _Note that earlier versions of `wascap` came with a CLI. This is no longer available and has been supercede by the `wash` CLI._
 
 While there are some standard, well-known claims already defined in the library (such as `wasmcloud:messaging` and `wasmcloud:keyvalue`), you can add custom claims in your own namespaces.
 

--- a/crates/wash-cli/CONTRIBUTING.md
+++ b/crates/wash-cli/CONTRIBUTING.md
@@ -10,6 +10,6 @@ start if you're looking to contribute.
 - [Developing `wash` Rust Development Guide](./docs/DEVELOPMENT.md)
 - [Contributing to the Washboard UI](./washboard/CONTRIBUTING.md)
 
-[0]: https://github.com/wasmcloud/wash/issues/new/choose
-[1]: https://github.com/wasmcloud/wash/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
+[0]: https://github.com/wasmCloud/wasmCloud/issues/new/choose
+[1]: https://github.com/wasmCloud/wasmCloud/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
 [2]: https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

--- a/crates/wash-cli/README.md
+++ b/crates/wash-cli/README.md
@@ -69,10 +69,15 @@ sudo apt install wash
 sudo snap install wash --edge --devmode
 ```
 
+### Linux (brew)
+
+```
+brew install wash
+```
+
 ### MacOS (brew)
 
 ```
-brew tap wasmcloud/wasmcloud
 brew install wash
 ```
 

--- a/crates/wash-cli/README.md
+++ b/crates/wash-cli/README.md
@@ -1,8 +1,8 @@
-[![Latest Release](https://img.shields.io/github/v/release/wasmcloud/wash?color=success&include_prereleases)](https://github.com/wasmCloud/wash/releases)
-[![Rust Build](https://img.shields.io/github/actions/workflow/status/wasmcloud/wash/rust_ci.yml?branch=main)](https://github.com/wasmCloud/wash/actions/workflows/rust_ci.yml)
+[![Latest Release](https://img.shields.io/github/v/release/wasmCloud/wasmCloud?filter=wash*)](https://github.com/wasmCloud/wasmCloud/releases)
+[![Rust Build](https://img.shields.io/github/actions/workflow/status/wasmCloud/wasmCloud/wash.yml?branch=main)](https://github.com/wasmCloud/wasmCloud/actions/workflows/wash.yml)
 [![Rust Version](https://img.shields.io/badge/rustc-1.66.0-orange.svg)](https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html)
-[![Contributors](https://img.shields.io/github/contributors/wasmcloud/wash)](https://github.com/wasmCloud/wash/graphs/contributors)
-[![Good first issues](https://img.shields.io/github/issues/wasmcloud/wash/good%20first%20issue?label=good%20first%20issues)](https://github.com/wasmCloud/wash/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+[![Contributors](https://img.shields.io/github/contributors/wasmCloud/wasmCloud)](https://github.com/wasmCloud/wasmCloud/graphs/contributors)
+[![Good first issues](https://img.shields.io/github/issues/wasmCloud/wasmCloud/good%20first%20issue?label=good%20first%20issues)](https://github.com/wasmCloud/wasmCloud/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+label%3A%22wash-cli%22)
 [![wash-cli](https://img.shields.io/crates/v/wash-cli)](https://crates.io/crates/wash-cli)
 
 ```

--- a/crates/wash-cli/src/completions.rs
+++ b/crates/wash-cli/src/completions.rs
@@ -10,7 +10,8 @@ use wash_lib::cli::CommandOutput;
 use wash_lib::config::cfg_dir;
 
 const TOKEN_FILE: &str = ".completion_suggested";
-const COMPLETION_DOC_URL: &str = "https://github.com/wasmCloud/wash/blob/main/Completions.md";
+const COMPLETION_DOC_URL: &str =
+    "https://github.com/wasmCloud/wasmCloud/blob/main/crates/wash-cli/Completions.md";
 
 fn instructions() -> String {
     format!(

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -1,6 +1,6 @@
 //! A crate that implements the functionality behind the wasmCloud shell
 //!
-//! The `wash` command line interface <https://github.com/wasmcloud/wash> is a great place
+//! The `wash` command line interface <https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-cli> is a great place
 //! to find examples on how to fully utilize this library.
 //!
 //! This library contains a few feature flags, most enabled by default but optional in order to

--- a/crates/wash-lib/src/wait.rs
+++ b/crates/wash-lib/src/wait.rs
@@ -96,7 +96,7 @@ async fn find_event<T>(
             // Should only happen due to an internal failure with the events receiver
             Ok(None) => {
                 return Ok(FindEventOutcome::Failure(anyhow!(
-                    "Channel dropped before event was received, please report this at https://github.com/wasmCloud/wash/issues with details to reproduce"
+                    "Channel dropped before event was received, please report this at https://github.com/wasmCloud/wasmCloud/issues with details to reproduce"
                 )))
             }
 

--- a/examples/golang/actors/http-echo-tinygo/README.md
+++ b/examples/golang/actors/http-echo-tinygo/README.md
@@ -110,7 +110,7 @@ go test -tags e2e
 > Note that the tests use `go`, _not_ `tinygo`, and require `wash` to be installed
 
 [wasmcloud]: https://github.com/wasmCloud/wasmCloud
-[wash]: https://github.com/wasmCloud/wash
+[wash]: https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-cli
 [go]: https://go.dev
 [tinygo]: https://tinygo.org
 [tinygo-toolchain]: https://tinygo.org/getting-started/install/

--- a/washboard-ui/CONTRIBUTING.md
+++ b/washboard-ui/CONTRIBUTING.md
@@ -51,5 +51,5 @@ wash up --nats-websocket-port 4001
 Otherwise, verify the port you are using to connect to the NATS server. Visit [NATS Websocket Configuration][1] for more
 information.
 
-[0]: https://github.com/wasmCloud/wash/blob/a74b50297496578e5e6c0ee806304a3ff05cd073/packages/washboard/src/lattice/lattice-service.ts#L70
+[0]: https://github.com/wasmCloud/wasmCloud/blob/5fbc982aea164a738b9254952ca91b0a5fd3bb82/washboard-ui/src/lattice/lattice-service.ts#L70
 [1]: https://docs.nats.io/running-a-nats-service/configuration/websocket/websocket_conf


### PR DESCRIPTION
## Feature or Problem
Now that the [formula installs from released binaries](https://github.com/wasmCloud/homebrew-wasmcloud/pull/51), it's no longer needed to `tap`

I also updated outdated URLs to wash