### PR TITLE
feat(wrpc): Add support for interface linking and storing component specifications

### DIFF
--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -433,6 +433,31 @@ pub struct LinkDefinition {
     pub values: LinkSettings,
 }
 
+/// A link definition between a source and target component (actor or provider) on a given
+/// interface. An [`InterfaceLinkDefinition`] connects one component's import to another
+/// component's export, specifying the configuration each component needs in order to execute
+/// the request, and represents an operator's intent to allow the source to invoke the target.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+pub struct InterfaceLinkDefinition {
+    /// Source identifier for the link
+    pub source_id: String,
+    /// Target for the link, which can be a unique identifier or (future) a routing group
+    pub target: String,
+    /// Name of the link. Not providing this is equivalent to specifying Some("default")
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Package of the link operation, e.g. `wasi:keyvalue`
+    pub package: String,
+    /// Interfaces to be used for the link, e.g. `readwrite`, `atomic`, etc.
+    pub interfaces: Vec<String>,
+    /// List of named configurations to provide to the source upon request
+    #[serde(default)]
+    pub source_config: Vec<String>,
+    /// List of named configurations to provide to the target upon request
+    #[serde(default)]
+    pub target_config: Vec<String>,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct HostLabel {
     pub key: String,

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -721,6 +721,13 @@ impl Bus for Handler {
         &self,
         target_interface: &TargetInterface,
     ) -> anyhow::Result<Option<TargetEntity>> {
+        // NOTE(brooksmtownsend): this should be removed by @vados-cosmonic when we drop `set_target` in favor of
+        // `set_link_name`
+        let targets = self.wrpc_targets.read().await;
+        if let Some(interface) = targets.get(target_interface) {
+            return Ok(Some(interface.clone()));
+        };
+
         let links = self.interface_links.read().await;
         let link_name = self.interface_link_name.read().await.clone();
         let (namespace, package, interface) = target_interface.as_parts();
@@ -2574,15 +2581,18 @@ impl Host {
             }
             wasmcloud_runtime::Actor::Component(_) => {
                 debug!(actor_ref, "instantiating component");
-                let wrpc = "wrpc";
-                let wrpc_version = "0.0.1";
-                // Components communicate over wRPC
+                // TODO: Components subscribe on wRPC topics
                 // Example incoming topic:
                 //   default.echo.wrpc.0.0.1.wasi:http/incoming-handler.handle
+                // format!(
+                //     "{lattice}.{component_id}.{WRPC}.{WRPC_VERSION}.>",
+                //     lattice = self.host_config.lattice,
+                //     component_id = sanitize_reference(actor_ref),
+                // )
                 format!(
-                    "{lattice}.{component_id}.{wrpc}.{wrpc_version}.>",
+                    "wasmbus.rpc.{lattice}.{subject}",
                     lattice = self.host_config.lattice,
-                    component_id = sanitize_reference(actor_ref),
+                    subject = claims.subject
                 )
             }
         };

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -4607,24 +4607,6 @@ impl Host {
     }
 }
 
-/// Santize a component reference to create a NATS/storage safe key. This is a placeholder
-/// for what will eventually go into `wash` and `wadm` as a more specific utility.
-fn sanitize_reference(reference: &str) -> String {
-    if reference.starts_with("file://") {
-        // Transforms a possibly complex file reference, e.g. "file:///path/to/http_hello_s.wasm" into a
-        // nicer key, "http_hello"
-        reference
-            .split('/')
-            .last()
-            .unwrap_or(reference)
-            .trim_end_matches(".wasm")
-            .trim_end_matches("_s")
-    } else {
-        reference
-    }
-    .replace([':', '/', '.', '-'], "_")
-}
-
 // TODO: remove StoredClaims in #1093
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/crates/runtime/src/capability/builtin.rs
+++ b/crates/runtime/src/capability/builtin.rs
@@ -189,12 +189,25 @@ impl PartialEq for ActorIdentifier {
 impl Eq for ActorIdentifier {}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Interface target to be invoked over `wRPC`
+pub struct InterfaceTarget {
+    /// wRPC component routing identifier
+    pub id: String,
+    /// wRPC component interface
+    pub interface: TargetInterface,
+    /// Link name used to resolve the target
+    pub link_name: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 /// Target entity
 pub enum TargetEntity {
     /// Link target entity
     Link(Option<String>),
     /// Actor target entity
     Actor(ActorIdentifier),
+    /// WRPC component
+    Wrpc(InterfaceTarget),
 }
 
 impl TryFrom<bus::lattice::ActorIdentifier> for ActorIdentifier {
@@ -247,6 +260,26 @@ pub enum TargetInterface {
         /// Interface name
         interface: String,
     },
+}
+
+impl TargetInterface {
+    /// Returns the 3-tuple of (namespace, package, interface) for this interface
+    #[must_use]
+    pub fn as_parts(&self) -> (&str, &str, &str) {
+        match self {
+            Self::WasiBlobstoreBlobstore => ("wasi", "blobstore", "blobstore"),
+            Self::WasiHttpOutgoingHandler => ("wasi", "http", "outgoing-handler"),
+            Self::WasiKeyvalueAtomic => ("wasi", "keyvalue", "atomic"),
+            Self::WasiKeyvalueEventual => ("wasi", "keyvalue", "eventual"),
+            Self::WasiLoggingLogging => ("wasi", "logging", "logging"),
+            Self::WasmcloudMessagingConsumer => ("wasmcloud", "messaging", "consumer"),
+            Self::Custom {
+                namespace,
+                package,
+                interface,
+            } => (namespace, package, interface),
+        }
+    }
 }
 
 /// Outgoing HTTP request

--- a/crates/runtime/src/capability/mod.rs
+++ b/crates/runtime/src/capability/mod.rs
@@ -4,8 +4,9 @@ pub(crate) mod builtin;
 pub mod provider;
 
 pub use builtin::{
-    ActorIdentifier, Blobstore, Bus, IncomingHttp, KeyValueAtomic, KeyValueEventual, Logging,
-    Messaging, OutgoingHttp, OutgoingHttpRequest, TargetEntity, TargetInterface,
+    ActorIdentifier, Blobstore, Bus, IncomingHttp, InterfaceTarget, KeyValueAtomic,
+    KeyValueEventual, Logging, Messaging, OutgoingHttp, OutgoingHttpRequest, TargetEntity,
+    TargetInterface,
 };
 
 #[allow(clippy::doc_markdown)]


### PR DESCRIPTION
## Feature or Problem
This PR introduces mostly backwards compatible changes (new public member in control interface may be considered breaking, new functionality in RPC isn't documented but could alter behavior) to support both actor component interface linking and storing component specifications in the `LATTICEDATA` bucket.

This is designed in a way that we can make incremental progress towards a full wRPC implementation but does not alter the test functionality. Because of this, it's not recommended to merge this to `main` until we can release v0.82 after #1478.

## Related Issues
Partially implements #1389 

## Release Information
v1.0.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
No tests were modified for this PR as the point is to get some of the plumbing for wRPC components implemented without modifying today's functionality.

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
To test this PR, I went through a few manual steps to ensure that a component could receive a message on its wRPC topic and send a wasmbus Invocation out on a wRPC topic.

```bash
# Start the example component from our quickstart
wash start actor file:///Users/brooks/github.com/wasmcloud/wasmCloud/examples/rust/actors/http-hello-world/build/http_hello_world_s.wasm --skip-wait --max 5
# Interface link the component to another component for its keyvalue calls
nats req 'wasmbus.ctl.default.linkdefs.wrpc' '{"source_id": "http_hello_world", "target": "wasmcloud_azurecr_io_kvredis_0_19_0", "package": "wasi:keyvalue", "interfaces": ["atomic", "readwrite"]}'
# Send request to wRPC topic
nats req "default.http_hello_world.wrpc.0.0.1.wasi:http/incoming-handler.handle" 'hello'
```

In another terminal, subscribing on `*.*.wrpc.>` will show you:
```bash
[#13] Received on "default.wasmcloud_azurecr_io_kvredis_0_19_0.wrpc.0.0.1.wasi:keyvalue/atomic.increment" with reply "_INBOX.NEqcFNu6SQ8Ka2NYvMhMSF.NEqcFNu6SQ8Ka2NYvMhMYt"
originpublic_key8MDMIKQQUBEQ7XROPNV4C2EXDU6MWFXWYGLYKTQNPMG4QMAK37K3KQIZ6link_namecontract_idtargetpublic_key#wasmcloud_azurecr_io_kvredis_0_19_0link_namedefaultcontract
......
```

This testing was done using the commented-out functionality to set the `component_id` to a sanitized version of the OCI reference, which is similar to what wash or wadm may do in the future. What this does show is that a component can receive an invocation on a wRPC topic and the inner component plumbing can properly resolve a target based on the Wasm interface call.
