### PR TITLE
refactor(providers): get values from new link def constistently

### DIFF
--- a/crates/core/src/link.rs
+++ b/crates/core/src/link.rs
@@ -1,5 +1,7 @@
 //! Core reusable types related to links on wasmCloud lattices
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -60,6 +62,20 @@ pub struct InterfaceLinkDefinition {
     /// List of named configurations to provide to the target upon request
     #[serde(default)]
     pub target_config: Vec<KnownConfigName>,
+}
+
+impl InterfaceLinkDefinition {
+    /// This function is here temporarily to allow pulling a map of configuration out of
+    /// [`InterfaceLinkDefinition`]s that are fed to providers.
+    ///
+    /// The configuration is expected to be extracted from target_config (i.e. upon initial `put_link` to the provider).
+    /// This utility function should be removed in the near future, and provider named configuration should be used.
+    pub fn extract_provider_config_values(&self) -> HashMap<&str, &str> {
+        self.target_config
+            .iter()
+            .flat_map(|v| v.split_once('='))
+            .collect::<HashMap<&str, &str>>()
+    }
 }
 
 /// Helper function to provide a default link name

--- a/crates/provider-sdk/src/lib.rs
+++ b/crates/provider-sdk/src/lib.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
+use std::time::Duration;
 
 use anyhow::Context as _;
 use async_nats::{ConnectOptions, Event};
@@ -219,7 +220,6 @@ pub trait WrpcNats {
 /// todo: invert this so that the provider takes the wrpc_transport::Client and then hooks up it's own handlers
 
 /// Handler for dispatching invocations that come via wRPC
-// todo(vados-cosmonic): should this replace MessageDispatch all together
 #[async_trait]
 pub trait WrpcDispatch {
     /// Dispatch a single invocation that came in over wRPC

--- a/crates/providers/blobstore-fs/src/lib.rs
+++ b/crates/providers/blobstore-fs/src/lib.rs
@@ -257,20 +257,16 @@ impl FsProvider {
 impl WasmcloudCapabilityProvider for FsProvider {
     /// The fs provider has one configuration parameter, the root of the file system
     async fn put_link(&self, ld: &InterfaceLinkDefinition) -> bool {
-        // todo(vados-cosmonic): needs to be adapted to use named config
-        //
-        // for val in ld.values.iter() {
-        //     info!("ld conf {:?}", val);
-        // }
+        let config_values = ld.extract_provider_config_values();
+        for (k, v) in config_values.iter() {
+            info!("link definition configuration [{k}] set to [{v}]");
+        }
 
-        // todo(vados-cosmonic): needs to be adapted to use named config
-        //
-        // // Determine the root path value
-        // let root_val: PathBuf = match ld.values.iter().find(|(key, _)| key == "ROOT") {
-        //     None => "/tmp".into(),
-        //     Some((_, value)) => value.into(),
-        // };
-        let root_val = PathBuf::from("/tmp");
+        // Determine the root path value
+        let root_val: PathBuf = match config_values.iter().find(|(key, _)| **key == "ROOT") {
+            None => "/tmp".into(),
+            Some((_, value)) => value.into(),
+        };
 
         // Build configuration for FS Provider to use later
         let config = FsProviderConfig {

--- a/crates/providers/messaging-nats/src/connection.rs
+++ b/crates/providers/messaging-nats/src/connection.rs
@@ -1,13 +1,17 @@
+use std::collections::HashMap;
+
+use anyhow::{bail, Context as _, Result};
+use base64::Engine;
+
 use wasmcloud_provider_wit_bindgen::deps::serde::{Deserialize, Serialize};
+use wasmcloud_provider_wit_bindgen::deps::serde_json;
 
 const DEFAULT_NATS_URI: &str = "0.0.0.0:4222";
 
-// todo(vados-cosmonic): these can't be used until named config is implemented for providers
-//
-// const ENV_NATS_SUBSCRIPTION: &str = "SUBSCRIPTION";
-// const ENV_NATS_URI: &str = "URI";
-// const ENV_NATS_CLIENT_JWT: &str = "CLIENT_JWT";
-// const ENV_NATS_CLIENT_SEED: &str = "CLIENT_SEED";
+const ENV_NATS_SUBSCRIPTION: &str = "SUBSCRIPTION";
+const ENV_NATS_URI: &str = "URI";
+const ENV_NATS_CLIENT_JWT: &str = "CLIENT_JWT";
+const ENV_NATS_CLIENT_SEED: &str = "CLIENT_SEED";
 
 /// Configuration for connecting a nats client.
 /// More options are available if you use the json than variables in the values string map.
@@ -35,34 +39,32 @@ pub struct ConnectionConfig {
     pub ping_interval_sec: Option<u16>,
 }
 
-// todo(vados-cosmonic): unused due to named config not being implemented
-//
-// impl ConnectionConfig {
-//     /// Merge a given [`ConnectionConfig`] with another, coalescing fields and overriding
-//     /// where necessary
-//     pub fn merge(&self, extra: &ConnectionConfig) -> ConnectionConfig {
-//         let mut out = self.clone();
-//         if !extra.subscriptions.is_empty() {
-//             out.subscriptions = extra.subscriptions.clone();
-//         }
-//         // If the default configuration has a URL in it, and then the link definition
-//         // also provides a URL, the assumption is to replace/override rather than combine
-//         // the two into a potentially incompatible set of URIs
-//         if !extra.cluster_uris.is_empty() {
-//             out.cluster_uris = extra.cluster_uris.clone();
-//         }
-//         if extra.auth_jwt.is_some() {
-//             out.auth_jwt = extra.auth_jwt.clone()
-//         }
-//         if extra.auth_seed.is_some() {
-//             out.auth_seed = extra.auth_seed.clone()
-//         }
-//         if extra.ping_interval_sec.is_some() {
-//             out.ping_interval_sec = extra.ping_interval_sec
-//         }
-//         out
-//     }
-// }
+impl ConnectionConfig {
+    /// Merge a given [`ConnectionConfig`] with another, coalescing fields and overriding
+    /// where necessary
+    pub fn merge(&self, extra: &ConnectionConfig) -> ConnectionConfig {
+        let mut out = self.clone();
+        if !extra.subscriptions.is_empty() {
+            out.subscriptions = extra.subscriptions.clone();
+        }
+        // If the default configuration has a URL in it, and then the link definition
+        // also provides a URL, the assumption is to replace/override rather than combine
+        // the two into a potentially incompatible set of URIs
+        if !extra.cluster_uris.is_empty() {
+            out.cluster_uris = extra.cluster_uris.clone();
+        }
+        if extra.auth_jwt.is_some() {
+            out.auth_jwt = extra.auth_jwt.clone()
+        }
+        if extra.auth_seed.is_some() {
+            out.auth_seed = extra.auth_seed.clone()
+        }
+        if extra.ping_interval_sec.is_some() {
+            out.ping_interval_sec = extra.ping_interval_sec
+        }
+        out
+    }
+}
 
 impl Default for ConnectionConfig {
     fn default() -> ConnectionConfig {
@@ -76,44 +78,39 @@ impl Default for ConnectionConfig {
     }
 }
 
-// todo(vados-cosmonic): this can't be used until named config is implemented for providers
-//
-// impl ConnectionConfig {
-//     pub fn from_tuples(values: &[(String, String)]) -> Result<ConnectionConfig> {
-//         // NOTE(thomastaylor312): This only happens on linkdef and is easier to read if we just
-//         // collect the vec to a hashmap. So worth the allocations IMO
-//         let values = values.iter().cloned().collect::<HashMap<_, _>>();
-//         let mut config = if let Some(config_b64) = values.get("config_b64") {
-//             let bytes = base64::engine::general_purpose::STANDARD
-//                 .decode(config_b64.as_bytes())
-//                 .context("invalid base64 encoding")?;
-//             serde_json::from_slice::<ConnectionConfig>(&bytes).context("corrupt config_b64")?
-//         } else if let Some(config) = values.get("config_json") {
-//             serde_json::from_str::<ConnectionConfig>(config).context("corrupt config_json")?
-//         } else {
-//             ConnectionConfig::default()
-//         };
+impl ConnectionConfig {
+    pub fn from_map(values: &HashMap<String, String>) -> Result<ConnectionConfig> {
+        let mut config = if let Some(config_b64) = values.get("config_b64") {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(config_b64.as_bytes())
+                .context("invalid base64 encoding")?;
+            serde_json::from_slice::<ConnectionConfig>(&bytes).context("corrupt config_b64")?
+        } else if let Some(config) = values.get("config_json") {
+            serde_json::from_str::<ConnectionConfig>(config).context("corrupt config_json")?
+        } else {
+            ConnectionConfig::default()
+        };
 
-//         if let Some(sub) = values.get(ENV_NATS_SUBSCRIPTION) {
-//             config
-//                 .subscriptions
-//                 .extend(sub.split(',').map(|s| s.to_string()));
-//         }
-//         if let Some(url) = values.get(ENV_NATS_URI) {
-//             config.cluster_uris = url.split(',').map(String::from).collect();
-//         }
-//         if let Some(jwt) = values.get(ENV_NATS_CLIENT_JWT) {
-//             config.auth_jwt = Some(jwt.clone());
-//         }
-//         if let Some(seed) = values.get(ENV_NATS_CLIENT_SEED) {
-//             config.auth_seed = Some(seed.clone());
-//         }
-//         if config.auth_jwt.is_some() && config.auth_seed.is_none() {
-//             bail!("if you specify jwt, you must also specify a seed");
-//         }
-//         if config.cluster_uris.is_empty() {
-//             config.cluster_uris.push(DEFAULT_NATS_URI.to_string());
-//         }
-//         Ok(config)
-//     }
-// }
+        if let Some(sub) = values.get(ENV_NATS_SUBSCRIPTION) {
+            config
+                .subscriptions
+                .extend(sub.split(',').map(|s| s.to_string()));
+        }
+        if let Some(url) = values.get(ENV_NATS_URI) {
+            config.cluster_uris = url.split(',').map(String::from).collect();
+        }
+        if let Some(jwt) = values.get(ENV_NATS_CLIENT_JWT) {
+            config.auth_jwt = Some(jwt.clone());
+        }
+        if let Some(seed) = values.get(ENV_NATS_CLIENT_SEED) {
+            config.auth_seed = Some(seed.clone());
+        }
+        if config.auth_jwt.is_some() && config.auth_seed.is_none() {
+            bail!("if you specify jwt, you must also specify a seed");
+        }
+        if config.cluster_uris.is_empty() {
+            config.cluster_uris.push(DEFAULT_NATS_URI.to_string());
+        }
+        Ok(config)
+    }
+}


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit updates all providers that were marked with TODOs related to using named config to use `InterfaceLinkDefinition.target_config` temporarily.

The idea is to stuff configuration into the "names"s of configs that were supposed to be in use (i.e. `["NAME=VALUE", "NAME=VALUE"]` rather than `["config-1", "config-2"]`), ahead of named config being ready.


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
