### PR TITLE
ci: add conditions to rust build code

### DIFF
--- a/.github/workflows/_check-for-changes.yml
+++ b/.github/workflows/_check-for-changes.yml
@@ -1,0 +1,88 @@
+name: 🔄 Check for File Changes
+
+on:
+  workflow_call:
+    outputs:
+      adr:
+        description: 'Changes have occurred in the ADR related directories'
+        value: ${{ jobs.check_for_changes.outputs.adr }}
+      any:
+        description: 'Changes have occurred in any directory'
+        value: ${{ jobs.check_for_changes.outputs.any }}
+      ci:
+        description: 'Changes have occurred in any of the ci related directories'
+        value: ${{ jobs.check_for_changes.outputs.ci }}
+      devcontainer:
+        description: 'Changes have occurred in the devcontainer directory'
+        value: ${{ jobs.check_for_changes.outputs.devcontainer }}
+      docs:
+        description: 'Changes have occurred in the docs directory'
+        value: ${{ jobs.check_for_changes.outputs.docs }}
+      examples:
+        description: 'Changes have occurred in the examples directory'
+        value: ${{ jobs.check_for_changes.outputs.examples }}
+      github:
+        description: 'Changes have occurred in the github related directories'
+        value: ${{ jobs.check_for_changes.outputs.github }}
+      javascript:
+        description: 'Changes have occurred in the javascript/typescript related directories. Includes CI changes.'
+        value: ${{ jobs.check_for_changes.outputs.javascript || jobs.check_for_changes.outputs.ci }}
+      nix:
+        description: 'Changes have occurred in the nix related directories'
+        value: ${{ jobs.check_for_changes.outputs.nix }}
+      rust:
+        description: 'Changes have occurred in the rust/cargo related directories. Includes CI changes.'
+        value: ${{ jobs.check_for_changes.outputs.rust || jobs.check_for_changes.outputs.ci }}
+
+jobs:
+  check_for_changes:
+    runs-on: ubuntu-latest
+
+    outputs:
+      adr: ${{ steps.check.outputs.adr_any_changed }}
+      any: ${{ steps.check.outputs.any_any_changed }}
+      ci: ${{ steps.check.outputs.nix_any_changed || steps.check.outputs.github_any_changed }}
+      devcontainer: ${{ steps.check.outputs.devcontainer_any_changed }}
+      docs: ${{ steps.check.outputs.docs_any_changed }}
+      examples: ${{ steps.check.outputs.examples_any_changed }}
+      github: ${{ steps.check.outputs.github_any_changed }}
+      javascript: ${{ steps.check.outputs.javascript_any_changed }}
+      nix: ${{ steps.check.outputs.nix_any_changed }}
+      rust: ${{ steps.check.outputs.rust_any_changed }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes
+        id: check
+        uses: tj-actions/changed-files@v42
+        with:
+          files_yaml: |
+            adr:
+              - 'adr/**'
+            any:
+              - '**'
+            devcontainer:
+              - '.devcontainer/**'
+            docs:
+              - '**/*.md'
+            examples:
+              - 'examples/**'
+            github:
+              - '.github/**'
+            javascript:
+              - 'washboard-ui/**'
+            nix:
+              - 'flake.lock'
+              - 'flake.nix'
+              - 'garnix.nix'
+            rust:
+              - 'Cargo.*'
+              - 'rust*.toml'
+              - 'src/**'
+              - 'tests/**'
+              - 'crates/**'
+              - '!**/*.md'

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -2,9 +2,8 @@ name: wasmCloud
 
 on:
   pull_request:
-    paths-ignore:
-      - washboard-ui/**
   merge_group:
+  workflow_dispatch:
   push:
     branches:
     - main
@@ -41,13 +40,15 @@ on:
     - 'wash-cli-v[0-9].[0-9]+.[0-9]+-*'
     - 'wash-lib-v[0-9].[0-9]+.[0-9]+'
     - 'wash-lib-v[0-9].[0-9]+.[0-9]+-*'
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check_for_changes:
+    uses: ./.github/workflows/_check-for-changes.yml
+    
   build-bin:
     strategy:
       matrix:
@@ -102,25 +103,33 @@ jobs:
             docker run --rm wasmcloud:$(nix eval --raw .#wasmcloud-x86_64-unknown-linux-musl-oci.imageTag) wasmcloud --version
 
     name: wasmcloud-${{ matrix.config.target }}
+    needs: check_for_changes
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4.1.1
     - uses: ./.github/actions/install-nix
+      # need to run condition inside job steps so that job will pass if all steps are skipped
+      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore
+      if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
       with:
         cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - uses: ./.github/actions/build-nix
+      if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
       with:
         package: wasmcloud-${{ matrix.config.target }}
     - run: ${{ matrix.config.test-bin }}
+      if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
     - uses: ./.github/actions/build-nix
+      if: ${{ !endsWith(matrix.config.target, 'fhs') && needs.check_for_changes.outputs.rust == 'true' }}
       with:
         package: wasmcloud-${{ matrix.config.target }}-oci
-      if: ${{ !endsWith(matrix.config.target, 'fhs') }}
     - run: ${{ matrix.config.test-oci }}
-      if: ${{ !endsWith(matrix.config.target, 'fhs') }}
+      if: ${{ !endsWith(matrix.config.target, 'fhs') && needs.check_for_changes.outputs.rust == 'true' }}
 
   build-windows:
     name: wasmcloud-x86_64-pc-windows-msvc
+    needs: check_for_changes
+    if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
     runs-on: windows-latest-8-cores
     steps:
     - uses: actions/checkout@v4.1.1
@@ -135,7 +144,10 @@ jobs:
 
   build-lipo:
     name: wasmcloud-universal-darwin
-    needs: build-bin
+    needs:
+      - build-bin
+      - check_for_changes
+    if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
     runs-on: macos-12
     steps:
     - uses: actions/download-artifact@v4
@@ -167,7 +179,10 @@ jobs:
 
   test-linux:
     runs-on: ubuntu-22.04
-    needs: build-bin
+    needs:
+      - build-bin
+      - check_for_changes
+    if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
     steps:
     - uses: actions/download-artifact@v4
       with:
@@ -179,7 +194,10 @@ jobs:
 
   test-windows:
     runs-on: windows-2022
-    needs: build-windows
+    needs:
+      - build-windows
+      - check_for_changes
+    if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
     steps:
     - uses: actions/download-artifact@v4
       with:
@@ -191,22 +209,29 @@ jobs:
     strategy:
       matrix:
         check:
-        - audit
-        - fmt
-        - clippy
-        - nextest
+          - audit
+          - fmt
+          - clippy
+          - nextest
 
     name: cargo ${{ matrix.check }}
     runs-on: ubuntu-22.04
+    needs: check_for_changes
     steps:
     - uses: actions/checkout@v4.1.1
     - uses: ./.github/actions/install-nix
+      # need to run condition inside job steps so that job will pass if all steps are skipped
+      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore
+      if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
       with:
         cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix build -L .#checks.x86_64-linux.${{ matrix.check }}
+      if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
 
   build-doc:
     runs-on: ubuntu-22.04
+    needs: check_for_changes
+    if: ${{ needs.check_for_changes.outputs.docs == 'true' }}
     steps:
     - uses: actions/checkout@v4.1.1
     - uses: ./.github/actions/install-nix
@@ -245,6 +270,7 @@ jobs:
       id: deployment
 
   oci:
+    if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
     strategy:
       matrix:
         include:
@@ -259,6 +285,7 @@ jobs:
     needs:
     - build-bin
     - test-linux
+    - check_for_changes
     steps:
     - uses: actions/checkout@v4.1.1
     - uses: ./.github/actions/install-nix
@@ -537,7 +564,10 @@ jobs:
           workspace-dependencies: true
 
     name: publish ${{ matrix.crate }} to crates.io
-    needs: cargo
+    needs: 
+      - cargo
+      - check_for_changes
+    if: ${{ needs.check_for_changes.outputs.rust == 'true' }}
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4.1.1


### PR DESCRIPTION
## Feature or Problem
After adding a path filter to the `wasmcloud` job, I noticed that PRs with only changes in the `washboard-ui` directory were stuck in a pending state because of [this issue](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore):
> If a workflow is skipped due to branch filtering, [path filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), or a [commit message](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs), then checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging.

## Solution
This PR adds a new `_file-changes.yml` workflow which categorizes changed files into groups, and then surfaces those groups as flags if the contents in those files changed.

Note that this is a temporary solution until a repo re-structure takes place and we can consolidate some of the pipeline steps and change the checks that are required for PRs to merge.
