### PR TITLE
feat(wash-lib): support other build languages

### DIFF
--- a/crates/wash-cli/README.md
+++ b/crates/wash-cli/README.md
@@ -109,7 +109,7 @@ There are three main sections of a `wasmcloud.toml` file: common config, languag
 | name          | string |                               | Name of the project                                                                    |
 | version       | string |                               | Semantic version of the project                                                        |
 | path          | string | `{pwd}`                       | Path to the project directory to determine where built and signed artifacts are output |
-| language      | enum   | [rust, tinygo]                | Language that actor or provider is written in                                          |
+| language      | enum   | [rust, tinygo, other]         | Language that actor or provider is written in                                          |
 | type          | enum   | [actor, provider, interface ] | Type of wasmcloud artifact that is being generated                                     |
 | wasm_bin_name | string | "name" setting                | Expected name of the wasm module binary that will be generated                         |
 
@@ -131,6 +131,12 @@ There are three main sections of a `wasmcloud.toml` file: common config, languag
 | ----------- | ------ | ------------- | --------------------------------------- |
 | cargo_path  | string | `which cargo` | The path to the cargo binary            |
 | target_path | string | ./target      | Path to cargo/rust's `target` directory |
+
+#### Language Config - [other]
+
+If you are using a language other than Rust or Go, you can designate your language as any string (ex. `javascript`).
+
+Since `wash` will be unable to infer the build toolchain from the language you provide, you must supply the `build_command` and the path to the `build_artifact` so that the artifact can be built and found before signing.
 
 #### Type Config - [actor]
 

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -126,6 +126,17 @@ pub fn build_actor(
                 };
                 actor_wasm_path
             }
+            LanguageConfig::Other(_) if actor_config.build_command.is_some() => {
+                // SAFETY: We checked that the build command is not None above
+                build_custom_actor(
+                    common_config,
+                    actor_config,
+                    actor_config.build_command.as_ref().unwrap(),
+                )?
+            }
+            LanguageConfig::Other(other) => {
+                bail!("build command is required for unsupported language {other}");
+            }
         };
 
         // If the actor has been configured as WASI Preview2, adapt it from preview1

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -15,6 +15,7 @@ use wasmcloud_control_interface::{RegistryCredential, RegistryCredentialMap};
 pub enum LanguageConfig {
     Rust(RustConfig),
     TinyGo(TinyGoConfig),
+    Other(String),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -506,9 +507,7 @@ impl RawProjectConfig {
                 Some(tinygo_config) => LanguageConfig::TinyGo(tinygo_config.try_into()?),
                 None => LanguageConfig::TinyGo(TinyGoConfig::default()),
             },
-            _ => {
-                bail!("unknown language in wasmcloud.toml: {}", self.language);
-            }
+            other => LanguageConfig::Other(other.to_string()),
         };
 
         let registry_config = self
@@ -545,7 +544,7 @@ impl RawProjectConfig {
                 }
             }
 
-            LanguageConfig::TinyGo(_) => Ok(CommonConfig {
+            LanguageConfig::TinyGo(_) | LanguageConfig::Other(_) => Ok(CommonConfig {
                 name: self
                     .name
                     .ok_or_else(|| anyhow!("Missing name in wasmcloud.toml"))?,


### PR DESCRIPTION
## Feature or Problem
This PR allows `wash` to support other languages than Rust or TinyGo by using the `build_command` and `build_artifact` information from wasmcloud.toml. The proper usage of these fields is to supply a build command that wash can execute for you, and then the build artifact should be the path to the built Wasm component so wash can then load it to sign the component. For example, a Javascript component will be compilable by wash if you use a wasmcloud.toml like so:
```toml
name = "componentize"
language = "javascript"
version = "0.1.0"
type = "actor"

[actor]
claims = []
build_command = "node componentize.mjs"
build_artifact = "hello.component.wasm"
destination = "hello_s.component.wasm"
```

I left the language as a completely open String, so users could supply any language other than rust or go if that's what they are using.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
Patch bump in wash-lib and wash-cli, so whenever we release the next version

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
This worked for my componentize-js demo!