### PR TITLE
feat(example): add logging and keyvalue for tutorial use

### DIFF
--- a/examples/golang/actors/http-hello-world/wit/deps.lock
+++ b/examples/golang/actors/http-hello-world/wit/deps.lock
@@ -14,11 +14,22 @@ sha512 = "2c242489801a75466986fe014d730fb3aa7b5c6e56a230c8735e6672711b58bcbe92ba
 url = "https://github.com/WebAssembly/wasi-http/archive/v0.2.0-rc-2023-12-05.tar.gz"
 sha256 = "a23ccbc045dc53a7ffdddba0a708eb71df77b93d637fc41fe842d41031ff2ace"
 sha512 = "077f4ba1b848c3273ca2cc4f15fd6a298f5896b150c0d89279fe4f56313cddc3af23b31dab457e6e302350083582a2e3042f09ddbdbfd7284845b111f6786982"
-deps = ["cli", "clocks", "filesystem", "io", "random", "sockets"]
+deps = ["cli", "clocks", "filesystem", "random", "sockets"]
 
 [io]
-sha256 = "b622db2755978a49d18d35d84d75f66b2b1ed23d7bf413e5c9e152e190cc7d4b"
-sha512 = "d19c9004e75bf3ebe3e34cff498c3d7fee04cd57a7fba7ed12a0c5ad842ba5715c009de77a152c57da0500f6ca0986b6791b6f022829bdd5a024f7bc114c2ff6"
+url = "https://github.com/WebAssembly/wasi-io/archive/v0.2.0-rc-2023-11-10.tar.gz"
+sha256 = "f2e6127b235c37c06be675a904d6acf08db953ea688d78c42892c6ad3bd194e4"
+sha512 = "32feefbc115c34bf6968cb6e9dc15e755698ee90648e5a5d84448917c36a318bd61b401195eb64330e2475e1d098bfb8dee1440d594a68e0797748762bd84ae5"
+
+[keyvalue]
+url = "https://github.com/WebAssembly/wasi-keyvalue/archive/main.tar.gz"
+sha256 = "b9f920d85151a6dc36cd987b492cf497a5d2a781d0bd7c94f05a603d32277858"
+sha512 = "db116140eb0b0ec8c9e632d1e6f964463afa52f4d9784c7771f45c159d0a85106e4d37d16f4c4fb25c0fae6700dd7332848ad7c016a760a73d1fbb4f37e347e1"
+
+[logging]
+url = "https://github.com/WebAssembly/wasi-logging/archive/main.tar.gz"
+sha256 = "9676b482485bb0fd2751a390374c1108865a096b7037f4b5dbe524f066bfb06e"
+sha512 = "30a621a6d48a0175e8047c062e618523a85f69c45a7c31918da2b888f7527fce1aca67fa132552222725d0f6cdcaed95be7f16c28488d9468c0fad00cb7450b9"
 
 [random]
 sha256 = "11afcbff9920f5f1f72b6764d01e59a5faa2c671f0c59f0c9b405778f3708745"

--- a/examples/golang/actors/http-hello-world/wit/deps.toml
+++ b/examples/golang/actors/http-hello-world/wit/deps.toml
@@ -1,2 +1,4 @@
 http = "https://github.com/WebAssembly/wasi-http/archive/v0.2.0-rc-2023-12-05.tar.gz"
-
+io = "https://github.com/WebAssembly/wasi-io/archive/v0.2.0-rc-2023-11-10.tar.gz"
+logging = "https://github.com/WebAssembly/wasi-logging/archive/main.tar.gz"
+keyvalue = "https://github.com/WebAssembly/wasi-keyvalue/archive/main.tar.gz"

--- a/examples/golang/actors/http-hello-world/wit/deps/io/poll.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/io/poll.wit
@@ -3,7 +3,7 @@ package wasi:io@0.2.0-rc-2023-11-10;
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.
 interface poll {
-    /// `pollable` represents a single I/O event which may be ready, or not.
+    /// `pollable` epresents a single I/O event which may be ready, or not.
     resource pollable {
 
       /// Return the readiness of a pollable. This function never blocks.

--- a/examples/golang/actors/http-hello-world/wit/deps/io/streams.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/io/streams.wit
@@ -131,7 +131,7 @@ interface streams {
         /// let pollable = this.subscribe();
         /// while !contents.is_empty() {
         ///     // Wait for the stream to become writable
-        ///     pollable.block();
+        ///     poll-one(pollable);
         ///     let Ok(n) = this.check-write(); // eliding error handling
         ///     let len = min(n, contents.len());
         ///     let (chunk, rest) = contents.split_at(len);
@@ -140,7 +140,7 @@ interface streams {
         /// }
         /// this.flush();
         /// // Wait for completion of `flush`
-        /// pollable.block();
+        /// poll-one(pollable);
         /// // Check for any errors that arose during `flush`
         /// let _ = this.check-write();         // eliding error handling
         /// ```
@@ -178,7 +178,7 @@ interface streams {
 
         /// Write zeroes to a stream.
         ///
-        /// This should be used precisely like `write` with the exact same
+        /// this should be used precisely like `write` with the exact same
         /// preconditions (must use check-write first), but instead of
         /// passing a list of bytes, you simply pass the number of zero-bytes
         /// that should be written.
@@ -199,7 +199,7 @@ interface streams {
         /// let pollable = this.subscribe();
         /// while num_zeroes != 0 {
         ///     // Wait for the stream to become writable
-        ///     pollable.block();
+        ///     poll-one(pollable);
         ///     let Ok(n) = this.check-write(); // eliding error handling
         ///     let len = min(n, num_zeroes);
         ///     this.write-zeroes(len);         // eliding error handling
@@ -207,7 +207,7 @@ interface streams {
         /// }
         /// this.flush();
         /// // Wait for completion of `flush`
-        /// pollable.block();
+        /// poll-one(pollable);
         /// // Check for any errors that arose during `flush`
         /// let _ = this.check-write();         // eliding error handling
         /// ```

--- a/examples/golang/actors/http-hello-world/wit/deps/keyvalue/atomic.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/keyvalue/atomic.wit
@@ -1,0 +1,20 @@
+/// A keyvalue interface that provides atomic operations.
+interface atomic {
+	/// A keyvalue interface that provides atomic operations.
+	use types.{bucket, error, key};
+
+	/// Atomically increment the value associated with the key in the bucket by the 
+	/// given delta. It returns the new value.
+	///
+	/// If the key does not exist in the bucket, it creates a new key-value pair
+	/// with the value set to the given delta. 
+	///
+	/// If any other error occurs, it returns an error.
+	increment: func(bucket: bucket, key: key, delta: u64) -> result<u64, error>;
+	
+	/// Atomically compare and swap the value associated with the key in the bucket.
+	/// It returns a boolean indicating if the swap was successful.
+	///
+	/// If the key does not exist in the bucket, it returns an error.
+	compare-and-swap: func(bucket: bucket, key: key, old: u64, new: u64) -> result<bool, error>;
+}

--- a/examples/golang/actors/http-hello-world/wit/deps/keyvalue/batch.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/keyvalue/batch.wit
@@ -1,0 +1,27 @@
+/// A keyvalue interface that provides batch operations.
+interface batch {
+	/// A keyvalue interface that provides batch get operations.
+	use types.{bucket, error, key, keys, incoming-value, outgoing-value};
+
+	/// Get the values associated with the keys in the bucket. It returns a list of
+	/// incoming-values that can be consumed to get the values.
+	///
+	/// If any of the keys do not exist in the bucket, it returns an error.
+	get-many: func(bucket: bucket, keys: keys) -> result<list<incoming-value>, error>;
+
+	/// Get all the keys in the bucket. It returns a list of keys.
+	get-keys: func(bucket: bucket) -> keys;
+
+	/// Set the values associated with the keys in the bucket. If the key already
+	/// exists in the bucket, it overwrites the value.
+	///
+	/// If any of the keys do not exist in the bucket, it creates a new key-value pair.
+	/// If any other error occurs, it returns an error.
+	set-many: func(bucket: bucket, key-values: list<tuple<key, outgoing-value>>) -> result<_, error>;
+
+	/// Delete the key-value pairs associated with the keys in the bucket.
+	///
+	/// If any of the keys do not exist in the bucket, it skips the key.
+	/// If any other error occurs, it returns an error.
+	delete-many: func(bucket: bucket, keys: keys) -> result<_, error>;
+}

--- a/examples/golang/actors/http-hello-world/wit/deps/keyvalue/caching.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/keyvalue/caching.wit
@@ -1,0 +1,98 @@
+// The `wasi:keyvalue/cache` interface defines the operations of a single
+// instance of a "cache", which is a non-durable, weakly-consistent key-value
+// store. "Non-durable" means that caches are allowed and expected to
+// arbitrarily discard key-value entries. "Weakly-consistent" means that there
+// are essentially no guarantees that operations will agree on their results: a
+// get following a set may not observe the set value; multiple gets may observe
+// different previous set values; etc. The only guarantee is that values are
+// not materialized "out of thin air": if a `get` returns a value, that value
+// was passed to a `set` operation at some point in time in the past.
+// Additionally, caches MUST make a best effort to respect the supplied
+// Time-to-Live values (within the usual limitations around time in a
+// distributed setting).
+interface cache {
+    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+    use types.{key, incoming-value, outgoing-value, error};
+
+    // The `get` operation returns the value passed by a previous `set` for the
+    // same key within the given TTL or none if there is no such value.
+    get: func(k: key) -> future-get-result;
+
+    // This block defines a special resource type used by `get` to emulate
+    // `future<result<option<incoming-value>,error>>`. In the return value
+    // of the `get` method, the outer `option` returns `none` when the pollable
+    // is not yet ready and the inner `option` returns `none` when the
+    // requested key wasn't present.
+    type future-get-result = u32;
+    drop-future-get-result: func(f: future-get-result);
+    future-get-result-get: func(f: future-get-result) -> option<result<option<incoming-value>, error>>;
+    listen-to-future-get-result: func(f: future-get-result) -> pollable;
+
+    // The `exists` operation returns whether a value was previously `set` for
+    // the given key within the TTL.
+    exists: func(k: key) -> future-exists-result;
+
+    // This block defines a special resource type used by `exists` to emulate
+    // `future<result<bool,error>>`.
+    type future-exists-result = u32;
+    drop-future-exists-result: func(f: future-exists-result);
+    future-exists-result-get: func(f: future-exists-result) -> option<result<bool, error>>;
+    listen-to-future-exists-result: func(f: future-exists-result) -> pollable;
+
+    // The `set` operation sets the given value for the given key for the given
+    // time-to-live (TTL) duration, if supplied, specified in milliseconds. If
+    // a TTL is not supplied, the key may be kept indefinitely (as-if a very
+    // large TTL were used). If the key is already present in the cache, the
+    // value is updated in-place. In the common case of computing and caching a
+    // value if the given key is not already in the cache, consider using
+    // `get-or-set` (below) intead of separate `get` and `set` operations.
+    set: func(k: key, v: outgoing-value, TTL-ms: option<u32>) -> future-result;
+
+    // This block defines a special resource type used by `set` and `delete` to
+    // emulate `future<result<_,error>>`.
+    type future-result = u32;
+    drop-future-result: func(f: future-result);
+    future-result-get: func(f: future-result) -> option<result<_, error>>;
+    listen-to-future-result: func(f: future-result) -> pollable;
+
+    // The `get-or-set` operation asynchronously returns one of two cases
+    // enumerated by `get-or-set-entry`: in the `occupied` case, the given key
+    // already has a value present in the cache; in the `vacant` case, there
+    // was no value and the caller should write a value into the returned
+    // `vacancy`. This operation allows multiple concurrent `get-or-set`
+    // invocations to rendezvous such that only one invocation receives the
+    // `vacant` result while all other invocations wait until the vacancy is
+    // filled before receiving an `occupied` result. Implementations are not
+    // required to implement this rendezvous or to rendezvous in all possible
+    // cases.
+    variant get-or-set-entry {
+      occupied(incoming-value),
+      vacant(vacancy)
+    }
+    get-or-set: func(k: key) -> future-get-or-set-result;
+
+    // This block defines a special resource type used by `get-or-set` to
+    // emulate `future<result<get-or-set-entry,error>>`.
+    type future-get-or-set-result = u32;
+    drop-future-get-or-set-result: func(f: future-get-or-set-result);
+    future-get-or-set-result-get: func(f: future-get-or-set-result) -> option<result<get-or-set-entry, error>>;
+    listen-to-future-get-or-set-result: func(f: future-get-or-set-result) -> pollable;
+
+    // The following block defines the `vacancy` resource type. (When resource
+    // types are added, the `u32` type aliases can be replaced by proper
+    // `resource` types.) When the caller of `get-or-set` receives a `vacancy`,
+    // they must either call the `fill` method or drop the `vacancy` to
+    // indicate an error that prevents calling `fill`. An implementation MAY
+    // have a timeout that drops a vacancy that hasn't been filled in order
+    // to unblock other waiting `get-or-set` callers.
+    type vacancy = u32;
+    drop-vacancy: func(v: vacancy);
+    vacancy-fill: func(v: vacancy, TTL-ms: option<u32>) -> outgoing-value;
+
+    // The `delete` operation removes any value with the given key from the
+    // cache. Like all cache operations, `delete` is weakly ordered and thus
+    // concurrent `get` calls may still see deleted keys for a period of time.
+    // Additionally, due to weak ordering, concurrent `set` calls for the same
+    // key may or may not get deleted.
+    delete: func(k: key) -> future-result;
+} 

--- a/examples/golang/actors/http-hello-world/wit/deps/keyvalue/error.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/keyvalue/error.wit
@@ -1,0 +1,10 @@
+interface wasi-cloud-error {
+	/// An error resource type for keyvalue operations.
+	/// Currently, this provides only one function to return a string representation
+	/// of the error. In the future, this will be extended to provide more information
+	/// about the error.
+	// Soon: switch to `resource error { ... }`
+	type error = u32;
+	drop-error: func(error: error);
+	trace: func(error: error) -> string;
+}

--- a/examples/golang/actors/http-hello-world/wit/deps/keyvalue/handle-watch.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/keyvalue/handle-watch.wit
@@ -1,0 +1,12 @@
+/// A keyvalue interface that provides handle-watch operations.
+interface handle-watch {
+	/// A keyvalue interface that provides handle-watch operations.
+	use types.{bucket, key, incoming-value};
+
+	/// Handle the set event for the given bucket and key. 
+	/// It returns a incoming-value that can be consumed to get the value.
+	on-set: func(bucket: bucket, key: key, incoming-value: incoming-value);
+
+	/// Handle the delete event for the given bucket and key.
+	on-delete: func(bucket: bucket, key: key);
+}

--- a/examples/golang/actors/http-hello-world/wit/deps/keyvalue/readwrite.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/keyvalue/readwrite.wit
@@ -1,0 +1,26 @@
+/// A keyvalue interface that provides simple read and write operations.
+interface readwrite {
+	/// A keyvalue interface that provides simple read and write operations.
+	use types.{bucket, error, incoming-value, key, outgoing-value};
+	
+	/// Get the value associated with the key in the bucket. It returns a incoming-value
+	/// that can be consumed to get the value.
+	///
+	/// If the key does not exist in the bucket, it returns an error.
+	get: func(bucket: bucket, key: key) -> result<incoming-value, error>;
+
+	/// Set the value associated with the key in the bucket. If the key already
+	/// exists in the bucket, it overwrites the value.
+	///
+	/// If the key does not exist in the bucket, it creates a new key-value pair.
+	/// If any other error occurs, it returns an error.
+	set: func(bucket: bucket, key: key, outgoing-value: outgoing-value) -> result<_, error>;
+
+	/// Delete the key-value pair associated with the key in the bucket.
+	///
+	/// If the key does not exist in the bucket, it returns an error.
+	delete: func(bucket: bucket, key: key) -> result<_, error>;
+
+	/// Check if the key exists in the bucket.
+	exists: func(bucket: bucket, key: key) -> result<bool, error>;
+}

--- a/examples/golang/actors/http-hello-world/wit/deps/keyvalue/types.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/keyvalue/types.wit
@@ -1,0 +1,60 @@
+// A generic keyvalue interface for WASI.
+interface types {
+	/// A bucket is a collection of key-value pairs. Each key-value pair is stored
+	/// as a entry in the bucket, and the bucket itself acts as a collection of all
+	/// these entries. 
+	///
+	/// It is worth noting that the exact terminology for bucket in key-value stores
+	/// can very depending on the specific implementation. For example,
+	/// 1. Amazon DynamoDB calls a collection of key-value pairs a table
+	/// 2. Redis has hashes, sets, and sorted sets as different types of collections
+	/// 3. Cassandra calls a collection of key-value pairs a column family
+	/// 4. MongoDB calls a collection of key-value pairs a collection
+	/// 5. Riak calls a collection of key-value pairs a bucket
+	/// 6. Memcached calls a collection of key-value pairs a slab
+	/// 7. Azure Cosmos DB calls a collection of key-value pairs a container
+	///
+	/// In this interface, we use the term `bucket` to refer to a collection of key-value
+	// Soon: switch to `resource bucket { ... }`
+	type bucket = u32;
+	drop-bucket: func(bucket: bucket);
+	open-bucket: func(name: string) -> result<bucket, error>;
+
+	/// A key is a unique identifier for a value in a bucket. The key is used to
+	/// retrieve the value from the bucket.
+	type key = string;
+
+	/// A list of keys
+	type keys = list<key>;
+
+	use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
+	use wasi-cloud-error.{ error };
+	/// A value is the data stored in a key-value pair. The value can be of any type
+	/// that can be represented in a byte array. It provides a way to write the value
+	/// to the output-stream defined in the `wasi-io` interface.
+	// Soon: switch to `resource value { ... }`
+	type outgoing-value = u32;
+	type outgoing-value-body-async = output-stream;
+	type outgoing-value-body-sync = list<u8>;
+	drop-outgoing-value: func(outgoing-value: outgoing-value);
+	new-outgoing-value: func() -> outgoing-value;
+	outgoing-value-write-body-async: func(outgoing-value: outgoing-value) -> result<outgoing-value-body-async, error>;
+	outgoing-value-write-body-sync: func(outgoing-value: outgoing-value, value: outgoing-value-body-sync) -> result<_, error>;
+
+	/// A incoming-value is a wrapper around a value. It provides a way to read the value
+	/// from the input-stream defined in the `wasi-io` interface.
+	///
+	/// The incoming-value provides two ways to consume the value:
+	/// 1. `incoming-value-consume-sync` consumes the value synchronously and returns the
+	///    value as a list of bytes.
+	/// 2. `incoming-value-consume-async` consumes the value asynchronously and returns the
+	///    value as an input-stream.
+	// Soon: switch to `resource incoming-value { ... }`
+	type incoming-value = u32;
+	type incoming-value-async-body = input-stream;
+	type incoming-value-sync-body = list<u8>;
+	drop-incoming-value: func(incoming-value: incoming-value);
+	incoming-value-consume-sync: func(incoming-value: incoming-value) -> result<incoming-value-sync-body, error>;
+	incoming-value-consume-async: func(incoming-value: incoming-value) -> result<incoming-value-async-body, error>;
+	size: func(incoming-value: incoming-value) -> u64;
+}

--- a/examples/golang/actors/http-hello-world/wit/deps/keyvalue/world.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/keyvalue/world.wit
@@ -1,0 +1,12 @@
+package wasi:keyvalue;
+
+world keyvalue {
+	import readwrite;
+	import atomic;
+	import batch;
+}
+
+world keyvalue-handle-watch {
+	include keyvalue;
+	export handle-watch;
+}

--- a/examples/golang/actors/http-hello-world/wit/deps/logging/logging.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/logging/logging.wit
@@ -1,0 +1,35 @@
+/// WASI Logging is a logging API intended to let users emit log messages with
+/// simple priority levels and context values.
+interface logging {
+    /// A log level, describing a kind of message.
+    enum level {
+       /// Describes messages about the values of variables and the flow of
+       /// control within a program.
+       trace,
+
+       /// Describes messages likely to be of interest to someone debugging a
+       /// program.
+       debug,
+
+       /// Describes messages likely to be of interest to someone monitoring a
+       /// program.
+       info,
+
+       /// Describes messages indicating hazardous situations.
+       warn,
+
+       /// Describes messages indicating serious errors.
+       error,
+
+       /// Describes messages indicating fatal errors.
+       critical,
+    }
+
+    /// Emit a log message.
+    ///
+    /// A log message has a `level` describing what kind of message is being
+    /// sent, a context, which is an uninterpreted string meant to help
+    /// consumers group similar messages, and a string containing the message
+    /// text.
+    log: func(level: level, context: string, message: string);
+}

--- a/examples/golang/actors/http-hello-world/wit/deps/logging/world.wit
+++ b/examples/golang/actors/http-hello-world/wit/deps/logging/world.wit
@@ -1,0 +1,5 @@
+package wasi:logging;
+
+world imports {
+    import logging;
+}

--- a/examples/rust/actors/http-hello-world/wit/deps.lock
+++ b/examples/rust/actors/http-hello-world/wit/deps.lock
@@ -14,11 +14,22 @@ sha512 = "2c242489801a75466986fe014d730fb3aa7b5c6e56a230c8735e6672711b58bcbe92ba
 url = "https://github.com/WebAssembly/wasi-http/archive/v0.2.0-rc-2023-12-05.tar.gz"
 sha256 = "a23ccbc045dc53a7ffdddba0a708eb71df77b93d637fc41fe842d41031ff2ace"
 sha512 = "077f4ba1b848c3273ca2cc4f15fd6a298f5896b150c0d89279fe4f56313cddc3af23b31dab457e6e302350083582a2e3042f09ddbdbfd7284845b111f6786982"
-deps = ["cli", "clocks", "filesystem", "io", "random", "sockets"]
+deps = ["cli", "clocks", "filesystem", "random", "sockets"]
 
 [io]
-sha256 = "b622db2755978a49d18d35d84d75f66b2b1ed23d7bf413e5c9e152e190cc7d4b"
-sha512 = "d19c9004e75bf3ebe3e34cff498c3d7fee04cd57a7fba7ed12a0c5ad842ba5715c009de77a152c57da0500f6ca0986b6791b6f022829bdd5a024f7bc114c2ff6"
+url = "https://github.com/WebAssembly/wasi-io/archive/v0.2.0-rc-2023-11-10.tar.gz"
+sha256 = "f2e6127b235c37c06be675a904d6acf08db953ea688d78c42892c6ad3bd194e4"
+sha512 = "32feefbc115c34bf6968cb6e9dc15e755698ee90648e5a5d84448917c36a318bd61b401195eb64330e2475e1d098bfb8dee1440d594a68e0797748762bd84ae5"
+
+[keyvalue]
+url = "https://github.com/WebAssembly/wasi-keyvalue/archive/main.tar.gz"
+sha256 = "b9f920d85151a6dc36cd987b492cf497a5d2a781d0bd7c94f05a603d32277858"
+sha512 = "db116140eb0b0ec8c9e632d1e6f964463afa52f4d9784c7771f45c159d0a85106e4d37d16f4c4fb25c0fae6700dd7332848ad7c016a760a73d1fbb4f37e347e1"
+
+[logging]
+url = "https://github.com/WebAssembly/wasi-logging/archive/main.tar.gz"
+sha256 = "9676b482485bb0fd2751a390374c1108865a096b7037f4b5dbe524f066bfb06e"
+sha512 = "30a621a6d48a0175e8047c062e618523a85f69c45a7c31918da2b888f7527fce1aca67fa132552222725d0f6cdcaed95be7f16c28488d9468c0fad00cb7450b9"
 
 [random]
 sha256 = "11afcbff9920f5f1f72b6764d01e59a5faa2c671f0c59f0c9b405778f3708745"

--- a/examples/rust/actors/http-hello-world/wit/deps.toml
+++ b/examples/rust/actors/http-hello-world/wit/deps.toml
@@ -1,1 +1,4 @@
 http = "https://github.com/WebAssembly/wasi-http/archive/v0.2.0-rc-2023-12-05.tar.gz"
+io = "https://github.com/WebAssembly/wasi-io/archive/v0.2.0-rc-2023-11-10.tar.gz"
+logging = "https://github.com/WebAssembly/wasi-logging/archive/main.tar.gz"
+keyvalue = "https://github.com/WebAssembly/wasi-keyvalue/archive/main.tar.gz"

--- a/examples/rust/actors/http-hello-world/wit/deps/io/poll.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/io/poll.wit
@@ -3,7 +3,7 @@ package wasi:io@0.2.0-rc-2023-11-10;
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.
 interface poll {
-    /// `pollable` represents a single I/O event which may be ready, or not.
+    /// `pollable` epresents a single I/O event which may be ready, or not.
     resource pollable {
 
       /// Return the readiness of a pollable. This function never blocks.

--- a/examples/rust/actors/http-hello-world/wit/deps/io/streams.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/io/streams.wit
@@ -131,7 +131,7 @@ interface streams {
         /// let pollable = this.subscribe();
         /// while !contents.is_empty() {
         ///     // Wait for the stream to become writable
-        ///     pollable.block();
+        ///     poll-one(pollable);
         ///     let Ok(n) = this.check-write(); // eliding error handling
         ///     let len = min(n, contents.len());
         ///     let (chunk, rest) = contents.split_at(len);
@@ -140,7 +140,7 @@ interface streams {
         /// }
         /// this.flush();
         /// // Wait for completion of `flush`
-        /// pollable.block();
+        /// poll-one(pollable);
         /// // Check for any errors that arose during `flush`
         /// let _ = this.check-write();         // eliding error handling
         /// ```
@@ -178,7 +178,7 @@ interface streams {
 
         /// Write zeroes to a stream.
         ///
-        /// This should be used precisely like `write` with the exact same
+        /// this should be used precisely like `write` with the exact same
         /// preconditions (must use check-write first), but instead of
         /// passing a list of bytes, you simply pass the number of zero-bytes
         /// that should be written.
@@ -199,7 +199,7 @@ interface streams {
         /// let pollable = this.subscribe();
         /// while num_zeroes != 0 {
         ///     // Wait for the stream to become writable
-        ///     pollable.block();
+        ///     poll-one(pollable);
         ///     let Ok(n) = this.check-write(); // eliding error handling
         ///     let len = min(n, num_zeroes);
         ///     this.write-zeroes(len);         // eliding error handling
@@ -207,7 +207,7 @@ interface streams {
         /// }
         /// this.flush();
         /// // Wait for completion of `flush`
-        /// pollable.block();
+        /// poll-one(pollable);
         /// // Check for any errors that arose during `flush`
         /// let _ = this.check-write();         // eliding error handling
         /// ```

--- a/examples/rust/actors/http-hello-world/wit/deps/keyvalue/atomic.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/keyvalue/atomic.wit
@@ -1,0 +1,20 @@
+/// A keyvalue interface that provides atomic operations.
+interface atomic {
+	/// A keyvalue interface that provides atomic operations.
+	use types.{bucket, error, key};
+
+	/// Atomically increment the value associated with the key in the bucket by the 
+	/// given delta. It returns the new value.
+	///
+	/// If the key does not exist in the bucket, it creates a new key-value pair
+	/// with the value set to the given delta. 
+	///
+	/// If any other error occurs, it returns an error.
+	increment: func(bucket: bucket, key: key, delta: u64) -> result<u64, error>;
+	
+	/// Atomically compare and swap the value associated with the key in the bucket.
+	/// It returns a boolean indicating if the swap was successful.
+	///
+	/// If the key does not exist in the bucket, it returns an error.
+	compare-and-swap: func(bucket: bucket, key: key, old: u64, new: u64) -> result<bool, error>;
+}

--- a/examples/rust/actors/http-hello-world/wit/deps/keyvalue/batch.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/keyvalue/batch.wit
@@ -1,0 +1,27 @@
+/// A keyvalue interface that provides batch operations.
+interface batch {
+	/// A keyvalue interface that provides batch get operations.
+	use types.{bucket, error, key, keys, incoming-value, outgoing-value};
+
+	/// Get the values associated with the keys in the bucket. It returns a list of
+	/// incoming-values that can be consumed to get the values.
+	///
+	/// If any of the keys do not exist in the bucket, it returns an error.
+	get-many: func(bucket: bucket, keys: keys) -> result<list<incoming-value>, error>;
+
+	/// Get all the keys in the bucket. It returns a list of keys.
+	get-keys: func(bucket: bucket) -> keys;
+
+	/// Set the values associated with the keys in the bucket. If the key already
+	/// exists in the bucket, it overwrites the value.
+	///
+	/// If any of the keys do not exist in the bucket, it creates a new key-value pair.
+	/// If any other error occurs, it returns an error.
+	set-many: func(bucket: bucket, key-values: list<tuple<key, outgoing-value>>) -> result<_, error>;
+
+	/// Delete the key-value pairs associated with the keys in the bucket.
+	///
+	/// If any of the keys do not exist in the bucket, it skips the key.
+	/// If any other error occurs, it returns an error.
+	delete-many: func(bucket: bucket, keys: keys) -> result<_, error>;
+}

--- a/examples/rust/actors/http-hello-world/wit/deps/keyvalue/caching.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/keyvalue/caching.wit
@@ -1,0 +1,98 @@
+// The `wasi:keyvalue/cache` interface defines the operations of a single
+// instance of a "cache", which is a non-durable, weakly-consistent key-value
+// store. "Non-durable" means that caches are allowed and expected to
+// arbitrarily discard key-value entries. "Weakly-consistent" means that there
+// are essentially no guarantees that operations will agree on their results: a
+// get following a set may not observe the set value; multiple gets may observe
+// different previous set values; etc. The only guarantee is that values are
+// not materialized "out of thin air": if a `get` returns a value, that value
+// was passed to a `set` operation at some point in time in the past.
+// Additionally, caches MUST make a best effort to respect the supplied
+// Time-to-Live values (within the usual limitations around time in a
+// distributed setting).
+interface cache {
+    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+    use types.{key, incoming-value, outgoing-value, error};
+
+    // The `get` operation returns the value passed by a previous `set` for the
+    // same key within the given TTL or none if there is no such value.
+    get: func(k: key) -> future-get-result;
+
+    // This block defines a special resource type used by `get` to emulate
+    // `future<result<option<incoming-value>,error>>`. In the return value
+    // of the `get` method, the outer `option` returns `none` when the pollable
+    // is not yet ready and the inner `option` returns `none` when the
+    // requested key wasn't present.
+    type future-get-result = u32;
+    drop-future-get-result: func(f: future-get-result);
+    future-get-result-get: func(f: future-get-result) -> option<result<option<incoming-value>, error>>;
+    listen-to-future-get-result: func(f: future-get-result) -> pollable;
+
+    // The `exists` operation returns whether a value was previously `set` for
+    // the given key within the TTL.
+    exists: func(k: key) -> future-exists-result;
+
+    // This block defines a special resource type used by `exists` to emulate
+    // `future<result<bool,error>>`.
+    type future-exists-result = u32;
+    drop-future-exists-result: func(f: future-exists-result);
+    future-exists-result-get: func(f: future-exists-result) -> option<result<bool, error>>;
+    listen-to-future-exists-result: func(f: future-exists-result) -> pollable;
+
+    // The `set` operation sets the given value for the given key for the given
+    // time-to-live (TTL) duration, if supplied, specified in milliseconds. If
+    // a TTL is not supplied, the key may be kept indefinitely (as-if a very
+    // large TTL were used). If the key is already present in the cache, the
+    // value is updated in-place. In the common case of computing and caching a
+    // value if the given key is not already in the cache, consider using
+    // `get-or-set` (below) intead of separate `get` and `set` operations.
+    set: func(k: key, v: outgoing-value, TTL-ms: option<u32>) -> future-result;
+
+    // This block defines a special resource type used by `set` and `delete` to
+    // emulate `future<result<_,error>>`.
+    type future-result = u32;
+    drop-future-result: func(f: future-result);
+    future-result-get: func(f: future-result) -> option<result<_, error>>;
+    listen-to-future-result: func(f: future-result) -> pollable;
+
+    // The `get-or-set` operation asynchronously returns one of two cases
+    // enumerated by `get-or-set-entry`: in the `occupied` case, the given key
+    // already has a value present in the cache; in the `vacant` case, there
+    // was no value and the caller should write a value into the returned
+    // `vacancy`. This operation allows multiple concurrent `get-or-set`
+    // invocations to rendezvous such that only one invocation receives the
+    // `vacant` result while all other invocations wait until the vacancy is
+    // filled before receiving an `occupied` result. Implementations are not
+    // required to implement this rendezvous or to rendezvous in all possible
+    // cases.
+    variant get-or-set-entry {
+      occupied(incoming-value),
+      vacant(vacancy)
+    }
+    get-or-set: func(k: key) -> future-get-or-set-result;
+
+    // This block defines a special resource type used by `get-or-set` to
+    // emulate `future<result<get-or-set-entry,error>>`.
+    type future-get-or-set-result = u32;
+    drop-future-get-or-set-result: func(f: future-get-or-set-result);
+    future-get-or-set-result-get: func(f: future-get-or-set-result) -> option<result<get-or-set-entry, error>>;
+    listen-to-future-get-or-set-result: func(f: future-get-or-set-result) -> pollable;
+
+    // The following block defines the `vacancy` resource type. (When resource
+    // types are added, the `u32` type aliases can be replaced by proper
+    // `resource` types.) When the caller of `get-or-set` receives a `vacancy`,
+    // they must either call the `fill` method or drop the `vacancy` to
+    // indicate an error that prevents calling `fill`. An implementation MAY
+    // have a timeout that drops a vacancy that hasn't been filled in order
+    // to unblock other waiting `get-or-set` callers.
+    type vacancy = u32;
+    drop-vacancy: func(v: vacancy);
+    vacancy-fill: func(v: vacancy, TTL-ms: option<u32>) -> outgoing-value;
+
+    // The `delete` operation removes any value with the given key from the
+    // cache. Like all cache operations, `delete` is weakly ordered and thus
+    // concurrent `get` calls may still see deleted keys for a period of time.
+    // Additionally, due to weak ordering, concurrent `set` calls for the same
+    // key may or may not get deleted.
+    delete: func(k: key) -> future-result;
+} 

--- a/examples/rust/actors/http-hello-world/wit/deps/keyvalue/error.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/keyvalue/error.wit
@@ -1,0 +1,10 @@
+interface wasi-cloud-error {
+	/// An error resource type for keyvalue operations.
+	/// Currently, this provides only one function to return a string representation
+	/// of the error. In the future, this will be extended to provide more information
+	/// about the error.
+	// Soon: switch to `resource error { ... }`
+	type error = u32;
+	drop-error: func(error: error);
+	trace: func(error: error) -> string;
+}

--- a/examples/rust/actors/http-hello-world/wit/deps/keyvalue/handle-watch.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/keyvalue/handle-watch.wit
@@ -1,0 +1,12 @@
+/// A keyvalue interface that provides handle-watch operations.
+interface handle-watch {
+	/// A keyvalue interface that provides handle-watch operations.
+	use types.{bucket, key, incoming-value};
+
+	/// Handle the set event for the given bucket and key. 
+	/// It returns a incoming-value that can be consumed to get the value.
+	on-set: func(bucket: bucket, key: key, incoming-value: incoming-value);
+
+	/// Handle the delete event for the given bucket and key.
+	on-delete: func(bucket: bucket, key: key);
+}

--- a/examples/rust/actors/http-hello-world/wit/deps/keyvalue/readwrite.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/keyvalue/readwrite.wit
@@ -1,0 +1,26 @@
+/// A keyvalue interface that provides simple read and write operations.
+interface readwrite {
+	/// A keyvalue interface that provides simple read and write operations.
+	use types.{bucket, error, incoming-value, key, outgoing-value};
+	
+	/// Get the value associated with the key in the bucket. It returns a incoming-value
+	/// that can be consumed to get the value.
+	///
+	/// If the key does not exist in the bucket, it returns an error.
+	get: func(bucket: bucket, key: key) -> result<incoming-value, error>;
+
+	/// Set the value associated with the key in the bucket. If the key already
+	/// exists in the bucket, it overwrites the value.
+	///
+	/// If the key does not exist in the bucket, it creates a new key-value pair.
+	/// If any other error occurs, it returns an error.
+	set: func(bucket: bucket, key: key, outgoing-value: outgoing-value) -> result<_, error>;
+
+	/// Delete the key-value pair associated with the key in the bucket.
+	///
+	/// If the key does not exist in the bucket, it returns an error.
+	delete: func(bucket: bucket, key: key) -> result<_, error>;
+
+	/// Check if the key exists in the bucket.
+	exists: func(bucket: bucket, key: key) -> result<bool, error>;
+}

--- a/examples/rust/actors/http-hello-world/wit/deps/keyvalue/types.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/keyvalue/types.wit
@@ -1,0 +1,60 @@
+// A generic keyvalue interface for WASI.
+interface types {
+	/// A bucket is a collection of key-value pairs. Each key-value pair is stored
+	/// as a entry in the bucket, and the bucket itself acts as a collection of all
+	/// these entries. 
+	///
+	/// It is worth noting that the exact terminology for bucket in key-value stores
+	/// can very depending on the specific implementation. For example,
+	/// 1. Amazon DynamoDB calls a collection of key-value pairs a table
+	/// 2. Redis has hashes, sets, and sorted sets as different types of collections
+	/// 3. Cassandra calls a collection of key-value pairs a column family
+	/// 4. MongoDB calls a collection of key-value pairs a collection
+	/// 5. Riak calls a collection of key-value pairs a bucket
+	/// 6. Memcached calls a collection of key-value pairs a slab
+	/// 7. Azure Cosmos DB calls a collection of key-value pairs a container
+	///
+	/// In this interface, we use the term `bucket` to refer to a collection of key-value
+	// Soon: switch to `resource bucket { ... }`
+	type bucket = u32;
+	drop-bucket: func(bucket: bucket);
+	open-bucket: func(name: string) -> result<bucket, error>;
+
+	/// A key is a unique identifier for a value in a bucket. The key is used to
+	/// retrieve the value from the bucket.
+	type key = string;
+
+	/// A list of keys
+	type keys = list<key>;
+
+	use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
+	use wasi-cloud-error.{ error };
+	/// A value is the data stored in a key-value pair. The value can be of any type
+	/// that can be represented in a byte array. It provides a way to write the value
+	/// to the output-stream defined in the `wasi-io` interface.
+	// Soon: switch to `resource value { ... }`
+	type outgoing-value = u32;
+	type outgoing-value-body-async = output-stream;
+	type outgoing-value-body-sync = list<u8>;
+	drop-outgoing-value: func(outgoing-value: outgoing-value);
+	new-outgoing-value: func() -> outgoing-value;
+	outgoing-value-write-body-async: func(outgoing-value: outgoing-value) -> result<outgoing-value-body-async, error>;
+	outgoing-value-write-body-sync: func(outgoing-value: outgoing-value, value: outgoing-value-body-sync) -> result<_, error>;
+
+	/// A incoming-value is a wrapper around a value. It provides a way to read the value
+	/// from the input-stream defined in the `wasi-io` interface.
+	///
+	/// The incoming-value provides two ways to consume the value:
+	/// 1. `incoming-value-consume-sync` consumes the value synchronously and returns the
+	///    value as a list of bytes.
+	/// 2. `incoming-value-consume-async` consumes the value asynchronously and returns the
+	///    value as an input-stream.
+	// Soon: switch to `resource incoming-value { ... }`
+	type incoming-value = u32;
+	type incoming-value-async-body = input-stream;
+	type incoming-value-sync-body = list<u8>;
+	drop-incoming-value: func(incoming-value: incoming-value);
+	incoming-value-consume-sync: func(incoming-value: incoming-value) -> result<incoming-value-sync-body, error>;
+	incoming-value-consume-async: func(incoming-value: incoming-value) -> result<incoming-value-async-body, error>;
+	size: func(incoming-value: incoming-value) -> u64;
+}

--- a/examples/rust/actors/http-hello-world/wit/deps/keyvalue/world.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/keyvalue/world.wit
@@ -1,0 +1,12 @@
+package wasi:keyvalue;
+
+world keyvalue {
+	import readwrite;
+	import atomic;
+	import batch;
+}
+
+world keyvalue-handle-watch {
+	include keyvalue;
+	export handle-watch;
+}

--- a/examples/rust/actors/http-hello-world/wit/deps/logging/logging.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/logging/logging.wit
@@ -1,0 +1,35 @@
+/// WASI Logging is a logging API intended to let users emit log messages with
+/// simple priority levels and context values.
+interface logging {
+    /// A log level, describing a kind of message.
+    enum level {
+       /// Describes messages about the values of variables and the flow of
+       /// control within a program.
+       trace,
+
+       /// Describes messages likely to be of interest to someone debugging a
+       /// program.
+       debug,
+
+       /// Describes messages likely to be of interest to someone monitoring a
+       /// program.
+       info,
+
+       /// Describes messages indicating hazardous situations.
+       warn,
+
+       /// Describes messages indicating serious errors.
+       error,
+
+       /// Describes messages indicating fatal errors.
+       critical,
+    }
+
+    /// Emit a log message.
+    ///
+    /// A log message has a `level` describing what kind of message is being
+    /// sent, a context, which is an uninterpreted string meant to help
+    /// consumers group similar messages, and a string containing the message
+    /// text.
+    log: func(level: level, context: string, message: string);
+}

--- a/examples/rust/actors/http-hello-world/wit/deps/logging/world.wit
+++ b/examples/rust/actors/http-hello-world/wit/deps/logging/world.wit
@@ -1,0 +1,5 @@
+package wasi:logging;
+
+world imports {
+    import logging;
+}


### PR DESCRIPTION
## Feature or Problem
This PR adds `wasi:keyvalue` and `wasi:logging` to the wit dependencies for both of our hello world examples for use in the quickstart tutorials. Without this, developers would need to manually modify the `deps.toml` file and run `wit-deps` update, so now during the quickstart documentation they can simply add these imports to their `wit/hello.wit` file and then use the capabilities.

This is only a temporary fix. Ideally these examples don't come with a wit deps directory at all and the only wit modification needed will be to specify custom import/exports, and a crate like `wasmcloud-actor` would be used to wrap wit definitions. I think that it's important to start here as a baseline and then remove some of the low level WebAssembly concepts as we can, as this level of detail will be necessary for languages where we don't have some sort of higher level SDK or library support.

## Related Issues
Enables https://github.com/wasmCloud/wasmcloud.com/pull/250

## Release Information
N/A

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
