### PR TITLE
feat(host): add event name as suffix on event subject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "46ca43acc1b21c6cc2d1d3129c19e323a613935b5bc28fb3b33b5b2e5fb00030"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -767,7 +767,7 @@ version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffe91f06a11b4b9420f62103854e90867812cd5d01557f853c5ee8e791b12ae"
 dependencies = [
- "clap 4.4.8",
+ "clap 4.4.9",
 ]
 
 [[package]]
@@ -927,7 +927,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "log",
  "regalloc2",
  "smallvec",
@@ -1154,7 +1154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1447,9 +1447,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -1598,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
  "indexmap 2.1.0",
@@ -1609,15 +1609,15 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
  "aho-corasick",
  "bstr",
- "fnv",
  "log",
- "regex",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1676,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
 ]
@@ -1956,9 +1956,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1966,17 +1966,16 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+checksum = "747ad1b4ae841a78e8aba0d63adbfbeaea26b517b63705d47856b73015d27060"
 dependencies = [
+ "crossbeam-deque",
  "globset",
- "lazy_static",
  "log",
  "memchr",
- "regex",
+ "regex-automata 0.4.3",
  "same-file",
- "thread_local",
  "walkdir",
  "winapi-util",
 ]
@@ -1998,7 +1997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -2120,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2137,7 +2136,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.5",
  "bytecount",
- "clap 4.4.8",
+ "clap 4.4.9",
  "fancy-regex",
  "fraction",
  "getrandom",
@@ -2612,7 +2611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "crc32fast",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "indexmap 2.1.0",
  "memchr",
 ]
@@ -2867,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
@@ -3038,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -4607,9 +4606,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4794,7 +4793,7 @@ dependencies = [
  "atelier_core 0.2.22",
  "bytes",
  "cargo_atelier",
- "clap 4.4.8",
+ "clap 4.4.9",
  "clap_complete",
  "cloudevents-sdk",
  "console",
@@ -4857,7 +4856,7 @@ dependencies = [
  "cargo_toml",
  "chrono",
  "claims",
- "clap 4.4.8",
+ "clap 4.4.9",
  "cloudevents-sdk",
  "command-group",
  "config",
@@ -4960,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4970,9 +4969,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -4985,9 +4984,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4997,9 +4996,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5007,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5020,9 +5019,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-encoder"
@@ -5088,7 +5087,7 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "async-nats",
- "clap 4.4.8",
+ "clap 4.4.9",
  "futures",
  "hyper 0.14.27",
  "nkeys",
@@ -5817,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "weld-codegen"
@@ -5835,7 +5834,7 @@ dependencies = [
  "atelier_smithy",
  "bytes",
  "cfg-if",
- "clap 4.4.8",
+ "clap 4.4.9",
  "directories",
  "downloader",
  "handlebars",

--- a/crates/control-interface/src/broker.rs
+++ b/crates/control-interface/src/broker.rs
@@ -1,5 +1,4 @@
 const DEFAULT_TOPIC_PREFIX: &str = "wasmbus.ctl";
-const EVT_TOPIC_PREFIX: &str = "wasmbus.evt";
 
 fn prefix(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
     format!(
@@ -9,10 +8,6 @@ fn prefix(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
             .unwrap_or(&DEFAULT_TOPIC_PREFIX.to_string()),
         lattice_prefix
     )
-}
-
-pub fn control_event(lattice_prefix: &str) -> String {
-    format!("{EVT_TOPIC_PREFIX}.{lattice_prefix}")
 }
 
 pub fn provider_auction_subject(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {

--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -744,7 +744,7 @@ impl Client {
         let (sender, receiver) = tokio::sync::mpsc::channel(5000);
         let mut sub = self
             .nc
-            .subscribe(broker::control_event(&self.lattice_prefix))
+            .subscribe(format!("wasmbus.evt.{}", self.lattice_prefix))
             .await?;
         tokio::spawn(async move {
             while let Some(msg) = sub.next().await {

--- a/crates/providers/nats/README.md
+++ b/crates/providers/nats/README.md
@@ -10,5 +10,3 @@ To configure this provider, use the following link settings in link definitions:
 | `URI` | NATS connection uri. If not specified, the default is `0.0.0.0:4222` |
 | `CLIENT_JWT` | Optional JWT auth token. For JWT authentication, both `CLIENT_JWT` and `CLIENT_SEED` must be provided. |
 | `CLIENT_SEED` | Private seed for JWT authentication. |
-
-⚠️ A word of caution, setting the subscription link definition value to `wasmbus.evt.*` or `wasmbus.evt.<your_lattice_prefix>` _will_ cause that actor to infinite loop when handling a message. We publish events for when actor invocations succeed or fail on the `wasmbus.evt.<prefix>` topic, and the act of handling that message results in another invocation event.

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -93,18 +93,14 @@ async fn assert_scale_actor(
 
     // Naive wait for at least a stopped / started event before exiting this function. This prevents
     // assuming we're done with scaling too early since scale is an early-ack ctl request.
-    loop {
-        tokio::select! {
-            _ = sub_started.next() => {
-                break;
-            }
-            _ = sub_stopped.next() => {
-                break;
-            }
-            _ = tokio::time::sleep(Duration::from_secs(10)) => {
-                bail!("timed out waiting for actor scale event");
-            },
+    tokio::select! {
+        _ = sub_started.next() => {
         }
+        _ = sub_stopped.next() => {
+        }
+        _ = tokio::time::sleep(Duration::from_secs(10)) => {
+            bail!("timed out waiting for actor scale event");
+        },
     }
 
     Ok(())

--- a/washboard-ui/src/lattice/lattice-service.ts
+++ b/washboard-ui/src/lattice/lattice-service.ts
@@ -133,6 +133,7 @@ class LatticeService {
       const message = await connection.request('wasmbus.ctl.default.get.links');
       this.linkState$.next(message.json<{links: WadmLink[]}>());
 
+      // TODO(pre-1.0): subscribe to specific event subjects instead of all events
       const watch = await connection.subscribe('wasmbus.evt.default');
       for await (const event of watch) {
         const parsedEvent = event.json<CloudEvent>();


### PR DESCRIPTION
## Feature or Problem
This publishes events on `wasmbus.evt.{latticeID}.{eventName}`, in addition to the existing subject. The existing subject should be removed prior to wasmCloud 1.0

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/1089

## Release Information
Next

## Consumer Impact
None for now, but removing the existing subject will be a breaking change

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
Updated the wasmbus tests to subscribe to the new subjects

### Manual Verification
```
nats sub 'wasmbus.evt.>'
14:33:04 Subscribing on wasmbus.evt.>
[#1] Received on "wasmbus.evt.default"
{"specversion":"1.0","id":"018c0866-8bc3-d066-599f-da1fa20d346e","type":"com.wasmcloud.lattice.host_started","source":"NBG37K5KJUZ3SRRCOTFG3IOIRA77FFG3HINLDD66HXCECGEHJ4VWB7RB","datacontenttype":"application/json","time":"2023-11-25T21:33:07.395933Z","data":{"friendly_name":"mauve-dew-2146","labels":{"hostcore.arch":"aarch64","hostcore.os":"macos","hostcore.osfamily":"unix"},"uptime_seconds":0,"version":"0.80.0"}}

[#2] Received on "wasmbus.evt.default.host_started"
{"specversion":"1.0","id":"018c0866-8bc3-d066-599f-da1fa20d346e","type":"com.wasmcloud.lattice.host_started","source":"NBG37K5KJUZ3SRRCOTFG3IOIRA77FFG3HINLDD66HXCECGEHJ4VWB7RB","datacontenttype":"application/json","time":"2023-11-25T21:33:07.395933Z","data":{"friendly_name":"mauve-dew-2146","labels":{"hostcore.arch":"aarch64","hostcore.os":"macos","hostcore.osfamily":"unix"},"uptime_seconds":0,"version":"0.80.0"}}

[#3] Received on "wasmbus.evt.default"
{"specversion":"1.0","id":"018c0866-a792-729b-4b54-64bd6ddc14d1","type":"com.wasmcloud.lattice.actor_started","source":"NBG37K5KJUZ3SRRCOTFG3IOIRA77FFG3HINLDD66HXCECGEHJ4VWB7RB","datacontenttype":"application/json","time":"2023-11-25T21:33:14.514690Z","data":{"annotations":{},"api_version":"n/a","claims":{"call_alias":null,"caps":["wasmcloud:httpserver","wasmcloud:builtin:logging"],"expires_human":"TODO","issuer":"ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW","name":"Echo","not_before_human":"TODO","revision":4,"tags":[],"version":"0.3.8"},"image_ref":"wasmcloud.azurecr.io/echo:0.3.8","instance_id":"018c0866-a792-f3b5-6337-f1a945bae7bf","public_key":"MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"}}

[#4] Received on "wasmbus.evt.default.actor_started"
{"specversion":"1.0","id":"018c0866-a792-729b-4b54-64bd6ddc14d1","type":"com.wasmcloud.lattice.actor_started","source":"NBG37K5KJUZ3SRRCOTFG3IOIRA77FFG3HINLDD66HXCECGEHJ4VWB7RB","datacontenttype":"application/json","time":"2023-11-25T21:33:14.514690Z","data":{"annotations":{},"api_version":"n/a","claims":{"call_alias":null,"caps":["wasmcloud:httpserver","wasmcloud:builtin:logging"],"expires_human":"TODO","issuer":"ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW","name":"Echo","not_before_human":"TODO","revision":4,"tags":[],"version":"0.3.8"},"image_ref":"wasmcloud.azurecr.io/echo:0.3.8","instance_id":"018c0866-a792-f3b5-6337-f1a945bae7bf","public_key":"MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"}}
```