### PR TITLE
feat(runtime,host): Updates to request throughput

### DIFF
--- a/crates/runtime/src/actor/component/http.rs
+++ b/crates/runtime/src/actor/component/http.rs
@@ -93,10 +93,9 @@ impl Instance {
     pub async fn into_incoming_http(
         mut self,
     ) -> anyhow::Result<InterfaceInstance<incoming_http_bindings::IncomingHttp>> {
-        let (bindings, _) = incoming_http_bindings::IncomingHttp::instantiate_async(
+        let (bindings, _) = incoming_http_bindings::IncomingHttp::instantiate_pre(
             &mut self.store,
-            &self.component,
-            &self.linker,
+            &self.instance_pre,
         )
         .await?;
         Ok(InterfaceInstance {

--- a/crates/runtime/src/actor/component/logging.rs
+++ b/crates/runtime/src/actor/component/logging.rs
@@ -34,12 +34,8 @@ impl Instance {
     pub async fn into_logging(
         mut self,
     ) -> anyhow::Result<InterfaceInstance<logging_bindings::Logging>> {
-        let (bindings, _) = logging_bindings::Logging::instantiate_async(
-            &mut self.store,
-            &self.component,
-            &self.linker,
-        )
-        .await?;
+        let (bindings, _) =
+            logging_bindings::Logging::instantiate_pre(&mut self.store, &self.instance_pre).await?;
         Ok(InterfaceInstance {
             store: Mutex::new(self.store),
             bindings,


### PR DESCRIPTION
This PR consists of two commits that help improve the ability of the system to manage higher numbers of requests per second. The first commit updates the components to be pre-instantiated rather than doing a full instantiation each time. The second commit fixes an issue where we were write locking on the policy decision cache for every request. Now we only write lock when necessary. 

In my load testing of this locally, these led to a 25-28% increase in throughput. Please note I only did the preinstantiation for components as we're removing module support for 1.0