### PR TITLE
docs(providers): update README for blobstore-fs

### DIFF
--- a/crates/providers/blobstore-fs/README.md
+++ b/crates/providers/blobstore-fs/README.md
@@ -1,17 +1,19 @@
-# Blobstore-Fs capability provider
+# `blobstore-fs` capability provider
 
-This capability provider implements the `wasmcloud:blobstore` capability for
-Unix and Windows file system. The provider will store files in the local host where the
-provider executes.
+This capability provider implements the `wasmcloud:blobstore` capability for Unix and Windows file systems. 
 
-## Building
-
-Build with 'make'. Test with 'make test'.
-Testing requires docker.
+The provider will store files and folders on the host where the provider executes, and expose those folders and files within as a blobstore (AKA object storage).
 
 ## Configuration
 
-The provider is configured with the link configuration value `ROOT=<path>` which specifies where files will be stored/read.
-The default root path is `/tmp`. The provider must have read and write access to the root location.
-Each actor will store its files under the directory `$ROOT/<actor_id>`.
+Similar to other wasmcloud providers, this provider is configured wiht link configuration values:
+
+| Link value | Default | Example            | Description                               |
+|------------|---------|--------------------|-------------------------------------------|
+| `ROOT`     | `/tmp`  | `/tmp/your-folder` | The root folder where data will be stored |
+
+> [!INFO]
+> The provider must have read and write access to the disk location specified by `ROOT`
+>
+> Each actor's files will be stored under the path `$ROOT/<actor id>`
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

In the conversion of blobstore-fs codebase from the older capability-providers repos and into provider-wit-bindgen usage, the README continued to contain the older Makefile based instructions.

This commit updates the outdated README for blobstore-fs, stopping short of a complete overhaul of the documentation.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
