### PR TITLE
chore(host): update wrpc-transport-nats 0.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6592,9 +6592,9 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1409ea5be0dfcb5b1ad0d0fdc627e901016a19da5155d0e8efc7b32c6e9806d1"
+checksum = "76ef78721062d992d3fcd6e3e7c9577876708bea6c859658d9da85610abbd7d7"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/crates/host/src/wasmbus/wasmcloud_transport.rs
+++ b/crates/host/src/wasmbus/wasmcloud_transport.rs
@@ -34,7 +34,7 @@ impl TransmitterWithHeaders {
 #[async_trait]
 impl wrpc_transport::Transmitter for TransmitterWithHeaders {
     type Subject = Subject;
-    type PublishError = async_nats::PublishError;
+    type PublishError = wrpc_transport_nats::PublishError;
 
     #[instrument(level = "trace", ret, skip(self))]
     async fn transmit(


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
This PR makes a small change to update `wrpc_transport_nats` to 0.11.5, just changing an error type. This does result in faster invocations, since that version drops a message from each wrpc invocation.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
