### PR TITLE
fix(provider-wit-bindgen): argument bundling & type resolution

### DIFF
--- a/crates/provider-wit-bindgen-macro/src/bindgen_visitor.rs
+++ b/crates/provider-wit-bindgen-macro/src/bindgen_visitor.rs
@@ -455,6 +455,7 @@ impl VisitMut for WitBindgenOutputVisitor {
                     ty: ref mut item_ty,
                     ..
                 } = cloned_t;
+
                 // If the type that we're about to process has `super::`s attached, we need to translate those
                 // to the actual types they *should* be, which are likely hanging off the crate or some other
                 // dep like `wasmtime` (ex. `wasmtime::component::Resource`)
@@ -697,9 +698,12 @@ impl VisitMut for WitBindgenOutputVisitor {
                     // this is used later to generate interfaces, when generating interfaces, as a import path lookup
                     // so that types can be resolved (i.e. T -> path::to::T)
                     let mut struct_import_path = Punctuated::<syn::PathSegment, Token![::]>::new();
+
+                    // Add all parents until this point to the internal struct's name
                     for p in self.parents.iter() {
                         struct_import_path.push(syn::PathSegment::from(p.clone()));
                     }
+                    // Add the struct name itself
                     struct_import_path.push(syn::PathSegment::from(s.ident.clone()));
 
                     // Disallow the case where two identically named structs exist under different paths

--- a/crates/provider-wit-bindgen-macro/src/rust.rs
+++ b/crates/provider-wit-bindgen-macro/src/rust.rs
@@ -201,18 +201,7 @@ pub(crate) fn convert_to_owned_type_arg(
                 panic!("unexpectedly missing the first token in FnArg");
             }
 
-            // With a completely unknown type, we should attempt to replace it with a qualified type name
-            match &ts[2] {
-                // If the third token (after the arg name and ':') has a type we know, fill in the qualified name
-                TokenTree::Ident(name) if type_lookup.contains_key(&name.to_string()) => {
-                    let qualified_type = type_lookup.get(&name.to_string()).unwrap().0.to_token_stream();
-                    tokens.append_all(&ts[0..2]);
-                    tokens.append_all(qualified_type);
-                    tokens.append_all(&ts[3..]);
-                }
-                // Ignore types that aren't in some lookup
-                _ => tokens.append_all(ts)
-            }
+            tokens.append_all(ts);
         }
     }
 

--- a/crates/provider-wit-bindgen-macro/src/wit.rs
+++ b/crates/provider-wit-bindgen-macro/src/wit.rs
@@ -550,8 +550,12 @@ impl WitFunctionLatticeTranslationStrategy {
                     ))]);
                 }
 
-                // Match on a single input argument in the function signature,
-                // converting known types to ones that can be used as invocation struct members.
+                // For the current input argument in the function signature,
+                // convert known types to ones that can be used as invocation struct members.
+                //
+                // i.e. given some `record type {...}` defined in WIT, a Rust `struct Type {...}` will be produced.
+                // if we see some::path::to::Type, we should replace it with Type, because all of those types have been
+                // extracted, raised and put at the top level by our bindgen
                 let (arg_name, owned_type_tokens) = convert_to_owned_type_arg(
                     struct_lookup,
                     type_lookup,
@@ -559,12 +563,10 @@ impl WitFunctionLatticeTranslationStrategy {
                     bindgen_cfg.replace_witified_maps,
                 );
 
-                // Raw arg_names are produced
-                //
-                // TODO: is this a bug???
-                if arg_name.to_string().ends_with("_map") {
-                    invocation_arg_names.push(arg_name);
-                }
+                // Add the invocation argument name to the list,
+                // so that when we convert this LatticeMethod into an exported function
+                // we can re-create the arguments as if they were never bundled into a struct.
+                invocation_arg_names.push(arg_name);
 
                 // Add the generated `FnArg` tokens
                 tokens.extend(owned_type_tokens);


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit fixes two issues with provider bindgen:

- Types replaced as part of structs were using their full qualified paths, depsite types being lifted to the top level (with structs), not needing it.

- Invocation arguments for `LatticeMethod`s that were recorded were not being saved when processing structs. This comes up when exporting a function that needed it's arguments bundled into a struct

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
