### PR TITLE
wRPC component export support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,6 +5485,9 @@ dependencies = [
  "wasmcloud-core",
  "wasmcloud-runtime",
  "wasmcloud-tracing",
+ "wrpc-transport",
+ "wrpc-transport-nats",
+ "wrpc-types",
 ]
 
 [[package]]
@@ -6474,6 +6477,22 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "wrpc-types",
+]
+
+[[package]]
+name = "wrpc-transport-nats"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c383e66c649fc032b440ec4a1b0b2356da9f0e82f6fe1a432669e053c5829d0"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "bytes",
+ "futures",
+ "tokio",
+ "tracing",
+ "wrpc-transport",
 ]
 
 [[package]]

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -47,3 +47,6 @@ wasmcloud-control-interface = { workspace = true }
 wasmcloud-core = { workspace = true, features = ["otel"] }
 wasmcloud-runtime = { workspace = true }
 wasmcloud-tracing = { workspace = true, features = ["otel"] }
+wrpc-transport = { workspace = true }
+wrpc-transport-nats = { workspace = true }
+wrpc-types = { workspace = true }

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -42,16 +42,6 @@ use tracing::{debug, instrument, warn};
 use url::Url;
 use wascap::jwt;
 
-#[cfg(unix)]
-fn socket_pair() -> anyhow::Result<(tokio::net::UnixStream, tokio::net::UnixStream)> {
-    tokio::net::UnixStream::pair().context("failed to create an unnamed unix socket pair")
-}
-
-#[cfg(windows)]
-fn socket_pair() -> anyhow::Result<(tokio::io::DuplexStream, tokio::io::DuplexStream)> {
-    Ok(tokio::io::duplex(8196))
-}
-
 #[derive(PartialEq)]
 enum ResourceRef<'a> {
     File(PathBuf),

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -48,7 +48,7 @@ use wasmcloud_control_interface::{
     HostLabel, InterfaceLinkDefinition, LinkDefinition, LinkDefinitionList, ProviderAuctionAck,
     ProviderAuctionRequest, ProviderDescription, RegistryCredential, RegistryCredentialMap,
     RemoveLinkDefinitionRequest, ScaleActorCommand, StartProviderCommand, StopHostCommand,
-    StopProviderCommand, UpdateActorCommand, WitInterface, WitNamespace, WitPackage,
+    StopProviderCommand, UpdateActorCommand, WitInterface,
 };
 use wasmcloud_core::{
     HealthCheckResponse, HostData, Invocation, InvocationResponse, LatticeTargetId, LinkName,
@@ -58,7 +58,7 @@ use wasmcloud_runtime::capability::logging::logging;
 use wasmcloud_runtime::capability::{
     blobstore, guest_config, messaging, ActorIdentifier, Blobstore, Bus, CallTargetInterface,
     KeyValueAtomic, KeyValueEventual, Logging, Messaging, OutgoingHttp, OutgoingHttpRequest,
-    TargetEntity,
+    TargetEntity, WrpcInterfaceTarget,
 };
 use wasmcloud_runtime::Runtime;
 use wasmcloud_tracing::context::TraceContextInjector;
@@ -282,12 +282,8 @@ struct Handler {
     /// - A routing group
     /// - Some other opaque string
     #[allow(clippy::type_complexity)]
-    interface_links: Arc<
-        RwLock<HashMap<LinkName, HashMap<WitNsAndPackage, HashMap<WitInterface, LatticeTargetId>>>>,
-    >,
-
-    // NOTE(brooksmtownsend): needs deduplication of responsibility with interface_links
-    wrpc_targets: Arc<RwLock<HashMap<TargetInterface, TargetEntity>>>,
+    interface_links:
+        Arc<RwLock<HashMap<LinkName, HashMap<String, HashMap<WitInterface, LatticeTargetId>>>>>,
     aliases: Arc<RwLock<HashMap<String, WasmCloudEntity>>>,
     // interface -> function -> result types
     polyfilled_imports: HashMap<String, HashMap<String, Arc<[wrpc_types::Type]>>>,
@@ -341,13 +337,14 @@ impl Handler {
         request: Vec<u8>,
     ) -> anyhow::Result<Result<Vec<u8>, String>> {
         let operation = operation.into();
+        let links = self.links.read().await;
+        let aliases = self.aliases.read().await;
 
         // Determine the target for the operation
         let (package, interface_and_func) = operation
             .rsplit_once('/')
             .context("failed to parse operation")?;
-        let inv_target =
-            resolve_target(target.as_ref(), self.links.get(package), &self.aliases).await?;
+        let inv_target = resolve_target(target.as_ref(), links.get(package), &aliases).await?;
         let injector = TraceContextInjector::default_with_span();
         let headers = injector_to_headers(&injector);
         let invocation = Invocation::new(
@@ -398,7 +395,6 @@ impl Handler {
         let InvocationResponse {
             invocation_id,
             msg,
-            content_length,
             error,
             ..
         } = rmp_serde::from_slice(&res.payload).context("failed to decode invocation response")?;
@@ -418,6 +414,8 @@ impl Handler {
         operation: impl Into<String>,
         request: &impl Serialize,
     ) -> anyhow::Result<Vec<u8>> {
+        // TODO(brooksmtownsend): This handler should be sending requests over wRPC, rather than creating
+        // invocations.
         let request = rmp_serde::to_vec_named(request).context("failed to encode request")?;
         self.call_operation_with_payload(target, operation, request)
             .await
@@ -454,7 +452,12 @@ impl Blobstore for Handler {
     #[instrument]
     async fn create_container(&self, name: &str) -> anyhow::Result<()> {
         let target = self
-            .identify_interface_target(&TargetInterface::WasiBlobstoreBlobstore)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "blobstore",
+                "blobstore",
+                None,
+            )))
             .await?;
         self.call_operation(
             target,
@@ -468,7 +471,12 @@ impl Blobstore for Handler {
     #[instrument]
     async fn container_exists(&self, name: &str) -> anyhow::Result<bool> {
         let target = self
-            .identify_interface_target(&TargetInterface::WasiBlobstoreBlobstore)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "blobstore",
+                "blobstore",
+                None,
+            )))
             .await?;
         self.call_operation(
             target,
@@ -482,7 +490,12 @@ impl Blobstore for Handler {
     #[instrument]
     async fn delete_container(&self, name: &str) -> anyhow::Result<()> {
         let target = self
-            .identify_interface_target(&TargetInterface::WasiBlobstoreBlobstore)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "blobstore",
+                "blobstore",
+                None,
+            )))
             .await?;
         self.call_operation(
             target,
@@ -499,7 +512,12 @@ impl Blobstore for Handler {
         name: &str,
     ) -> anyhow::Result<blobstore::container::ContainerMetadata> {
         let target = self
-            .identify_interface_target(&TargetInterface::WasiBlobstoreBlobstore)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "blobstore",
+                "blobstore",
+                None,
+            )))
             .await?;
         let res = self
             .call_operation(
@@ -530,7 +548,12 @@ impl Blobstore for Handler {
         range: RangeInclusive<u64>,
     ) -> anyhow::Result<(Box<dyn AsyncRead + Sync + Send + Unpin>, u64)> {
         let target = self
-            .identify_interface_target(&TargetInterface::WasiBlobstoreBlobstore)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "blobstore",
+                "blobstore",
+                None,
+            )))
             .await?;
         let res = self
             .call_operation(
@@ -578,7 +601,12 @@ impl Blobstore for Handler {
     #[instrument]
     async fn has_object(&self, container: &str, name: String) -> anyhow::Result<bool> {
         let target = self
-            .identify_interface_target(&TargetInterface::WasiBlobstoreBlobstore)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "blobstore",
+                "blobstore",
+                None,
+            )))
             .await?;
         self.call_operation(
             target,
@@ -605,7 +633,12 @@ impl Blobstore for Handler {
             .await
             .context("failed to read bytes")?;
         let target = self
-            .identify_interface_target(&TargetInterface::WasiBlobstoreBlobstore)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "blobstore",
+                "blobstore",
+                None,
+            )))
             .await?;
         let res = self
             .call_operation(
@@ -635,7 +668,12 @@ impl Blobstore for Handler {
     #[instrument]
     async fn delete_objects(&self, container: &str, names: Vec<String>) -> anyhow::Result<()> {
         let target = self
-            .identify_interface_target(&TargetInterface::WasiBlobstoreBlobstore)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "blobstore",
+                "blobstore",
+                None,
+            )))
             .await?;
         let res = self
             .call_operation(
@@ -667,7 +705,12 @@ impl Blobstore for Handler {
         container: &str,
     ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<String>> + Sync + Send + Unpin>> {
         let target = self
-            .identify_interface_target(&TargetInterface::WasiBlobstoreBlobstore)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "blobstore",
+                "blobstore",
+                None,
+            )))
             .await?;
         let res = self
             .call_operation(
@@ -699,7 +742,12 @@ impl Blobstore for Handler {
         name: String,
     ) -> anyhow::Result<blobstore::container::ObjectMetadata> {
         let target = self
-            .identify_interface_target(&TargetInterface::WasiBlobstoreBlobstore)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "blobstore",
+                "blobstore",
+                None,
+            )))
             .await?;
         let res = self
             .call_operation(target, "wasmcloud:blobstore/Blobstore.GetObjectInfo", &name)
@@ -724,11 +772,11 @@ impl Bus for Handler {
     #[instrument(level = "trace", skip(self))]
     async fn identify_interface_target(
         &self,
-        target_interface: &TargetInterface,
+        target_interface: &CallTargetInterface,
     ) -> anyhow::Result<Option<TargetEntity>> {
         let links = self.interface_links.read().await;
         let link_name = self.interface_link_name.read().await.clone();
-        let (namespace, package, interface, func) = target_interface.as_parts();
+        let (namespace, package, interface, _) = target_interface.as_parts();
 
         // Determine the lattice target ID we should be sending to
         let lattice_target_id = links
@@ -738,7 +786,7 @@ impl Bus for Handler {
 
         // If we managed to find a target ID, convert it into an entity
         let target_entity = lattice_target_id.map(|id| {
-            TargetEntity::Wrpc(InterfaceTarget {
+            TargetEntity::Wrpc(WrpcInterfaceTarget {
                 id: id.clone(),
                 interface: target_interface.clone(),
                 link_name,
@@ -761,10 +809,9 @@ impl Bus for Handler {
     async fn set_link_name(
         &self,
         link_name: LinkName,
-        interfaces: Vec<TargetInterface>,
+        _interfaces: Vec<CallTargetInterface>,
     ) -> anyhow::Result<()> {
-        let mut current_link_name = self.interface_link_name.write().await;
-        *current_link_name = link_name.unwrap_or_else(|| DEFAULT_LINK_NAME.into());
+        *self.interface_link_name.write().await = link_name;
         Ok(())
     }
 
@@ -836,7 +883,9 @@ impl KeyValueAtomic for Handler {
         }
         let value = delta.try_into().context("delta does not fit in `i32`")?;
         let target = self
-            .identify_interface_target(&TargetInterface::WasiKeyvalueAtomic)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi", "keyvalue", "atomic", None,
+            )))
             .await?;
         let res = self
             .call_operation(
@@ -875,7 +924,9 @@ impl KeyValueEventual for Handler {
             bail!("buckets not currently supported")
         }
         let target = self
-            .identify_interface_target(&TargetInterface::WasiKeyvalueEventual)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi", "keyvalue", "eventual", None,
+            )))
             .await?;
         let res = self
             .call_operation(target, "wasmcloud:keyvalue/KeyValue.Get", &key)
@@ -908,7 +959,9 @@ impl KeyValueEventual for Handler {
             .await
             .context("failed to read value")?;
         let target = self
-            .identify_interface_target(&TargetInterface::WasiKeyvalueEventual)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi", "keyvalue", "eventual", None,
+            )))
             .await?;
         self.call_operation(
             target,
@@ -929,7 +982,9 @@ impl KeyValueEventual for Handler {
             bail!("buckets not currently supported")
         }
         let target = self
-            .identify_interface_target(&TargetInterface::WasiKeyvalueEventual)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi", "keyvalue", "eventual", None,
+            )))
             .await?;
         let res = self
             .call_operation(target, "wasmcloud:keyvalue/KeyValue.Del", &key)
@@ -945,7 +1000,9 @@ impl KeyValueEventual for Handler {
             bail!("buckets not currently supported")
         }
         let target = self
-            .identify_interface_target(&TargetInterface::WasiKeyvalueEventual)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi", "keyvalue", "eventual", None,
+            )))
             .await?;
         self.call_operation(target, "wasmcloud:keyvalue/KeyValue.Contains", &key)
             .await
@@ -1036,7 +1093,12 @@ impl Messaging for Handler {
             .try_into()
             .context("timeout milliseconds do not fit in `u32`")?;
         let target = self
-            .identify_interface_target(&TargetInterface::WasmcloudMessagingConsumer)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasmcloud",
+                "messaging",
+                "consumer",
+                None,
+            )))
             .await?;
         let res = self
             .call_operation(
@@ -1088,7 +1150,12 @@ impl Messaging for Handler {
         }: messaging::types::BrokerMessage,
     ) -> anyhow::Result<()> {
         let target = self
-            .identify_interface_target(&TargetInterface::WasmcloudMessagingConsumer)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasmcloud",
+                "messaging",
+                "consumer",
+                None,
+            )))
             .await?;
         self.call_operation(
             target,
@@ -1122,7 +1189,12 @@ impl OutgoingHttp for Handler {
             .await
             .context("failed to convert HTTP request")?;
         let target = self
-            .identify_interface_target(&CallTargetInterface::WasiHttpOutgoingHandler)
+            .identify_interface_target(&CallTargetInterface::from_parts((
+                "wasi",
+                "http",
+                "outgoing-handler",
+                None,
+            )))
             .await?;
         let res = self
             .call_operation(target, "wasmcloud:httpclient/HttpClient.Request", &req)
@@ -2306,7 +2378,6 @@ impl Host {
             links: Arc::new(RwLock::new(links)),
             interface_link_name: Arc::new(RwLock::new("default".to_string())),
             interface_links: Arc::new(RwLock::new(component_spec.links)),
-            wrpc_targets: Arc::new(RwLock::default()),
             host_key: Arc::clone(&self.host_key),
             polyfilled_imports: imports,
         };
@@ -3413,7 +3484,7 @@ impl Host {
 
         info!(
             source_id,
-            target, package, name, "handling put wrpc link definition"
+            target, wit_package, name, "handling put wrpc link definition"
         );
 
         // Write link for each interface in the package
@@ -3425,7 +3496,7 @@ impl Host {
             .entry(name)
             .and_modify(|link_for_name| {
                 link_for_name
-                    .entry(package.clone())
+                    .entry(wit_package.clone())
                     .and_modify(|package| {
                         for interface in &interfaces {
                             package.insert(interface.clone(), target.clone());
@@ -3443,7 +3514,7 @@ impl Host {
                     .iter()
                     .map(|interface| (interface.clone(), target.clone()))
                     .collect::<HashMap<String, String>>();
-                HashMap::from_iter([(package.clone(), interfaces_map)])
+                HashMap::from_iter([(wit_package.clone(), interfaces_map)])
             });
 
         let spec = actor.component_specification().await;

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -57,9 +57,9 @@ use wasmcloud_core::{
 };
 use wasmcloud_runtime::capability::logging::logging;
 use wasmcloud_runtime::capability::{
-    blobstore, guest_config, messaging, ActorIdentifier, Blobstore, Bus, IncomingHttp,
-    InterfaceTarget, KeyValueAtomic, KeyValueEventual, Logging, Messaging, OutgoingHttp,
-    OutgoingHttpRequest, TargetEntity, TargetInterface,
+    blobstore, guest_config, messaging, ActorIdentifier, Blobstore, Bus, InterfaceTarget,
+    KeyValueAtomic, KeyValueEventual, Logging, Messaging, OutgoingHttp, OutgoingHttpRequest,
+    TargetEntity, TargetInterface,
 };
 use wasmcloud_runtime::Runtime;
 use wasmcloud_tracing::context::TraceContextInjector;
@@ -67,8 +67,7 @@ use wrpc_transport::{Client, Transmitter};
 
 use crate::{
     fetch_actor, HostMetrics, OciConfig, PolicyAction, PolicyHostInfo, PolicyManager,
-    PolicyRequestSource, PolicyRequestTarget, PolicyResponse, RegistryAuth, RegistryConfig,
-    RegistryType,
+    PolicyRequestTarget, PolicyResponse, RegistryAuth, RegistryConfig, RegistryType,
 };
 
 /// wasmCloud host configuration
@@ -214,6 +213,8 @@ impl ActorInstance {
         response_subject: wrpc_transport_nats::Subject,
         transmitter: wrpc_transport_nats::Transmitter,
     ) -> anyhow::Result<()> {
+        // TODO(#1548): implement querying policy server
+
         // Instantiate component with expected handlers
         let mut component_instance = self
             .instantiate()
@@ -2884,7 +2885,7 @@ impl Host {
         if let Ok(spec) = self.get_component_spec(&component_id).await {
             if spec.url != provider_ref {
                 bail!(
-                    "componnet specification URL does not match provider reference: {} != {}",
+                    "component specification URL does not match provider reference: {} != {}",
                     spec.url,
                     provider_ref
                 );

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -24,7 +24,7 @@ use cloudevents::{EventBuilder, EventBuilderV10};
 use futures::stream::{AbortHandle, Abortable, SelectAll};
 use futures::{
     future::{self, Either},
-    join, stream, try_join, FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt,
+    join, stream, try_join, Stream, StreamExt, TryFutureExt, TryStreamExt,
 };
 use nkeys::{KeyPair, KeyPairType};
 use serde::{Deserialize, Serialize};
@@ -63,9 +63,10 @@ use wasmcloud_runtime::capability::{
 };
 use wasmcloud_runtime::Runtime;
 use wasmcloud_tracing::context::TraceContextInjector;
+use wrpc_transport::{Client, Transmitter};
 
 use crate::{
-    fetch_actor, socket_pair, HostMetrics, OciConfig, PolicyAction, PolicyHostInfo, PolicyManager,
+    fetch_actor, HostMetrics, OciConfig, PolicyAction, PolicyHostInfo, PolicyManager,
     PolicyRequestSource, PolicyRequestTarget, PolicyResponse, RegistryAuth, RegistryConfig,
     RegistryType,
 };
@@ -176,7 +177,7 @@ impl Queue {
 
 #[derive(Debug)]
 struct ActorInstance {
-    actor: wasmcloud_runtime::Actor,
+    actor: wasmcloud_runtime::Component,
     nats: async_nats::Client,
     id: Ulid,
     calls: AbortHandle,
@@ -196,7 +197,7 @@ struct ActorInstance {
 }
 
 impl Deref for ActorInstance {
-    type Target = wasmcloud_runtime::Actor;
+    type Target = wasmcloud_runtime::Component;
 
     fn deref(&self) -> &Self::Target {
         &self.actor
@@ -204,18 +205,20 @@ impl Deref for ActorInstance {
 }
 
 impl ActorInstance {
-    pub(crate) async fn instantiate(&self) -> anyhow::Result<wasmcloud_runtime::actor::Instance> {
-        self.actor
-            .instantiate()
-            .await
-            .context("failed to instantiate actor")
-    }
-
-    pub(crate) async fn add_handlers<'a>(
+    /// Handle an incoming wRpc request to invoke an export on this actor instance.
+    async fn handle_wrpc_call(
         &self,
-        instance: &'a mut wasmcloud_runtime::actor::Instance,
+        instance: &str,
+        name: &str,
+        inv_params: Vec<wrpc_transport::Value>,
+        response_subject: wrpc_transport_nats::Subject,
+        transmitter: wrpc_transport_nats::Transmitter,
     ) -> anyhow::Result<()> {
-        instance
+        // Instantiate component with expected handlers
+        let mut component_instance = self
+            .instantiate()
+            .expect("should be able to instantiate actor");
+        component_instance
             .stderr(stderr())
             .await
             .context("failed to set stderr")?
@@ -226,7 +229,31 @@ impl ActorInstance {
             .logging(Arc::new(self.handler.clone()))
             .messaging(Arc::new(self.handler.clone()))
             .outgoing_http(Arc::new(self.handler.clone()));
-        Ok(())
+
+        let start_at = Instant::now();
+        let response = component_instance.call(instance, name, inv_params).await;
+        // Record metric on duration of the call
+        let elapsed = u64::try_from(start_at.elapsed().as_nanos()).unwrap_or_default();
+        self.metrics
+            .wasmcloud_host_handle_rpc_message_duration_ns
+            .record(
+                elapsed,
+                &[
+                    KeyValue::new("actor.ref", self.image_reference.clone()),
+                    KeyValue::new("operation", format!("{instance}/{name}")),
+                ],
+            );
+        match response {
+            Ok(resp) => {
+                transmitter
+                    .transmit_tuple_dynamic(response_subject, resp)
+                    .await
+            }
+            Err(e) => {
+                error!("failed to handle wrpc request: {e}");
+                Ok(())
+            }
+        }
     }
 }
 
@@ -798,163 +825,28 @@ impl Bus for Handler {
             .unwrap_or_default()))
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, params))]
     async fn call(
         &self,
         target: Option<TargetEntity>,
-        operation: String,
-    ) -> anyhow::Result<(
-        Pin<Box<dyn Future<Output = Result<(), String>> + Send>>,
-        Box<dyn AsyncWrite + Sync + Send + Unpin>,
-        Box<dyn AsyncRead + Sync + Send + Unpin>,
-    )> {
-        let (mut req_r, req_w) = socket_pair()?;
-        let (res_r, mut res_w) = socket_pair()?;
+        instance: &str,
+        name: &str,
+        params: Vec<wrpc_transport::Value>,
+    ) -> anyhow::Result<Vec<wrpc_transport::Value>> {
+        if let Some(TargetEntity::Wrpc(interface_target)) = target {
+            let prefix = format!("{}.{}", self.lattice, interface_target.id);
+            let wrpc_client =
+                wrpc_transport_nats::Client::new(self.nats.clone(), prefix.to_string());
+            let (result, _tx) = wrpc_client
+                // TODO: get types
+                .invoke_dynamic(instance, name, params, &[])
+                .await?;
 
-        let links = Arc::clone(&self.links);
-        let aliases = Arc::clone(&self.aliases);
-        let nats = self.nats.clone();
-        let chunk_endpoint = self.chunk_endpoint.clone();
-        let lattice = self.lattice.clone();
-        let origin = self.origin.clone();
-        let cluster_key = self.cluster_key.clone();
-        let host_key = self.host_key.clone();
-        Ok((
-            async move {
-                // TODO: Stream data
-                let mut request = vec![];
-                req_r
-                    .read_to_end(&mut request)
-                    .await
-                    .context("failed to read request")
-                    .map_err(|e| e.to_string())?;
-                let links = links.read().await;
-                let aliases = aliases.read().await;
-                let (package, interface_and_func) = operation
-                    .rsplit_once('/')
-                    .context("failed to parse operation")
-                    .map_err(|e| e.to_string())?;
-                let inv_target = resolve_target(target.as_ref(), links.get(package), &aliases)
-                    .await
-                    .map_err(|e| e.to_string())?;
-                let needs_chunking = request.len() > CHUNK_THRESHOLD_BYTES;
-                let injector = TraceContextInjector::default_with_span();
-                let headers = injector_to_headers(&injector);
-                let mut invocation = Invocation::new(
-                    &cluster_key,
-                    &host_key,
-                    origin,
-                    inv_target.clone(),
-                    operation.clone(),
-                    request,
-                    injector.into(),
-                )
-                .map_err(|e| e.to_string())?;
-
-                if needs_chunking {
-                    chunk_endpoint
-                        .chunkify(&invocation.id, Cursor::new(invocation.msg))
-                        .await
-                        .context("failed to chunk invocation")
-                        .map_err(|e| e.to_string())?;
-                    invocation.msg = vec![];
-                }
-
-                let payload = rmp_serde::to_vec_named(&invocation)
-                    .context("failed to encode invocation")
-                    .map_err(|e| e.to_string())?;
-
-                // Build subject from what we know about the operation
-                let subject = match target {
-                    Some(TargetEntity::Wrpc(target)) => {
-                        let (_, function) = interface_and_func
-                            .split_once('.')
-                            .expect("interface and function should be specified");
-                        let (namespace, package, interface) = target.interface.as_parts();
-                        format!(
-                            "{}.{}.{WRPC}.{WRPC_VERSION}.{}:{}/{}.{}",
-                            lattice, target.id, namespace, package, interface, function
-                        )
-                    }
-                    None | Some(TargetEntity::Link(_)) => format!(
-                        "wasmbus.rpc.{lattice}.{}.{}",
-                        invocation.target.public_key, invocation.target.link_name,
-                    ),
-                    Some(TargetEntity::Actor(_)) => {
-                        format!("wasmbus.rpc.{lattice}.{}", invocation.target.public_key)
-                    }
-                };
-
-                // Determine the timeout required for the request
-                let timeout = needs_chunking.then_some(CHUNK_RPC_EXTRA_TIME); // TODO: add rpc_nats timeout
-
-                // Build and send the NATS request
-                let request = async_nats::Request::new()
-                    .payload(payload.into())
-                    .timeout(timeout)
-                    .headers(headers); // TODO: remove headers once all providers are built off the new SDK, which parses the trace context in the invocation
-                let res = nats
-                    .send_request(subject, request)
-                    .await
-                    .context("failed to call provider")
-                    .map_err(|e| e.to_string())?;
-
-                // Process response
-                let InvocationResponse {
-                    invocation_id,
-                    mut msg,
-                    content_length,
-                    error,
-                    ..
-                } = rmp_serde::from_slice(&res.payload)
-                    .context("failed to decode invocation response")
-                    .map_err(|e| e.to_string())?;
-                if invocation_id != invocation.id {
-                    return Err("invocation ID mismatch".into());
-                }
-
-                let resp_length = usize::try_from(content_length)
-                    .context("content length does not fit in usize")
-                    .map_err(|e| e.to_string())?;
-                if resp_length > CHUNK_THRESHOLD_BYTES {
-                    msg = chunk_endpoint
-                        .get_unchunkified_response(&invocation_id)
-                        .await
-                        .context("failed to dechunk response")
-                        .map_err(|e| e.to_string())?;
-                } else if resp_length != msg.len() {
-                    return Err("message size mismatch".into());
-                }
-
-                // If there was an error then we can
-                if let Some(error) = error {
-                    return Err(error);
-                }
-
-                res_w
-                    .write_all(&msg)
-                    .await
-                    .context("failed to write reply")
-                    .map_err(|e| e.to_string())?;
-                Ok(())
-            }
-            .boxed(),
-            Box::new(req_w),
-            Box::new(res_r),
-        ))
-    }
-
-    #[instrument(level = "trace", skip(self, request))]
-    async fn call_sync(
-        &self,
-        target: Option<TargetEntity>,
-        operation: String,
-        request: Vec<u8>,
-    ) -> anyhow::Result<Vec<u8>> {
-        self.call_operation_with_payload(target, operation, request)
-            .await
-            .context("failed to call linked provider")?
-            .map_err(|e| anyhow!(e).context("provider call failed"))
+            Ok(result)
+        } else {
+            error!("invalid target");
+            Ok(vec![])
+        }
     }
 }
 
@@ -1266,344 +1158,12 @@ impl OutgoingHttp for Handler {
     }
 }
 
-impl ActorInstance {
-    #[instrument(level = "debug", skip(self, msg))]
-    async fn handle_invocation(
-        &self,
-        contract_id: &str,
-        operation: &str,
-        msg: Vec<u8>,
-    ) -> anyhow::Result<Result<Vec<u8>, String>> {
-        let mut instance = self
-            .instantiate()
-            .await
-            .expect("should be able to instantiate actor");
-        self.add_handlers(&mut instance)
-            .await
-            .expect("should be able to setup handlers");
-        #[allow(clippy::single_match_else)] // TODO: Remove once more interfaces supported
-        match (contract_id, operation) {
-            ("wasmcloud:httpserver", "HttpServer.HandleRequest") => {
-                let req: wasmcloud_compat::HttpServerRequest =
-                    rmp_serde::from_slice(&msg).context("failed to decode HTTP request")?;
-                let req = http::Request::try_from(req).context("failed to convert request")?;
-                let res = match instance
-                    .into_incoming_http()
-                    .await
-                    .context("failed to instantiate `wasi:http/incoming-handler`")?
-                    .handle(req.map(|body| -> Box<dyn AsyncRead + Send + Sync + Unpin> {
-                        Box::new(Cursor::new(body))
-                    }))
-                    .await
-                {
-                    Ok(res) => res,
-                    Err(err) => return Ok(Err(format!("{err:#}"))),
-                };
-                let res = wasmcloud_compat::HttpResponse::from_http(res)
-                    .await
-                    .context("failed to convert response")?;
-                let res = rmp_serde::to_vec_named(&res).context("failed to encode response")?;
-                Ok(Ok(res))
-            }
-            _ => {
-                let res = AsyncBytesMut::default();
-                match instance
-                    .call(operation, Cursor::new(msg), res.clone())
-                    .await
-                    .context("failed to call actor")?
-                {
-                    Ok(()) => {
-                        let res = res.try_into().context("failed to unwrap bytes")?;
-                        Ok(Ok(res))
-                    }
-                    Err(e) => Ok(Err(e)),
-                }
-            }
-        }
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    async fn handle_call(&self, invocation: Invocation) -> anyhow::Result<(Vec<u8>, u64)> {
-        trace!(?invocation.origin, ?invocation.target, invocation.operation, "validate actor invocation");
-        invocation.validate_antiforgery(&self.valid_issuers)?;
-
-        let content_length: usize = invocation
-            .content_length
-            .try_into()
-            .context("failed to convert content_length to usize")?;
-        let inv_msg = if content_length > CHUNK_THRESHOLD_BYTES {
-            debug!(inv_id = invocation.id, "dechunking invocation");
-            self.chunk_endpoint.get_unchunkified(&invocation.id).await?
-        } else {
-            invocation.msg
-        };
-
-        trace!(?invocation.origin, ?invocation.target, invocation.operation, "handle actor invocation");
-
-        let source_public_key = invocation.origin.public_key;
-        // actors don't have a contract_id
-        let source = if invocation.origin.contract_id.is_empty() {
-            let actor_claims = self.actor_claims.read().await;
-            let claims = actor_claims
-                .get(&source_public_key)
-                .cloned()
-                .context("failed to look up claims for origin")?;
-            PolicyRequestSource::from(claims)
-        } else {
-            let provider_claims = self.provider_claims.read().await;
-            let claims = provider_claims
-                .get(&source_public_key)
-                .cloned()
-                .context("failed to look up claims for origin")?;
-            let mut source = PolicyRequestSource::from(claims);
-            source.link_name = Some(invocation.origin.link_name.clone());
-            source
-        };
-
-        // actors don't have a contract_id
-        let target_public_key = invocation.target.public_key;
-        let target = if invocation.target.contract_id.is_empty() {
-            let actor_claims = self.actor_claims.read().await;
-            let claims = actor_claims
-                .get(&target_public_key)
-                .cloned()
-                .context("failed to look up claims for target")?;
-            PolicyRequestTarget::from(claims)
-        } else {
-            let provider_claims = self.provider_claims.read().await;
-            let claims = provider_claims
-                .get(&target_public_key)
-                .cloned()
-                .context("failed to look up claims for target")?;
-            let mut target = PolicyRequestTarget::from(claims);
-            target.link_name = Some(invocation.target.link_name.clone());
-            target
-        };
-
-        let resp = self
-            .policy_manager
-            .evaluate_action(Some(source), target, PolicyAction::PerformInvocation)
-            .await?;
-        if !resp.permitted {
-            bail!(
-                "Policy denied request to invoke actor `{}`: `{:?}`",
-                resp.request_id,
-                resp.message
-            );
-        };
-
-        let maybe_resp = self
-            .handle_invocation(
-                &invocation.origin.contract_id,
-                &invocation.operation,
-                inv_msg,
-            )
-            .await
-            .context("failed to handle invocation")?;
-
-        match maybe_resp {
-            Ok(resp_msg) => {
-                let content_length = resp_msg.len();
-                let resp_msg = if content_length > CHUNK_THRESHOLD_BYTES {
-                    debug!(inv_id = invocation.id, "chunking invocation response");
-                    self.chunk_endpoint
-                        .chunkify_response(&invocation.id, Cursor::new(resp_msg))
-                        .await
-                        .context("failed to chunk invocation response")?;
-                    vec![]
-                } else {
-                    resp_msg
-                };
-                Ok((
-                    resp_msg,
-                    content_length
-                        .try_into()
-                        .context("failed to convert content_length to u64")?,
-                ))
-            }
-            Err(e) => Err(anyhow!(e)),
-        }
-    }
-
-    #[instrument(level = "info", skip_all)] // NOTE: level needs to stay at info here to attach the incoming span context
-    async fn handle_rpc_message(&self, message: async_nats::Message) {
-        let async_nats::Message {
-            ref subject,
-            ref reply,
-            ref payload,
-            ..
-        } = message;
-
-        let injector = TraceContextInjector::default_with_span();
-        let headers = injector_to_headers(&injector);
-        let trace_context = injector.into();
-
-        // NOTE(brooksmtownsend): This is some branching code to help us test wRPC handlers. Not
-        // robust but it will help us test.
-        if subject.contains("wrpc") && !subject.contains("wasmbus") && reply.is_some() {
-            self.handle_wrpc_message(message).await;
-            return;
-        }
-
-        let inv_resp = match rmp_serde::from_slice::<Invocation>(payload) {
-            Ok(invocation) => {
-                if !invocation.trace_context.is_empty() {
-                    wasmcloud_tracing::context::attach_span_context(&invocation.trace_context);
-                } else if message.headers.is_some() {
-                    // TODO: remove once all providers are built off the new SDK, which passes the trace context in the invocation
-                    // fall back on message headers
-                    opentelemetry_nats::attach_span_context(&message);
-                }
-
-                let invocation_id = invocation.id.clone();
-                let origin = invocation.origin.clone();
-                let target = invocation.target.clone();
-                let operation = invocation.operation.clone();
-
-                let start_at = Instant::now();
-                let res = self.handle_call(invocation).await;
-                let elapsed = u64::try_from(start_at.elapsed().as_nanos()).unwrap_or_default();
-
-                self.metrics
-                    .wasmcloud_host_handle_rpc_message_duration_ns
-                    .record(
-                        elapsed,
-                        &[
-                            KeyValue::new("actor.ref", self.image_reference.clone()),
-                            KeyValue::new("operation", operation.clone()),
-                        ],
-                    );
-
-                match res {
-                    Ok((msg, content_length)) => InvocationResponse {
-                        msg,
-                        invocation_id,
-                        content_length,
-                        trace_context,
-                        ..Default::default()
-                    },
-                    Err(e) => {
-                        error!(
-                            ?origin,
-                            ?target,
-                            ?operation,
-                            ?invocation_id,
-                            ?e,
-                            "failed to handle request"
-                        );
-                        InvocationResponse {
-                            invocation_id,
-                            error: Some(e.to_string()),
-                            trace_context,
-                            ..Default::default()
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                error!(?subject, ?e, "failed to decode invocation"); // Note: this won't be traced
-                InvocationResponse {
-                    invocation_id: "UNKNOWN".to_string(),
-                    error: Some(e.to_string()),
-                    trace_context,
-                    ..Default::default()
-                }
-            }
-        };
-
-        if let Some(reply) = reply {
-            match rmp_serde::to_vec_named(&inv_resp) {
-                Ok(buf) => {
-                    if let Err(e) = self
-                        .nats
-                        .publish_with_headers(reply.clone(), headers, buf.into())
-                        .await
-                    {
-                        error!(?reply, ?e, "failed to publish response to request");
-                    }
-                }
-                Err(e) => {
-                    error!(?e, "failed to encode response");
-                }
-            }
-        }
-    }
-
-    // NOTE(brooksmtownsend): I doubt this is the proper way to split out the wrpc message handling,
-    // but I'm intentionally keeping it in a separate place for now to make it easier to remove.
-    //
-    // There's no notion of an [`Invocation`] here, as wRPC will deal with encoding and transport, so I'm
-    // working solely with the message payload for now. This is basically set up to enable invoking a component
-    // on its wRPC wasi:http/incoming-handler interface easily.
-    async fn handle_wrpc_message(&self, message: async_nats::Message) {
-        let async_nats::Message {
-            ref subject,
-            ref reply,
-            ref payload,
-            ..
-        } = message;
-        // <lattice>.<id>.wrpc.0.0.1.<interface>.<operation>
-        let subject_parts = subject.split('.').collect::<Vec<_>>();
-        let interface = subject_parts.get(6).unwrap_or(&"UNKNOWNINTERFACE");
-        let operation = subject_parts.get(7).unwrap_or(&"UNKNOWNOPERATION");
-
-        let resp = match (*interface, *operation) {
-            ("wasi:http/incoming-handler", "handle") => {
-                let mut instance = self
-                    .instantiate()
-                    .await
-                    .expect("should be able to instantiate actor");
-                self.add_handlers(&mut instance)
-                    .await
-                    .expect("should be able to setup handlers");
-                let http_request = http::Request::new(payload.clone());
-                let res = match instance
-                    .into_incoming_http()
-                    .await
-                    .context("failed to instantiate `wasi:http/incoming-handler`")
-                    .expect("to instantiate `wasi:http/incoming-handler`")
-                    .handle(
-                        http_request.map(|body| -> Box<dyn AsyncRead + Send + Sync + Unpin> {
-                            Box::new(Cursor::new(body))
-                        }),
-                    )
-                    .await
-                {
-                    Ok(response) => response,
-                    Err(err) => {
-                        error!(err = err.to_string(), "Failure handling wRPC invocation");
-                        return;
-                    }
-                };
-                let wasmcloud_http_response = wasmcloud_compat::HttpResponse::from_http(res)
-                    .await
-                    .expect("failed to convert response");
-                wasmcloud_http_response.body
-            }
-            _ => format!("Unknown WASI handler {interface} {operation}").into_bytes(),
-        };
-
-        if let Err(e) = self
-            .nats
-            .publish_with_headers(
-                // SAFETY: we know it's safe because we checked for a reply before calling this function
-                reply.clone().expect("reply to exist"),
-                async_nats::HeaderMap::new(),
-                resp.into(),
-            )
-            .await
-        {
-            error!(?reply, ?e, "failed to publish response to request");
-        }
-    }
-}
-
 type Annotations = BTreeMap<String, String>;
 
 #[derive(Debug)]
 struct Actor {
     #[allow(clippy::struct_field_names)]
-    actor: wasmcloud_runtime::Actor,
+    actor: wasmcloud_runtime::Component,
     /// `instances` is a map from a set of Annotations to the instance associated
     /// with those annotations
     instances: RwLock<HashMap<Annotations, Arc<ActorInstance>>>,
@@ -1611,7 +1171,7 @@ struct Actor {
 }
 
 impl Deref for Actor {
-    type Target = wasmcloud_runtime::Actor;
+    type Target = wasmcloud_runtime::Component;
 
     fn deref(&self) -> &Self::Target {
         &self.actor
@@ -2571,7 +2131,7 @@ impl Host {
         annotations: &Annotations,
         actor_ref: impl AsRef<str>,
         max_instances: NonZeroUsize,
-        actor: wasmcloud_runtime::Actor,
+        actor: wasmcloud_runtime::Component,
         handler: Handler,
     ) -> anyhow::Result<Arc<ActorInstance>> {
         trace!(
@@ -2581,48 +2141,19 @@ impl Host {
         );
 
         let actor_ref = actor_ref.as_ref();
-        let topic = match actor {
-            wasmcloud_runtime::Actor::Module(_) => {
-                debug!(actor_ref, "instantiating module");
-                // (DEPRECATED) Modules communicate over wasmbus RPC
-                // Example incoming topic: wasmbus.rpc.default.MBASDMYACTORID
-                format!(
-                    "wasmbus.rpc.{lattice}.{subject}",
-                    lattice = self.host_config.lattice,
-                    subject = claims.subject
-                )
-            }
-            wasmcloud_runtime::Actor::Component(_) => {
-                debug!(actor_ref, "instantiating component");
-                // TODO: Components subscribe on wRPC topics
-                // Example incoming topic:
-                //   default.echo.wrpc.0.0.1.wasi:http/incoming-handler.handle
-                // format!(
-                //     "{lattice}.{component_id}.{WRPC}.{WRPC_VERSION}.>",
-                //     lattice = self.host_config.lattice,
-                //     component_id = sanitize_reference(actor_ref),
-                // )
-                format!(
-                    "wasmbus.rpc.{lattice}.{subject}",
-                    lattice = self.host_config.lattice,
-                    subject = claims.subject
-                )
-            }
-        };
         let actor = actor.clone();
         let handler = handler.clone();
-        let instance = async move {
-            let calls = self
-                .rpc_nats
-                .queue_subscribe(topic.clone(), topic)
-                .await
-                .context("failed to subscribe to actor call queue")?;
 
+        let component_id = &claims.subject;
+        let lattice = &self.host_config.lattice;
+        let prefix = format!("{lattice}.{component_id}");
+        let wrpc_client = wrpc_transport_nats::Client::new(self.rpc_nats.clone(), prefix);
+        let instance = async move {
             let (calls_abort, calls_abort_reg) = AbortHandle::new_pair();
             let id = Ulid::new();
-            let instance = Arc::new(ActorInstance {
+            let actor_instance = Arc::new(ActorInstance {
                 nats: self.rpc_nats.clone(),
-                actor,
+                actor: actor.clone(),
                 id,
                 calls: calls_abort,
                 handler: handler.clone(),
@@ -2637,20 +2168,60 @@ impl Host {
                 metrics: Arc::clone(&self.metrics),
             });
 
+            let mut component_export_handlers = Vec::new();
+            let exports = actor.exports();
+            for (instance, name_and_func) in exports.iter() {
+                for (name, function) in name_and_func {
+                    if let wrpc_types::DynamicFunction::Static { params, .. } = function {
+                        let instance = instance.clone();
+                        let name = name.clone();
+                        // TODO(#1220): In order to implement invocation signing and response verification, we can override the
+                        // wrpc_transport::Invocation and wrpc_transport::Client trait in order to wrap the invocation with necessary
+                        // logic to verify the incoming invocations and sign the outgoing responses.
+                        trace!(instance, name, "serving wrpc function export");
+                        let export_handler = wrpc_client
+                            .serve_dynamic(&instance, &name, params.clone())
+                            .await
+                            .expect("should be able to serve function export")
+                            // map the stream to include the instance and name to call for each invocation
+                            .map(move |invocation| (instance.clone(), name.clone(), invocation));
+                        component_export_handlers.push(export_handler);
+                    }
+                }
+            }
+
+            let all_handlers = futures::stream::select_all::select_all(component_export_handlers);
+            let limit = max_instances.get();
+            let actor_instance = Arc::clone(&actor_instance);
             let _calls = spawn({
-                let instance = Arc::clone(&instance);
-                let limit = max_instances.get();
-                // Each Nats request needs to be handled by a different async task, to use all CPU core
-                Abortable::new(calls, calls_abort_reg).for_each_concurrent(limit, move |msg| {
-                    let instance = Arc::clone(&instance);
-                    spawn(async move {
-                        let instance = Arc::clone(&instance);
-                        instance.handle_rpc_message(msg).await;
-                    });
-                    future::ready(())
-                })
+                let actor_instance = Arc::clone(&actor_instance);
+                Abortable::new(all_handlers, calls_abort_reg).for_each_concurrent(
+                    limit,
+                    move |(instance, name, invocation)| {
+                        let actor_instance = Arc::clone(&actor_instance);
+                        let Ok((inv_params, response_subject, tx)) = invocation else {
+                            error!("invocation did not include ok");
+                            return future::ready(());
+                        };
+                        // TODO(#1568): When headers are added to wRPC, ensure we propagate the trace parent
+                        // Linked PR above is when the functionality was removed.
+                        spawn(async move {
+                            let actor_instance = Arc::clone(&actor_instance);
+                            actor_instance
+                                .handle_wrpc_call(
+                                    &instance,
+                                    &name,
+                                    inv_params,
+                                    response_subject,
+                                    tx,
+                                )
+                                .await
+                        });
+                        future::ready(())
+                    },
+                )
             });
-            anyhow::Result::<_>::Ok(instance)
+            anyhow::Result::<_>::Ok(actor_instance)
         }
         .await
         .context("failed to instantiate actor")?;
@@ -2674,7 +2245,7 @@ impl Host {
     async fn start_actor<'a>(
         &self,
         entry: hash_map::VacantEntry<'a, String, Arc<Actor>>,
-        actor: wasmcloud_runtime::Actor,
+        actor: wasmcloud_runtime::Component,
         actor_ref: String,
         max_instances: NonZeroUsize,
         host_id: &str,
@@ -2887,7 +2458,7 @@ impl Host {
     }
 
     #[instrument(level = "trace", skip_all)]
-    async fn fetch_actor(&self, actor_ref: &str) -> anyhow::Result<wasmcloud_runtime::Actor> {
+    async fn fetch_actor(&self, actor_ref: &str) -> anyhow::Result<wasmcloud_runtime::Component> {
         let registry_config = self.registry_config.read().await;
         let actor = fetch_actor(
             actor_ref,
@@ -2896,7 +2467,7 @@ impl Host {
         )
         .await
         .context("failed to fetch actor")?;
-        let actor = wasmcloud_runtime::Actor::new(&self.runtime, actor)
+        let actor = wasmcloud_runtime::Component::new(&self.runtime, actor)
             .context("failed to initialize actor")?;
         Ok(actor)
     }

--- a/crates/runtime/src/actor/component/mod.rs
+++ b/crates/runtime/src/actor/component/mod.rs
@@ -1,6 +1,6 @@
 use crate::actor::claims;
-use crate::capability::{builtin, Bus, Interfaces};
 use crate::capability::builtin::CallTargetInterface;
+use crate::capability::{builtin, Bus, Interfaces};
 use crate::Runtime;
 
 use core::fmt::{self, Debug};

--- a/crates/runtime/src/capability/builtin.rs
+++ b/crates/runtime/src/capability/builtin.rs
@@ -229,6 +229,7 @@ pub struct CallTargetInterface {
     pub package: String,
     /// WIT interface (ex. `readwrite` in `wasi:keyvalue/readwrite.get`)
     pub interface: String,
+    // TODO(brooksmtownsend): I'm almost certain we do not need this.
     /// WIT package name (ex. `get` in `wasi:keyvalue/readwrite.get`)
     pub function: Option<String>,
 }

--- a/crates/runtime/src/capability/mod.rs
+++ b/crates/runtime/src/capability/mod.rs
@@ -5,7 +5,7 @@ pub mod provider;
 
 pub use builtin::{
     ActorIdentifier, Blobstore, Bus, IncomingHttp, KeyValueAtomic, KeyValueEventual, Logging,
-    Messaging, OutgoingHttp, OutgoingHttpRequest, TargetEntity, 
+    Messaging, OutgoingHttp, OutgoingHttpRequest, TargetEntity, WrpcInterfaceTarget,
 };
 
 // NOTE: this import is used below in bindgen


### PR DESCRIPTION
## Features
This PR adds support for components serving dynamic functions based on their exports on wRPC topics. I've tested this using a small binary that invokes a component exporting a function `foo`, as shown below in the manual verification section. The vast majority of this PR is removing code that's no longer exercised for handling and sending invocations over wasmbus, instead replaced with serving dynamic functions on wRPC.

I also implemented importing functions and, using the polyfilled interfaces, invoking other components on the lattice via wRPC. This will work great for our custom interfaces, but HTTP, keyvalue, blobstore, and messaging all need to be reworked to send wRPC messages instead (see TODO under `call_operation`).

I've left a few `TODO` comments regarding policy checking and invocation signing/response signing so we can keep an eye on where those should be implemented.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification