### PR TITLE
chore: Update the default OTLP HTTP port to match the current spec

### DIFF
--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -53,7 +53,7 @@ impl<'a> Drop for LockedWriter<'a> {
 static STDERR: OnceCell<std::io::Stderr> = OnceCell::new();
 
 #[cfg(feature = "otel")]
-const DEFAULT_TRACING_ENDPOINT: &str = "http://localhost:55681/v1/traces";
+const DEFAULT_TRACING_ENDPOINT: &str = "http://localhost:4318/v1/traces";
 
 /// A struct that allows us to dynamically choose JSON formatting without using dynamic dispatch.
 /// This is just so we avoid any sort of possible slow down in logging code

--- a/examples/docker/docker-compose-auxiliary.yml
+++ b/examples/docker/docker-compose-auxiliary.yml
@@ -27,5 +27,5 @@ services:
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
+      - 4318:4318 # otlp http
       - 7999:7999 # tempo
-      - 55681:55681 # otlp http  

--- a/examples/docker/docker-compose-full.yml
+++ b/examples/docker/docker-compose-full.yml
@@ -36,8 +36,8 @@ services:
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
+      - 4318:4318 # otlp http
       - 7999:7999 # tempo
-      - 55681:55681 # otlp http
 
   wasmcloud:
     depends_on:
@@ -53,7 +53,7 @@ services:
       WASMCLOUD_ALLOW_FILE_LOAD: "true"
       WASMCLOUD_OCI_ALLOWED_INSECURE: registry:5000
       OTEL_TRACES_EXPORTER: otlp
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:55681/v1/traces
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318/v1/traces
     ports:
       - "8000-8100:8000-8100" # Expose ports 8000-8100 for examples that use an HTTP server
 

--- a/examples/docker/docker-compose-websockets.yml
+++ b/examples/docker/docker-compose-websockets.yml
@@ -40,8 +40,8 @@ services:
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
+      - 4318:4318 # otlp http
       - 7999:7999 # tempo
-      - 55681:55681 # otlp http
 
   wasmcloud:
     depends_on:
@@ -57,7 +57,7 @@ services:
       WASMCLOUD_ALLOW_FILE_LOAD: "true"
       WASMCLOUD_OCI_ALLOWED_INSECURE: registry:5000
       OTEL_TRACES_EXPORTER: otlp
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:55681/v1/traces
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318/v1/traces
     ports:
       - "8000-8010:8000-8010" # Expose ports 8000-8010 for examples that use an HTTP server
 

--- a/examples/docker/tempo.yaml
+++ b/examples/docker/tempo.yaml
@@ -8,7 +8,7 @@ distributor:
     otlp:
       protocols:
         http:
-          endpoint: "0.0.0.0:55681"
+          endpoint: "0.0.0.0:4318"
 
 storage:
   trace:


### PR DESCRIPTION
## Feature or Problem

OTEL changed it's default port from 55680/55681 to 4317/4318 for [gRPC](https://opentelemetry.io/docs/specs/otlp/#otlpgrpc-default-port) and [HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp-default-port) respectively [a while back in the spec](https://github.com/open-telemetry/opentelemetry-specification/pull/1839) and [in the collector](https://github.com/open-telemetry/opentelemetry-collector/pull/3743), let's switch over to using the current ports defined in the spec.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
