### PR TITLE
fix(ci): make dry-run publish failures visible

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -539,7 +539,6 @@ jobs:
 
     - name: dry-run publish ${{ matrix.crate }} to crates.io
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      continue-on-error: ${{ matrix.workspace-dependencies }} # publish may fail due to workspace crates not being published yet
       run: cargo publish --dry-run
       working-directory: ./crates/${{ matrix.crate }}
 


### PR DESCRIPTION
## Feature or Problem
We've had a couple instances where we fail to publish a crate, or after it's published, users cannot install it, because a downstream dependency had a breaking change. Since the dry-run step is not currently required to merge, it's okay to let it fail, and this should help make failures much more visible
