### PR TITLE
feat(examples): add docker compose examples

### DIFF
--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,30 @@
+## Overview
+
+This directory contains Docker Compose files for starting containers helpful for running wasmCloud examples. These containers include:
+
+- a [NATS](https://nats.io) server with JetStream enabled, needed to support the network for a lattice
+- an OCI registry, to support pushing and pulling locally-built artifacts
+- [Grafana](https://grafana.com/) + [Tempo](https://grafana.com/oss/tempo/), for viewing distributed traces
+- the wasmCloud host
+- a [WADM](/docs/category/declarative-application-deployment-wadm) server, for managing wasmCloud applications
+
+## Running the entire ecosystem in Docker
+
+```bash
+docker compose -f docker-compose-full.yml up
+```
+
+## Running supporting services in Docker
+
+```bash
+docker compose -f docker-compose-auxiliary.yml up
+OTEL_TRACES_EXPORTER=otlp wash up # start the host with OTEL exports enabled
+```
+
+## Viewing traces
+
+Navigate to http://localhost:5050/explore, click the dropdown in the upper left, and select "Tempo".
+
+There are several ways to query traces in Tempo. To see all traces from the host, change the "Query type" tab to "Search", then click the "Service Name" dropdown and select "wasmCloud Host." You can also increase the "Limit" field to something more than the default (20).
+
+To search, press Shift-Enter. You can click on any of the Trace IDs to view all the spans associated with the trace.

--- a/examples/docker/docker-compose-auxiliary.yml
+++ b/examples/docker/docker-compose-auxiliary.yml
@@ -1,0 +1,31 @@
+# This docker-compose file starts supporting services for a wasmCloud ecosystem, including: 
+#   a local OCI registry
+#   grafana + tempo for tracing
+# This file is intended to be used with `wash up` to start a NATS server, wasmCloud host, and WADM server
+
+version: "3"
+services:
+  registry:
+    image: registry:2.8
+    ports:
+      - "5000:5000"
+  grafana:
+    image: grafana/grafana:10.0.10
+    ports:
+      - 5050:3000
+    volumes:
+      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    depends_on:
+      - tempo  
+  tempo:
+    image: grafana/tempo:2.3.1
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+    ports:
+      - 8000:8000 # tempo
+      - 55681:55681 # otlp http  

--- a/examples/docker/docker-compose-full.yml
+++ b/examples/docker/docker-compose-full.yml
@@ -1,0 +1,64 @@
+# This docker-compose file starts an entire wasmCloud ecosystem, including:
+#   a NATS server
+#   a local OCI registry
+#   grafana + tempo for tracing
+#   a wasmCloud host
+#   a WADM server for managing applications
+
+version: "3"
+services:
+  nats:
+    image: nats:2.10.7-alpine
+    ports:
+      - "4222:4222"
+      - "6222:6222"
+      - "8222:8222"
+    command: ["-js"]
+  registry:
+    image: registry:2.8
+    ports:
+      - "5000:5000"
+  grafana:
+    image: grafana/grafana:10.0.10
+    ports:
+      - 5050:3000
+    volumes:
+      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    depends_on:
+      - tempo
+  tempo:
+    image: grafana/tempo:2.3.1
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+    ports:
+      - 8000:8000 # tempo
+      - 55681:55681 # otlp http
+
+  wasmcloud:
+    depends_on:
+      - "nats"
+      - "grafana"
+      - "tempo"
+    image: wasmcloud/wasmcloud:latest
+    environment:
+      RUST_LOG: debug,hyper=info,async_nats=info,oci_distribution=info,cranelift_codegen=warn
+      WASMCLOUD_LOG_LEVEL: debug
+      WASMCLOUD_RPC_HOST: nats
+      WASMCLOUD_CTL_HOST: nats
+      WASMCLOUD_OCI_ALLOWED_INSECURE: registry:5000
+      OTEL_TRACES_EXPORTER: otlp
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:55681/v1/traces
+    ports:
+      - "8000-8100:8000-8100" # Expose ports 8000-8100 for examples that use an HTTP server
+
+  wadm:
+    depends_on:
+      - "nats"
+    image: ghcr.io/wasmcloud/wadm:latest
+    environment:
+      - WADM_NATS_SERVER=nats

--- a/examples/docker/grafana-datasources.yaml
+++ b/examples/docker/grafana-datasources.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:8000
+    version: 1
+    editable: false
+    uid: tempo  

--- a/examples/docker/tempo.yaml
+++ b/examples/docker/tempo.yaml
@@ -1,0 +1,22 @@
+server:
+  http_listen_port: 8000
+
+distributor:
+  log_received_spans:
+    enabled: true
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: "0.0.0.0:55681"
+
+storage:
+  trace:
+    backend: local
+    block:
+      v2_encoding: zstd
+    wal:
+      path: /tmp/tempo/wal
+      v2_encoding: none
+    local:
+      path: /tmp/tempo/blocks


### PR DESCRIPTION
This migrates the docker compose examples into the main repo. The contents are mostly the same as https://github.com/wasmcloud/examples/tree/main/docker, but with updated versions and a more detailed README