### PR TITLE
refactor(*)!: rename lattice prefix to just lattice

### DIFF
--- a/crates/control-interface/src/broker.rs
+++ b/crates/control-interface/src/broker.rs
@@ -1,169 +1,131 @@
 const DEFAULT_TOPIC_PREFIX: &str = "wasmbus.ctl";
 
-fn prefix(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
+fn prefix(topic_prefix: &Option<String>, lattice: &str) -> String {
     format!(
         "{}.{}",
         topic_prefix
             .as_ref()
             .unwrap_or(&DEFAULT_TOPIC_PREFIX.to_string()),
-        lattice_prefix
+        lattice
     )
 }
 
-pub fn provider_auction_subject(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
-    format!("{}.auction.provider", prefix(topic_prefix, lattice_prefix))
+pub fn provider_auction_subject(topic_prefix: &Option<String>, lattice: &str) -> String {
+    format!("{}.auction.provider", prefix(topic_prefix, lattice))
 }
 
-pub fn actor_auction_subject(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
-    format!("{}.auction.actor", prefix(topic_prefix, lattice_prefix))
+pub fn actor_auction_subject(topic_prefix: &Option<String>, lattice: &str) -> String {
+    format!("{}.auction.actor", prefix(topic_prefix, lattice))
 }
 
-pub fn advertise_link(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
-    format!("{}.linkdefs.put", prefix(topic_prefix, lattice_prefix))
+pub fn advertise_link(topic_prefix: &Option<String>, lattice: &str) -> String {
+    format!("{}.linkdefs.put", prefix(topic_prefix, lattice))
 }
 
-pub fn remove_link(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
-    format!("{}.linkdefs.del", prefix(topic_prefix, lattice_prefix))
+pub fn remove_link(topic_prefix: &Option<String>, lattice: &str) -> String {
+    format!("{}.linkdefs.del", prefix(topic_prefix, lattice))
 }
 
-pub fn publish_registries(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
-    format!("{}.registries.put", prefix(topic_prefix, lattice_prefix))
+pub fn publish_registries(topic_prefix: &Option<String>, lattice: &str) -> String {
+    format!("{}.registries.put", prefix(topic_prefix, lattice))
 }
 
 pub fn put_config(
     topic_prefix: &Option<String>,
-    lattice_prefix: &str,
+    lattice: &str,
     entity_id: &str,
     key: &str,
 ) -> String {
     format!(
         "{}.config.put.{entity_id}.{key}",
-        prefix(topic_prefix, lattice_prefix)
+        prefix(topic_prefix, lattice)
     )
 }
 
 pub fn delete_config(
     topic_prefix: &Option<String>,
-    lattice_prefix: &str,
+    lattice: &str,
     entity_id: &str,
     key: &str,
 ) -> String {
     format!(
         "{}.config.del.{entity_id}.{key}",
-        prefix(topic_prefix, lattice_prefix)
+        prefix(topic_prefix, lattice)
     )
 }
 
-pub fn clear_config(
-    topic_prefix: &Option<String>,
-    lattice_prefix: &str,
-    entity_id: &str,
-) -> String {
-    format!(
-        "{}.config.del.{entity_id}",
-        prefix(topic_prefix, lattice_prefix)
-    )
+pub fn clear_config(topic_prefix: &Option<String>, lattice: &str, entity_id: &str) -> String {
+    format!("{}.config.del.{entity_id}", prefix(topic_prefix, lattice))
 }
 
-pub fn put_label(topic_prefix: &Option<String>, lattice_prefix: &str, host_id: &str) -> String {
-    format!(
-        "{}.labels.{}.put",
-        prefix(topic_prefix, lattice_prefix),
-        host_id
-    )
+pub fn put_label(topic_prefix: &Option<String>, lattice: &str, host_id: &str) -> String {
+    format!("{}.labels.{}.put", prefix(topic_prefix, lattice), host_id)
 }
 
-pub fn delete_label(topic_prefix: &Option<String>, lattice_prefix: &str, host_id: &str) -> String {
-    format!(
-        "{}.labels.{}.del",
-        prefix(topic_prefix, lattice_prefix),
-        host_id
-    )
+pub fn delete_label(topic_prefix: &Option<String>, lattice: &str, host_id: &str) -> String {
+    format!("{}.labels.{}.del", prefix(topic_prefix, lattice), host_id)
 }
 
 pub mod commands {
     use super::prefix;
 
-    pub fn scale_actor(topic_prefix: &Option<String>, lattice_prefix: &str, host: &str) -> String {
-        format!(
-            "{}.cmd.{}.scale",
-            prefix(topic_prefix, lattice_prefix),
-            host
-        )
+    pub fn scale_actor(topic_prefix: &Option<String>, lattice: &str, host: &str) -> String {
+        format!("{}.cmd.{}.scale", prefix(topic_prefix, lattice), host)
     }
 
-    pub fn stop_actor(topic_prefix: &Option<String>, lattice_prefix: &str, host: &str) -> String {
-        format!("{}.cmd.{}.sa", prefix(topic_prefix, lattice_prefix), host) // sa - stop actor
+    pub fn stop_actor(topic_prefix: &Option<String>, lattice: &str, host: &str) -> String {
+        format!("{}.cmd.{}.sa", prefix(topic_prefix, lattice), host) // sa - stop actor
     }
 
-    pub fn start_provider(
-        topic_prefix: &Option<String>,
-        lattice_prefix: &str,
-        host: &str,
-    ) -> String {
-        format!("{}.cmd.{}.lp", prefix(topic_prefix, lattice_prefix), host)
+    pub fn start_provider(topic_prefix: &Option<String>, lattice: &str, host: &str) -> String {
+        format!("{}.cmd.{}.lp", prefix(topic_prefix, lattice), host)
     }
 
-    pub fn stop_provider(
-        topic_prefix: &Option<String>,
-        lattice_prefix: &str,
-        host: &str,
-    ) -> String {
-        format!("{}.cmd.{}.sp", prefix(topic_prefix, lattice_prefix), host)
+    pub fn stop_provider(topic_prefix: &Option<String>, lattice: &str, host: &str) -> String {
+        format!("{}.cmd.{}.sp", prefix(topic_prefix, lattice), host)
     }
 
-    pub fn update_actor(topic_prefix: &Option<String>, lattice_prefix: &str, host: &str) -> String {
-        format!("{}.cmd.{}.upd", prefix(topic_prefix, lattice_prefix), host)
+    pub fn update_actor(topic_prefix: &Option<String>, lattice: &str, host: &str) -> String {
+        format!("{}.cmd.{}.upd", prefix(topic_prefix, lattice), host)
     }
 
-    pub fn stop_host(topic_prefix: &Option<String>, lattice_prefix: &str, host: &str) -> String {
-        format!("{}.cmd.{}.stop", prefix(topic_prefix, lattice_prefix), host)
+    pub fn stop_host(topic_prefix: &Option<String>, lattice: &str, host: &str) -> String {
+        format!("{}.cmd.{}.stop", prefix(topic_prefix, lattice), host)
     }
 }
 
 pub mod queries {
     use super::prefix;
 
-    pub fn link_definitions(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
-        format!("{}.get.links", prefix(topic_prefix, lattice_prefix))
+    pub fn link_definitions(topic_prefix: &Option<String>, lattice: &str) -> String {
+        format!("{}.get.links", prefix(topic_prefix, lattice))
     }
 
-    pub fn claims(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
-        format!("{}.get.claims", prefix(topic_prefix, lattice_prefix))
+    pub fn claims(topic_prefix: &Option<String>, lattice: &str) -> String {
+        format!("{}.get.claims", prefix(topic_prefix, lattice))
     }
 
-    pub fn host_inventory(
-        topic_prefix: &Option<String>,
-        lattice_prefix: &str,
-        host: &str,
-    ) -> String {
-        format!("{}.get.{}.inv", prefix(topic_prefix, lattice_prefix), host)
+    pub fn host_inventory(topic_prefix: &Option<String>, lattice: &str, host: &str) -> String {
+        format!("{}.get.{}.inv", prefix(topic_prefix, lattice), host)
     }
 
-    pub fn hosts(topic_prefix: &Option<String>, lattice_prefix: &str) -> String {
-        format!("{}.ping.hosts", prefix(topic_prefix, lattice_prefix))
+    pub fn hosts(topic_prefix: &Option<String>, lattice: &str) -> String {
+        format!("{}.ping.hosts", prefix(topic_prefix, lattice))
     }
 
     pub fn config(
         topic_prefix: &Option<String>,
-        lattice_prefix: &str,
+        lattice: &str,
         entity_id: &str,
         key: &str,
     ) -> String {
         format!(
             "{}.get.config.{entity_id}.{key}",
-            prefix(topic_prefix, lattice_prefix),
+            prefix(topic_prefix, lattice),
         )
     }
 
-    pub fn all_config(
-        topic_prefix: &Option<String>,
-        lattice_prefix: &str,
-        entity_id: &str,
-    ) -> String {
-        format!(
-            "{}.get.config.{entity_id}",
-            prefix(topic_prefix, lattice_prefix),
-        )
+    pub fn all_config(topic_prefix: &Option<String>, lattice: &str, entity_id: &str) -> String {
+        format!("{}.get.config.{entity_id}", prefix(topic_prefix, lattice),)
     }
 }

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -115,7 +115,9 @@ pub struct Host {
     pub labels: Option<KeyValueMap>,
     /// Lattice prefix/ID used by the host
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lattice_prefix: Option<String>,
+    pub lattice: Option<String>,
+    #[serde(default, skip_serializing)]
+    lattice_prefix: Option<String>, // TODO(pre-1.0): remove me once all clients are updated to control interface v0.33
     /// NATS server host used for regular RPC
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rpc_host: Option<String>,
@@ -128,6 +130,14 @@ pub struct Host {
     /// Current wasmCloud Host software version
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+}
+
+// TODO(pre-1.0): remove me once all clients are updated to control interface v0.33
+impl Host {
+    #[must_use]
+    pub fn lattice(&self) -> Option<&String> {
+        self.lattice.as_ref().or(self.lattice_prefix.as_ref())
+    }
 }
 
 /// Describes the known contents of a given host at the time of

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -33,7 +33,7 @@ pub struct Host {
     /// Whether to require TLS for RPC connection
     pub rpc_tls: bool,
     /// The lattice the host belongs to
-    pub lattice_prefix: String,
+    pub lattice: String,
     /// The domain to use for host Jetstream operations
     pub js_domain: Option<String>,
     /// Labels (key-value pairs) to add to the host
@@ -88,7 +88,7 @@ impl Default for Host {
             rpc_jwt: None,
             rpc_key: None,
             rpc_tls: false,
-            lattice_prefix: "default".to_string(),
+            lattice: "default".to_string(),
             js_domain: None,
             labels: HashMap::default(),
             host_key: None,

--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -250,7 +250,7 @@ pub fn config_deleted(entity_id: impl AsRef<str>, key: impl AsRef<str>) -> serde
 pub(crate) async fn publish(
     event_builder: &EventBuilderV10,
     ctl_nats: &async_nats::Client,
-    lattice_prefix: &str,
+    lattice: &str,
     name: &str,
     data: serde_json::Value,
 ) -> anyhow::Result<()> {
@@ -268,11 +268,11 @@ pub(crate) async fn publish(
     let ev = serde_json::to_vec(&ev).context("failed to serialize event")?;
     // TODO(pre-1.0): deprecate general subject and remove this
     let _ = ctl_nats
-        .publish(format!("wasmbus.evt.{lattice_prefix}"), ev.clone().into())
+        .publish(format!("wasmbus.evt.{lattice}"), ev.clone().into())
         .await
         .with_context(|| format!("failed to publish `{name}` event on general subject"));
     ctl_nats
-        .publish(format!("wasmbus.evt.{lattice_prefix}.{name}"), ev.into())
+        .publish(format!("wasmbus.evt.{lattice}.{name}"), ev.into())
         .await
         .with_context(|| format!("failed to publish `{name}` event"))
 }

--- a/crates/provider-sdk/src/lib.rs
+++ b/crates/provider-sdk/src/lib.rs
@@ -40,16 +40,16 @@ pub fn serialize<T: Serialize>(data: &T) -> InvocationResult<Vec<u8>> {
 /// Returns the rpc topic (subject) name for sending to an actor or provider.
 /// A provider entity must have the public_key and link_name fields filled in.
 /// An actor entity must have a public_key and an empty link_name.
-pub fn rpc_topic(entity: &WasmCloudEntity, lattice_prefix: &str) -> String {
+pub fn rpc_topic(entity: &WasmCloudEntity, lattice: &str) -> String {
     if !entity.link_name.is_empty() {
         // provider target
         format!(
             "wasmbus.rpc.{}.{}.{}",
-            lattice_prefix, entity.public_key, entity.link_name
+            lattice, entity.public_key, entity.link_name
         )
     } else {
         // actor target
-        format!("wasmbus.rpc.{}.{}", lattice_prefix, entity.public_key)
+        format!("wasmbus.rpc.{}.{}", lattice, entity.public_key)
     }
 }
 

--- a/crates/provider-sdk/src/provider.rs
+++ b/crates/provider-sdk/src/provider.rs
@@ -73,7 +73,7 @@ macro_rules! process_until_quit {
 pub struct ProviderConnection {
     links: Arc<RwLock<HashMap<String, LinkDefinition>>>,
     rpc_client: RpcClient,
-    lattice_prefix: String,
+    lattice: String,
     host_data: Arc<HostData>,
     // We keep these around so they can drop
     _listener_handles: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
@@ -85,7 +85,7 @@ impl std::fmt::Debug for ProviderConnection {
             .field("provider_id", &self.host_data.provider_key)
             .field("host_id", &self.host_data.host_id)
             .field("link", &self.host_data.link_name)
-            .field("lattice_prefix", &self.lattice_prefix)
+            .field("lattice", &self.lattice)
             .finish()
     }
 }
@@ -111,7 +111,7 @@ impl ProviderConnection {
         Ok(ProviderConnection {
             links: Arc::new(RwLock::new(HashMap::new())),
             rpc_client,
-            lattice_prefix: host_data.lattice_rpc_prefix.to_owned(),
+            lattice: host_data.lattice_rpc_prefix.to_owned(),
             host_data: Arc::new(host_data.to_owned()),
             _listener_handles: Default::default(),
         })
@@ -186,7 +186,7 @@ impl ProviderConnection {
     pub fn provider_rpc_topic(&self) -> String {
         format!(
             "wasmbus.rpc.{}.{}.{}",
-            &self.lattice_prefix, &self.host_data.provider_key, self.host_data.link_name
+            &self.lattice, &self.host_data.provider_key, self.host_data.link_name
         )
     }
 
@@ -342,7 +342,7 @@ impl ProviderConnection {
     {
         let shutdown_topic = format!(
             "wasmbus.rpc.{}.{}.{}.shutdown",
-            &self.lattice_prefix, &self.host_data.provider_key, self.host_data.link_name
+            &self.lattice, &self.host_data.provider_key, self.host_data.link_name
         );
         debug!("subscribing for shutdown : {}", &shutdown_topic);
         let mut sub = self.rpc_client.client().subscribe(shutdown_topic).await?;
@@ -403,7 +403,7 @@ impl ProviderConnection {
     {
         let ldput_topic = format!(
             "wasmbus.rpc.{}.{}.{}.linkdefs.put",
-            &self.lattice_prefix, &self.host_data.provider_key, &self.host_data.link_name
+            &self.lattice, &self.host_data.provider_key, &self.host_data.link_name
         );
 
         let mut sub = self.rpc_client.client().subscribe(ldput_topic).await?;
@@ -456,7 +456,7 @@ impl ProviderConnection {
         // Link Delete
         let link_del_topic = format!(
             "wasmbus.rpc.{}.{}.{}.linkdefs.del",
-            &self.lattice_prefix, &self.host_data.provider_key, &self.host_data.link_name
+            &self.lattice, &self.host_data.provider_key, &self.host_data.link_name
         );
         debug!(topic = %link_del_topic, "subscribing for link del");
         let mut sub = self
@@ -491,7 +491,7 @@ impl ProviderConnection {
     {
         let topic = format!(
             "wasmbus.rpc.{}.{}.{}.health",
-            &self.lattice_prefix, &self.host_data.provider_key, &self.host_data.link_name
+            &self.lattice, &self.host_data.provider_key, &self.host_data.link_name
         );
 
         let mut sub = self.rpc_client.client().subscribe(topic).await?;

--- a/crates/providers/lattice-controller/src/client_cache.rs
+++ b/crates/providers/lattice-controller/src/client_cache.rs
@@ -126,11 +126,11 @@ async fn create_client(
 ) -> ProviderInvocationResult<wasmcloud_control_interface::Client> {
     let timeout = Duration::from_millis(config.timeout_ms);
     let auction_timeout = Duration::from_millis(config.auction_timeout_ms);
-    let lattice_prefix = config.lattice_prefix.clone();
+    let lattice = config.lattice.clone();
     let conn = connect(config).await?;
 
     Ok(wasmcloud_control_interface::ClientBuilder::new(conn)
-        .lattice_prefix(lattice_prefix)
+        .lattice(lattice)
         .timeout(timeout)
         .auction_timeout(auction_timeout)
         .build())

--- a/crates/providers/lattice-controller/src/lib.rs
+++ b/crates/providers/lattice-controller/src/lib.rs
@@ -20,7 +20,7 @@ const DEFAULT_TIMEOUT_MS: u64 = 2000;
 // cooperating providers/actors, since the *entire* auction duration will be awaited
 // for operations like `get-hosts`
 const DEFAULT_AUCTION_TIMEOUT_MS: u64 = 3000;
-const DEFAULT_LATTICE_PREFIX: &str = "default";
+const DEFAULT_LATTICE: &str = "default";
 
 use wasmcloud_provider_sdk::error::{ProviderInvocationError, ProviderInvocationResult};
 use wasmcloud_provider_sdk::Context;
@@ -83,9 +83,9 @@ struct ConnectionConfig {
     #[serde(default)]
     auth_seed: Option<String>,
 
-    /// Prefix for the lattice to use
+    /// Name of the lattice
     #[serde(default)]
-    lattice_prefix: String,
+    lattice: String,
 
     /// NATS JetStream domain
     #[serde(default)]
@@ -105,7 +105,7 @@ impl Default for ConnectionConfig {
             auth_jwt: None,
             js_domain: None,
             auth_seed: None,
-            lattice_prefix: String::from(DEFAULT_LATTICE_PREFIX),
+            lattice: String::from(DEFAULT_LATTICE),
             timeout_ms: DEFAULT_TIMEOUT_MS,
             auction_timeout_ms: DEFAULT_AUCTION_TIMEOUT_MS,
         }
@@ -155,7 +155,7 @@ impl WasmcloudLatticeControlLatticeController for LatticeControllerProvider {
                 .unwrap_or_else(|| "0.0.0.0:4222".to_string())],
             auth_jwt: arg.user_jwt.clone(),
             auth_seed: arg.user_seed.clone(),
-            lattice_prefix: arg.lattice_id.to_string(),
+            lattice: arg.lattice_id.to_string(),
             js_domain: arg.js_domain.clone(),
             ..Default::default()
         };
@@ -290,19 +290,21 @@ impl WasmcloudLatticeControlLatticeController for LatticeControllerProvider {
             .await
             .map(|v| {
                 v.into_iter()
-                    .map(|h| Host {
+                    .map(|h| {
+                        let lattice_prefix = h.lattice().cloned();
+                        Host {
                         cluster_issuers: h.cluster_issuers,
                         ctl_host: h.ctl_host,
                         id: h.id,
                         js_domain: h.js_domain,
                         labels: h.labels,
-                        lattice_prefix: h.lattice_prefix,
+                        lattice_prefix, // NOTE: the control interface type has been updated to just `lattice`, but the wit type is still `lattice_prefix`
                         prov_rpc_host: h.rpc_host.clone(),
                         rpc_host: h.rpc_host,
                         uptime_human: h.uptime_human,
                         uptime_seconds: h.uptime_seconds,
                         version: h.version,
-                    })
+                    }})
                     .collect::<Vec<_>>()
             })
             .map_err(|e| ProviderInvocationError::Provider(e.to_string()))?)

--- a/crates/wash-cli/src/app/mod.rs
+++ b/crates/wash-cli/src/app/mod.rs
@@ -178,23 +178,17 @@ pub async fn handle_command(
 async fn undeploy_model(cmd: UndeployCommand) -> Result<DeployModelResponse> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
-    let lattice_prefix = Some(connection_opts.get_lattice_prefix());
+    let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
-    wash_lib::app::undeploy_model(
-        &client,
-        lattice_prefix,
-        &cmd.model_name,
-        cmd.non_destructive,
-    )
-    .await
+    wash_lib::app::undeploy_model(&client, lattice, &cmd.model_name, cmd.non_destructive).await
 }
 
 async fn deploy_model(cmd: DeployCommand) -> Result<DeployModelResponse> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
-    let lattice_prefix = Some(connection_opts.get_lattice_prefix());
+    let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
@@ -205,17 +199,16 @@ async fn deploy_model(cmd: DeployCommand) -> Result<DeployModelResponse> {
 
     match app_manifest {
         AppManifest::SerializedModel(manifest) => {
-            let put_res =
-                wash_lib::app::put_model(&client, lattice_prefix.clone(), &manifest).await?;
+            let put_res = wash_lib::app::put_model(&client, lattice.clone(), &manifest).await?;
 
             let model_name = match put_res.result {
                 PutResult::Created | PutResult::NewVersion => put_res.name,
                 _ => bail!("Could not put manifest to deploy {}", put_res.message),
             };
-            wash_lib::app::deploy_model(&client, lattice_prefix, &model_name, cmd.version).await
+            wash_lib::app::deploy_model(&client, lattice, &model_name, cmd.version).await
         }
         AppManifest::ModelName(model_name) => {
-            wash_lib::app::deploy_model(&client, lattice_prefix, &model_name, cmd.version).await
+            wash_lib::app::deploy_model(&client, lattice, &model_name, cmd.version).await
         }
     }
 }
@@ -223,7 +216,7 @@ async fn deploy_model(cmd: DeployCommand) -> Result<DeployModelResponse> {
 async fn put_model(cmd: PutCommand) -> Result<PutModelResponse> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
-    let lattice_prefix = Some(connection_opts.get_lattice_prefix());
+    let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
@@ -234,7 +227,7 @@ async fn put_model(cmd: PutCommand) -> Result<PutModelResponse> {
 
     match app_manifest {
         AppManifest::SerializedModel(manifest) => {
-            wash_lib::app::put_model(&client, lattice_prefix, &manifest).await
+            wash_lib::app::put_model(&client, lattice, &manifest).await
         }
         AppManifest::ModelName(_) => {
             bail!("failed to retrieve manifest at `{:?}`", cmd.source)
@@ -245,33 +238,33 @@ async fn put_model(cmd: PutCommand) -> Result<PutModelResponse> {
 async fn get_model_history(cmd: HistoryCommand) -> Result<VersionResponse> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
-    let lattice_prefix = Some(connection_opts.get_lattice_prefix());
+    let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
-    wash_lib::app::get_model_history(&client, lattice_prefix, &cmd.model_name).await
+    wash_lib::app::get_model_history(&client, lattice, &cmd.model_name).await
 }
 
 async fn get_model_details(cmd: GetCommand) -> Result<GetModelResponse> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
-    let lattice_prefix = Some(connection_opts.get_lattice_prefix());
+    let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
-    wash_lib::app::get_model_details(&client, lattice_prefix, &cmd.model_name, cmd.version).await
+    wash_lib::app::get_model_details(&client, lattice, &cmd.model_name, cmd.version).await
 }
 
 async fn delete_model_version(cmd: DeleteCommand) -> Result<DeleteModelResponse> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
-    let lattice_prefix = Some(connection_opts.get_lattice_prefix());
+    let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
     wash_lib::app::delete_model_version(
         &client,
-        lattice_prefix,
+        lattice,
         &cmd.model_name,
         cmd.version,
         cmd.delete_all,
@@ -282,10 +275,10 @@ async fn delete_model_version(cmd: DeleteCommand) -> Result<DeleteModelResponse>
 async fn get_models(cmd: ListCommand) -> Result<Vec<ModelSummary>> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
-    let lattice_prefix = Some(connection_opts.get_lattice_prefix());
+    let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
-    wash_lib::app::get_models(&client, lattice_prefix).await
+    wash_lib::app::get_models(&client, lattice).await
 }
 
 fn list_models_output(results: Vec<ModelSummary>) -> CommandOutput {

--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -230,6 +230,15 @@ async fn main() {
         .with_writer(std::io::stderr)
         .with_env_filter(EnvFilter::from_default_env())
         .init();
+
+    // TODO(pre-1.0): remove me
+    if let Ok(lattice) = std::env::var("WASMCLOUD_LATTICE_PREFIX") {
+        eprintln!(
+            "The `WASMCLOUD_LATTICE_PREFIX` environment variable is deprecated and will be removed. Please use `WASMCLOUD_LATTICE` instead."
+        );
+        std::env::set_var("WASMCLOUD_LATTICE", lattice);
+    }
+
     let cli: Cli = Parser::parse();
 
     let output_kind = cli.output;

--- a/crates/wash-cli/src/common/start_cmd.rs
+++ b/crates/wash-cli/src/common/start_cmd.rs
@@ -46,7 +46,7 @@ mod test {
 
     const CTL_HOST: &str = "127.0.0.1";
     const CTL_PORT: &str = "4222";
-    const LATTICE_PREFIX: &str = "default";
+    const DEFAULT_LATTICE: &str = "default";
 
     const HOST_ID: &str = "NCE7YHGI42RWEKBRDJZWXBEJJCFNE5YIWYMSTLGHQBEGFY55BKJ3EG3G";
 
@@ -59,8 +59,8 @@ mod test {
             "ctl",
             "start",
             "actor",
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -86,7 +86,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(auction_timeout_ms, 2002);
                 assert_eq!(host_id.unwrap(), HOST_ID.to_string());
                 assert_eq!(actor_ref, "wasmcloud.azurecr.io/actor:v1".to_string());
@@ -98,8 +98,8 @@ mod test {
             "ctl",
             "start",
             "provider",
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -130,7 +130,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(config_json, None);
                 assert_eq!(auction_timeout_ms, 2002);

--- a/crates/wash-cli/src/common/stop_cmd.rs
+++ b/crates/wash-cli/src/common/stop_cmd.rs
@@ -47,7 +47,7 @@ mod test {
 
     const CTL_HOST: &str = "127.0.0.1";
     const CTL_PORT: &str = "4222";
-    const LATTICE_PREFIX: &str = "default";
+    const DEFAULT_LATTICE: &str = "default";
 
     const ACTOR_ID: &str = "MDPDJEYIAK6MACO67PRFGOSSLODBISK4SCEYDY3HEOY4P5CVJN6UCWUK";
     const HOST_ID: &str = "NCE7YHGI42RWEKBRDJZWXBEJJCFNE5YIWYMSTLGHQBEGFY55BKJ3EG3G";
@@ -74,8 +74,8 @@ mod test {
             "--host-id",
             HOST_ID,
             ACTOR_ID,
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -106,7 +106,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert!(skip_wait);
                 assert_eq!(host_id.unwrap(), HOST_ID);
                 assert_eq!(actor_id.to_string(), ACTOR_ID);
@@ -143,8 +143,8 @@ mod test {
             CTL_CREDSFILE,
             "--js-domain",
             JS_DOMAIN,
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--timeout-ms",
             &TIMEOUT_MS.to_string(),
             "--context",
@@ -162,7 +162,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(link_name, "default".to_string());
                 assert_eq!(host_id.unwrap(), HOST_ID);
@@ -199,8 +199,8 @@ mod test {
             CTL_CREDSFILE,
             "--js-domain",
             JS_DOMAIN,
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--timeout-ms",
             &TIMEOUT_MS.to_string(),
             "--context",
@@ -217,7 +217,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, TIMEOUT_MS);
                 assert_eq!(host_shutdown_timeout, HOST_TIMEOUT_MS);
                 assert_eq!(host_id.to_string(), HOST_ID);

--- a/crates/wash-cli/src/ctl/mod.rs
+++ b/crates/wash-cli/src/ctl/mod.rs
@@ -153,7 +153,7 @@ mod test {
 
     const CTL_HOST: &str = "127.0.0.1";
     const CTL_PORT: &str = "4222";
-    const LATTICE_PREFIX: &str = "default";
+    const DEFAULT_LATTICE: &str = "default";
     const JS_DOMAIN: &str = "custom-domain";
 
     const ACTOR_ID: &str = "MDPDJEYIAK6MACO67PRFGOSSLODBISK4SCEYDY3HEOY4P5CVJN6UCWUK";
@@ -169,8 +169,8 @@ mod test {
             "ctl",
             "stop",
             "actor",
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -192,7 +192,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id, Some(HOST_ID.to_string()));
                 assert_eq!(actor_id, ACTOR_ID);
@@ -214,8 +214,8 @@ mod test {
             "ctl",
             "stop",
             "provider",
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -239,7 +239,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id, Some(HOST_ID.to_string()));
                 assert_eq!(provider_id, PROVIDER_ID);
@@ -270,8 +270,8 @@ mod test {
             "ctl",
             "get",
             "hosts",
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -283,7 +283,7 @@ mod test {
             CtlCliCommand::Get(CtlGetCommand::Hosts(GetHostsCommand { opts })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, 2001);
             }
             cmd => panic!("ctl get hosts constructed incorrect command {cmd:?}"),
@@ -292,8 +292,8 @@ mod test {
             "ctl",
             "get",
             "inventory",
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -309,7 +309,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id.unwrap(), HOST_ID.parse()?);
             }
@@ -319,8 +319,8 @@ mod test {
             "ctl",
             "get",
             "claims",
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -334,7 +334,7 @@ mod test {
             CtlCliCommand::Get(CtlGetCommand::Claims(GetClaimsCommand { opts })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(opts.js_domain.unwrap(), JS_DOMAIN);
             }
@@ -344,8 +344,8 @@ mod test {
             "ctl",
             "link",
             "put",
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -371,7 +371,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(actor_id, ACTOR_ID);
                 assert_eq!(provider_id, PROVIDER_ID);
@@ -385,8 +385,8 @@ mod test {
             "ctl",
             "update",
             "actor",
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -407,7 +407,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id, Some(HOST_ID.to_string()));
                 assert_eq!(actor_id, ACTOR_ID);
@@ -420,8 +420,8 @@ mod test {
             "ctl",
             "scale",
             "actor",
-            "--lattice-prefix",
-            LATTICE_PREFIX,
+            "--lattice",
+            DEFAULT_LATTICE,
             "--ctl-host",
             CTL_HOST,
             "--ctl-port",
@@ -446,7 +446,7 @@ mod test {
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);
-                assert_eq!(&opts.lattice_prefix.unwrap(), LATTICE_PREFIX);
+                assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, 2001);
                 assert_eq!(host_id, HOST_ID);
                 assert_eq!(actor_ref, "wasmcloud.azurecr.io/actor:v2".to_string());

--- a/crates/wash-cli/src/ctx/mod.rs
+++ b/crates/wash-cli/src/ctx/mod.rs
@@ -11,9 +11,7 @@ use serde_json::json;
 use tracing::warn;
 use wash_lib::{
     cli::CommandOutput,
-    config::{
-        DEFAULT_LATTICE_PREFIX, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT, DEFAULT_NATS_TIMEOUT_MS,
-    },
+    config::{DEFAULT_LATTICE, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT, DEFAULT_NATS_TIMEOUT_MS},
     context::{fs::ContextDir, ContextManager, WashContext, HOST_CONFIG_NAME},
     id::ClusterSeed,
 };
@@ -309,9 +307,9 @@ fn prompt_for_context() -> Result<WashContext> {
         &Some(DEFAULT_NATS_TIMEOUT_MS.to_string()),
     )?;
 
-    let lattice_prefix = user_question(
+    let lattice = user_question(
         "What is the lattice prefix that the host will communicate on?",
-        &Some(DEFAULT_LATTICE_PREFIX.to_string()),
+        &Some(DEFAULT_LATTICE.to_string()),
     )?;
 
     let js_domain = match user_question(
@@ -369,7 +367,7 @@ fn prompt_for_context() -> Result<WashContext> {
         ctl_seed,
         ctl_credsfile: ctl_credsfile.map(PathBuf::from),
         ctl_timeout: ctl_timeout.parse()?,
-        lattice_prefix,
+        lattice,
         js_domain,
         rpc_host,
         rpc_port: rpc_port.parse().unwrap_or_default(),

--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -15,8 +15,8 @@ pub const WADM_VERSION: &str = "v0.9.1";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
 pub const WASMCLOUD_HOST_VERSION: &str = "v0.81.0";
 // NATS isolation configuration variables
-pub const WASMCLOUD_LATTICE_PREFIX: &str = "WASMCLOUD_LATTICE_PREFIX";
-pub const DEFAULT_LATTICE_PREFIX: &str = "default";
+pub const WASMCLOUD_LATTICE: &str = "WASMCLOUD_LATTICE";
+pub const DEFAULT_LATTICE: &str = "default";
 pub const WASMCLOUD_JS_DOMAIN: &str = "WASMCLOUD_JS_DOMAIN";
 // Host / Cluster configuration
 pub const WASMCLOUD_CLUSTER_ISSUERS: &str = "WASMCLOUD_CLUSTER_ISSUERS";
@@ -58,10 +58,10 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
     let mut host_config = HashMap::new();
     // NATS isolation configuration variables
     host_config.insert(
-        WASMCLOUD_LATTICE_PREFIX.to_string(),
+        WASMCLOUD_LATTICE.to_string(),
         wasmcloud_opts
-            .lattice_prefix
-            .unwrap_or(DEFAULT_LATTICE_PREFIX.to_string()),
+            .lattice
+            .unwrap_or(DEFAULT_LATTICE.to_string()),
     );
     if let Some(js_domain) = wasmcloud_opts.wasmcloud_js_domain {
         host_config.insert(WASMCLOUD_JS_DOMAIN.to_string(), js_domain);

--- a/crates/wash-lib/src/app.rs
+++ b/crates/wash-lib/src/app.rs
@@ -14,7 +14,7 @@ use wadm::server::{
 use tokio::io::{AsyncRead, AsyncReadExt};
 use url::Url;
 
-use crate::config::DEFAULT_LATTICE_PREFIX;
+use crate::config::DEFAULT_LATTICE;
 
 /// The NATS prefix wadm's API is listening on
 const WADM_API_PREFIX: &str = "wadm.api";
@@ -108,19 +108,19 @@ impl FromStr for AppManifestSource {
 ///
 /// # Arguments
 /// * `client` - The [Client](async_nats::Client) to use in order to send the request message
-/// * `lattice_prefix` - Optional lattice prefix that the application is managed on, defaults to `default`
+/// * `lattice` - Optional lattice name that the application is managed on, defaults to `default`
 /// * `model_name` - Model name to undeploy
 /// * `non_destructive` - Undeploy deletes managed resources by default, this can be overridden by setting this to `true`
 pub async fn undeploy_model(
     client: &Client,
-    lattice_prefix: Option<String>,
+    lattice: Option<String>,
     model_name: &str,
     non_destructive: bool,
 ) -> Result<DeployModelResponse> {
     let res = model_request(
         client,
         ModelOperation::Undeploy,
-        lattice_prefix,
+        lattice,
         Some(model_name),
         serde_json::to_vec(&UndeployModelRequest { non_destructive })?,
     )
@@ -133,19 +133,19 @@ pub async fn undeploy_model(
 ///
 /// # Arguments
 /// * `client` - The [Client](async_nats::Client) to use in order to send the request message
-/// * `lattice_prefix` - Optional lattice prefix that the application will be managed on, defaults to `default`
+/// * `lattice` - Optional lattice name that the application will be managed on, defaults to `default`
 /// * `model_name` - Model name to deploy
 /// * `version` - Version to deploy, defaults to deploying the latest "put" version
 pub async fn deploy_model(
     client: &Client,
-    lattice_prefix: Option<String>,
+    lattice: Option<String>,
     model_name: &str,
     version: Option<String>,
 ) -> Result<DeployModelResponse> {
     let res = model_request(
         client,
         ModelOperation::Deploy,
-        lattice_prefix,
+        lattice,
         Some(model_name),
         serde_json::to_vec(&DeployModelRequest { version })?,
     )
@@ -158,17 +158,17 @@ pub async fn deploy_model(
 ///
 /// # Arguments
 /// * `client` - The [Client](async_nats::Client) to use in order to send the request message
-/// * `lattice_prefix` - Optional lattice prefix that the application manifest will be stored on, defaults to `default`
+/// * `lattice` - Optional lattice name that the application manifest will be stored on, defaults to `default`
 /// * `model` - The full YAML or JSON string containing the OAM wadm manifest
 pub async fn put_model(
     client: &Client,
-    lattice_prefix: Option<String>,
+    lattice: Option<String>,
     model: &str,
 ) -> Result<PutModelResponse> {
     let res = model_request(
         client,
         ModelOperation::Put,
-        lattice_prefix,
+        lattice,
         None,
         model.as_bytes().to_vec(),
     )
@@ -181,17 +181,17 @@ pub async fn put_model(
 ///
 /// # Arguments
 /// * `client` - The [Client](async_nats::Client) to use in order to send the request message
-/// * `lattice_prefix` - Optional lattice prefix that the application manifest is stored on, defaults to `default`
+/// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model to retrieve history for
 pub async fn get_model_history(
     client: &Client,
-    lattice_prefix: Option<String>,
+    lattice: Option<String>,
     model_name: &str,
 ) -> Result<VersionResponse> {
     let res = model_request(
         client,
         ModelOperation::History,
-        lattice_prefix,
+        lattice,
         Some(model_name),
         vec![],
     )
@@ -204,17 +204,17 @@ pub async fn get_model_history(
 ///
 /// # Arguments
 /// * `client` - The [Client](async_nats::Client) to use in order to send the request message
-/// * `lattice_prefix` - Optional lattice prefix that the application manifest is stored on, defaults to `default`
+/// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model to retrieve status for
 pub async fn get_model_status(
     client: &Client,
-    lattice_prefix: Option<String>,
+    lattice: Option<String>,
     model_name: &str,
 ) -> Result<StatusResponse> {
     let res = model_request(
         client,
         ModelOperation::Status,
-        lattice_prefix,
+        lattice,
         Some(model_name),
         vec![],
     )
@@ -227,19 +227,19 @@ pub async fn get_model_status(
 ///
 /// # Arguments
 /// * `client` - The [Client](async_nats::Client) to use in order to send the request message
-/// * `lattice_prefix` - Optional lattice prefix that the application manifest is stored on, defaults to `default`
+/// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model to retrieve history for
 /// * `version` - Version to retrieve, defaults to retrieving the latest "put" version
 pub async fn get_model_details(
     client: &Client,
-    lattice_prefix: Option<String>,
+    lattice: Option<String>,
     model_name: &str,
     version: Option<String>,
 ) -> Result<GetModelResponse> {
     let res = model_request(
         client,
         ModelOperation::Get,
-        lattice_prefix,
+        lattice,
         Some(model_name),
         serde_json::to_vec(&GetModelRequest { version })?,
     )
@@ -252,13 +252,13 @@ pub async fn get_model_details(
 ///
 /// # Arguments
 /// * `client` - The [Client](async_nats::Client) to use in order to send the request message
-/// * `lattice_prefix` - Optional lattice prefix that the application manifest is stored on, defaults to `default`
+/// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model
 /// * `version` - Version to retrieve, defaults to deleting the latest "put" version (or all if `delete_all` is specified)
 /// * `delete_all` - Whether or not to delete all versions for a given model name
 pub async fn delete_model_version(
     client: &Client,
-    lattice_prefix: Option<String>,
+    lattice: Option<String>,
     model_name: &str,
     version: Option<String>,
     delete_all: bool,
@@ -266,7 +266,7 @@ pub async fn delete_model_version(
     let res = model_request(
         client,
         ModelOperation::Delete,
-        lattice_prefix,
+        lattice,
         Some(model_name),
         serde_json::to_vec(&DeleteModelRequest {
             version: version.unwrap_or_default(),
@@ -282,12 +282,9 @@ pub async fn delete_model_version(
 ///
 /// # Arguments
 /// * `client` - The [Client](async_nats::Client) to use in order to send the request message
-/// * `lattice_prefix` - Optional lattice prefix that the application manifests are stored on, defaults to `default`
-pub async fn get_models(
-    client: &Client,
-    lattice_prefix: Option<String>,
-) -> Result<Vec<ModelSummary>> {
-    let res = model_request(client, ModelOperation::List, lattice_prefix, None, vec![]).await?;
+/// * `lattice` - Optional lattice name that the application manifests are stored on, defaults to `default`
+pub async fn get_models(client: &Client, lattice: Option<String>) -> Result<Vec<ModelSummary>> {
+    let res = model_request(client, ModelOperation::List, lattice, None, vec![]).await?;
 
     serde_json::from_slice(&res.payload).map_err(|e| anyhow::anyhow!(e))
 }
@@ -297,7 +294,7 @@ pub async fn get_models(
 async fn model_request(
     client: &Client,
     operation: ModelOperation,
-    lattice_prefix: Option<String>,
+    lattice: Option<String>,
     object_name: Option<&str>,
     bytes: Vec<u8>,
 ) -> Result<Message> {
@@ -305,7 +302,7 @@ async fn model_request(
     // We let callers of this function dictate the topic after the prefix + lattice
     let topic = format!(
         "{WADM_API_PREFIX}.{}.model.{}{}",
-        lattice_prefix.unwrap_or_else(|| DEFAULT_LATTICE_PREFIX.to_string()),
+        lattice.unwrap_or_else(|| DEFAULT_LATTICE.to_string()),
         operation.to_string(),
         object_name
             .map(|name| format!(".{name}"))

--- a/crates/wash-lib/src/cli/capture.rs
+++ b/crates/wash-lib/src/cli/capture.rs
@@ -151,22 +151,18 @@ pub async fn handle_command(cmd: CaptureCommand) -> Result<CommandOutput> {
         let window_size = Duration::from_secs(cmd.window_size_minutes * 60);
         return enable(
             js_context,
-            wco.lattice_prefix.as_deref().unwrap_or("default"),
+            wco.lattice.as_deref().unwrap_or("default"),
             window_size,
         )
         .await;
     } else if cmd.disable {
-        return disable(
-            js_context,
-            wco.lattice_prefix.as_deref().unwrap_or("default"),
-        )
-        .await;
+        return disable(js_context, wco.lattice.as_deref().unwrap_or("default")).await;
     }
 
     capture(
         js_context,
         ctl_client,
-        wco.lattice_prefix.as_deref().unwrap_or("default"),
+        wco.lattice.as_deref().unwrap_or("default"),
     )
     .await
 }

--- a/crates/wash-lib/src/config.rs
+++ b/crates/wash-lib/src/config.rs
@@ -13,7 +13,7 @@ pub const WASH_DIR: &str = ".wash";
 const DOWNLOADS_DIR: &str = "downloads";
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
-pub const DEFAULT_LATTICE_PREFIX: &str = "default";
+pub const DEFAULT_LATTICE: &str = "default";
 pub const DEFAULT_NATS_TIMEOUT_MS: u64 = 2_000;
 pub const DEFAULT_START_ACTOR_TIMEOUT_MS: u64 = 5_000;
 pub const DEFAULT_START_PROVIDER_TIMEOUT_MS: u64 = 60_000;
@@ -65,8 +65,8 @@ pub struct WashConnectionOptions {
     /// JS domain for wasmcloud control interface. Defaults to None
     pub js_domain: Option<String>,
 
-    /// Lattice prefix for wasmcloud control interface, defaults to "default"
-    pub lattice_prefix: Option<String>,
+    /// Lattice name for wasmcloud control interface, defaults to "default"
+    pub lattice: Option<String>,
 
     /// Timeout length to await a control interface response, defaults to 2000 milliseconds
     pub timeout_ms: u64,
@@ -78,9 +78,7 @@ pub struct WashConnectionOptions {
 impl WashConnectionOptions {
     /// Create a control client from connection options
     pub async fn into_ctl_client(self, auction_timeout_ms: Option<u64>) -> Result<CtlClient> {
-        let lattice_prefix = self
-            .lattice_prefix
-            .unwrap_or_else(|| self.ctx.lattice_prefix.clone());
+        let lattice = self.lattice.unwrap_or_else(|| self.ctx.lattice.clone());
 
         let ctl_host = self.ctl_host.unwrap_or_else(|| self.ctx.ctl_host.clone());
         let ctl_port = self
@@ -100,7 +98,7 @@ impl WashConnectionOptions {
                 .context("Failed to create NATS client")?;
 
         let mut builder = CtlClientBuilder::new(nc)
-            .lattice_prefix(lattice_prefix)
+            .lattice(lattice)
             .timeout(tokio::time::Duration::from_millis(self.timeout_ms))
             .auction_timeout(tokio::time::Duration::from_millis(auction_timeout_ms));
 
@@ -132,11 +130,11 @@ impl WashConnectionOptions {
         Ok(nc)
     }
 
-    /// Either returns the opts.lattice prefix or opts.ctx.lattice_prefix... if both are absent/None,  returns the default lattice prefix (DEFAULT_LATTICE_PREFIX).
-    pub fn get_lattice_prefix(&self) -> String {
-        self.lattice_prefix
+    /// Either returns the opts.lattice or opts.ctx.lattice... if both are absent/None,  returns the default lattice prefix (DEFAULT_LATTICE).
+    pub fn get_lattice(&self) -> String {
+        self.lattice
             .clone()
-            .unwrap_or_else(|| self.ctx.lattice_prefix.clone())
+            .unwrap_or_else(|| self.ctx.lattice.clone())
     }
 }
 

--- a/crates/wash-lib/src/context/fs.rs
+++ b/crates/wash-lib/src/context/fs.rs
@@ -245,7 +245,7 @@ mod test {
 
         let mut orig_ctx = WashContext {
             name: "happy_path".to_string(),
-            lattice_prefix: "foobar".to_string(),
+            lattice: "foobar".to_string(),
             ..Default::default()
         };
 
@@ -274,13 +274,13 @@ mod test {
             .load_context("happy_path")
             .expect("Should be able to load context from disk");
         assert!(
-            orig_ctx.name == loaded.name && orig_ctx.lattice_prefix == loaded.lattice_prefix,
+            orig_ctx.name == loaded.name && orig_ctx.lattice == loaded.lattice,
             "Should have loaded the correct context from disk"
         );
 
         // Save one more context
         orig_ctx.name = "happy_gilmore".to_string();
-        orig_ctx.lattice_prefix = "baz".to_string();
+        orig_ctx.lattice = "baz".to_string();
         ctx_dir
             .save_context(&orig_ctx)
             .expect("Should be able to save second context");
@@ -307,7 +307,7 @@ mod test {
             .load_default_context()
             .expect("Should be able to load default context from disk");
         assert!(
-            orig_ctx.name == loaded.name && orig_ctx.lattice_prefix == loaded.lattice_prefix,
+            orig_ctx.name == loaded.name && orig_ctx.lattice == loaded.lattice,
             "Should have loaded the correct context from disk"
         );
 

--- a/crates/wash-lib/src/context/mod.rs
+++ b/crates/wash-lib/src/context/mod.rs
@@ -8,9 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, NoneAsEmptyString};
 
 use crate::{
-    config::{
-        DEFAULT_LATTICE_PREFIX, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT, DEFAULT_NATS_TIMEOUT_MS,
-    },
+    config::{DEFAULT_LATTICE, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT, DEFAULT_NATS_TIMEOUT_MS},
     id::ClusterSeed,
 };
 
@@ -67,8 +65,9 @@ pub struct WashContext {
     #[serde(default = "default_timeout_ms")]
     pub ctl_timeout: u64,
 
-    #[serde(default = "default_lattice_prefix")]
-    pub lattice_prefix: String,
+    // NOTE: lattice_prefix was renamed to lattice in most places, but this alias will need to remain for backwards compatibility with existing context files
+    #[serde(alias = "lattice_prefix", default = "default_lattice")]
+    pub lattice: String,
 
     pub js_domain: Option<String>,
 
@@ -107,7 +106,7 @@ impl Default for WashContext {
             ctl_seed: None,
             ctl_credsfile: None,
             ctl_timeout: DEFAULT_NATS_TIMEOUT_MS,
-            lattice_prefix: DEFAULT_LATTICE_PREFIX.to_string(),
+            lattice: DEFAULT_LATTICE.to_string(),
             js_domain: None,
             rpc_host: DEFAULT_NATS_HOST.to_string(),
             rpc_port: DEFAULT_NATS_PORT.parse().unwrap(),
@@ -129,8 +128,8 @@ fn default_nats_port() -> u16 {
     DEFAULT_NATS_PORT.parse().unwrap()
 }
 
-fn default_lattice_prefix() -> String {
-    DEFAULT_LATTICE_PREFIX.to_string()
+fn default_lattice() -> String {
+    DEFAULT_LATTICE.to_string()
 }
 
 pub fn default_timeout_ms() -> u64 {

--- a/crates/wash-lib/src/spier.rs
+++ b/crates/wash-lib/src/spier.rs
@@ -96,7 +96,7 @@ impl Spier {
         let (actor_id, friendly_name) = find_actor_id(actor_id_or_name, ctl_client).await?;
         let linked_providers = get_linked_providers(&actor_id, ctl_client).await?;
 
-        let rpc_topic_prefix = format!("wasmbus.rpc.{}", ctl_client.lattice_prefix);
+        let rpc_topic_prefix = format!("wasmbus.rpc.{}", ctl_client.lattice);
         let actor_stream = nats_client
             .subscribe(format!("{}.{}", rpc_topic_prefix, actor_id.as_ref()))
             .await?;

--- a/tests/blobstore-s3.rs
+++ b/tests/blobstore-s3.rs
@@ -25,7 +25,7 @@ use crate::common::{
     assert_advertise_link, assert_start_actor, assert_start_provider, stop_server,
 };
 
-const LATTICE_PREFIX: &str = "test-blobstore-s3";
+const LATTICE: &str = "test-blobstore-s3";
 
 /// Test all functionality for the blobstore-s3 provider
 ///
@@ -62,7 +62,7 @@ async fn blobstore_s3_suite() -> Result<()> {
 
     // Build client for interacting with the lattice
     let ctl_client = ClientBuilder::new(nats_client.clone())
-        .lattice_prefix(LATTICE_PREFIX.to_string())
+        .lattice(LATTICE.to_string())
         .build();
 
     // Start a wasmcloud host
@@ -71,7 +71,7 @@ async fn blobstore_s3_suite() -> Result<()> {
     let (_host, shutdown_host) = Host::new(HostConfig {
         ctl_nats_url: nats_url.clone(),
         rpc_nats_url: nats_url.clone(),
-        lattice_prefix: LATTICE_PREFIX.into(),
+        lattice: LATTICE.into(),
         cluster_key: Some(Arc::clone(&cluster_key)),
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key.public_key()]),
         host_key: Some(Arc::clone(&host_key)),
@@ -133,7 +133,7 @@ async fn blobstore_s3_suite() -> Result<()> {
     assert_start_actor(
         &ctl_client,
         &nats_client,
-        LATTICE_PREFIX,
+        LATTICE,
         &host_key,
         blobstore_http_smithy_actor_url,
         1,
@@ -144,7 +144,7 @@ async fn blobstore_s3_suite() -> Result<()> {
     assert_start_provider(
         &ctl_client,
         &nats_client,
-        LATTICE_PREFIX,
+        LATTICE,
         &host_key,
         &httpserver_provider_key,
         "default",
@@ -157,7 +157,7 @@ async fn blobstore_s3_suite() -> Result<()> {
     assert_start_provider(
         &ctl_client,
         &nats_client,
-        LATTICE_PREFIX,
+        LATTICE,
         &host_key,
         &blobstore_s3_provider_key,
         "default",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -43,13 +43,13 @@ pub async fn free_port() -> Result<u16> {
 pub async fn assert_start_actor(
     ctl_client: &wasmcloud_control_interface::Client,
     nats_client: &async_nats::Client, // TODO: This should be exposed by `wasmcloud_control_interface::Client`
-    lattice_prefix: &str,
+    lattice: &str,
     host_key: &KeyPair,
     url: impl AsRef<str>,
     count: u32,
 ) -> anyhow::Result<()> {
     let mut sub_started = nats_client
-        .subscribe(format!("wasmbus.evt.{lattice_prefix}.actors_started"))
+        .subscribe(format!("wasmbus.evt.{lattice}.actors_started"))
         .await?;
 
     let CtlOperationAck { accepted, error } = ctl_client
@@ -75,17 +75,17 @@ pub async fn assert_start_actor(
 pub async fn assert_scale_actor(
     ctl_client: &wasmcloud_control_interface::Client,
     nats_client: &async_nats::Client, // TODO: This should be exposed by `wasmcloud_control_interface::Client`
-    lattice_prefix: &str,
+    lattice: &str,
     host_key: &KeyPair,
     url: impl AsRef<str>,
     annotations: Option<HashMap<String, String>>,
     count: u32,
 ) -> anyhow::Result<()> {
     let mut sub_started = nats_client
-        .subscribe(format!("wasmbus.evt.{lattice_prefix}.actors_started"))
+        .subscribe(format!("wasmbus.evt.{lattice}.actors_started"))
         .await?;
     let mut sub_stopped = nats_client
-        .subscribe(format!("wasmbus.evt.{lattice_prefix}.actors_stopped"))
+        .subscribe(format!("wasmbus.evt.{lattice}.actors_stopped"))
         .await?;
     let CtlOperationAck { accepted, error } = ctl_client
         .scale_actor(&host_key.public_key(), url.as_ref(), count, annotations)
@@ -113,7 +113,7 @@ pub async fn assert_scale_actor(
 pub async fn assert_start_provider(
     client: &wasmcloud_control_interface::Client,
     rpc_client: &async_nats::Client,
-    lattice_prefix: &str,
+    lattice: &str,
     host_key: &KeyPair,
     provider_key: &KeyPair,
     link_name: &str,
@@ -147,7 +147,7 @@ pub async fn assert_start_provider(
         .then(|_| rpc_client.request(
             format!(
                 "wasmbus.rpc.{}.{}.{}.health",
-                lattice_prefix,
+                lattice,
                 provider_key.public_key(),
                 link_name,
             ),

--- a/tests/kv-vault.rs
+++ b/tests/kv-vault.rs
@@ -23,7 +23,7 @@ use crate::common::{
     assert_advertise_link, assert_start_actor, assert_start_provider, stop_server,
 };
 
-const LATTICE_PREFIX: &str = "test-kv-vault";
+const LATTICE: &str = "test-kv-vault";
 
 /// Test all functionality for the kv-vault provider
 #[tokio::test(flavor = "multi_thread")]
@@ -57,7 +57,7 @@ async fn kv_vault_suite() -> Result<()> {
 
     // Build client for interacting with the lattice
     let ctl_client = ClientBuilder::new(nats_client.clone())
-        .lattice_prefix(LATTICE_PREFIX.to_string())
+        .lattice(LATTICE.to_string())
         .build();
 
     // Start a wasmcloud host
@@ -66,7 +66,7 @@ async fn kv_vault_suite() -> Result<()> {
     let (_host, shutdown_host) = Host::new(HostConfig {
         ctl_nats_url: nats_url.clone(),
         rpc_nats_url: nats_url.clone(),
-        lattice_prefix: LATTICE_PREFIX.into(),
+        lattice: LATTICE.into(),
         cluster_key: Some(Arc::clone(&cluster_key)),
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key.public_key()]),
         host_key: Some(Arc::clone(&host_key)),
@@ -121,7 +121,7 @@ async fn kv_vault_suite() -> Result<()> {
     assert_start_actor(
         &ctl_client,
         &nats_client,
-        LATTICE_PREFIX,
+        LATTICE,
         &host_key,
         kv_http_smithy_actor_url,
         1,
@@ -132,7 +132,7 @@ async fn kv_vault_suite() -> Result<()> {
     assert_start_provider(
         &ctl_client,
         &nats_client,
-        LATTICE_PREFIX,
+        LATTICE,
         &host_key,
         &httpserver_provider_key,
         "default",
@@ -145,7 +145,7 @@ async fn kv_vault_suite() -> Result<()> {
     assert_start_provider(
         &ctl_client,
         &nats_client,
-        LATTICE_PREFIX,
+        LATTICE,
         &host_key,
         &kv_vault_provider_key,
         "default",

--- a/tests/messaging-nats.rs
+++ b/tests/messaging-nats.rs
@@ -25,7 +25,7 @@ use crate::common::{
     assert_advertise_link, assert_start_actor, assert_start_provider, stop_server,
 };
 
-const LATTICE_PREFIX: &str = "test-messaging-nats";
+const LATTICE: &str = "test-messaging-nats";
 
 /// Test all functionality for the messaging-nats provider
 ///
@@ -67,7 +67,7 @@ async fn messaging_nats_suite() -> Result<()> {
 
     // Build client for interacting with the lattice
     let ctl_client = ClientBuilder::new(nats_client.clone())
-        .lattice_prefix(LATTICE_PREFIX.to_string())
+        .lattice(LATTICE.to_string())
         .build();
 
     // Start a wasmcloud host
@@ -76,7 +76,7 @@ async fn messaging_nats_suite() -> Result<()> {
     let (_host, shutdown_host) = Host::new(HostConfig {
         ctl_nats_url: nats_url.clone(),
         rpc_nats_url: nats_url.clone(),
-        lattice_prefix: LATTICE_PREFIX.into(),
+        lattice: LATTICE.into(),
         cluster_key: Some(Arc::clone(&cluster_key)),
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key.public_key()]),
         host_key: Some(Arc::clone(&host_key)),
@@ -138,7 +138,7 @@ async fn messaging_nats_suite() -> Result<()> {
     assert_start_actor(
         &ctl_client,
         &nats_client,
-        LATTICE_PREFIX,
+        LATTICE,
         &host_key,
         messaging_sender_http_smithy_actor_url,
         1,
@@ -173,7 +173,7 @@ async fn messaging_nats_suite() -> Result<()> {
     assert_start_actor(
         &ctl_client,
         &nats_client,
-        LATTICE_PREFIX,
+        LATTICE,
         &host_key,
         messaging_receiver_smithy_actor_url,
         1,
@@ -184,7 +184,7 @@ async fn messaging_nats_suite() -> Result<()> {
     assert_start_provider(
         &ctl_client,
         &nats_client,
-        LATTICE_PREFIX,
+        LATTICE,
         &host_key,
         &httpserver_provider_key,
         "default",
@@ -197,7 +197,7 @@ async fn messaging_nats_suite() -> Result<()> {
     assert_start_provider(
         &ctl_client,
         &nats_client,
-        LATTICE_PREFIX,
+        LATTICE,
         &host_key,
         &messaging_nats_provider_key,
         "default",


### PR DESCRIPTION
## Feature or Problem
This renames `lattice_prefix` to just `lattice` internally, including in user-facing ways:
- `--lattice-prefix` in the host/wash is now just `--lattice`
  - backwards compatibility is maintained via a clap alias, for the time being
- the `WASMCLOUD_LATTICE_PREFIX` env var is now just `WASMCLOUD_LATTICE`
  - backwards compatibility is maintained via manual checking, which emits a warning when the old env var is used

## Related Issues
https://github.com/wasmCloud/wasmCloud/issues/1221

## Release Information
- v0.33 of the control interface (breaking change)
- v0.82 of the host (not a breaking change, but that's the next version)
- v0.26 of wash (breaking change due to pulling in the new control interface)

## Consumer Impact
There shouldn't be any, other than users receiving warnings if they use the old env var

Users of the control interface crate will need to update now that `lattice_prefix` is not a public field

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
The existing test suite has good coverage

### Manual Verification
I also played around with starting the host and using wash with the new flag/env var