### PR TITLE
fix(host): update format for serialized claims

### DIFF
--- a/crates/wash-cli/src/ctl/output.rs
+++ b/crates/wash-cli/src/ctl/output.rs
@@ -207,7 +207,9 @@ pub fn claims_table(list: Vec<HashMap<String, String>>) -> String {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment("Issuer", 1, Alignment::Left),
             TableCell::new_with_alignment(
-                c.get("iss").unwrap_or(&"".to_string()),
+                c.get("issuer")
+                    .or_else(|| c.get("iss"))
+                    .unwrap_or(&"".to_string()),
                 1,
                 Alignment::Left,
             ),
@@ -215,7 +217,9 @@ pub fn claims_table(list: Vec<HashMap<String, String>>) -> String {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment("Subject", 1, Alignment::Left),
             TableCell::new_with_alignment(
-                c.get("sub").unwrap_or(&"".to_string()),
+                c.get("subject")
+                    .or_else(|| c.get("sub"))
+                    .unwrap_or(&"".to_string()),
                 1,
                 Alignment::Left,
             ),
@@ -223,7 +227,9 @@ pub fn claims_table(list: Vec<HashMap<String, String>>) -> String {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment("Capabilities", 1, Alignment::Left),
             TableCell::new_with_alignment(
-                c.get("caps").unwrap_or(&"".to_string()),
+                c.get("capabilities")
+                    .or_else(|| c.get("caps"))
+                    .unwrap_or(&"".to_string()),
                 1,
                 Alignment::Left,
             ),
@@ -239,7 +245,9 @@ pub fn claims_table(list: Vec<HashMap<String, String>>) -> String {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment("Revision", 1, Alignment::Left),
             TableCell::new_with_alignment(
-                c.get("rev").unwrap_or(&"".to_string()),
+                c.get("revision")
+                    .or_else(|| c.get("rev"))
+                    .unwrap_or(&"".to_string()),
                 1,
                 Alignment::Left,
             ),


### PR DESCRIPTION
## Feature or Problem
This:
- updates the serialized format for claims
  - actor and provider claims are now separate, removing the unused fields from each
  - `sub` (`subject`), `iss`, (`issuer`), `caps` (`capabilities`), and `rev` (`revision`) are no longer abbreviated
    - serde's `alias` is used to maintain backwards-compatibility with deserializing
  - `capabilities` and `tags` are now `Vec<String>` instead of a comma-delimited string
    - backwards-compatibility was maintained via a custom deserializer/visitor 
  - both abbreviated and non-abbreviated fields are sent over the wire to maintain backwards-compatibility
- updates wash to expect the non-abbreviated fields

**Note** wadm needs to be updated to not expect the abbreviated fields as well, before the abbreviated fields can be removed

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/508
Related to https://github.com/wasmCloud/wasmCloud/issues/1093

## Release Information
Next

## Consumer Impact
None for now

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tested e2e with latest released wash, and built with changes in this PR:
```
wash get claims


                                   Claims
  Issuer          ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW
  Subject         MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E
  Capabilities    wasmcloud:httpserver,wasmcloud:keyvalue
  Version         0.4.0
  Revision        0

  Issuer          ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW
  Subject         MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5
  Capabilities    wasmcloud:httpserver,wasmcloud:builtin:logging
  Version         0.3.8
  Revision        4
```

```
./target/debug/wash get claims


                                   Claims
  Issuer          ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW
  Subject         MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E
  Capabilities    wasmcloud:httpserver,wasmcloud:keyvalue
  Version         0.4.0
  Revision        0

  Issuer          ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW
  Subject         MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5
  Capabilities    wasmcloud:httpserver,wasmcloud:builtin:logging
  Version         0.3.8
  Revision        4
```

And also inspected the underlying stored data, to confirm that heterogenous serialized data is supported:
```                                                                                                    
nats kv get LATTICEDATA_default CLAIMS_MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E --raw | jq
{
  "call_alias": "",
  "capabilities": [
    "wasmcloud:httpserver",
    "wasmcloud:keyvalue"
  ],
  "issuer": "ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW",
  "name": "kvcounter",
  "revision": "0",
  "subject": "MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E",
  "tags": [],
  "version": "0.4.0"
}

nats kv get LATTICEDATA_default CLAIMS_MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5 --raw | jq
{
  "call_alias": "",
  "caps": "wasmcloud:httpserver,wasmcloud:builtin:logging",
  "contract_id": "",
  "iss": "ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW",
  "name": "Echo",
  "rev": "4",
  "sub": "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5",
  "tags": "",
  "version": "0.3.8"
}
```
