### PR TITLE
chore(wasmcloud-chart): bump version of wasmcloud-charthost to 0.7.2

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -18,6 +18,6 @@ type: application
 # Note: Ensure you bump this `version` field in a separate PR than what you plan
 # to tag as the updated wasmCloud version. To be safe, bump and release wasmCloud
 # in one PR, then open a new PR updating this `version` and `appVersion`.
-version: 0.7.1
+version: 0.7.2
 
-appVersion: "0.80.0"
+appVersion: "0.81.0"

--- a/chart/README.md
+++ b/chart/README.md
@@ -23,7 +23,7 @@ recommend deploying your main NATS server with another chart.
 You can install the chart via [the `wasmcloud-chart` package on ArtifactHub][artifacthub-wasmcloud]:
 
 ```console
-$ helm install wasmcloud oci://ghcr.io/wasmcloud/wasmcloud-chart --version 0.7.0
+$ helm install wasmcloud oci://ghcr.io/wasmcloud/wasmcloud-chart --version 0.7.2
 ```
 
 > [!NOTE]
@@ -31,7 +31,7 @@ $ helm install wasmcloud oci://ghcr.io/wasmcloud/wasmcloud-chart --version 0.7.0
 > You can replace `wasmcloud` with whatever you'd like to call your instantiation
 > of the helm chart.
 >
-> Version `0.7.0` of the helm chart (released Nov 9th, 2023) deploys version [`v0.80.0`][wasmcloud-v0.80.0] of the host by default.
+> Version `0.7.2` of the helm chart (released Jan 2nd, 2024) deploys version [`v0.81.0`][wasmcloud-v0.81.0] of the host by default.
 >
 > To change the version of the wasmcloud host that is deployed, set `wasmcloud.image.tag` in [`values.yaml`][values-yaml] to the
 > [docker image tag][wasmcloud-docker-tags] you'd like to deploy instead.
@@ -48,7 +48,7 @@ $ kubectl port-forward deployment/${RELEASE_NAME} 4222
 ```
 
 [artifacthub-wasmcloud]: https://artifacthub.io/packages/helm/wasmcloud-chart/wasmcloud-chart
-[wasmcloud-v0.80.0]: https://github.com/wasmCloud/wasmCloud/tree/v0.80.0
+[wasmcloud-v0.81.0]: https://github.com/wasmCloud/wasmCloud/tree/v0.81.0
 [wasmcloud-docker-tags]: https://hub.docker.com/r/wasmcloud/wasmcloud/tags
 [values-yaml]: ./values.yaml
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -90,7 +90,7 @@ nats:
     pullPolicy: IfNotPresent
     # NOTE: The alpine image is required if you are doing leafnode configuration. Otherwise the base
     # nats image is missing the root certificates needed for validation
-    tag: "2.9-alpine"
+    tag: "2.10.7-alpine"
   resources: {}
 
 imagePullSecrets: []


### PR DESCRIPTION
This bumps the version of the host in the chart to 0.81.0