### PR TITLE
refactor(host): move label parsing out of host library

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -5,7 +5,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 use core::time::Duration;
 use std::collections::hash_map::{self, Entry};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::env::consts::{ARCH, FAMILY, OS};
 use std::io::Cursor;
@@ -1904,24 +1904,6 @@ impl Host {
             ("hostcore.osfamily".into(), FAMILY.into()),
         ]);
         labels.extend(config.labels.clone().into_iter());
-        let existing_labels: HashSet<String> = labels.keys().cloned().collect();
-        labels.extend(env::vars().filter_map(|(key, value)| {
-            let key = if key.starts_with("HOST_") {
-                warn!("labels set via HOST_ environment variables are deprecated and will be removed in a future version. Please use WASMCLOUD_LABEL_ as the prefix instead");
-                key.strip_prefix("HOST_")?.to_string()
-            } else if key.starts_with("WASMCLOUD_LABEL_") {
-                key.strip_prefix("WASMCLOUD_LABEL_")?.to_string()
-            } else {
-                return None;
-            };
-            if existing_labels.contains(&key) {
-                warn!(
-                    ?key,
-                    "label provided via environment variable will override existing label"
-                );
-            }
-            Some((key, value))
-        }));
         let friendly_name =
             Self::generate_friendly_name().context("failed to generate friendly name")?;
 

--- a/tests/wasmbus.rs
+++ b/tests/wasmbus.rs
@@ -249,7 +249,6 @@ async fn wasmbus() -> anyhow::Result<()> {
     let cluster_key_two = KeyPair::new_cluster();
     let host_key_two = KeyPair::new_server();
 
-    env::set_var("HOST_PATH", "test-path");
     let base_labels = HashMap::from([
         ("hostcore.arch".into(), ARCH.into()),
         ("hostcore.os".into(), OS.into()),
@@ -265,7 +264,10 @@ async fn wasmbus() -> anyhow::Result<()> {
         rpc_nats_url: rpc_nats_url.clone(),
         lattice: TEST_LATTICE.to_string(),
         js_domain: None,
-        labels: HashMap::from([("label1".into(), "value1".into())]),
+        labels: HashMap::from([
+            ("label1".into(), "value1".into()),
+            ("PATH".into(), "test-path".into()),
+        ]),
         cluster_key: Some(Arc::clone(&cluster_key)),
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key_two.public_key()]),
         host_key: Some(Arc::clone(&host_key)),
@@ -282,7 +284,10 @@ async fn wasmbus() -> anyhow::Result<()> {
         ctl_nats_url: ctl_nats_url.clone(),
         rpc_nats_url: rpc_nats_url.clone(),
         lattice: TEST_LATTICE.to_string(),
-        labels: HashMap::from([("label1".into(), "value1".into())]),
+        labels: HashMap::from([
+            ("label1".into(), "value1".into()),
+            ("PATH".into(), "test-path".into()),
+        ]),
         cluster_key: Some(Arc::clone(&cluster_key_two)),
         cluster_issuers: Some(vec![cluster_key.public_key(), cluster_key_two.public_key()]),
         host_key: Some(Arc::clone(&host_key_two)),


### PR DESCRIPTION
## Feature or Problem
This is a simple refactor which moves the parsing logic for labels set via env vars to the main binary, rather than the host library.

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/757

## Release Information
Next

## Consumer Impact
v0.82.0. I also removed support for the (very old) `HOST_` prefix, so this is technically a breaking change

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
