### PR TITLE
chore: Remove check for default OpenTelemetry traces path

### DIFF
--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -53,9 +53,6 @@ impl<'a> Drop for LockedWriter<'a> {
 static STDERR: OnceCell<std::io::Stderr> = OnceCell::new();
 
 #[cfg(feature = "otel")]
-const TRACING_PATH: &str = "/v1/traces";
-
-#[cfg(feature = "otel")]
 const DEFAULT_TRACING_ENDPOINT: &str = "http://localhost:55681/v1/traces";
 
 /// A struct that allows us to dynamically choose JSON formatting without using dynamic dispatch.
@@ -201,14 +198,11 @@ pub fn configure_tracing(
 
 #[cfg(feature = "otel")]
 fn get_tracer(
-    mut tracing_endpoint: String,
+    tracing_endpoint: String,
     service_name: String,
 ) -> Result<opentelemetry::sdk::trace::Tracer, opentelemetry::trace::TraceError> {
     use opentelemetry_otlp::WithExportConfig;
 
-    if !tracing_endpoint.ends_with(TRACING_PATH) {
-        tracing_endpoint.push_str(TRACING_PATH);
-    };
     opentelemetry_otlp::new_pipeline()
         .tracing()
         .with_exporter(


### PR DESCRIPTION
## Feature or Problem

As it stands, the check restricts the ability to customize the OTLP tracing endpoint more than is necessary.

Discussed a couple of options with @connorsmith256 offline, and this seems like the best path forward.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
