### PR TITLE
fix(wash-lib): enable docs feature when building for docs.rs

### DIFF
--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -29,10 +29,10 @@ cli = [
     "path-absolutize",
 ]
 nats = ["async-nats", "wadm"]
+docs = ["wasmcloud-component-adapters/docs"]
 
 [package.metadata.docs.rs]
-no-default-features = true # skip building adapters (which requires internet access)
-features = ["start", "parser", "nats"]
+features = ["start", "parser", "nats", "docs"]
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## Feature or Problem
It looks like the `docs` feature got dropped from `wasmcloud-component-adapters`. I think we need this enabled in order to ensure the docs.rs build will pass (by avoiding downloading the adapters, which will fail inside the container)