### PR TITLE
chore(wash-cli): bump NATS server version

### DIFF
--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -7,7 +7,7 @@ use crate::up::{credsfile::parse_credsfile, WasmcloudOpts};
 pub const DOWNLOADS_DIR: &str = "downloads";
 pub const WASMCLOUD_PID_FILE: &str = "wasmcloud.pid";
 // NATS configuration values
-pub const NATS_SERVER_VERSION: &str = "v2.9.14";
+pub const NATS_SERVER_VERSION: &str = "v2.10.7";
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -81,7 +81,7 @@ pub struct NatsOpts {
     )]
     pub connect_only: bool,
 
-    /// NATS server version to download, e.g. `v2.7.2`. See https://github.com/nats-io/nats-server/releases/ for releases
+    /// NATS server version to download, e.g. `v2.10.7`. See https://github.com/nats-io/nats-server/releases/ for releases
     #[clap(long = "nats-version", default_value = NATS_SERVER_VERSION, env = "NATS_VERSION")]
     pub nats_version: String,
 
@@ -751,7 +751,7 @@ mod tests {
             "--nats-remote-url",
             "tls://remote.global",
             "--nats-version",
-            "v2.8.4",
+            "v2.10.7",
             "--provider-delay",
             "500",
             "--rpc-credsfile",
@@ -845,7 +845,7 @@ mod tests {
             up_all_flags.wasmcloud_opts.wasmcloud_js_domain,
             Some("domain".to_string())
         );
-        assert_eq!(up_all_flags.nats_opts.nats_version, "v2.8.4".to_string());
+        assert_eq!(up_all_flags.nats_opts.nats_version, "v2.10.7".to_string());
         assert_eq!(
             up_all_flags.nats_opts.nats_remote_url,
             Some("tls://remote.global".to_string())

--- a/crates/wash-cli/tests/common/mod.rs
+++ b/crates/wash-cli/tests/common/mod.rs
@@ -94,7 +94,7 @@ pub async fn set_test_file_content(path: &PathBuf, content: &str) -> Result<()> 
 
 #[allow(unused)]
 pub async fn start_nats(port: u16, nats_install_dir: &PathBuf) -> Result<Child> {
-    let nats_binary = ensure_nats_server("v2.8.4", nats_install_dir).await?;
+    let nats_binary = ensure_nats_server("v2.10.7", nats_install_dir).await?;
     let config = NatsConfig::new_standalone("127.0.0.1", port, None);
     start_nats_server(nats_binary, std::process::Stdio::null(), config).await
 }

--- a/crates/wash-cli/tools/docker-compose.yml
+++ b/crates/wash-cli/tools/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
      - "5001:5000"
   nats:
-    image: nats:2.1.9
+    image: nats:2.10.7-alpine
     ports:
       - "6222:6222"
       - "4222:4222"

--- a/crates/wash-lib/src/start/mod.rs
+++ b/crates/wash-lib/src/start/mod.rs
@@ -18,7 +18,7 @@
 //!     let install_dir = PathBuf::from("/tmp");
 //!
 //!     // Download NATS if not already installed
-//!     let nats_binary = ensure_nats_server("v2.8.4", &install_dir).await?;
+//!     let nats_binary = ensure_nats_server("v2.10.7", &install_dir).await?;
 //!
 //!     // Start NATS server, redirecting output to a log file
 //!     let nats_log_path = install_dir.join("nats.log");

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -29,7 +29,7 @@ pub const NATS_SERVER_BINARY: &str = "nats-server.exe";
 /// # #[tokio::main]
 /// # async fn main() {
 /// use wash_lib::start::ensure_nats_server;
-/// let res = ensure_nats_server("v2.8.4", "/tmp/").await;
+/// let res = ensure_nats_server("v2.10.7", "/tmp/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/nats-server");
 /// # }
@@ -59,7 +59,7 @@ where
 /// use wash_lib::start::ensure_nats_server_for_os_arch_pair;
 /// let os = std::env::consts::OS;
 /// let arch = std::env::consts::ARCH;
-/// let res = ensure_nats_server_for_os_arch_pair(os, arch, "v2.8.4", "/tmp/").await;
+/// let res = ensure_nats_server_for_os_arch_pair(os, arch, "v2.10.7", "/tmp/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/nats-server");
 /// # }
@@ -94,7 +94,7 @@ where
 /// # #[tokio::main]
 /// # async fn main() {
 /// use wash_lib::start::download_nats_server;
-/// let res = download_nats_server("v2.8.4", "/tmp/").await;
+/// let res = download_nats_server("v2.10.7", "/tmp/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/nats-server");
 /// # }
@@ -330,7 +330,7 @@ mod test {
         io::AsyncReadExt,
     };
 
-    const NATS_SERVER_VERSION: &str = "v2.8.4";
+    const NATS_SERVER_VERSION: &str = "v2.10.7";
 
     #[tokio::test]
     #[cfg_attr(not(can_reach_github_com), ignore = "github.com is not reachable")]

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -379,7 +379,7 @@ mod test {
         let _ = remove_dir_all(download_dir).await;
     }
 
-    const NATS_SERVER_VERSION: &str = "v2.8.4";
+    const NATS_SERVER_VERSION: &str = "v2.10.7";
 
     #[tokio::test]
     #[cfg_attr(not(can_reach_github_com), ignore = "github.com is not reachable")]


### PR DESCRIPTION
This bumps the NATS server versions everywhere to the latest release (2.10.7)