### PR TITLE
release(wash-lib): v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.14.0"
+version = "0.15.0"
 categories = ["wasm", "wasmcloud"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]


### PR DESCRIPTION
## Feature or Problem
https://github.com/wasmCloud/wasmCloud/pull/1049 bumped wash-cli, but wash-lib v0.14 still uses async-nats v0.31, so we need a minor bump here as well