### PR TITLE
feat(wash-cli)!: enable websocket port by default

### DIFF
--- a/crates/wash-cli/src/ui/mod.rs
+++ b/crates/wash-cli/src/ui/mod.rs
@@ -17,10 +17,11 @@ const DEFAULT_WASHBOARD_VERSION: &str = "v0.1.0";
 
 #[derive(Parser, Debug, Clone)]
 pub struct UiCommand {
-    /// Whist port to run the UI on, defaults to 3030
+    /// Which port to run the UI on, defaults to 3030
     #[clap(short = 'p', long = "port", default_value = DEFAULT_WASH_UI_PORT)]
     pub port: u16,
 
+    /// Which version of the UI to run
     #[clap(short = 'v', long = "version", default_value = DEFAULT_WASHBOARD_VERSION)]
     pub version: String,
 }

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -94,11 +94,15 @@ pub struct NatsOpts {
     #[clap(long = "nats-port", env = "WASMCLOUD_NATS_PORT", alias = "NATS_PORT")]
     pub nats_port: Option<u16>,
 
-    /// NATS websocket port to use. Websocket support will not be enabled if this option isn't set. TLS is not supported. This is required for the wash ui to connect from localhost
-    #[clap(long = "nats-websocket-port", env = "NATS_WEBSOCKET_PORT")]
-    pub nats_websocket_port: Option<u16>,
+    /// NATS websocket port to use. TLS is not supported. This is required for the wash ui to connect from localhost
+    #[clap(
+        long = "nats-websocket-port",
+        env = "NATS_WEBSOCKET_PORT",
+        default_value_t = 4001
+    )]
+    pub nats_websocket_port: u16,
 
-    /// NATS Server Jetstream domain, defaults to `core`
+    /// NATS Server Jetstream domain for extending superclusters
     #[clap(long = "nats-js-domain", env = "NATS_JS_DOMAIN")]
     pub nats_js_domain: Option<String>,
 }
@@ -120,7 +124,7 @@ impl From<NatsOpts> for NatsConfig {
             js_domain: other.nats_js_domain,
             remote_url: other.nats_remote_url,
             credentials: other.nats_credsfile,
-            websocket_port: other.nats_websocket_port,
+            websocket_port: Some(other.nats_websocket_port),
         }
     }
 }
@@ -368,7 +372,7 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
             js_domain: cmd.nats_opts.nats_js_domain,
             remote_url: cmd.nats_opts.nats_remote_url,
             credentials: cmd.nats_opts.nats_credsfile.clone(),
-            websocket_port: cmd.nats_opts.nats_websocket_port,
+            websocket_port: Some(cmd.nats_opts.nats_websocket_port),
         };
         start_nats(&install_dir, &nats_binary, nats_config).await?;
         Some(nats_binary)

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -300,9 +300,11 @@ pub struct WadmOpts {
     #[clap(long = "wadm-version", default_value = WADM_VERSION, env = "WADM_VERSION")]
     pub wadm_version: String,
 
+    /// If enabled, wadm will not be downloaded or run as a part of the up command
     #[clap(long = "disable-wadm")]
     pub disable_wadm: bool,
 
+    /// The JetStream domain to use for wadm
     #[clap(long = "wadm-js-domain", env = "WADM_JS_DOMAIN")]
     pub wadm_js_domain: Option<String>,
 }


### PR DESCRIPTION
## Feature or Problem
This PR sets the NATS server launched with `wash up` to always listen on port 4001 for websocket connections, letting `wash ui` work out-of-the-box with a host launched with vanilla options.

## Related Issues
N/A

## Release Information
v0.26.0

## Consumer Impact
Users of `wash-cli` will need to be aware that this opens up a websocket port for NATS to listen on that does not have TLS enabled. `wash up` is not the recommended tool for running in production, and for those use cases it's much better to adhere to our [deployment guide](https://wasmcloud.com/docs/deployment/lattice/) to understand how to deploy NATS infrastructure.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
This worked!
```
cargo run -- up -d
cargo run -- ui
```
