### PR TITLE
ci(wash-cli): properly format wash version

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -462,7 +462,7 @@ jobs:
     - name: Build `deb` and `rpm`
       working-directory: ./crates/wash-cli
       run: |
-        export VERSION=$(echo $REF | cut -d/ -f3)
+        export VERSION=$(echo $REF| cut -d- -f3 | tr -d "v")
         nfpm pkg --packager deb -f build/nfpm.amd64.yaml
         nfpm pkg --packager deb -f build/nfpm.arm64.yaml
         nfpm pkg --packager rpm -f build/nfpm.amd64.yaml


### PR DESCRIPTION
## Feature or Problem
This PR, hopefully the last of its kind, resolves yet another issue that came from the apt install after publishing. Previously, the `github.ref` reference would get `cut` into:
```
wash-cli-v0.25.0
```

Which would cause this issue when attempting to install:
```
Get:1 https://packagecloud.io/wasmCloud/core/ubuntu jammy/main amd64 wash amd64 wash-cli-v0.25.0-packagecloudfix [15.1 MB]
Fetched 15.1 MB in 1s (27.3 MB/s)
dpkg: error processing archive /var/cache/apt/archives/wash_wash-cli-v0.25.0-packagecloudfix_amd64.deb (--unpack):
 parsing file '/var/lib/dpkg/tmp.ci/control' near line 2 package 'wash':
 'Version' field value 'wash-cli-v0.25.0-packagecloudfix': version number does not start with digit
Errors were encountered while processing:
 /var/cache/apt/archives/wash_wash-cli-v0.25.0-packagecloudfix_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

Now, the reference is `cut` and then trimmed into
```
0.25.0
```

## Related Issues
#1306 
#1303 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
This time I did verify that this actually parses properly into `0.25.0`. I can only hope that it's the last issue here as I can't test without having a package in packagecloud
