### PR TITLE
`wrpc:http/outgoing-handler` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5324,6 +5324,7 @@ dependencies = [
  "wasmcloud-host",
  "wasmcloud-test-util",
  "wasmcloud-tracing",
+ "wrpc-interface-http",
  "wrpc-transport",
  "wrpc-transport-nats",
  "wrpc-types",
@@ -5465,6 +5466,7 @@ dependencies = [
  "futures",
  "hex",
  "http 1.0.0",
+ "http-body 1.0.0",
  "humantime",
  "names",
  "nkeys",
@@ -5490,6 +5492,8 @@ dependencies = [
  "wasmcloud-core",
  "wasmcloud-runtime",
  "wasmcloud-tracing",
+ "wasmtime-wasi-http",
+ "wrpc-interface-http",
  "wrpc-transport",
  "wrpc-transport-nats",
  "wrpc-types",
@@ -6477,10 +6481,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "wrpc-runtime-wasmtime"
-version = "0.3.0"
+name = "wrpc-interface-http"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd7e2ef8190da62227e2c60df1833d8fb72204dae6d6863494088708cb9888"
+checksum = "bc563243cc546d3878ba3ac34198b8da0285fb1bdb24b4d371a72fc58bf9fdd9"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "futures",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "wasmtime-wasi-http",
+ "wrpc-transport",
+]
+
+[[package]]
+name = "wrpc-runtime-wasmtime"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718e39f98f06ee5acc17bc23f37dddcd2f36a34d6671aca7ae623b287fcd4ce2"
 dependencies = [
  "anyhow",
  "futures",
@@ -6492,9 +6516,9 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport"
-version = "0.12.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b31b0a64eda7d308bb49ab2114b43dc79ff94bc2f32484c59d74ebd6a8981b"
+checksum = "89c48ebeb12d9c32d8cdfc11786d24c08a70bfa299ee3c836ffe4ffc7bbd2682"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -6510,9 +6534,9 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90565e4becebda83ee51b90734dc9d4624ae06d28f5a3da9b525991107e64f46"
+checksum = "51a68e4a866b03424542b07ee3a98925ca3455f56a61a3c4e866d22a5b8f88f8"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ vaultrs = { workspace = true, features = ["rustls"] }
 wascap = { workspace = true }
 wasmcloud-control-interface = { workspace = true }
 wasmcloud-test-util = { workspace = true }
+wrpc-interface-http = { workspace = true }
 wrpc-transport = { workspace = true }
 wrpc-transport-nats = { workspace = true }
 wrpc-types = { workspace = true }
@@ -214,7 +215,8 @@ wit-bindgen-core = { version = "=0.17.0", default-features = false }
 wit-bindgen-go = { version = "0.17", default-features = false }
 wit-component = { version = "0.20", default-features = false }
 wit-parser = { version = "0.13", default-features = false }
-wrpc-runtime-wasmtime = { version = "0.3", default-features = false }
-wrpc-transport = { version = "0.12", default-features = false }
-wrpc-transport-nats = { version = "0.9", default-features = false }
+wrpc-interface-http = { version = "0.11.2", default-features = false }
+wrpc-runtime-wasmtime = { version = "0.5", default-features = false }
+wrpc-transport = { version = "0.14", default-features = false }
+wrpc-transport-nats = { version = "0.11", default-features = false }
 wrpc-types = { version = "0.4", default-features = false }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -22,6 +22,7 @@ cloudevents-sdk = { workspace = true }
 futures = { workspace = true, features = ["async-await", "std"] }
 hex = { workspace = true, features = ["std"] }
 http = { workspace = true }
+http-body = { workspace = true }
 humantime = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"] }
 names = { workspace = true }
@@ -35,7 +36,14 @@ serde_bytes = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 time = { workspace = true, features = ["formatting"] }
-tokio = { workspace = true, features = ["fs", "io-std", "io-util", "process", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = [
+    "fs",
+    "io-std",
+    "io-util",
+    "process",
+    "rt-multi-thread",
+    "time",
+] }
 tokio-stream = { workspace = true, features = ["net", "time"] }
 tracing = { workspace = true }
 ulid = { workspace = true, features = ["std"] }
@@ -47,6 +55,8 @@ wasmcloud-control-interface = { workspace = true }
 wasmcloud-core = { workspace = true, features = ["otel"] }
 wasmcloud-runtime = { workspace = true }
 wasmcloud-tracing = { workspace = true, features = ["otel"] }
+wasmtime-wasi-http = { workspace = true }
+wrpc-interface-http = { workspace = true, features = ["http", "wasmtime-wasi-http"] }
 wrpc-transport = { workspace = true }
 wrpc-transport-nats = { workspace = true }
 wrpc-types = { workspace = true }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -59,7 +59,7 @@ use wasmcloud_runtime::capability::{
 };
 use wasmcloud_runtime::Runtime;
 use wasmcloud_tracing::context::TraceContextInjector;
-use wrpc_transport::{AcceptedInvocation, Client, Transmitter};
+use wrpc_transport::{AcceptedInvocation, Client, DynamicTuple, Transmitter};
 use wrpc_types::DynamicFunction;
 
 use crate::{
@@ -222,7 +222,7 @@ async fn resolve_target(target: Option<&TargetEntity>) -> anyhow::Result<WasmClo
 }
 
 impl Handler {
-    #[instrument(level = "debug", skip(self, operation, request))]
+    #[instrument(level = "debug", skip_all)]
     async fn call_operation_with_payload(
         &self,
         target: Option<TargetEntity>,
@@ -291,7 +291,7 @@ impl Handler {
         }
     }
 
-    #[instrument(level = "debug", skip(self, operation, request))]
+    #[instrument(level = "debug", skip_all)]
     async fn call_operation(
         &self,
         target: Option<TargetEntity>,
@@ -731,7 +731,7 @@ impl Bus for Handler {
             .unwrap_or_default()))
     }
 
-    #[instrument(level = "debug", skip(self, params))]
+    #[instrument(level = "debug", skip(self, target, params))]
     async fn call(
         &self,
         target: Option<TargetEntity>,
@@ -748,7 +748,7 @@ impl Bus for Handler {
                 self.nats.clone(),
                 format!("{}.{id}", self.lattice),
             )
-            .invoke_dynamic(instance, name, params, results)
+            .invoke_dynamic(instance, name, DynamicTuple(params), results)
             .await?;
             tx.await.context("failed to transmit parameters")?;
             Ok(results)

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -3641,9 +3641,9 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport"
-version = "0.12.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b31b0a64eda7d308bb49ab2114b43dc79ff94bc2f32484c59d74ebd6a8981b"
+checksum = "89c48ebeb12d9c32d8cdfc11786d24c08a70bfa299ee3c836ffe4ffc7bbd2682"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/crates/runtime/src/capability/builtin.rs
+++ b/crates/runtime/src/capability/builtin.rs
@@ -15,6 +15,7 @@ use futures::{Stream, TryStreamExt};
 use nkeys::{KeyPair, KeyPairType};
 use tokio::io::AsyncRead;
 use tracing::{instrument, trace};
+use wasmtime_wasi_http::body::HyperIncomingBody;
 
 #[derive(Clone, Default)]
 pub struct Handler {
@@ -475,8 +476,13 @@ pub trait OutgoingHttp {
     /// Handle `wasi:http/outgoing-handler`
     async fn handle(
         &self,
-        request: OutgoingHttpRequest,
-    ) -> anyhow::Result<::http::Response<Box<dyn AsyncRead + Sync + Send + Unpin>>>;
+        request: wasmtime_wasi_http::types::OutgoingRequest,
+    ) -> anyhow::Result<
+        Result<
+            http::Response<HyperIncomingBody>,
+            wasmtime_wasi_http::bindings::http::types::ErrorCode,
+        >,
+    >;
 }
 
 #[async_trait]
@@ -780,8 +786,13 @@ impl OutgoingHttp for Handler {
     #[instrument(skip(request))]
     async fn handle(
         &self,
-        request: OutgoingHttpRequest,
-    ) -> anyhow::Result<::http::Response<Box<dyn AsyncRead + Sync + Send + Unpin>>> {
+        request: wasmtime_wasi_http::types::OutgoingRequest,
+    ) -> anyhow::Result<
+        Result<
+            http::Response<HyperIncomingBody>,
+            wasmtime_wasi_http::bindings::http::types::ErrorCode,
+        >,
+    > {
         proxy(
             &self.outgoing_http,
             "OutgoingHttp",

--- a/tests/actors/rust/Cargo.lock
+++ b/tests/actors/rust/Cargo.lock
@@ -3237,6 +3237,7 @@ dependencies = [
 name = "wrpc-pinger-component"
 version = "0.1.0"
 dependencies = [
+ "wasmcloud-actor",
  "wit-bindgen 0.16.0",
 ]
 

--- a/tests/actors/rust/wrpc-pinger-component/Cargo.toml
+++ b/tests/actors/rust/wrpc-pinger-component/Cargo.toml
@@ -10,4 +10,5 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
+wasmcloud-actor = { workspace = true }
 wit-bindgen = { workspace = true, features = ["default"] }

--- a/tests/actors/rust/wrpc-pinger-component/src/lib.rs
+++ b/tests/actors/rust/wrpc-pinger-component/src/lib.rs
@@ -3,15 +3,54 @@ wit_bindgen::generate!({
     exports: {
         "wasmcloud:testing/invoke": Actor,
     },
+    with: {
+        "wasi:io/streams@0.2.0": wasmcloud_actor::wasi::io::streams,
+    }
 });
 
-use crate::wasmcloud::testing::*;
-use exports::wasmcloud::testing::invoke::Guest;
+use std::io::{Read, Write};
+
+use wasi::http;
+use wasi::io::poll::poll;
+use wasmcloud::testing::*;
+use wasmcloud_actor::{InputStreamReader, OutputStreamWriter};
 
 struct Actor;
 
-impl Guest for Actor {
+impl exports::wasmcloud::testing::invoke::Guest for Actor {
     fn call() -> String {
+        let http_request = http::types::OutgoingRequest::new(http::types::Fields::new());
+        http_request
+            .set_method(&http::types::Method::Put)
+            .expect("failed to set request method");
+        http_request
+            .set_path_with_query(Some("/test"))
+            .expect("failed to set request path with query");
+        http_request
+            .set_scheme(Some(&http::types::Scheme::Https))
+            .expect("failed to set request scheme");
+        http_request
+            .set_authority(Some("localhost:4242"))
+            .expect("failed to set request authority");
+        let http_request_body = http_request
+            .body()
+            .expect("failed to get outgoing request body");
+        {
+            let mut stream = http_request_body
+                .write()
+                .expect("failed to get outgoing request stream");
+            let mut w = OutputStreamWriter::from(&mut stream);
+            w.write_all(b"test")
+                .expect("failed to write `test` to outgoing request stream");
+            w.flush().expect("failed to flush outgoing request stream");
+        }
+        http::types::OutgoingBody::finish(http_request_body, None)
+            .expect("failed to finish sending request body");
+
+        let http_response = http::outgoing_handler::handle(http_request, None)
+            .expect("failed to handle HTTP request");
+        let http_response_sub = http_response.subscribe();
+
         // No args, return string
         let pong = pingpong::ping();
         // Number arg, return number
@@ -26,6 +65,33 @@ impl Guest for Actor {
         };
         // Record / struct argument
         let is_good_boy = busybox::is_good_boy(&doggo);
+
+        assert_eq!(poll(&[&http_response_sub]), [0]);
+        let http_response = http_response
+            .get()
+            .expect("HTTP request response missing")
+            .expect("HTTP request response requested more than once")
+            .expect("HTTP request failed");
+        assert_eq!(http_response.status(), 200);
+
+        // TODO: Assert headers
+        _ = http_response.headers();
+        let http_response_body = http_response
+            .consume()
+            .expect("failed to get incoming request body");
+        {
+            let mut buf = vec![];
+            let mut stream = http_response_body
+                .stream()
+                .expect("failed to get HTTP request response stream");
+            InputStreamReader::from(&mut stream)
+                .read_to_end(&mut buf)
+                .expect("failed to read value from HTTP request response stream");
+            assert_eq!(buf, b"test");
+        };
+        // TODO: Assert trailers
+        let _trailers = http::types::IncomingBody::finish(http_response_body);
+
         format!("Ping {pong}, meaning of universe is: {meaning_of_universe}, split: {other:?}, is_same: {is_same}, archie good boy: {is_good_boy}")
     }
 }

--- a/tests/actors/rust/wrpc-pinger-component/wit/world.wit
+++ b/tests/actors/rust/wrpc-pinger-component/wit/world.wit
@@ -1,6 +1,7 @@
 package test-wrpc:pinger;
 
 world actor {
+  import wasi:http/outgoing-handler@0.2.0;
   import wasmcloud:testing/pingpong;
   import wasmcloud:testing/busybox;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -22,7 +22,7 @@ pub fn tempdir() -> Result<TempDir> {
 
 /// Retrieve a free port to use from the OS
 pub async fn free_port() -> Result<u16> {
-    TcpListener::bind((Ipv6Addr::UNSPECIFIED, 0))
+    TcpListener::bind((Ipv6Addr::LOCALHOST, 0))
         .await
         .context("failed to start TCP listener")?
         .local_addr()

--- a/tests/wrpc.rs
+++ b/tests/wrpc.rs
@@ -1,9 +1,16 @@
+use core::time::Duration;
+
 use anyhow::Context;
+use futures::stream;
+use futures::TryStreamExt as _;
 use test_actors::{RUST_WRPC_PINGER_COMPONENT, RUST_WRPC_PONGER_COMPONENT};
+use tokio::try_join;
+use tracing::info;
+use tracing_subscriber::prelude::*;
 use wasmcloud_test_util::{
     actor::assert_scale_actor, host::WasmCloudTestHost, lattice::link::assert_advertise_link,
 };
-use wrpc_transport::Client;
+use wrpc_transport::{AcceptedInvocation, Client as _, Transmitter as _};
 
 pub mod common;
 use common::nats::start_nats;
@@ -14,6 +21,15 @@ const PONGER_COMPONENT_ID: &str = "wrpc_ponger_component";
 
 #[tokio::test]
 async fn wrpc() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().pretty().without_time())
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")
+            }),
+        )
+        .init();
+
     // Start NATS server
     let (nats_server, nats_url, nats_client) =
         start_nats().await.expect("should be able to start NATS");
@@ -21,12 +37,19 @@ async fn wrpc() -> anyhow::Result<()> {
     let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
         .lattice(LATTICE.to_string())
         .build();
-    let wrpc_client =
-        wrpc_transport_nats::Client::new(nats_client, format!("{LATTICE}.{PINGER_COMPONENT_ID}"));
+    let wrpc_client = wrpc_transport_nats::Client::new(
+        nats_client.clone(),
+        format!("{LATTICE}.{PINGER_COMPONENT_ID}"),
+    );
     // Build the host
     let host = WasmCloudTestHost::start(&nats_url, LATTICE, None, None)
         .await
         .context("failed to start test host")?;
+
+    let mut outgoing_http_invocations =
+        wrpc_interface_http::OutgoingHandler::serve_handle(&wrpc_client)
+            .await
+            .context("failed to serve `wrpc:http/outgoing-handler` invocations")?;
 
     // Scale pinger
     assert_scale_actor(
@@ -67,25 +90,122 @@ async fn wrpc() -> anyhow::Result<()> {
     .await
     .expect("should advertise link");
 
-    let result = wrpc_client
-        .invoke_dynamic(
-            "wasmcloud:testing/invoke",
-            "call",
-            (),
-            &[wrpc_types::Type::String],
-        )
-        .await;
-    match result {
-        Ok((values, _tx)) => {
-            if let Some(wrpc_transport::Value::String(result)) = values.first() {
-                assert_eq!(result, "Ping pong, meaning of universe is: 42, split: [\"hi\", \"there\", \"friend\"], is_same: true, archie good boy: true");
-            } else {
-                panic!("Got something other than a string from the component")
-            }
-        }
-        _ => panic!("Error"),
-    }
+    // Link pinger --wasi:http/outgoing-handler--> pinger
+    assert_advertise_link(
+        &ctl_client,
+        PINGER_COMPONENT_ID,
+        PINGER_COMPONENT_ID,
+        "default",
+        "wasi",
+        "http",
+        vec!["outgoing-handler".to_string()],
+        vec![],
+        vec![],
+    )
+    .await
+    .expect("should advertise link");
 
+    try_join!(
+        async {
+            let (results, tx) = wrpc_client
+                .invoke_static::<String>("wasmcloud:testing/invoke", "call", ())
+                .await
+                .context("invocation failed")?;
+            tx.await.context("failed to transmit parameters")?;
+            assert_eq!(
+                results,
+                r#"Ping pong, meaning of universe is: 42, split: ["hi", "there", "friend"], is_same: true, archie good boy: true"#
+            );
+            anyhow::Ok(())
+        },
+        async {
+            let AcceptedInvocation {
+                params:
+                    (
+                        wrpc_interface_http::Request {
+                            mut body,
+                            trailers,
+                            method,
+                            path_with_query,
+                            scheme,
+                            authority,
+                            headers,
+                        },
+                        opts,
+                    ),
+                result_subject,
+                transmitter,
+                ..
+            } = outgoing_http_invocations
+                .try_next()
+                .await
+                .context("failed to accept `wrpc:http/outgoing-handler.handle` invocation")?
+                .context("invocation stream unexpectedly finished")?;
+            assert_eq!(method, wrpc_interface_http::Method::Put);
+            assert_eq!(path_with_query.as_deref(), Some("/test"));
+            assert_eq!(scheme, Some(wrpc_interface_http::Scheme::HTTPS));
+            assert_eq!(authority.as_deref(), Some("localhost:4242"));
+            assert_eq!(
+                headers,
+                vec![("host".into(), vec!["localhost:4242".into()])],
+            );
+            // wasmtime defaults
+            assert_eq!(
+                opts,
+                Some(wrpc_interface_http::RequestOptions {
+                    connect_timeout: Some(Duration::from_secs(600)),
+                    first_byte_timeout: Some(Duration::from_secs(600)),
+                    between_bytes_timeout: Some(Duration::from_secs(600)),
+                })
+            );
+            try_join!(
+                async {
+                    info!("transmit response");
+                    transmitter
+                        .transmit_static(
+                            result_subject,
+                            Ok::<_, wrpc_interface_http::ErrorCode>(
+                                wrpc_interface_http::Response {
+                                    body: stream::iter([("test".into())]),
+                                    trailers: async { None },
+                                    status: 200,
+                                    headers: Vec::default(),
+                                },
+                            ),
+                        )
+                        .await
+                        .context("failed to transmit response")?;
+                    info!("response transmitted");
+                    anyhow::Ok(())
+                },
+                async {
+                    info!("await request body element");
+                    let item = body
+                        .try_next()
+                        .await
+                        .context("failed to receive body item")?
+                        .context("unexpected end of body stream")?;
+                    assert_eq!(String::from_utf8(item).unwrap(), "test");
+                    info!("await request body end");
+                    let item = body
+                        .try_next()
+                        .await
+                        .context("failed to receive end item")?;
+                    assert_eq!(item, None);
+                    info!("request body verified");
+                    Ok(())
+                },
+                async {
+                    info!("await request trailers");
+                    let trailers = trailers.await.context("failed to receive trailers")?;
+                    assert_eq!(trailers, None);
+                    info!("request trailers verified");
+                    Ok(())
+                }
+            )?;
+            Ok(())
+        }
+    )?;
     nats_server
         .stop()
         .await

--- a/tests/wrpc.rs
+++ b/tests/wrpc.rs
@@ -22,7 +22,7 @@ const PONGER_COMPONENT_ID: &str = "wrpc_ponger_component";
 #[tokio::test]
 async fn wrpc() -> anyhow::Result<()> {
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().pretty().without_time())
+        .with(tracing_subscriber::fmt::layer().compact().without_time())
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
                 tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")


### PR DESCRIPTION
Tested with an ad-hoc hand-written "provider" in the `wrpc` test