### PR TITLE
fix macro generation wit functions

### DIFF
--- a/crates/provider-wit-bindgen-macro/src/wit.rs
+++ b/crates/provider-wit-bindgen-macro/src/wit.rs
@@ -520,7 +520,7 @@ impl WitFunctionLatticeTranslationStrategy {
         // (ex. MessagingConsumerRequestMultiInvocation)
         let struct_name = format_ident!(
             "{}{}Invocation",
-            wit_iface_name.to_upper_camel_case(),
+            wit_iface_name.replace(".", "").to_upper_camel_case(),
             trait_method.sig.ident.to_string().to_upper_camel_case()
         );
 


### PR DESCRIPTION
## Feature or Problem
When generating macros for my custom wit providers i would get error messages saying 'not a valid identifier'
e.g. 
   = help: message: `"org.package.methodnameInvocation"` is not a valid identifier

# Proposed solution
It seems that the method names separated by periods may be used for lattice linking and for generating the rust structs, where this seems it needs to be sanitised and does not correctly line up with the doc comments above.

# Potential issue
Ensure that this lines up with the lattice method mapping inside Wasmcloud. 