### PR TITLE
ci(wash-cli): parse version from github ref

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -434,6 +434,7 @@ jobs:
   nfpm:
     if: startsWith(github.ref, 'refs/tags/wash-cli-v')
     env:
+      REF: ${{ github.ref }}
       PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_API_TOKEN }}
     needs:
     - cargo


### PR DESCRIPTION
## Feature or Problem
This PR fixes one other issue with the wash-cli release to packagecloud which was a missing environment variable for parsing the reference. The release worked great, just had the default version.

## Related Issues
#1303 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
