### PR TITLE
chore(providers): consistent kebab case names for start_provider()

### DIFF
--- a/crates/providers/blobstore-fs/src/bin/blobstore_fs.rs
+++ b/crates/providers/blobstore-fs/src/bin/blobstore_fs.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // and returns only when it receives a shutdown message
     wasmcloud_provider_sdk::start_provider(
         FsProvider::default(),
-        Some("Blobstore FS Provider".to_string()),
+        Some("blobstore-fs-provider".to_string()),
     )?;
 
     eprintln!("Blobstore FS Provider exiting");

--- a/crates/providers/blobstore-s3/src/bin/blobstore_s3.rs
+++ b/crates/providers/blobstore-s3/src/bin/blobstore_s3.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // and returns only when it receives a shutdown message
     wasmcloud_provider_sdk::start_provider(
         BlobstoreS3Provider::default(),
-        Some("Blobstore S3 Provider".to_string()),
+        Some("blobstore-s3-provider".to_string()),
     )?;
 
     eprintln!("Blobstore S3 Provider exiting");

--- a/crates/providers/http-client/src/bin/httpclient.rs
+++ b/crates/providers/http-client/src/bin/httpclient.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // and returns only when it receives a shutdown message
     wasmcloud_provider_sdk::start_provider(
         HttpClientProvider{},
-        Some("HttpClient Provider".to_string()),
+        Some("http-client-provider".to_string()),
     )?;
 
     eprintln!("HttpClient provider exiting");

--- a/crates/providers/kv-redis/src/bin/kvredis.rs
+++ b/crates/providers/kv-redis/src/bin/kvredis.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     start_provider(
         KvRedisProvider::new(&default_connect_url),
-        Some("KeyValue Redis Provider".to_string()),
+        Some("kv-redis-provider".to_string()),
     )?;
 
     eprintln!("KVRedis provider exiting");


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit makes the kebab case used in provider names consistent for
in-tree providers that have been converted to use the `provider-wit-bindgen` crate.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
