### PR TITLE
feat(host)!: fully support component interface links, remove aliases

### DIFF
--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -180,6 +180,12 @@ pub struct LinkDefinitionList {
     pub links: Vec<LinkDefinition>,
 }
 
+/// A list of interface link definitions
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct InterfaceLinkDefinitionList {
+    pub links: Vec<InterfaceLinkDefinition>,
+}
+
 /// One of a potential list of responses to a provider auction
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ProviderAuctionAck {
@@ -309,6 +315,22 @@ pub struct RemoveLinkDefinitionRequest {
     /// The provider's link name
     #[serde(default)]
     pub link_name: String,
+}
+
+/// A request to remove a link definition and detach the relevant actor
+/// from the given provider
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RemoveInterfaceLinkDefinitionRequest {
+    /// The actor's public key. This cannot be an image reference
+    #[serde(default)]
+    pub source_id: String,
+    /// Name of the link. Not providing this is equivalent to specifying Some("default")
+    #[serde(default = "default_link_name")]
+    pub name: LinkName,
+    /// WIT namespace of the link operation, e.g. `wasi` in `wasi:keyvalue/readwrite.get`
+    pub wit_namespace: WitNamespace,
+    /// WIT package of the link operation, e.g. `keyvalue` in `wasi:keyvalue/readwrite.get`
+    pub wit_package: WitPackage,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -462,15 +484,15 @@ pub type KnownConfigName = String;
 /// interface. An [`InterfaceLinkDefinition`] connects one component's import to another
 /// component's export, specifying the configuration each component needs in order to execute
 /// the request, and represents an operator's intent to allow the source to invoke the target.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize, Hash)]
 pub struct InterfaceLinkDefinition {
     /// Source identifier for the link
     pub source_id: ComponentId,
     /// Target for the link, which can be a unique identifier or (future) a routing group
     pub target: LatticeTarget,
-    /// Name of the link. Not providing this is equivalent to specifying Some("default")
-    #[serde(default)]
-    pub name: Option<LinkName>,
+    /// Name of the link. Not providing this is equivalent to specifying "default"
+    #[serde(default = "default_link_name")]
+    pub name: LinkName,
     /// WIT namespace of the link operation, e.g. `wasi` in `wasi:keyvalue/readwrite.get`
     pub wit_namespace: WitNamespace,
     /// WIT package of the link operation, e.g. `keyvalue` in `wasi:keyvalue/readwrite.get`
@@ -483,6 +505,11 @@ pub struct InterfaceLinkDefinition {
     /// List of named configurations to provide to the target upon request
     #[serde(default)]
     pub target_config: Vec<KnownConfigName>,
+}
+
+/// Helper function to provide a default link name
+fn default_link_name() -> LinkName {
+    "default".to_string()
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -5,7 +5,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 use core::time::Duration;
 use std::collections::hash_map::{self, Entry};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::env::consts::{ARCH, FAMILY, OS};
 use std::io::Cursor;
@@ -45,9 +45,9 @@ pub use config::Host as HostConfig;
 use wascap::{jwt, prelude::ClaimsBuilder};
 use wasmcloud_control_interface::{
     ActorAuctionAck, ActorAuctionRequest, ActorDescription, GetClaimsResponse, HostInventory,
-    HostLabel, InterfaceLinkDefinition, LinkDefinition, LinkDefinitionList, ProviderAuctionAck,
+    HostLabel, InterfaceLinkDefinition, InterfaceLinkDefinitionList, ProviderAuctionAck,
     ProviderAuctionRequest, ProviderDescription, RegistryCredential, RegistryCredentialMap,
-    RemoveLinkDefinitionRequest, ScaleActorCommand, StartProviderCommand, StopHostCommand,
+    RemoveInterfaceLinkDefinitionRequest, ScaleActorCommand, StartProviderCommand, StopHostCommand,
     StopProviderCommand, UpdateActorCommand, WitInterface,
 };
 use wasmcloud_core::{
@@ -56,9 +56,9 @@ use wasmcloud_core::{
 };
 use wasmcloud_runtime::capability::logging::logging;
 use wasmcloud_runtime::capability::{
-    blobstore, guest_config, messaging, ActorIdentifier, Blobstore, Bus, CallTargetInterface,
-    KeyValueAtomic, KeyValueEventual, Logging, Messaging, OutgoingHttp, OutgoingHttpRequest,
-    TargetEntity, WrpcInterfaceTarget,
+    blobstore, guest_config, messaging, Blobstore, Bus, CallTargetInterface, KeyValueAtomic,
+    KeyValueEventual, Logging, Messaging, OutgoingHttp, OutgoingHttpRequest, TargetEntity,
+    WrpcInterfaceTarget,
 };
 use wasmcloud_runtime::Runtime;
 use wasmcloud_tracing::context::TraceContextInjector;
@@ -266,9 +266,6 @@ struct Handler {
     host_key: Arc<KeyPair>,
     claims: jwt::Claims<jwt::Actor>,
     origin: WasmCloudEntity,
-    // package -> target -> entity
-    links: Arc<RwLock<HashMap<String, HashMap<String, WasmCloudEntity>>>>,
-
     /// The current link name to use for interface targets, overridable in actor code via set_target()
     interface_link_name: Arc<RwLock<LinkName>>,
 
@@ -284,26 +281,17 @@ struct Handler {
     #[allow(clippy::type_complexity)]
     interface_links:
         Arc<RwLock<HashMap<LinkName, HashMap<String, HashMap<WitInterface, LatticeTargetId>>>>>,
-    aliases: Arc<RwLock<HashMap<String, WasmCloudEntity>>>,
     // interface -> function -> result types
     polyfilled_imports: HashMap<String, HashMap<String, Arc<[wrpc_types::Type]>>>,
 }
 
 #[instrument(level = "trace")]
-async fn resolve_target(
-    target: Option<&TargetEntity>,
-    links: Option<&HashMap<String, WasmCloudEntity>>,
-    aliases: &HashMap<String, WasmCloudEntity>,
-) -> anyhow::Result<WasmCloudEntity> {
+async fn resolve_target(target: Option<&TargetEntity>) -> anyhow::Result<WasmCloudEntity> {
     const DEFAULT_LINK_NAME: &str = "default";
 
     trace!("resolve target");
 
     let target = match target {
-        None => links
-            .and_then(|targets| targets.get(DEFAULT_LINK_NAME))
-            .context("link not found")?
-            .clone(),
         Some(TargetEntity::Wrpc(target)) => {
             let (namespace, package, _, _) = target.interface.as_parts();
             WasmCloudEntity {
@@ -312,18 +300,7 @@ async fn resolve_target(
                 link_name: target.link_name.clone(),
             }
         }
-        Some(TargetEntity::Link(link_name)) => links
-            .and_then(|targets| targets.get(link_name.as_deref().unwrap_or(DEFAULT_LINK_NAME)))
-            .context("link not found")?
-            .clone(),
-        Some(TargetEntity::Actor(ActorIdentifier::Key(key))) => WasmCloudEntity {
-            public_key: key.public_key(),
-            ..Default::default()
-        },
-        Some(TargetEntity::Actor(ActorIdentifier::Alias(alias))) => aliases
-            .get(alias)
-            .context("unknown actor call alias")?
-            .clone(),
+        _ => bail!("target not found"),
     };
     Ok(target)
 }
@@ -337,14 +314,11 @@ impl Handler {
         request: Vec<u8>,
     ) -> anyhow::Result<Result<Vec<u8>, String>> {
         let operation = operation.into();
-        let links = self.links.read().await;
-        let aliases = self.aliases.read().await;
-
         // Determine the target for the operation
-        let (package, interface_and_func) = operation
+        let (_, interface_and_func) = operation
             .rsplit_once('/')
             .context("failed to parse operation")?;
-        let inv_target = resolve_target(target.as_ref(), links.get(package), &aliases).await?;
+        let inv_target = resolve_target(target.as_ref()).await?;
         let injector = TraceContextInjector::default_with_span();
         let headers = injector_to_headers(&injector);
         let invocation = Invocation::new(
@@ -372,14 +346,8 @@ impl Handler {
                     self.lattice, target.id, namespace, package, interface, function
                 )
             }
-            None | Some(TargetEntity::Link(_)) => format!(
-                "wasmbus.rpc.{}.{}.{}",
-                self.lattice, invocation.target.public_key, invocation.target.link_name,
-            ),
-            Some(TargetEntity::Actor(_)) => format!(
-                "wasmbus.rpc.{}.{}",
-                self.lattice, invocation.target.public_key
-            ),
+            // TODO: just remove other options entirely
+            _ => bail!("invalid target"),
         };
 
         let request = async_nats::Request::new()
@@ -1309,8 +1277,8 @@ pub struct Host {
     stop_tx: watch::Sender<Option<Instant>>,
     stop_rx: watch::Receiver<Option<Instant>>,
     queue: AbortHandle,
-    aliases: Arc<RwLock<HashMap<String, WasmCloudEntity>>>,
-    links: RwLock<HashMap<String, LinkDefinition>>,
+    // Component ID -> All Links
+    links: RwLock<HashMap<String, HashSet<InterfaceLinkDefinition>>>,
     actor_claims: Arc<RwLock<HashMap<String, jwt::Claims<jwt::Actor>>>>, // TODO: use a single map once Claims is an enum
     provider_claims: Arc<RwLock<HashMap<String, jwt::Claims<jwt::CapabilityProvider>>>>,
     config_data_cache: Arc<RwLock<ConfigCache>>,
@@ -1815,7 +1783,6 @@ impl Host {
             stop_rx,
             stop_tx,
             queue: queue_abort.clone(),
-            aliases: Arc::default(),
             links: RwLock::default(),
             actor_claims: Arc::default(),
             provider_claims: Arc::default(),
@@ -2316,30 +2283,6 @@ impl Host {
             .await
             .context("failed to store claims")?;
 
-        let links = self.links.read().await;
-        let links = links
-            .values()
-            .filter(|ld| ld.actor_id == claims.subject)
-            .fold(
-                HashMap::<_, HashMap<_, _>>::default(),
-                |mut links,
-                 LinkDefinition {
-                     link_name,
-                     contract_id,
-                     provider_id,
-                     ..
-                 }| {
-                    links.entry(contract_id.clone()).or_default().insert(
-                        link_name.clone(),
-                        WasmCloudEntity {
-                            link_name: link_name.clone(),
-                            contract_id: contract_id.clone(),
-                            public_key: provider_id.clone(),
-                        },
-                    );
-                    links
-                },
-            );
         let origin = WasmCloudEntity {
             public_key: claims.subject.clone(),
             ..Default::default()
@@ -2374,8 +2317,6 @@ impl Host {
             origin,
             cluster_key: Arc::clone(&self.cluster_key),
             claims: claims.clone(),
-            aliases: Arc::clone(&self.aliases),
-            links: Arc::new(RwLock::new(links)),
             interface_link_name: Arc::new(RwLock::new("default".to_string())),
             interface_links: Arc::new(RwLock::new(component_spec.links)),
             host_key: Arc::clone(&self.host_key),
@@ -2536,33 +2477,6 @@ impl Host {
 
     #[instrument(level = "trace", skip_all)]
     async fn store_actor_claims(&self, claims: jwt::Claims<jwt::Actor>) -> anyhow::Result<()> {
-        if let Some(call_alias) = claims
-            .metadata
-            .as_ref()
-            .and_then(|jwt::Actor { call_alias, .. }| call_alias.clone())
-        {
-            let mut aliases = self.aliases.write().await;
-            match aliases.entry(call_alias) {
-                Entry::Occupied(mut entry) => {
-                    warn!(
-                        alias = entry.key(),
-                        existing_public_key = entry.get().public_key,
-                        new_public_key = claims.subject,
-                        "call alias clash. Replacing existing entry"
-                    );
-                    entry.insert(WasmCloudEntity {
-                        public_key: claims.subject.clone(),
-                        ..Default::default()
-                    });
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(WasmCloudEntity {
-                        public_key: claims.subject.clone(),
-                        ..Default::default()
-                    });
-                }
-            }
-        }
         let mut actor_claims = self.actor_claims.write().await;
         actor_claims.insert(claims.subject.clone(), claims);
         Ok(())
@@ -2975,20 +2889,6 @@ impl Host {
                 .cluster_key
                 .seed()
                 .context("cluster key seed missing")?;
-            let links = self.links.read().await;
-            // TODO: update type of links to use wasmcloud_core::LinkDefinition
-            let link_definitions: Vec<_> = links
-                .clone()
-                .into_values()
-                .filter(|ld| ld.provider_id == claims.subject && ld.link_name == link_name)
-                .map(|ld| wasmcloud_core::LinkDefinition {
-                    actor_id: ld.actor_id,
-                    provider_id: ld.provider_id,
-                    link_name: ld.link_name,
-                    contract_id: ld.contract_id,
-                    values: ld.values.into_iter().collect(),
-                })
-                .collect();
             let lattice_rpc_user_seed = self
                 .host_config
                 .rpc_key
@@ -3017,7 +2917,8 @@ impl Host {
                 env_values: vec![],
                 instance_id: Uuid::from_u128(id.into()).to_string(),
                 provider_key: component_id.clone(),
-                link_definitions,
+                // TODO: update type of links to provide wrpc links
+                link_definitions: vec![],
                 config_json: configuration,
                 default_rpc_timeout_ms,
                 cluster_issuers: self.cluster_issuers.clone(),
@@ -3374,13 +3275,13 @@ impl Host {
         Ok(res.into())
     }
 
-    // #[instrument(level = "debug", skip_all)] // FIXME: this is temporarily disabled because wadm (as of v0.8.0) queries links too often
+    #[instrument(level = "debug", skip_all)]
     async fn handle_links(&self) -> anyhow::Result<Bytes> {
-        trace!("handling links"); // FIXME: set back to debug when instrumentation is re-enabled
+        debug!("handling links");
 
         let links = self.links.read().await;
-        let links: Vec<LinkDefinition> = links.values().cloned().collect();
-        let res = serde_json::to_vec(&LinkDefinitionList { links })
+        let links: Vec<InterfaceLinkDefinition> = links.values().cloned().flatten().collect();
+        let res = serde_json::to_vec(&InterfaceLinkDefinitionList { links })
             .context("failed to serialize response")?;
         Ok(res.into())
     }
@@ -3462,15 +3363,17 @@ impl Host {
     #[instrument(level = "debug", skip_all)]
     async fn handle_interface_link_put(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
         let payload = payload.as_ref();
+        let interface_link_definition: InterfaceLinkDefinition = serde_json::from_slice(payload)
+            .context("failed to deserialize wrpc link definition")?;
         let InterfaceLinkDefinition {
             source_id,
             target,
+            wit_namespace,
             wit_package,
             interfaces,
-            name: link_name,
+            name,
             ..
-        } = serde_json::from_slice(payload)
-            .context("failed to deserialize wrpc link definition")?;
+        } = interface_link_definition.clone();
 
         let actors = self.actors.read().await;
 
@@ -3479,12 +3382,11 @@ impl Host {
             return Ok(r#"{"accepted":false,"error":"no actor found for that ID"}"#.into());
         };
 
-        // NOTE: We can't leave it as an Option<String> as a `None` key cannot be serialized to JSON
-        let name = link_name.clone().unwrap_or("default".to_string());
+        let ns_and_package = format!("{}:{}", wit_namespace, wit_package);
 
-        info!(
+        debug!(
             source_id,
-            target, wit_package, name, "handling put wrpc link definition"
+            target, ns_and_package, name, "handling put wrpc link definition"
         );
 
         // Write link for each interface in the package
@@ -3496,7 +3398,7 @@ impl Host {
             .entry(name)
             .and_modify(|link_for_name| {
                 link_for_name
-                    .entry(wit_package.clone())
+                    .entry(ns_and_package.clone())
                     .and_modify(|package| {
                         for interface in &interfaces {
                             package.insert(interface.clone(), target.clone());
@@ -3514,62 +3416,112 @@ impl Host {
                     .iter()
                     .map(|interface| (interface.clone(), target.clone()))
                     .collect::<HashMap<String, String>>();
-                HashMap::from_iter([(wit_package.clone(), interfaces_map)])
+                HashMap::from_iter([(ns_and_package.clone(), interfaces_map)])
             });
 
         let spec = actor.component_specification().await;
         self.store_component_spec(&source_id, &spec).await?;
 
+        // Insert link into host map
+        self.links
+            .write()
+            .await
+            .entry(source_id.clone())
+            .and_modify(|links| {
+                links.replace(interface_link_definition.clone());
+            })
+            .or_insert(HashSet::from_iter([interface_link_definition]));
+
+        // TODO: Publish event
+        // self.publish_event(
+        //     "linkdef_set",
+        //     event::linkdef_set(id, actor_id, provider_id, link_name, contract_id, values),
+        // )
+        // .await?;
+        // TODO: tell the provider to set the link
+        // self.rpc_nats
+        // .publish_with_headers(
+        //     format!("wasmbus.rpc.{lattice}.{provider_id}.{link_name}.linkdefs.set",),
+        //     injector_to_headers(&TraceContextInjector::default_with_span()),
+        //     msgp.into(),
+        // )
+        // .await
+        // .context("failed to publish link definition set")?;
+
         Ok(ACCEPTED.into())
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn handle_linkdef_put(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
+    /// Remove an interface link on a source component for a specific package
+    async fn handle_interface_link_del(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
         let payload = payload.as_ref();
-        let Ok(LinkDefinition {
-            actor_id,
-            provider_id,
-            link_name,
-            contract_id,
+        let RemoveInterfaceLinkDefinitionRequest {
+            source_id,
+            wit_namespace,
+            wit_package,
+            name,
             ..
-        }) = serde_json::from_slice(payload).context("failed to deserialize link definition")
-        else {
-            // TODO(#1568): make this the default instead of the fallback
-            return self.handle_interface_link_put(payload).await;
+        } = serde_json::from_slice(payload)
+            .context("failed to deserialize wrpc link definition")?;
+
+        let actors = self.actors.read().await;
+
+        let Ok(actor) = actors.get(&source_id).context("actor not found") else {
+            return Ok(r#"{"accepted":true,"error":""}"#.into());
         };
-        let id = linkdef_hash(&actor_id, &contract_id, &link_name);
 
-        info!(
-            actor_id,
-            provider_id, link_name, contract_id, "handling put link definition"
+        let ns_and_package = format!("{}:{}", wit_namespace, wit_package);
+
+        debug!(
+            source_id,
+            ns_and_package, name, "handling del wrpc link definition"
         );
 
-        self.data
-            .put(format!("LINKDEF_{id}"), Bytes::copy_from_slice(payload))
+        // Remove the interface links for the given link name and package
+        actor
+            .handler
+            .interface_links
+            .write()
             .await
-            .map_err(|e| anyhow!(e).context("failed to store link definition"))?;
-        Ok(ACCEPTED.into())
-    }
+            .entry(name.clone())
+            .and_modify(|link_for_name| {
+                link_for_name.remove(&ns_and_package);
+            });
 
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_linkdef_del(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
-        let RemoveLinkDefinitionRequest {
-            actor_id,
-            ref link_name,
-            contract_id,
-        } = serde_json::from_slice(payload.as_ref())
-            .context("failed to deserialize link definition deletion command")?;
-        let id = linkdef_hash(&actor_id, &contract_id, link_name);
+        let spec = actor.component_specification().await;
+        self.store_component_spec(&source_id, &spec).await?;
 
-        info!(
-            actor_id,
-            link_name, contract_id, "handling delete link definition"
-        );
-
-        self.data
-            .delete(format!("LINKDEF_{id}"))
+        // Remove link from host map
+        self.links
+            .write()
             .await
-            .map_err(|e| anyhow!(e).context("failed to delete link definition"))?;
+            .entry(source_id.clone())
+            // TODO: would be more efficient to be able to look up the link by hash and remove instead of iterating
+            .and_modify(|links| {
+                // Retain links that don't match the link we're removing
+                links.retain(|interface_link_definition| {
+                    interface_link_definition.wit_namespace != wit_namespace
+                        || interface_link_definition.wit_package != wit_package
+                        || interface_link_definition.name != name
+                });
+            });
+
+        // TODO: Publish event
+        // self.publish_event(
+        //     "linkdef_deleted",
+        //     event::linkdef_deleted(id, actor_id, link_name, contract_id),
+        // )
+        // .await?;
+        // TODO: tell the provider to delete the link
+        // self.rpc_nats
+        // .publish_with_headers(
+        //     format!("wasmbus.rpc.{lattice}.{provider_id}.{link_name}.linkdefs.del",),
+        //     injector_to_headers(&TraceContextInjector::default_with_span()),
+        //     msgp.into(),
+        // )
+        // .await
+        // .context("failed to publish link definition deletion")?;
+
         Ok(ACCEPTED.into())
     }
 
@@ -3744,12 +3696,14 @@ impl Host {
             (Some("claims"), Some("get"), None, None) => self.handle_claims().await.map(Some),
 
             (Some("link"), Some("get"), None, None) => self.handle_links().await.map(Some),
-            (Some("link"), Some("put"), None, None) => {
-                self.handle_linkdef_put(message.payload).await.map(Some)
-            }
-            (Some("link"), Some("del"), None, None) => {
-                self.handle_linkdef_del(message.payload).await.map(Some)
-            }
+            (Some("link"), Some("put"), None, None) => self
+                .handle_interface_link_put(message.payload)
+                .await
+                .map(Some),
+            (Some("link"), Some("del"), None, None) => self
+                .handle_interface_link_del(message.payload)
+                .await
+                .map(Some),
 
             (Some("label"), Some("del"), Some(_host_id), None) => {
                 self.handle_label_del(message.payload).await.map(Some)
@@ -3916,126 +3870,6 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn process_linkdef_put(
-        &self,
-        id: impl AsRef<str>,
-        value: impl AsRef<[u8]>,
-        publish: bool,
-    ) -> anyhow::Result<()> {
-        let id = id.as_ref();
-        let value = value.as_ref();
-        let ref ld @ LinkDefinition {
-            ref actor_id,
-            ref provider_id,
-            ref link_name,
-            ref contract_id,
-            ref values,
-            ..
-        } = serde_json::from_slice(value).context("failed to deserialize link definition")?;
-        ensure!(
-            id == linkdef_hash(actor_id, contract_id, link_name),
-            "linkdef hash mismatch"
-        );
-
-        info!(
-            actor_id,
-            provider_id, link_name, contract_id, "process link definition entry put"
-        );
-
-        self.links.write().await.insert(id.to_string(), ld.clone()); // NOTE: this is one statement so the write lock is immediately dropped
-        if let Some(actor) = self.actors.read().await.get(actor_id) {
-            let mut links = actor.handler.links.write().await;
-            links.entry(contract_id.clone()).or_default().insert(
-                ld.link_name.clone(),
-                WasmCloudEntity {
-                    link_name: ld.link_name.clone(),
-                    contract_id: ld.contract_id.clone(),
-                    public_key: ld.provider_id.clone(),
-                },
-            );
-        }
-
-        if publish {
-            self.publish_event(
-                "linkdef_set",
-                event::linkdef_set(id, actor_id, provider_id, link_name, contract_id, values),
-            )
-            .await?;
-        }
-
-        let msgp = rmp_serde::to_vec_named(ld).context("failed to encode link definition")?;
-        let lattice = &self.host_config.lattice;
-        self.rpc_nats
-            .publish_with_headers(
-                format!("wasmbus.rpc.{lattice}.{provider_id}.{link_name}.linkdefs.put",),
-                injector_to_headers(&TraceContextInjector::default_with_span()),
-                msgp.into(),
-            )
-            .await
-            .context("failed to publish link definition")?;
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn process_linkdef_delete(
-        &self,
-        id: impl AsRef<str>,
-        _value: impl AsRef<[u8]>,
-        publish: bool,
-    ) -> anyhow::Result<()> {
-        let id = id.as_ref();
-
-        // NOTE: There is a race condition here, which occurs when `linkdefs.del`
-        // is used before `data_watch` task has fully imported the current lattice,
-        // but that command is deprecated, so assume it's fine
-        let ref ld @ LinkDefinition {
-            ref actor_id,
-            ref provider_id,
-            ref link_name,
-            ref contract_id,
-            ref values,
-            ..
-        } = self
-            .links
-            .write() // NOTE: this is one statement so the write lock is immediately dropped
-            .await
-            .remove(id)
-            .context("attempt to remove a non-existent link")?;
-
-        info!(
-            actor_id,
-            provider_id, link_name, contract_id, "process link definition entry deletion"
-        );
-
-        if let Some(actor) = self.actors.read().await.get(actor_id) {
-            let mut links = actor.handler.links.write().await;
-            if let Some(links) = links.get_mut(contract_id) {
-                links.remove(link_name);
-            }
-        }
-
-        if publish {
-            self.publish_event(
-                "linkdef_deleted",
-                event::linkdef_deleted(id, actor_id, provider_id, link_name, contract_id, values),
-            )
-            .await?;
-        }
-
-        let msgp = rmp_serde::to_vec_named(ld).context("failed to encode link definition")?;
-        let lattice = &self.host_config.lattice;
-        self.rpc_nats
-            .publish_with_headers(
-                format!("wasmbus.rpc.{lattice}.{provider_id}.{link_name}.linkdefs.del",),
-                injector_to_headers(&TraceContextInjector::default_with_span()),
-                msgp.into(),
-            )
-            .await
-            .context("failed to publish link definition deletion")?;
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
     async fn process_claims_put(
         &self,
         pubkey: impl AsRef<str>,
@@ -4081,14 +3915,9 @@ impl Host {
                 let mut actor_claims = self.actor_claims.write().await;
                 actor_claims.remove(&claims.subject);
 
-                let Some(call_alias) = claims.metadata.and_then(|m| m.call_alias) else {
+                let Some(_call_alias) = claims.metadata.and_then(|m| m.call_alias) else {
                     return Ok(());
                 };
-
-                let mut aliases = self.aliases.write().await;
-                aliases
-                    .remove(&call_alias)
-                    .context("attempt to remove a non-existent call alias")?;
             }
             Claims::Provider(claims) => {
                 let mut provider_claims = self.provider_claims.write().await;
@@ -4118,11 +3947,13 @@ impl Host {
             (Operation::Delete, Some(("COMPONENT", id))) => {
                 self.process_component_spec_delete(id, value, publish).await
             }
-            (Operation::Put, Some(("LINKDEF", id))) => {
-                self.process_linkdef_put(id, value, publish).await
+            (Operation::Put, Some(("LINKDEF", _id))) => {
+                debug!("ignoring deprecated LINKDEF put operation");
+                Ok(())
             }
-            (Operation::Delete, Some(("LINKDEF", id))) => {
-                self.process_linkdef_delete(id, value, publish).await
+            (Operation::Delete, Some(("LINKDEF", _id))) => {
+                debug!("ignoring deprecated LINKDEF delete operation");
+                Ok(())
             }
             (Operation::Put, Some(("CLAIMS", pubkey))) => {
                 self.process_claims_put(pubkey, value).await


### PR DESCRIPTION
## Feature or Problem
This PR updates the plumbing around link definitions to completely support interface links and remove call aliases as they are no longer needed. Leaving in draft as I'd rather merge #1568 first since this branch contains a few commits from there to minimize conflicts. This also isn't completely finished.

Outstanding work to be done
- [ ] Publish linkdef set/deleted events
- [ ] Publish linkdef set/deleted events to providers (assuming they need this information, might be replaced with put/delete configuration)
- [ ] Improve the matching of `resolve_target`, since we are now only targeting wRPC entities. 
- [ ] Depending on the link, we _might_ be able to attempt to turn a previously stored LinkDefinition into an InterfaceLinkDefinition. Consider the usefulness of this migration.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
