### PR TITLE
feat(DockerFileLoad): Enable actor file load for docker

### DIFF
--- a/examples/docker/docker-compose-full.yml
+++ b/examples/docker/docker-compose-full.yml
@@ -50,6 +50,7 @@ services:
       WASMCLOUD_LOG_LEVEL: debug
       WASMCLOUD_RPC_HOST: nats
       WASMCLOUD_CTL_HOST: nats
+      WASMCLOUD_ALLOW_FILE_LOAD: "true"
       WASMCLOUD_OCI_ALLOWED_INSECURE: registry:5000
       OTEL_TRACES_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:55681/v1/traces


### PR DESCRIPTION
## Feature or Problem
<!---
When we run wasmcloud using docker-compose and then use wash cli to deploy the wadm , the docker container for wasmcloud returns an error stating that 

`unable to start actor from file, file loading is disabled`
This PR is to enable file loading when using docker-compose.
--->

## Related Issues
<!--- 
https://github.com/wasmCloud/wasmCloud/issues/1343
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
