### PR TITLE
fix(examples): update port for tempo to remove conflict with host ports

### DIFF
--- a/examples/docker/docker-compose-auxiliary.yml
+++ b/examples/docker/docker-compose-auxiliary.yml
@@ -27,5 +27,5 @@ services:
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
-      - 8000:8000 # tempo
+      - 7999:7999 # tempo
       - 55681:55681 # otlp http  

--- a/examples/docker/docker-compose-full.yml
+++ b/examples/docker/docker-compose-full.yml
@@ -36,7 +36,7 @@ services:
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
-      - 8000:8000 # tempo
+      - 7999:7999 # tempo
       - 55681:55681 # otlp http
 
   wasmcloud:

--- a/examples/docker/grafana-datasources.yaml
+++ b/examples/docker/grafana-datasources.yaml
@@ -4,7 +4,7 @@ datasources:
   - name: Tempo
     type: tempo
     access: proxy
-    url: http://tempo:8000
+    url: http://tempo:7999
     version: 1
     editable: false
     uid: tempo  

--- a/examples/docker/tempo.yaml
+++ b/examples/docker/tempo.yaml
@@ -1,5 +1,5 @@
 server:
-  http_listen_port: 8000
+  http_listen_port: 7999
 
 distributor:
   log_received_spans:


### PR DESCRIPTION
I noticed this error:
```
docker-grafana-1    | logger=plugins.update.checker t=2024-01-17T19:00:23.605767216Z level=info msg="Update check succeeded" duration=119.701458ms
Error response from daemon: driver failed programming external connectivity on endpoint docker-wasmcloud-1 (a763906bc096c57b9addf7cead80f1eb84f61ded4344e69166a56b75f98bd801): Bind for 0.0.0.0:8000 failed: port is already allocated
```

So I simply updated the tempo port from 8000 to 7999