### PR TITLE
fix(providers): Fixes broken tests in providers

### DIFF
--- a/crates/providers/blobstore-s3/tests/storage.rs
+++ b/crates/providers/blobstore-s3/tests/storage.rs
@@ -5,7 +5,7 @@ use wasmcloud_provider_blobstore_s3::{
     Chunk, ContainerObjectSelector, GetObjectRequest, ListObjectsRequest, PutObjectRequest,
     RemoveObjectsRequest, StorageClient, StorageConfig,
 };
-use wasmcloud_provider_sdk::Context;
+use wasmcloud_provider_wit_bindgen::deps::wasmcloud_provider_sdk::Context;
 
 /// Helper function to create a StorageClient with local testing overrides
 async fn test_client() -> StorageClient {

--- a/crates/providers/http-server/src/settings.rs
+++ b/crates/providers/http-server/src/settings.rs
@@ -630,9 +630,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::settings::{CorsOrigin, ServiceSettings};
-    //use assert_matches::assert_matches;
     use std::str::FromStr;
+
+    use wasmcloud_provider_wit_bindgen::deps::serde_json;
+
+    use crate::settings::{CorsOrigin, ServiceSettings};
 
     const GOOD_ORIGINS: &[&str] = &[
         // origins that should be parsed correctly

--- a/crates/providers/kv-redis/src/bin/kvredis.rs
+++ b/crates/providers/kv-redis/src/bin/kvredis.rs
@@ -386,6 +386,8 @@ fn get_redis_url(link_values: &[(String, String)], default_connect_url: &str) ->
 
 #[cfg(test)]
 mod test {
+    use wasmcloud_provider_wit_bindgen::deps::serde_json;
+
     use super::{get_redis_url, KvRedisConfig};
 
     const PROPER_URL: &str = "redis://127.0.0.1:6379";

--- a/crates/providers/messaging-kafka/src/lib.rs
+++ b/crates/providers/messaging-kafka/src/lib.rs
@@ -202,9 +202,9 @@ impl WasmcloudMessagingMessaging for KafkaMessagingProvider {
             let config = connections
                 .get(&ctx.actor.clone().unwrap())
                 .ok_or_else(|| {
-                    ProviderInvocationError::Provider(format!(
-                        "failed to find actor for connection"
-                    ))
+                    ProviderInvocationError::Provider(
+                        "failed to find actor for connection".to_string(),
+                    )
                 })?;
 
             config.connection_hosts.clone()

--- a/crates/providers/messaging-nats/src/lib.rs
+++ b/crates/providers/messaging-nats/src/lib.rs
@@ -383,8 +383,9 @@ fn should_strip_headers(topic: &str) -> bool {
 #[cfg(test)]
 mod test {
     use crate::{ConnectionConfig, NatsMessagingProvider};
-    use wasmcloud_provider_sdk::core::LinkDefinition;
-    use wasmcloud_provider_sdk::ProviderHandler;
+    use wasmcloud_provider_wit_bindgen::deps::serde_json;
+    use wasmcloud_provider_wit_bindgen::deps::wasmcloud_provider_sdk::core::LinkDefinition;
+    use wasmcloud_provider_wit_bindgen::deps::wasmcloud_provider_sdk::ProviderHandler;
 
     #[test]
     fn test_default_connection_serialize() {


### PR DESCRIPTION
After the change to bring in the deps via provider bindgen, some of the tests were not using those same deps.
