### PR TITLE
chore(provider-wit-bindgen): bump version to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5577,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-wit-bindgen-macro"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "heck 0.4.1",

--- a/crates/provider-wit-bindgen-macro/Cargo.toml
+++ b/crates/provider-wit-bindgen-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-wit-bindgen-macro"
-version = "0.1.0"
+version = "0.1.1"
 description = """
 Internal-use bindgen macro for binary-based wasmCloud capability providers written in Rust
 """


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This PR commits a new version of  `provider-wit-bindgen-macro` crates:

- `provider-wit-bindgen-macro` `v0.1.1`

While the crate is unreleased, people depending on the versions committed to `main` should benefit from the bugfixes -- in particular https://github.com/wasmCloud/wasmCloud/commit/51c4f8e271a9d4d6fea95653ed31cc57069e9665

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
