### PR TITLE
refactor: remove deprecated code related to start actor cmd

### DIFF
--- a/crates/control-interface/src/broker.rs
+++ b/crates/control-interface/src/broker.rs
@@ -84,16 +84,6 @@ pub fn delete_label(topic_prefix: &Option<String>, lattice_prefix: &str, host_id
 pub mod commands {
     use super::prefix;
 
-    /// Actor commands require a host target
-    #[deprecated(
-        since = "0.30.0",
-        note = "Use `scale_actor` instead. This will be removed in a future release."
-    )]
-    #[allow(dead_code)]
-    pub fn start_actor(topic_prefix: &Option<String>, lattice_prefix: &str, host: &str) -> String {
-        format!("{}.cmd.{}.la", prefix(topic_prefix, lattice_prefix), host) // la - launch actor
-    }
-
     pub fn scale_actor(topic_prefix: &Option<String>, lattice_prefix: &str, host: &str) -> String {
         format!(
             "{}.cmd.{}.scale",

--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -92,14 +92,6 @@ impl ClientBuilder {
         }
     }
 
-    /// Sets the timeout for standard calls and RPC invocations used by the client. If not set, the
-    /// default will be 2 seconds
-    #[deprecated(since = "0.30.0", note = "please use `timeout` instead")]
-    #[must_use]
-    pub fn rpc_timeout(self, timeout: Duration) -> ClientBuilder {
-        ClientBuilder { timeout, ..self }
-    }
-
     /// Sets the timeout for control interface requests issued by the client. If not set, the
     /// default will be 2 seconds
     #[must_use]
@@ -239,33 +231,6 @@ impl Client {
         })?;
         debug!("provider_auction:publish {}", &subject);
         self.publish_and_wait(subject, bytes).await
-    }
-
-    /// Sends a request to the given host to start a given actor by its OCI reference. This returns
-    /// an acknowledgement of _receipt_ of the command, not a confirmation that the actor started.
-    /// An acknowledgement will either indicate some form of validation failure, or, if no failure
-    /// occurs, the receipt of the command. To avoid blocking consumers, wasmCloud hosts will
-    /// acknowledge the start actor command prior to fetching the actor's OCI bytes. If a client
-    /// needs deterministic results as to whether the actor completed its startup process, the
-    /// client will have to monitor the appropriate event in the control event stream
-    #[instrument(level = "debug", skip_all)]
-    #[deprecated(since = "0.30.0", note = "please use `scale_actor` instead")]
-    pub async fn start_actor(
-        &self,
-        host_id: &str,
-        actor_ref: &str,
-        count: u16,
-        annotations: Option<HashMap<String, String>>,
-    ) -> Result<CtlOperationAck> {
-        // It makes no logical sense to start 0 actors, so we represent that as an unbounded max instead.
-        let max = if count == 0 { None } else { Some(count) };
-        self.scale_actor(
-            parse_identifier(&IdentifierKind::HostId, host_id)?.as_str(),
-            parse_identifier(&IdentifierKind::ActorRef, actor_ref)?.as_str(),
-            max,
-            annotations,
-        )
-        .await
     }
 
     /// Sends a request to the given host to scale a given actor. This returns an acknowledgement of

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use std::collections::HashMap;
 
 use anyhow::bail;
@@ -307,30 +306,6 @@ pub struct ScaleActorCommand {
     #[serde(default, alias = "count", rename = "count")]
     pub max_concurrent: Option<u16>,
     /// Host ID on which to scale this actor
-    #[serde(default)]
-    pub host_id: String,
-}
-
-#[deprecated(
-    since = "0.30.0",
-    note = "Use `ScaleActorCommand` instead. This will be removed in a future release."
-)]
-/// A command sent to a specific host instructing it to start the actor
-/// indicated by the reference.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct StartActorCommand {
-    /// Reference for the actor. Can be any of the acceptable forms of unique identification
-    #[serde(default)]
-    pub actor_ref: String,
-    /// Optional set of annotations used to describe the nature of this actor start command. For
-    /// example, autonomous agents may wish to "tag" start requests as part of a given deployment
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<AnnotationMap>,
-    /// The number of actors to start
-    /// A zero value will be interpreted as 1.
-    #[serde(default)]
-    pub count: u16,
-    /// Host ID on which this actor should start
     #[serde(default)]
     pub host_id: String,
 }

--- a/crates/wash-cli/src/common/stop_cmd.rs
+++ b/crates/wash-cli/src/common/stop_cmd.rs
@@ -98,19 +98,16 @@ mod test {
         ])?;
 
         match stop_actor_all.command {
-            #[allow(deprecated)]
             CtlCliCommand::Stop(StopCommand::Actor(StopActorCommand {
                 opts,
                 host_id,
                 actor_id,
                 skip_wait,
-                count,
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
                 assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
                 assert!(skip_wait);
-                assert_eq!(count, 1);
                 assert_eq!(host_id.unwrap(), HOST_ID);
                 assert_eq!(actor_id.to_string(), ACTOR_ID);
             }

--- a/crates/wash-cli/src/ctl/mod.rs
+++ b/crates/wash-cli/src/ctl/mod.rs
@@ -186,12 +186,10 @@ mod test {
             ACTOR_ID,
         ])?;
         match stop_actor_all.command {
-            #[allow(deprecated)]
             CtlCliCommand::Stop(StopCommand::Actor(StopActorCommand {
                 opts,
                 host_id,
                 actor_id,
-                count,
                 skip_wait,
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
@@ -200,14 +198,12 @@ mod test {
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id, Some(HOST_ID.to_string()));
                 assert_eq!(actor_id, ACTOR_ID);
-                assert_eq!(count, 2);
                 assert!(!skip_wait);
             }
             cmd => panic!("ctl stop actor constructed incorrect command {cmd:?}"),
         }
         let stop_actor_minimal: Cmd = Parser::try_parse_from(["ctl", "stop", "actor", "foobar"])?;
         match stop_actor_minimal.command {
-            #[allow(deprecated)]
             CtlCliCommand::Stop(StopCommand::Actor(StopActorCommand {
                 host_id, actor_id, ..
             })) => {

--- a/crates/wash-lib/src/actor.rs
+++ b/crates/wash-lib/src/actor.rs
@@ -51,9 +51,13 @@ pub async fn start_actor(
         .context("Failed to get lattice event channel")?;
 
     // Start the actor
-    #[allow(deprecated)]
     let ack = ctl_client
-        .start_actor(host_id, actor_ref, count, None)
+        .scale_actor(
+            host_id,
+            actor_ref,
+            if count == 0 { None } else { Some(count) },
+            None,
+        )
         .await
         .map_err(boxed_err_to_anyhow)
         .with_context(|| format!("Failed to start actor: {}", actor_ref))?;

--- a/crates/wash-lib/src/cli/dev.rs
+++ b/crates/wash-lib/src/cli/dev.rs
@@ -3,7 +3,7 @@ use console::style;
 use wasmcloud_control_interface::Client;
 
 use crate::{
-    actor::{start_actor, update_actor, StartActorArgs},
+    actor::update_actor,
     build::{build_project, SignConfig},
     generate::emoji,
     id::{ModuleId, ServerId},

--- a/crates/wash-lib/src/cli/dev.rs
+++ b/crates/wash-lib/src/cli/dev.rs
@@ -43,15 +43,6 @@ pub async fn run_dev_loop(
             );
 
             update_actor(ctl_client, &host_id, &actor_id, actor_ref).await?;
-            start_actor(StartActorArgs {
-                ctl_client,
-                host_id: &host_id,
-                actor_ref,
-                count: 1,
-                skip_wait: false,
-                timeout_ms: None,
-            })
-            .await?;
         }
     }
 

--- a/crates/wash-lib/src/cli/dev.rs
+++ b/crates/wash-lib/src/cli/dev.rs
@@ -3,9 +3,8 @@ use console::style;
 use wasmcloud_control_interface::Client;
 
 use crate::{
-    actor::{start_actor, stop_actor, StartActorArgs},
+    actor::{start_actor, update_actor, StartActorArgs},
     build::{build_project, SignConfig},
-    context::default_timeout_ms,
     generate::emoji,
     id::{ModuleId, ServerId},
     parser::{ProjectConfig, TypeConfig},
@@ -42,16 +41,8 @@ pub async fn run_dev_loop(
                 ))
                 .bold(),
             );
-            // TODO: Just use update actor here
-            stop_actor(
-                ctl_client,
-                &host_id,
-                &actor_id,
-                None,
-                default_timeout_ms(),
-                false,
-            )
-            .await?;
+
+            update_actor(ctl_client, &host_id, &actor_id, actor_ref).await?;
             start_actor(StartActorArgs {
                 ctl_client,
                 host_id: &host_id,

--- a/crates/wash-lib/src/cli/stop.rs
+++ b/crates/wash-lib/src/cli/stop.rs
@@ -51,14 +51,6 @@ pub struct StopActorCommand {
     #[clap(name = "actor-id")]
     pub actor_id: String,
 
-    /// Number of actors to stop (DEPRECATED: count is ignored)
-    #[clap(long = "count", default_value = "1")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "actor will be stopped regardless of scale, count is now ignored"
-    )]
-    pub count: u16,
-
     /// By default, the command will wait until the actor has been stopped.
     /// If this flag is passed, the command will return immediately after acknowledgement from the host, without waiting for the actor to stp[].
     #[clap(long = "skip-wait")]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -49,10 +49,13 @@ pub async fn assert_start_actor(
         .subscribe(format!("wasmbus.evt.{lattice_prefix}.actors_started"))
         .await?;
 
-    // TODO(#740): Remove deprecated once control clients no longer use this command
-    #[allow(deprecated)]
     let CtlOperationAck { accepted, error } = ctl_client
-        .start_actor(&host_key.public_key(), url.as_ref(), count, None)
+        .scale_actor(
+            &host_key.public_key(),
+            url.as_ref(),
+            if count == 0 { None } else { Some(count) },
+            None,
+        )
         .await
         .map_err(|e| anyhow!(e).context("failed to start actor"))?;
     ensure!(error == "");


### PR DESCRIPTION
## Feature or Problem
In #710 we introduced a few clippy warnings about deprecated control interface functionality in order to support the start actor command in a backwards compatible way. As of the control interface 0.29.0 and applicable wadm/wash versions (TBD), this command isn't used anywhere and can be fully removed instead of just deprecated.

## Related Issues
#740 

## Release Information
`wasmCloud v0.80` & `wash-cli v0.24.1`

## Consumer Impact
there should be none

## Testing
all unit tests and integration tests pass
