### PR TITLE
chore: remove references to PROV_RPC settings

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -156,29 +156,6 @@ spec:
             - name: WASMCLOUD_RPC_TLS
               value: {{ .Values.wasmcloud.config.rpc.tls | quote }}
             {{- end }}
-            {{- if .Values.wasmcloud.config.providerRpc.natsHost }}
-            - name: WASMCLOUD_PROV_RPC_HOST
-              value: {{ .Values.wasmcloud.config.providerRpc.natsHost | quote }}
-            {{- end }}
-            {{- if .Values.wasmcloud.config.providerRpc.natsPort }}
-            - name: WASMCLOUD_PROV_RPC_PORT
-              value: {{ .Values.wasmcloud.config.providerRpc.natsPort | quote }}
-            {{- end }}
-            {{- if .Values.wasmcloud.config.providerRpc.natsJwt }}
-            - name: WASMCLOUD_PROV_RPC_JWT
-              value: {{ .Values.wasmcloud.config.providerRpc.natsJwt | quote }}
-            {{- end }}
-            {{- if .Values.wasmcloud.config.providerRpc.natsSeed }}
-            - name: WASMCLOUD_PROV_RPC_SEED
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "wasmcloud_host.fullname" . }}
-                  key: providerRpcNatsSeed
-            {{- end }}
-            {{- if .Values.wasmcloud.config.providerRpc.tls }}
-            - name: WASMCLOUD_PROV_RPC_TLS
-              value: {{ .Values.wasmcloud.config.providerRpc.tls | quote }}
-            {{- end }}
             {{- if .Values.wasmcloud.config.otel.exporter }}
             - name: OTEL_TRACES_EXPORTER
               value: {{ .Values.wasmcloud.config.otel.exporter | quote }}

--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -94,13 +94,9 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
     // NATS RPC connection configuration
     if let Some(host) = wasmcloud_opts.rpc_host {
         host_config.insert(WASMCLOUD_RPC_HOST.to_string(), host.clone());
-        // TODO: remove me after the host removes support for PROV_RPC connections
-        host_config.insert("WASMCLOUD_PROV_RPC_HOST".to_string(), host);
     }
     if let Some(port) = wasmcloud_opts.rpc_port {
         host_config.insert(WASMCLOUD_RPC_PORT.to_string(), port.to_string());
-        // TODO: remove me after the host removes support for PROV_RPC connections
-        host_config.insert("WASMCLOUD_PROV_RPC_PORT".to_string(), port.to_string());
     }
     if let Some(rpc_timeout_ms) = wasmcloud_opts.rpc_timeout_ms {
         host_config.insert(
@@ -112,9 +108,6 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
         if let Ok((jwt, seed)) = parse_credsfile(path).await {
             host_config.insert(WASMCLOUD_RPC_JWT.to_string(), jwt.clone());
             host_config.insert(WASMCLOUD_RPC_SEED.to_string(), seed.clone());
-            // TODO: remove me after the host removes support for PROV_RPC connections
-            host_config.insert("WASMCLOUD_PROV_RPC_JWT".to_string(), jwt);
-            host_config.insert("WASMCLOUD_PROV_RPC_SEED".to_string(), seed);
         };
     } else {
         if let Some(jwt) = wasmcloud_opts.rpc_jwt {
@@ -126,8 +119,6 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
     }
     if wasmcloud_opts.rpc_tls {
         host_config.insert(WASMCLOUD_RPC_TLS.to_string(), "1".to_string());
-        // TODO: remove me after the host removes support for PROV_RPC connections
-        host_config.insert("WASMCLOUD_PROV_RPC_TLS".to_string(), "1".to_string());
     }
 
     // NATS CTL connection configuration


### PR DESCRIPTION
This removes references to PROC_RPC settings from wash and the helm chart, in anticipation of wasmcloud v0.81, which no longer supports these settings