### PR TITLE
refactor: move wasmcloud wrpc transport client to core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5403,6 +5403,7 @@ version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-nats",
+ "async-trait",
  "bytes",
  "cloudevents-sdk",
  "futures",
@@ -5443,6 +5444,8 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-nats",
+ "async-trait",
+ "bytes",
  "futures",
  "hex",
  "nkeys",
@@ -5454,6 +5457,8 @@ dependencies = [
  "ulid",
  "uuid 1.7.0",
  "wascap",
+ "wrpc-transport",
+ "wrpc-transport-nats",
 ]
 
 [[package]]

--- a/crates/control-interface/Cargo.toml
+++ b/crates/control-interface/Cargo.toml
@@ -16,6 +16,7 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-nats = { workspace = true }
+async-trait = { workspace = true }
 bytes = { workspace = true }
 cloudevents-sdk = { workspace = true }
 futures = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,8 @@ otel = []
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 async-nats = { workspace = true }
+async-trait = { workspace = true }
+bytes = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true, features = ["std"] }
 nkeys = { workspace = true }
@@ -27,3 +29,5 @@ tracing = { workspace = true }
 ulid = { workspace = true, features = ["std"] }
 uuid = { workspace = true, features = ["serde"] }
 wascap = { workspace = true }
+wrpc-transport = { workspace = true }
+wrpc-transport-nats = { workspace = true }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,6 +19,8 @@ pub use otel::*;
 pub mod rpc;
 pub use rpc::*;
 
+pub mod wrpc;
+
 pub mod wit;
 pub use wit::*;
 

--- a/crates/core/src/wrpc.rs
+++ b/crates/core/src/wrpc.rs
@@ -1,7 +1,11 @@
 //! This module provides `wasmcloud`-specific implementations of `wrpc_transport` traits.
-//! Specifically, we wrap the [wrpc_transport::Transmitter], [wrpc_transport::Invocation],
-//! and [wrpc_transport::Client] traits in order to pass invocations with headers, which is how
-//! we propagate trace context and named configuration information along with the invocation.
+//!
+//! Specifically, we wrap the [`wrpc_transport::Transmitter`], [`wrpc_transport::Invocation`],
+//! and [`wrpc_transport::Client`] traits in order to:
+//! - Propagate trace context
+//! - Append invocation headers
+//! - Perform invocation validation (where necessary)
+//!
 //! Most logic is delegated to the underlying `wrpc_transport_nats` client, which provides the
 //! actual NATS-based transport implementation.
 
@@ -17,7 +21,7 @@ use wrpc_transport_nats::{Subject, Subscriber, Transmission};
 
 /// Wrapper around [wrpc_transport_nats::Transmitter] that includes a [async_nats::HeaderMap] for
 /// passing invocation and trace context.
-pub(crate) struct TransmitterWithHeaders {
+pub struct TransmitterWithHeaders {
     inner: wrpc_transport_nats::Transmitter,
     headers: HeaderMap,
 }
@@ -50,7 +54,7 @@ impl wrpc_transport::Transmitter for TransmitterWithHeaders {
 
 /// Wrapper around [wrpc_transport_nats::Invocation] that includes a [async_nats::HeaderMap] for
 /// passing invocation and trace context.
-pub(crate) struct InvocationWithHeaders {
+pub struct InvocationWithHeaders {
     inner: wrpc_transport_nats::Invocation,
     headers: HeaderMap,
 }
@@ -89,7 +93,7 @@ impl wrpc_transport::Invocation for InvocationWithHeaders {
 
 /// Wrapper around [wrpc_transport_nats::Acceptor] that includes a [async_nats::HeaderMap] for
 /// passing invocation and trace context.
-pub(crate) struct AcceptorWithHeaders {
+pub struct AcceptorWithHeaders {
     inner: wrpc_transport_nats::Acceptor,
     headers: HeaderMap,
 }
@@ -115,10 +119,10 @@ impl wrpc_transport::Acceptor for AcceptorWithHeaders {
     }
 }
 
-/// Wrapper around [wrpc_transport_nats::Client] that includes a [async_nats::HeaderMap] for
+/// Wrapper around [`wrpc_transport_nats::Client`] that includes a [`async_nats::HeaderMap`] for
 /// passing invocation and trace context.
 #[derive(Debug, Clone)]
-pub(crate) struct Client {
+pub struct Client {
     inner: wrpc_transport_nats::Client,
     headers: HeaderMap,
 }
@@ -130,7 +134,7 @@ impl Client {
     /// * `nats` - The NATS client to use for communication.
     /// * `lattice` - The lattice to use for communication.
     /// * `headers` - The headers to include with each outbound invocation.
-    pub(crate) fn new(
+    pub fn new(
         nats: impl Into<Arc<async_nats::Client>>,
         lattice: String,
         headers: HeaderMap,

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -63,9 +63,6 @@ use crate::{
     RegistryAuth, RegistryConfig, RegistryType,
 };
 
-/// wasmCloud [wrpc_transport] implementations
-pub mod wasmcloud_transport;
-
 /// wasmCloud host configuration
 pub mod host_config;
 pub use host_config::Host as HostConfig;
@@ -631,7 +628,7 @@ impl Bus for Handler {
             let injector = TraceContextInjector::default_with_span();
             let mut headers = injector_to_headers(&injector);
             headers.insert("source-id", self.component_id.as_str());
-            let (results, tx) = wasmcloud_transport::Client::new(
+            let (results, tx) = wasmcloud_core::wrpc::Client::new(
                 self.nats.clone(),
                 format!("{}.{id}", self.lattice),
                 headers,
@@ -1148,7 +1145,7 @@ impl Actor {
         context: Option<async_nats::HeaderMap>,
         params: InvocationParams,
         result_subject: wrpc_transport_nats::Subject,
-        transmitter: &wasmcloud_transport::TransmitterWithHeaders,
+        transmitter: &wasmcloud_core::wrpc::TransmitterWithHeaders,
     ) -> anyhow::Result<()> {
         let (interface, function) = match params {
             InvocationParams::Custom {
@@ -2108,7 +2105,7 @@ impl Host {
     ) -> anyhow::Result<Arc<Actor>> {
         trace!(actor_ref, max_instances, "instantiating actor");
 
-        let wrpc = wasmcloud_transport::Client::new(
+        let wrpc = wasmcloud_core::wrpc::Client::new(
             self.rpc_nats.clone(),
             format!("{}.{actor_id}", self.host_config.lattice),
             // NOTE(brooksmtownsend): We only use this client for serving functions,

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -3933,6 +3933,7 @@ version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-nats",
+ "async-trait",
  "bytes",
  "cloudevents-sdk",
  "futures",
@@ -3964,6 +3965,8 @@ dependencies = [
  "ulid",
  "uuid",
  "wascap",
+ "wrpc-transport 0.16.0",
+ "wrpc-transport-nats 0.13.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit moves the wasmcloud-specific wrpc transport client to the `wasmcloud-control-interface` crate. From here, it can be used by both the host (`wasmbus`) and other places like tests.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
