### PR TITLE
ci(wash-cli): make deb/rpm wash executable

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -458,6 +458,11 @@ jobs:
       with:
         name: wasmcloud-x86_64-unknown-linux-musl
         path: ./crates/wash-cli/x86_64
+    - name: Make wash executable
+      working-directory: ./crates/wash-cli
+      run: |
+        chmod +x ./aarch64/bin/wash
+        chmod +x ./x86_64/bin/wash
 
     - name: Build `deb` and `rpm`
       working-directory: ./crates/wash-cli


### PR DESCRIPTION
## Feature or Problem
Alrighty, so we properly got `0.25.0` released but it didn't have the executable bit set, so it would fail out of the box on deb/rpm systems.

If anyone is looking at this PR looking for a resolution, you can simply run `chmod +x /usr/local/bin/wash` and get off to the races.

## Related Issues
#1308 
#1303 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
