### PR TITLE
chore(wash,host): remove ineffective ENV aliases

### DIFF
--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -87,11 +87,11 @@ pub struct NatsOpts {
     pub nats_version: String,
 
     /// NATS server host to connect to
-    #[clap(long = "nats-host", env = "WASMCLOUD_NATS_HOST", alias = "NATS_HOST")]
+    #[clap(long = "nats-host", env = "WASMCLOUD_NATS_HOST")]
     pub nats_host: Option<String>,
 
     /// NATS server port to connect to. This will be used as the NATS listen port if `--nats-connect-only` isn't set
-    #[clap(long = "nats-port", env = "WASMCLOUD_NATS_PORT", alias = "NATS_PORT")]
+    #[clap(long = "nats-port", env = "WASMCLOUD_NATS_PORT")]
     pub nats_port: Option<u16>,
 
     /// NATS websocket port to use. TLS is not supported. This is required for the wash ui to connect from localhost

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,20 +32,10 @@ struct Args {
     #[clap(long = "nats-port", default_value_t = 4222, env = "NATS_PORT")]
     nats_port: u16,
     /// A user JWT to use to authenticate to NATS
-    #[clap(
-        long = "nats-jwt",
-        env = "WASMCLOUD_NATS_JWT",
-        alias = "NATS_JWT",
-        requires = "nats_seed"
-    )]
+    #[clap(long = "nats-jwt", env = "WASMCLOUD_NATS_JWT", requires = "nats_seed")]
     nats_jwt: Option<String>,
     /// A seed nkey to use to authenticate to NATS
-    #[clap(
-        long = "nats-seed",
-        env = "WASMCOULD_NATS_SEED",
-        alias = "NATS_SEED",
-        requires = "nats_jwt"
-    )]
+    #[clap(long = "nats-seed", env = "WASMCOULD_NATS_SEED", requires = "nats_jwt")]
     nats_seed: Option<String>,
     /// The lattice the host belongs to
     #[clap(
@@ -193,7 +183,6 @@ struct Args {
     #[clap(
         long = "oci-registry",
         env = "WASMCLOUD_OCI_REGISTRY",
-        alias = "OCI_REGISTRY",
         requires = "oci_user",
         requires = "oci_password"
     )]
@@ -202,7 +191,6 @@ struct Args {
     #[clap(
         long = "oci-user",
         env = "WASMCLOUD_OCI_REGISTRY_USER",
-        alias = "OCI_REGISTRY_USER",
         requires = "oci_registry",
         requires = "oci_password"
     )]
@@ -211,7 +199,6 @@ struct Args {
     #[clap(
         long = "oci-password",
         env = "WASMCLOUD_OCI_REGISTRY_PASSWORD",
-        alias = "OCI_REGISTRY_PASSWORD",
         requires = "oci_registry",
         requires = "oci_user"
     )]


### PR DESCRIPTION

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit removes what were supposed to be ENV aliases that don't work, which were introduced by https://github.com/wasmCloud/wasmCloud/pull/1243

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
