### PR TITLE
Feat/dynamic log level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5355,6 +5355,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
+ "wasmcloud-core",
 ]
 
 [[package]]
@@ -5405,6 +5406,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-subscriber",
  "ulid",
  "url",
  "uuid 1.7.0",

--- a/crates/control-interface/Cargo.toml
+++ b/crates/control-interface/Cargo.toml
@@ -14,15 +14,16 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 async-nats = { workspace = true }
 bytes = { workspace = true }
 cloudevents-sdk = { workspace = true }
 futures = { workspace = true }
+oci-distribution = { workspace = true, features = ["rustls-tls"] }
 opentelemetry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
-oci-distribution = { workspace = true, features = ["rustls-tls"] }
-anyhow = { workspace = true }
+wasmcloud-core = { workspace = true }

--- a/crates/control-interface/src/broker.rs
+++ b/crates/control-interface/src/broker.rs
@@ -92,6 +92,10 @@ pub mod commands {
     pub fn stop_host(topic_prefix: &Option<String>, lattice: &str, host: &str) -> String {
         format!("{}.cmd.{}.stop", prefix(topic_prefix, lattice), host)
     }
+
+    pub fn set_logging_config(topic_prefix: &Option<String>, lattice: &str, host: &str) -> String {
+        format!("{}.logs.set.{}", prefix(topic_prefix, lattice), host)
+    }
 }
 
 pub mod queries {
@@ -127,5 +131,9 @@ pub mod queries {
 
     pub fn all_config(topic_prefix: &Option<String>, lattice: &str, entity_id: &str) -> String {
         format!("{}.get.config.{entity_id}", prefix(topic_prefix, lattice),)
+    }
+
+    pub fn logging_config(topic_prefix: &Option<String>, lattice: &str, host: &str) -> String {
+        format!("{}.logs.get.{}", prefix(topic_prefix, lattice), host)
     }
 }

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -92,6 +92,11 @@ pub struct GetConfigKeyResponse {
     pub data: Vec<u8>,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct GetLoggingConfigResponse {
+    pub level: wasmcloud_core::logging::Level,
+}
+
 /// A summary representation of a host
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Host {
@@ -309,6 +314,11 @@ pub struct RemoveLinkDefinitionRequest {
     /// The provider's link name
     #[serde(default)]
     pub link_name: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SetLoggingConfigCommand {
+    pub level: wasmcloud_core::logging::Level,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/core/src/logging.rs
+++ b/crates/core/src/logging.rs
@@ -1,16 +1,18 @@
-// This would be the generated types from wasi logging when we generate it
+use std::fmt;
 
+use anyhow::bail;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Level {
+    Critical,
     Error,
     Warn,
+    #[default]
     Info,
     Debug,
     Trace,
-    Critical,
 }
 
 impl From<tracing::Level> for Level {
@@ -21,6 +23,37 @@ impl From<tracing::Level> for Level {
             tracing::Level::INFO => Self::Info,
             tracing::Level::DEBUG => Self::Debug,
             tracing::Level::TRACE => Self::Trace,
+        }
+    }
+}
+
+impl TryFrom<String> for Level {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self, anyhow::Error> {
+        match value.to_lowercase().as_str() {
+            "critical" => Ok(Self::Critical),
+            "error" => Ok(Self::Error),
+            "warn" => Ok(Self::Warn),
+            "info" => Ok(Self::Info),
+            "debug" => Ok(Self::Debug),
+            "trace" => Ok(Self::Trace),
+            _ => bail!(
+                "invalid log level. Must be one of: critical, error, warn, info, debug, trace"
+            ),
+        }
+    }
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::Critical => write!(f, "critical"),
+            Self::Error => write!(f, "error"),
+            Self::Warn => write!(f, "warn"),
+            Self::Info => write!(f, "info"),
+            Self::Debug => write!(f, "debug"),
+            Self::Trace => write!(f, "trace"),
         }
     }
 }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -38,6 +38,7 @@ time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true, features = ["fs", "io-std", "io-util", "process", "rt-multi-thread", "time"] }
 tokio-stream = { workspace = true, features = ["net", "time"] }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 ulid = { workspace = true, features = ["std"] }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["serde"] }

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -50,10 +50,8 @@ pub struct Host {
     pub oci_opts: OciConfig,
     /// Whether to allow loading actor or provider components from the filesystem
     pub allow_file_load: bool,
-    /// Whether or not structured logging is enabled
-    pub enable_structured_logging: bool,
-    /// Log level to pass to capability providers to use. Should be parsed from a [`tracing::Level`]
-    pub log_level: LogLevel,
+    /// Configuration for logging
+    pub logging_config: Logging,
     /// Whether to enable loading supplemental configuration
     pub config_service_enabled: bool,
     /// configuration for OpenTelemetry tracing
@@ -71,6 +69,22 @@ pub struct PolicyService {
     pub policy_changes_topic: Option<String>,
     /// The timeout for policy requests
     pub policy_timeout_ms: Option<Duration>,
+}
+
+/// Configuration for logging
+#[derive(Clone, Debug, Default)]
+pub struct Logging {
+    /// Whether or not structured logging is enabled
+    pub enable_structured_logging: bool,
+    /// Log level for the host and capability providers to use. Should be parsed from a [`tracing::Level`]
+    pub log_level: LogLevel,
+    /// A handle to dynamically reload the level filter
+    pub level_reload_handle: Option<
+        tracing_subscriber::reload::Handle<
+            tracing_subscriber::EnvFilter,
+            tracing_subscriber::Registry,
+        >,
+    >,
 }
 
 impl Default for Host {
@@ -97,8 +111,7 @@ impl Default for Host {
             provider_shutdown_delay: None,
             oci_opts: OciConfig::default(),
             allow_file_load: false,
-            enable_structured_logging: false,
-            log_level: LogLevel::Info,
+            logging_config: Logging::default(),
             config_service_enabled: false,
             otel_config: OtelConfig::default(),
             policy_service_config: PolicyService::default(),

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -3182,9 +3182,9 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111495d6204760238512f57a9af162f45086504da332af210f2f75dd80b34f1d"
+checksum = "d162eb64168969ae90e8668ca0593b0e47667e315aa08e717a9c9574d700d826"
 dependencies = [
  "leb128",
 ]
@@ -3228,6 +3228,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
+ "wasmcloud-core",
 ]
 
 [[package]]

--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -26,6 +26,7 @@ use wash_lib::cli::get::GetCommand;
 use wash_lib::cli::inspect::InspectCliCommand;
 use wash_lib::cli::label::LabelHostCommand;
 use wash_lib::cli::link::LinkCommand;
+use wash_lib::cli::logs::LogsCommand;
 use wash_lib::cli::registry::{RegistryCommand, RegistryPullCommand, RegistryPushCommand};
 use wash_lib::cli::scale::ScaleCommand;
 use wash_lib::cli::spy::SpyCommand;
@@ -73,6 +74,7 @@ Iterate:
   call         Invoke a wasmCloud actor
   ctl          Interact with a wasmCloud control interface (deprecated, use above commands)
   label        Label (or un-label) a host with a key=value label pair
+  logs         Set or get the log level for a host
 
 Publish:
   pull         Pull an artifact from an OCI compliant registry
@@ -173,12 +175,18 @@ enum CliCommand {
     /// Utilities for generating and managing keys
     #[clap(name = "keys", alias = "key", subcommand)]
     Keys(KeysCliCommand),
+    /// Label (or un-label) a host
+    #[clap(name = "label", alias = "tag")]
+    Label(LabelHostCommand),
     /// Perform lint checks on smithy models
     #[clap(name = "lint")]
     Lint(LintCli),
     /// Link an actor and a provider
     #[clap(name = "link", alias = "links", subcommand)]
     Link(LinkCommand),
+    /// Set or get the log level for a host
+    #[clap(name = "logs", subcommand)]
+    Logs(LogsCommand),
     /// Create a new project from template
     #[clap(name = "new", subcommand)]
     New(NewCliCommand),
@@ -206,9 +214,6 @@ enum CliCommand {
     /// Stop an actor, provider, or host
     #[clap(name = "stop", subcommand)]
     Stop(StopCommand),
-    /// Label (or un-label) a host
-    #[clap(name = "label", alias = "tag")]
-    Label(LabelHostCommand),
     /// Update an actor running in a host to a newer version
     #[clap(name = "update", subcommand)]
     Update(UpdateCommand),
@@ -273,8 +278,12 @@ async fn main() {
             wash_lib::cli::inspect::handle_command(inspect_cli, output_kind).await
         }
         CliCommand::Keys(keys_cli) => keys::handle_command(keys_cli),
+        CliCommand::Label(label_cli) => {
+            common::label_cmd::handle_command(label_cli, output_kind).await
+        }
         CliCommand::Lint(lint_cli) => smithy::handle_lint_command(lint_cli).await,
         CliCommand::Link(link_cli) => common::link_cmd::handle_command(link_cli, output_kind).await,
+        CliCommand::Logs(logs_cli) => common::logs_cmd::handle_command(logs_cli, output_kind).await,
         CliCommand::New(new_cli) => generate::handle_command(new_cli).await,
         CliCommand::Par(par_cli) => par::handle_command(par_cli, output_kind).await,
         CliCommand::Reg(reg_cli) => {
@@ -300,9 +309,6 @@ async fn main() {
             common::start_cmd::handle_command(start_cli, output_kind).await
         }
         CliCommand::Stop(stop_cli) => common::stop_cmd::handle_command(stop_cli, output_kind).await,
-        CliCommand::Label(label_cli) => {
-            common::label_cmd::handle_command(label_cli, output_kind).await
-        }
         CliCommand::Update(update_cli) => {
             common::update_cmd::handle_command(update_cli, output_kind).await
         }

--- a/crates/wash-cli/src/common/logs_cmd.rs
+++ b/crates/wash-cli/src/common/logs_cmd.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+
+use wash_lib::cli::{
+    logs::{handle_get_logging_config, handle_set_logging_config, LogsCommand},
+    CommandOutput, OutputKind,
+};
+
+use crate::appearance::spinner::Spinner;
+
+pub async fn handle_command(
+    command: LogsCommand,
+    output_kind: OutputKind,
+) -> Result<CommandOutput> {
+    let sp: Spinner = Spinner::new(&output_kind)?;
+    let out: CommandOutput = match command {
+        LogsCommand::Get(cmd) => handle_get_logging_config(cmd).await?,
+        LogsCommand::Set(cmd) => handle_set_logging_config(cmd).await?,
+    };
+
+    sp.finish_and_clear();
+
+    Ok(out)
+}

--- a/crates/wash-cli/src/common/mod.rs
+++ b/crates/wash-cli/src/common/mod.rs
@@ -1,6 +1,7 @@
 pub mod get_cmd;
 pub mod label_cmd;
 pub mod link_cmd;
+pub mod logs_cmd;
 pub mod registry_cmd;
 pub mod scale_cmd;
 pub mod start_cmd;

--- a/crates/wash-lib/src/cli/logs.rs
+++ b/crates/wash-lib/src/cli/logs.rs
@@ -1,0 +1,103 @@
+use anyhow::{bail, Result};
+use clap::Parser;
+
+use crate::{
+    cli::{CliConnectionOpts, CommandOutput},
+    common::{boxed_err_to_anyhow, find_host_id},
+    config::WashConnectionOptions,
+};
+
+#[derive(Clone, Debug, Parser)]
+pub struct GetLoggingConfigCommand {
+    #[clap(flatten)]
+    pub opts: CliConnectionOpts,
+
+    /// ID of host to update the actor on. If a non-ID is provided, the host will be selected based
+    /// on matching the prefix of the ID or the friendly name and will return an error if more than
+    /// one host matches.
+    #[clap(name = "host-id")]
+    pub host_id: String,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub struct SetLoggingConfigCommand {
+    #[clap(flatten)]
+    pub opts: CliConnectionOpts,
+
+    /// ID of host to update the actor on. If a non-ID is provided, the host will be selected based
+    /// on matching the prefix of the ID or the friendly name and will return an error if more than
+    /// one host matches.
+    #[clap(name = "host-id")]
+    pub host_id: String,
+
+    /// Logging level to set
+    #[clap(short = 'l', long = "level")]
+    pub level: String,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub enum LogsCommand {
+    /// Get the logging config for a host
+    #[clap(name = "get")]
+    Get(GetLoggingConfigCommand),
+
+    /// Set the logging config for a host
+    #[clap(name = "set")]
+    Set(SetLoggingConfigCommand),
+}
+
+pub async fn handle_get_logging_config(cmd: GetLoggingConfigCommand) -> Result<CommandOutput> {
+    let wco: WashConnectionOptions = cmd.opts.try_into()?;
+    let client = wco.into_ctl_client(None).await?;
+
+    let (host_id, friendly_name) = find_host_id(&cmd.host_id, &client).await?;
+
+    let friendly_name = if friendly_name.is_empty() {
+        host_id.to_string()
+    } else {
+        friendly_name
+    };
+
+    let config = client
+        .get_logging_config(&host_id)
+        .await
+        .map_err(boxed_err_to_anyhow)?;
+
+    Ok(CommandOutput::from_key_and_text(
+        "result",
+        format!(
+            "Host `{}` configured with log level `{}`",
+            friendly_name, config.level
+        ),
+    ))
+}
+
+pub async fn handle_set_logging_config(cmd: SetLoggingConfigCommand) -> Result<CommandOutput> {
+    let wco: WashConnectionOptions = cmd.opts.try_into()?;
+    let client = wco.into_ctl_client(None).await?;
+
+    let (host_id, friendly_name) = find_host_id(&cmd.host_id, &client).await?;
+
+    let friendly_name = if friendly_name.is_empty() {
+        host_id.to_string()
+    } else {
+        friendly_name
+    };
+
+    let ack = client
+        .set_logging_config(&host_id, cmd.level.clone().try_into()?)
+        .await
+        .map_err(boxed_err_to_anyhow)?;
+
+    if !ack.accepted {
+        bail!("Operation failed: {}", ack.error);
+    }
+
+    Ok(CommandOutput::from_key_and_text(
+        "result",
+        format!(
+            "Host `{}` configured with log level `{}`",
+            friendly_name, cmd.level
+        ),
+    ))
+}

--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -39,6 +39,7 @@ pub mod get;
 pub mod inspect;
 pub mod label;
 pub mod link;
+pub mod logs;
 pub mod output;
 pub mod par;
 pub mod registry;


### PR DESCRIPTION
## Feature or Problem
Today it's not possible to update the host's log level at runtime, which can make it impossible to debug issues which go away after restarts. This updates the host to listen on a subject and update its log level (and a companion subject for simply returning the current log level), which included a lot of plumbing. I also added `wash logs get/set` for good measure

**NOTE**: I tried to follow the subject convention outlined in https://github.com/wasmCloud/wasmCloud/issues/1108, so the new subjects might look out of place compared to the status quo.

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/998

## Release Information
Next, for `core`, `tracing`, `control-interface`, the host, `wash-lib`, and `wash-cli` 😅 

## Consumer Impact
N/A, new feature

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tested e2e with new builds:
```
./target/debug/wasmcloud
2024-01-29T23:21:50.310400Z  INFO async_nats::options: event: connected
2024-01-29T23:21:50.310410Z  INFO async_nats::options: event: connected
2024-01-29T23:21:50.311812Z  INFO wasmcloud_host::wasmbus: bucket already exists. Skipping creation. bucket=LATTICEDATA_default
2024-01-29T23:21:50.312093Z  INFO wasmcloud_host::wasmbus: bucket already exists. Skipping creation. bucket=CONFIGDATA_default
2024-01-29T23:21:50.315665Z  INFO wasmcloud_host::wasmbus: wasmCloud host started host_id="NAHSIKVUXY6THUZRHNG2KWCR725CRT3YEN2XWSDB62DDYOID6BYS4NLR"
2024-01-29T23:22:16.507724Z  INFO wasmcloud_host::wasmbus: updating log level level=Trace
2024-01-29T23:22:16.510618Z TRACE wasmcloud_host::wasmbus: handled control interface request
2024-01-29T23:22:20.281526Z TRACE heartbeat: wasmcloud_host::wasmbus: generating heartbeat
2024-01-29T23:22:20.281713Z TRACE heartbeat:inventory: wasmcloud_host::wasmbus: generating host inventory
2024-01-29T23:22:50.269039Z TRACE heartbeat: wasmcloud_host::wasmbus: generating heartbeat
2024-01-29T23:22:50.269222Z TRACE heartbeat:inventory: wasmcloud_host::wasmbus: generating host inventory
```

```
~/wasmcloud/wasmcloud/target/debug/wash logs get snowy

Host `snowy-dream-3908` configured with log level `info`

~/wasmcloud/wasmcloud/target/debug/wash logs set snowy -l trace

Host `snowy-dream-3908` configured with log level `trace`
```
