### PR TITLE
docs(host): add README for the host crate

### DIFF
--- a/crates/host/README.md
+++ b/crates/host/README.md
@@ -1,0 +1,18 @@
+# 💻 Distributed computing, _simplified_
+
+The wasmCloud runtime is a vessel for running applications in the cloud, at the edge, in the browser, on small devices, and anywhere else you can imagine.
+
+**Move from concept to production without changing your design, architecture, or your programming environment.**
+
+wasmCloud lets you focus on shipping _features_. Build secure, portable, re-usable components. Get rid of the headaches from being smothered by boilerplate, dependency hell, tight coupling, and designs mandated by your infrastructure.
+
+## Core Tenets
+
+- Dead simple distributed applications
+- Run anywhere
+- Secure by default
+- Productivity for both developers and operations
+
+# wasmCloud Host Runtime
+
+This crate contains the host runtime itself. Check out the [top-level project](https://github.com/wasmCloud/wasmCloud) for information about the wasmCloud ecosystem as a whole.


### PR DESCRIPTION
Resolves https://github.com/wasmCloud/wasmCloud/issues/1045

I just took the first section from our top level README and added a callout that this crate is for the host runtime. Feedback welcome, but I mostly just wanted _something_ in place