### PR TITLE
Fix the build problem of `wash-lib` with `--no-default-features` flag.

### DIFF
--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["start", "parser", "nats"]
 start = ["semver"]
-parser = ["config", "semver", "serde", "serde_json"]
+parser = ["config", "semver"]
 cli = [
     "clap",
     "term-table",
@@ -64,10 +64,10 @@ regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
 rmp-serde = { workspace = true }
 semver = { workspace = true, features = ["serde"], optional = true }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"] }
 serde-transcode = { workspace = true }
 serde_cbor = { workspace = true, features = ["std"] }
-serde_json = { workspace = true, optional = true }
+serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["macros"] }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -28,14 +28,21 @@ pub mod parser;
 #[cfg(feature = "start")]
 pub mod start;
 
+#[cfg(feature = "nats")]
 pub mod actor;
+#[cfg(feature = "nats")]
 pub mod capture;
 pub mod common;
+#[cfg(feature = "nats")]
 pub mod config;
+#[cfg(feature = "nats")]
 pub mod context;
+#[cfg(feature = "nats")]
 pub mod drain;
 pub mod id;
 pub mod keys;
 pub mod registry;
+#[cfg(feature = "nats")]
 pub mod spier;
+#[cfg(feature = "nats")]
 pub mod wait;

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -13,7 +13,7 @@
 //! | start | true | Contains the [start](start) module, with utilities to start wasmCloud runtimes, NATS, and wadm |
 //! | parser | true | Contains the [parser](parser) module, with utilities to parse `wasmcloud.toml` files |
 //! | cli | false | Contains the build, cli, and generate modules with additional trait derives for usage in building CLI applications |
-//! | nats| true| Contains the [app](app) module with a dependency on `async_nats` |
+//! | nats| true| Contains the [app](app), [actor](actor), [capture](capture), [config](config), [context](context), [drain](drain), [spier](spier) and [wait](wait) modules with a dependency on `async_nats` |
 
 #[cfg(feature = "nats")]
 pub mod app;


### PR DESCRIPTION
## Feature or Problem

Fixes the build problem of `wash-lib` with `--no-default-features` flag.

## Related Issues

Fixes issue #862 

## Release Information

N/A

## Consumer Impact

N/A

## Testing

build succeeds in `crates/wash-lib`: `cargo build --no-default-features`

### Unit Test(s)

N/A

### Acceptance or Integration

N/A

### Manual Verification

N/A
