### PR TITLE
feat(wash-cli): remove experimental flag from

### DIFF
--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -125,7 +125,7 @@ struct Cli {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Subcommand)]
 enum CliCommand {
-    /// Manage declarative applications and deployments (wadm) (experimental)
+    /// Manage declarative applications and deployments (wadm)
     #[clap(name = "app", subcommand)]
     App(AppCliCommand),
     /// Build (and sign) a wasmCloud actor, provider, or interface
@@ -149,7 +149,7 @@ enum CliCommand {
     /// Manage wasmCloud host configuration contexts
     #[clap(name = "ctx", alias = "context", alias = "contexts", subcommand)]
     Ctx(CtxCommand),
-    /// (experimental) Run a local development loop for an actor
+    /// Run a local development loop for an actor
     #[clap(name = "dev")]
     Dev(DevCommand),
     /// Tear down a wasmCloud environment launched with wash up
@@ -246,13 +246,7 @@ async fn main() {
         }
         CliCommand::Ctl(ctl_cli) => ctl::handle_command(ctl_cli, output_kind).await,
         CliCommand::Ctx(ctx_cli) => ctx::handle_command(ctx_cli).await,
-        CliCommand::Dev(dev_cli) => {
-            if cli.experimental {
-                dev::handle_command(dev_cli, output_kind).await
-            } else {
-                experimental_error_message("dev")
-            }
-        }
+        CliCommand::Dev(dev_cli) => dev::handle_command(dev_cli, output_kind).await,
         CliCommand::Down(down_cli) => down::handle_command(down_cli, output_kind).await,
         CliCommand::Drain(drain_cli) => drain::handle_command(drain_cli),
         CliCommand::Get(get_cli) => common::get_cmd::handle_command(get_cli, output_kind).await,

--- a/crates/wash-cli/tests/wash_dev.rs
+++ b/crates/wash-cli/tests/wash_dev.rs
@@ -4,7 +4,7 @@ use common::{
     find_open_port, init, start_nats, test_dir_with_subfolder, wait_for_no_hosts, wait_for_no_nats,
 };
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::{anyhow, bail};
 #[cfg(target_family = "unix")]
@@ -44,7 +44,6 @@ async fn integration_dev_hello_actor_serial() -> Result<()> {
                 "--disable-wadm",
             ])
             .kill_on_drop(true)
-            .envs(HashMap::from([("WASH_EXPERIMENTAL", "true")]))
             .spawn()
             .context("failed running cargo dev")?,
     ));


### PR DESCRIPTION
This removes the `experimental` flag as a required option on `wash dev`