### PR TITLE
build: pin control interface version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ wasmcloud-actor = { version = "0", path = "./crates/actor", default-features = f
 wasmcloud-actor-macros = { version = "0", path = "./crates/actor/macros", default-features = false }
 wasmcloud-compat = { version = "0", path = "./crates/compat", default-features = false }
 wasmcloud-component-adapters = { version = "0.3", default-features = false }
-wasmcloud-control-interface = { version = "0", path = "./crates/control-interface", default-features = false }
+wasmcloud-control-interface = { version = "0.32", path = "./crates/control-interface", default-features = false }
 wasmcloud-core = { version = "0", path = "./crates/core", default-features = false }
 wasmcloud-host = { version = "0", path = "./crates/host", default-features = false }
 wasmcloud-provider-sdk = { version = "0", path = "./crates/provider-sdk", default-features = false }

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -2379,9 +2379,9 @@ checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.36.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ae0be20bf87918df4fa831bfbbd0b491d24aee407ed86360eae4c2c5608d38"
+checksum = "7d135e8940b69dbee0f5b0a0be9c1cd6fa8b71d774904c13a3fcfc5dc265e43d"
 dependencies = [
  "leb128",
 ]


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

It appears that this may prevent #1038 from happening in the future by enforcing that the same version of control interface is used as during publish.
Note, that this likely will block releases of `wash-cli` including control interface updates on `wadm` updates (which would be a good thing)

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
