### PR TITLE
feat(wash-cli): add support for wash app status

### DIFF
--- a/crates/wash-cli/src/app/output.rs
+++ b/crates/wash-cli/src/app/output.rs
@@ -3,7 +3,7 @@ use term_table::{
     table_cell::{Alignment, TableCell},
     Table,
 };
-use wadm::server::VersionInfo;
+use wadm::server::{Status, VersionInfo};
 
 use super::ModelSummary;
 
@@ -56,6 +56,27 @@ pub fn list_models_table(models: Vec<ModelSummary>) -> String {
             ),
         ]))
     });
+
+    table.render()
+}
+
+pub fn status_table(model_name: String, status: Status) -> String {
+    let mut table = Table::new();
+    crate::util::configure_table_style(&mut table);
+
+    table.add_row(Row::new(vec![
+        TableCell::new_with_alignment("Name", 1, Alignment::Left),
+        TableCell::new_with_alignment("Deployed Version", 1, Alignment::Left),
+        TableCell::new_with_alignment("Deploy Status", 1, Alignment::Left),
+        TableCell::new_with_alignment("Status Message", 1, Alignment::Left),
+    ]));
+
+    table.add_row(Row::new(vec![
+        TableCell::new_with_alignment(model_name, 1, Alignment::Left),
+        TableCell::new_with_alignment(status.version, 1, Alignment::Left),
+        TableCell::new_with_alignment(format!("{:?}", status.info.status_type), 1, Alignment::Left),
+        TableCell::new_with_alignment(status.info.message, 1, Alignment::Left),
+    ]));
 
     table.render()
 }


### PR DESCRIPTION
## Feature or Problem
This adds support for `wash app status [model]`

Given the verbosity of the status message, I'm not sure I like the table view, so I'm open to suggestions

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/857

## Release Information
Next minor bump

## Consumer Impact
N/A

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
```
~/wasmcloud/wasmcloud/target/debug/wash app status typescript-http-hello-world -o json

{
  "status": {
    "message": "Successfully fetched status for model typescript-http-hello-world",
    "result": "ok",
    "status": {
      "components": [],
      "status": {
        "message": "Linkdef pending, waiting for file:///Users/connor/Documents/wasmCloud/wasmCloud/examples/typescript/actors/http-hello-world/build/index_s.wasm and wasmcloud.azurecr.io/httpserver:0.19.1 to start",
        "type": "reconciling"
      },
      "version": "v0.0.1"
    }
  },
  "success": true
}
```
```
~/wasmcloud/wasmcloud/target/debug/wash app status typescript-http-hello-world

                                                                                                                                                                                   
  Name                          Deployed Version   Deploy Status   Status Message                                                                                                  
  typescript-http-hello-world   v0.0.1             Reconciling     Linkdef pending, waiting for file:///Users/connor/Documents/wasmCloud/wasmCloud/examples/typescript/actors/http-hello-world/build/index_s.wasm and wasmcloud.azurecr.io/httpserver:0.19.1 to start
```

