### PR TITLE
fix(host): set log_level for providers

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -3172,10 +3172,6 @@ impl Host {
                 traces_exporter: self.host_config.otel_config.traces_exporter.clone(),
                 exporter_otlp_endpoint: self.host_config.otel_config.exporter_otlp_endpoint.clone(),
             };
-            // TODO: set back to Some(self.host_config.log_level.clone()) once all providers can be
-            // assumed to be built using the new SDK. Providers built using wasmbus-rpc <= 0.15
-            // ignore RUST_LOG when log_level is set
-            let log_level: Option<wasmcloud_core::logging::Level> = None;
             let host_data = HostData {
                 host_id: self.host_key.public_key(),
                 lattice_rpc_prefix: self.host_config.lattice.clone(),
@@ -3191,7 +3187,7 @@ impl Host {
                 default_rpc_timeout_ms,
                 cluster_issuers: self.cluster_issuers.clone(),
                 invocation_seed,
-                log_level,
+                log_level: Some(self.host_config.log_level.clone()),
                 structured_logging: self.host_config.enable_structured_logging,
                 otel_config,
             };


### PR DESCRIPTION
## Feature or Problem
This sets the `log_level` in the `HostData`, allowing providers built using the new SDK to inherit their logging level from the host

**This should not be merged before v0.82 of the host is released**

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/1487

## Release Information
1.0, since this will break legacy wasmbus-rpc providers

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
See the `subscribing for` debug logs from the provider binary:
```
./target/debug/wasmcloud --log-level debug --allow-file-load
2024-02-12T22:28:16.389792Z DEBUG new: wasmcloud_host::wasmbus: adding cluster key to cluster issuers cluster_pub_key="CBW56ENZ3AWPAKOHVUELI7SD6PYNHF7WLNNWAX2VI7QHCKI2JDNFACLP"
2024-02-12T22:28:16.390373Z DEBUG new: wasmcloud_host::wasmbus: connecting to NATS control server ctl_nats_url="nats://127.0.0.1:4222"
2024-02-12T22:28:16.390496Z DEBUG new: wasmcloud_host::wasmbus: connecting to NATS RPC server rpc_nats_url="nats://127.0.0.1:4222"
2024-02-12T22:28:16.392418Z  INFO async_nats::options: event: connected
2024-02-12T22:28:16.392419Z  INFO async_nats::options: event: connected
2024-02-12T22:28:16.393718Z  INFO new:create_bucket: wasmcloud_host::wasmbus: bucket already exists. Skipping creation. bucket=LATTICEDATA_default
2024-02-12T22:28:16.394059Z  INFO new:create_bucket: wasmcloud_host::wasmbus: bucket already exists. Skipping creation. bucket=CONFIGDATA_default
2024-02-12T22:28:16.395861Z DEBUG new:process_claims_put: wasmcloud_host::wasmbus: process claim entry put pubkey="VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"
2024-02-12T22:28:16.396289Z DEBUG new:process_claims_put: wasmcloud_host::wasmbus: process claim entry put pubkey="VAQ44JZI5TVX4LBBDOP3PCGTG7VW4DLJYWKCY5SA36UGTFKHHGNYS2Q5"
2024-02-12T22:28:16.396643Z  INFO new:process_linkdef_put: wasmcloud_host::wasmbus: process link definition entry put actor_id="MBLXMMR4HJK6IC4N5PCR5SZ233L74UKENCZX33Y2CZGMHUHJHZKUBCES" provider_id="VAQ44JZI5TVX4LBBDOP3PCGTG7VW4DLJYWKCY5SA36UGTFKHHGNYS2Q5" link_name="default" contract_id="wasmcloud:httpserver"
2024-02-12T22:28:16.397471Z  INFO new: wasmcloud_host::wasmbus: wasmCloud host started host_id="NCPNIEJ4AMWEVI3L6OYEURW5XAAPLA7SXZR3MCVG6CCGT4RHFAIU7MNC"
2024-02-12T22:28:21.021293Z  INFO handle_auction_provider: wasmcloud_host::wasmbus: handling auction for provider provider_ref="file:///Users/connor/Documents/wasmCloud/wasmCloud/crates/providers/target/debug/httpserver.par.gz" link_name="default" constraints={}
2024-02-12T22:28:23.024605Z  INFO handle_launch_provider: wasmcloud_host::wasmbus: handling launch provider provider_ref="file:///Users/connor/Documents/wasmCloud/wasmCloud/crates/providers/target/debug/httpserver.par.gz" link_name="default"
2024-02-12T22:28:23.947234Z DEBUG process_claims_put: wasmcloud_host::wasmbus: process claim entry put pubkey="VAQ44JZI5TVX4LBBDOP3PCGTG7VW4DLJYWKCY5SA36UGTFKHHGNYS2Q5"
2024-02-12T22:28:23.949058Z  INFO handle_launch_provider_task: wasmcloud_host::wasmbus: provider started provider_ref="file:///Users/connor/Documents/wasmCloud/wasmCloud/crates/providers/target/debug/httpserver.par.gz" link_name="default"
2024-02-12T22:28:23.960374Z  INFO wasmcloud_provider_sdk::provider_main: Starting capability provider VAQ44JZI5TVX4LBBDOP3PCGTG7VW4DLJYWKCY5SA36UGTFKHHGNYS2Q5 instance 018d9f6f-8b0b-20c5-efc1-dca0456a2ac1 with nats url nats://127.0.0.1:4222
2024-02-12T22:28:23.962546Z  INFO wasmcloud_provider_sdk: nats client connected
2024-02-12T22:28:23.962974Z  INFO wasmcloud_provider_httpserver: httpserver starting listener for actor addr=0.0.0.0:8080 actor_id=MBLXMMR4HJK6IC4N5PCR5SZ233L74UKENCZX33Y2CZGMHUHJHZKUBCES
2024-02-12T22:28:23.963203Z DEBUG wasmcloud_provider_sdk::provider: subscribing for link del topic=wasmbus.rpc.default.VAQ44JZI5TVX4LBBDOP3PCGTG7VW4DLJYWKCY5SA36UGTFKHHGNYS2Q5.default.linkdefs.del
2024-02-12T22:28:23.963233Z DEBUG wasmcloud_provider_sdk::provider: subscribing for shutdown : wasmbus.rpc.default.VAQ44JZI5TVX4LBBDOP3PCGTG7VW4DLJYWKCY5SA36UGTFKHHGNYS2Q5.default.shutdown
```
