### PR TITLE
ci: upload `wash-universal-darwin` binary

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -138,29 +138,23 @@ jobs:
         name: wasmcloud-x86_64-apple-darwin
         path: x86_64
 
-    - run: chmod +x ./x86_64/bin/wash
-    - run: chmod +x ./x86_64/bin/wasmcloud
+    - run: chmod +x ./x86_64/bin/*
     - run: ./x86_64/bin/wash --version
     - run: ./x86_64/bin/wasmcloud --version
 
-    - run: mkdir -p ./wash/bin
-    - run: lipo -create ./aarch64/bin/wash ./x86_64/bin/wash -output ./wash/bin/wash
-    - run: mkdir -p ./wasmcloud/bin
-    - run: lipo -create ./aarch64/bin/wasmcloud ./x86_64/bin/wasmcloud -output ./wasmcloud/bin/wasmcloud
+    - run: mkdir -p ./artifact/bin
+    - run: lipo -create ./aarch64/bin/wash ./x86_64/bin/wash -output ./artifact/bin/wash
+    - run: lipo -create ./aarch64/bin/wasmcloud ./x86_64/bin/wasmcloud -output ./artifact/bin/wasmcloud
 
-    - run: chmod +x ./wash/bin/wash
-    - run: ./wash/bin/wash --version
-    - run: chmod +x ./wasmcloud/bin/wasmcloud
-    - run: ./wasmcloud/bin/wasmcloud --version
+    - run: chmod +x ./artifact/bin/wash
+    - run: ./artifact/bin/wash --version
+    - run: chmod +x ./artifact/bin/wasmcloud
+    - run: ./artifact/bin/wasmcloud --version
 
-    - uses: actions/upload-artifact@v3
-      with:
-        name: wash-universal-darwin
-        path: wash
     - uses: actions/upload-artifact@v3
       with:
         name: wasmcloud-universal-darwin
-        path: wasmcloud
+        path: artifact
 
   test-linux:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Release script expects all artifacts to be located in `wasmcloud-*`, but we were uploading `wash` LIPO into `wash-universal-darwin`. Use `wasmcloud-universal-binary` artifact for both LIPOs, just like for all other binaries.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
