### PR TITLE
ci(wash-cli): fix packagecloud release

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -433,6 +433,8 @@ jobs:
 
   nfpm:
     if: startsWith(github.ref, 'refs/tags/wash-cli-v')
+    env:
+      PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_API_TOKEN }}
     needs:
     - cargo
     - build-bin
@@ -465,7 +467,6 @@ jobs:
         nfpm pkg --packager rpm -f build/nfpm.amd64.yaml
         nfpm pkg --packager rpm -f build/nfpm.arm64.yaml
     - name: Push `deb`
-      continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
       working-directory: ./crates/wash-cli
       run: |
         debs=(35 203 206 207 210 215 219 220 221 233 235 237 261 266)
@@ -474,7 +475,6 @@ jobs:
           curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_arm64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
         done
     - name: Push `rpm`
-      continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
       working-directory: ./crates/wash-cli
       run: |
         rpms=(194 204 209 216 226 231 236 239 240 244 260 273)


### PR DESCRIPTION
## Feature or Problem
This PR puts the packagecloud token back into the environment so we can release via nfpm. It also removes the continue on error clause to ensure we catch issues with that workflow sooner.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
