### PR TITLE
chore(control-interface): bump to 0.32.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4855,7 +4855,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "uuid 1.6.1",
- "wasmcloud-control-interface 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmcloud-control-interface 0.32.0",
 ]
 
 [[package]]
@@ -4991,7 +4991,7 @@ dependencies = [
  "warp-embed",
  "wascap",
  "wash-lib",
- "wasmcloud-control-interface 0.32.0",
+ "wasmcloud-control-interface 0.32.1",
  "wasmcloud-core",
  "wasmcloud-provider-sdk",
  "weld-codegen",
@@ -5051,7 +5051,7 @@ dependencies = [
  "wascap",
  "wasm-encoder",
  "wasmcloud-component-adapters",
- "wasmcloud-control-interface 0.32.0",
+ "wasmcloud-control-interface 0.32.1",
  "wasmcloud-core",
  "wasmparser",
  "wat",
@@ -5255,7 +5255,7 @@ dependencies = [
  "uuid 1.6.1",
  "vaultrs",
  "wascap",
- "wasmcloud-control-interface 0.32.0",
+ "wasmcloud-control-interface 0.32.1",
  "wasmcloud-core",
  "wasmcloud-host",
  "wasmcloud-tracing",
@@ -5320,13 +5320,13 @@ dependencies = [
 [[package]]
 name = "wasmcloud-control-interface"
 version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c67369563f873509343dd6bad5f2bcd07ccb4db09d882dcf85efff581ed8a0"
 dependencies = [
- "anyhow",
  "async-nats",
  "bytes",
  "cloudevents-sdk",
  "futures",
- "oci-distribution",
  "opentelemetry",
  "serde",
  "serde_json",
@@ -5337,14 +5337,14 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c67369563f873509343dd6bad5f2bcd07ccb4db09d882dcf85efff581ed8a0"
+version = "0.32.1"
 dependencies = [
+ "anyhow",
  "async-nats",
  "bytes",
  "cloudevents-sdk",
  "futures",
+ "oci-distribution",
  "opentelemetry",
  "serde",
  "serde_json",
@@ -5406,7 +5406,7 @@ dependencies = [
  "uuid 1.6.1",
  "wascap",
  "wasmcloud-compat",
- "wasmcloud-control-interface 0.32.0",
+ "wasmcloud-control-interface 0.32.1",
  "wasmcloud-core",
  "wasmcloud-runtime",
  "wasmcloud-tracing",

--- a/crates/control-interface/Cargo.toml
+++ b/crates/control-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.32.0"
+version = "0.32.1"
 homepage = "https://wasmcloud.com"
 description = "A client library for communicating with hosts on a wasmCloud lattice"
 documentation = "https://docs.rs/wasmcloud-control-interface"

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-nats",


### PR DESCRIPTION
Below is the generated changelog for the control interface.
# Changelog

## [Unreleased](https://github.com/wasmCloud/wasmCloud/compare/control-interface-v0.32.0...HEAD) (2023-12-28)

### Features

* **host:** add event name as suffix on event topic
([6994a22](https://github.com/wasmCloud/wasmCloud/commit/6994a2202f856da93d0fe50e40c8e72dd3b7d9e6))
* enable updating host labels via the control interface
([85cb573](https://github.com/wasmCloud/wasmCloud/commit/85cb573d29c75eae4fdaca14be808131383ca3cd))

## Feature or Problem
This PR bumps the control interface to `0.32.1` as per the conventional commits specifying no breaking changes. This is required to bring in a `TryFrom` impl.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
control-interface v0.32.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
