### PR TITLE
chore(core)!: bump to 0.2.0 for async-nats release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ wasmcloud-actor-macros = { version = "0", path = "./crates/actor/macros", defaul
 wasmcloud-compat = { version = "0.1", path = "./crates/compat", default-features = false }
 wasmcloud-component-adapters = { version = "0.3", default-features = false }
 wasmcloud-control-interface = { version = "0.32", path = "./crates/control-interface", default-features = false }
-wasmcloud-core = { version = "0.1", path = "./crates/core", default-features = false }
+wasmcloud-core = { version = "0.2", path = "./crates/core", default-features = false }
 wasmcloud-host = { version = "0", path = "./crates/host", default-features = false }
 wasmcloud-provider-sdk = { version = "0.2", path = "./crates/provider-sdk", default-features = false }
 wasmcloud-provider-wit-bindgen = { version = "0.1", path = "./crates/provider-wit-bindgen", default-features = false }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-core"
-version = "0.1.0"
+version = "0.2.0"
 description = "wasmCloud core functionality shared throughout the ecosystem"
 
 authors.workspace = true


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
This PR bumps wasmcloud-core for 0.2.0 release in order to fix transitive conflicting NATS dependencies.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wasmcloud-core 0.2.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
