### PR TITLE
feat(wadm): allow relative paths in file-based WADM manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5025,6 +5025,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_with",
+ "serde_yaml",
  "tempfile",
  "term-table",
  "test-case",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -66,6 +66,7 @@ serde-transcode = { workspace = true }
 serde_cbor = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, features = ["macros"] }
+serde_yaml = { workspace = true }
 tempfile = { workspace = true }
 term-table = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/crates/wash-lib/src/generate/genconfig.rs
+++ b/crates/wash-lib/src/generate/genconfig.rs
@@ -177,7 +177,7 @@ mod tests {
 
         assert_eq!(result.placeholders.len(), 2);
 
-        let pa = result.placeholders.get(0).unwrap();
+        let pa = result.placeholders.first().unwrap();
         let pb = result.placeholders.get(1).unwrap();
 
         assert_eq!(pa.len(), 4);

--- a/examples/rust/actors/http-hello-world/wadm.yaml
+++ b/examples/rust/actors/http-hello-world/wadm.yaml
@@ -13,7 +13,7 @@ spec:
       properties:
         # TODO: you must replace the path below to match your genreated code in build
         # Try using `wash build -o json` and use the `actor_path` field, prepended with `file://`
-        image: file:///the/absolute/path/to/build/http-hello-world-component_s.wasm
+        image: file:///the/absolute/path/to/build/http_hello_world_s.wasm
       traits:
         # Govern the spread/scheduling of the actor
         - type: spreadscaler


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

WADM does not allow non-relative file paths to be used for values like `image:` (which is relevant for actors and providers specified in the manifest).

If a user is using a local file path, it's very likely that the host on which the declarative architecture will be deployed is the same host as the one that is running `wadm`.

To enable users to more conveniently build declarative manifests, we can resolve `file://...` paths based on the path to the WADM file itself (which is known at load time).

The basic scheme is to update the `AppManifest`s to store YAML structure rather than a simple `String`, in order to enable iterating and replacing paths as is necessary.

This commit allows for relative paths in WADM manifests that are fed to commands like `wash app deploy`.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
