### PR TITLE
fix(host): override previous call alias on clash

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2668,14 +2668,17 @@ impl Host {
         {
             let mut aliases = self.aliases.write().await;
             match aliases.entry(call_alias) {
-                Entry::Occupied(entry) => {
-                    ensure!(
-                        entry.get().public_key == claims.subject,
-                        "call alias `{}` clash between `{}` and `{}`",
-                        entry.key(),
-                        entry.get().public_key,
-                        claims.subject
+                Entry::Occupied(mut entry) => {
+                    warn!(
+                        alias = entry.key(),
+                        existing_public_key = entry.get().public_key,
+                        new_public_key = claims.subject,
+                        "call alias clash. Replacing existing entry"
                     );
+                    entry.insert(WasmCloudEntity {
+                        public_key: claims.subject.clone(),
+                        ..Default::default()
+                    });
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(WasmCloudEntity {


### PR DESCRIPTION
## Feature or Problem
Update the host to override previously cached call aliases when an alias is re-used. The host will emit a warning, since this can result in unintuitive behavior

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/1011

## Release Information
Next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Built two copies of the ponger actor, ponger1 and ponger2:
```
wash start actor file://$(realpath pinger/build/pinger_s.wasm)
wash start provider wasmcloud.azurecr.io/httpserver:0.19.1
wash link put MB2SLLXFTWEX7HR6F6PTLPWSU35MJKHR6CQHFN4QCWEIVBVJA2CFXHLY VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M wasmcloud:httpserver address=0.0.0.0:1234
```

```
wash start actor file://$(realpath ponger1/build/ponger_s.wasm)

curl 127.0.0.1:1234
Ping pong1%

wash start actor file://$(realpath ponger2/build/ponger_s.wasm)

curl 127.0.0.1:1234
Ping pong2%
```

