### PR TITLE
chore(wash-cli): update wasmcloud version to 0.81

### DIFF
--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -13,7 +13,7 @@ pub const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values
 pub const WADM_VERSION: &str = "v0.9.1";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub const WASMCLOUD_HOST_VERSION: &str = "v0.81.0-rc1";
+pub const WASMCLOUD_HOST_VERSION: &str = "v0.81.0";
 // NATS isolation configuration variables
 pub const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
 pub const DEFAULT_LATTICE_PREFIX: &str = "default";

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -302,7 +302,7 @@ mod test {
     use tokio::net::TcpListener;
     use tokio::time::Duration;
 
-    const WASMCLOUD_VERSION: &str = "v0.81.0-rc1";
+    const WASMCLOUD_VERSION: &str = "v0.81.0";
 
     /// Returns an open port on the interface, searching within the range endpoints, inclusive
     async fn find_open_port() -> Result<u16> {
@@ -511,7 +511,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn can_properly_deny_elixir_release_hosts() -> anyhow::Result<()> {
+    async fn can_properly_deny_too_old_hosts() -> anyhow::Result<()> {
         // Ensure we allow versions >= 0.81.0
         assert!(check_version("v0.81.0").is_ok());
         assert!(check_version(MINIMUM_WASMCLOUD_VERSION).is_ok());


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
This PR just updates the wasmCloud version in wash-cli to be pinned to v0.81.0 instead of the release candidate for release.

As far as I know this was the only outstanding change, please request changes on this PR if you're aware of something else.

## Related Issues
N/A

## Release Information
wash-lib 0.16.0
wash-cli 0.25.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
