### PR TITLE
fix(wasmbus): publish claims with actor_scaled

### DIFF
--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -99,6 +99,7 @@ pub fn actor_scaled(
 ) -> serde_json::Value {
     json!({
         "public_key": claims.subject,
+        "claims": format_actor_claims(claims),
         "annotations": annotations,
         "host_id": host_id.as_ref(),
         "image_ref": image_ref.as_ref(),


### PR DESCRIPTION
## Feature or Problem
This PR adds another field to the `actor_scaled` event which adds some necessary information in order to replace the `actors_started` event.

## Related Issues
Upcoming PR for wadm

## Release Information
v0.82.0, alongside releasing the event in the first place

## Consumer Impact
No impact on consumers as this event is still unreleased

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
