### PR TITLE
Feat/otel logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,6 +1662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,19 +2764,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.20.0",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.1.0",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c4bd073648dae8ac45cfc81588d74b3dc5f334119ac08567ddcbfe16f2d809"
+dependencies = [
+ "once_cell",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
+checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
 dependencies = [
  "async-trait",
  "bytes",
  "http 0.2.11",
- "opentelemetry_api",
+ "opentelemetry 0.21.0",
  "reqwest",
 ]
 
@@ -2779,25 +2815,26 @@ name = "opentelemetry-nats"
 version = "0.1.0"
 dependencies = [
  "async-nats",
- "opentelemetry",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
+checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
 dependencies = [
  "async-trait",
  "futures-core",
  "http 0.2.11",
+ "opentelemetry 0.21.0",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
- "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.21.2",
  "prost",
  "reqwest",
  "thiserror",
@@ -2807,23 +2844,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
+checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
  "prost",
  "tonic",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
+checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.21.0",
 ]
 
 [[package]]
@@ -2855,10 +2892,29 @@ dependencies = [
  "futures-util",
  "once_cell",
  "opentelemetry_api",
- "ordered-float",
+ "ordered-float 3.9.2",
  "percent-encoding",
  "rand",
- "regex",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry 0.21.0",
+ "ordered-float 4.2.0",
+ "percent-encoding",
+ "rand",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2870,6 +2926,15 @@ name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -4586,10 +4651,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc09e402904a5261e42cf27aea09ccb7d5318c6717a9eec3d8e2e65c56b18f19"
 dependencies = [
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.20.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time 0.2.4",
 ]
 
 [[package]]
@@ -4666,7 +4747,7 @@ checksum = "7e3c3b4dcec1e4729aab50688a1a0631483d79e65b194851425e7748287715a6"
 dependencies = [
  "getrandom",
  "rand",
- "web-time",
+ "web-time 1.0.0",
 ]
 
 [[package]]
@@ -5331,12 +5412,12 @@ dependencies = [
  "cloudevents-sdk",
  "futures",
  "oci-distribution",
- "opentelemetry",
+ "opentelemetry 0.20.0",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.20.0",
 ]
 
 [[package]]
@@ -5349,12 +5430,13 @@ dependencies = [
  "cloudevents-sdk",
  "futures",
  "oci-distribution",
- "opentelemetry",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
 ]
 
 [[package]]
@@ -5437,7 +5519,7 @@ dependencies = [
  "futures",
  "nkeys",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.21.0",
  "rmp-serde",
  "serde",
  "serde_bytes",
@@ -5447,7 +5529,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
  "uuid 1.7.0",
  "wascap",
  "wasmcloud-core",
@@ -5524,12 +5606,14 @@ dependencies = [
  "anyhow",
  "heck 0.4.1",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.21.0",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
+ "opentelemetry_sdk 0.21.2",
  "serde",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
  "tracing-subscriber",
  "wasmcloud-core",
 ]
@@ -5936,6 +6020,16 @@ name = "web-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,9 +121,11 @@ notify = { version = "6", default-features = false }
 nuid = { version = "0.4", default-features = false }
 oci-distribution = { version = "0.9", default-features = false }
 once_cell = { version = "1", default-features = false }
-opentelemetry = { version = "0.20", default-features = false }
+opentelemetry = { version = "0.21", default-features = false }
+opentelemetry-appender-tracing = { version = "0.2", default-features = false }
 opentelemetry-nats = { version = "0.1", path = "./crates/opentelemetry-nats", default-features = false }
-opentelemetry-otlp = { version = "0.13", default-features = false }
+opentelemetry-otlp = { version = "0.14", default-features = false }
+opentelemetry_sdk = { version = "0.21", default-features = false }
 path-absolutize = { version = "3", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 provider-archive = { version = "0.8", path = "./crates/provider-archive", default-features = false }
@@ -165,7 +167,7 @@ tokio-util = { version = "0.7", default-features = false }
 toml = { version = "0.7", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-futures = { version = "0.2", default-features = false }
-tracing-opentelemetry = { version = "0.20", default-features = false }
+tracing-opentelemetry = { version = "0.22", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 ulid = { version = "1", default-features = false }
 url = { version = "2", default-features = false }

--- a/crates/control-interface/Cargo.toml
+++ b/crates/control-interface/Cargo.toml
@@ -19,6 +19,11 @@ bytes = { workspace = true }
 cloudevents-sdk = { workspace = true }
 futures = { workspace = true }
 opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = [
+    "trace",
+    "logs",
+    "rt-tokio",
+] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time"] }

--- a/crates/control-interface/src/otel.rs
+++ b/crates/control-interface/src/otel.rs
@@ -5,10 +5,8 @@
 //! is only available with the `otel` feature enabled
 
 use async_nats::header::HeaderMap;
-use opentelemetry::{
-    propagation::{Injector, TextMapPropagator},
-    sdk::propagation::TraceContextPropagator,
-};
+use opentelemetry::propagation::{Injector, TextMapPropagator};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing::span::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 

--- a/crates/opentelemetry-nats/Cargo.toml
+++ b/crates/opentelemetry-nats/Cargo.toml
@@ -14,6 +14,11 @@ default = []
 
 [dependencies]
 async-nats = { workspace = true }
-opentelemetry = { workspace = true, features = ["rt-tokio"] }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = [
+    "trace",
+    "logs",
+    "rt-tokio",
+] }
 tracing = { workspace = true, features = ["log"] }
 tracing-opentelemetry = { workspace = true }

--- a/crates/opentelemetry-nats/src/lib.rs
+++ b/crates/opentelemetry-nats/src/lib.rs
@@ -1,10 +1,8 @@
 use std::sync::OnceLock;
 
 use async_nats::header::{HeaderMap, HeaderValue};
-use opentelemetry::{
-    propagation::{Extractor, Injector, TextMapPropagator},
-    sdk::propagation::TraceContextPropagator,
-};
+use opentelemetry::propagation::{Extractor, Injector, TextMapPropagator};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing::span::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 

--- a/crates/provider-sdk/Cargo.toml
+++ b/crates/provider-sdk/Cargo.toml
@@ -21,7 +21,7 @@ data-encoding = { workspace = true }
 futures = { workspace = true }
 nkeys = { workspace = true }
 once_cell = { workspace = true }
-opentelemetry = { workspace = true, features = ["rt-tokio"], optional = true }
+opentelemetry = { workspace = true, optional = true }
 rmp-serde = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true, features = ["default"] }

--- a/crates/provider-sdk/src/provider_main.rs
+++ b/crates/provider-sdk/src/provider_main.rs
@@ -59,7 +59,7 @@ where
             ProviderInitError::Initialization(format!("Unable to load host data: {e}"))
         })??;
     if let Err(e) = wasmcloud_tracing::configure_tracing(
-        friendly_name.unwrap_or(host_data.provider_key.clone()),
+        &friendly_name.unwrap_or(host_data.provider_key.clone()),
         &host_data.otel_config,
         host_data.structured_logging,
         host_data.log_level.as_ref(),

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -1078,6 +1078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,19 +1649,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.20.0",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.1.0",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c4bd073648dae8ac45cfc81588d74b3dc5f334119ac08567ddcbfe16f2d809"
+dependencies = [
+ "once_cell",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
+checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry_api",
+ "opentelemetry 0.21.0",
  "reqwest",
 ]
 
@@ -1664,25 +1700,26 @@ name = "opentelemetry-nats"
 version = "0.1.0"
 dependencies = [
  "async-nats",
- "opentelemetry",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
+checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
 dependencies = [
  "async-trait",
  "futures-core",
  "http",
+ "opentelemetry 0.21.0",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
- "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.21.2",
  "prost",
  "reqwest",
  "thiserror",
@@ -1692,23 +1729,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
+checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
  "prost",
  "tonic",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
+checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.21.0",
 ]
 
 [[package]]
@@ -1740,10 +1777,29 @@ dependencies = [
  "futures-util",
  "once_cell",
  "opentelemetry_api",
- "ordered-float",
+ "ordered-float 3.9.2",
  "percent-encoding",
  "rand",
- "regex",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry 0.21.0",
+ "ordered-float 4.2.0",
+ "percent-encoding",
+ "rand",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1755,6 +1811,15 @@ name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -2883,15 +2948,32 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc09e402904a5261e42cf27aea09ccb7d5318c6717a9eec3d8e2e65c56b18f19"
+checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
 dependencies = [
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.20.0",
+ "opentelemetry_sdk 0.20.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -3222,12 +3304,13 @@ dependencies = [
  "cloudevents-sdk",
  "futures",
  "oci-distribution",
- "opentelemetry",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
 ]
 
 [[package]]
@@ -3366,12 +3449,12 @@ dependencies = [
  "base64 0.21.5",
  "bytes",
  "futures",
- "opentelemetry",
+ "opentelemetry 0.21.0",
  "opentelemetry-nats",
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.21.0",
  "wascap",
  "wasmcloud-provider-wit-bindgen",
 ]
@@ -3387,7 +3470,7 @@ dependencies = [
  "futures",
  "nkeys",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.21.0",
  "rmp-serde",
  "serde",
  "serde_bytes",
@@ -3397,7 +3480,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
  "uuid",
  "wascap",
  "wasmcloud-core",
@@ -3439,12 +3522,14 @@ dependencies = [
  "anyhow",
  "heck",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.21.0",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
+ "opentelemetry_sdk 0.21.2",
  "serde",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
  "tracing-subscriber",
  "wasmcloud-core",
 ]
@@ -3476,6 +3561,16 @@ name = "web-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/providers/Cargo.toml
+++ b/crates/providers/Cargo.toml
@@ -39,12 +39,12 @@ flume = { version = "0.11", default-features = false }
 futures = { version = "0.3", default-features = false }
 http = { version = "0.2", default-features = false }
 hyper-rustls = { version = "0.24", default-features = false }
-opentelemetry = { version = "0.20", default-features = false }
+opentelemetry = { version = "0.21", default-features = false }
 opentelemetry-nats = { path = "../opentelemetry-nats" }
 path-clean = { version = "1", default-features = false }
 redis = { version = "0.23", default-features = false }
 reqwest = { version = "0.11", default-features = false }
-rskafka = { version = "0.5.0", default-features = false } 
+rskafka = { version = "0.5.0", default-features = false }
 serde = { version = "1", default-features = false }
 serde_bytes = { version = "0.11", default-features = false }
 serde_json = { version = "1", default-features = false }
@@ -53,7 +53,7 @@ tokio = { version = "1", default-features = false }
 toml = { version = "0.8", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-futures = { version = "0.2", default-features = false }
-tracing-opentelemetry = { version = "0.20", default-features = false }
+tracing-opentelemetry = { version = "0.21", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 url = { version = "2.4", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
@@ -61,7 +61,7 @@ warp = { version = "0.3", default-features = false }
 wascap = { version = "*", path = "../wascap" }
 wasmcloud-compat = { path = "../compat", default-features = false }
 wasmcloud-core = { path = "../core", default-features = false }
-wasmcloud-interface-httpclient = { version = "0.11" } # TODO: Replace by WIT
+wasmcloud-interface-httpclient = { version = "0.11" }                                           # TODO: Replace by WIT
 wasmcloud-control-interface = { path = "../control-interface" }
 wasmcloud-provider-sdk = { path = "../provider-sdk", default-features = false }
 wasmcloud-provider-wit-bindgen = { path = "../provider-wit-bindgen", default-features = false }

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -11,15 +11,30 @@ repository.workspace = true
 
 [features]
 default = []
-otel = ["opentelemetry", "tracing-opentelemetry", "opentelemetry-otlp"]
+otel = [
+    "opentelemetry",
+    "opentelemetry_sdk",
+    "opentelemetry-appender-tracing",
+    "tracing-opentelemetry",
+    "opentelemetry-otlp",
+]
 
 [dependencies]
 anyhow = { workspace = true }
 heck = { workspace = true }
 once_cell = { workspace = true }
-opentelemetry = { workspace = true, features = ["rt-tokio"], optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true, features = [
+    "logs",
+    "trace",
+    "rt-tokio",
+] }
+opentelemetry-appender-tracing = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, features = [
+    "grpc-tonic",
     "http-proto",
+    "logs",
+    "trace",
     "reqwest-client",
 ], optional = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/tracing/src/context.rs
+++ b/crates/tracing/src/context.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::ops::Deref;
 
 use opentelemetry::propagation::{Extractor, Injector, TextMapPropagator};
-use opentelemetry::sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing::span::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use wasmcloud_core::TraceContext;

--- a/examples/docker/docker-compose-auxiliary.yml
+++ b/examples/docker/docker-compose-auxiliary.yml
@@ -1,4 +1,4 @@
-# This docker-compose file starts supporting services for a wasmCloud ecosystem, including: 
+# This docker-compose file starts supporting services for a wasmCloud ecosystem, including:
 #   a local OCI registry
 #   grafana + tempo for tracing
 # This file is intended to be used with `wash up` to start a NATS server, wasmCloud host, and WADM server
@@ -20,7 +20,7 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
     depends_on:
-      - tempo  
+      - tempo
   tempo:
     image: grafana/tempo:2.3.1
     command: ["-config.file=/etc/tempo.yaml"]

--- a/examples/docker/docker-compose-websockets.yml
+++ b/examples/docker/docker-compose-websockets.yml
@@ -15,7 +15,7 @@ services:
       - "8222:8222"
       - "4001:4001"
     command:
-     - "-c=/etc/nats/nats-server.conf"
+      - "-c=/etc/nats/nats-server.conf"
     volumes:
       - ./nats.websocket.conf:/etc/nats/nats-server.conf
   registry:

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,7 +238,7 @@ async fn main() -> anyhow::Result<()> {
     };
     let log_level = WasmcloudLogLevel::from(args.log_level);
     if let Err(e) = configure_tracing(
-        "wasmcloud-host".to_string(),
+        "wasmcloud-host",
         &otel_config,
         args.enable_structured_logging,
         Some(&log_level),


### PR DESCRIPTION
## Feature or Problem
This adds support for exporting OTEL logs over OTLP. In doing so, I refactored and simplified the "tracing" logic, which should make it easier to add metrics support as well (@joonas shared a POC of that work today)

The wasmCloud host now supports:
- exporting OTEL traces, when the `otlp` exporter is provided
- exporting OTEL logs, when the `otlp` exporter is provided
- logging to stderr in JSON, when the structured logging flag is enabled
- logging to stderr in plaintext, by default

(Note that there's no conflict between logging locally and exporting logs via OTEL)

"Tracing" is in quotes because it's ambiguous whether "tracing" refers to the `tracing` crate, which we use to emit logs _and_ events inside spans, or distributed traces/tracing.

Since wasmCloud is all-in on OTEL, I think we should rename this crate to `wasmcloud-otel`, but I didn't do that yet, in case others were opposed

## Related Issues

## Release Information
Next. No breaking changes, although now it should be clear that the `OTEL_EXPORTER_OTLP_ENDPOINT` env var/arg should _not_ include a path like `/v1/traces`. It should just be the address of the server handling the given type of data. The underlying otel crates handle appending the appropriate path.

## Consumer Impact
N/A

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
So, so, so much manual testing. It's hard to display that here, but in summary I:
- set things up
  - started tempo using the [auxiliary](https://github.com/wasmCloud/wasmCloud/blob/main/examples/docker/docker-compose-auxiliary.yml) docker file
  - ran `otel/opentelemetry-collector:0.93.0` on another port
- confirmed that the host handles every combination of args and env vars related to OTEL
- confirmed that the host was able to log to stderr without impacting OTEL exports
- confirmed that the host could export logs and traces to separate servers