### PR TITLE
[FEATURE] support for registry config in wasmcloud.toml 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,6 +5197,7 @@ dependencies = [
  "bytes",
  "cloudevents-sdk",
  "futures",
+ "oci-distribution",
  "opentelemetry",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5193,6 +5193,7 @@ dependencies = [
 name = "wasmcloud-control-interface"
 version = "0.32.0"
 dependencies = [
+ "anyhow",
  "async-nats",
  "bytes",
  "cloudevents-sdk",

--- a/crates/control-interface/Cargo.toml
+++ b/crates/control-interface/Cargo.toml
@@ -25,3 +25,4 @@ tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"] }
+anyhow = { workspace = true }

--- a/crates/control-interface/Cargo.toml
+++ b/crates/control-interface/Cargo.toml
@@ -24,3 +24,4 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+oci-distribution = { workspace = true, features = ["rustls-tls"] }

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -237,6 +237,37 @@ pub struct RegistryCredential {
     pub registry_type: String,
 }
 
+impl RegistryCredential {
+    #[must_use]
+    pub fn as_oci_registry_auth(&self) -> Option<oci_distribution::secrets::RegistryAuth> {
+        if self.registry_type != "oci" {
+            return None;
+        }
+
+        match self {
+            RegistryCredential {
+                username: Some(username),
+                password: Some(password),
+                ..
+            } => Some(oci_distribution::secrets::RegistryAuth::Basic(
+                username.clone(),
+                password.clone(),
+            )),
+
+            RegistryCredential {
+                username: Some(username),
+                password: None,
+                token: Some(token),
+                ..
+            } => Some(oci_distribution::secrets::RegistryAuth::Basic(
+                username.clone(),
+                token.clone(),
+            )),
+            _ => None,
+        }
+    }
+}
+
 fn default_registry_type() -> String {
     "oci".to_string()
 }

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -233,8 +233,12 @@ pub struct RegistryCredential {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
     /// The type of the registry (only "oci" is supported at this time")
-    #[serde(rename = "registryType")]
+    #[serde(rename = "registryType", default = "default_registry_type")]
     pub registry_type: String,
+}
+
+fn default_registry_type() -> String {
+    "oci".to_string()
 }
 
 /// A set of credentials to be used for fetching from specific registries

--- a/crates/wash-cli/src/common/registry_cmd.rs
+++ b/crates/wash-cli/src/common/registry_cmd.rs
@@ -4,6 +4,7 @@ use anyhow::{bail, Context, Result};
 use log::warn;
 use oci_distribution::{
     client::{Client, ClientConfig, ClientProtocol},
+    secrets::RegistryAuth,
     Reference,
 };
 use serde_json::json;
@@ -92,7 +93,7 @@ pub async fn registry_ping(cmd: RegistryPingCommand) -> Result<CommandOutput> {
         _ => resolve_registry_credentials(image.registry()).await,
     }?;
 
-    let Some(credentials) = credentials.as_oci_registry_auth() else {
+    let Ok(credentials) = RegistryAuth::try_from(&credentials) else {
         bail!("failed to resolve registry credentials")
     };
 

--- a/crates/wash-cli/tests/common/mod.rs
+++ b/crates/wash-cli/tests/common/mod.rs
@@ -78,6 +78,21 @@ pub fn test_dir_file(subfolder: &str, file: &str) -> PathBuf {
 }
 
 #[allow(unused)]
+/// writes content to specified file path... creates file if it doesn't exist
+pub async fn set_test_file_content(path: &PathBuf, content: &str) -> Result<()> {
+    let mut file = File::create(path).await.context(format!(
+        "failed to open/create test file {}",
+        path.to_string_lossy()
+    ))?;
+
+    file.write_all(content.as_bytes()).await.context(format!(
+        "failed to write content to test file {}",
+        path.to_string_lossy()
+    ))?;
+    Ok(())
+}
+
+#[allow(unused)]
 pub async fn start_nats(port: u16, nats_install_dir: &PathBuf) -> Result<Child> {
     let nats_binary = ensure_nats_server("v2.8.4", nats_install_dir).await?;
     let config = NatsConfig::new_standalone("127.0.0.1", port, None);

--- a/crates/wash-cli/tests/wash_reg.rs
+++ b/crates/wash-cli/tests/wash_reg.rs
@@ -245,7 +245,7 @@ fn integration_reg_push_comprehensive() {
     not(can_reach_wasmcloud_azurecr_io),
     ignore = "wasmcloud.azurecr.io is not reachable"
 )]
-async fn intergration_reg_config() -> Result<()> {
+async fn integration_reg_config() -> Result<()> {
     //===== Inital project setup and build actor artifact
     let test_setup = init(
         /* actor_name= */ "hello", /* template_name= */ "hello",

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -577,6 +577,7 @@ mod tests {
     use wascap::{jwt::Token, wasm::extract_claims};
     use wasmparser::{Parser, Payload};
 
+    use crate::parser::RegistryConfig;
     use crate::{
         build::{embed_wasm_component_metadata, WASMCLOUD_WASM_TAG_EXPERIMENTAL},
         parser::{ActorConfig, CommonConfig, WasmTarget},
@@ -699,6 +700,7 @@ world downstream {
                     revision: 0,
                     path: project_dir.path().into(),
                     wasm_bin_name: Some("test.wasm".into()),
+                    registry: RegistryConfig::default(),
                 },
                 &ActorConfig {
                     wasm_target: wasm_target.clone(),

--- a/crates/wash-lib/src/cli/registry.rs
+++ b/crates/wash-lib/src/cli/registry.rs
@@ -48,6 +48,10 @@ pub struct RegistryPullCommand {
     #[clap(long = "destination")]
     pub destination: Option<String>,
 
+    /// Registry of artifact. This is only needed if the URL is not a full (OCI) artifact URL (ie, missing the registry fragment)
+    #[clap(short = 'r', long = "registry", env = "WASH_REG_URL")]
+    pub registry: Option<String>,
+
     /// Digest to verify artifact against
     #[clap(short = 'd', long = "digest")]
     pub digest: Option<String>,
@@ -70,6 +74,10 @@ pub struct RegistryPushCommand {
     #[clap(name = "artifact")]
     pub artifact: String,
 
+    /// Registry of artifact. This is only needed if the URL is not a full (OCI) artifact URL (ie, missing the registry fragment)
+    #[clap(short = 'r', long = "registry", env = "WASH_REG_URL")]
+    pub registry: Option<String>,
+
     /// Path to config file, if omitted will default to a blank configuration
     #[clap(short = 'c', long = "config")]
     pub config: Option<String>,
@@ -91,6 +99,10 @@ pub struct RegistryPingCommand {
     /// URL of artifact
     #[clap(name = "url")]
     pub url: String,
+
+    /// Registry of artifact. This is only needed if the URL is not a full (OCI) artifact URL (ie, missing the registry fragment)
+    #[clap(short = 'r', long = "registry", env = "WASH_REG_URL")]
+    pub registry: Option<String>,
 
     #[clap(flatten)]
     pub opts: AuthOpts,

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -6,10 +6,9 @@ use std::{collections::HashSet, fmt::Display, fs, path::PathBuf};
 use anyhow::{anyhow, bail, Context, Result};
 use cargo_toml::{Manifest, Product};
 use config::Config;
-use oci_distribution::secrets::RegistryAuth;
 use semver::Version;
 use serde::Deserialize;
-use wasmcloud_control_interface::RegistryCredentialMap;
+use wasmcloud_control_interface::{RegistryCredential, RegistryCredentialMap};
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
@@ -544,56 +543,37 @@ impl RawProjectConfig {
 }
 
 impl ProjectConfig {
-    pub fn resolve_registry_url(&self) -> Result<String> {
-        let registry_url = match &self.common.registry.url {
-            Some(url) => url.clone(),
-            None => {
-                bail!("No registry URL specified in wasmcloud.toml");
-            }
-        };
-
-        Ok(registry_url)
-    }
-
     pub async fn resolve_registry_credentials(
         &self,
         registry: impl AsRef<str>,
-    ) -> Result<RegistryAuth> {
+    ) -> Result<RegistryCredential> {
         let credentials_file = &self.common.registry.credentials.to_owned();
 
-        if credentials_file.is_none() {
-            return Ok(RegistryAuth::Anonymous);
-        }
-
-        let credentials_file = credentials_file.clone().unwrap();
+        let Some(credentials_file) = credentials_file else {
+            return Ok(RegistryCredential::default());
+        };
 
         if !credentials_file.exists() {
-            return Ok(RegistryAuth::Anonymous);
+            return Ok(RegistryCredential::default());
         }
 
-        let credentials = tokio::fs::read_to_string(&credentials_file).await;
-        if credentials.is_err() {
-            return Ok(RegistryAuth::Anonymous);
-        }
+        let credentials = tokio::fs::read_to_string(&credentials_file)
+            .await
+            .context(format!(
+                "Failed to read registry credentials file {}",
+                credentials_file.display()
+            ))?;
 
         let credentials =
-            serde_json::from_str::<RegistryCredentialMap>(&credentials.unwrap_or_default());
-        if credentials.is_err() {
-            return Ok(RegistryAuth::Anonymous);
-        }
+            serde_json::from_str::<RegistryCredentialMap>(&credentials).context(format!(
+                "Failed to parse registry credentials from file {}",
+                credentials_file.display()
+            ))?;
 
-        let credentials = credentials.unwrap_or_default();
-        if let Some(credentials) = credentials.get(registry.as_ref()) {
-            match (credentials.username.clone(), credentials.password.clone()) {
-                (Some(user), Some(password)) => {
-                    return Ok(RegistryAuth::Basic(user, password));
-                }
-                _ => {
-                    return Ok(RegistryAuth::Anonymous);
-                }
-            }
-        }
+        let Some(credentials) = credentials.get(registry.as_ref()) else {
+            return Ok(RegistryCredential::default());
+        };
 
-        Ok(RegistryAuth::Anonymous)
+        Ok(credentials.clone())
     }
 }

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -3,8 +3,8 @@ use std::{collections::HashSet, fs, path::PathBuf};
 use claims::{assert_err, assert_ok};
 use semver::Version;
 use wash_lib::parser::{
-    get_config, ActorConfig, CommonConfig, LanguageConfig, RustConfig, TinyGoConfig, TypeConfig,
-    WasmTarget,
+    get_config, ActorConfig, CommonConfig, LanguageConfig, RegistryConfig, RustConfig,
+    TinyGoConfig, TypeConfig, WasmTarget,
 };
 
 #[test]
@@ -28,7 +28,7 @@ fn rust_actor() {
         config.project_type,
         TypeConfig::Actor(ActorConfig {
             claims: vec!["wasmcloud:httpserver".to_string()],
-            registry: Some("localhost:8080".to_string()),
+
             push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             filename: Some("testactor.wasm".to_string()),
@@ -49,6 +49,7 @@ fn rust_actor() {
                 .canonicalize()
                 .unwrap(),
             wasm_bin_name: None,
+            registry: RegistryConfig::default(),
         }
     );
 }
@@ -77,7 +78,7 @@ fn rust_actor_with_revision() {
         config.project_type,
         TypeConfig::Actor(ActorConfig {
             claims: vec!["wasmcloud:httpserver".to_string()],
-            registry: Some("localhost:8080".to_string()),
+
             push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             filename: Some("testactor.wasm".to_string()),
@@ -99,6 +100,7 @@ fn rust_actor_with_revision() {
                 .canonicalize()
                 .unwrap(),
             wasm_bin_name: None,
+            registry: RegistryConfig::default(),
         }
     );
 }
@@ -125,7 +127,7 @@ fn tinygo_actor_module() {
         config.project_type,
         TypeConfig::Actor(ActorConfig {
             claims: vec!["wasmcloud:httpserver".to_string()],
-            registry: Some("localhost:8080".to_string()),
+
             push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             filename: Some("testactor.wasm".to_string()),
@@ -146,6 +148,7 @@ fn tinygo_actor_module() {
                 .canonicalize()
                 .unwrap(),
             wasm_bin_name: None,
+            registry: RegistryConfig::default(),
         }
     );
 }
@@ -165,7 +168,7 @@ fn tinygo_actor_component() {
         config.project_type,
         TypeConfig::Actor(ActorConfig {
             claims: vec!["wasmcloud:httpserver".to_string()],
-            registry: Some("localhost:8080".to_string()),
+
             push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             filename: Some("testactor.wasm".to_string()),
@@ -337,7 +340,7 @@ fn minimal_rust_actor() {
         config.project_type,
         TypeConfig::Actor(ActorConfig {
             claims: vec!["wasmcloud:httpserver".to_string()],
-            registry: None,
+
             push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             filename: None,
@@ -358,6 +361,7 @@ fn minimal_rust_actor() {
                 .unwrap(),
             revision: 0,
             wasm_bin_name: None,
+            registry: RegistryConfig::default(),
         }
     )
 }
@@ -385,7 +389,7 @@ fn cargo_toml_actor() {
         config.project_type,
         TypeConfig::Actor(ActorConfig {
             claims: vec!["wasmcloud:httpserver".to_string()],
-            registry: None,
+
             push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             filename: None,
@@ -406,6 +410,7 @@ fn cargo_toml_actor() {
                 .unwrap(),
             revision: 0,
             wasm_bin_name: None,
+            registry: RegistryConfig::default(),
         }
     )
 }


### PR DESCRIPTION
## Feature or Problem
As a user, I would really like it if I didn't have to manually type out my URL to push my actor every time I need to push a new version.

## Related Issues
#860 

## Release Information
`wash-cli v0.23.0`

## Consumer Impact
better DX

## Testing

### Acceptance or Integration
[intergration_reg_config](https://github.com/ahmedtadde/wasmCloud/blob/63d95e548e5fa063bcc7c38ae4009c6f85928f72/crates/wash-cli/tests/wash_reg.rs#L248)

