### PR TITLE
fix(wash-lib): fix generating from git branch

### DIFF
--- a/crates/wash-lib/src/generate/git.rs
+++ b/crates/wash-lib/src/generate/git.rs
@@ -41,7 +41,16 @@ pub async fn clone_git_template(opts: CloneTemplate) -> Result<()> {
     };
 
     let cmd_out = Command::new("git")
-        .args(["clone", &repo_url, "--depth", "1", "--no-checkout", "."])
+        .args([
+            "clone",
+            &repo_url,
+            "--depth",
+            "1",
+            "--no-checkout",
+            "--branch",
+            &opts.repo_branch,
+            ".",
+        ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
This PR addresses an issue where our shallow clone of a repository wouldn't `fetch` the branches. Now the `wash new` command will fetch a git repository using only the supplied branch, defaulting to `main` if not supplied.

## Related Issues
Fixes #845

## Release Information
next

## Consumer Impact
This doesn't change default behavior, but users that are attempting to clone templates from a repo where the primary branch is `master` will have to supply `--branch master`

## Testing


### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Made sure this worked with #1184
