### PR TITLE
feat(wash-lib)!: add support for inspecting wit

### DIFF
--- a/crates/wash-cli/src/par.rs
+++ b/crates/wash-cli/src/par.rs
@@ -197,6 +197,7 @@ impl From<InspectCommand> for inspect::InspectCliCommand {
         inspect::InspectCliCommand {
             target: cmd.archive,
             jwt_only: false,
+            wit: false,
             digest: cmd.digest,
             allow_latest: cmd.allow_latest,
             user: cmd.user,

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -85,6 +85,7 @@ wasm-encoder = { workspace = true }
 wasmcloud-component-adapters = { version = "0.2.4" } # override this version, since 0.3.0 uses an adapter based on wasmtime v0.14
 wasmcloud-control-interface = { workspace = true }
 wasmcloud-core = { workspace = true }
+wasmparser = { workspace = true }
 wat = { workspace = true }
 weld-codegen = { workspace = true, features = ["wasmbus"] }
 wit-bindgen-core = { workspace = true }

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -42,6 +42,10 @@ pub struct InspectCommand {
     #[clap(name = "jwt_only", long = "jwt-only")]
     pub(crate) jwt_only: bool,
 
+    /// Extract the WIT world from a component and print to stdout instead of the claims
+    #[clap(name = "wit", long = "wit", alias = "world")]
+    pub wit: bool,
+
     /// Digest to verify artifact against (if OCI URL is provided for <module>)
     #[clap(short = 'd', long = "digest")]
     pub(crate) digest: Option<String>,
@@ -301,6 +305,7 @@ impl From<InspectCommand> for inspect::InspectCliCommand {
         inspect::InspectCliCommand {
             target: cmd.module,
             jwt_only: cmd.jwt_only,
+            wit: cmd.wit,
             digest: cmd.digest,
             allow_latest: cmd.allow_latest,
             user: cmd.user,
@@ -786,6 +791,7 @@ mod test {
                 password,
                 insecure,
                 no_cache,
+                wit,
             }) => {
                 assert_eq!(module, SUBSCRIBER_OCI);
                 assert_eq!(
@@ -798,6 +804,7 @@ mod test {
                 assert!(insecure);
                 assert!(jwt_only);
                 assert!(no_cache);
+                assert!(!wit);
             }
             cmd => panic!("claims constructed incorrect command: {:?}", cmd),
         }
@@ -829,6 +836,7 @@ mod test {
                 password,
                 insecure,
                 no_cache,
+                wit,
             }) => {
                 assert_eq!(module, SUBSCRIBER_OCI);
                 assert_eq!(
@@ -841,6 +849,7 @@ mod test {
                 assert!(insecure);
                 assert!(jwt_only);
                 assert!(no_cache);
+                assert!(!wit);
             }
             cmd => panic!("claims constructed incorrect command: {:?}", cmd),
         }


### PR DESCRIPTION
## Feature or Problem
This PR allows `wash` users to add `--wit` after or before their file/oci reference to print out the embedded wit world in a WASI preview 2 component. In the case that it is an empty wit world, it's assumed that it is a WASI preview 1 component and we output a message accordingly.

I also changed the heading from the claims inspect from `Module` to `Actor` and `Provider Archive` to `Capability Provider`. Keeping it as module just felt confusing when we'll be inspecting components too.
```
cargo run -- inspect wasmcloud.azurecr.io/echo:0.3.4      
    Finished dev [unoptimized + debuginfo] target(s) in 0.36s
     Running `/Users/brooks/github.com/wasmcloud/wasmCloud/target/debug/wash inspect 'wasmcloud.azurecr.io/echo:0.3.4'`

                                                                          
                               Echo - Actor                               
  Account       ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW  
  Actor         MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5  
  Expires                                                          never  
  Can Be Used                                                immediately  
  Version                                                      0.3.4 (4)  
  Call Alias                                                   (Not set)  
                               Capabilities                               
  HTTP Server                                                             
                                   Tags                                   
  None  
```
## Related Issues
Related to #336 

## Release Information
wash-lib 0.16.0

## Consumer Impact
This is a backwards compatible change in `wash-cli`, but consumers of wash-lib that are instantiating the full `InspectCommand` struct will need to add the `wit` boolean field.

## Testing

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Module
```
cargo run -- inspect wasmcloud.azurecr.io/echo:0.3.4 --wit                    
    Finished dev [unoptimized + debuginfo] target(s) in 0.38s
     Running `/Users/brooks/github.com/wasmcloud/wasmCloud/target/debug/wash inspect 'wasmcloud.azurecr.io/echo:0.3.4' --wit`

WIT World 'root' is empty, this looks like a WASI Preview 1 Module
```

Component
```
➜ cargo run -- inspect ~/demo/componentize-js/hello_s.component.wasm --wit 
    Finished dev [unoptimized + debuginfo] target(s) in 0.38s
     Running `/Users/brooks/github.com/wasmcloud/wasmCloud/target/debug/wash inspect /Users/brooks/demo/componentize-js/hello_s.component.wasm --wit`

package root:component;

world root {
  import wasi:io/error@0.2.0-rc-2023-11-10;
  import wasi:io/streams@0.2.0-rc-2023-11-10;
  import wasi:filesystem/types@0.2.0-rc-2023-11-10;
  import wasi:filesystem/preopens@0.2.0-rc-2023-11-10;
  import wasi:sockets/tcp@0.2.0-rc-2023-11-10;
  import wasi:cli/stdin@0.2.0-rc-2023-11-10;
  import wasi:cli/stdout@0.2.0-rc-2023-11-10;
  import wasi:cli/stderr@0.2.0-rc-2023-11-10;
  import wasi:cli/terminal-input@0.2.0-rc-2023-11-10;
  import wasi:cli/terminal-output@0.2.0-rc-2023-11-10;
  import wasi:cli/terminal-stdin@0.2.0-rc-2023-11-10;
  import wasi:cli/terminal-stdout@0.2.0-rc-2023-11-10;
  import wasi:cli/terminal-stderr@0.2.0-rc-2023-11-10;

  export wasmcloud:bus/guest;
}
```
