### PR TITLE
fix(wash): only generate tinygo when wit-dir present

### DIFF
--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -315,7 +315,14 @@ fn build_tinygo_actor(
     }
 
     // Generate wit-bindgen code for Golang actors which are components-first
-    if let WasmTarget::WasiPreview1 | WasmTarget::WasiPreview2 = &actor_config.wasm_target {
+    //
+    // Running wit-bindgen via go generate is only for WIT-enabled projects, so we must limit
+    // to only projects that have their WIT defined in the expected top level wit directory
+    //
+    // While wasmcloud and it's tooling is WIT-first, it is possible to build preview1/preview2
+    // components that are *not* WIT enabled. To determine whether the project is WIT-enabled
+    // we check for the `wit` directory which would be passed through to bindgen.
+    if actor_config.wit_world.is_some() {
         generate_tinygo_bindgen(
             &output_dir,
             common_config.path.join("wit"),
@@ -323,7 +330,7 @@ fn build_tinygo_actor(
                 "missing `wit_world` in wasmcloud.toml ([actor] section) to run go bindgen generate",
             )?,
         )
-            .context("generating golang bindgen code failed")?;
+                .context("generating golang bindgen code failed")?;
     }
 
     let result = command
@@ -421,6 +428,13 @@ fn generate_tinygo_bindgen(
         bail!(
             "bindgen directory @ [{}] does not exist",
             bindgen_dir.as_ref().display(),
+        );
+    }
+
+    if !wit_dir.as_ref().exists() {
+        bail!(
+            "top level WIT directory @ [{}] does not exist",
+            wit_dir.as_ref().display(),
         );
     }
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Golang projects built by wash which have
`wasm32-wasi-preview1` set as their `wasm_target` (in `wasmcloud.toml`) fail to build due to go
bindgen (i.e. `wit-bindgen-go`) being run on them.

While the wasmcloud ecosystem is WIT-first, it is possible to build preview1/preview2 components *without* WIT (i.e. with the legacy Smithy ecosystem), and projects that are built in that way should not have bindgen run on them.

This commit improves the check to use `wit_world` to determine whether to run go-based bindgen

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

https://github.com/wasmCloud/wasmCloud/issues/1241

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

templates built with tinygo that are using legacy smithy interfaces will build when using `wasm_target = "wasm32-wasi-preview1"`)

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

There's a test that caught this failure -- `integration_build_tinygo_actor_unsigned`

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

Verified manually
