### PR TITLE
Control interface component ID support, flatten actor/provider instances

### DIFF
--- a/crates/control-interface/src/broker.rs
+++ b/crates/control-interface/src/broker.rs
@@ -18,11 +18,11 @@ pub fn actor_auction_subject(topic_prefix: &Option<String>, lattice: &str) -> St
     format!("{}.actor.auction", prefix(topic_prefix, lattice))
 }
 
-pub fn advertise_link(topic_prefix: &Option<String>, lattice: &str) -> String {
+pub fn put_link(topic_prefix: &Option<String>, lattice: &str) -> String {
     format!("{}.link.put", prefix(topic_prefix, lattice))
 }
 
-pub fn remove_link(topic_prefix: &Option<String>, lattice: &str) -> String {
+pub fn delete_link(topic_prefix: &Option<String>, lattice: &str) -> String {
     format!("{}.link.del", prefix(topic_prefix, lattice))
 }
 

--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -542,12 +542,7 @@ impl Client {
     /// _will not_ supply a discrete confirmation that a provider has terminated. For that kind of
     /// information, the client must also monitor the control event stream
     #[instrument(level = "debug", skip_all)]
-    pub async fn stop_provider(
-        &self,
-        host_id: &str,
-        provider_id: &str,
-        annotations: Option<HashMap<String, String>>,
-    ) -> Result<CtlOperationAck> {
+    pub async fn stop_provider(&self, host_id: &str, provider_id: &str) -> Result<CtlOperationAck> {
         let host_id = parse_identifier(&IdentifierKind::HostId, host_id)?;
 
         let subject =
@@ -556,7 +551,6 @@ impl Client {
         let bytes = json_serialize(StopProviderCommand {
             host_id,
             provider_id: parse_identifier(&IdentifierKind::ComponentId, provider_id)?,
-            annotations,
         })?;
 
         match self.request_timeout(subject, bytes, self.timeout).await {

--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -285,8 +285,14 @@ impl Client {
     /// be listening and all will overwrite their registry credential map with the new information.
     /// It is highly recommended you use TLS connections with NATS and isolate the control interface
     /// credentials when using this function in production as the data contains secrets
+    ///
+    /// # Arguments
+    /// - `registries`: A map of registry names to their credentials to be used for fetching from specific registries
     #[instrument(level = "debug", skip_all)]
-    pub async fn put_registries(&self, registries: RegistryCredentialMap) -> Result<()> {
+    pub async fn put_registries(
+        &self,
+        registries: HashMap<String, RegistryCredential>,
+    ) -> Result<()> {
         let subject = broker::publish_registries(&self.topic_prefix, &self.lattice);
         debug!("put_registries:publish {}", &subject);
         let bytes = json_serialize(&registries)?;

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -280,7 +280,7 @@ impl TryFrom<&RegistryCredential> for oci_distribution::secrets::RegistryAuth {
 /// A request to remove a link definition and detach the relevant actor
 /// from the given provider
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct RemoveInterfaceLinkDefinitionRequest {
+pub struct DeleteInterfaceLinkDefinitionRequest {
     /// The source component's identifier.
     pub source_id: ComponentId,
     /// Name of the link. Not providing this is equivalent to specifying Some("default")

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -179,6 +179,12 @@ pub struct LinkDefinitionList {
     pub links: Vec<LinkDefinition>,
 }
 
+/// A list of interface link definitions
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct InterfaceLinkDefinitionList {
+    pub links: Vec<InterfaceLinkDefinition>,
+}
+
 /// One of a potential list of responses to a provider auction
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ProviderAuctionAck {
@@ -308,6 +314,22 @@ pub struct RemoveLinkDefinitionRequest {
     /// The provider's link name
     #[serde(default)]
     pub link_name: String,
+}
+
+/// A request to remove a link definition and detach the relevant actor
+/// from the given provider
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RemoveInterfaceLinkDefinitionRequest {
+    /// The actor's public key. This cannot be an image reference
+    #[serde(default)]
+    pub source_id: String,
+    /// Name of the link. Not providing this is equivalent to specifying Some("default")
+    #[serde(default = "default_link_name")]
+    pub name: LinkName,
+    /// WIT namespace of the link operation, e.g. `wasi` in `wasi:keyvalue/readwrite.get`
+    pub wit_namespace: WitNamespace,
+    /// WIT package of the link operation, e.g. `keyvalue` in `wasi:keyvalue/readwrite.get`
+    pub wit_package: WitPackage,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -461,15 +483,15 @@ pub type KnownConfigName = String;
 /// interface. An [`InterfaceLinkDefinition`] connects one component's import to another
 /// component's export, specifying the configuration each component needs in order to execute
 /// the request, and represents an operator's intent to allow the source to invoke the target.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize, Hash)]
 pub struct InterfaceLinkDefinition {
     /// Source identifier for the link
     pub source_id: ComponentId,
     /// Target for the link, which can be a unique identifier or (future) a routing group
     pub target: LatticeTarget,
-    /// Name of the link. Not providing this is equivalent to specifying Some("default")
-    #[serde(default)]
-    pub name: Option<LinkName>,
+    /// Name of the link. Not providing this is equivalent to specifying "default"
+    #[serde(default = "default_link_name")]
+    pub name: LinkName,
     /// WIT namespace of the link operation, e.g. `wasi` in `wasi:keyvalue/readwrite.get`
     pub wit_namespace: WitNamespace,
     /// WIT package of the link operation, e.g. `keyvalue` in `wasi:keyvalue/readwrite.get`
@@ -482,6 +504,11 @@ pub struct InterfaceLinkDefinition {
     /// List of named configurations to provide to the target upon request
     #[serde(default)]
     pub target_config: Vec<KnownConfigName>,
+}
+
+/// Helper function to provide a default link name
+fn default_link_name() -> LinkName {
+    "default".to_string()
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/control-interface/src/types.rs
+++ b/crates/control-interface/src/types.rs
@@ -3,12 +3,6 @@ use std::collections::HashMap;
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
 
-pub type ConstraintMap = std::collections::HashMap<String, String>;
-pub type AnnotationMap = std::collections::HashMap<String, String>;
-pub type KeyValueMap = std::collections::HashMap<String, String>;
-pub type LabelsMap = std::collections::HashMap<String, String>;
-pub type ProviderDescriptions = Vec<ProviderDescription>;
-
 /// A host response to a request to start an actor, confirming the host
 /// has enough capacity to start the actor
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -37,7 +31,7 @@ pub struct ActorAuctionRequest {
     /// that no other actor with the same ID is running on the host
     pub actor_id: ComponentId,
     /// The set of constraints that must match the labels of a suitable target host
-    pub constraints: ConstraintMap,
+    pub constraints: HashMap<String, String>,
 }
 
 /// A summary description of an actor within a host inventory
@@ -55,7 +49,7 @@ pub struct ActorDescription {
     /// The annotations that were used in the start request that produced
     /// this actor instance
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<AnnotationMap>,
+    pub annotations: Option<HashMap<String, String>>,
     /// The revision number for this actor instance
     #[serde(default)]
     pub revision: i32,
@@ -69,7 +63,7 @@ pub struct ActorInstance {
     /// The annotations that were used in the start request that produced
     /// this actor instance
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<AnnotationMap>,
+    pub annotations: Option<HashMap<String, String>>,
     /// Image reference for this actor
     #[serde(default)]
     pub image_ref: String,
@@ -131,7 +125,7 @@ pub struct Host {
     pub js_domain: Option<String>,
     /// Hash map of label-value pairs for this host
     #[serde(default)]
-    pub labels: KeyValueMap,
+    pub labels: HashMap<String, String>,
     /// The lattice that this host is a member of
     #[serde(default)]
     pub lattice: String,
@@ -153,7 +147,7 @@ pub struct HostInventory {
     /// Actors running on this host.
     pub actors: Vec<ActorDescription>,
     /// Providers running on this host
-    pub providers: ProviderDescriptions,
+    pub providers: Vec<ProviderDescription>,
     /// The host's unique ID
     #[serde(default)]
     pub host_id: String,
@@ -165,7 +159,7 @@ pub struct HostInventory {
     pub friendly_name: String,
     /// The host's labels
     #[serde(default)]
-    pub labels: LabelsMap,
+    pub labels: HashMap<String, String>,
     /// The host version
     #[serde(default)]
     pub version: String,
@@ -202,7 +196,7 @@ pub struct ProviderAuctionAck {
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ProviderAuctionRequest {
     /// The set of constraints that must match the labels of a suitable target host
-    pub constraints: ConstraintMap,
+    pub constraints: HashMap<String, String>,
     /// The image reference, file or OCI, for this provider.
     #[serde(default)]
     pub provider_ref: String,
@@ -217,7 +211,7 @@ pub struct ProviderDescription {
     /// The annotations that were used in the start request that produced
     /// this provider instance
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<AnnotationMap>,
+    pub annotations: Option<HashMap<String, String>>,
     /// Provider's unique identifier
     #[serde(default)]
     pub id: ComponentId,
@@ -283,9 +277,6 @@ impl TryFrom<&RegistryCredential> for oci_distribution::secrets::RegistryAuth {
     }
 }
 
-/// A set of credentials to be used for fetching from specific registries
-pub type RegistryCredentialMap = std::collections::HashMap<String, RegistryCredential>;
-
 /// A request to remove a link definition and detach the relevant actor
 /// from the given provider
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -311,7 +302,7 @@ pub struct ScaleActorCommand {
     /// Optional set of annotations used to describe the nature of this actor scale command. For
     /// example, autonomous agents may wish to "tag" scale requests as part of a given deployment
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<AnnotationMap>,
+    pub annotations: Option<HashMap<String, String>>,
     /// The maximum number of concurrent executing instances of this actor. Setting this to `0` will
     /// stop the actor.
     // NOTE: renaming to `count` lets us remain backwards compatible for a few minor versions
@@ -329,7 +320,7 @@ pub struct StartProviderCommand {
     /// Optional set of annotations used to describe the nature of this provider start command. For
     /// example, autonomous agents may wish to "tag" start requests as part of a given deployment
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<AnnotationMap>,
+    pub annotations: Option<HashMap<String, String>>,
     /// Unique identifier of the provider to start.
     pub provider_id: ComponentId,
     /// Optional provider configuration in the form of an opaque string. Many
@@ -379,7 +370,7 @@ pub struct UpdateActorCommand {
     /// update request. Only actor instances that have matching annotations
     /// will be upgraded, allowing for instance isolation by
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<AnnotationMap>,
+    pub annotations: Option<HashMap<String, String>>,
     /// The host ID of the host to perform the live update
     #[serde(default)]
     pub host_id: String,

--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -1,6 +1,6 @@
 use core::num::NonZeroUsize;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use anyhow::Context;
 use cloudevents::{EventBuilder, EventBuilderV10};
@@ -126,57 +126,53 @@ pub fn actor_scale_failed(
 }
 
 pub fn linkdef_set(
-    id: impl AsRef<str>,
-    actor_id: impl AsRef<str>,
-    provider_id: impl AsRef<str>,
-    link_name: impl AsRef<str>,
-    contract_id: impl AsRef<str>,
-    values: &HashMap<String, String>,
+    source_id: impl AsRef<str>,
+    target: impl AsRef<str>,
+    name: impl AsRef<str>,
+    wit_namespace: impl AsRef<str>,
+    wit_package: impl AsRef<str>,
+    interfaces: &Vec<String>,
+    source_config: &Vec<String>,
+    target_config: &Vec<String>,
 ) -> serde_json::Value {
     json!({
-        "id": id.as_ref(),
-        "actor_id": actor_id.as_ref(),
-        "provider_id": provider_id.as_ref(),
-        "link_name": link_name.as_ref(),
-        "contract_id": contract_id.as_ref(),
-        "values": values,
+        "source_id": source_id.as_ref(),
+        "target": target.as_ref(),
+        "name": name.as_ref(),
+        "wit_namespace": wit_namespace.as_ref(),
+        "wit_package": wit_package.as_ref(),
+        "interfaces": interfaces,
+        "source_config": source_config,
+        "target_config": target_config,
     })
 }
 
 pub fn linkdef_deleted(
-    id: impl AsRef<str>,
-    actor_id: impl AsRef<str>,
-    provider_id: impl AsRef<str>,
-    link_name: impl AsRef<str>,
-    contract_id: impl AsRef<str>,
-    values: &HashMap<String, String>,
+    source_id: impl AsRef<str>,
+    name: impl AsRef<str>,
+    wit_namespace: impl AsRef<str>,
+    wit_package: impl AsRef<str>,
 ) -> serde_json::Value {
     json!({
-        "id": id.as_ref(),
-        "actor_id": actor_id.as_ref(),
-        "provider_id": provider_id.as_ref(),
-        "link_name": link_name.as_ref(),
-        "contract_id": contract_id.as_ref(),
-        "values": values,
+        "source_id": source_id.as_ref(),
+        "name": name.as_ref(),
+        "wit_namespace": wit_namespace.as_ref(),
+        "wit_package": wit_package.as_ref(),
     })
 }
 
 pub fn provider_started(
     claims: &jwt::Claims<jwt::CapabilityProvider>,
     annotations: &BTreeMap<String, String>,
-    instance_id: Uuid,
     host_id: impl AsRef<str>,
     image_ref: impl AsRef<str>,
-    link_name: impl AsRef<str>,
+    provider_id: impl AsRef<str>,
 ) -> serde_json::Value {
     let metadata = claims.metadata.as_ref();
     json!({
         "host_id": host_id.as_ref(),
-        "public_key": claims.subject,
         "image_ref": image_ref.as_ref(),
-        "link_name": link_name.as_ref(),
-        "contract_id": metadata.map(|jwt::CapabilityProvider { capid, .. }| capid),
-        "instance_id": instance_id,
+        "provider_id": provider_id.as_ref(),
         "annotations": annotations,
         "claims": {
             "issuer": &claims.issuer,
@@ -186,38 +182,46 @@ pub fn provider_started(
             "not_before_human": "TODO",
             "expires_human": "TODO",
         },
+        // TODO(#1548): remove these fields when we don't depend on them
+        "instance_id": provider_id.as_ref(),
+        "public_key": provider_id.as_ref(),
+        "link_name": "default",
+        "contract_id": metadata.map(|jwt::CapabilityProvider { capid, .. }| capid),
     })
 }
 
 pub fn provider_start_failed(
     provider_ref: impl AsRef<str>,
-    link_name: impl AsRef<str>,
+    provider_id: impl AsRef<str>,
     error: &anyhow::Error,
 ) -> serde_json::Value {
     json!({
         "provider_ref": provider_ref.as_ref(),
-        "link_name": link_name.as_ref(),
+        "provider_id": provider_id.as_ref(),
         "error": format!("{error:#}"),
+        // TODO(#1548): remove this field when we don't depend on it
+        "link_name": "default",
     })
 }
 
 pub fn provider_stopped(
     claims: &jwt::Claims<jwt::CapabilityProvider>,
     annotations: &BTreeMap<String, String>,
-    instance_id: Uuid,
     host_id: impl AsRef<str>,
-    link_name: impl AsRef<str>,
+    provider_id: impl AsRef<str>,
     reason: impl AsRef<str>,
 ) -> serde_json::Value {
     let metadata = claims.metadata.as_ref();
     json!({
         "host_id": host_id.as_ref(),
-        "public_key": claims.subject,
-        "link_name": link_name.as_ref(),
-        "contract_id": metadata.map(|jwt::CapabilityProvider { capid, .. }| capid),
-        "instance_id": instance_id,
+        "provider_id": provider_id.as_ref(),
         "annotations": annotations,
         "reason": reason.as_ref(),
+        // TODO(#1548): remove these fields when we don't depend on them
+        "instance_id": provider_id.as_ref(),
+        "public_key": provider_id.as_ref(),
+        "link_name": "default",
+        "contract_id": metadata.map(|jwt::CapabilityProvider { capid, .. }| capid),
     })
 }
 

--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -72,24 +72,17 @@ pub fn actor_scale_failed(
 }
 
 pub fn linkdef_set(
-    source_id: impl AsRef<str>,
-    target: impl AsRef<str>,
-    name: impl AsRef<str>,
-    wit_namespace: impl AsRef<str>,
-    wit_package: impl AsRef<str>,
-    interfaces: &Vec<String>,
-    source_config: &Vec<String>,
-    target_config: &Vec<String>,
+    link: &wasmcloud_control_interface::InterfaceLinkDefinition,
 ) -> serde_json::Value {
     json!({
-        "source_id": source_id.as_ref(),
-        "target": target.as_ref(),
-        "name": name.as_ref(),
-        "wit_namespace": wit_namespace.as_ref(),
-        "wit_package": wit_package.as_ref(),
-        "interfaces": interfaces,
-        "source_config": source_config,
-        "target_config": target_config,
+        "source_id": link.source_id,
+        "target": link.target,
+        "name": link.name,
+        "wit_namespace": link.wit_namespace,
+        "wit_package": link.wit_package,
+        "interfaces": link.interfaces,
+        "source_config": link.source_config,
+        "target_config": link.target_config,
     })
 }
 

--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -36,65 +36,11 @@ fn format_actor_claims(claims: &jwt::Claims<jwt::Actor>) -> serde_json::Value {
     }
 }
 
-// TODO(#1092): Remove this event in favor of `actor_scaled`
-pub fn actors_started(
-    claims: &jwt::Claims<jwt::Actor>,
-    annotations: &BTreeMap<String, String>,
-    host_id: impl AsRef<str>,
-    count: impl Into<usize>,
-    image_ref: impl AsRef<str>,
-) -> serde_json::Value {
-    json!({
-        "public_key": claims.subject,
-        "image_ref": image_ref.as_ref(),
-        "annotations": annotations,
-        "host_id": host_id.as_ref(),
-        "claims": format_actor_claims(claims),
-        "count": count.into(),
-    })
-}
-
-// TODO(#1092): Remove this event in favor of `actor_scaled`
-pub fn actors_start_failed(
-    claims: &jwt::Claims<jwt::Actor>,
-    annotations: &BTreeMap<String, String>,
-    host_id: impl AsRef<str>,
-    image_ref: impl AsRef<str>,
-    error: &anyhow::Error,
-) -> serde_json::Value {
-    json!({
-        "public_key": claims.subject,
-        "image_ref": image_ref.as_ref(),
-        "annotations": annotations,
-        "host_id": host_id.as_ref(),
-        "error": format!("{error:#}"),
-    })
-}
-
-// TODO(#1092): Remove this event in favor of `actor_scaled`
-pub fn actors_stopped(
-    claims: &jwt::Claims<jwt::Actor>,
-    annotations: &BTreeMap<String, String>,
-    host_id: impl AsRef<str>,
-    count: NonZeroUsize,
-    remaining: usize,
-    image_ref: impl AsRef<str>,
-) -> serde_json::Value {
-    json!({
-        "public_key": claims.subject,
-        "annotations": annotations,
-        "host_id": host_id.as_ref(),
-        "count": count,
-        "remaining": remaining,
-        "image_ref": image_ref.as_ref(),
-    })
-}
-
 pub fn actor_scaled(
     claims: &jwt::Claims<jwt::Actor>,
     annotations: &BTreeMap<String, String>,
     host_id: impl AsRef<str>,
-    max_instances: NonZeroUsize,
+    max_instances: impl Into<usize>,
     image_ref: impl AsRef<str>,
 ) -> serde_json::Value {
     json!({
@@ -103,7 +49,7 @@ pub fn actor_scaled(
         "annotations": annotations,
         "host_id": host_id.as_ref(),
         "image_ref": image_ref.as_ref(),
-        "max_instances": max_instances,
+        "max_instances": max_instances.into(),
     })
 }
 

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -710,7 +710,8 @@ impl Bus for Handler {
         let data = conf
             .get(&self.claims.subject)
             .and_then(|conf| conf.get(key))
-            .cloned();
+            .cloned()
+            .map(|val| val.into_bytes());
         Ok(Ok(data))
     }
 
@@ -724,7 +725,11 @@ impl Bus for Handler {
             .await
             .get(&self.claims.subject)
             .cloned()
-            .map(|conf| conf.into_iter().collect::<Vec<_>>())
+            .map(|conf| {
+                conf.into_iter()
+                    .map(|(key, val)| (key, val.into_bytes()))
+                    .collect::<Vec<_>>()
+            })
             .unwrap_or_default()))
     }
 
@@ -1113,11 +1118,14 @@ struct Actor {
     metrics: Arc<HostMetrics>,
     // TODO(#1220): implement issuer verification
     /// Cluster issuers that this actor should accept invocations from
+    #[allow(unused)]
     valid_issuers: Vec<String>,
     // TODO(#1548): ensure we are validating actor start and invocations
+    #[allow(unused)]
     policy_manager: Arc<PolicyManager>,
     // TODO: use a single map once Claims is an enum
     // TODO(#1548): make optional
+    #[allow(unused)]
     actor_claims: Arc<RwLock<HashMap<String, jwt::Claims<jwt::Actor>>>>,
 }
 
@@ -1200,7 +1208,7 @@ struct Provider {
     claims: jwt::Claims<jwt::CapabilityProvider>,
 }
 
-type ConfigCache = HashMap<String, HashMap<String, Vec<u8>>>;
+type ConfigCache = HashMap<String, HashMap<String, String>>;
 
 /// wasmCloud Host
 pub struct Host {
@@ -3083,32 +3091,6 @@ impl Host {
         Ok(res.into())
     }
 
-    #[instrument(level = "trace", skip_all)]
-    async fn handle_config_get_one(&self, entity_id: &str, key: &str) -> anyhow::Result<Bytes> {
-        trace!(%entity_id, %key, "handling config");
-        let json = match self
-            .config_data_cache
-            .read()
-            .await
-            .get(entity_id)
-            .and_then(|map| map.get(key))
-        {
-            Some(data) => json!({
-                "found": true,
-                "data": data,
-            }),
-            None => {
-                json!({
-                    "found": false,
-                    "data": [],
-                })
-            }
-        };
-        serde_json::to_vec(&json)
-            .map(Bytes::from)
-            .map_err(anyhow::Error::from)
-    }
-
     #[instrument(level = "trace", skip(self))]
     async fn handle_config_get(&self, entity_id: &str) -> anyhow::Result<Bytes> {
         trace!(%entity_id, "handling all config");
@@ -3359,66 +3341,35 @@ impl Host {
         Ok(ACCEPTED.into())
     }
 
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_config_put(
-        &self,
-        entity_id: &str,
-        key: &str,
-        data: Bytes,
-    ) -> anyhow::Result<Bytes> {
-        debug!(%entity_id, %key, "handle config entry put");
-        // Simple check for a valid entity key. A valid public nkey is 56 chars and it should start
-        // with the proper character. It isn't worth the overhead of actually parsing the key, but
-        // if that is an issue in the future we can ensure it is a fully parsable nkey.
-        if entity_id.len() != 56 || (!entity_id.starts_with('M') && !entity_id.starts_with('V')) {
-            bail!("Invalid entity ID. The entity ID must be a valid public nkey for an actor or provider");
-        }
+    #[instrument(level = "debug", skip_all, fields(%config_name))]
+    async fn handle_config_put(&self, config_name: &str, data: Bytes) -> anyhow::Result<Bytes> {
+        debug!("handle config entry put");
+        // Validate that the data is of the proper type by deserialing it
+        serde_json::from_slice::<HashMap<String, String>>(&data)
+            .context("Config data should be a map of string -> string")?;
         self.config_data
-            .put(format!("{entity_id}_{key}"), data)
+            .put(config_name, data)
             .await
             .context("Unable to store config data")?;
         // We don't write it into the cached data and instead let the caching thread handle it as we
         // won't need it immediately.
-
-        self.publish_event("config_set", event::config_set(entity_id, key))
+        self.publish_event("config_set", event::config_set(config_name))
             .await?;
 
         Ok(ACCEPTED.into())
     }
 
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_config_delete(&self, entity_id: &str, key: &str) -> anyhow::Result<Bytes> {
-        debug!(%entity_id, %key, "handle config entry deletion");
+    #[instrument(level = "debug", skip_all, fields(%config_name))]
+    async fn handle_config_delete(&self, config_name: &str) -> anyhow::Result<Bytes> {
+        debug!("handle config entry deletion");
 
         self.config_data
-            .purge(format!("{entity_id}_{key}"))
+            .purge(config_name)
             .await
             .context("Unable to delete config data")?;
 
-        self.publish_event("config_deleted", event::config_deleted(entity_id, key))
+        self.publish_event("config_deleted", event::config_deleted(config_name))
             .await?;
-
-        Ok(ACCEPTED.into())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_config_clear(&self, entity_id: &str) -> anyhow::Result<Bytes> {
-        debug!(%entity_id, "handle config clear");
-
-        // NOTE(thomastaylor312): I specifically made the decision not to key the current list of
-        // keys directly from the KV bucket because we'd have to list _all_ keys and then filter
-        // them out. Using the cache lets us get only what we need, at the slight risk of missing a
-        // newly created key
-        let config_cache = self.config_data_cache.read().await;
-        let Some(all_data) = config_cache.get(entity_id) else {
-            return Ok(ACCEPTED.into());
-        };
-        let futs = all_data
-            .keys()
-            .map(|key| self.handle_config_delete(entity_id, key));
-        futures::future::try_join_all(futs)
-            .await
-            .context("Unable to delete all config keys. Some keys may remain")?;
 
         Ok(ACCEPTED.into())
     }
@@ -3523,21 +3474,15 @@ impl Host {
                 self.handle_registries_put(message.payload).await.map(Some)
             }
 
-            (Some("config"), Some("get"), Some(entity_id), Some(key)) => {
-                self.handle_config_get_one(entity_id, key).await.map(Some)
+            (Some("config"), Some("get"), Some(config_name), None) => {
+                self.handle_config_get(config_name).await.map(Some)
             }
-            (Some("config"), Some("get"), Some(entity_id), None) => {
-                self.handle_config_get(entity_id).await.map(Some)
-            }
-            (Some("config"), Some("put"), Some(entity_id), Some(key)) => self
-                .handle_config_put(entity_id, key, message.payload)
+            (Some("config"), Some("put"), Some(config_name), None) => self
+                .handle_config_put(config_name, message.payload)
                 .await
                 .map(Some),
-            (Some("config"), Some("del"), Some(entity_id), Some(key)) => {
-                self.handle_config_delete(entity_id, key).await.map(Some)
-            }
-            (Some("config"), Some("clear"), Some(entity_id), None) => {
-                self.handle_config_clear(entity_id).await.map(Some)
+            (Some("config"), Some("del"), Some(config_name), None) => {
+                self.handle_config_delete(config_name).await.map(Some)
             }
             _ => {
                 warn!(%subject, "received control interface request on unsupported subject");
@@ -3781,25 +3726,20 @@ impl Host {
 
     #[instrument(level = "trace", skip_all, fields(bucket = %entry.bucket, key = %entry.key, revision = %entry.revision, operation = ?entry.operation))]
     async fn process_config_entry(&self, entry: KvEntry) {
-        match (entry.operation, entry.key.split_once('_')) {
-            (Operation::Put, Some((id, key))) => {
-                self.config_data_cache
-                    .write()
-                    .await
-                    .entry(id.to_owned())
-                    .or_default()
-                    .insert(key.to_owned(), Vec::from(entry.value));
+        match entry.operation {
+            Operation::Put => {
+                let data: HashMap<String, String> = match serde_json::from_slice(&entry.value) {
+                    Ok(data) => data,
+                    Err(error) => {
+                        error!(?error, "failed to decode config data on entry update");
+                        return;
+                    }
+                };
+                let mut lock = self.config_data_cache.write().await;
+                lock.insert(entry.key, data);
             }
-            (Operation::Delete | Operation::Purge, Some((id, key))) => {
-                self.config_data_cache
-                    .write()
-                    .await
-                    .entry(id.to_owned())
-                    .or_default()
-                    .remove(key);
-            }
-            (_, None) => {
-                error!(key = %entry.key, "Found key that doesn't match config format");
+            Operation::Delete | Operation::Purge => {
+                self.config_data_cache.write().await.remove(&entry.key);
             }
         }
     }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -44,9 +44,9 @@ use wascap::{jwt, prelude::ClaimsBuilder};
 use wasmcloud_control_interface::{
     ActorAuctionAck, ActorAuctionRequest, ActorDescription, GetClaimsResponse, HostInventory,
     HostLabel, InterfaceLinkDefinition, ProviderAuctionAck, ProviderAuctionRequest,
-    ProviderDescription, RegistryCredential, RegistryCredentialMap,
-    RemoveInterfaceLinkDefinitionRequest, ScaleActorCommand, StartProviderCommand, StopHostCommand,
-    StopProviderCommand, UpdateActorCommand, WitInterface,
+    ProviderDescription, RegistryCredential, RemoveInterfaceLinkDefinitionRequest,
+    ScaleActorCommand, StartProviderCommand, StopHostCommand, StopProviderCommand,
+    UpdateActorCommand, WitInterface,
 };
 use wasmcloud_core::{
     HealthCheckResponse, HostData, Invocation, InvocationResponse, LatticeTargetId, LinkName,
@@ -3333,8 +3333,9 @@ impl Host {
 
     #[instrument(level = "debug", skip_all)]
     async fn handle_registries_put(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
-        let registry_creds: RegistryCredentialMap = serde_json::from_slice(payload.as_ref())
-            .context("failed to deserialize registries put command")?;
+        let registry_creds: HashMap<String, RegistryCredential> =
+            serde_json::from_slice(payload.as_ref())
+                .context("failed to deserialize registries put command")?;
 
         info!(
             registries = ?registry_creds.keys(),

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -5,7 +5,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 use core::time::Duration;
 use std::collections::hash_map::{self, Entry};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::env::consts::{ARCH, FAMILY, OS};
 use std::io::Cursor;
@@ -45,9 +45,9 @@ pub use config::Host as HostConfig;
 use wascap::{jwt, prelude::ClaimsBuilder};
 use wasmcloud_control_interface::{
     ActorAuctionAck, ActorAuctionRequest, ActorDescription, GetClaimsResponse, HostInventory,
-    HostLabel, InterfaceLinkDefinition, LinkDefinition, LinkDefinitionList, ProviderAuctionAck,
+    HostLabel, InterfaceLinkDefinition, InterfaceLinkDefinitionList, ProviderAuctionAck,
     ProviderAuctionRequest, ProviderDescription, RegistryCredential, RegistryCredentialMap,
-    RemoveLinkDefinitionRequest, ScaleActorCommand, StartProviderCommand, StopHostCommand,
+    RemoveInterfaceLinkDefinitionRequest, ScaleActorCommand, StartProviderCommand, StopHostCommand,
     StopProviderCommand, UpdateActorCommand, WitInterface,
 };
 use wasmcloud_core::{
@@ -56,9 +56,9 @@ use wasmcloud_core::{
 };
 use wasmcloud_runtime::capability::logging::logging;
 use wasmcloud_runtime::capability::{
-    blobstore, guest_config, messaging, ActorIdentifier, Blobstore, Bus, CallTargetInterface,
-    KeyValueAtomic, KeyValueEventual, Logging, Messaging, OutgoingHttp, OutgoingHttpRequest,
-    TargetEntity, WrpcInterfaceTarget,
+    blobstore, guest_config, messaging, Blobstore, Bus, CallTargetInterface, KeyValueAtomic,
+    KeyValueEventual, Logging, Messaging, OutgoingHttp, OutgoingHttpRequest, TargetEntity,
+    WrpcInterfaceTarget,
 };
 use wasmcloud_runtime::Runtime;
 use wasmcloud_tracing::context::TraceContextInjector;
@@ -271,9 +271,6 @@ struct Handler {
     host_key: Arc<KeyPair>,
     claims: jwt::Claims<jwt::Actor>,
     origin: WasmCloudEntity,
-    // package -> target -> entity
-    links: Arc<RwLock<HashMap<String, HashMap<String, WasmCloudEntity>>>>,
-
     /// The current link name to use for interface targets, overridable in actor code via set_target()
     interface_link_name: Arc<RwLock<LinkName>>,
 
@@ -289,26 +286,17 @@ struct Handler {
     #[allow(clippy::type_complexity)]
     interface_links:
         Arc<RwLock<HashMap<LinkName, HashMap<String, HashMap<WitInterface, LatticeTargetId>>>>>,
-    aliases: Arc<RwLock<HashMap<String, WasmCloudEntity>>>,
     // interface -> function -> result types
     polyfilled_imports: HashMap<String, HashMap<String, Arc<[wrpc_types::Type]>>>,
 }
 
 #[instrument(level = "trace")]
-async fn resolve_target(
-    target: Option<&TargetEntity>,
-    links: Option<&HashMap<String, WasmCloudEntity>>,
-    aliases: &HashMap<String, WasmCloudEntity>,
-) -> anyhow::Result<WasmCloudEntity> {
+async fn resolve_target(target: Option<&TargetEntity>) -> anyhow::Result<WasmCloudEntity> {
     const DEFAULT_LINK_NAME: &str = "default";
 
     trace!("resolve target");
 
     let target = match target {
-        None => links
-            .and_then(|targets| targets.get(DEFAULT_LINK_NAME))
-            .context("link not found")?
-            .clone(),
         Some(TargetEntity::Wrpc(target)) => {
             let (namespace, package, _, _) = target.interface.as_parts();
             WasmCloudEntity {
@@ -317,18 +305,7 @@ async fn resolve_target(
                 link_name: target.link_name.clone(),
             }
         }
-        Some(TargetEntity::Link(link_name)) => links
-            .and_then(|targets| targets.get(link_name.as_deref().unwrap_or(DEFAULT_LINK_NAME)))
-            .context("link not found")?
-            .clone(),
-        Some(TargetEntity::Actor(ActorIdentifier::Key(key))) => WasmCloudEntity {
-            public_key: key.public_key(),
-            ..Default::default()
-        },
-        Some(TargetEntity::Actor(ActorIdentifier::Alias(alias))) => aliases
-            .get(alias)
-            .context("unknown actor call alias")?
-            .clone(),
+        _ => bail!("target not found"),
     };
     Ok(target)
 }
@@ -342,14 +319,11 @@ impl Handler {
         request: Vec<u8>,
     ) -> anyhow::Result<Result<Vec<u8>, String>> {
         let operation = operation.into();
-        let links = self.links.read().await;
-        let aliases = self.aliases.read().await;
-
         // Determine the target for the operation
-        let (package, interface_and_func) = operation
+        let (_, interface_and_func) = operation
             .rsplit_once('/')
             .context("failed to parse operation")?;
-        let inv_target = resolve_target(target.as_ref(), links.get(package), &aliases).await?;
+        let inv_target = resolve_target(target.as_ref()).await?;
         let injector = TraceContextInjector::default_with_span();
         let headers = injector_to_headers(&injector);
         let invocation = Invocation::new(
@@ -377,14 +351,8 @@ impl Handler {
                     self.lattice, target.id, namespace, package, interface, function
                 )
             }
-            None | Some(TargetEntity::Link(_)) => format!(
-                "wasmbus.rpc.{}.{}.{}",
-                self.lattice, invocation.target.public_key, invocation.target.link_name,
-            ),
-            Some(TargetEntity::Actor(_)) => format!(
-                "wasmbus.rpc.{}.{}",
-                self.lattice, invocation.target.public_key
-            ),
+            // TODO: just remove other options entirely
+            _ => bail!("invalid target"),
         };
 
         let request = async_nats::Request::new()
@@ -829,8 +797,7 @@ impl Bus for Handler {
         let data = conf
             .get(&self.claims.subject)
             .and_then(|conf| conf.get(key))
-            .cloned()
-            .map(|val| val.into_bytes());
+            .cloned();
         Ok(Ok(data))
     }
 
@@ -844,11 +811,7 @@ impl Bus for Handler {
             .await
             .get(&self.claims.subject)
             .cloned()
-            .map(|conf| {
-                conf.into_iter()
-                    .map(|(key, val)| (key, val.into_bytes()))
-                    .collect::<Vec<_>>()
-            })
+            .map(|conf| conf.into_iter().collect::<Vec<_>>())
             .unwrap_or_default()))
     }
 
@@ -1288,7 +1251,7 @@ struct Provider {
     image_ref: String,
 }
 
-type ConfigCache = HashMap<String, HashMap<String, String>>;
+type ConfigCache = HashMap<String, HashMap<String, Vec<u8>>>;
 
 /// wasmCloud Host
 pub struct Host {
@@ -1319,8 +1282,8 @@ pub struct Host {
     stop_tx: watch::Sender<Option<Instant>>,
     stop_rx: watch::Receiver<Option<Instant>>,
     queue: AbortHandle,
-    aliases: Arc<RwLock<HashMap<String, WasmCloudEntity>>>,
-    links: RwLock<HashMap<String, LinkDefinition>>,
+    // Component ID -> All Links
+    links: RwLock<HashMap<String, HashSet<InterfaceLinkDefinition>>>,
     actor_claims: Arc<RwLock<HashMap<String, jwt::Claims<jwt::Actor>>>>, // TODO: use a single map once Claims is an enum
     provider_claims: Arc<RwLock<HashMap<String, jwt::Claims<jwt::CapabilityProvider>>>>,
     config_data_cache: Arc<RwLock<ConfigCache>>,
@@ -1825,7 +1788,6 @@ impl Host {
             stop_rx,
             stop_tx,
             queue: queue_abort.clone(),
-            aliases: Arc::default(),
             links: RwLock::default(),
             actor_claims: Arc::default(),
             provider_claims: Arc::default(),
@@ -2326,30 +2288,6 @@ impl Host {
             .await
             .context("failed to store claims")?;
 
-        let links = self.links.read().await;
-        let links = links
-            .values()
-            .filter(|ld| ld.actor_id == claims.subject)
-            .fold(
-                HashMap::<_, HashMap<_, _>>::default(),
-                |mut links,
-                 LinkDefinition {
-                     link_name,
-                     contract_id,
-                     provider_id,
-                     ..
-                 }| {
-                    links.entry(contract_id.clone()).or_default().insert(
-                        link_name.clone(),
-                        WasmCloudEntity {
-                            link_name: link_name.clone(),
-                            contract_id: contract_id.clone(),
-                            public_key: provider_id.clone(),
-                        },
-                    );
-                    links
-                },
-            );
         let origin = WasmCloudEntity {
             public_key: claims.subject.clone(),
             ..Default::default()
@@ -2384,8 +2322,6 @@ impl Host {
             origin,
             cluster_key: Arc::clone(&self.cluster_key),
             claims: claims.clone(),
-            aliases: Arc::clone(&self.aliases),
-            links: Arc::new(RwLock::new(links)),
             interface_link_name: Arc::new(RwLock::new("default".to_string())),
             interface_links: Arc::new(RwLock::new(component_spec.links)),
             host_key: Arc::clone(&self.host_key),
@@ -2546,33 +2482,6 @@ impl Host {
 
     #[instrument(level = "trace", skip_all)]
     async fn store_actor_claims(&self, claims: jwt::Claims<jwt::Actor>) -> anyhow::Result<()> {
-        if let Some(call_alias) = claims
-            .metadata
-            .as_ref()
-            .and_then(|jwt::Actor { call_alias, .. }| call_alias.clone())
-        {
-            let mut aliases = self.aliases.write().await;
-            match aliases.entry(call_alias) {
-                Entry::Occupied(mut entry) => {
-                    warn!(
-                        alias = entry.key(),
-                        existing_public_key = entry.get().public_key,
-                        new_public_key = claims.subject,
-                        "call alias clash. Replacing existing entry"
-                    );
-                    entry.insert(WasmCloudEntity {
-                        public_key: claims.subject.clone(),
-                        ..Default::default()
-                    });
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(WasmCloudEntity {
-                        public_key: claims.subject.clone(),
-                        ..Default::default()
-                    });
-                }
-            }
-        }
         let mut actor_claims = self.actor_claims.write().await;
         actor_claims.insert(claims.subject.clone(), claims);
         Ok(())
@@ -2985,20 +2894,6 @@ impl Host {
                 .cluster_key
                 .seed()
                 .context("cluster key seed missing")?;
-            let links = self.links.read().await;
-            // TODO: update type of links to use wasmcloud_core::LinkDefinition
-            let link_definitions: Vec<_> = links
-                .clone()
-                .into_values()
-                .filter(|ld| ld.provider_id == claims.subject && ld.link_name == link_name)
-                .map(|ld| wasmcloud_core::LinkDefinition {
-                    actor_id: ld.actor_id,
-                    provider_id: ld.provider_id,
-                    link_name: ld.link_name,
-                    contract_id: ld.contract_id,
-                    values: ld.values.into_iter().collect(),
-                })
-                .collect();
             let lattice_rpc_user_seed = self
                 .host_config
                 .rpc_key
@@ -3027,7 +2922,8 @@ impl Host {
                 env_values: vec![],
                 instance_id: Uuid::from_u128(id.into()).to_string(),
                 provider_key: component_id.clone(),
-                link_definitions,
+                // TODO: update type of links to provide wrpc links
+                link_definitions: vec![],
                 config_json: configuration,
                 default_rpc_timeout_ms,
                 cluster_issuers: self.cluster_issuers.clone(),
@@ -3384,34 +3280,54 @@ impl Host {
         Ok(res.into())
     }
 
-    // #[instrument(level = "debug", skip_all)] // FIXME: this is temporarily disabled because wadm (as of v0.8.0) queries links too often
+    #[instrument(level = "debug", skip_all)]
     async fn handle_links(&self) -> anyhow::Result<Bytes> {
-        trace!("handling links"); // FIXME: set back to debug when instrumentation is re-enabled
+        debug!("handling links");
 
         let links = self.links.read().await;
-        let links: Vec<LinkDefinition> = links.values().cloned().collect();
-        let res = serde_json::to_vec(&LinkDefinitionList { links })
+        let links: Vec<InterfaceLinkDefinition> = links.values().cloned().flatten().collect();
+        let res = serde_json::to_vec(&InterfaceLinkDefinitionList { links })
             .context("failed to serialize response")?;
         Ok(res.into())
     }
 
+    #[instrument(level = "trace", skip_all)]
+    async fn handle_config_get_one(&self, entity_id: &str, key: &str) -> anyhow::Result<Bytes> {
+        trace!(%entity_id, %key, "handling config");
+        let json = match self
+            .config_data_cache
+            .read()
+            .await
+            .get(entity_id)
+            .and_then(|map| map.get(key))
+        {
+            Some(data) => json!({
+                "found": true,
+                "data": data,
+            }),
+            None => {
+                json!({
+                    "found": false,
+                    "data": [],
+                })
+            }
+        };
+        serde_json::to_vec(&json)
+            .map(Bytes::from)
+            .map_err(anyhow::Error::from)
+    }
+
     #[instrument(level = "trace", skip(self))]
     async fn handle_config_get(&self, entity_id: &str) -> anyhow::Result<Bytes> {
-        trace!(%entity_id, "handling get config");
+        trace!(%entity_id, "handling all config");
         self.config_data_cache
             .read()
             .await
             .get(entity_id)
             .map_or_else(
-                || {
-                    let json = serde_json::json!({ "found": false });
-                    serde_json::to_vec(&json)
-                        .map(Bytes::from)
-                        .map_err(anyhow::Error::from)
-                },
+                || Ok(Bytes::default()),
                 |data| {
-                    let json = serde_json::json!({ "found": true, "data": data });
-                    serde_json::to_vec(&json)
+                    serde_json::to_vec(data)
                         .map(Bytes::from)
                         .map_err(anyhow::Error::from)
                 },
@@ -3452,15 +3368,17 @@ impl Host {
     #[instrument(level = "debug", skip_all)]
     async fn handle_interface_link_put(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
         let payload = payload.as_ref();
+        let interface_link_definition: InterfaceLinkDefinition = serde_json::from_slice(payload)
+            .context("failed to deserialize wrpc link definition")?;
         let InterfaceLinkDefinition {
             source_id,
             target,
+            wit_namespace,
             wit_package,
             interfaces,
-            name: link_name,
+            name,
             ..
-        } = serde_json::from_slice(payload)
-            .context("failed to deserialize wrpc link definition")?;
+        } = interface_link_definition.clone();
 
         let actors = self.actors.read().await;
 
@@ -3469,12 +3387,11 @@ impl Host {
             return Ok(r#"{"accepted":false,"error":"no actor found for that ID"}"#.into());
         };
 
-        // NOTE: We can't leave it as an Option<String> as a `None` key cannot be serialized to JSON
-        let name = link_name.clone().unwrap_or("default".to_string());
+        let ns_and_package = format!("{}:{}", wit_namespace, wit_package);
 
-        info!(
+        debug!(
             source_id,
-            target, wit_package, name, "handling put wrpc link definition"
+            target, ns_and_package, name, "handling put wrpc link definition"
         );
 
         // Write link for each interface in the package
@@ -3486,7 +3403,7 @@ impl Host {
             .entry(name)
             .and_modify(|link_for_name| {
                 link_for_name
-                    .entry(wit_package.clone())
+                    .entry(ns_and_package.clone())
                     .and_modify(|package| {
                         for interface in &interfaces {
                             package.insert(interface.clone(), target.clone());
@@ -3504,62 +3421,112 @@ impl Host {
                     .iter()
                     .map(|interface| (interface.clone(), target.clone()))
                     .collect::<HashMap<String, String>>();
-                HashMap::from_iter([(wit_package.clone(), interfaces_map)])
+                HashMap::from_iter([(ns_and_package.clone(), interfaces_map)])
             });
 
         let spec = actor.component_specification().await;
         self.store_component_spec(&source_id, &spec).await?;
 
+        // Insert link into host map
+        self.links
+            .write()
+            .await
+            .entry(source_id.clone())
+            .and_modify(|links| {
+                links.replace(interface_link_definition.clone());
+            })
+            .or_insert(HashSet::from_iter([interface_link_definition]));
+
+        // TODO: Publish event
+        // self.publish_event(
+        //     "linkdef_set",
+        //     event::linkdef_set(id, actor_id, provider_id, link_name, contract_id, values),
+        // )
+        // .await?;
+        // TODO: tell the provider to set the link
+        // self.rpc_nats
+        // .publish_with_headers(
+        //     format!("wasmbus.rpc.{lattice}.{provider_id}.{link_name}.linkdefs.set",),
+        //     injector_to_headers(&TraceContextInjector::default_with_span()),
+        //     msgp.into(),
+        // )
+        // .await
+        // .context("failed to publish link definition set")?;
+
         Ok(ACCEPTED.into())
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn handle_linkdef_put(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
+    /// Remove an interface link on a source component for a specific package
+    async fn handle_interface_link_del(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
         let payload = payload.as_ref();
-        let Ok(LinkDefinition {
-            actor_id,
-            provider_id,
-            link_name,
-            contract_id,
+        let RemoveInterfaceLinkDefinitionRequest {
+            source_id,
+            wit_namespace,
+            wit_package,
+            name,
             ..
-        }) = serde_json::from_slice(payload).context("failed to deserialize link definition")
-        else {
-            // TODO(#1568): make this the default instead of the fallback
-            return self.handle_interface_link_put(payload).await;
+        } = serde_json::from_slice(payload)
+            .context("failed to deserialize wrpc link definition")?;
+
+        let actors = self.actors.read().await;
+
+        let Ok(actor) = actors.get(&source_id).context("actor not found") else {
+            return Ok(r#"{"accepted":true,"error":""}"#.into());
         };
-        let id = linkdef_hash(&actor_id, &contract_id, &link_name);
 
-        info!(
-            actor_id,
-            provider_id, link_name, contract_id, "handling put link definition"
+        let ns_and_package = format!("{}:{}", wit_namespace, wit_package);
+
+        debug!(
+            source_id,
+            ns_and_package, name, "handling del wrpc link definition"
         );
 
-        self.data
-            .put(format!("LINKDEF_{id}"), Bytes::copy_from_slice(payload))
+        // Remove the interface links for the given link name and package
+        actor
+            .handler
+            .interface_links
+            .write()
             .await
-            .map_err(|e| anyhow!(e).context("failed to store link definition"))?;
-        Ok(ACCEPTED.into())
-    }
+            .entry(name.clone())
+            .and_modify(|link_for_name| {
+                link_for_name.remove(&ns_and_package);
+            });
 
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_linkdef_del(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
-        let RemoveLinkDefinitionRequest {
-            actor_id,
-            ref link_name,
-            contract_id,
-        } = serde_json::from_slice(payload.as_ref())
-            .context("failed to deserialize link definition deletion command")?;
-        let id = linkdef_hash(&actor_id, &contract_id, link_name);
+        let spec = actor.component_specification().await;
+        self.store_component_spec(&source_id, &spec).await?;
 
-        info!(
-            actor_id,
-            link_name, contract_id, "handling delete link definition"
-        );
-
-        self.data
-            .delete(format!("LINKDEF_{id}"))
+        // Remove link from host map
+        self.links
+            .write()
             .await
-            .map_err(|e| anyhow!(e).context("failed to delete link definition"))?;
+            .entry(source_id.clone())
+            // TODO: would be more efficient to be able to look up the link by hash and remove instead of iterating
+            .and_modify(|links| {
+                // Retain links that don't match the link we're removing
+                links.retain(|interface_link_definition| {
+                    interface_link_definition.wit_namespace != wit_namespace
+                        || interface_link_definition.wit_package != wit_package
+                        || interface_link_definition.name != name
+                });
+            });
+
+        // TODO: Publish event
+        // self.publish_event(
+        //     "linkdef_deleted",
+        //     event::linkdef_deleted(id, actor_id, link_name, contract_id),
+        // )
+        // .await?;
+        // TODO: tell the provider to delete the link
+        // self.rpc_nats
+        // .publish_with_headers(
+        //     format!("wasmbus.rpc.{lattice}.{provider_id}.{link_name}.linkdefs.del",),
+        //     injector_to_headers(&TraceContextInjector::default_with_span()),
+        //     msgp.into(),
+        // )
+        // .await
+        // .context("failed to publish link definition deletion")?;
+
         Ok(ACCEPTED.into())
     }
 
@@ -3590,35 +3557,66 @@ impl Host {
         Ok(ACCEPTED.into())
     }
 
-    #[instrument(level = "debug", skip_all, fields(%config_name))]
-    async fn handle_config_put(&self, config_name: &str, data: Bytes) -> anyhow::Result<Bytes> {
-        debug!("handle config entry put");
-        // Validate that the data is of the proper type by deserialing it
-        serde_json::from_slice::<HashMap<String, String>>(&data)
-            .context("Config data should be a map of string -> string")?;
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_config_put(
+        &self,
+        entity_id: &str,
+        key: &str,
+        data: Bytes,
+    ) -> anyhow::Result<Bytes> {
+        debug!(%entity_id, %key, "handle config entry put");
+        // Simple check for a valid entity key. A valid public nkey is 56 chars and it should start
+        // with the proper character. It isn't worth the overhead of actually parsing the key, but
+        // if that is an issue in the future we can ensure it is a fully parsable nkey.
+        if entity_id.len() != 56 || (!entity_id.starts_with('M') && !entity_id.starts_with('V')) {
+            bail!("Invalid entity ID. The entity ID must be a valid public nkey for an actor or provider");
+        }
         self.config_data
-            .put(config_name, data)
+            .put(format!("{entity_id}_{key}"), data)
             .await
             .context("Unable to store config data")?;
         // We don't write it into the cached data and instead let the caching thread handle it as we
         // won't need it immediately.
-        self.publish_event("config_set", event::config_set(config_name))
+
+        self.publish_event("config_set", event::config_set(entity_id, key))
             .await?;
 
         Ok(ACCEPTED.into())
     }
 
-    #[instrument(level = "debug", skip_all, fields(%config_name))]
-    async fn handle_config_delete(&self, config_name: &str) -> anyhow::Result<Bytes> {
-        debug!("handle config entry deletion");
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_config_delete(&self, entity_id: &str, key: &str) -> anyhow::Result<Bytes> {
+        debug!(%entity_id, %key, "handle config entry deletion");
 
         self.config_data
-            .purge(config_name)
+            .purge(format!("{entity_id}_{key}"))
             .await
             .context("Unable to delete config data")?;
 
-        self.publish_event("config_deleted", event::config_deleted(config_name))
+        self.publish_event("config_deleted", event::config_deleted(entity_id, key))
             .await?;
+
+        Ok(ACCEPTED.into())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_config_clear(&self, entity_id: &str) -> anyhow::Result<Bytes> {
+        debug!(%entity_id, "handle config clear");
+
+        // NOTE(thomastaylor312): I specifically made the decision not to key the current list of
+        // keys directly from the KV bucket because we'd have to list _all_ keys and then filter
+        // them out. Using the cache lets us get only what we need, at the slight risk of missing a
+        // newly created key
+        let config_cache = self.config_data_cache.read().await;
+        let Some(all_data) = config_cache.get(entity_id) else {
+            return Ok(ACCEPTED.into());
+        };
+        let futs = all_data
+            .keys()
+            .map(|key| self.handle_config_delete(entity_id, key));
+        futures::future::try_join_all(futs)
+            .await
+            .context("Unable to delete all config keys. Some keys may remain")?;
 
         Ok(ACCEPTED.into())
     }
@@ -3703,12 +3701,14 @@ impl Host {
             (Some("claims"), Some("get"), None, None) => self.handle_claims().await.map(Some),
 
             (Some("link"), Some("get"), None, None) => self.handle_links().await.map(Some),
-            (Some("link"), Some("put"), None, None) => {
-                self.handle_linkdef_put(message.payload).await.map(Some)
-            }
-            (Some("link"), Some("del"), None, None) => {
-                self.handle_linkdef_del(message.payload).await.map(Some)
-            }
+            (Some("link"), Some("put"), None, None) => self
+                .handle_interface_link_put(message.payload)
+                .await
+                .map(Some),
+            (Some("link"), Some("del"), None, None) => self
+                .handle_interface_link_del(message.payload)
+                .await
+                .map(Some),
 
             (Some("label"), Some("del"), Some(_host_id), None) => {
                 self.handle_label_del(message.payload).await.map(Some)
@@ -3721,15 +3721,21 @@ impl Host {
                 self.handle_registries_put(message.payload).await.map(Some)
             }
 
-            (Some("config"), Some("get"), Some(config_name), None) => {
-                self.handle_config_get(config_name).await.map(Some)
+            (Some("config"), Some("get"), Some(entity_id), Some(key)) => {
+                self.handle_config_get_one(entity_id, key).await.map(Some)
             }
-            (Some("config"), Some("put"), Some(config_name), None) => self
-                .handle_config_put(config_name, message.payload)
+            (Some("config"), Some("get"), Some(entity_id), None) => {
+                self.handle_config_get(entity_id).await.map(Some)
+            }
+            (Some("config"), Some("put"), Some(entity_id), Some(key)) => self
+                .handle_config_put(entity_id, key, message.payload)
                 .await
                 .map(Some),
-            (Some("config"), Some("del"), Some(config_name), None) => {
-                self.handle_config_delete(config_name).await.map(Some)
+            (Some("config"), Some("del"), Some(entity_id), Some(key)) => {
+                self.handle_config_delete(entity_id, key).await.map(Some)
+            }
+            (Some("config"), Some("clear"), Some(entity_id), None) => {
+                self.handle_config_clear(entity_id).await.map(Some)
             }
             _ => {
                 warn!(%subject, "received control interface request on unsupported subject");
@@ -3869,126 +3875,6 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn process_linkdef_put(
-        &self,
-        id: impl AsRef<str>,
-        value: impl AsRef<[u8]>,
-        publish: bool,
-    ) -> anyhow::Result<()> {
-        let id = id.as_ref();
-        let value = value.as_ref();
-        let ref ld @ LinkDefinition {
-            ref actor_id,
-            ref provider_id,
-            ref link_name,
-            ref contract_id,
-            ref values,
-            ..
-        } = serde_json::from_slice(value).context("failed to deserialize link definition")?;
-        ensure!(
-            id == linkdef_hash(actor_id, contract_id, link_name),
-            "linkdef hash mismatch"
-        );
-
-        info!(
-            actor_id,
-            provider_id, link_name, contract_id, "process link definition entry put"
-        );
-
-        self.links.write().await.insert(id.to_string(), ld.clone()); // NOTE: this is one statement so the write lock is immediately dropped
-        if let Some(actor) = self.actors.read().await.get(actor_id) {
-            let mut links = actor.handler.links.write().await;
-            links.entry(contract_id.clone()).or_default().insert(
-                ld.link_name.clone(),
-                WasmCloudEntity {
-                    link_name: ld.link_name.clone(),
-                    contract_id: ld.contract_id.clone(),
-                    public_key: ld.provider_id.clone(),
-                },
-            );
-        }
-
-        if publish {
-            self.publish_event(
-                "linkdef_set",
-                event::linkdef_set(id, actor_id, provider_id, link_name, contract_id, values),
-            )
-            .await?;
-        }
-
-        let msgp = rmp_serde::to_vec_named(ld).context("failed to encode link definition")?;
-        let lattice = &self.host_config.lattice;
-        self.rpc_nats
-            .publish_with_headers(
-                format!("wasmbus.rpc.{lattice}.{provider_id}.{link_name}.linkdefs.put",),
-                injector_to_headers(&TraceContextInjector::default_with_span()),
-                msgp.into(),
-            )
-            .await
-            .context("failed to publish link definition")?;
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn process_linkdef_delete(
-        &self,
-        id: impl AsRef<str>,
-        _value: impl AsRef<[u8]>,
-        publish: bool,
-    ) -> anyhow::Result<()> {
-        let id = id.as_ref();
-
-        // NOTE: There is a race condition here, which occurs when `linkdefs.del`
-        // is used before `data_watch` task has fully imported the current lattice,
-        // but that command is deprecated, so assume it's fine
-        let ref ld @ LinkDefinition {
-            ref actor_id,
-            ref provider_id,
-            ref link_name,
-            ref contract_id,
-            ref values,
-            ..
-        } = self
-            .links
-            .write() // NOTE: this is one statement so the write lock is immediately dropped
-            .await
-            .remove(id)
-            .context("attempt to remove a non-existent link")?;
-
-        info!(
-            actor_id,
-            provider_id, link_name, contract_id, "process link definition entry deletion"
-        );
-
-        if let Some(actor) = self.actors.read().await.get(actor_id) {
-            let mut links = actor.handler.links.write().await;
-            if let Some(links) = links.get_mut(contract_id) {
-                links.remove(link_name);
-            }
-        }
-
-        if publish {
-            self.publish_event(
-                "linkdef_deleted",
-                event::linkdef_deleted(id, actor_id, provider_id, link_name, contract_id, values),
-            )
-            .await?;
-        }
-
-        let msgp = rmp_serde::to_vec_named(ld).context("failed to encode link definition")?;
-        let lattice = &self.host_config.lattice;
-        self.rpc_nats
-            .publish_with_headers(
-                format!("wasmbus.rpc.{lattice}.{provider_id}.{link_name}.linkdefs.del",),
-                injector_to_headers(&TraceContextInjector::default_with_span()),
-                msgp.into(),
-            )
-            .await
-            .context("failed to publish link definition deletion")?;
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
     async fn process_claims_put(
         &self,
         pubkey: impl AsRef<str>,
@@ -4034,14 +3920,9 @@ impl Host {
                 let mut actor_claims = self.actor_claims.write().await;
                 actor_claims.remove(&claims.subject);
 
-                let Some(call_alias) = claims.metadata.and_then(|m| m.call_alias) else {
+                let Some(_call_alias) = claims.metadata.and_then(|m| m.call_alias) else {
                     return Ok(());
                 };
-
-                let mut aliases = self.aliases.write().await;
-                aliases
-                    .remove(&call_alias)
-                    .context("attempt to remove a non-existent call alias")?;
             }
             Claims::Provider(claims) => {
                 let mut provider_claims = self.provider_claims.write().await;
@@ -4071,11 +3952,13 @@ impl Host {
             (Operation::Delete, Some(("COMPONENT", id))) => {
                 self.process_component_spec_delete(id, value, publish).await
             }
-            (Operation::Put, Some(("LINKDEF", id))) => {
-                self.process_linkdef_put(id, value, publish).await
+            (Operation::Put, Some(("LINKDEF", _id))) => {
+                debug!("ignoring deprecated LINKDEF put operation");
+                Ok(())
             }
-            (Operation::Delete, Some(("LINKDEF", id))) => {
-                self.process_linkdef_delete(id, value, publish).await
+            (Operation::Delete, Some(("LINKDEF", _id))) => {
+                debug!("ignoring deprecated LINKDEF delete operation");
+                Ok(())
             }
             (Operation::Put, Some(("CLAIMS", pubkey))) => {
                 self.process_claims_put(pubkey, value).await
@@ -4100,20 +3983,25 @@ impl Host {
 
     #[instrument(level = "trace", skip_all, fields(bucket = %entry.bucket, key = %entry.key, revision = %entry.revision, operation = ?entry.operation))]
     async fn process_config_entry(&self, entry: KvEntry) {
-        match entry.operation {
-            Operation::Put => {
-                let data: HashMap<String, String> = match serde_json::from_slice(&entry.value) {
-                    Ok(data) => data,
-                    Err(error) => {
-                        error!(?error, "failed to decode config data on entry update");
-                        return;
-                    }
-                };
-                let mut lock = self.config_data_cache.write().await;
-                lock.insert(entry.key, data);
+        match (entry.operation, entry.key.split_once('_')) {
+            (Operation::Put, Some((id, key))) => {
+                self.config_data_cache
+                    .write()
+                    .await
+                    .entry(id.to_owned())
+                    .or_default()
+                    .insert(key.to_owned(), Vec::from(entry.value));
             }
-            Operation::Delete | Operation::Purge => {
-                self.config_data_cache.write().await.remove(&entry.key);
+            (Operation::Delete | Operation::Purge, Some((id, key))) => {
+                self.config_data_cache
+                    .write()
+                    .await
+                    .entry(id.to_owned())
+                    .or_default()
+                    .remove(key);
+            }
+            (_, None) => {
+                error!(key = %entry.key, "Found key that doesn't match config format");
             }
         }
     }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -42,11 +42,10 @@ use wasmcloud_tracing::{global, KeyValue};
 pub use config::Host as HostConfig;
 use wascap::{jwt, prelude::ClaimsBuilder};
 use wasmcloud_control_interface::{
-    ActorAuctionAck, ActorAuctionRequest, ActorDescription, GetClaimsResponse, HostInventory,
-    HostLabel, InterfaceLinkDefinition, ProviderAuctionAck, ProviderAuctionRequest,
-    ProviderDescription, RegistryCredential, RemoveInterfaceLinkDefinitionRequest,
-    ScaleActorCommand, StartProviderCommand, StopHostCommand, StopProviderCommand,
-    UpdateActorCommand, WitInterface,
+    ActorAuctionAck, ActorAuctionRequest, ActorDescription, DeleteInterfaceLinkDefinitionRequest,
+    GetClaimsResponse, HostInventory, HostLabel, InterfaceLinkDefinition, ProviderAuctionAck,
+    ProviderAuctionRequest, ProviderDescription, RegistryCredential, ScaleActorCommand,
+    StartProviderCommand, StopHostCommand, StopProviderCommand, UpdateActorCommand, WitInterface,
 };
 use wasmcloud_core::{
     HealthCheckResponse, HostData, Invocation, InvocationResponse, LatticeTargetId, LinkName,
@@ -2164,7 +2163,6 @@ impl Host {
         actor_ref: String,
         actor_id: String,
         max_instances: NonZeroUsize,
-        host_id: &str,
         annotations: impl Into<Annotations>,
     ) -> anyhow::Result<&'a mut Arc<Actor>> {
         debug!(actor_ref, ?max_instances, "starting new actor");
@@ -2244,7 +2242,13 @@ impl Host {
         info!(actor_ref, "actor started");
         self.publish_event(
             "actor_scaled",
-            event::actor_scaled(claims, &annotations, host_id, max_instances, &actor_ref),
+            event::actor_scaled(
+                claims,
+                &annotations,
+                &self.host_key.public_key(),
+                max_instances,
+                &actor_ref,
+            ),
         )
         .await?;
 
@@ -2479,7 +2483,6 @@ impl Host {
                         actor_ref.clone(),
                         actor_id.to_string(),
                         max,
-                        host_id,
                         annotations.clone(),
                     )
                     .await
@@ -3151,8 +3154,8 @@ impl Host {
             wit_package,
             interfaces,
             name,
-            source_config,
-            target_config,
+            source_config: _,
+            target_config: _,
         } = interface_link_definition.clone();
 
         let actors = self.actors.read().await;
@@ -3203,6 +3206,8 @@ impl Host {
         let spec = actor.component_specification().await;
         self.store_component_spec(&source_id, &spec).await?;
 
+        let set_event = event::linkdef_set(&interface_link_definition);
+
         // Insert link into host map
         self.links
             .write()
@@ -3213,20 +3218,7 @@ impl Host {
             })
             .or_insert(HashSet::from_iter([interface_link_definition]));
 
-        self.publish_event(
-            "linkdef_set",
-            event::linkdef_set(
-                source_id,
-                target,
-                name,
-                wit_namespace,
-                wit_package,
-                &interfaces,
-                &source_config,
-                &target_config,
-            ),
-        )
-        .await?;
+        self.publish_event("linkdef_set", set_event).await?;
         // TODO(#1548): When providers can handle interface links, tell them to set the link.
         // Alternatively, send them configuration cc @thomastaylor312
         // self.rpc_nats
@@ -3245,7 +3237,7 @@ impl Host {
     /// Remove an interface link on a source component for a specific package
     async fn handle_interface_link_del(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<Bytes> {
         let payload = payload.as_ref();
-        let RemoveInterfaceLinkDefinitionRequest {
+        let DeleteInterfaceLinkDefinitionRequest {
             source_id,
             wit_namespace,
             wit_package,

--- a/crates/providers/lattice-controller/src/bin/lattice-controller.rs
+++ b/crates/providers/lattice-controller/src/bin/lattice-controller.rs
@@ -1,12 +1,13 @@
-use wasmcloud_provider_wit_bindgen::deps::wasmcloud_provider_sdk;
+// TODO(brooksmtownsend): bring the lattice control capability provider up-to-date with the control interface
+// use wasmcloud_provider_wit_bindgen::deps::wasmcloud_provider_sdk;
 
-use wasmcloud_provider_lattice_controller::LatticeControllerProvider;
+// use wasmcloud_provider_lattice_controller::LatticeControllerProvider;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    wasmcloud_provider_sdk::start_provider(
-        LatticeControllerProvider::with_cache_timeout_minutes(600),
-        Some("lattice-control-provider".to_string()),
-    )?;
+    // wasmcloud_provider_sdk::start_provider(
+    //     LatticeControllerProvider::with_cache_timeout_minutes(600),
+    //     Some("lattice-control-provider".to_string()),
+    // )?;
 
     eprintln!("Lattice Controller capability provider exiting");
     Ok(())

--- a/crates/providers/lattice-controller/src/lib.rs
+++ b/crates/providers/lattice-controller/src/lib.rs
@@ -1,819 +1,820 @@
-//! wasmCloud Lattice Control capability provider
-//!
-//!
-use std::collections::HashMap;
-use std::sync::Arc;
+// TODO(brooksmtownsend): bring the lattice control capability provider up-to-date with the control interface
+// //! wasmCloud Lattice Control capability provider
+// //!
+// //!
+// use std::collections::HashMap;
+// use std::sync::Arc;
 
-use tokio::sync::{RwLock, RwLockReadGuard};
-use tracing::{error, instrument, warn};
-use wasmcloud_control_interface as interface_client;
+// use tokio::sync::{RwLock, RwLockReadGuard};
+// use tracing::{error, instrument, warn};
+// use wasmcloud_control_interface as interface_client;
 
-mod client_cache;
-use client_cache::ClientCache;
+// mod client_cache;
+// use client_cache::ClientCache;
 
-const DEFAULT_NATS_URI: &str = "0.0.0.0:4222";
-const DEFAULT_TIMEOUT_MS: u64 = 2000;
+// const DEFAULT_NATS_URI: &str = "0.0.0.0:4222";
+// const DEFAULT_TIMEOUT_MS: u64 = 2000;
 
-// NOTE: Exercise caution when adjusting this value, as it can cause tests and
-// other examples to fail, due to going against various timeouts set on the host and
-// cooperating providers/actors, since the *entire* auction duration will be awaited
-// for operations like `get-hosts`
-const DEFAULT_AUCTION_TIMEOUT_MS: u64 = 3000;
-const DEFAULT_LATTICE: &str = "default";
+// // NOTE: Exercise caution when adjusting this value, as it can cause tests and
+// // other examples to fail, due to going against various timeouts set on the host and
+// // cooperating providers/actors, since the *entire* auction duration will be awaited
+// // for operations like `get-hosts`
+// const DEFAULT_AUCTION_TIMEOUT_MS: u64 = 3000;
+// const DEFAULT_LATTICE: &str = "default";
 
-use wasmcloud_provider_wit_bindgen::deps::{
-    async_trait::async_trait,
-    serde::{Deserialize, Serialize},
-    wasmcloud_provider_sdk::{load_host_data, Context},
-};
+// use wasmcloud_provider_wit_bindgen::deps::{
+//     async_trait::async_trait,
+//     serde::{Deserialize, Serialize},
+//     wasmcloud_provider_sdk::{load_host_data, Context},
+// };
 
-wasmcloud_provider_wit_bindgen::generate!({
-    impl_struct: LatticeControllerProvider,
-    contract: "wasmcloud:latticecontrol",
-    replace_witified_maps: true,
-    wit_bindgen_cfg: "provider"
-});
+// wasmcloud_provider_wit_bindgen::generate!({
+//     impl_struct: LatticeControllerProvider,
+//     contract: "wasmcloud:latticecontrol",
+//     replace_witified_maps: true,
+//     wit_bindgen_cfg: "provider"
+// });
 
-/// lattice-controller capability provider implementation
-#[derive(Clone)]
-pub struct LatticeControllerProvider {
-    connection_timeout_mins: u64,
-    connections: Arc<RwLock<Option<ClientCache>>>,
-}
+// /// lattice-controller capability provider implementation
+// #[derive(Clone)]
+// pub struct LatticeControllerProvider {
+//     connection_timeout_mins: u64,
+//     connections: Arc<RwLock<Option<ClientCache>>>,
+// }
 
-impl LatticeControllerProvider {
-    /// Create a controller provider with a specified cache timeout in minutes
-    pub fn with_cache_timeout_minutes(mins: u64) -> Self {
-        Self {
-            connection_timeout_mins: mins,
-            connections: Arc::new(RwLock::new(None)),
-        }
-    }
+// impl LatticeControllerProvider {
+//     /// Create a controller provider with a specified cache timeout in minutes
+//     pub fn with_cache_timeout_minutes(mins: u64) -> Self {
+//         Self {
+//             connection_timeout_mins: mins,
+//             connections: Arc::new(RwLock::new(None)),
+//         }
+//     }
 
-    /// Retrieve the the connection cache, initializing if necessary
-    ///
-    /// This is necessary to avoid having to use an async `main()`,
-    /// as the tokio runtime spawned will clash with an existing running one
-    async fn get_connections(&self) -> RwLockReadGuard<ClientCache> {
-        if self.connections.read().await.is_none() {
-            let cache = ClientCache::new(self.connection_timeout_mins).await;
-            let mut connections = self.connections.write().await;
-            *connections = Some(cache);
-            drop(connections);
-        }
-        let guard = self.connections.read().await;
-        match RwLockReadGuard::try_map(guard, |v| v.as_ref()) {
-            Ok(v) => v,
-            Err(_) => unreachable!("the connections cache must have been initialized"),
-        }
-    }
-}
+//     /// Retrieve the the connection cache, initializing if necessary
+//     ///
+//     /// This is necessary to avoid having to use an async `main()`,
+//     /// as the tokio runtime spawned will clash with an existing running one
+//     async fn get_connections(&self) -> RwLockReadGuard<ClientCache> {
+//         if self.connections.read().await.is_none() {
+//             let cache = ClientCache::new(self.connection_timeout_mins).await;
+//             let mut connections = self.connections.write().await;
+//             *connections = Some(cache);
+//             drop(connections);
+//         }
+//         let guard = self.connections.read().await;
+//         match RwLockReadGuard::try_map(guard, |v| v.as_ref()) {
+//             Ok(v) => v,
+//             Err(_) => unreachable!("the connections cache must have been initialized"),
+//         }
+//     }
+// }
 
-/// Configuration for connecting a nats client.
-/// More options are available if you use the json than variables in the values string map.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(crate = "wasmcloud_provider_wit_bindgen::deps::serde")]
-struct ConnectionConfig {
-    /// URIs used to connect to the cluster
-    #[serde(default)]
-    cluster_uris: Vec<String>,
+// /// Configuration for connecting a nats client.
+// /// More options are available if you use the json than variables in the values string map.
+// #[derive(Debug, Clone, Serialize, Deserialize)]
+// #[serde(crate = "wasmcloud_provider_wit_bindgen::deps::serde")]
+// struct ConnectionConfig {
+//     /// URIs used to connect to the cluster
+//     #[serde(default)]
+//     cluster_uris: Vec<String>,
 
-    /// Authentication JWT
-    #[serde(default)]
-    auth_jwt: Option<String>,
+//     /// Authentication JWT
+//     #[serde(default)]
+//     auth_jwt: Option<String>,
 
-    /// Authentication Seed
-    #[serde(default)]
-    auth_seed: Option<String>,
+//     /// Authentication Seed
+//     #[serde(default)]
+//     auth_seed: Option<String>,
 
-    /// Name of the lattice
-    #[serde(default)]
-    lattice: String,
+//     /// Name of the lattice
+//     #[serde(default)]
+//     lattice: String,
 
-    /// NATS JetStream domain
-    #[serde(default)]
-    js_domain: Option<String>,
+//     /// NATS JetStream domain
+//     #[serde(default)]
+//     js_domain: Option<String>,
 
-    /// Operation timeout used for the lattice client interface
-    timeout_ms: u64,
+//     /// Operation timeout used for the lattice client interface
+//     timeout_ms: u64,
 
-    /// Auction timeout used for the lattice client interface
-    auction_timeout_ms: u64,
-}
+//     /// Auction timeout used for the lattice client interface
+//     auction_timeout_ms: u64,
+// }
 
-impl Default for ConnectionConfig {
-    fn default() -> Self {
-        Self {
-            cluster_uris: vec![DEFAULT_NATS_URI.to_owned()],
-            auth_jwt: None,
-            js_domain: None,
-            auth_seed: None,
-            lattice: String::from(DEFAULT_LATTICE),
-            timeout_ms: DEFAULT_TIMEOUT_MS,
-            auction_timeout_ms: DEFAULT_AUCTION_TIMEOUT_MS,
-        }
-    }
-}
+// impl Default for ConnectionConfig {
+//     fn default() -> Self {
+//         Self {
+//             cluster_uris: vec![DEFAULT_NATS_URI.to_owned()],
+//             auth_jwt: None,
+//             js_domain: None,
+//             auth_seed: None,
+//             lattice: String::from(DEFAULT_LATTICE),
+//             timeout_ms: DEFAULT_TIMEOUT_MS,
+//             auction_timeout_ms: DEFAULT_AUCTION_TIMEOUT_MS,
+//         }
+//     }
+// }
 
-/// Implement the basic requirements of a wasmcloud capability provider
-#[async_trait]
-impl WasmcloudCapabilityProvider for LatticeControllerProvider {
-    #[instrument(level = "debug", skip(self, _ld), fields(actor_id = %_ld.actor_id))]
-    async fn put_link(
-        &self,
-        _ld: &wasmcloud_provider_wit_bindgen::deps::wasmcloud_provider_sdk::core::LinkDefinition,
-    ) -> bool {
-        // This provider is *externally* multiplexed -- link definitions
-        // contain no useful data
-        true
-    }
+// /// Implement the basic requirements of a wasmcloud capability provider
+// #[async_trait]
+// impl WasmcloudCapabilityProvider for LatticeControllerProvider {
+//     #[instrument(level = "debug", skip(self, _ld), fields(actor_id = %_ld.actor_id))]
+//     async fn put_link(
+//         &self,
+//         _ld: &wasmcloud_provider_wit_bindgen::deps::wasmcloud_provider_sdk::core::LinkDefinition,
+//     ) -> bool {
+//         // This provider is *externally* multiplexed -- link definitions
+//         // contain no useful data
+//         true
+//     }
 
-    /// Handle notification that a link is dropped
-    #[instrument(level = "debug", skip(self), fields(actor_id = ?_actor_id))]
-    async fn delete_link(&self, _actor_id: &str) {
-        // Link definitions do not determine the NATS connections
-        // so there is nothing to clean up per link removal
-    }
+//     /// Handle notification that a link is dropped
+//     #[instrument(level = "debug", skip(self), fields(actor_id = ?_actor_id))]
+//     async fn delete_link(&self, _actor_id: &str) {
+//         // Link definitions do not determine the NATS connections
+//         // so there is nothing to clean up per link removal
+//     }
 
-    /// Handle shutdown request
-    #[instrument(level = "debug", skip(self))]
-    async fn shutdown(&self) {
-        // No cleanup necessary for shutdown, since links do not
-        // determine/regulate the NATS connections
-    }
-}
+//     /// Handle shutdown request
+//     #[instrument(level = "debug", skip(self))]
+//     async fn shutdown(&self) {
+//         // No cleanup necessary for shutdown, since links do not
+//         // determine/regulate the NATS connections
+//     }
+// }
 
-/// Implement the lattice-controller-provider provider contract specified in WIT (see provider.wit)
-#[async_trait]
-impl WasmcloudLatticeControlLatticeController for LatticeControllerProvider {
-    /// Sets lattice credentials and stores them in the cache to be used to create a
-    /// connection in the next operation that requires one
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?arg.lattice_id))]
-    async fn set_lattice_credentials(
-        &self,
-        _ctx: Context,
-        arg: SetLatticeCredentialsRequest,
-    ) -> CtlOperationAck {
-        let config = ConnectionConfig {
-            cluster_uris: vec![arg
-                .nats_url
-                .clone()
-                .unwrap_or_else(|| "0.0.0.0:4222".to_string())],
-            auth_jwt: arg.user_jwt.clone(),
-            auth_seed: arg.user_seed.clone(),
-            lattice: arg.lattice_id.to_string(),
-            js_domain: arg.js_domain.clone(),
-            ..Default::default()
-        };
+// /// Implement the lattice-controller-provider provider contract specified in WIT (see provider.wit)
+// #[async_trait]
+// impl WasmcloudLatticeControlLatticeController for LatticeControllerProvider {
+//     /// Sets lattice credentials and stores them in the cache to be used to create a
+//     /// connection in the next operation that requires one
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?arg.lattice_id))]
+//     async fn set_lattice_credentials(
+//         &self,
+//         _ctx: Context,
+//         arg: SetLatticeCredentialsRequest,
+//     ) -> CtlOperationAck {
+//         let config = ConnectionConfig {
+//             cluster_uris: vec![arg
+//                 .nats_url
+//                 .clone()
+//                 .unwrap_or_else(|| "0.0.0.0:4222".to_string())],
+//             auth_jwt: arg.user_jwt.clone(),
+//             auth_seed: arg.user_seed.clone(),
+//             lattice: arg.lattice_id.to_string(),
+//             js_domain: arg.js_domain.clone(),
+//             ..Default::default()
+//         };
 
-        // Setting the auction_timeout to a large value may trigger timeouts in distant code.
-        //
-        // - host configuration rpc_timeout
-        // - `LatticeControllerSender`s which have embedded RPC clients w/ internal timeouts
-        // - httpserver/messaging provider(s) which expect a certain response speed from calling actors
-        //
-        // Since auctions will *wait* until the auction_timeout to do operations like gathering hosts,
-        // we must manually ensure this value is unlikely to cause timeouts.
-        let host_data = match load_host_data() {
-            Ok(host_data) => host_data,
-            Err(e) => {
-                error!("failed to load host data: {e}");
-                return CtlOperationAck {
-                    accepted: false,
-                    error: "failed to load host data".into(),
-                };
-            }
-        };
+//         // Setting the auction_timeout to a large value may trigger timeouts in distant code.
+//         //
+//         // - host configuration rpc_timeout
+//         // - `LatticeControllerSender`s which have embedded RPC clients w/ internal timeouts
+//         // - httpserver/messaging provider(s) which expect a certain response speed from calling actors
+//         //
+//         // Since auctions will *wait* until the auction_timeout to do operations like gathering hosts,
+//         // we must manually ensure this value is unlikely to cause timeouts.
+//         let host_data = match load_host_data() {
+//             Ok(host_data) => host_data,
+//             Err(e) => {
+//                 error!("failed to load host data: {e}");
+//                 return CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to load host data".into(),
+//                 };
+//             }
+//         };
 
-        if host_data
-            .default_rpc_timeout_ms
-            .is_some_and(|v| v < config.timeout_ms)
-        {
-            warn!(
-                host_rpc_timeout_ms = host_data.default_rpc_timeout_ms,
-                auction_timeout = config.auction_timeout_ms,
-                "host default RPC timeout < auction timeout, operations that rely on auctions are likely to time out"
-            );
-        }
+//         if host_data
+//             .default_rpc_timeout_ms
+//             .is_some_and(|v| v < config.timeout_ms)
+//         {
+//             warn!(
+//                 host_rpc_timeout_ms = host_data.default_rpc_timeout_ms,
+//                 auction_timeout = config.auction_timeout_ms,
+//                 "host default RPC timeout < auction timeout, operations that rely on auctions are likely to time out"
+//             );
+//         }
 
-        self.get_connections()
-            .await
-            .put_config(&arg.lattice_id, config)
-            .await;
+//         self.get_connections()
+//             .await
+//             .put_config(&arg.lattice_id, config)
+//             .await;
 
-        CtlOperationAck {
-            accepted: true,
-            error: "".to_string(),
-        }
-    }
+//         CtlOperationAck {
+//             accepted: true,
+//             error: "".to_string(),
+//         }
+//     }
 
-    /// Sets registry credentials, storing them in the cache
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?arg.lattice_id))]
-    async fn set_registry_credentials(
-        &self,
-        _ctx: Context,
-        arg: SetRegistryCredentialsRequest,
-    ) -> () {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&arg.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return;
-            }
-        };
+//     /// Sets registry credentials, storing them in the cache
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?arg.lattice_id))]
+//     async fn set_registry_credentials(
+//         &self,
+//         _ctx: Context,
+//         arg: SetRegistryCredentialsRequest,
+//     ) -> () {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&arg.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return;
+//             }
+//         };
 
-        let mut hm = HashMap::new();
-        if let Some(ref c) = arg.credentials {
-            for (k, v) in c {
-                hm.insert(
-                    k.to_string(),
-                    interface_client::RegistryCredential {
-                        password: v.password.clone(),
-                        token: v.token.clone(),
-                        username: v.username.clone(),
-                        registry_type: "".to_string(),
-                    },
-                );
-            }
-        }
+//         let mut hm = HashMap::new();
+//         if let Some(ref c) = arg.credentials {
+//             for (k, v) in c {
+//                 hm.insert(
+//                     k.to_string(),
+//                     interface_client::RegistryCredential {
+//                         password: v.password.clone(),
+//                         token: v.token.clone(),
+//                         username: v.username.clone(),
+//                         registry_type: "".to_string(),
+//                     },
+//                 );
+//             }
+//         }
 
-        if let Err(e) = client.put_registries(hm).await {
-            error!("failed to set registry credentials: {e}");
-        };
-    }
+//         if let Err(e) = client.put_registries(hm).await {
+//             error!("failed to set registry credentials: {e}");
+//         };
+//     }
 
-    /// Auction a provider on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?arg.lattice_id))]
-    async fn auction_provider(
-        &self,
-        _ctx: Context,
-        arg: ProviderAuctionRequest,
-    ) -> Vec<ProviderAuctionAck> {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&arg.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return Vec::new();
-            }
-        };
+//     /// Auction a provider on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?arg.lattice_id))]
+//     async fn auction_provider(
+//         &self,
+//         _ctx: Context,
+//         arg: ProviderAuctionRequest,
+//     ) -> Vec<ProviderAuctionAck> {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&arg.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return Vec::new();
+//             }
+//         };
 
-        client
-            .perform_provider_auction(&arg.provider_ref, &arg.link_name, arg.constraints.clone())
-            .await
-            .map(|v| {
-                v.into_iter()
-                    .map(|a| ProviderAuctionAck {
-                        host_id: a.host_id,
-                        link_name: a.link_name,
-                        provider_ref: a.provider_ref,
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to auction provider: {e}");
-                Vec::new()
-            })
-    }
+//         client
+//             .perform_provider_auction(&arg.provider_ref, &arg.link_name, arg.constraints.clone())
+//             .await
+//             .map(|v| {
+//                 v.into_iter()
+//                     .map(|a| ProviderAuctionAck {
+//                         host_id: a.host_id,
+//                         link_name: a.link_name,
+//                         provider_ref: a.provider_ref,
+//                     })
+//                     .collect::<Vec<_>>()
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to auction provider: {e}");
+//                 Vec::new()
+//             })
+//     }
 
-    /// Auction an actor on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?arg.lattice_id))]
-    async fn auction_actor(&self, _ctx: Context, arg: ActorAuctionRequest) -> Vec<ActorAuctionAck> {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&arg.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return Vec::new();
-            }
-        };
+//     /// Auction an actor on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?arg.lattice_id))]
+//     async fn auction_actor(&self, _ctx: Context, arg: ActorAuctionRequest) -> Vec<ActorAuctionAck> {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&arg.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return Vec::new();
+//             }
+//         };
 
-        client
-            .perform_actor_auction(&arg.actor_ref, arg.constraints.clone())
-            .await
-            .map(|v| {
-                v.into_iter()
-                    .map(|a| ActorAuctionAck {
-                        actor_ref: a.actor_ref,
-                        host_id: a.host_id,
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to auction actor: {e}");
-                Vec::new()
-            })
-    }
+//         client
+//             .perform_actor_auction(&arg.actor_ref, arg.constraints.clone())
+//             .await
+//             .map(|v| {
+//                 v.into_iter()
+//                     .map(|a| ActorAuctionAck {
+//                         actor_ref: a.actor_ref,
+//                         host_id: a.host_id,
+//                     })
+//                     .collect::<Vec<_>>()
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to auction actor: {e}");
+//                 Vec::new()
+//             })
+//     }
 
-    /// Retrieve all hosts on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = %lattice_id))]
-    async fn get_hosts(&self, _ctx: Context, lattice_id: String) -> Vec<Host> {
-        let client = match self.get_connections().await.get_client(&lattice_id).await {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return Vec::new();
-            }
-        };
+//     /// Retrieve all hosts on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = %lattice_id))]
+//     async fn get_hosts(&self, _ctx: Context, lattice_id: String) -> Vec<Host> {
+//         let client = match self.get_connections().await.get_client(&lattice_id).await {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return Vec::new();
+//             }
+//         };
 
-        client
-            .get_hosts()
-            .await
-            .map(|v| {
-                v.into_iter()
-                    .map(|h| {
-                        let lattice_prefix = h.lattice().cloned();
-                        Host {
-                            cluster_issuers: h.cluster_issuers,
-                            ctl_host: h.ctl_host,
-                            id: h.id,
-                            js_domain: h.js_domain,
-                            labels: h.labels,
-                            lattice_prefix, // NOTE: the control interface type has been updated to just `lattice`, but the wit type is still `lattice_prefix`
-                            prov_rpc_host: h.rpc_host.clone(),
-                            rpc_host: h.rpc_host,
-                            uptime_human: h.uptime_human,
-                            uptime_seconds: h.uptime_seconds,
-                            version: h.version,
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to get hosts: {e}");
-                Vec::new()
-            })
-    }
+//         client
+//             .get_hosts()
+//             .await
+//             .map(|v| {
+//                 v.into_iter()
+//                     .map(|h| {
+//                         let lattice_prefix = h.lattice().cloned();
+//                         Host {
+//                             cluster_issuers: h.cluster_issuers,
+//                             ctl_host: h.ctl_host,
+//                             id: h.id,
+//                             js_domain: h.js_domain,
+//                             labels: h.labels,
+//                             lattice_prefix, // NOTE: the control interface type has been updated to just `lattice`, but the wit type is still `lattice_prefix`
+//                             prov_rpc_host: h.rpc_host.clone(),
+//                             rpc_host: h.rpc_host,
+//                             uptime_human: h.uptime_human,
+//                             uptime_seconds: h.uptime_seconds,
+//                             version: h.version,
+//                         }
+//                     })
+//                     .collect::<Vec<_>>()
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to get hosts: {e}");
+//                 Vec::new()
+//             })
+//     }
 
-    /// Retrieve inventory for a given host on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, host = ?arg.host_id, lattice_id = ?arg.lattice_id))]
-    async fn get_host_inventory(
-        &self,
-        _ctx: Context,
-        arg: GetHostInventoryRequest,
-    ) -> HostInventory {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&arg.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return HostInventory {
-                    host_id: String::default(),
-                    labels: HashMap::new(),
-                    actors: Vec::new(),
-                    providers: Vec::new(),
-                };
-            }
-        };
+//     /// Retrieve inventory for a given host on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, host = ?arg.host_id, lattice_id = ?arg.lattice_id))]
+//     async fn get_host_inventory(
+//         &self,
+//         _ctx: Context,
+//         arg: GetHostInventoryRequest,
+//     ) -> HostInventory {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&arg.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return HostInventory {
+//                     host_id: String::default(),
+//                     labels: HashMap::new(),
+//                     actors: Vec::new(),
+//                     providers: Vec::new(),
+//                 };
+//             }
+//         };
 
-        client
-            .get_host_inventory(&arg.host_id)
-            .await
-            .map(|hi| HostInventory {
-                actors: hi
-                    .actors
-                    .into_iter()
-                    .map(|ad| ActorDescription {
-                        id: ad.id,
-                        image_ref: ad.image_ref,
-                        instances: ad
-                            .instances
-                            .into_iter()
-                            .map(|ai| ActorInstance {
-                                annotations: ai.annotations,
-                                instance_id: ai.instance_id,
-                                revision: ai.revision,
-                            })
-                            .collect::<Vec<_>>(),
-                        name: ad.name,
-                    })
-                    .collect::<Vec<_>>(),
-                host_id: hi.host_id,
-                labels: hi.labels,
-                providers: hi
-                    .providers
-                    .into_iter()
-                    .map(|pd| ProviderDescription {
-                        annotations: pd.annotations,
-                        id: pd.id,
-                        image_ref: pd.image_ref,
-                        link_name: pd.link_name,
-                        name: pd.name,
-                        revision: pd.revision,
-                    })
-                    .collect::<Vec<_>>(),
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to get host inventory : {e}");
-                HostInventory {
-                    host_id: String::default(),
-                    labels: HashMap::new(),
-                    actors: Vec::new(),
-                    providers: Vec::new(),
-                }
-            })
-    }
+//         client
+//             .get_host_inventory(&arg.host_id)
+//             .await
+//             .map(|hi| HostInventory {
+//                 actors: hi
+//                     .actors
+//                     .into_iter()
+//                     .map(|ad| ActorDescription {
+//                         id: ad.id,
+//                         image_ref: ad.image_ref,
+//                         instances: ad
+//                             .instances
+//                             .into_iter()
+//                             .map(|ai| ActorInstance {
+//                                 annotations: ai.annotations,
+//                                 instance_id: ai.instance_id,
+//                                 revision: ai.revision,
+//                             })
+//                             .collect::<Vec<_>>(),
+//                         name: ad.name,
+//                     })
+//                     .collect::<Vec<_>>(),
+//                 host_id: hi.host_id,
+//                 labels: hi.labels,
+//                 providers: hi
+//                     .providers
+//                     .into_iter()
+//                     .map(|pd| ProviderDescription {
+//                         annotations: pd.annotations,
+//                         id: pd.id,
+//                         image_ref: pd.image_ref,
+//                         link_name: pd.link_name,
+//                         name: pd.name,
+//                         revision: pd.revision,
+//                     })
+//                     .collect::<Vec<_>>(),
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to get host inventory : {e}");
+//                 HostInventory {
+//                     host_id: String::default(),
+//                     labels: HashMap::new(),
+//                     actors: Vec::new(),
+//                     providers: Vec::new(),
+//                 }
+//             })
+//     }
 
-    /// Retrieve claims for a given client
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id))]
-    async fn get_claims(&self, _ctx: Context, lattice_id: String) -> GetClaimsResponse {
-        let client = match self.get_connections().await.get_client(&lattice_id).await {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return GetClaimsResponse { claims: Vec::new() };
-            }
-        };
+//     /// Retrieve claims for a given client
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id))]
+//     async fn get_claims(&self, _ctx: Context, lattice_id: String) -> GetClaimsResponse {
+//         let client = match self.get_connections().await.get_client(&lattice_id).await {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return GetClaimsResponse { claims: Vec::new() };
+//             }
+//         };
 
-        client
-            .get_claims()
-            .await
-            .map(|claims| GetClaimsResponse { claims })
-            .unwrap_or_else(|e| {
-                error!("failed to get claims: {e}");
-                GetClaimsResponse { claims: Vec::new() }
-            })
-    }
+//         client
+//             .get_claims()
+//             .await
+//             .map(|claims| GetClaimsResponse { claims })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to get claims: {e}");
+//                 GetClaimsResponse { claims: Vec::new() }
+//             })
+//     }
 
-    /// Start an actor on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?cmd.lattice_id))]
-    async fn start_actor(&self, _ctx: Context, cmd: StartActorCommand) -> CtlOperationAck {
-        let count = if cmd.count == 0 {
-            1_u32
-        } else {
-            cmd.count.into()
-        };
+//     /// Start an actor on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?cmd.lattice_id))]
+//     async fn start_actor(&self, _ctx: Context, cmd: StartActorCommand) -> CtlOperationAck {
+//         let count = if cmd.count == 0 {
+//             1_u32
+//         } else {
+//             cmd.count.into()
+//         };
 
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&cmd.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return CtlOperationAck {
-                    accepted: false,
-                    error: "failed to get client for connection".into(),
-                };
-            }
-        };
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&cmd.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to get client for connection".into(),
+//                 };
+//             }
+//         };
 
-        client
-            .scale_actor(
-                &cmd.host_id,
-                &cmd.actor_ref,
-                count,
-                Some(cmd.annotations.clone()),
-            )
-            .await
-            .map(|ack| CtlOperationAck {
-                accepted: ack.accepted,
-                error: ack.error,
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to start actor: {e}");
-                CtlOperationAck {
-                    accepted: false,
-                    error: "failed to start actor".into(),
-                }
-            })
-    }
+//         client
+//             .scale_actor(
+//                 &cmd.host_id,
+//                 &cmd.actor_ref,
+//                 count,
+//                 Some(cmd.annotations.clone()),
+//             )
+//             .await
+//             .map(|ack| CtlOperationAck {
+//                 accepted: ack.accepted,
+//                 error: ack.error,
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to start actor: {e}");
+//                 CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to start actor".into(),
+//                 }
+//             })
+//     }
 
-    /// Scale an actor on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?cmd.lattice_id))]
-    async fn scale_actor(&self, _ctx: Context, cmd: ScaleActorCommand) -> CtlOperationAck {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&cmd.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return CtlOperationAck {
-                    accepted: false,
-                    error: "failed to get client for connection".into(),
-                };
-            }
-        };
+//     /// Scale an actor on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?cmd.lattice_id))]
+//     async fn scale_actor(&self, _ctx: Context, cmd: ScaleActorCommand) -> CtlOperationAck {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&cmd.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to get client for connection".into(),
+//                 };
+//             }
+//         };
 
-        client
-            .scale_actor(
-                &cmd.host_id,
-                &cmd.actor_ref,
-                cmd.count,
-                Some(cmd.annotations.clone()),
-            )
-            .await
-            .map(|a| CtlOperationAck {
-                accepted: a.accepted,
-                error: a.error,
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to scale actor: {e}");
-                CtlOperationAck {
-                    accepted: false,
-                    error: "failed to scale actor".into(),
-                }
-            })
-    }
+//         client
+//             .scale_actor(
+//                 &cmd.host_id,
+//                 &cmd.actor_ref,
+//                 cmd.count,
+//                 Some(cmd.annotations.clone()),
+//             )
+//             .await
+//             .map(|a| CtlOperationAck {
+//                 accepted: a.accepted,
+//                 error: a.error,
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to scale actor: {e}");
+//                 CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to scale actor".into(),
+//                 }
+//             })
+//     }
 
-    /// Advertise a link on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?req.lattice_id))]
-    async fn advertise_link(&self, _ctx: Context, req: AdvertiseLinkRequest) -> CtlOperationAck {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&req.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return CtlOperationAck {
-                    accepted: false,
-                    error: "failed to get client for connection".into(),
-                };
-            }
-        };
+//     /// Advertise a link on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?req.lattice_id))]
+//     async fn advertise_link(&self, _ctx: Context, req: AdvertiseLinkRequest) -> CtlOperationAck {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&req.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to get client for connection".into(),
+//                 };
+//             }
+//         };
 
-        client
-            .advertise_link(
-                &req.link.actor_id,
-                &req.link.provider_id,
-                &req.link.contract_id,
-                &req.link.link_name,
-                req.link.values.clone().unwrap_or_default(),
-            )
-            .await
-            .map(|ack| CtlOperationAck {
-                accepted: ack.accepted,
-                error: ack.error,
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to advertise link: {e}");
-                CtlOperationAck {
-                    accepted: false,
-                    error: "failed to advertise link".into(),
-                }
-            })
-    }
+//         client
+//             .advertise_link(
+//                 &req.link.actor_id,
+//                 &req.link.provider_id,
+//                 &req.link.contract_id,
+//                 &req.link.link_name,
+//                 req.link.values.clone().unwrap_or_default(),
+//             )
+//             .await
+//             .map(|ack| CtlOperationAck {
+//                 accepted: ack.accepted,
+//                 error: ack.error,
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to advertise link: {e}");
+//                 CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to advertise link".into(),
+//                 }
+//             })
+//     }
 
-    /// Remove a link on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?req.lattice_id))]
-    async fn remove_link(
-        &self,
-        _ctx: Context,
-        req: RemoveLinkDefinitionRequest,
-    ) -> CtlOperationAck {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&req.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return CtlOperationAck {
-                    accepted: false,
-                    error: "failed to start actor".into(),
-                };
-            }
-        };
+//     /// Remove a link on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?req.lattice_id))]
+//     async fn remove_link(
+//         &self,
+//         _ctx: Context,
+//         req: RemoveLinkDefinitionRequest,
+//     ) -> CtlOperationAck {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&req.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to start actor".into(),
+//                 };
+//             }
+//         };
 
-        client
-            .remove_link(&req.actor_id, &req.actor_id, &req.link_name)
-            .await
-            .map(|a| CtlOperationAck {
-                accepted: a.accepted,
-                error: a.error,
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to remove link: {e}");
-                CtlOperationAck {
-                    accepted: false,
-                    error: "failed to remove link".into(),
-                }
-            })
-    }
+//         client
+//             .remove_link(&req.actor_id, &req.actor_id, &req.link_name)
+//             .await
+//             .map(|a| CtlOperationAck {
+//                 accepted: a.accepted,
+//                 error: a.error,
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to remove link: {e}");
+//                 CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to remove link".into(),
+//                 }
+//             })
+//     }
 
-    /// Retrieve links on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id))]
-    async fn get_links(&self, _ctx: Context, lattice_id: String) -> Vec<LinkDefinition> {
-        let client = match self.get_connections().await.get_client(&lattice_id).await {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return Vec::new();
-            }
-        };
+//     /// Retrieve links on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id))]
+//     async fn get_links(&self, _ctx: Context, lattice_id: String) -> Vec<LinkDefinition> {
+//         let client = match self.get_connections().await.get_client(&lattice_id).await {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return Vec::new();
+//             }
+//         };
 
-        client
-            .query_links()
-            .await
-            .map(|links| {
-                links
-                    .into_iter()
-                    .map(|client_ld| LinkDefinition {
-                        actor_id: client_ld.actor_id,
-                        provider_id: client_ld.provider_id,
-                        contract_id: client_ld.contract_id,
-                        link_name: client_ld.link_name,
-                        values: Some(client_ld.values),
-                    })
-                    .collect()
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to get links: {e}");
-                Vec::new()
-            })
-    }
+//         client
+//             .query_links()
+//             .await
+//             .map(|links| {
+//                 links
+//                     .into_iter()
+//                     .map(|client_ld| LinkDefinition {
+//                         actor_id: client_ld.actor_id,
+//                         provider_id: client_ld.provider_id,
+//                         contract_id: client_ld.contract_id,
+//                         link_name: client_ld.link_name,
+//                         values: Some(client_ld.values),
+//                     })
+//                     .collect()
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to get links: {e}");
+//                 Vec::new()
+//             })
+//     }
 
-    /// Update an actor running on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?cmd.lattice_id))]
-    async fn update_actor(&self, _ctx: Context, cmd: UpdateActorCommand) -> CtlOperationAck {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&cmd.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return CtlOperationAck {
-                    accepted: false,
-                    error: "failed to get client for connection".into(),
-                };
-            }
-        };
+//     /// Update an actor running on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?cmd.lattice_id))]
+//     async fn update_actor(&self, _ctx: Context, cmd: UpdateActorCommand) -> CtlOperationAck {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&cmd.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to get client for connection".into(),
+//                 };
+//             }
+//         };
 
-        client
-            .update_actor(
-                &cmd.host_id,
-                &cmd.actor_id,
-                &cmd.new_actor_ref,
-                cmd.annotations.clone(),
-            )
-            .await
-            .map(|a| CtlOperationAck {
-                accepted: a.accepted,
-                error: a.error,
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to update actor: {e}");
-                CtlOperationAck {
-                    accepted: false,
-                    error: "failed to update actor".into(),
-                }
-            })
-    }
+//         client
+//             .update_actor(
+//                 &cmd.host_id,
+//                 &cmd.actor_id,
+//                 &cmd.new_actor_ref,
+//                 cmd.annotations.clone(),
+//             )
+//             .await
+//             .map(|a| CtlOperationAck {
+//                 accepted: a.accepted,
+//                 error: a.error,
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to update actor: {e}");
+//                 CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to update actor".into(),
+//                 }
+//             })
+//     }
 
-    /// Start a provider on the lattice
-    #[instrument(
-        level = "debug",
-        skip_all,
-        fields(
-            actor_id = ?_ctx.actor,
-            host_id = %cmd.host_id,
-            provider_ref = %cmd.provider_ref,
-            link_name = %cmd.link_name,
-            lattice_id = ?cmd.lattice_id
-        )
-    )]
-    async fn start_provider(&self, _ctx: Context, cmd: StartProviderCommand) -> CtlOperationAck {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&cmd.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return CtlOperationAck {
-                    accepted: false,
-                    error: "failed to start actor".into(),
-                };
-            }
-        };
+//     /// Start a provider on the lattice
+//     #[instrument(
+//         level = "debug",
+//         skip_all,
+//         fields(
+//             actor_id = ?_ctx.actor,
+//             host_id = %cmd.host_id,
+//             provider_ref = %cmd.provider_ref,
+//             link_name = %cmd.link_name,
+//             lattice_id = ?cmd.lattice_id
+//         )
+//     )]
+//     async fn start_provider(&self, _ctx: Context, cmd: StartProviderCommand) -> CtlOperationAck {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&cmd.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to start actor".into(),
+//                 };
+//             }
+//         };
 
-        client
-            .start_provider(
-                &cmd.host_id,
-                &cmd.provider_ref,
-                Some(cmd.link_name.to_owned()),
-                Some(cmd.annotations.clone()),
-                Some(cmd.configuration.clone()),
-            )
-            .await
-            .map(|a| CtlOperationAck {
-                accepted: a.accepted,
-                error: a.error,
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to start provider: {e}");
-                CtlOperationAck {
-                    accepted: false,
-                    error: "failed to start provider".into(),
-                }
-            })
-    }
+//         client
+//             .start_provider(
+//                 &cmd.host_id,
+//                 &cmd.provider_ref,
+//                 Some(cmd.link_name.to_owned()),
+//                 Some(cmd.annotations.clone()),
+//                 Some(cmd.configuration.clone()),
+//             )
+//             .await
+//             .map(|a| CtlOperationAck {
+//                 accepted: a.accepted,
+//                 error: a.error,
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to start provider: {e}");
+//                 CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to start provider".into(),
+//                 }
+//             })
+//     }
 
-    /// Stop a provider on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?cmd.lattice_id))]
-    async fn stop_provider(&self, _ctx: Context, cmd: StopProviderCommand) -> CtlOperationAck {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&cmd.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return CtlOperationAck {
-                    accepted: false,
-                    error: "failed to get client for connection".into(),
-                };
-            }
-        };
+//     /// Stop a provider on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?cmd.lattice_id))]
+//     async fn stop_provider(&self, _ctx: Context, cmd: StopProviderCommand) -> CtlOperationAck {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&cmd.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to get client for connection".into(),
+//                 };
+//             }
+//         };
 
-        client
-            .stop_provider(
-                &cmd.host_id,
-                &cmd.provider_id,
-                &cmd.link_name,
-                &cmd.contract_id,
-                Some(cmd.annotations.clone()),
-            )
-            .await
-            .map(|a| CtlOperationAck {
-                accepted: a.accepted,
-                error: a.error,
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to stop provider: {e}");
-                CtlOperationAck {
-                    accepted: false,
-                    error: "failed to stop provider".into(),
-                }
-            })
-    }
+//         client
+//             .stop_provider(
+//                 &cmd.host_id,
+//                 &cmd.provider_id,
+//                 &cmd.link_name,
+//                 &cmd.contract_id,
+//                 Some(cmd.annotations.clone()),
+//             )
+//             .await
+//             .map(|a| CtlOperationAck {
+//                 accepted: a.accepted,
+//                 error: a.error,
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to stop provider: {e}");
+//                 CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to stop provider".into(),
+//                 }
+//             })
+//     }
 
-    /// Stop a host on the lattice
-    #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?cmd.lattice_id))]
-    async fn stop_host(&self, _ctx: Context, cmd: StopHostCommand) -> CtlOperationAck {
-        let client = match self
-            .get_connections()
-            .await
-            .get_client(&cmd.lattice_id)
-            .await
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!("failed to get client for connection: {e}");
-                return CtlOperationAck {
-                    accepted: false,
-                    error: "failed to start actor".into(),
-                };
-            }
-        };
+//     /// Stop a host on the lattice
+//     #[instrument(level = "debug", skip_all, fields(actor_id = ?_ctx.actor, lattice_id = ?cmd.lattice_id))]
+//     async fn stop_host(&self, _ctx: Context, cmd: StopHostCommand) -> CtlOperationAck {
+//         let client = match self
+//             .get_connections()
+//             .await
+//             .get_client(&cmd.lattice_id)
+//             .await
+//         {
+//             Ok(client) => client,
+//             Err(e) => {
+//                 error!("failed to get client for connection: {e}");
+//                 return CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to start actor".into(),
+//                 };
+//             }
+//         };
 
-        client
-            .stop_host(&cmd.host_id, cmd.timeout)
-            .await
-            .map(|a| CtlOperationAck {
-                accepted: a.accepted,
-                error: a.error,
-            })
-            .unwrap_or_else(|e| {
-                error!("failed to stop host: {e}");
-                CtlOperationAck {
-                    accepted: false,
-                    error: "failed to stop host".into(),
-                }
-            })
-    }
-}
+//         client
+//             .stop_host(&cmd.host_id, cmd.timeout)
+//             .await
+//             .map(|a| CtlOperationAck {
+//                 accepted: a.accepted,
+//                 error: a.error,
+//             })
+//             .unwrap_or_else(|e| {
+//                 error!("failed to stop host: {e}");
+//                 CtlOperationAck {
+//                     accepted: false,
+//                     error: "failed to stop host".into(),
+//                 }
+//             })
+//     }
+// }

--- a/crates/providers/lattice-controller/src/lib.rs
+++ b/crates/providers/lattice-controller/src/lib.rs
@@ -559,7 +559,7 @@
 //         };
 
 //         client
-//             .advertise_link(
+//             .put_link(
 //                 &req.link.actor_id,
 //                 &req.link.provider_id,
 //                 &req.link.contract_id,

--- a/crates/runtime/src/capability/builtin.rs
+++ b/crates/runtime/src/capability/builtin.rs
@@ -247,11 +247,12 @@ impl CallTargetInterface {
     /// Build a [`TargetInterface`] from constituent parts
     #[must_use]
     pub fn from_parts(parts: (&str, &str, &str, Option<&str>)) -> Self {
+        let (ns, pkg, iface, func) = parts;
         Self {
-            namespace: parts.0.into(),
-            package: parts.1.into(),
-            interface: parts.2.into(),
-            function: parts.3.map(String::from),
+            namespace: ns.into(),
+            package: pkg.into(),
+            interface: iface.into(),
+            function: func.map(String::from),
         }
     }
 }

--- a/crates/test-util/src/actor.rs
+++ b/crates/test-util/src/actor.rs
@@ -37,6 +37,7 @@ pub async fn assert_start_actor(
     ctl_client: impl Into<&WasmCloudCtlClient>,
     host_key: impl AsRef<KeyPair>,
     url: impl AsRef<str>,
+    actor_id: impl AsRef<str>,
     count: u32,
 ) -> Result<()> {
     let ctl_client = ctl_client.into();
@@ -49,7 +50,13 @@ pub async fn assert_start_actor(
     let host_key = host_key.as_ref();
 
     let CtlOperationAck { accepted, error } = ctl_client
-        .scale_actor(&host_key.public_key(), url.as_ref(), count, None)
+        .scale_actor(
+            &host_key.public_key(),
+            url.as_ref(),
+            actor_id.as_ref(),
+            count,
+            None,
+        )
         .await
         .map_err(|e| anyhow!(e).context("failed to start actor"))?;
     ensure!(error == "");
@@ -70,6 +77,7 @@ pub async fn assert_scale_actor(
     ctl_client: impl Into<&WasmCloudCtlClient>,
     host_key: impl AsRef<KeyPair>,
     url: impl AsRef<str>,
+    actor_id: impl AsRef<str>,
     annotations: Option<HashMap<String, String>>,
     count: u32,
 ) -> anyhow::Result<()> {
@@ -85,7 +93,13 @@ pub async fn assert_scale_actor(
         NonZeroUsize::try_from(NonZeroU32::new(count).context("failed to create nonzero u32")?)
             .context("failed to convert nonzero u32 to nonzero usize")?;
     let CtlOperationAck { accepted, error } = ctl_client
-        .scale_actor(&host_key.public_key(), url.as_ref(), count, annotations)
+        .scale_actor(
+            &host_key.public_key(),
+            url.as_ref(),
+            actor_id.as_ref(),
+            count,
+            annotations,
+        )
         .await
         .map_err(|e| anyhow!(e).context("failed to start actor"))?;
     ensure!(error == "");

--- a/crates/test-util/src/lattice/config.rs
+++ b/crates/test-util/src/lattice/config.rs
@@ -1,20 +1,18 @@
 //! Utilities for managing on-lattice configuration
+use std::collections::HashMap;
+
 use anyhow::{anyhow, Result};
-use wascap::jwt;
 
 /// Put a configuration value, ensuring that the put succeeded
 pub async fn assert_config_put(
     client: impl AsRef<wasmcloud_control_interface::Client>,
-    actor_claims: impl AsRef<jwt::Claims<jwt::Actor>>,
-    key: impl AsRef<str>,
-    value: impl Into<Vec<u8>>,
+    name: impl AsRef<str>,
+    config: HashMap<String, String>,
 ) -> Result<()> {
     let client = client.as_ref();
-    let actor_claims = actor_claims.as_ref();
-    let key = key.as_ref();
-    let value = value.into();
+    let name = name.as_ref();
     client
-        .put_config(&actor_claims.subject, key, value)
+        .put_config(name, config)
         .await
         .map(|_| ())
         .map_err(|e| anyhow!(e).context("failed to put config"))

--- a/crates/test-util/src/lattice/link.rs
+++ b/crates/test-util/src/lattice/link.rs
@@ -1,33 +1,37 @@
 //! Utilities for managing lattice links
 
-use std::collections::HashMap;
-
 use anyhow::{anyhow, Result};
-use nkeys::KeyPair;
+use wasmcloud_control_interface::InterfaceLinkDefinition;
 
-use wascap::jwt;
-
+#[allow(clippy::too_many_arguments)]
 pub async fn assert_advertise_link(
     client: impl Into<&wasmcloud_control_interface::Client>,
-    actor_claims: impl Into<&jwt::Claims<jwt::Actor>>,
-    provider_key: impl Into<&KeyPair>,
-    contract_id: impl AsRef<str>,
+    source_id: impl AsRef<str>,
+    target: impl AsRef<str>,
     link_name: impl AsRef<str>,
-    values: HashMap<String, String>,
+    wit_namespace: impl AsRef<str>,
+    wit_package: impl AsRef<str>,
+    interfaces: Vec<String>,
+    source_config: Vec<String>,
+    target_config: Vec<String>,
 ) -> Result<()> {
     let client = client.into();
-    let actor_claims = actor_claims.into();
-    let provider_key = provider_key.into();
-    let contract_id = contract_id.as_ref();
+    let source_id = source_id.as_ref();
+    let target = target.as_ref();
     let link_name = link_name.as_ref();
+    let wit_namespace = wit_namespace.as_ref();
+    let wit_package = wit_package.as_ref();
     client
-        .advertise_link(
-            &actor_claims.subject,
-            &provider_key.public_key(),
-            contract_id,
-            link_name,
-            values,
-        )
+        .put_link(InterfaceLinkDefinition {
+            source_id: source_id.to_string(),
+            target: target.to_string(),
+            name: link_name.to_string(),
+            wit_namespace: wit_namespace.to_string(),
+            wit_package: wit_package.to_string(),
+            interfaces,
+            source_config,
+            target_config,
+        })
         .await
         .map_err(|e| anyhow!(e).context("failed to advertise link"))?;
     Ok(())
@@ -35,17 +39,19 @@ pub async fn assert_advertise_link(
 
 pub async fn assert_remove_link(
     client: impl Into<&wasmcloud_control_interface::Client>,
-    actor_claims: impl Into<&jwt::Claims<jwt::Actor>>,
-    contract_id: impl AsRef<str>,
+    actor_id: impl AsRef<str>,
+    wit_namespace: impl AsRef<str>,
+    wit_package: impl AsRef<str>,
     link_name: impl AsRef<str>,
 ) -> Result<()> {
     let client = client.into();
-    let actor_claims = actor_claims.into();
-    let contract_id = contract_id.as_ref();
+    let actor_id = actor_id.as_ref();
+    let wit_namespace = wit_namespace.as_ref();
+    let wit_package = wit_package.as_ref();
     let link_name = link_name.as_ref();
     client
-        .remove_link(&actor_claims.subject, contract_id, link_name)
+        .delete_link(actor_id, link_name, wit_namespace, wit_package)
         .await
-        .map_err(|e| anyhow!(e).context("failed to remove link"))?;
+        .map_err(|e| anyhow!(e).context("failed to delete link"))?;
     Ok(())
 }

--- a/crates/test-util/src/provider.rs
+++ b/crates/test-util/src/provider.rs
@@ -20,7 +20,7 @@ pub struct StartProviderArgs<'a> {
     pub lattice: &'a str,
     pub host_key: &'a KeyPair,
     pub provider_key: &'a KeyPair,
-    pub link_name: &'a str,
+    pub provider_id: &'a str,
     pub url: &'a Url,
     pub configuration: Option<String>,
 }
@@ -46,7 +46,7 @@ pub async fn assert_start_provider(
         lattice,
         host_key,
         provider_key,
-        link_name,
+        provider_id,
         url,
         configuration,
     }: StartProviderArgs<'_>,
@@ -56,7 +56,7 @@ pub async fn assert_start_provider(
         .start_provider(
             &host_key.public_key(),
             url.as_ref(),
-            Some(link_name.to_string()),
+            provider_id,
             None,
             configuration,
         )
@@ -72,7 +72,7 @@ pub async fn assert_start_provider(
                 "wasmbus.rpc.{}.{}.{}.health",
                 lattice,
                 provider_key.public_key(),
-                link_name,
+                "default",
             ),
             "".into(),
         ))


### PR DESCRIPTION
## Feature or Problem
This PR includes quite a few changes in the control interface and host, but in sum:
1. Updates actor and provider commands on the control interface to support pulling in component IDs, which is a unique identifier for the component itself and used in routing
2. Flattens both the `ActorInstance` and `ProviderInstance` into their parent `Actor` / `Provider` struct, now that component IDs uniquely identify the component we don't need to index based on annotations
3. Drop the `link_name` and `contract_id` from providers, since we don't need them anymore. I attempted to keep the `link_name` as default in many places for some amount of backwards compat with provider things.
4. Fully support interface links through the `get` / `put` / `del` control interface topics
5. Remove the concept of aliases, no longer needed!

## Related Issues
Original PR that I closed: #1572 
Fully fixes #1092 by removing old events

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
