### PR TITLE
feat(example): added minimal docker compose example

### DIFF
--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -3,10 +3,18 @@
 This directory contains Docker Compose files for starting containers helpful for running wasmCloud examples. These containers include:
 
 - a [NATS](https://nats.io) server with JetStream enabled, needed to support the network for a lattice
-- an OCI registry, to support pushing and pulling locally-built artifacts
-- [Grafana](https://grafana.com/) + [Tempo](https://grafana.com/oss/tempo/), for viewing distributed traces
 - the wasmCloud host
 - a [WADM](/docs/category/declarative-application-deployment-wadm) server, for managing wasmCloud applications
+- an OCI registry, to support pushing and pulling locally-built artifacts
+- [Grafana](https://grafana.com/) + [Tempo](https://grafana.com/oss/tempo/), for viewing distributed traces
+
+## Running the minimal wasmCloud infrastructure
+
+The minimum required infrastructure for wasmCloud is a NATS server and a wasmCloud host.
+
+```bash
+docker compose -f docker-compose.minimal.yml up
+```
 
 ## Running the entire ecosystem in Docker
 
@@ -22,6 +30,7 @@ docker compose -f docker-compose-websockets.yml up
 ```
 
 ## Running supporting services in Docker
+The auxiliary services include a local registry for managing OCI components and Grafana and Tempo in order to view distributed traces.
 
 ```bash
 docker compose -f docker-compose-auxiliary.yml up

--- a/examples/docker/docker-compose-minimal.yml
+++ b/examples/docker/docker-compose-minimal.yml
@@ -1,0 +1,24 @@
+# This docker-compose file starts the required services for wasmCloud, which is just:
+#   a NATS server
+#   a wasmCloud host
+
+version: "3"
+services:
+  nats:
+    image: nats:2.10.7-alpine
+    ports:
+      - "4222:4222"
+      - "6222:6222"
+      - "8222:8222"
+    command: ["-js"]
+  wasmcloud:
+    depends_on:
+      - "nats"
+    image: wasmcloud/wasmcloud:latest
+    environment:
+      RUST_LOG: debug,hyper=info,async_nats=info,oci_distribution=info,cranelift_codegen=warn
+      WASMCLOUD_LOG_LEVEL: debug
+      WASMCLOUD_RPC_HOST: nats
+      WASMCLOUD_CTL_HOST: nats
+    ports:
+      - "8000-8100:8000-8100" # Expose ports 8000-8100 for examples that use an HTTP server


### PR DESCRIPTION
## Feature or Problem
This PR just adds the minimal docker compose example to give onlookers an idea of the required set of infrastructure they need to run. This notably excludes Wadm as there is a bit of confusion as to whether it's _required_ to run wasmCloud, so I want to be explicit on the minimal requirements.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I did make sure this compose worked.
