### PR TITLE
fix(host): re-tag request type enum policy

### DIFF
--- a/crates/host/src/policy.rs
+++ b/crates/host/src/policy.rs
@@ -99,7 +99,6 @@ pub struct HostInfo {
 
 /// The action being requested
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Hash)]
-#[serde(untagged)]
 pub enum RequestKind {
     /// The host is checking whether it may invoke the target component
     #[serde(rename = "performInvocation")]


### PR DESCRIPTION
## Feature or Problem
This PR re-tags the enum for `RequestType` since omitting it actually sets that field to `null`, breaking the policy service.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
