### PR TITLE
feat(wash)!: Removes need for actor/provider/host IDs in almost all cases

### DIFF
--- a/crates/wash-cli/src/common/link_cmd.rs
+++ b/crates/wash-cli/src/common/link_cmd.rs
@@ -7,7 +7,7 @@ use wash_lib::cli::link::{
     LinkQueryCommand,
 };
 use wash_lib::cli::{CommandOutput, OutputKind};
-use wash_lib::id::{validate_contract_id, ModuleId, ServiceId};
+use wash_lib::id::validate_contract_id;
 use wasmcloud_control_interface::LinkDefinition;
 
 use crate::appearance::spinner::Spinner;
@@ -15,10 +15,12 @@ use crate::ctl::{link_del_output, links_table};
 
 /// Generate output for link put command
 pub fn link_put_output(
-    actor_id: &ModuleId,
-    provider_id: &ServiceId,
+    actor_id: impl AsRef<str>,
+    provider_id: impl AsRef<str>,
     failure: Option<String>,
 ) -> Result<CommandOutput> {
+    let actor_id = actor_id.as_ref();
+    let provider_id = provider_id.as_ref();
     match failure {
         None => {
             let mut map = HashMap::new();

--- a/crates/wash-cli/src/common/start_cmd.rs
+++ b/crates/wash-cli/src/common/start_cmd.rs
@@ -88,7 +88,7 @@ mod test {
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(auction_timeout_ms, 2002);
-                assert_eq!(host_id.unwrap(), HOST_ID.parse()?);
+                assert_eq!(host_id.unwrap(), HOST_ID.to_string());
                 assert_eq!(actor_ref, "wasmcloud.azurecr.io/actor:v1".to_string());
                 assert_eq!(constraints.unwrap(), vec!["arch=x86_64".to_string()]);
             }
@@ -136,7 +136,7 @@ mod test {
                 assert_eq!(auction_timeout_ms, 2002);
                 assert_eq!(link_name, "default".to_string());
                 assert_eq!(constraints.unwrap(), vec!["arch=x86_64".to_string()]);
-                assert_eq!(host_id.unwrap(), HOST_ID.parse()?);
+                assert_eq!(host_id.unwrap(), HOST_ID.to_string());
                 assert_eq!(provider_ref, "wasmcloud.azurecr.io/provider:v1".to_string());
                 assert!(skip_wait);
             }

--- a/crates/wash-cli/src/common/stop_cmd.rs
+++ b/crates/wash-cli/src/common/stop_cmd.rs
@@ -71,6 +71,7 @@ mod test {
             "ctl",
             "stop",
             "actor",
+            "--host-id",
             HOST_ID,
             ACTOR_ID,
             "--lattice-prefix",
@@ -110,8 +111,8 @@ mod test {
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert!(skip_wait);
                 assert_eq!(count, 1);
-                assert_eq!(host_id.to_string(), HOST_ID);
-                assert_eq!(actor_id.to_string(), ACTOR_ID,);
+                assert_eq!(host_id.unwrap(), HOST_ID);
+                assert_eq!(actor_id.to_string(), ACTOR_ID);
             }
             cmd => panic!("stop actor constructed incorrect command {cmd:?}"),
         }
@@ -128,10 +129,11 @@ mod test {
             "ctl",
             "stop",
             "provider",
+            "--host-id",
             HOST_ID,
             PROVIDER_ID,
-            LINK_NAME,
             CONTRACT_ID,
+            LINK_NAME,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -166,10 +168,10 @@ mod test {
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(link_name, "default".to_string());
-                assert_eq!(host_id.to_string(), HOST_ID);
+                assert_eq!(host_id.unwrap(), HOST_ID);
                 assert_eq!(contract_id, CONTRACT_ID);
                 assert_eq!(link_name, LINK_NAME);
-                assert_eq!(provider_id.to_string(), PROVIDER_ID,);
+                assert_eq!(provider_id.to_string(), PROVIDER_ID);
                 assert!(skip_wait);
             }
             cmd => panic!("stop provider constructed incorrect command {cmd:?}"),

--- a/crates/wash-cli/src/ctl/mod.rs
+++ b/crates/wash-cli/src/ctl/mod.rs
@@ -181,6 +181,7 @@ mod test {
             "2001",
             "--count",
             "2",
+            "--host-id",
             HOST_ID,
             ACTOR_ID,
         ])?;
@@ -197,10 +198,21 @@ mod test {
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms, 2001);
-                assert_eq!(host_id, HOST_ID.parse()?);
-                assert_eq!(actor_id, ACTOR_ID.parse()?);
+                assert_eq!(host_id, Some(HOST_ID.to_string()));
+                assert_eq!(actor_id, ACTOR_ID);
                 assert_eq!(count, 2);
                 assert!(!skip_wait);
+            }
+            cmd => panic!("ctl stop actor constructed incorrect command {cmd:?}"),
+        }
+        let stop_actor_minimal: Cmd = Parser::try_parse_from(["ctl", "stop", "actor", "foobar"])?;
+        match stop_actor_minimal.command {
+            #[allow(deprecated)]
+            CtlCliCommand::Stop(StopCommand::Actor(StopActorCommand {
+                host_id, actor_id, ..
+            })) => {
+                assert_eq!(host_id, None);
+                assert_eq!(actor_id, "foobar");
             }
             cmd => panic!("ctl stop actor constructed incorrect command {cmd:?}"),
         }
@@ -216,10 +228,11 @@ mod test {
             CTL_PORT,
             "--timeout-ms",
             "2001",
+            "--host-id",
             HOST_ID,
             PROVIDER_ID,
-            "default",
             "wasmcloud:provider",
+            "blahblah",
         ])?;
         match stop_provider_all.command {
             CtlCliCommand::Stop(StopCommand::Provider(StopProviderCommand {
@@ -234,11 +247,28 @@ mod test {
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms, 2001);
-                assert_eq!(host_id, HOST_ID.parse()?);
-                assert_eq!(provider_id, PROVIDER_ID.parse()?);
-                assert_eq!(link_name, "default".to_string());
+                assert_eq!(host_id, Some(HOST_ID.to_string()));
+                assert_eq!(provider_id, PROVIDER_ID);
+                assert_eq!(link_name, "blahblah");
                 assert_eq!(contract_id, "wasmcloud:provider".to_string());
                 assert!(!skip_wait);
+            }
+            cmd => panic!("ctl stop actor constructed incorrect command {cmd:?}"),
+        }
+        let stop_provider_minimal: Cmd =
+            Parser::try_parse_from(["ctl", "stop", "provider", "foobar", "wasmcloud:provider"])?;
+        match stop_provider_minimal.command {
+            CtlCliCommand::Stop(StopCommand::Provider(StopProviderCommand {
+                host_id,
+                provider_id,
+                link_name,
+                contract_id,
+                ..
+            })) => {
+                assert_eq!(host_id, None);
+                assert_eq!(provider_id, "foobar");
+                assert_eq!(link_name, "default");
+                assert_eq!(contract_id, "wasmcloud:provider");
             }
             cmd => panic!("ctl stop actor constructed incorrect command {cmd:?}"),
         }
@@ -349,8 +379,8 @@ mod test {
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms, 2001);
-                assert_eq!(actor_id, ACTOR_ID.parse()?);
-                assert_eq!(provider_id, PROVIDER_ID.parse()?);
+                assert_eq!(actor_id, ACTOR_ID);
+                assert_eq!(provider_id, PROVIDER_ID);
                 assert_eq!(contract_id, "wasmcloud:provider".to_string());
                 assert_eq!(link_name.unwrap(), "default".to_string());
                 assert_eq!(values, vec!["THING=foo".to_string()]);
@@ -369,6 +399,7 @@ mod test {
             CTL_PORT,
             "--timeout-ms",
             "2001",
+            "--host-id",
             HOST_ID,
             ACTOR_ID,
             "wasmcloud.azurecr.io/actor:v2",
@@ -384,8 +415,8 @@ mod test {
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms, 2001);
-                assert_eq!(host_id, HOST_ID.parse()?);
-                assert_eq!(actor_id, ACTOR_ID.parse()?);
+                assert_eq!(host_id, Some(HOST_ID.to_string()));
+                assert_eq!(actor_id, ACTOR_ID);
                 assert_eq!(new_actor_ref, "wasmcloud.azurecr.io/actor:v2".to_string());
             }
             cmd => panic!("ctl get claims constructed incorrect command {cmd:?}"),
@@ -423,7 +454,7 @@ mod test {
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert_eq!(opts.timeout_ms, 2001);
-                assert_eq!(host_id, HOST_ID.parse()?);
+                assert_eq!(host_id, HOST_ID);
                 assert_eq!(actor_ref, "wasmcloud.azurecr.io/actor:v2".to_string());
                 assert_eq!(max_concurrent, Some(1));
                 assert_eq!(annotations, vec!["foo=bar".to_string()]);

--- a/crates/wash-cli/src/ctl/output.rs
+++ b/crates/wash-cli/src/ctl/output.rs
@@ -8,7 +8,6 @@ use term_table::{
     Table,
 };
 use wash_lib::cli::CommandOutput;
-use wash_lib::id::ModuleId;
 use wasmcloud_control_interface::{Host, HostInventory, LinkDefinition};
 
 use crate::util::format_optional;
@@ -32,7 +31,7 @@ pub fn get_claims_output(claims: Vec<HashMap<String, String>>) -> CommandOutput 
 }
 
 pub fn link_del_output(
-    actor_id: &ModuleId,
+    actor_id: &str,
     contract_id: &str,
     link_name: &str,
     failure: Option<String>,

--- a/crates/wash-cli/tests/wash_start.rs
+++ b/crates/wash-cli/tests/wash_start.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use std::process::Stdio;
+
 use common::{TestWashInstance, ECHO_OCI_REF, PROVIDER_HTTPSERVER_OCI_REF};
 
 use anyhow::{Context, Result};
@@ -13,7 +15,7 @@ use wash_lib::cli::output::StartCommandOutput;
     not(can_reach_wasmcloud_azurecr_io),
     ignore = "wasmcloud.azurecr.io is not reachable"
 )]
-async fn integration_start_actor_serial() -> Result<()> {
+async fn integration_start_stop_actor_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
@@ -39,12 +41,35 @@ async fn integration_start_actor_serial() -> Result<()> {
         serde_json::from_slice(&output.stdout).context("failed to parse output")?;
     assert!(cmd_output.success, "command returned success");
 
+    // Test stopping using only aliases, yes I know this mixes stop and start, but saves on copied
+    // code
+    let status = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args([
+            "stop",
+            "actor",
+            "echo",
+            "--output",
+            "json",
+            "--timeout-ms",
+            "40000",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
+        ])
+        .kill_on_drop(true)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .context("failed to start actor")?;
+
+    assert!(status.success(), "Sucessfully stopped actor");
+
     Ok(())
 }
 
 #[tokio::test]
 #[serial]
-async fn integration_start_provider_serial() -> Result<()> {
+async fn integration_start_stop_provider_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
@@ -69,6 +94,30 @@ async fn integration_start_provider_serial() -> Result<()> {
     let cmd_output: StartCommandOutput =
         serde_json::from_slice(&output.stdout).context("failed to parse output")?;
     assert!(cmd_output.success, "command returned success");
+
+    // Test stopping using only aliases, yes I know this mixes stop and start, but saves on copied
+    // code
+    let status = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args([
+            "stop",
+            "provider",
+            "server",
+            "wasmcloud:httpserver",
+            "--output",
+            "json",
+            "--timeout-ms",
+            "40000",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
+        ])
+        .kill_on_drop(true)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .context("failed to start actor")?;
+
+    assert!(status.success(), "Sucessfully stopped provider");
 
     Ok(())
 }

--- a/crates/wash-cli/tests/wash_stop.rs
+++ b/crates/wash-cli/tests/wash_stop.rs
@@ -52,6 +52,7 @@ async fn integration_stop_actor_serial() -> Result<()> {
         .args([
             "stop",
             "actor",
+            "--host-id",
             &host_id,
             &actor_id,
             "--output",
@@ -119,10 +120,11 @@ async fn integration_stop_provider_serial() -> Result<()> {
         .args([
             "stop",
             "provider",
+            "--host-id",
             &host_id,
             &provider_id,
-            &link_name,
             &contract_id,
+            &link_name,
             "--output",
             "json",
             "--ctl-port",

--- a/crates/wash-cli/tests/wash_update.rs
+++ b/crates/wash-cli/tests/wash_update.rs
@@ -90,6 +90,7 @@ async fn integration_update_actor_serial() -> Result<()> {
         .args([
             "update",
             "actor",
+            "--host-id",
             wash_instance.host_id.as_str(),
             ECHO_ACTOR_ID,
             ECHO_OCI_REF,

--- a/crates/wash-lib/src/cli/stop.rs
+++ b/crates/wash-lib/src/cli/stop.rs
@@ -2,14 +2,18 @@ use anyhow::{bail, Result};
 use clap::Parser;
 use std::collections::HashMap;
 use tokio::time::Duration;
+use wasmcloud_control_interface::HostInventory;
 
 use crate::{
     actor::stop_actor,
     cli::{CliConnectionOpts, CommandOutput},
-    common::boxed_err_to_anyhow,
+    common::{
+        boxed_err_to_anyhow, find_actor_id, find_host_id, find_provider_id, get_all_inventories,
+        FindIdError, Match,
+    },
     config::WashConnectionOptions,
     context::default_timeout_ms,
-    id::{validate_contract_id, ModuleId, ServerId, ServiceId},
+    id::{validate_contract_id, ServerId},
     wait::{wait_for_provider_stop_event, ActorStoppedInfo, FindEventOutcome, ProviderStoppedInfo},
 };
 
@@ -33,13 +37,19 @@ pub struct StopActorCommand {
     #[clap(flatten)]
     pub opts: CliConnectionOpts,
 
-    /// Id of host
-    #[clap(name = "host-id", value_parser)]
-    pub host_id: ServerId,
+    /// Id of host to stop actor on. If a non-ID is provided, the host will be selected based
+    /// on matching the prefix of the ID or the friendly name and will return an error if more than
+    /// one host matches. If no host ID is passed, a host will be selected based on whether or not
+    /// the actor is running on it. If more than 1 host is running this actor, an error will be
+    /// returned with a list of hosts running the actor
+    #[clap(long = "host-id")]
+    pub host_id: Option<String>,
 
-    /// Actor Id, e.g. the public key for the actor
-    #[clap(name = "actor-id", value_parser)]
-    pub actor_id: ModuleId,
+    /// Actor Id (e.g. the public key for the actor) or a string to match on the prefix of the ID,
+    /// or friendly name, or call alias of the actor. If multiple actors are matched, then an error
+    /// will be returned with a list of all matching options
+    #[clap(name = "actor-id")]
+    pub actor_id: String,
 
     /// Number of actors to stop (DEPRECATED: count is ignored)
     #[clap(long = "count", default_value = "1")]
@@ -60,24 +70,33 @@ pub struct StopProviderCommand {
     #[clap(flatten)]
     pub opts: CliConnectionOpts,
 
-    /// Id of host
-    #[clap(name = "host-id", value_parser)]
-    pub host_id: ServerId,
+    /// Id of host to stop provider on. If a non-ID is provided, the host will be selected based on
+    /// matching the prefix of the ID or the friendly name and will return an error if more than one
+    /// host matches. If no host ID is passed, a host will be selected based on whether or not the
+    /// actor is running on it. If more than 1 host is running this actor, an error will be returned
+    /// with a list of hosts running the actor
+    #[clap(long = "host-id")]
+    pub host_id: Option<String>,
 
-    /// Provider Id, e.g. the public key for the provider
-    #[clap(name = "provider-id", value_parser)]
-    pub provider_id: ServiceId,
+    /// Provider Id (e.g. the public key for the provider) or a string to match on the prefix of the
+    /// ID, or friendly name, or call alias of the provider. If multiple providers are matched, then
+    /// an error will be returned with a list of all matching options
+    #[clap(name = "provider-id")]
+    pub provider_id: String,
 
-    /// Link name of provider
-    #[clap(name = "link-name")]
-    pub link_name: String,
-
-    /// Capability contract Id of provider
+    /// Capability contract Id of provider.
     #[clap(name = "contract-id")]
     pub contract_id: String,
 
-    /// By default, the command will wait until the provider has been stopped.
-    /// If this flag is passed, the command will return immediately after acknowledgement from the host, without waiting for the provider to stop.
+    // NOTE(thomastaylor312): Since this is a positional argument and is optional, it has to be the
+    // last one
+    /// Link name of provider. If none is provided, it will default to "default"
+    #[clap(name = "link-name", default_value = "default")]
+    pub link_name: String,
+
+    /// By default, the command will wait until the provider has been stopped. If this flag is
+    /// passed, the command will return immediately after acknowledgement from the host, without
+    /// waiting for the provider to stop.
     #[clap(long = "skip-wait")]
     pub skip_wait: bool,
 }
@@ -87,9 +106,11 @@ pub struct StopHostCommand {
     #[clap(flatten)]
     pub opts: CliConnectionOpts,
 
-    /// Id of host
-    #[clap(name = "host-id", value_parser)]
-    pub host_id: ServerId,
+    /// Id of host to stop. If a non-ID is provided, the host will be selected based on matching the
+    /// prefix of the ID or the friendly name and will return an error if more than one host
+    /// matches.
+    #[clap(name = "host-id")]
+    pub host_id: String,
 
     /// The timeout in ms for how much time to give the host for graceful shutdown
     #[clap(
@@ -110,10 +131,17 @@ pub async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOutput> {
         .await
         .map_err(boxed_err_to_anyhow)?;
 
+    let (provider_id, friendly_name) = find_provider_id(&cmd.provider_id, &client).await?;
+    let host_id = if let Some(host_id) = cmd.host_id {
+        find_host_id(&host_id, &client).await?.0
+    } else {
+        find_host_with_provider(&provider_id, &client).await?
+    };
+
     let ack = client
         .stop_provider(
-            &cmd.host_id,
-            &cmd.provider_id,
+            &host_id,
+            &provider_id,
             &cmd.link_name,
             &cmd.contract_id,
             None,
@@ -125,15 +153,18 @@ pub async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOutput> {
         bail!("Operation failed: {}", ack.error);
     }
     if cmd.skip_wait {
-        let text = format!("Provider {} stop request received", cmd.provider_id);
+        let text = format!(
+            "Provider {} stop request received",
+            friendly_name.as_deref().unwrap_or(provider_id.as_ref())
+        );
         return Ok(CommandOutput::new(
             text.clone(),
             HashMap::from([
                 ("result".into(), text.into()),
-                ("provider_id".into(), cmd.provider_id.to_string().into()),
+                ("provider_id".into(), provider_id.to_string().into()),
                 ("link_name".into(), cmd.link_name.into()),
                 ("contract_id".into(), cmd.contract_id.into()),
-                ("host_id".into(), cmd.host_id.to_string().into()),
+                ("host_id".into(), host_id.to_string().into()),
             ]),
         ));
     }
@@ -141,8 +172,8 @@ pub async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOutput> {
     let event = wait_for_provider_stop_event(
         &mut receiver,
         Duration::from_millis(timeout_ms),
-        cmd.host_id.to_string(),
-        cmd.provider_id.to_string(),
+        host_id.to_string(),
+        provider_id.to_string(),
     )
     .await?;
 
@@ -153,7 +184,10 @@ pub async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOutput> {
             link_name,
             contract_id,
         }) => {
-            let text = format!("Provider [{}] stopped successfully", &provider_id);
+            let text = format!(
+                "Provider [{}] stopped successfully",
+                friendly_name.as_deref().unwrap_or(provider_id.as_ref())
+            );
             Ok(CommandOutput::new(
                 text.clone(),
                 HashMap::from([
@@ -174,10 +208,18 @@ pub async fn handle_stop_actor(cmd: StopActorCommand) -> Result<CommandOutput> {
     let wco: WashConnectionOptions = cmd.opts.try_into()?;
     let client = wco.into_ctl_client(None).await?;
 
+    let (actor_id, friendly_name) = find_actor_id(&cmd.actor_id, &client).await?;
+
+    let host_id = if let Some(host_id) = cmd.host_id {
+        find_host_id(&host_id, &client).await?.0
+    } else {
+        find_host_with_actor(&actor_id, &client).await?
+    };
+
     let ActorStoppedInfo { actor_id, host_id } = stop_actor(
         &client,
-        &cmd.host_id,
-        &cmd.actor_id,
+        &host_id,
+        &actor_id,
         None,
         timeout_ms,
         cmd.skip_wait,
@@ -185,9 +227,15 @@ pub async fn handle_stop_actor(cmd: StopActorCommand) -> Result<CommandOutput> {
     .await?;
 
     let text = if cmd.skip_wait {
-        format!("Request to stop actor {} received", &actor_id)
+        format!(
+            "Request to stop actor {} received",
+            friendly_name.as_deref().unwrap_or(actor_id.as_ref())
+        )
     } else {
-        format!("Actor [{}] stopped", &actor_id)
+        format!(
+            "Actor [{}] stopped",
+            friendly_name.as_deref().unwrap_or(actor_id.as_ref())
+        )
     };
 
     Ok(CommandOutput::new(
@@ -216,4 +264,63 @@ pub async fn stop_host(cmd: StopHostCommand) -> Result<CommandOutput> {
         "result",
         format!("Host {} acknowledged stop request", cmd.host_id),
     ))
+}
+
+async fn find_host_with_provider(
+    provider_id: &str,
+    ctl_client: &wasmcloud_control_interface::Client,
+) -> Result<ServerId, FindIdError> {
+    find_host_with_filter(ctl_client, |inv| {
+        inv.providers
+            .into_iter()
+            .any(|prov| prov.id == provider_id)
+            .then_some((inv.host_id, inv.friendly_name))
+            .and_then(|(id, friendly_name)| id.parse().ok().map(|i| (i, friendly_name)))
+    })
+    .await
+}
+
+pub(crate) async fn find_host_with_actor(
+    actor_id: &str,
+    ctl_client: &wasmcloud_control_interface::Client,
+) -> Result<ServerId, FindIdError> {
+    find_host_with_filter(ctl_client, |inv| {
+        inv.actors
+            .into_iter()
+            .any(|actor| actor.id == actor_id)
+            .then_some((inv.host_id, inv.friendly_name))
+            .and_then(|(id, friendly_name)| id.parse().ok().map(|i| (i, friendly_name)))
+    })
+    .await
+}
+
+async fn find_host_with_filter<F>(
+    ctl_client: &wasmcloud_control_interface::Client,
+    filter: F,
+) -> Result<ServerId, FindIdError>
+where
+    F: FnMut(HostInventory) -> Option<(ServerId, String)>,
+{
+    let inventories = get_all_inventories(ctl_client).await?;
+    let all_matching = inventories
+        .into_iter()
+        .filter_map(filter)
+        .collect::<Vec<(ServerId, String)>>();
+
+    if all_matching.is_empty() {
+        Err(FindIdError::NoMatches)
+    } else if all_matching.len() > 1 {
+        Err(FindIdError::MultipleMatches(
+            all_matching
+                .into_iter()
+                .map(|(id, friendly_name)| Match {
+                    id: id.into_string(),
+                    friendly_name: Some(friendly_name),
+                })
+                .collect(),
+        ))
+    } else {
+        // SAFETY: We know there is exactly one match at this point
+        Ok(all_matching.into_iter().next().unwrap().0)
+    }
 }

--- a/crates/wash-lib/src/cli/update.rs
+++ b/crates/wash-lib/src/cli/update.rs
@@ -3,8 +3,8 @@ use clap::Parser;
 
 use crate::{
     actor::update_actor,
+    common::{find_actor_id, find_host_id},
     config::WashConnectionOptions,
-    id::{ModuleId, ServerId},
 };
 
 use super::{CliConnectionOpts, CommandOutput};
@@ -21,13 +21,19 @@ pub struct UpdateActorCommand {
     #[clap(flatten)]
     pub opts: CliConnectionOpts,
 
-    /// Id of host
-    #[clap(name = "host-id", value_parser)]
-    pub host_id: ServerId,
+    /// ID of host to update the actor on. If a non-ID is provided, the host will be selected based
+    /// on matching the prefix of the ID or the friendly name and will return an error if more than
+    /// one host matches. If no host ID is passed, a host will be selected based on whether or not
+    /// the actor is running on it. If more than 1 host is running this actor, an error will be
+    /// returned with a list of hosts running the actor
+    #[clap(long = "host-id")]
+    pub host_id: Option<String>,
 
-    /// Actor Id, e.g. the public key for the actor
-    #[clap(name = "actor-id", value_parser)]
-    pub actor_id: ModuleId,
+    /// Actor Id (e.g. the public key for the actor) or a string to match on the friendly name or
+    /// call alias of the actor. If multiple actors are matched, then an error will be returned with
+    /// a list of all matching options
+    #[clap(name = "actor-id")]
+    pub actor_id: String,
 
     /// Actor reference, e.g. the OCI URL for the actor.
     #[clap(name = "new-actor-ref")]
@@ -38,13 +44,25 @@ pub async fn handle_update_actor(cmd: UpdateActorCommand) -> Result<CommandOutpu
     let wco: WashConnectionOptions = cmd.opts.try_into()?;
     let client = wco.into_ctl_client(None).await?;
 
-    let ack = update_actor(&client, &cmd.host_id, &cmd.actor_id, &cmd.new_actor_ref).await?;
+    let (actor_id, friendly_name) = find_actor_id(&cmd.actor_id, &client).await?;
+
+    let host_id = if let Some(host_id) = cmd.host_id {
+        find_host_id(&host_id, &client).await?.0
+    } else {
+        super::stop::find_host_with_actor(&actor_id, &client).await?
+    };
+
+    let ack = update_actor(&client, &host_id, &actor_id, &cmd.new_actor_ref).await?;
     if !ack.accepted {
         bail!("Operation failed: {}", ack.error);
     }
 
     Ok(CommandOutput::from_key_and_text(
         "result",
-        format!("Actor {} updated to {}", cmd.actor_id, cmd.new_actor_ref),
+        format!(
+            "Actor {} updated to {}",
+            friendly_name.as_deref().unwrap_or(actor_id.as_ref()),
+            cmd.new_actor_ref
+        ),
     ))
 }

--- a/crates/wash-lib/src/common.rs
+++ b/crates/wash-lib/src/common.rs
@@ -1,6 +1,12 @@
-use std::str::FromStr;
+use std::{
+    fmt::{Debug, Display},
+    str::FromStr,
+};
 
-use crate::id::ModuleId;
+use anyhow::Context;
+use wasmcloud_control_interface::HostInventory;
+
+use crate::id::{ModuleId, ServerId, ServiceId};
 
 const CLAIMS_CALL_ALIAS: &str = "call_alias";
 pub(crate) const CLAIMS_NAME: &str = "name";
@@ -8,57 +14,112 @@ pub(crate) const CLAIMS_SUBJECT: &str = "sub";
 
 /// Converts error from Send + Sync error to standard anyhow error
 pub(crate) fn boxed_err_to_anyhow(e: Box<dyn ::std::error::Error + Send + Sync>) -> anyhow::Error {
-    anyhow::anyhow!(e.to_string())
+    anyhow::anyhow!(e)
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum FindIdError {
     /// No matches were found
-    #[error("No actor found with the search term")]
+    #[error("No matches found with the provided search term")]
     NoMatches,
-    /// Multiple matches were found. The vector contains the list of actors that matched
-    #[error("Multiple actors found with the search term: {0:?}")]
-    MultipleMatches(Vec<String>),
+    /// Multiple matches were found. The vector contains the list of actors or providers that
+    /// matched
+    #[error("Multiple matches found with the provided search term: {0:?}")]
+    MultipleMatches(Vec<Match>),
     #[error(transparent)]
     Error(#[from] anyhow::Error),
 }
 
-/// Given a string, attempts to resolve an actor ID. Returning the actor ID and an optional friendly name
+/// Represents a single match against a search term
+#[derive(Clone)]
+pub struct Match {
+    pub id: String,
+    pub friendly_name: Option<String>,
+}
+
+impl Display for Match {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(friendly_name) = &self.friendly_name {
+            write!(f, "{} ({friendly_name})", self.id)
+        } else {
+            write!(f, "{}", self.id)
+        }
+    }
+}
+
+impl Debug for Match {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self, f)
+    }
+}
+
+/// Given a string, attempts to resolve an actor ID. Returning the actor ID and an optional friendly
+/// name
 ///
-/// If the string is a valid actor ID, it will be returned unchanged. Resolution works by checking
-/// if the actor_name or call_alias fields from the actor's claims contains the given string. If
-/// more than one matches, then an error will be returned indicating the options to choose from
+/// If the string is a valid actor ID, it will be returned unchanged. If it is not an ID, it will
+/// attempt to resolve an ID in the following order:
+///
+/// 1. The value matches the prefix of the ID of an actor
+/// 2. The value is contained in the call alias of an actor
+/// 3. The value is contained in the name field of an actor
+///
+/// If more than one matches, then an error will be returned indicating the options to choose from
 pub async fn find_actor_id(
     value: &str,
     ctl_client: &wasmcloud_control_interface::Client,
 ) -> Result<(ModuleId, Option<String>), FindIdError> {
-    if let Ok(id) = ModuleId::from_str(value) {
+    find_id_matches(value, ctl_client).await
+}
+
+/// Given a string, attempts to resolve an provider ID. Returning the provider ID and an optional
+/// friendly name
+///
+/// If the string is a valid provider ID, it will be returned unchanged. If it is not an ID, it will
+/// attempt to resolve an ID in the following order:
+///
+/// 1. The value matches the prefix of the ID of a provider
+/// 2. The value is contained in the name field of a provider
+///
+/// If more than one matches, then an error will be returned indicating the options to choose from
+pub async fn find_provider_id(
+    value: &str,
+    ctl_client: &wasmcloud_control_interface::Client,
+) -> Result<(ServiceId, Option<String>), FindIdError> {
+    find_id_matches(value, ctl_client).await
+}
+
+async fn find_id_matches<T: FromStr + ToString + Display>(
+    value: &str,
+    ctl_client: &wasmcloud_control_interface::Client,
+) -> Result<(T, Option<String>), FindIdError> {
+    if let Ok(id) = T::from_str(value) {
         return Ok((id, None));
     }
-
     // Case insensitive searching here to make things nicer
     let value = value.to_lowercase();
     // If it wasn't an ID, get the claims
     let claims = ctl_client
         .get_claims()
         .await
-        .map_err(|e| FindIdError::Error(anyhow::anyhow!("Unable to get claims: {}", e)))?;
+        .map_err(boxed_err_to_anyhow)
+        .context("unable to get claims for lookup")?;
     let all_matches = claims
         .iter()
         .filter_map(|v| {
-            let id = v
+            let id_str = v
                 .get(CLAIMS_SUBJECT)
                 .map(|s| s.as_str())
                 .unwrap_or_default();
-            // If it isn't a module, just skip
-            let id = match ModuleId::from_str(id) {
+            // If it doesn't parse to our type, just skip
+            let id = match T::from_str(id_str) {
                 Ok(id) => id,
                 Err(_) => return None,
             };
-            (v.get(CLAIMS_CALL_ALIAS)
-                .map(|s| s.to_lowercase())
-                .unwrap_or_default()
-                .contains(&value)
+            (id_str.to_lowercase().starts_with(&value)
+                || v.get(CLAIMS_CALL_ALIAS)
+                    .map(|s| s.to_lowercase())
+                    .unwrap_or_default()
+                    .contains(&value)
                 || v.get(CLAIMS_NAME)
                     .map(|s| s.to_ascii_lowercase())
                     .unwrap_or_default()
@@ -66,18 +127,16 @@ pub async fn find_actor_id(
             .then(|| (id, v.get(CLAIMS_NAME).map(|s| s.to_string())))
         })
         .collect::<Vec<_>>();
+
     if all_matches.is_empty() {
         Err(FindIdError::NoMatches)
     } else if all_matches.len() > 1 {
         Err(FindIdError::MultipleMatches(
             all_matches
                 .into_iter()
-                .map(|(id, friendly_name)| {
-                    if let Some(name) = friendly_name {
-                        format!("{} ({})", id, name)
-                    } else {
-                        id.into_string()
-                    }
+                .map(|(id, friendly_name)| Match {
+                    id: id.to_string(),
+                    friendly_name,
                 })
                 .collect(),
         ))
@@ -85,4 +144,87 @@ pub async fn find_actor_id(
         // SAFETY: We know we have exactly one match at this point
         Ok(all_matches.into_iter().next().unwrap())
     }
+}
+
+/// Given a string, attempts to resolve a host ID. Returning the host ID and its friendly name.
+///
+/// If the string is a valid host ID, it will be returned unchanged. If it is not an ID, it will
+/// attempt to resolve an ID in the following order:
+///
+/// 1. The value matches the prefix of the ID of a host
+/// 2. The value is contained in the friendly name field of a host
+///
+/// If more than one matches, then an error will be returned indicating the options to choose from
+pub async fn find_host_id(
+    value: &str,
+    ctl_client: &wasmcloud_control_interface::Client,
+) -> Result<(ServerId, String), FindIdError> {
+    if let Ok(id) = ServerId::from_str(value) {
+        return Ok((id, String::new()));
+    }
+
+    // Case insensitive searching here to make things nicer
+    let value = value.to_lowercase();
+
+    let hosts = ctl_client
+        .get_hosts()
+        .await
+        .map_err(boxed_err_to_anyhow)
+        .context("unable to fetch hosts for lookup")?;
+
+    let all_matches = hosts
+        .into_iter()
+        .filter_map(|h| {
+            if h.id.to_lowercase().starts_with(&value)
+                || h.friendly_name.to_lowercase().contains(&value)
+            {
+                ServerId::from_str(&h.id)
+                    .ok()
+                    .map(|id| (id, h.friendly_name))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if all_matches.is_empty() {
+        Err(FindIdError::NoMatches)
+    } else if all_matches.len() > 1 {
+        Err(FindIdError::MultipleMatches(
+            all_matches
+                .into_iter()
+                .map(|(id, friendly_name)| Match {
+                    id: id.to_string(),
+                    friendly_name: Some(friendly_name),
+                })
+                .collect(),
+        ))
+    } else {
+        // SAFETY: We know we have exactly one match at this point
+        Ok(all_matches.into_iter().next().unwrap())
+    }
+}
+
+pub async fn get_all_inventories(
+    client: &wasmcloud_control_interface::Client,
+) -> anyhow::Result<Vec<HostInventory>> {
+    let hosts = client.get_hosts().await.map_err(boxed_err_to_anyhow)?;
+    let host_ids = match hosts.len() {
+        0 => return Ok(Vec::with_capacity(0)),
+        _ => hosts.into_iter().map(|h| h.id),
+    };
+
+    let futs =
+        host_ids
+            .map(|host_id| (client.clone(), host_id))
+            .map(|(client, host_id)| async move {
+                client
+                    .get_host_inventory(&host_id)
+                    .await
+                    .map_err(boxed_err_to_anyhow)
+            });
+    futures::future::join_all(futs)
+        .await
+        .into_iter()
+        .collect::<anyhow::Result<Vec<HostInventory>>>()
 }


### PR DESCRIPTION
This is something that has been bugging me for a while. It has been such a pain to look up and copy paste all the proper IDs to run various wash commands.

This PR is a breaking change for several commands (like stop provider, which reorders some things and most other commands requiring a host ID now have that as an optional flag) and makes it so you can pass a string that it will attempt to match on to find IDs

## Release Information

vNext

## Consumer Impact

Namely the structure of many of the commands have changed, but since everything requires less, I think this is fine

## Testing

I added a few more tests in places where we already had some and then manually verified the rest

### Manual Verification

```
./target/debug/wash link put echo 'http server' wasmcloud:httpserver 'ADDRESS=0.0.0.0:8080'

Published link (echo) <-> (http server) successfully
```

After starting httpclient:

```
./target/debug/wash link put echo http wasmcloud:httpserver 'ADDRESS=0.0.0.0:8080'

Error advertising link: Multiple matches found with the provided search term: [VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M (HTTP Server), VCCVLH4XWGI3SGARFNYKYT2A32SUYA2KVAIV2U2Q34DQA7WWJPFRKIKM (HTTP Client)]
```

Other examples of the updated commands:

```
./target/debug/wash stop actor echo

Actor [Echo] stopped
```

```
./target/debug/wash stop provider VCCVL wasmcloud:httpclient

Provider [HTTP Client] stopped successfully
```

```
./target/debug/wash link del echo wasmcloud:httpserver

Deleted link for echo on wasmcloud:httpserver (default) successfully
```

```
./target/debug/wash stop provider --host-id dark-sun client wasmcloud:httpclient

Provider [HTTP Client] stopped successfully
```

I also tested that passing in IDs everywhere also worked