### PR TITLE
fix(host): improve error handling for wrpc links

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -45,8 +45,8 @@ use wasmcloud_core::{HealthCheckResponse, HostData, LatticeTargetId, LinkName, O
 use wasmcloud_runtime::capability::logging::logging;
 use wasmcloud_runtime::capability::{
     blobstore, guest_config, messaging, Blobstore, Bus, CallTargetInterface, IncomingHttp as _,
-    KeyValueAtomic, KeyValueEventual, Logging, Messaging, OutgoingHttp, TargetEntity,
-    WrpcInterfaceTarget,
+    KeyValueAtomic, KeyValueEventual, LatticeInterfaceTarget, Logging, Messaging, OutgoingHttp,
+    TargetEntity,
 };
 use wasmcloud_runtime::Runtime;
 use wasmcloud_tracing::context::TraceContextInjector;
@@ -210,14 +210,14 @@ impl Blobstore for Handler {
     async fn create_container(&self, name: &str) -> anyhow::Result<()> {
         use wrpc_interface_blobstore::Blobstore;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -235,14 +235,14 @@ impl Blobstore for Handler {
     async fn container_exists(&self, name: &str) -> anyhow::Result<bool> {
         use wrpc_interface_blobstore::Blobstore;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -260,14 +260,14 @@ impl Blobstore for Handler {
     async fn delete_container(&self, name: &str) -> anyhow::Result<()> {
         use wrpc_interface_blobstore::Blobstore;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -288,14 +288,14 @@ impl Blobstore for Handler {
     ) -> anyhow::Result<blobstore::container::ContainerMetadata> {
         use wrpc_interface_blobstore::{Blobstore, ContainerMetadata};
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -319,14 +319,14 @@ impl Blobstore for Handler {
     ) -> anyhow::Result<IncomingInputStream> {
         use wrpc_interface_blobstore::{Blobstore, ObjectId};
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -351,14 +351,14 @@ impl Blobstore for Handler {
     async fn has_object(&self, container: &str, name: String) -> anyhow::Result<bool> {
         use wrpc_interface_blobstore::{Blobstore, ObjectId};
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -384,14 +384,14 @@ impl Blobstore for Handler {
     ) -> anyhow::Result<()> {
         use wrpc_interface_blobstore::{Blobstore, ObjectId};
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -420,14 +420,14 @@ impl Blobstore for Handler {
     async fn delete_objects(&self, container: &str, names: Vec<String>) -> anyhow::Result<()> {
         use wrpc_interface_blobstore::Blobstore;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -450,14 +450,14 @@ impl Blobstore for Handler {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -479,14 +479,14 @@ impl Blobstore for Handler {
     ) -> anyhow::Result<blobstore::container::ObjectMetadata> {
         use wrpc_interface_blobstore::{Blobstore, ObjectId, ObjectMetadata};
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -517,14 +517,14 @@ impl Blobstore for Handler {
     async fn clear_container(&self, container: &str) -> anyhow::Result<()> {
         use wrpc_interface_blobstore::Blobstore;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "blobstore",
                 "blobstore",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -546,7 +546,7 @@ impl Bus for Handler {
     async fn identify_interface_target(
         &self,
         target_interface: &CallTargetInterface,
-    ) -> anyhow::Result<Option<TargetEntity>> {
+    ) -> Option<TargetEntity> {
         let links = self.interface_links.read().await;
         let link_name = self.interface_link_name.read().await.clone();
         let (namespace, package, interface, _) = target_interface.as_parts();
@@ -559,13 +559,24 @@ impl Bus for Handler {
 
         // If we managed to find a target ID, convert it into an entity
         let target_entity = lattice_target_id.map(|id| {
-            TargetEntity::Wrpc(WrpcInterfaceTarget {
+            TargetEntity::Lattice(LatticeInterfaceTarget {
                 id: id.clone(),
                 interface: target_interface.clone(),
                 link_name,
             })
         });
-        Ok(target_entity)
+
+        if target_entity.is_none() {
+            debug!(
+                namespace,
+                package,
+                interface,
+                ?self.component_id,
+                "component is not linked to a lattice target for the given interface"
+            );
+        }
+
+        target_entity
     }
 
     /// Get the current link name
@@ -618,12 +629,12 @@ impl Bus for Handler {
     #[instrument(level = "info", skip(self, params, instance, name), fields(interface = instance, function = name))]
     async fn call(
         &self,
-        target: Option<TargetEntity>,
+        target: TargetEntity,
         instance: &str,
         name: &str,
         params: Vec<wrpc_transport::Value>,
     ) -> anyhow::Result<Vec<wrpc_transport::Value>> {
-        if let Some(TargetEntity::Wrpc(WrpcInterfaceTarget { id, .. })) = target {
+        if let TargetEntity::Lattice(LatticeInterfaceTarget { id, .. }) = target {
             let results = self
                 .polyfilled_imports
                 .get(instance)
@@ -642,7 +653,7 @@ impl Bus for Handler {
             tx.await.context("failed to transmit parameters")?;
             Ok(results)
         } else {
-            bail!("invalid target")
+            bail!("component attempted to invoke a function on an unknown target")
         }
     }
 }
@@ -653,11 +664,11 @@ impl KeyValueAtomic for Handler {
     async fn increment(&self, bucket: &str, key: String, delta: u64) -> anyhow::Result<u64> {
         use wrpc_interface_keyvalue::Atomic;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi", "keyvalue", "atomic", None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -682,11 +693,11 @@ impl KeyValueAtomic for Handler {
     ) -> anyhow::Result<bool> {
         use wrpc_interface_keyvalue::Atomic;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi", "keyvalue", "atomic", None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -707,11 +718,11 @@ impl KeyValueEventual for Handler {
     async fn get(&self, bucket: &str, key: String) -> anyhow::Result<Option<IncomingInputStream>> {
         use wrpc_interface_keyvalue::Eventual;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi", "keyvalue", "eventual", None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -734,11 +745,11 @@ impl KeyValueEventual for Handler {
     ) -> anyhow::Result<()> {
         use wrpc_interface_keyvalue::Eventual;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi", "keyvalue", "eventual", None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -762,11 +773,11 @@ impl KeyValueEventual for Handler {
     async fn delete(&self, bucket: &str, key: String) -> anyhow::Result<()> {
         use wrpc_interface_keyvalue::Eventual;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi", "keyvalue", "eventual", None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -785,11 +796,11 @@ impl KeyValueEventual for Handler {
     async fn exists(&self, bucket: &str, key: String) -> anyhow::Result<bool> {
         use wrpc_interface_keyvalue::Eventual;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi", "keyvalue", "eventual", None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -947,14 +958,14 @@ impl Messaging for Handler {
         body: Option<Vec<u8>>,
         timeout: Duration,
     ) -> anyhow::Result<messaging::types::BrokerMessage> {
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasmcloud",
                 "messaging",
                 "consumer",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -980,14 +991,14 @@ impl Messaging for Handler {
         timeout: Duration,
         max_results: u32,
     ) -> anyhow::Result<Vec<messaging::types::BrokerMessage>> {
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasmcloud",
                 "messaging",
                 "consumer",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -1008,14 +1019,14 @@ impl Messaging for Handler {
 
     #[instrument(skip_all)]
     async fn publish(&self, msg: messaging::types::BrokerMessage) -> anyhow::Result<()> {
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasmcloud",
                 "messaging",
                 "consumer",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));
@@ -1048,14 +1059,14 @@ impl OutgoingHttp for Handler {
     > {
         use wrpc_interface_http::OutgoingHandler;
 
-        let WrpcInterfaceTarget { id, .. } = self
+        let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
                 "wasi",
                 "http",
                 "outgoing-handler",
                 None,
             )))
-            .await?
+            .await
             .context("unknown target")?;
         let wrpc =
             wrpc_transport_nats::Client::new(self.nats.clone(), format!("{}.{id}", self.lattice));

--- a/crates/runtime/src/actor/component/mod.rs
+++ b/crates/runtime/src/actor/component/mod.rs
@@ -382,7 +382,7 @@ where
                         let result_values = handler
                             .call(target, &instance_name, &func_name, params)
                             .await
-                            .context("failed to call target")?;
+                            .context("failed to call target interface")?;
                         let result_ty = store
                             .data()
                             .custom_result_types

--- a/crates/runtime/src/capability/builtin.rs
+++ b/crates/runtime/src/capability/builtin.rs
@@ -9,12 +9,12 @@ use core::time::Duration;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use futures::Stream;
 use nkeys::{KeyPair, KeyPairType};
 use tokio::io::AsyncRead;
-use tracing::{instrument, trace};
+use tracing::{error, instrument, trace};
 use wasmtime_wasi_http::body::{HyperIncomingBody, HyperOutgoingBody};
 use wrpc_transport::IncomingInputStream;
 
@@ -189,8 +189,8 @@ impl PartialEq for ActorIdentifier {
 impl Eq for ActorIdentifier {}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-/// Interface target to be invoked over `wRPC`
-pub struct WrpcInterfaceTarget {
+/// Interface target to be invoked over the lattice using `wRPC`
+pub struct LatticeInterfaceTarget {
     /// wRPC component routing identifier
     pub id: String,
     /// wRPC component interface
@@ -199,7 +199,7 @@ pub struct WrpcInterfaceTarget {
     pub link_name: String,
 }
 
-impl std::fmt::Display for WrpcInterfaceTarget {
+impl std::fmt::Display for LatticeInterfaceTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let (wit_ns, wit_pkg, wit_iface, _) = self.interface.as_parts();
         let link_name = &self.link_name;
@@ -209,25 +209,15 @@ impl std::fmt::Display for WrpcInterfaceTarget {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-/// Target entity
+#[non_exhaustive]
+/// Target entity for a component interface invocation
 pub enum TargetEntity {
-    /// Link target entity
-    Link(Option<String>),
-    /// Actor target entity
-    Actor(ActorIdentifier),
-    /// WRPC component
-    Wrpc(WrpcInterfaceTarget),
-}
-
-impl TargetEntity {
-    /// Tries to unwrap [`WrpcInterfaceTarget`]
-    pub fn try_unwrap_wrpc(self) -> Option<WrpcInterfaceTarget> {
-        if let Self::Wrpc(target) = self {
-            Some(target)
-        } else {
-            None
-        }
-    }
+    /// Component to invoke over the lattice using wRPC
+    Lattice(LatticeInterfaceTarget),
+    // NOTE(brooksmtownsend): This is an enum with one member
+    // to allow for future expansion of the `TargetEntity` type,
+    // for example to route invocations in-process instead of over
+    // the lattice.
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
@@ -351,21 +341,18 @@ pub trait Bus {
     async fn identify_interface_target(
         &self,
         interface: &CallTargetInterface,
-    ) -> anyhow::Result<Option<TargetEntity>>;
+    ) -> Option<TargetEntity>;
 
     /// Identify the wRPC target of component interface invocation
     async fn identify_wrpc_target(
         &self,
         interface: &CallTargetInterface,
-    ) -> anyhow::Result<Option<WrpcInterfaceTarget>> {
-        let target = self.identify_interface_target(interface).await?;
-        let Some(target) = target else {
-            return Ok(None);
+    ) -> Option<LatticeInterfaceTarget> {
+        let target = self.identify_interface_target(interface).await;
+        let Some(TargetEntity::Lattice(lattice_target)) = target else {
+            return None;
         };
-        target
-            .try_unwrap_wrpc()
-            .context("invalid target type")
-            .map(Some)
+        Some(lattice_target)
     }
 
     /// Set link name
@@ -393,7 +380,7 @@ pub trait Bus {
     /// Handle `wasmcloud:bus/host.call` without streaming
     async fn call(
         &self,
-        target: Option<TargetEntity>,
+        target: TargetEntity,
         instance: &str,
         name: &str,
         params: Vec<wrpc_transport::Value>,
@@ -610,12 +597,13 @@ impl Bus for Handler {
     async fn identify_interface_target(
         &self,
         interface: &CallTargetInterface,
-    ) -> anyhow::Result<Option<TargetEntity>> {
+    ) -> Option<TargetEntity> {
         if let Some(ref bus) = self.bus {
             trace!("call `Bus` handler");
             bus.identify_interface_target(interface).await
         } else {
-            bail!("host cannot identify the interface call target")
+            error!("host cannot identify the interface call target");
+            None
         }
     }
 
@@ -657,7 +645,7 @@ impl Bus for Handler {
     #[instrument(level = "trace", skip_all)]
     async fn call(
         &self,
-        target: Option<TargetEntity>,
+        target: TargetEntity,
         instance: &str,
         name: &str,
         params: Vec<wrpc_transport::Value>,

--- a/crates/runtime/src/capability/mod.rs
+++ b/crates/runtime/src/capability/mod.rs
@@ -4,8 +4,8 @@ pub(crate) mod builtin;
 pub mod provider;
 
 pub use builtin::{
-    ActorIdentifier, Blobstore, Bus, IncomingHttp, KeyValueAtomic, KeyValueEventual, Logging,
-    Messaging, OutgoingHttp, OutgoingHttpRequest, TargetEntity, WrpcInterfaceTarget,
+    ActorIdentifier, Blobstore, Bus, IncomingHttp, KeyValueAtomic, KeyValueEventual,
+    LatticeInterfaceTarget, Logging, Messaging, OutgoingHttp, OutgoingHttpRequest, TargetEntity,
 };
 
 // NOTE: this import is used below in bindgen


### PR DESCRIPTION
## Feature or Problem
This PR updates a few of our internal structs for target entity discovery and routing and removes some outdated enum members. In addition, this PR includes some updates to error messages when a component isn't linked on a given interface.

If a component attempts to invoke something it's not linked to, here are the logs and error message:
```
2024-03-01T15:45:38.757607Z DEBUG handle_invocation{params=Custom { interface: "wasmcloud:testing/invoke", function: "call" } component_id="ponger" component_ref="file:///Users/brooks/github.com/wasmcloud/wasmcloud/tests/actors/rust/wrpc-pinger-component/build/wrpc_pinger_component_s.wasm"}:call{interface="wasmcloud:testing/invoke" function="call"}: wasmcloud_host::wasmbus: component is not linked to a lattice target for the given interface namespace="wasmcloud" package="testing" interface="pingpong" __self.component_id="ponger"
2024-03-01T15:45:38.758697Z ERROR wasmcloud_host::wasmbus: failed to handle invocation err=failed to call actor

Caused by:
    0: failed to call function
    1: error while executing at wasm backtrace:
           0: 0x19f264 - wit-component:shim!indirect-wasmcloud:testing/pingpong-ping
           1:  0xfce - <unknown>!wasmcloud:testing/invoke#call
       note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information
    2: failed to identify interface target
```

The goal here is to help developers identify the problem, here being that the component isn't linked to a target for that interface. 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
@vados-cosmonic this might touch some of the same code you're working on for provider invocation, so if it does I'll rebase this on top of your work.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
