### PR TITLE
ci: reduce dependabot frequency to weekly for washboard-ui

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
 - package-ecosystem: npm
   directory: "/washboard-ui"
   schedule:
-    interval: "daily"
+    interval: "weekly"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Dependabot can be pretty noisy, and since the washboard doesn't have as many maintainers or get as many contributions, daily updates feel excessive