### PR TITLE
fix(wash-lib): listen to deprecated start/stop events

### DIFF
--- a/crates/wash-lib/src/actor.rs
+++ b/crates/wash-lib/src/actor.rs
@@ -46,6 +46,8 @@ pub async fn start_actor(
     // Create a receiver to use with the client
     let mut receiver = ctl_client
         .events_receiver(vec![
+            "actor_started".to_string(),
+            "actor_start_failed".to_string(),
             "actor_scaled".to_string(),
             "actor_scale_failed".to_string(),
         ])
@@ -130,6 +132,8 @@ pub async fn stop_actor(
 ) -> Result<ActorStoppedInfo> {
     let mut receiver = client
         .events_receiver(vec![
+            "actor_stopped".to_string(),
+            "actor_stop_failed".to_string(),
             "actor_scaled".to_string(),
             "actor_scale_failed".to_string(),
         ])

--- a/crates/wash-lib/src/wait.rs
+++ b/crates/wash-lib/src/wait.rs
@@ -124,7 +124,7 @@ pub async fn wait_for_actor_start_event(
         }
 
         match cloud_event.event_type.as_str() {
-            "com.wasmcloud.lattice.actor_scaled" => {
+            "com.wasmcloud.lattice.actor_started" | "com.wasmcloud.lattice.actor_scaled" => {
                 let image_ref = get_string_data_from_json(&cloud_event.data, "image_ref")?;
 
                 if image_ref == actor_ref {
@@ -136,7 +136,8 @@ pub async fn wait_for_actor_start_event(
                     }));
                 }
             }
-            "com.wasmcloud.lattice.actor_scale_failed" => {
+            "com.wasmcloud.lattice.actor_start_failed"
+            | "com.wasmcloud.lattice.actor_scale_failed" => {
                 let returned_actor_ref = get_string_data_from_json(&cloud_event.data, "actor_ref")?;
 
                 if returned_actor_ref == actor_ref {
@@ -335,7 +336,7 @@ pub async fn wait_for_actor_stop_event(
         }
 
         match cloud_event.event_type.as_str() {
-            "com.wasmcloud.lattice.actor_scaled" => {
+            "com.wasmcloud.lattice.actor_stopped" | "com.wasmcloud.lattice.actor_scaled" => {
                 let returned_actor_id = get_string_data_from_json(&cloud_event.data, "public_key")?;
                 if returned_actor_id == actor_id {
                     return Ok(EventCheckOutcome::Success(ActorStoppedInfo {
@@ -344,7 +345,8 @@ pub async fn wait_for_actor_stop_event(
                     }));
                 }
             }
-            "com.wasmcloud.lattice.actor_scale_failed" => {
+            "com.wasmcloud.lattice.actor_stop_failed"
+            | "com.wasmcloud.lattice.actor_scale_failed" => {
                 let returned_actor_id = get_string_data_from_json(&cloud_event.data, "public_key")?;
 
                 if returned_actor_id == actor_id {


### PR DESCRIPTION
https://github.com/wasmCloud/wasmCloud/pull/1381 updated wash-lib to listen to the scale events, but it appears these aren't in v0.81 of the host. This updates wash-lib to listen to the deprecated events and the new scale events