### PR TITLE
feat(control-interface)!: rename max-concurrent to max-instances, simplify scale

### DIFF
--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -244,14 +244,14 @@ impl Client {
     /// # Arguments
     /// `host_id`: The ID of the host to scale the actor on
     /// `actor_ref`: The OCI reference of the actor to scale
-    /// `max_instances`: The maximum number of requests this actor handle run concurrently. Specifying `0` will stop the actor.
+    /// `max_instances`: The maximum number of instances this actor can run concurrently. Specifying `0` will stop the actor.
     /// `annotations`: Optional annotations to apply to the actor
     #[instrument(level = "debug", skip_all)]
     pub async fn scale_actor(
         &self,
         host_id: &str,
         actor_ref: &str,
-        max_instances: u16,
+        max_instances: u32,
         annotations: Option<HashMap<String, String>>,
     ) -> Result<CtlOperationAck> {
         let host_id = parse_identifier(&IdentifierKind::HostId, host_id)?;

--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -244,15 +244,14 @@ impl Client {
     /// # Arguments
     /// `host_id`: The ID of the host to scale the actor on
     /// `actor_ref`: The OCI reference of the actor to scale
-    /// `max_concurrent`: The maximum number of requests this actor handle run concurrently. `None` represents an unbounded
-    /// level of concurrency while `0` will stop the actor.
+    /// `max_instances`: The maximum number of requests this actor handle run concurrently. Specifying `0` will stop the actor.
     /// `annotations`: Optional annotations to apply to the actor
     #[instrument(level = "debug", skip_all)]
     pub async fn scale_actor(
         &self,
         host_id: &str,
         actor_ref: &str,
-        max_concurrent: Option<u16>,
+        max_instances: u16,
         annotations: Option<HashMap<String, String>>,
     ) -> Result<CtlOperationAck> {
         let host_id = parse_identifier(&IdentifierKind::HostId, host_id)?;
@@ -263,7 +262,7 @@ impl Client {
         );
         debug!("scale_actor:request {}", &subject);
         let bytes = json_serialize(ScaleActorCommand {
-            max_concurrent,
+            max_instances,
             actor_ref: parse_identifier(&IdentifierKind::ActorRef, actor_ref)?,
             host_id,
             annotations,

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -63,7 +63,7 @@ pub struct ActorInstance {
     pub revision: i32,
     /// The maximum number of concurrent requests this instance can handle
     #[serde(default)]
-    pub max_instances: u16,
+    pub max_instances: u32,
 }
 
 pub type AnnotationMap = std::collections::HashMap<String, String>;
@@ -304,12 +304,39 @@ pub struct ScaleActorCommand {
     /// stop the actor.
     // NOTE: renaming to `count` lets us remain backwards compatible for a few minor versions
     #[serde(default, alias = "count", rename = "count")]
-    pub max_instances: u16,
+    pub max_instances: u32,
     /// Host ID on which to scale this actor
     #[serde(default)]
     pub host_id: String,
 }
 
+<<<<<<< HEAD
+=======
+#[deprecated(
+    since = "0.30.0",
+    note = "Use `ScaleActorCommand` instead. This will be removed in a future release."
+)]
+/// A command sent to a specific host instructing it to start the actor
+/// indicated by the reference.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct StartActorCommand {
+    /// Reference for the actor. Can be any of the acceptable forms of unique identification
+    #[serde(default)]
+    pub actor_ref: String,
+    /// Optional set of annotations used to describe the nature of this actor start command. For
+    /// example, autonomous agents may wish to "tag" start requests as part of a given deployment
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<AnnotationMap>,
+    /// The number of actors to start
+    /// A zero value will be interpreted as 1.
+    #[serde(default)]
+    pub count: u32,
+    /// Host ID on which this actor should start
+    #[serde(default)]
+    pub host_id: String,
+}
+
+>>>>>>> 2c37d705 (feat(control-interface)!: upgrade max_instances to u32)
 /// A command sent to a host requesting a capability provider be started with the
 /// given link name and optional configuration.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -63,7 +63,7 @@ pub struct ActorInstance {
     pub revision: i32,
     /// The maximum number of concurrent requests this instance can handle
     #[serde(default)]
-    pub max_concurrent: u16,
+    pub max_instances: u16,
 }
 
 pub type AnnotationMap = std::collections::HashMap<String, String>;
@@ -300,11 +300,11 @@ pub struct ScaleActorCommand {
     /// example, autonomous agents may wish to "tag" scale requests as part of a given deployment
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<AnnotationMap>,
-    /// The maximum number of concurrent executing instances of this actor. If set to `None` there
-    /// there is no maximum, while setting to `0` will stop the actor.
+    /// The maximum number of concurrent executing instances of this actor. Setting this to `0` will
+    /// stop the actor.
     // NOTE: renaming to `count` lets us remain backwards compatible for a few minor versions
     #[serde(default, alias = "count", rename = "count")]
-    pub max_concurrent: Option<u16>,
+    pub max_instances: u16,
     /// Host ID on which to scale this actor
     #[serde(default)]
     pub host_id: String,

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -310,33 +310,6 @@ pub struct ScaleActorCommand {
     pub host_id: String,
 }
 
-<<<<<<< HEAD
-=======
-#[deprecated(
-    since = "0.30.0",
-    note = "Use `ScaleActorCommand` instead. This will be removed in a future release."
-)]
-/// A command sent to a specific host instructing it to start the actor
-/// indicated by the reference.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct StartActorCommand {
-    /// Reference for the actor. Can be any of the acceptable forms of unique identification
-    #[serde(default)]
-    pub actor_ref: String,
-    /// Optional set of annotations used to describe the nature of this actor start command. For
-    /// example, autonomous agents may wish to "tag" start requests as part of a given deployment
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<AnnotationMap>,
-    /// The number of actors to start
-    /// A zero value will be interpreted as 1.
-    #[serde(default)]
-    pub count: u32,
-    /// Host ID on which this actor should start
-    #[serde(default)]
-    pub host_id: String,
-}
-
->>>>>>> 2c37d705 (feat(control-interface)!: upgrade max_instances to u32)
 /// A command sent to a host requesting a capability provider be started with the
 /// given link name and optional configuration.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -36,41 +36,7 @@ fn format_actor_claims(claims: &jwt::Claims<jwt::Actor>) -> serde_json::Value {
     }
 }
 
-pub fn actor_started(
-    claims: &jwt::Claims<jwt::Actor>,
-    annotations: &BTreeMap<String, String>,
-    instance_id: Uuid,
-    image_ref: impl AsRef<str>,
-) -> serde_json::Value {
-    json!({
-        "public_key": claims.subject,
-        "image_ref": image_ref.as_ref(),
-        "api_version": "n/a",
-        "instance_id": instance_id,
-        "annotations": annotations,
-        "claims": format_actor_claims(claims),
-    })
-}
-
-pub fn actor_start_failed(actor_ref: impl AsRef<str>, error: &anyhow::Error) -> serde_json::Value {
-    json!({
-        "actor_ref": actor_ref.as_ref(),
-        "error": format!("{error:#}"),
-    })
-}
-
-pub fn actor_stopped(
-    claims: &jwt::Claims<jwt::Actor>,
-    annotations: &BTreeMap<String, String>,
-    instance_id: Uuid,
-) -> serde_json::Value {
-    json!({
-        "public_key": claims.subject,
-        "instance_id": instance_id,
-        "annotations": annotations,
-    })
-}
-
+// TODO(#1092): Remove this event in favor of `actor_scaled`
 pub fn actors_started(
     claims: &jwt::Claims<jwt::Actor>,
     annotations: &BTreeMap<String, String>,
@@ -88,6 +54,7 @@ pub fn actors_started(
     })
 }
 
+// TODO(#1092): Remove this event in favor of `actor_scaled`
 pub fn actors_start_failed(
     claims: &jwt::Claims<jwt::Actor>,
     annotations: &BTreeMap<String, String>,
@@ -104,19 +71,56 @@ pub fn actors_start_failed(
     })
 }
 
+// TODO(#1092): Remove this event in favor of `actor_scaled`
 pub fn actors_stopped(
     claims: &jwt::Claims<jwt::Actor>,
     annotations: &BTreeMap<String, String>,
     host_id: impl AsRef<str>,
     count: NonZeroUsize,
     remaining: usize,
+    image_ref: impl AsRef<str>,
 ) -> serde_json::Value {
     json!({
-        "host_id": host_id.as_ref(),
         "public_key": claims.subject,
+        "annotations": annotations,
+        "host_id": host_id.as_ref(),
         "count": count,
         "remaining": remaining,
+        "image_ref": image_ref.as_ref(),
+    })
+}
+
+pub fn actor_scaled(
+    claims: &jwt::Claims<jwt::Actor>,
+    annotations: &BTreeMap<String, String>,
+    host_id: impl AsRef<str>,
+    max_instances: NonZeroUsize,
+    image_ref: impl AsRef<str>,
+) -> serde_json::Value {
+    json!({
+        "public_key": claims.subject,
         "annotations": annotations,
+        "host_id": host_id.as_ref(),
+        "image_ref": image_ref.as_ref(),
+        "max_instances": max_instances,
+    })
+}
+
+pub fn actor_scale_failed(
+    claims: &jwt::Claims<jwt::Actor>,
+    annotations: &BTreeMap<String, String>,
+    host_id: impl AsRef<str>,
+    image_ref: impl AsRef<str>,
+    max_instances: NonZeroUsize,
+    error: &anyhow::Error,
+) -> serde_json::Value {
+    json!({
+        "public_key": claims.subject,
+        "annotations": annotations,
+        "host_id": host_id.as_ref(),
+        "image_ref": image_ref.as_ref(),
+        "max_instances": max_instances,
+        "error": format!("{error:#}"),
     })
 }
 

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2751,7 +2751,7 @@ impl Host {
         &self,
         actor_ref: &str,
         host_id: &str,
-        max_instances: u16,
+        max_instances: u32,
         annotations: Annotations,
     ) -> anyhow::Result<()> {
         trace!(actor_ref, max_instances, "scale actor task");
@@ -2778,7 +2778,7 @@ impl Host {
         let actor_ref = actor_ref.to_string();
         match (
             self.actors.write().await.entry(actor_id),
-            NonZeroUsize::new(max_instances.into()),
+            NonZeroUsize::new(max_instances as usize),
         ) {
             // No actor is running and we requested to scale to zero, noop
             (hash_map::Entry::Vacant(_), None) => {}
@@ -3506,8 +3506,8 @@ impl Host {
                             instance_id,
                             revision,
                             image_ref: Some(instance.image_reference.clone()),
-                            // We only accept u16 values on the control interface, so the try_from is a safety measure.
-                            max_instances: u16::try_from(instance.max.get()).unwrap_or(u16::MAX),
+                            // We only accept u32 values on the control interface, so the try_from is a safety measure.
+                            max_instances: u32::try_from(instance.max.get()).unwrap_or(u32::MAX),
                         }
                     })
                     .collect();

--- a/crates/providers/lattice-controller/src/lib.rs
+++ b/crates/providers/lattice-controller/src/lib.rs
@@ -384,6 +384,7 @@ impl WasmcloudLatticeControlLatticeController for LatticeControllerProvider {
         _ctx: Context,
         cmd: StartActorCommand,
     ) -> ProviderInvocationResult<CtlOperationAck> {
+        let count = if cmd.count == 0 { 1_u32 } else { cmd.count.into() };
         Ok(self
             .get_connections()
             .await
@@ -392,7 +393,7 @@ impl WasmcloudLatticeControlLatticeController for LatticeControllerProvider {
             .scale_actor(
                 &cmd.host_id,
                 &cmd.actor_ref,
-                Some(cmd.count),
+                count,
                 Some(cmd.annotations.clone()),
             )
             .await
@@ -418,7 +419,7 @@ impl WasmcloudLatticeControlLatticeController for LatticeControllerProvider {
             .scale_actor(
                 &cmd.host_id,
                 &cmd.actor_ref,
-                Some(cmd.count),
+                cmd.count,
                 Some(cmd.annotations.clone()),
             )
             .await

--- a/crates/providers/lattice-controller/wit/deps/lattice-control/lattice-control.wit
+++ b/crates/providers/lattice-controller/wit/deps/lattice-control/lattice-control.wit
@@ -282,7 +282,7 @@ interface lattice-controller {
       annotations-map: list<tuple<string,string>>,
 
       /// The target number of actors
-      count: u16,
+      count: u32,
     }
 
     /// A command sent to a specific host requesting instance of a given actor

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.25.0"
+version = "0.24.1"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) CLI tool"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.24.1"
+version = "0.25.0"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) CLI tool"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-cli/src/common/scale_cmd.rs
+++ b/crates/wash-cli/src/common/scale_cmd.rs
@@ -14,13 +14,9 @@ pub async fn handle_command(
     let sp: Spinner = Spinner::new(&output_kind)?;
     let out = match command {
         ScaleCommand::Actor(cmd) => {
-            let max = cmd
-                .max_concurrent
-                .map(|max| max.to_string())
-                .unwrap_or_else(|| "unbounded".to_string());
             sp.update_spinner_message(format!(
                 " Scaling Actor {} to {} max concurrent instances ... ",
-                cmd.actor_ref, max
+                cmd.actor_ref, cmd.max_instances
             ));
             handle_scale_actor(cmd.clone()).await?
         }

--- a/crates/wash-cli/src/dev.rs
+++ b/crates/wash-cli/src/dev.rs
@@ -284,7 +284,7 @@ pub async fn handle_command(
         .find(|a| a.image_ref == Some(actor_ref.clone()))
     {
         actor_id = existing_actor.id;
-        scale_actor(&ctl_client, &host.id, &actor_ref, Some(1), None).await?;
+        scale_actor(&ctl_client, &host.id, &actor_ref, 1, None).await?;
     } else {
         // Start the actor for the first time
         actor_id = start_actor(StartActorArgs {

--- a/crates/wash-cli/tests/wash_scale.rs
+++ b/crates/wash-cli/tests/wash_scale.rs
@@ -83,10 +83,10 @@ async fn integration_scale_actor_serial() -> Result<()> {
                 .instances
                 .iter()
                 .map(|i| {
-                    if i.max_concurrent == 0 {
+                    if i.max_instances == 0 {
                         1
                     } else {
-                        i.max_concurrent
+                        i.max_instances
                     }
                 })
                 .sum::<u16>();
@@ -165,10 +165,10 @@ async fn integration_scale_actor_serial() -> Result<()> {
                 .instances
                 .iter()
                 .map(|i| {
-                    if i.max_concurrent == 0 {
+                    if i.max_instances == 0 {
                         1
                     } else {
-                        i.max_concurrent
+                        i.max_instances
                     }
                 })
                 .sum::<u16>();

--- a/crates/wash-cli/tests/wash_scale.rs
+++ b/crates/wash-cli/tests/wash_scale.rs
@@ -89,7 +89,7 @@ async fn integration_scale_actor_serial() -> Result<()> {
                         i.max_instances
                     }
                 })
-                .sum::<u16>();
+                .sum::<u32>();
             assert_eq!(max, 10);
             break;
         }
@@ -171,7 +171,7 @@ async fn integration_scale_actor_serial() -> Result<()> {
                         i.max_instances
                     }
                 })
-                .sum::<u16>();
+                .sum::<u32>();
             assert_eq!(max, 5);
             break;
         }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.16.0"
+version = "0.15.0"
 categories = ["wasm", "wasmcloud"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.15.0"
+version = "0.16.0"
 categories = ["wasm", "wasmcloud"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]
@@ -55,9 +55,7 @@ ignore = { workspace = true, optional = true }
 indicatif = { workspace = true, optional = true }
 nkeys = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"] }
-path-absolutize = { workspace = true, features = [
-    "once_cell_cache",
-], optional = true }
+path-absolutize = { workspace = true, features = ["once_cell_cache"], optional = true }
 provider-archive = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }

--- a/crates/wash-lib/src/actor.rs
+++ b/crates/wash-lib/src/actor.rs
@@ -52,12 +52,7 @@ pub async fn start_actor(
 
     // Start the actor
     let ack = ctl_client
-        .scale_actor(
-            host_id,
-            actor_ref,
-            if count == 0 { None } else { Some(count) },
-            None,
-        )
+        .scale_actor(host_id, actor_ref, count, None)
         .await
         .map_err(boxed_err_to_anyhow)
         .with_context(|| format!("Failed to start actor: {}", actor_ref))?;

--- a/crates/wash-lib/src/actor.rs
+++ b/crates/wash-lib/src/actor.rs
@@ -106,11 +106,11 @@ pub async fn scale_actor(
     client: &CtlClient,
     host_id: &str,
     actor_ref: &str,
-    max_concurrent: Option<u16>,
+    max_instances: u16,
     annotations: Option<HashMap<String, String>>,
 ) -> Result<()> {
     let ack = client
-        .scale_actor(host_id, actor_ref, max_concurrent, annotations)
+        .scale_actor(host_id, actor_ref, max_instances, annotations)
         .await
         .map_err(boxed_err_to_anyhow)?;
 

--- a/crates/wash-lib/src/actor.rs
+++ b/crates/wash-lib/src/actor.rs
@@ -17,7 +17,7 @@ pub struct StartActorArgs<'a> {
     pub ctl_client: &'a CtlClient,
     pub host_id: &'a str,
     pub actor_ref: &'a str,
-    pub count: u16,
+    pub count: u32,
     pub skip_wait: bool,
     pub timeout_ms: Option<u64>,
 }
@@ -106,7 +106,7 @@ pub async fn scale_actor(
     client: &CtlClient,
     host_id: &str,
     actor_ref: &str,
-    max_instances: u16,
+    max_instances: u32,
     annotations: Option<HashMap<String, String>>,
 ) -> Result<()> {
     let ack = client

--- a/crates/wash-lib/src/cli/scale.rs
+++ b/crates/wash-lib/src/cli/scale.rs
@@ -29,9 +29,9 @@ pub struct ScaleActorCommand {
     #[clap(name = "actor-ref")]
     pub actor_ref: String,
 
-    /// Maximum number of instances this actor can run concurrently.
-    #[clap(short = 'c', long = "max-instances", alias = "max-concurrent", alias = "max", alias = "count", default_value_t = u16::MAX)]
-    pub max_instances: u16,
+    /// Maximum number of actor instances allowed to run concurrently. Setting this value to `0` will stop the actor.
+    #[clap(short = 'c', long = "max-instances", alias = "max-concurrent", alias = "max", alias = "count", default_value_t = u32::MAX)]
+    pub max_instances: u32,
 
     /// Optional set of annotations used to describe the nature of this actor scale command.
     /// For example, autonomous agents may wish to “tag” scale requests as part of a given deployment

--- a/crates/wash-lib/src/cli/scale.rs
+++ b/crates/wash-lib/src/cli/scale.rs
@@ -29,9 +29,9 @@ pub struct ScaleActorCommand {
     #[clap(name = "actor-ref")]
     pub actor_ref: String,
 
-    /// Maximum number of instances this actor can run concurrently. Omitting this value means there is no maximum.
-    #[clap(short = 'c', long = "max-concurrent", alias = "max", alias = "count")]
-    pub max_concurrent: Option<u16>,
+    /// Maximum number of instances this actor can run concurrently.
+    #[clap(short = 'c', long = "max-instances", alias = "max-concurrent", alias = "max", alias = "count", default_value_t = u16::MAX)]
+    pub max_instances: u16,
 
     /// Optional set of annotations used to describe the nature of this actor scale command.
     /// For example, autonomous agents may wish to “tag” scale requests as part of a given deployment
@@ -51,21 +51,16 @@ pub async fn handle_scale_actor(cmd: ScaleActorCommand) -> Result<CommandOutput>
         // prompt the user to choose if more than one thing matches
         &find_host_id(&cmd.host_id, &client).await?.0,
         &cmd.actor_ref,
-        cmd.max_concurrent,
+        cmd.max_instances,
         Some(annotations),
     )
     .await?;
-
-    let max = cmd
-        .max_concurrent
-        .map(|max| max.to_string())
-        .unwrap_or_else(|| "unbounded".to_string());
 
     Ok(CommandOutput::from_key_and_text(
         "result",
         format!(
             "Request to scale actor {} to {} max concurrent instances received",
-            cmd.actor_ref, max
+            cmd.actor_ref, cmd.max_instances
         ),
     ))
 }

--- a/crates/wash-lib/src/cli/start.rs
+++ b/crates/wash-lib/src/cli/start.rs
@@ -52,7 +52,7 @@ pub struct StartActorCommand {
         alias = "count",
         default_value_t = 1
     )]
-    pub max_instances: u16,
+    pub max_instances: u32,
 
     /// Constraints for actor auction in the form of "label=value". If host-id is supplied, this list is ignored
     #[clap(short = 'c', long = "constraint", name = "constraints")]

--- a/crates/wash-lib/src/cli/start.rs
+++ b/crates/wash-lib/src/cli/start.rs
@@ -44,14 +44,15 @@ pub struct StartActorCommand {
     #[clap(name = "actor-ref")]
     pub actor_ref: String,
 
-    /// Maximum number of instances this actor can run concurrently. Setting this value to 0 means there is no maximum.
+    /// Maximum number of instances this actor can run concurrently.
     #[clap(
-        long = "max-concurrent",
+        long = "max-instances",
+        alias = "max-concurrent",
         alias = "max",
         alias = "count",
-        default_value = "1"
+        default_value_t = 1
     )]
-    pub max_concurrent: u16,
+    pub max_instances: u16,
 
     /// Constraints for actor auction in the form of "label=value". If host-id is supplied, this list is ignored
     #[clap(short = 'c', long = "constraint", name = "constraints")]
@@ -116,8 +117,8 @@ pub async fn handle_start_actor(cmd: StartActorCommand) -> Result<CommandOutput>
     } = start_actor(StartActorArgs {
         ctl_client: &client,
         host_id: &host,
-        actor_ref: &actor_ref,
-        count: cmd.max_concurrent,
+        actor_ref: &cmd.actor_ref,
+        count: cmd.max_instances,
         skip_wait: cmd.skip_wait,
         timeout_ms: Some(timeout_ms),
     })

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -53,12 +53,7 @@ pub async fn assert_start_actor(
         .await?;
 
     let CtlOperationAck { accepted, error } = ctl_client
-        .scale_actor(
-            &host_key.public_key(),
-            url.as_ref(),
-            if count == 0 { None } else { Some(count) },
-            None,
-        )
+        .scale_actor(&host_key.public_key(), url.as_ref(), count, None)
         .await
         .map_err(|e| anyhow!(e).context("failed to start actor"))?;
     ensure!(error == "");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -46,7 +46,7 @@ pub async fn assert_start_actor(
     lattice_prefix: &str,
     host_key: &KeyPair,
     url: impl AsRef<str>,
-    count: u16,
+    count: u32,
 ) -> anyhow::Result<()> {
     let mut sub_started = nats_client
         .subscribe(format!("wasmbus.evt.{lattice_prefix}.actors_started"))
@@ -84,7 +84,7 @@ pub async fn assert_scale_actor(
     host_key: &KeyPair,
     url: impl AsRef<str>,
     annotations: Option<HashMap<String, String>>,
-    count: u16,
+    count: u32,
 ) -> anyhow::Result<()> {
     let mut sub_started = nats_client
         .subscribe(format!("wasmbus.evt.{lattice_prefix}.actors_started"))

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -84,7 +84,7 @@ pub async fn assert_scale_actor(
     host_key: &KeyPair,
     url: impl AsRef<str>,
     annotations: Option<HashMap<String, String>>,
-    count: Option<u16>,
+    count: u16,
 ) -> anyhow::Result<()> {
     let mut sub_started = nats_client
         .subscribe(format!("wasmbus.evt.{lattice_prefix}.actors_started"))

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -1164,7 +1164,7 @@ expected: {expected_labels_two:?}"#
         &host_key,
         &foobar_actor_url,
         Some(HashMap::from_iter([("foo".to_string(), "bar".to_string())])),
-        u16::MAX,
+        u32::MAX,
     )
     .await
     .context("failed to scale foobar actor")?;

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -872,7 +872,7 @@ expected: {expected_name:?}"#
                 instance_id,
                 revision,
                 image_ref,
-                max_concurrent,
+                max_instances,
             } = component_instances
                 .pop()
                 .context("no component actor instances found")?;
@@ -884,7 +884,7 @@ expected: {expected_name:?}"#
             ensure!(Uuid::parse_str(&instance_id).is_ok());
             ensure!(revision == expected_revision.unwrap_or_default());
             ensure!(image_ref == component_image_ref);
-            ensure!(max_concurrent == 1);
+            ensure!(max_instances == 1);
 
             // TODO: Validate `constraints`
             ensure!(module_id == module_actor_claims.subject);
@@ -908,7 +908,7 @@ expected: {expected_name:?}"#
                 instance_id,
                 revision,
                 image_ref,
-                max_concurrent,
+                max_instances,
             } = module_instances
                 .pop()
                 .context("no module actor instances found")?;
@@ -920,7 +920,7 @@ expected: {expected_name:?}"#
             ensure!(Uuid::parse_str(&instance_id).is_ok());
             ensure!(revision == expected_revision.unwrap_or_default());
             ensure!(image_ref == module_image_ref);
-            ensure!(max_concurrent == 1);
+            ensure!(max_instances == 1);
 
             // TODO: Validate `constraints`
             ensure!(foobar_id == foobar_actor_claims.subject);
@@ -944,7 +944,7 @@ expected: {expected_name:?}"#
                 instance_id,
                 revision,
                 image_ref,
-                max_concurrent,
+                max_instances,
             } = foobar_instances
                 .pop()
                 .context("no foobar actor instances found")?;
@@ -956,7 +956,7 @@ expected: {expected_name:?}"#
             ensure!(Uuid::parse_str(&instance_id).is_ok());
             ensure!(revision == expected_revision.unwrap_or_default());
             ensure!(image_ref == foobar_image_ref);
-            ensure!(max_concurrent == 1);
+            ensure!(max_instances == 1);
         }
         (None, None, None, []) => bail!("no actor found"),
         _ => bail!("more than 3 actors found"),
@@ -1142,7 +1142,7 @@ expected: {expected_labels_two:?}"#
         &host_key,
         &foobar_actor_url,
         Some(HashMap::from_iter([("foo".to_string(), "bar".to_string())])),
-        Some(5),
+        5,
     )
     .await
     .context("failed to scale foobar actor")?;
@@ -1164,7 +1164,7 @@ expected: {expected_labels_two:?}"#
         &host_key,
         &foobar_actor_url,
         Some(HashMap::from_iter([("foo".to_string(), "bar".to_string())])),
-        None,
+        u16::MAX,
     )
     .await
     .context("failed to scale foobar actor")?;
@@ -1186,7 +1186,7 @@ expected: {expected_labels_two:?}"#
         &host_key,
         &foobar_actor_url,
         Some(HashMap::from_iter([("foo".to_string(), "bar".to_string())])),
-        Some(0),
+        0,
     )
     .await
     .context("failed to scale foobar actor")?;


### PR DESCRIPTION
## Feature or Problem
After a month or so of working with the changes from #696, I've come to a few conclusions about the developer experience of the new scaling model. All the thoughts below are up for discussion I just wanted to propose the changes.

1. This number `--max-concurrent` is describing "the maximum number of concurrent instances allowed to execute" and and I slightly prefer `--max-instances` to describe this number. This is also a more intuitive number when describing capability provider instances, and the eventual WASI provider instances, and will be better to replace the `replicas` field in wadm manifests. This might just be `instances`, but that can be determined later.
2. The difference between scaling to `None`, `Some(0)`, and `Some(10000)` is still confusing, and "unbounded" is a scary number.
3. It's a little weird to work with the `Option<NonZeroUsize>` type all over the place.

In order to address these issues, I made the following changes
1. Renamed from `--max-concurrent` / `max_concurrent` to `--max-instances` / `max_instances` around the codebase.
2. The maximum instances parameter is no longer an optional number, just a u32. In developer facing clients we'll default to `u16::MAX` and it will be easy to see that number.
    a. ~If we run into an issue in the future with an actor needing to scale past 65535 concurrent running instances you are welcome to @ me and I'll update everything to be u32s 😉~ It's u32 now 😉 
3. All max scale numbers are now `NonZeroUsize`s. I considered refactoring this to a `NonZeroU32` as well, but felt that was an unnecessary internal detail to correct before discussion.

## Related Issues
Addresses removing the singular events and adding `actor_scaled` re: #1092 

## Release Information
No rush on releasing these so they can go out with our next regular release.

control-interface v0.33.0
wash-lib v0.16.0
wash-cli v0.26.0
wasmCloud v0.82.0

## Consumer Impact
- control-interface has a few `Option<u16>` to `u32` changes, which should be simple and anyone previously passing `None` can simply pass `u32::MAX` to preserve the same behavior
- wash-lib has a few `Option<u16>` to `u32` changes, same as control-interface
- wash-cli won't have any breaking changes, only a name change in the flag (which has a backwards compatible alias)
- wasmCloud users will need to update their `wash-cli` as omitting the count will no longer scale to unbounded, it will stop the actor.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
Modified tests to use `u32`s instead of `Option<u16>`s 

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
