### PR TITLE
feat(host): implement `wrpc:http/incoming-handler`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6498,9 +6498,9 @@ dependencies = [
 
 [[package]]
 name = "wrpc-interface-http"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc563243cc546d3878ba3ac34198b8da0285fb1bdb24b4d371a72fc58bf9fdd9"
+checksum = "70125b9803618e479e5e0e671cba67d030399cc8b7084dd2da4d9924489d1e5a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,7 @@ wit-bindgen-go = { version = "0.17", default-features = false }
 wit-component = { version = "0.20", default-features = false }
 wit-parser = { version = "0.13", default-features = false }
 wrpc-interface-blobstore = { version = "0.4", default-features = false }
-wrpc-interface-http = { version = "0.11.2", default-features = false }
+wrpc-interface-http = { version = "0.11.4", default-features = false }
 wrpc-interface-keyvalue = { version = "0.3", default-features = false }
 wrpc-runtime-wasmtime = { version = "0.5", default-features = false }
 wrpc-transport = { version = "0.14", default-features = false }

--- a/crates/runtime/src/actor/component/http.rs
+++ b/crates/runtime/src/actor/component/http.rs
@@ -5,7 +5,7 @@ use crate::capability::{IncomingHttp, OutgoingHttp};
 
 use std::sync::Arc;
 
-use anyhow::{bail, Context as _};
+use anyhow::Context as _;
 use async_trait::async_trait;
 use tokio::sync::{oneshot, Mutex};
 use wasmtime::component::{Resource, ResourceTable};
@@ -119,9 +119,6 @@ impl IncomingHttp for InterfaceInstance<incoming_http_bindings::IncomingHttp> {
             .wasi_http_incoming_handler()
             .call_handle(&mut *store, request, response)
             .await?;
-        match response_rx.try_recv() {
-            Ok(res) => Ok(res),
-            Err(_) => bail!("a response was not set"),
-        }
+        response_rx.try_recv().context("a response was not set")
     }
 }

--- a/crates/runtime/src/actor/component/http.rs
+++ b/crates/runtime/src/actor/component/http.rs
@@ -3,20 +3,14 @@ use super::{Ctx, Instance, InterfaceInstance};
 use crate::capability::http::types;
 use crate::capability::{IncomingHttp, OutgoingHttp};
 
-use core::pin::Pin;
-use core::task::Poll;
-
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, Context as _};
+use anyhow::{bail, Context as _};
 use async_trait::async_trait;
-use bytes::{Bytes, BytesMut};
-use http_body::Body;
-use http_body_util::combinators::BoxBody;
-use tokio::io::{AsyncRead, ReadBuf};
 use tokio::sync::{oneshot, Mutex};
 use wasmtime::component::{Resource, ResourceTable};
 use wasmtime_wasi::preview2::{self};
+use wasmtime_wasi_http::body::{HyperIncomingBody, HyperOutgoingBody};
 use wasmtime_wasi_http::types::{
     HostFutureIncomingResponse, IncomingResponseInternal, OutgoingRequest,
 };
@@ -106,181 +100,16 @@ impl Instance {
     }
 }
 
-struct AsyncReadBody {
-    stream: Box<dyn AsyncRead + Sync + Send + Unpin>,
-    frame_size: usize,
-    end: bool,
-}
-
-impl AsyncReadBody {
-    pub fn new(
-        stream: Box<dyn AsyncRead + Sync + Send + Unpin>,
-        frame_size: usize,
-    ) -> AsyncReadBody {
-        Self {
-            stream,
-            frame_size,
-            end: false,
-        }
-    }
-}
-
-impl Body for AsyncReadBody {
-    type Data = Bytes;
-    type Error = types::ErrorCode;
-
-    fn poll_frame(
-        mut self: Pin<&mut Self>,
-        cx: &mut core::task::Context<'_>,
-    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
-        let mut bytes = BytesMut::zeroed(self.frame_size);
-        let mut buf = ReadBuf::new(&mut bytes);
-        match Pin::new(&mut self.stream).poll_read(cx, &mut buf) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Err(err)) => Poll::Ready(Some(Err(types::ErrorCode::InternalError(Some(
-                err.to_string(),
-            ))))),
-            Poll::Ready(Ok(())) => Poll::Ready({
-                let n = buf.filled().len();
-                if n == 0 {
-                    self.end = true;
-                    None
-                } else {
-                    bytes.truncate(n);
-                    Some(Ok(http_body::Frame::data(bytes.freeze())))
-                }
-            }),
-        }
-    }
-
-    fn is_end_stream(&self) -> bool {
-        self.end
-    }
-}
-
-struct BodyAsyncRead {
-    body: BoxBody<Bytes, types::ErrorCode>,
-    buffer: Bytes,
-}
-
-impl AsyncRead for BodyAsyncRead {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        match self.buffer.len() {
-            0 => match Pin::new(&mut self.body).poll_frame(cx) {
-                Poll::Pending => Poll::Pending,
-                Poll::Ready(None) => Poll::Ready(Ok(())),
-                Poll::Ready(Some(Ok(frame))) => {
-                    if let Ok(mut data) = frame.into_data() {
-                        let cap = buf.remaining();
-                        if data.len() > cap {
-                            self.buffer = data.split_off(cap);
-                        }
-                        buf.put_slice(&data);
-                    }
-                    // NOTE: Trailers are not currently supported
-                    Poll::Ready(Ok(()))
-                }
-                Poll::Ready(Some(Err(err))) => {
-                    Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::Other, err)))
-                }
-            },
-            buffered => {
-                let cap = buf.remaining();
-                if buffered > cap {
-                    let data = self.buffer.split_to(cap);
-                    buf.put_slice(&data);
-                } else {
-                    buf.put_slice(&self.buffer);
-                    self.buffer.clear();
-                }
-                Poll::Ready(Ok(()))
-            }
-        }
-    }
-}
-
-impl BodyAsyncRead {
-    pub fn new(body: BoxBody<Bytes, types::ErrorCode>) -> Self {
-        Self {
-            body,
-            buffer: Bytes::default(),
-        }
-    }
-}
-
-fn code_to_error(code: types::ErrorCode) -> anyhow::Error {
-    match code {
-        types::ErrorCode::DnsTimeout => anyhow!("DNS timeout"),
-        types::ErrorCode::DnsError(_) => anyhow!("DNS error"),
-        types::ErrorCode::DestinationNotFound => anyhow!("destination not found"),
-        types::ErrorCode::DestinationUnavailable => anyhow!("destination unavailable"),
-        types::ErrorCode::DestinationIpProhibited => anyhow!("destination IP prohibited"),
-        types::ErrorCode::DestinationIpUnroutable => anyhow!("destination IP unroutable"),
-        types::ErrorCode::ConnectionRefused => anyhow!("connection refused"),
-        types::ErrorCode::ConnectionTerminated => anyhow!("connection terminated"),
-        types::ErrorCode::ConnectionTimeout => anyhow!("connection timeout"),
-        types::ErrorCode::ConnectionReadTimeout => anyhow!("connection read timeout"),
-        types::ErrorCode::ConnectionWriteTimeout => anyhow!("connection write timeout"),
-        types::ErrorCode::ConnectionLimitReached => anyhow!("connection limit reached"),
-        types::ErrorCode::TlsProtocolError => anyhow!("TLS protocol error"),
-        types::ErrorCode::TlsCertificateError => anyhow!("TLS certificate error"),
-        types::ErrorCode::TlsAlertReceived(_) => anyhow!("TLS alert received"),
-        types::ErrorCode::HttpRequestDenied => anyhow!("HTTP request denied"),
-        types::ErrorCode::HttpRequestLengthRequired => anyhow!("HTTP request length required"),
-        types::ErrorCode::HttpRequestBodySize(_) => anyhow!("HTTP request body size"),
-        types::ErrorCode::HttpRequestMethodInvalid => anyhow!("HTTP request method invalid"),
-        types::ErrorCode::HttpRequestUriInvalid => anyhow!("HTTP request URI invalid"),
-        types::ErrorCode::HttpRequestUriTooLong => anyhow!("HTTP request URI too long"),
-        types::ErrorCode::HttpRequestHeaderSectionSize(_) => {
-            anyhow!("HTTP request header section size")
-        }
-        types::ErrorCode::HttpRequestHeaderSize(_) => anyhow!("HTTP request header size"),
-        types::ErrorCode::HttpRequestTrailerSectionSize(_) => {
-            anyhow!("HTTP request trailer section size")
-        }
-        types::ErrorCode::HttpRequestTrailerSize(_) => anyhow!("HTTP request trailer size"),
-        types::ErrorCode::HttpResponseIncomplete => anyhow!("HTTP response incomplete"),
-        types::ErrorCode::HttpResponseHeaderSectionSize(_) => {
-            anyhow!("HTTP response header section size")
-        }
-        types::ErrorCode::HttpResponseHeaderSize(_) => anyhow!("HTTP response header size"),
-        types::ErrorCode::HttpResponseBodySize(_) => anyhow!("HTTP response body size"),
-        types::ErrorCode::HttpResponseTrailerSectionSize(_) => {
-            anyhow!("HTTP response trailer section size")
-        }
-        types::ErrorCode::HttpResponseTrailerSize(_) => anyhow!("HTTP response trailer size"),
-        types::ErrorCode::HttpResponseTransferCoding(_) => {
-            anyhow!("HTTP response transfer coding")
-        }
-        types::ErrorCode::HttpResponseContentCoding(_) => {
-            anyhow!("HTTP response content coding")
-        }
-        types::ErrorCode::HttpResponseTimeout => anyhow!("HTTP response timed out"),
-        types::ErrorCode::HttpUpgradeFailed => anyhow!("HTTP upgrade failed"),
-        types::ErrorCode::HttpProtocolError => anyhow!("HTTP protocol error"),
-        types::ErrorCode::LoopDetected => anyhow!("loop detected"),
-        types::ErrorCode::ConfigurationError => anyhow!("configuration error"),
-        types::ErrorCode::InternalError(None) => anyhow!("internal error"),
-        types::ErrorCode::InternalError(Some(err)) => anyhow!(err).context("internal error"),
-    }
-}
-
 #[async_trait]
 impl IncomingHttp for InterfaceInstance<incoming_http_bindings::IncomingHttp> {
     async fn handle(
         &self,
-        request: http::Request<Box<dyn AsyncRead + Sync + Send + Unpin>>,
-    ) -> anyhow::Result<http::Response<Box<dyn AsyncRead + Sync + Send + Unpin>>> {
+        request: http::Request<HyperIncomingBody>,
+    ) -> anyhow::Result<Result<http::Response<HyperOutgoingBody>, types::ErrorCode>> {
         let mut store = self.store.lock().await;
         let ctx = store.data_mut();
         let request = ctx
-            .new_incoming_request(
-                request.map(|stream| BoxBody::new(AsyncReadBody::new(stream, 1024))),
-            )
+            .new_incoming_request(request)
             .context("failed to create incoming request")?;
         let (response_tx, mut response_rx) = oneshot::channel();
         let response = ctx
@@ -291,10 +120,7 @@ impl IncomingHttp for InterfaceInstance<incoming_http_bindings::IncomingHttp> {
             .call_handle(&mut *store, request, response)
             .await?;
         match response_rx.try_recv() {
-            Ok(Ok(res)) => Ok(res.map(|body| -> Box<dyn AsyncRead + Sync + Send + Unpin> {
-                Box::new(BodyAsyncRead::new(body))
-            })),
-            Ok(Err(err)) => Err(code_to_error(err)),
+            Ok(res) => Ok(res),
             Err(_) => bail!("a response was not set"),
         }
     }

--- a/crates/runtime/src/capability/builtin.rs
+++ b/crates/runtime/src/capability/builtin.rs
@@ -15,7 +15,7 @@ use futures::Stream;
 use nkeys::{KeyPair, KeyPairType};
 use tokio::io::AsyncRead;
 use tracing::{instrument, trace};
-use wasmtime_wasi_http::body::HyperIncomingBody;
+use wasmtime_wasi_http::body::{HyperIncomingBody, HyperOutgoingBody};
 use wrpc_transport::IncomingInputStream;
 
 #[derive(Clone, Default)]
@@ -406,8 +406,13 @@ pub trait IncomingHttp {
     /// Handle `wasi:http/incoming-handler`
     async fn handle(
         &self,
-        request: ::http::Request<Box<dyn AsyncRead + Sync + Send + Unpin>>,
-    ) -> anyhow::Result<::http::Response<Box<dyn AsyncRead + Sync + Send + Unpin>>>;
+        request: ::http::Request<HyperIncomingBody>,
+    ) -> anyhow::Result<
+        Result<
+            http::Response<HyperOutgoingBody>,
+            wasmtime_wasi_http::bindings::http::types::ErrorCode,
+        >,
+    >;
 }
 
 #[async_trait]
@@ -744,8 +749,13 @@ impl IncomingHttp for Handler {
     #[instrument(skip(request))]
     async fn handle(
         &self,
-        request: ::http::Request<Box<dyn AsyncRead + Sync + Send + Unpin>>,
-    ) -> anyhow::Result<::http::Response<Box<dyn AsyncRead + Sync + Send + Unpin>>> {
+        request: ::http::Request<HyperIncomingBody>,
+    ) -> anyhow::Result<
+        Result<
+            ::http::Response<HyperOutgoingBody>,
+            wasmtime_wasi_http::bindings::http::types::ErrorCode,
+        >,
+    > {
         proxy(
             &self.incoming_http,
             "IncomingHttp",


### PR DESCRIPTION
Allow components to export `wasi:http/incoming-handler` as `wrpc:http/incoming-handler`