### PR TITLE
feat(wash-cli): prefix absolute path references with file://

### DIFF
--- a/crates/wash-cli/src/common/start_cmd.rs
+++ b/crates/wash-cli/src/common/start_cmd.rs
@@ -1,7 +1,7 @@
 use crate::appearance::spinner::Spinner;
 
 use anyhow::Result;
-use wash_lib::cli::start::{handle_start_actor, start_provider, StartCommand};
+use wash_lib::cli::start::{handle_start_actor, handle_start_provider, StartCommand};
 use wash_lib::cli::{CommandOutput, OutputKind};
 
 pub async fn handle_command(
@@ -22,7 +22,7 @@ pub async fn handle_command(
 
             sp.update_spinner_message(format!(" Starting provider {provider_ref} ... "));
 
-            start_provider(cmd).await?
+            handle_start_provider(cmd).await?
         }
     };
 


### PR DESCRIPTION
A few users have been confused trying to run commands like `wash start actor /path/to/file` and seeing an error (from the host). The `file://` scheme is rough devX, so instead, if wash can detect the reference is an absolute file path (i.e. it starts with a `/`), wash can simply prefix the reference for the user