### PR TITLE
chore(ci): update artifact actions

### DIFF
--- a/.github/actions/build-nix/action.yml
+++ b/.github/actions/build-nix/action.yml
@@ -12,7 +12,7 @@ runs:
     shell: bash
   - run: nix run -L --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=cp -RLv ./result '${{ inputs.package }}'
     shell: bash
-  - uses: actions/upload-artifact@v3
+  - uses: actions/upload-artifact@v4
     with:
       name: ${{ inputs.package }}
       path: ${{ inputs.package }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,8 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  groups:
+    upload-download-artifact:
+      patterns:
+      - "*upload-artifact*"
+      - "*download-artifact*"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/washboard.yml
+++ b/.github/workflows/washboard.yml
@@ -50,13 +50,13 @@ jobs:
         run: tar -C dist -zcvf washboard.tar.gz .
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: washboard
           path: ./washboard-ui/washboard.tar.gz
 
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report
@@ -71,7 +71,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/washboard-ui-v')
     steps:
       - name: Download Asset
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: washboard
 

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -126,7 +126,7 @@ jobs:
     - run: mkdir "artifact/bin"
     - run: move "target/release/wasmcloud.exe" "artifact/bin/wasmcloud.exe"
     - run: move "target/release/wash.exe" "artifact/bin/wash.exe"
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: wasmcloud-x86_64-pc-windows-msvc
         path: artifact
@@ -136,11 +136,11 @@ jobs:
     needs: build-bin
     runs-on: macos-12
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wasmcloud-aarch64-apple-darwin
         path: aarch64
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wasmcloud-x86_64-apple-darwin
         path: x86_64
@@ -158,7 +158,7 @@ jobs:
     - run: chmod +x ./artifact/bin/wasmcloud
     - run: ./artifact/bin/wasmcloud --version
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: wasmcloud-universal-darwin
         path: artifact
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build-bin
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wasmcloud-x86_64-unknown-linux-musl
     - run: chmod +x ./bin/wash
@@ -179,7 +179,7 @@ jobs:
     runs-on: windows-2022
     needs: build-windows
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wasmcloud-x86_64-pc-windows-msvc
     - run: .\bin\wash.exe --version
@@ -373,7 +373,7 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v4.1.1
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         path: artifacts
     - run: |
@@ -450,11 +450,11 @@ jobs:
     - name: Install NFPM
       run: nix profile install -L --inputs-from . 'nixpkgs#nfpm'
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wasmcloud-aarch64-unknown-linux-musl
         path: ./crates/wash-cli/aarch64
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wasmcloud-x86_64-unknown-linux-musl
         path: ./crates/wash-cli/x86_64


### PR DESCRIPTION
Obviates https://github.com/wasmCloud/wasmCloud/pull/1181 and https://github.com/wasmCloud/wasmCloud/pull/1182

This also groups the upload and download actions in the dependabot config, so future automated bumps should work