### PR TITLE
Feat/update event subjects

### DIFF
--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -10,6 +10,7 @@ mod broker;
 mod otel;
 mod types;
 
+use async_nats::Subscriber;
 pub use types::*;
 
 use core::fmt::{self, Debug};
@@ -18,7 +19,7 @@ use core::time::Duration;
 use std::collections::HashMap;
 
 use cloudevents::event::Event;
-use futures::StreamExt;
+use futures::{StreamExt, TryFutureExt};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::Receiver;
@@ -677,7 +678,7 @@ impl Client {
         Ok(collect_sub_timeout::<D>(sub, self.auction_timeout, subject.as_str()).await)
     }
 
-    /// Returns the receiver end of a channel that subscribes to the lattice control event stream.
+    /// Returns the receiver end of a channel that subscribes to the lattice event stream.
     /// Any [`Event`](struct@Event)s that are published after this channel is created
     /// will be added to the receiver channel's buffer, which can be observed or handled if needed.
     /// See the example for how you could use this receiver to handle events.
@@ -690,59 +691,34 @@ impl Client {
     ///   let client = ClientBuilder::new(nc)
     ///                 .rpc_timeout(std::time::Duration::from_millis(1000))
     ///                 .auction_timeout(std::time::Duration::from_millis(1000))
-    ///                 .build();
-    ///   let mut receiver = client.events_receiver().await.unwrap();
-    ///   tokio::spawn( async move {
-    ///       while let Some(evt) = receiver.recv().await {
-    ///           println!("Event received: {:?}", evt);
-    ///       }
-    ///   });
-    ///   // perform other operations on client
-    ///   client.get_host_inventory("NAEXHW...").await.unwrap();
-    /// };
-    /// ```
-    ///
-    /// Once you're finished with the event receiver, be sure to call `drop` with the receiver
-    /// as an argument. This closes the channel and will prevent the sender from endlessly
-    /// sending messages into the channel buffer.
-    ///
-    /// # Example
-    /// ```rust
-    /// use wasmcloud_control_interface::{Client, ClientBuilder};
-    /// async {
-    ///   let nc = async_nats::connect("0.0.0.0:4222").await.unwrap();
-    ///   let client = ClientBuilder::new(nc)
-    ///                 .rpc_timeout(std::time::Duration::from_millis(1000))
-    ///                 .auction_timeout(std::time::Duration::from_millis(1000))
     ///                 .build();    
-    ///   let mut receiver = client.events_receiver().await.unwrap();
-    ///   // read the docs for flume receiver. You can use it in either sync or async code
-    ///   // The receiver can be cloned() as needed.
-    ///   // If you drop the receiver. The subscriber will exit
-    ///   // If the nats connection ic closed, the loop below will exit.
+    ///   let mut receiver = client.events_receiver("actor_scaled").await.unwrap();
     ///   while let Some(evt) = receiver.recv().await {
     ///       println!("Event received: {:?}", evt);
     ///   }
     /// };
     /// ```
     #[allow(clippy::missing_errors_doc)] // TODO: Document errors
-    pub async fn events_receiver(&self) -> Result<Receiver<Event>> {
-        use futures::StreamExt as _;
+    pub async fn events_receiver(&self, event_types: Vec<String>) -> Result<Receiver<Event>> {
         let (sender, receiver) = tokio::sync::mpsc::channel(5000);
-        let mut sub = self
-            .nc
-            .subscribe(format!("wasmbus.evt.{}", self.lattice))
-            .await?;
+        let futs = event_types.into_iter().map(|event_type| {
+            self.nc
+                .subscribe(format!("wasmbus.evt.{}.{}", self.lattice, event_type))
+                .map_err(anyhow::Error::from)
+        });
+        let subs: Vec<Subscriber> = futures::future::join_all(futs)
+            .await
+            .into_iter()
+            .collect::<std::result::Result<_, anyhow::Error>>()?;
+        let mut stream = futures::stream::select_all(subs);
         tokio::spawn(async move {
-            while let Some(msg) = sub.next().await {
+            while let Some(msg) = stream.next().await {
                 let Ok(evt) = json_deserialize::<Event>(&msg.payload) else {
                     error!("Object received on event stream was not a CloudEvent");
                     continue;
                 };
                 trace!("received event: {:?}", evt);
                 let Ok(()) = sender.send(evt).await else {
-                    // If the channel is disconnected, stop sending events
-                    let _ = sub.unsubscribe().await;
                     break;
                 };
             }
@@ -850,7 +826,10 @@ mod tests {
             .timeout(Duration::from_millis(1000))
             .auction_timeout(Duration::from_millis(1000))
             .build();
-        let mut receiver = client.events_receiver().await.unwrap();
+        let mut receiver = client
+            .events_receiver(vec!["foobar".to_string()])
+            .await
+            .unwrap();
         tokio::spawn(async move {
             while let Some(evt) = receiver.recv().await {
                 println!("Event received: {evt:?}");

--- a/crates/wash-lib/src/actor.rs
+++ b/crates/wash-lib/src/actor.rs
@@ -45,7 +45,10 @@ pub async fn start_actor(
 
     // Create a receiver to use with the client
     let mut receiver = ctl_client
-        .events_receiver()
+        .events_receiver(vec![
+            "actor_scaled".to_string(),
+            "actor_scale_failed".to_string(),
+        ])
         .await
         .map_err(boxed_err_to_anyhow)
         .context("Failed to get lattice event channel")?;
@@ -126,7 +129,10 @@ pub async fn stop_actor(
     skip_wait: bool,
 ) -> Result<ActorStoppedInfo> {
     let mut receiver = client
-        .events_receiver()
+        .events_receiver(vec![
+            "actor_scaled".to_string(),
+            "actor_scale_failed".to_string(),
+        ])
         .await
         .map_err(boxed_err_to_anyhow)?;
 

--- a/crates/wash-lib/src/cli/start.rs
+++ b/crates/wash-lib/src/cli/start.rs
@@ -249,7 +249,10 @@ pub async fn handle_start_provider(cmd: StartProviderCommand) -> Result<CommandO
     };
 
     let mut receiver = client
-        .events_receiver()
+        .events_receiver(vec![
+            "provider_started".to_string(),
+            "provider_start_failed".to_string(),
+        ])
         .await
         .map_err(boxed_err_to_anyhow)
         .context("Failed to get lattice event channel")?;

--- a/crates/wash-lib/src/cli/stop.rs
+++ b/crates/wash-lib/src/cli/stop.rs
@@ -119,7 +119,10 @@ pub async fn stop_provider(cmd: StopProviderCommand) -> Result<CommandOutput> {
     let client = wco.into_ctl_client(None).await?;
 
     let mut receiver = client
-        .events_receiver()
+        .events_receiver(vec![
+            "provider_stopped".to_string(),
+            "provider_stop_failed".to_string(),
+        ])
         .await
         .map_err(boxed_err_to_anyhow)?;
 

--- a/crates/wash-lib/src/wait.rs
+++ b/crates/wash-lib/src/wait.rs
@@ -124,7 +124,7 @@ pub async fn wait_for_actor_start_event(
         }
 
         match cloud_event.event_type.as_str() {
-            "com.wasmcloud.lattice.actor_started" => {
+            "com.wasmcloud.lattice.actor_scaled" => {
                 let image_ref = get_string_data_from_json(&cloud_event.data, "image_ref")?;
 
                 if image_ref == actor_ref {
@@ -136,7 +136,7 @@ pub async fn wait_for_actor_start_event(
                     }));
                 }
             }
-            "com.wasmcloud.lattice.actor_start_failed" => {
+            "com.wasmcloud.lattice.actor_scale_failed" => {
                 let returned_actor_ref = get_string_data_from_json(&cloud_event.data, "actor_ref")?;
 
                 if returned_actor_ref == actor_ref {
@@ -335,7 +335,7 @@ pub async fn wait_for_actor_stop_event(
         }
 
         match cloud_event.event_type.as_str() {
-            "com.wasmcloud.lattice.actor_stopped" => {
+            "com.wasmcloud.lattice.actor_scaled" => {
                 let returned_actor_id = get_string_data_from_json(&cloud_event.data, "public_key")?;
                 if returned_actor_id == actor_id {
                     return Ok(EventCheckOutcome::Success(ActorStoppedInfo {
@@ -344,7 +344,7 @@ pub async fn wait_for_actor_stop_event(
                     }));
                 }
             }
-            "com.wasmcloud.lattice.actor_stop_failed" => {
+            "com.wasmcloud.lattice.actor_scale_failed" => {
                 let returned_actor_id = get_string_data_from_json(&cloud_event.data, "public_key")?;
 
                 if returned_actor_id == actor_id {


### PR DESCRIPTION
## Feature or Problem
This updates the control interface and wash-lib to use the suffixed event subject. Since I modified a public function in the control interface, this is technically a breaking change. However, wash-lib is the only known client using this function

This also fixes an issue where wash would report `Timed out waiting for applicable event, operation may have failed`. The latest host emits the scale events, but wash was still looking for the start/stop events

## Related Issues
https://github.com/wasmCloud/wasmCloud/issues/1091

## Release Information
Next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Manually verified that `wash start actor` and `wash stop actor` received the correct events
