### PR TITLE
feat(wash): detect arch when building PAR files

### DIFF
--- a/crates/wash-cli/src/par.rs
+++ b/crates/wash-cli/src/par.rs
@@ -13,6 +13,11 @@ use wash_lib::cli::{extract_keypair, inspect, par, CommandOutput, OutputKind};
 
 const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
 
+/// Helper function for detecting the arch used by the current machine
+fn detect_arch() -> String {
+    format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS)
+}
+
 #[derive(Debug, Clone, Subcommand)]
 pub enum ParCliCommand {
     /// Build a provider archive file
@@ -85,7 +90,7 @@ pub struct CreateCommand {
     name: String,
 
     /// Architecture of provider binary in format ARCH-OS (e.g. x86_64-linux)
-    #[clap(short = 'a', long = "arch")]
+    #[clap(short = 'a', long = "arch", default_value_t = detect_arch())]
     arch: String,
 
     /// Path to provider binary for populating the archive
@@ -153,7 +158,7 @@ pub struct InsertCommand {
     archive: String,
 
     /// Architecture of binary in format ARCH-OS (e.g. x86_64-linux)
-    #[clap(short = 'a', long = "arch")]
+    #[clap(short = 'a', long = "arch", default_value_t = detect_arch())]
     arch: String,
 
     /// Path to provider binary to insert into archive


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit adds the ability to detect the arch + OS combination when building PAR files, and use that as a default valiue. It's unlikely that people will create PARs from *not* the native toolchain, and in those cases they can specify `--arch` as normal.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
