### PR TITLE
feat(wash-lib): update favorites to use components

### DIFF
--- a/crates/wash-cli/tests/wash_build.rs
+++ b/crates/wash-cli/tests/wash_build.rs
@@ -350,7 +350,7 @@ async fn integration_build_handles_dashed_names() -> Result<()> {
 
     // Execute wash new to create an actor with the given name
     let mut new_cmd = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args(["new", "actor", "dashed-actor", "-t", "hello"])
+        .args(["new", "actor", "dashed-actor", "-t", "hello-world-rust"])
         .kill_on_drop(true)
         .current_dir(&root_dir)
         .stdout(stdout.try_clone()?)

--- a/crates/wash-lib/src/generate/favorites.toml
+++ b/crates/wash-lib/src/generate/favorites.toml
@@ -13,28 +13,28 @@
 # path        path to template on disk          - either git or path is required
 
 [[actor]]
-name = "hello"
-description = "a hello-world actor (in Rust) that responds over an http connection"
-git = "wasmCloud/project-templates"
-subfolder = "actor/hello"
+name = "hello-world-rust"
+description = "a hello-world actor component (in Rust) that responds over an HTTP connection"
+git = "wasmCloud/wasmCloud"
+subfolder = "examples/rust/actors/http-hello-world"
 
 [[actor]]
-name = "echo-tinygo"
-description = "a hello-world actor (in TinyGo) that responds over an http connection"
-git = "wasmCloud/project-templates"
-subfolder = "actor/echo-tinygo"
+name = "hello-world-tinygo"
+description = "a hello-world actor component (in TinyGo) that responds over an HTTP connection"
+git = "wasmCloud/wasmCloud"
+subfolder = "examples/golang/actors/http-hello-world"
 
 [[actor]]
-name = "echo-messaging"
-description = "a hello-world actor (in Rust) that echoes a request back over a NATS connection"
-git = "wasmCloud/project-templates"
-subfolder = "actor/echo-messaging"
+name = "hello-world-typescript"
+description = "a hello-world actor component (in TypeScript) that responds over an HTTP connection"
+git = "wasmCloud/wasmCloud"
+subfolder = "examples/typescript/actors/http-hello-world"
 
 [[actor]]
-name = "kvcounter"
-description = "an example actor (in Rust) that increments a counter in a key-value store"
-git = "wasmCloud/project-templates"
-subfolder = "actor/kvcounter"
+name = "hello-world-python"
+description = "a hello-world actor component (in Python) that responds over an HTTP connection"
+git = "wasmCloud/wasmCloud"
+subfolder = "examples/python/actors/http-hello-world"
 
 [[interface]]
 name = "converter-interface"


### PR DESCRIPTION
## Feature or Problem
This updates the favorites file to use our componentized actor templates

**Note** that I left the interfaces and providers in there, even though those are smithy based. If we remove them, then e.g. `wash new provider` will error with:
```
Failed to generate project

Caused by:
    ⛔   templates missing for project type provider
```

Leaving as do-not-merge until we've released a new version of wash using v0.82 of the host

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/1500

## Release Information
Next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
```
~/wasmcloud/wasmcloud/target/debug/wash new actor -t hello-world-typescript hello-world-typescript
🔧   Cloning template from repo wasmCloud/wasmCloud subfolder examples/typescript/actors/http-hello-world...
🔧   Using template subfolder examples/typescript/actors/http-hello-world...
🔧   Generating template...
...
Done! New project created /Users/connor/Downloads/hello-world-typescript

Project generated and is located at: /Users/connor/Downloads/hello-world-typescript
```
