### PR TITLE
ci(dependabot): group wasmtime dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  groups:
+    wasmtime: # wasmtime dependencies need to be updated together
+      patterns:
+      - "wasmtime*"
 - package-ecosystem: "cargo"
   directory: "/crates/providers"
   schedule:


### PR DESCRIPTION
## Feature or Problem
Dependabot supports a `group` setting, which tells dependabot to open PRs [as a group](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#example-3)

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/1162
