### PR TITLE
feat(wash-cli): add label command to set and remove host labels

### DIFF
--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -23,6 +23,7 @@ use wash_lib::cli::capture::{CaptureCommand, CaptureSubcommand};
 use wash_lib::cli::claims::ClaimsCliCommand;
 use wash_lib::cli::get::GetCommand;
 use wash_lib::cli::inspect::InspectCliCommand;
+use wash_lib::cli::label::LabelHostCommand;
 use wash_lib::cli::link::LinkCommand;
 use wash_lib::cli::registry::{RegistryCommand, RegistryPullCommand, RegistryPushCommand};
 use wash_lib::cli::scale::ScaleCommand;
@@ -70,6 +71,7 @@ Iterate:
   link         Link an actor and a provider
   call         Invoke a wasmCloud actor
   ctl          Interact with a wasmCloud control interface (deprecated, use above commands)
+  label        Label (or un-label) a host with a key=value label pair
 
 Publish:
   pull         Pull an artifact from an OCI compliant registry
@@ -203,6 +205,9 @@ enum CliCommand {
     /// Stop an actor, provider, or host
     #[clap(name = "stop", subcommand)]
     Stop(StopCommand),
+    /// Label (or un-label) a host
+    #[clap(name = "label", alias = "tag")]
+    Label(LabelHostCommand),
     /// Update an actor running in a host to a newer version
     #[clap(name = "update", subcommand)]
     Update(UpdateCommand),
@@ -282,6 +287,9 @@ async fn main() {
             common::start_cmd::handle_command(start_cli, output_kind).await
         }
         CliCommand::Stop(stop_cli) => common::stop_cmd::handle_command(stop_cli, output_kind).await,
+        CliCommand::Label(label_cli) => {
+            common::label_cmd::handle_command(label_cli, output_kind).await
+        }
         CliCommand::Update(update_cli) => {
             common::update_cmd::handle_command(update_cli, output_kind).await
         }

--- a/crates/wash-cli/src/common/label_cmd.rs
+++ b/crates/wash-cli/src/common/label_cmd.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+
+use wash_lib::cli::{
+    label::{handle_label_host, LabelHostCommand},
+    CommandOutput, OutputKind,
+};
+
+use crate::appearance::spinner::Spinner;
+
+pub async fn handle_command(
+    cmd: LabelHostCommand,
+    output_kind: OutputKind,
+) -> Result<CommandOutput> {
+    let sp: Spinner = Spinner::new(&output_kind)?;
+    let out = handle_label_host(cmd).await?;
+    sp.finish_and_clear();
+
+    Ok(out)
+}

--- a/crates/wash-cli/src/common/mod.rs
+++ b/crates/wash-cli/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod get_cmd;
+pub mod label_cmd;
 pub mod link_cmd;
 pub mod registry_cmd;
 pub mod scale_cmd;

--- a/crates/wash-lib/src/cli/label.rs
+++ b/crates/wash-lib/src/cli/label.rs
@@ -1,0 +1,79 @@
+use anyhow::{bail, Result};
+use clap::Parser;
+
+use crate::{
+    common::{boxed_err_to_anyhow, find_host_id},
+    config::WashConnectionOptions,
+};
+
+use super::{CliConnectionOpts, CommandOutput};
+
+#[derive(Debug, Clone, Parser)]
+pub struct LabelHostCommand {
+    #[clap(flatten)]
+    pub opts: CliConnectionOpts,
+
+    /// ID of host to update the actor on. If a non-ID is provided, the host will be selected based
+    /// on matching the prefix of the ID or the friendly name and will return an error if more than
+    /// one host matches.
+    #[clap(name = "host-id")]
+    pub host_id: String,
+
+    /// Delete the label, instead of adding it
+    #[clap(long = "delete", default_value = "false")]
+    pub delete: bool,
+
+    /// Host label in the form of a `[key]=[value]` pair, e.g. "cloud=aws". When `--delete` is set, only the key is provided
+    #[clap(name = "label", alias = "label")]
+    pub label: String,
+}
+
+pub async fn handle_label_host(cmd: LabelHostCommand) -> Result<CommandOutput> {
+    let wco: WashConnectionOptions = cmd.opts.try_into()?;
+    let client = wco.into_ctl_client(None).await?;
+
+    let (host_id, friendly_name) = find_host_id(&cmd.host_id, &client).await?;
+
+    let friendly_name = if friendly_name.is_empty() {
+        host_id.to_string()
+    } else {
+        friendly_name
+    };
+
+    let (key, value) = match cmd.label.split_once('=') {
+        Some((k, v)) => (k, v),
+        None => (cmd.label.as_str(), ""),
+    };
+
+    if cmd.delete {
+        let ack = client
+            .delete_label(&host_id, key)
+            .await
+            .map_err(boxed_err_to_anyhow)?;
+        if !ack.accepted {
+            bail!("Operation failed: {}", ack.error);
+        }
+
+        Ok(CommandOutput::from_key_and_text(
+            "result",
+            format!("Host `{}` unlabeled with `{}`", friendly_name, key),
+        ))
+    } else {
+        if value.is_empty() {
+            bail!("No value provided");
+        }
+
+        let ack = client
+            .put_label(&host_id, key, value)
+            .await
+            .map_err(boxed_err_to_anyhow)?;
+        if !ack.accepted {
+            bail!("Operation failed: {}", ack.error);
+        }
+
+        Ok(CommandOutput::from_key_and_text(
+            "result",
+            format!("Host `{}` labeled with `{}={}`", friendly_name, key, value),
+        ))
+    }
+}

--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -37,6 +37,7 @@ pub mod claims;
 pub mod dev;
 pub mod get;
 pub mod inspect;
+pub mod label;
 pub mod link;
 pub mod output;
 pub mod par;


### PR DESCRIPTION
## Feature or Problem
This adds `wash label` as an option. It uses the `put_label` and `delete_label` control interface functions to add or remove labels

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/692

## Release Information
v0.26.0 (new feature)

## Consumer Impact
Jordan is happy :)

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification

Manually tested:
```
./target/debug/wash label damp foo=bar

Host `damp-rain-7348` labeled with `foo=bar`

wash get hosts -o json | jq -r '.hosts | .[] | .labels'
{
  "foo": "bar",
  "hostcore.arch": "aarch64",
  "hostcore.os": "macos",
  "hostcore.osfamily": "unix"
}
./target/debug/wash label damp foo --delete

Host `damp-rain-7348` unlabeled with `foo`
wash get hosts -o json | jq -r '.hosts | .[] | .labels'
{
  "hostcore.arch": "aarch64",
  "hostcore.os": "macos",
  "hostcore.osfamily": "unix"
}
```