### PR TITLE
chore: wasmCloud 0.81 bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5228,7 +5228,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-host"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "0.80.0"
+version = "0.81.0"
 description = "wasmCloud host runtime"
 
 authors.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ warp = { version = "0.3", default-features = false }
 warp-embed = { version = "0.4", default-features = false }
 wascap = { version = "0.12", path = "./crates/wascap", default-features = false }
 wash-cli = { version = "0", path = "./crates/wash-cli", default-features = false }
-wash-lib = { version = "0.15", path = "./crates/wash-lib", default-features = false }
+wash-lib = { version = "0.16", path = "./crates/wash-lib", default-features = false }
 wasi-common = { branch = "release-16.0.0", git = "https://github.com/bytecodealliance/wasmtime", default-features = false }
 wasm-encoder = { version = "0.38", default-features = false }
 wasm-gen = { version = "0.1", default-features = false }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.80.0"
+version = "0.81.0"
 description = "wasmCloud host library"
 
 authors.workspace = true

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.24.1"
+version = "0.25.0"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) CLI tool"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -11,9 +11,9 @@ pub const NATS_SERVER_VERSION: &str = "v2.9.14";
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values
-pub const WADM_VERSION: &str = "v0.7.1";
+pub const WADM_VERSION: &str = "v0.9.1";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub const WASMCLOUD_HOST_VERSION: &str = "v0.80.0";
+pub const WASMCLOUD_HOST_VERSION: &str = "v0.81.0";
 // NATS isolation configuration variables
 pub const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub const DEFAULT_LATTICE_PREFIX: &str = "default";

--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -13,7 +13,7 @@ pub const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values
 pub const WADM_VERSION: &str = "v0.9.1";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub const WASMCLOUD_HOST_VERSION: &str = "v0.81.0";
+pub const WASMCLOUD_HOST_VERSION: &str = "v0.81.0-rc1";
 // NATS isolation configuration variables
 pub const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub const DEFAULT_LATTICE_PREFIX: &str = "default";

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -412,14 +412,14 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
             Ok(path) => {
                 let wadm_child = start_wadm(&path, wadm_log_file, Some(config)).await;
                 if let Err(e) = &wadm_child {
-                    println!("🟨 Couldn't start wadm: {e}");
+                    eprintln!("🟨 Couldn't start wadm: {e}");
                     None
                 } else {
                     Some(wadm_child.unwrap())
                 }
             }
             Err(e) => {
-                println!("🟨 Couldn't download wadm {WADM_VERSION}: {e}");
+                eprintln!("🟨 Couldn't download wadm {WADM_VERSION}: {e}");
                 None
             }
         }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.15.0"
+version = "0.16.0"
 categories = ["wasm", "wasmcloud"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -23,9 +23,8 @@ pub const WASMCLOUD_HOST_BIN: &str = "wasmcloud_host";
 #[cfg(target_family = "windows")]
 pub const WASMCLOUD_HOST_BIN: &str = "wasmcloud_host.exe";
 
-// Any version of wasmCloud under 0.63.0 uses Elixir releases and is incompatible
-// See https://github.com/wasmCloud/wasmcloud-otp/pull/616 for the move to burrito releases
-const MINIMUM_WASMCLOUD_VERSION: &str = "0.78.0-rc2";
+// Any version of wasmCloud under 0.81 does not support wasmtime 16 wit worlds and is incompatible.
+const MINIMUM_WASMCLOUD_VERSION: &str = "0.81.0";
 
 /// A wrapper around the [ensure_wasmcloud_for_os_arch_pair] function that uses the
 /// architecture and operating system of the current host machine.
@@ -256,7 +255,7 @@ fn wasmcloud_url(version: &str) -> String {
     let os = "unknown-linux-gnu";
 
     #[cfg(target_os = "windows")]
-    let os = "pc-windows-gnu";
+    let os = "pc-windows-msvc.exe";
     format!(
         "{WASMCLOUD_GITHUB_RELEASE_URL}/{version}/wasmcloud-{arch}-{os}",
         arch = std::env::consts::ARCH
@@ -513,15 +512,15 @@ mod test {
 
     #[tokio::test]
     async fn can_properly_deny_elixir_release_hosts() -> anyhow::Result<()> {
-        // Ensure we allow versions >= 0.63.0
-        assert!(check_version("v0.78.0").is_ok());
+        // Ensure we allow versions >= 0.81.0
+        assert!(check_version("v0.81.0").is_ok());
         assert!(check_version(MINIMUM_WASMCLOUD_VERSION).is_ok());
 
         // Ensure we allow prerelease tags for testing
-        assert!(check_version("v0.79.0-rc.1").is_ok());
+        assert!(check_version("v0.81.0-rc1").is_ok());
 
         // Ensure we deny versions < MINIMUM_WASMCLOUD_VERSION
-        assert!(check_version("v0.63.1").is_err());
+        assert!(check_version("v0.80.99").is_err());
 
         if let Err(e) = check_version("v0.56.0") {
             assert_eq!(e.to_string(), format!("wasmCloud version v0.56.0 is earlier than the minimum supported version of v{MINIMUM_WASMCLOUD_VERSION}"));

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -442,7 +442,6 @@ mod test {
         let mut host_env = HashMap::new();
         host_env.insert("WASMCLOUD_RPC_PORT".to_string(), nats_port.to_string());
         host_env.insert("WASMCLOUD_CTL_PORT".to_string(), nats_port.to_string());
-        host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string()); // TODO: remove these after wasmCloud v0.80.0 is released, dropping support for prov_rpc connections
         let mut host_child = start_wasmcloud_host(
             &wasmcloud_binary,
             stdout_log_file,
@@ -496,7 +495,6 @@ mod test {
         let mut host_env = HashMap::new();
         host_env.insert("WASMCLOUD_RPC_PORT".to_string(), nats_port.to_string());
         host_env.insert("WASMCLOUD_CTL_PORT".to_string(), nats_port.to_string());
-        host_env.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), nats_port.to_string()); // TODO: remove these after wasmCloud v0.80.0 is released, dropping support for prov_rpc connections
         let child_res = start_wasmcloud_host(
             &wasmcloud_binary,
             std::process::Stdio::null(),

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -303,7 +303,7 @@ mod test {
     use tokio::net::TcpListener;
     use tokio::time::Duration;
 
-    const WASMCLOUD_VERSION: &str = "v0.79.0-rc3";
+    const WASMCLOUD_VERSION: &str = "v0.81.0-rc1";
 
     /// Returns an open port on the interface, searching within the range endpoints, inclusive
     async fn find_open_port() -> Result<u16> {


### PR DESCRIPTION
- chore: bump wasmcloud to 0.81
- chore: bump wash-lib to 0.16
- chore: bump wash-cli to 0.25

## Feature or Problem
This PR bumps wasmcloud, wash-lib, and wash-cli for release. We can merge this PR but it is not quite ready to release yet as there are one or two more changes required before we release:
- [x] Bump wasmCloud component adapters in wash-lib to wasmtime rc3 from @ricochet's repo
- [ ] Ensure that everything works out-of-the-box to build #1178, #1184, and our echo example
- [ ] ..?

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wasmCloud 0.81
wash-lib 0.16
wash-cli 0.25

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
I was able to `--dry-run` publish both wash-lib and wash-cli (minus the dependency on wash-lib 0.16).

Additionally, I used the following commands to verify the proper semver release for all of these crates:
```
➜ convco version --bump
0.81.0
➜ convco version --prefix wash-lib-v -P crates/wash-lib --bump
0.16.0
➜ convco version --prefix wash-cli-v -P crates/wash-cli --bump
0.25.0
```

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
This PR changed the Windows artifact to `pc-windows-msvc` as per #807, so we're enforcing that the minimum version of wasmCloud is now going to be 0.81. This is beneficial as we can also have a certain level of confidence w.r.t the wit worlds that we are using.

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
