### PR TITLE
fix(provider-wit-bindgen): type aliasing for nested types

### DIFF
--- a/crates/provider-wit-bindgen-macro/src/lib.rs
+++ b/crates/provider-wit-bindgen-macro/src/lib.rs
@@ -397,11 +397,14 @@ pub fn generate(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         .type_lookup
         .iter()
         .filter_map(|(_, (_, ty))| {
-            // If the name of the type is identical to a bindgen-produced struct that will
+            // If the name of the type is identical to a bindgen-produced struct or enum that will
             // be added later, this was likely a type alias -- we won't need it
             if visitor
                 .serde_extended_structs
                 .contains_key(&ty.ident.to_string())
+                || visitor
+                    .serde_extended_enums
+                    .contains_key(&ty.ident.to_string())
             {
                 None
             } else {

--- a/crates/provider-wit-bindgen-macro/src/wit.rs
+++ b/crates/provider-wit-bindgen-macro/src/wit.rs
@@ -865,7 +865,7 @@ impl WitFunctionLatticeTranslationStrategy {
                     .await?;
 
                 if let Some(err) = response.error {
-                    Err(::wasmcloud_provider_wit_bindgen::deps::wasmcloud_provider_sdk::error::InvocationError::Failed(err.to_string()))
+                    Err(::wasmcloud_provider_wit_bindgen::deps::wasmcloud_provider_sdk::error::InvocationError::Unexpected(err.to_string()))
                 } else {
                     Ok(::wasmcloud_provider_wit_bindgen::deps::wasmcloud_provider_sdk::deserialize(&response.msg)?)
                 }

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-wit-bindgen-macro"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "heck",


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

When using a type alias in WIT (ex. `type str-list = vec<string>`), if that type is inside an interface and used from another interface, there is an extra alias made to it.

Since bindgen sees *both* the "real" alias (in Rust `type StrList = Vec<String>`) and the local binding level alias (in Rust `type StrList = super::some::iface::StrList`), we need to make sure that the "real" alias is the one that is hoisted to the top.

This commit adds some checks to ensure that the alias that is *not* a reference is sure to be hoisted to the top (all generated code uses `T`, not `super::some::iface::T`). This is a a shortcut to avoid building a type reference graph.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
