### PR TITLE
feat(host)!: Combine heartbeat and inventory payloads

### DIFF
--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -34,7 +34,7 @@ pub type ConstraintMap = std::collections::HashMap<String, String>;
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ActorDescription {
     /// Actor's 56-character unique ID
-    #[serde(default)]
+    #[serde(default, alias = "public_key")]
     pub id: String,
     /// Image reference for this actor, if applicable
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -136,6 +136,8 @@ pub struct Host {
 pub struct HostInventory {
     /// Actors running on this host.
     pub actors: Vec<ActorDescription>,
+    /// Providers running on this host
+    pub providers: ProviderDescriptions,
     /// The host's unique ID
     #[serde(default)]
     pub host_id: String,
@@ -146,9 +148,17 @@ pub struct HostInventory {
     #[serde(default)]
     pub friendly_name: String,
     /// The host's labels
+    #[serde(default)]
     pub labels: LabelsMap,
-    /// Providers running on this host
-    pub providers: ProviderDescriptions,
+    /// The host version
+    #[serde(default)]
+    pub version: String,
+    /// The host uptime in human-readable form
+    #[serde(default)]
+    pub uptime_human: String,
+    /// The host uptime in seconds
+    #[serde(default)]
+    pub uptime_seconds: u64,
 }
 
 pub type KeyValueMap = std::collections::HashMap<String, String>;
@@ -201,7 +211,7 @@ pub struct ProviderDescription {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<AnnotationMap>,
     /// Provider's unique 56-character ID
-    #[serde(default)]
+    #[serde(default, alias = "public_key")]
     pub id: String,
     /// Image reference for this provider, if applicable
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -810,6 +810,9 @@ expected: {base_labels:?}"#
         mut providers,
         issuer,
         friendly_name,
+        version,
+        uptime_human,
+        uptime_seconds,
     } = ctl_client
         .get_host_inventory(&host_key.public_key())
         .await
@@ -827,6 +830,9 @@ expected: {base_labels:?}"#
 got: {labels:?}
 expected: {expected_labels:?}"#
     );
+    ensure!(version == env!("CARGO_PKG_VERSION"), "invalid version");
+    ensure!(!uptime_human.is_empty());
+    ensure!(uptime_seconds > 0);
     actors.sort_by(|a, b| b.name.cmp(&a.name));
     match (actors.pop(), actors.pop(), actors.pop(), actors.as_slice()) {
         (
@@ -1016,6 +1022,9 @@ expected: {expected_name:?}"#
         mut providers,
         issuer,
         friendly_name,
+        version,
+        uptime_human,
+        uptime_seconds,
     } = ctl_client
         .get_host_inventory(&host_key_two.public_key())
         .await
@@ -1034,6 +1043,10 @@ got: {labels:?}
 expected: {expected_labels_two:?}"#
     );
     ensure!(actors.is_empty());
+    ensure!(version == env!("CARGO_PKG_VERSION"), "invalid version");
+    ensure!(!uptime_human.is_empty());
+    ensure!(uptime_seconds > 0);
+
     match (providers.pop(), providers.as_slice()) {
         (Some(nats), []) => {
             // TODO: Validate `constraints`


### PR DESCRIPTION
- feat(host)!: change heartbeat payload to inventory
- feat(control-interface)!: add heartbeat fields to inventory

## Feature or Problem
In https://github.com/wasmCloud/wadm and https://github.com/wasmCloud/lattice-observer, and any other client, after a heartbeat a host inventory query is necessary in order to get enough information to reflect the state of the host. This PR solves this issue, giving any interested client the ability to know the full state of what's running on the host with only the heartbeat or the host inventory.

## Related Issues
Fixes #789 

## Release Information
wasmCloud v0.82.0
control interface v0.33.0

## Consumer Impact
The only consumers of the heartbeat payload, noted above, I'll update to work with both the old payload and the new payload. Worth noting that the only deserialize breaking change here is in the heartbeat, changing the actor map into a list and changing the provider "public_key" into "id" which I mitigated by adding a serde alias.

I see this as a test for future compatibility and will try out a strategy to see how we can work with deserializing two possible versions in the future.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
Modified wasmbus test to ensure that the new inventory variables, version, uptime_seconds, uptime_human come back as sensible values.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
