### PR TITLE
fix(wash): windows path to target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
 dependencies = [
  "bytes",
  "fnv",
@@ -1947,7 +1947,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.6",
  "httparse",
@@ -1970,7 +1970,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.0",
+ "h2 0.4.2",
  "http 1.0.0",
  "http-body 1.0.0",
  "httparse",
@@ -3427,7 +3427,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -4570,7 +4570,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,6 +2544,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5102,6 +5111,7 @@ dependencies = [
  "ignore",
  "indicatif",
  "nkeys",
+ "normpath",
  "oci-distribution",
  "path-absolutize",
  "provider-archive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ names = { version = "0.14", default-features = false }
 nix = { version = "0.27", default-features = false }
 nkeys = { version = "0.3", default-features = false }
 notify = { version = "6", default-features = false }
+normpath = { version = "1.1" , default-features = false }
 nuid = { version = "0.4", default-features = false }
 oci-distribution = { version = "0.9", default-features = false }
 once_cell = { version = "1", default-features = false }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -54,6 +54,7 @@ heck = { workspace = true, optional = true }
 ignore = { workspace = true, optional = true }
 indicatif = { workspace = true, optional = true }
 nkeys = { workspace = true }
+normpath = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"] }
 path-absolutize = { workspace = true, features = [
     "once_cell_cache",

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -281,7 +281,9 @@ fn build_rust_actor(
     let wasm_file = match wasm_path_buf.normalize() {
         Ok(p) => p,
         Err(e) => bail!(
-            "Could not find compiled wasm file, please ensure {:?} exists. Error: {:?}", wasm_path_buf, e
+            "Could not find compiled wasm file, please ensure {:?} exists. Error: {:?}",
+            wasm_path_buf,
+            e
         ),
     };
 

--- a/crates/wash-lib/src/build.rs
+++ b/crates/wash-lib/src/build.rs
@@ -268,11 +268,10 @@ fn build_rust_actor(
     // Once out of nightly, we should be able to use std::path::absolute
     // https://github.com/rust-lang/rust/pull/91673
     let metadata = cargo_metadata::MetadataCommand::new().exec()?;
-    let target_path = rust_config
+    let mut wasm_path_buf = rust_config
         .target_path
         .clone()
         .unwrap_or_else(|| PathBuf::from(metadata.target_directory.as_std_path()));
-    let mut wasm_path_buf = PathBuf::from(target_path);
     wasm_path_buf.push(build_target);
     wasm_path_buf.push("release");
     wasm_path_buf.push(format!("{}.wasm", wasm_bin_name));


### PR DESCRIPTION
Verbatim paths on Windows are not well supported,
e.g. "\\\\?\\C:\\Users..." while technically valid, causes some fs api's like `exists` to fail errantly.

The fix is to use a third party lib normpath to normalize the path to the wasm
binary.

Related issue: https://github.com/rust-lang/cargo/issues/9770

Fixes #1481

Signed-off-by: Bailey Hayes <behayes2@gmail.com>