### PR TITLE
fix(provider-sdk): set the default timeout of nats to None

### DIFF
--- a/crates/provider-sdk/src/provider_main.rs
+++ b/crates/provider-sdk/src/provider_main.rs
@@ -99,6 +99,7 @@ where
             }
         },
     )
+    .request_timeout(None)
     .connect(nats_server)
     .await?;
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
The request timeout in the configuration returned by `ConnectOptions::default()` is set to 10s. Even if the default_rpc_timeout is set to greater than 10s, the true timeout is still 10s.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
