### PR TITLE
feat(host): wasmcloud_transport wrappers to include headers on invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6563,9 +6563,9 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a68e4a866b03424542b07ee3a98925ca3455f56a61a3c4e866d22a5b8f88f8"
+checksum = "f2787648f758b5b5067e052bdbd9eab9913988b6058b664ff3c1935d5188ec48"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6563,9 +6563,9 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2787648f758b5b5067e052bdbd9eab9913988b6058b664ff3c1935d5188ec48"
+checksum = "1409ea5be0dfcb5b1ad0d0fdc627e901016a19da5155d0e8efc7b32c6e9806d1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -8,6 +8,7 @@ use std::collections::hash_map::{self, Entry};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::env::consts::{ARCH, FAMILY, OS};
+use std::f32::consts::E;
 use std::process::Stdio;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -65,6 +66,8 @@ use crate::{
 
 /// wasmCloud host configuration
 pub mod config;
+/// wasmCloud [wrpc_transport] implementations
+pub mod wasmcloud_transport;
 
 pub use config::Host as HostConfig;
 
@@ -171,6 +174,8 @@ struct Handler {
     config_data: Arc<RwLock<ConfigCache>>,
     lattice: String,
     claims: jwt::Claims<jwt::Actor>,
+    /// The identifier of the component that this handler is associated with
+    component_id: String,
     /// The current link name to use for interface targets, overridable in actor code via set_target()
     interface_link_name: Arc<RwLock<LinkName>>,
 
@@ -623,9 +628,14 @@ impl Bus for Handler {
                 .polyfilled_imports
                 .get(instance)
                 .and_then(|functions| functions.get(name)).with_context(|| format!("polyfilled import {instance}/{name} not found, could not determine result types"))?;
-            let (results, tx) = wrpc_transport_nats::Client::new(
+
+            let injector = TraceContextInjector::default_with_span();
+            let mut headers = injector_to_headers(&injector);
+            headers.insert("source-id", self.component_id.as_str());
+            let (results, tx) = wasmcloud_transport::Client::new(
                 self.nats.clone(),
                 format!("{}.{id}", self.lattice),
+                headers,
             )
             .invoke_dynamic(instance, name, DynamicTuple(params), results)
             .await?;
@@ -1120,11 +1130,29 @@ impl Actor {
     /// Handle an incoming wRPC request to invoke an export on this actor instance.
     async fn handle_invocation(
         &self,
+        context: Option<async_nats::HeaderMap>,
         params: InvocationParams,
         result_subject: wrpc_transport_nats::Subject,
         transmitter: &wrpc_transport_nats::Transmitter,
     ) -> anyhow::Result<()> {
         // TODO(#1548): implement querying policy server
+        let injector = TraceContextInjector::default_with_span();
+        let trace_headers = injector_to_headers(&injector);
+
+        if let Some(ref context) = context {
+            // Coerce the HashMap<String, Vec<String>> into a Vec<(String, String)> by
+            // flattening the values
+            let trace_context = context
+                .iter()
+                .flat_map(|(key, value)| {
+                    value
+                        .iter()
+                        .map(|v| (key.to_string(), v.to_string()))
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<(String, String)>>();
+            wasmcloud_tracing::context::attach_span_context(&trace_context);
+        }
 
         // Instantiate component with expected handlers
         let mut actor = self.instantiate().context("failed to instantiate actor")?;
@@ -1156,9 +1184,25 @@ impl Actor {
                         format!("{instance}/{name}"),
                         Box::pin(async {
                             let results = res?;
-                            transmitter
+                            if let Some(mut headers) = context {
+                                // Append the current trace context headers to the invocation context
+                                trace_headers.iter().for_each(|(k, v)| {
+                                    v.iter().for_each(|v| {
+                                        headers.append(k.clone(), v.clone());
+                                    });
+                                });
+                                // Transmit the response with context headers
+                                wasmcloud_transport::TransmitterWithHeaders::new(
+                                    transmitter,
+                                    headers,
+                                )
                                 .transmit_tuple_dynamic(result_subject, results)
                                 .await
+                            } else {
+                                transmitter
+                                    .transmit_tuple_dynamic(result_subject, results)
+                                    .await
+                            }
                         }),
                     )
                 }
@@ -2181,12 +2225,9 @@ impl Host {
                                 return;
                             }
                         };
-                        // TODO(#1568): Propagate the trace parent from context (headers)
-                        // Linked PR above is when the functionality was removed.
-                        _ = context;
                         if let Err(err) = {
                             actor
-                                .handle_invocation(params, result_subject, &transmitter)
+                                .handle_invocation(context, params, result_subject, &transmitter)
                                 .await
                         } {
                             error!(?err, "failed to handle invocation");
@@ -2263,6 +2304,7 @@ impl Host {
             nats: self.rpc_nats.clone(),
             config_data: Arc::clone(&self.config_data_cache),
             lattice: self.host_config.lattice.clone(),
+            component_id: actor_id.clone(),
             claims: claims.clone(),
             interface_link_name: Arc::new(RwLock::new("default".to_string())),
             interface_links: Arc::new(RwLock::new(component_spec.links)),

--- a/crates/host/src/wasmbus/wasmcloud_transport.rs
+++ b/crates/host/src/wasmbus/wasmcloud_transport.rs
@@ -1,0 +1,153 @@
+//! This module provides `wasmcloud`-specific implementations of `wrpc_transport` traits.
+//! Specifically, we wrap the [wrpc_transport::Transmitter], [wrpc_transport::Invocation],
+//! and [wrpc_transport::Client] traits in order to pass invocations with headers, which is how
+//! we propagate trace context and named configuration information along with the invocation.
+//! Most logic is delegated to the underlying `wrpc_transport_nats` client, which provides the
+//! actual NATS-based transport implementation.
+
+use std::{pin::Pin, sync::Arc};
+
+use async_nats::HeaderMap;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::{Future, Stream};
+use tracing::instrument;
+use wrpc_transport::{Encode, IncomingInvocation, OutgoingInvocation};
+use wrpc_transport_nats::{Acceptor, Subject, Subscriber, Transmission};
+
+/// Wrapper around [wrpc_transport_nats::Transmitter] that includes headers. Lifetime specifier
+/// is useful in order to be able to use a reference to the underlying transmitter.
+pub(crate) struct TransmitterWithHeaders<'a> {
+    inner: &'a wrpc_transport_nats::Transmitter,
+    headers: HeaderMap,
+}
+
+impl<'a> TransmitterWithHeaders<'a> {
+    pub(crate) fn new(
+        transmitter: &'a wrpc_transport_nats::Transmitter,
+        headers: HeaderMap,
+    ) -> Self {
+        Self {
+            inner: transmitter,
+            headers,
+        }
+    }
+}
+
+#[async_trait]
+impl<'a> wrpc_transport::Transmitter for TransmitterWithHeaders<'a> {
+    type Subject = Subject;
+    type PublishError = async_nats::PublishError;
+
+    #[instrument(level = "trace", ret, skip(self))]
+    async fn transmit(
+        &self,
+        subject: Self::Subject,
+        payload: Bytes,
+    ) -> Result<(), Self::PublishError> {
+        self.inner
+            .transmit_with_headers(subject, self.headers.clone(), payload)
+            .await
+    }
+}
+
+pub(crate) struct InvocationWithHeaders {
+    inner: wrpc_transport_nats::Invocation,
+    headers: HeaderMap,
+}
+
+impl InvocationWithHeaders {
+    /// This function just delegates to the underlying [wrpc_transport_nats::Invocation::begin] function,
+    /// but since we're consuming `self` it also returns the headers to avoid a clone in [InvocationWithHeaders::invoke].
+    pub(crate) async fn begin(
+        self,
+        params: impl wrpc_transport::Encode,
+    ) -> anyhow::Result<(wrpc_transport_nats::InvocationPre, HeaderMap)> {
+        self.inner
+            .begin(params)
+            .await
+            .map(|inv| (inv, self.headers))
+    }
+}
+
+impl wrpc_transport::Invocation for InvocationWithHeaders {
+    type Transmission = Transmission;
+    type TransmissionFailed = Box<dyn Future<Output = ()> + Send + Unpin>;
+
+    async fn invoke(
+        self,
+        instance: &str,
+        name: &str,
+        params: impl Encode,
+    ) -> anyhow::Result<(Self::Transmission, Self::TransmissionFailed)> {
+        let subject = self.inner.client().static_subject(instance, name);
+        let (inv, headers) = self.begin(params).await?;
+
+        let (tx, tx_failed) = inv.invoke_with_headers(subject, headers).await?;
+        Ok((tx, Box::new(tx_failed)))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Client {
+    inner: wrpc_transport_nats::Client,
+    headers: HeaderMap,
+}
+
+impl Client {
+    pub(crate) fn new(
+        nats: impl Into<Arc<async_nats::Client>>,
+        lattice: String,
+        headers: HeaderMap,
+    ) -> Self {
+        Self {
+            inner: wrpc_transport_nats::Client::new(nats, lattice),
+            headers,
+        }
+    }
+}
+
+#[async_trait]
+impl wrpc_transport::Client for Client {
+    type Context = Option<HeaderMap>;
+    type Subject = Subject;
+    type Subscriber = Subscriber;
+    type Transmission = Transmission;
+    type Acceptor = Acceptor;
+    type InvocationStream = Pin<
+        Box<
+            dyn Stream<
+                    Item = anyhow::Result<
+                        IncomingInvocation<
+                            Self::Context,
+                            Self::Subject,
+                            Self::Subscriber,
+                            Self::Acceptor,
+                        >,
+                    >,
+                > + Send,
+        >,
+    >;
+    type Invocation = InvocationWithHeaders;
+
+    #[instrument(level = "trace", skip(self))]
+    async fn serve(&self, instance: &str, func: &str) -> anyhow::Result<Self::InvocationStream> {
+        self.inner.serve(instance, func).await
+    }
+
+    fn new_invocation(
+        &self,
+    ) -> OutgoingInvocation<Self::Invocation, Self::Subscriber, Self::Subject> {
+        let transport_invocation = self.inner.new_invocation();
+        let invocation_with_headers = InvocationWithHeaders {
+            inner: transport_invocation.invocation,
+            headers: self.headers.clone(),
+        };
+        OutgoingInvocation {
+            invocation: invocation_with_headers,
+            subscriber: transport_invocation.subscriber,
+            result_subject: transport_invocation.result_subject,
+            error_subject: transport_invocation.error_subject,
+        }
+    }
+}

--- a/crates/runtime/src/actor/component/mod.rs
+++ b/crates/runtime/src/actor/component/mod.rs
@@ -625,7 +625,7 @@ impl Component {
     }
 
     /// Instantiates a [Component] and returns the resulting [Instance].
-    #[instrument]
+    #[instrument(level = "debug", skip(self))]
     pub fn instantiate(&self) -> anyhow::Result<Instance> {
         instantiate(
             self.component.clone(),
@@ -706,7 +706,7 @@ impl Instance {
     }
 
     /// Invoke an operation on an [Instance] producing a result.
-    #[instrument(skip_all)]
+    #[instrument(skip(self, params, instance, name), fields(interface = instance, function = name))]
     pub async fn call(
         &mut self,
         instance: &str,


### PR DESCRIPTION
## Feature or Problem
This PR wraps a few traits from [wrpc-transport](https://crates.io/crates/wrpc-transport) in order to pass and send back headers when handling invocations. We already receive headers from incoming invocations, this PR just ensures that we are sending traceparent headers _back_ in response to an invocation and to send them when creating an outbound invocation.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
This works and propagates headers all the way through! I tested it by invoking what we do in the wrpc integration test but invoking manually with a NATS header. For the curious:
```bash
> nats req "default.header.wrpc.0.0.1.wasmcloud:testing/pingpong.ping" "{}" -H source:myterminalteehee
[#15] Received on "default.header.wrpc.0.0.1.wasmcloud:testing/pingpong.ping" with reply "_INBOX.fnOVvdeTxGZoQazDtpSXAY.p0ShVKPK"
source: myterminalteehee

{}


[#16] Received on "_INBOX.fnOVvdeTxGZoQazDtpSXAY.p0ShVKPK" with reply "_INBOX.9ygF5OmJmpbGXiyXjq4LN4"
nil body


[#17] Received on "_INBOX.fnOVvdeTxGZoQazDtpSXAY.p0ShVKPK.results"
source: myterminalteehee

pong
```

Just a note that I tested this, and we _don't_ implicitly propagate all headers all the way through every single invocation, and that's actually intended. We want to be able to attach specific headers to invocations, and with tracing, we want to be able to propagate the traceparent header which is done using our injector traits. That's the only remaining TODO, to ensure that works well.

More verification, we can carry trace state and a trace parent all the way through!
```bash
[#557] Received on "_INBOX.6njCcm7AE4nmZIQCVPSHLD.results"
source-id: ponger
tracestate:
traceparent: 00-49089ae55b5d79d934114fe3032292d5-08fe6951080b0567-01

[#558] Received on "_INBOX.wN5l96SWWAfxigPUsPhlZK.cUMj2b66.results"
firstinvoker: myterminal

mPing pong, meaning of universe is: 42, split: ["hi", "there", "friend"], is_same: true, archie good boy: true
```

![image](https://github.com/wasmCloud/wasmCloud/assets/12040685/a157983f-96c7-4ce9-9634-72678fb52d8b)
![image](https://github.com/wasmCloud/wasmCloud/assets/12040685/f8ca8176-4706-4733-a176-da74ed512db4)
