### PR TITLE
feat(wash)!: implement wash building provider for host machine

### DIFF
--- a/crates/wash-cli/src/dev.rs
+++ b/crates/wash-cli/src/dev.rs
@@ -258,7 +258,8 @@ pub async fn handle_command(
     );
 
     // Build the project
-    let artifact_path = build_project(&project_cfg, sign_cfg.clone())
+    let artifact_path = build_project(&project_cfg, sign_cfg.as_ref())
+        .await
         .context("failed to build project")?
         .canonicalize()
         .context("failed to canonicalize path")?;

--- a/crates/wash-lib/src/build/mod.rs
+++ b/crates/wash-lib/src/build/mod.rs
@@ -1,0 +1,88 @@
+//! Build (and sign) a wasmCloud actor, or provider. Depends on the "cli" feature
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::info;
+use wit_parser::{Resolve, WorldId};
+
+use crate::parser::{ProjectConfig, TypeConfig};
+
+mod component;
+pub use component::*;
+mod provider;
+use provider::*;
+
+/// This tag indicates that a Wasm module uses experimental features of wasmCloud
+/// and/or the surrounding ecosystem.
+///
+/// This tag is normally embedded in a Wasm module as a custom section
+const WASMCLOUD_WASM_TAG_EXPERIMENTAL: &str = "wasmcloud.com/experimental";
+
+/// Configuration for signing an artifact (actor or provider) including issuer and subject key, the path to where keys can be found, and an option to
+/// disable automatic key generation if keys cannot be found.
+#[derive(Debug, Clone, Default)]
+pub struct SignConfig {
+    /// Location of key files for signing
+    pub keys_directory: Option<PathBuf>,
+
+    /// Path to issuer seed key (account). If this flag is not provided, the seed will be sourced from ($HOME/.wash/keys) or generated for you if it cannot be found.
+    pub issuer: Option<String>,
+
+    /// Path to subject seed key (module or service). If this flag is not provided, the seed will be sourced from ($HOME/.wash/keys) or generated for you if it cannot be found.
+    pub subject: Option<String>,
+
+    /// Disables autogeneration of keys if seed(s) are not provided
+    pub disable_keygen: bool,
+}
+
+/// Using a [ProjectConfig], usually parsed from a `wasmcloud.toml` file, build the project
+/// with the installed language toolchain. This will delegate to [build_actor] when the project is an actor,
+/// or [build_provider] when the project is a provider.
+///
+/// This function returns the path to the compiled artifact, a signed Wasm component or signed provider archive.
+///
+/// # Usage
+/// ```no_run
+/// use wash_lib::{build::build_project, parser::get_config};
+/// let config = get_config(None, Some(true))?;
+/// let artifact_path = build_project(config)?;
+/// println!("Here is the signed artifact: {}", artifact_path.to_string_lossy());
+/// ```
+/// # Arguments
+/// * `config`: [ProjectConfig] for required information to find, build, and sign an actor
+/// * `signing`: Optional [SignConfig] with information for signing the project artifact. If omitted, the artifact will only be built
+pub async fn build_project(
+    config: &ProjectConfig,
+    signing: Option<&SignConfig>,
+) -> Result<PathBuf> {
+    match &config.project_type {
+        TypeConfig::Actor(actor_config) => {
+            build_actor(actor_config, &config.language, &config.common, signing)
+        }
+        TypeConfig::Provider(provider_config) => {
+            build_provider(provider_config, &config.language, &config.common, signing).await
+        }
+    }
+}
+
+/// Build a [`wit_parser::Resolve`] from a provided directory
+/// and select a given world
+fn convert_wit_dir_to_world(
+    dir: impl AsRef<Path>,
+    world: impl AsRef<str>,
+) -> Result<(Resolve, WorldId)> {
+    // Resolve the WIT directory packages & worlds
+    let mut resolve = wit_parser::Resolve::default();
+    let (package_id, _paths) = resolve
+        .push_dir(dir.as_ref())
+        .with_context(|| format!("failed to add WIT directory @ [{}]", dir.as_ref().display()))?;
+    info!("successfully loaded WIT @ [{}]", dir.as_ref().display());
+
+    // Select the target world that was specified by the user
+    let world_id = resolve
+        .select_world(package_id, world.as_ref().into())
+        .context("failed to select world from built resolver")?;
+
+    Ok((resolve, world_id))
+}

--- a/crates/wash-lib/src/build/provider.rs
+++ b/crates/wash-lib/src/build/provider.rs
@@ -1,0 +1,134 @@
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::process;
+
+use anyhow::{anyhow, bail, Context, Result};
+use nkeys::KeyPairType;
+use tracing::warn;
+
+use crate::build::SignConfig;
+use crate::cli::par::{create_provider_archive, detect_arch, ParCreateArgs};
+use crate::cli::{extract_keypair, OutputKind};
+use crate::parser::{CommonConfig, LanguageConfig, ProviderConfig};
+
+/// Build a capability provider for the current machine's architecture
+/// and operating system using provided configuration.
+pub(crate) async fn build_provider(
+    provider_config: &ProviderConfig,
+    language_config: &LanguageConfig,
+    common_config: &CommonConfig,
+    signing_config: Option<&SignConfig>,
+) -> Result<PathBuf> {
+    let LanguageConfig::Rust(rust_config) = language_config else {
+        bail!("Unsupported language for provider: {:?}", language_config)
+    };
+    let mut command = match rust_config.cargo_path.as_ref() {
+        Some(path) => process::Command::new(path),
+        None => process::Command::new("cargo"),
+    };
+
+    // Change directory into the project directory
+    std::env::set_current_dir(&common_config.path)?;
+
+    // Build for a specified target if provided, or the default rust target
+    let mut build_args = Vec::with_capacity(4);
+    build_args.extend_from_slice(&["build", "--release"]);
+    if let Some(override_target) = &provider_config.rust_target {
+        build_args.extend_from_slice(&["--target", override_target]);
+    };
+
+    let result = command.args(build_args).status().map_err(|e| {
+        if e.kind() == ErrorKind::NotFound {
+            anyhow!("{:?} command is not found", command.get_program())
+        } else {
+            anyhow!(e)
+        }
+    })?;
+
+    if !result.success() {
+        bail!("Compiling provider failed: {result}")
+    }
+
+    let metadata = cargo_metadata::MetadataCommand::new().no_deps().exec()?;
+    let bin_name = if let Some(bin_name) = &provider_config.bin_name {
+        bin_name.to_string()
+    } else {
+        // Discover the binary name from the metadata
+        metadata
+            .packages
+            .iter()
+            .find_map(|p| {
+                p.targets.iter().find_map(|t| {
+                    if t.kind.iter().any(|k| k == "bin") {
+                        Some(t.name.clone())
+                    } else {
+                        None
+                    }
+                })
+            }).context("Could not infer provider binary name in metadata, please specify under provider.bin_name")?
+    };
+    let mut provider_path_buf = rust_config
+        .target_path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(metadata.target_directory.as_std_path()));
+    if let Some(override_target) = &provider_config.rust_target {
+        provider_path_buf.push(override_target);
+    }
+    provider_path_buf.push("release");
+    provider_path_buf.push(&bin_name);
+
+    let provider_bytes = tokio::fs::read(&provider_path_buf).await?;
+
+    let mut par = create_provider_archive(
+        ParCreateArgs {
+            capid: provider_config.wit_world.clone().unwrap_or_default(),
+            vendor: provider_config.vendor.to_string(),
+            revision: Some(common_config.revision),
+            version: Some(common_config.version.to_string()),
+            schema: None,
+            name: common_config.name.to_string(),
+            arch: detect_arch(),
+        },
+        &provider_bytes,
+    )
+    .context("failed to create initial provider archive with built provider")?;
+
+    // If no signing config supplied, just return the path to the provider
+    let Some(sign_config) = signing_config else {
+        warn!("No signing configuration supplied, could only build provider");
+        return Ok(provider_path_buf);
+    };
+
+    let destination = common_config
+        .path
+        .join("build")
+        .join(format!("{bin_name}.par.gz"));
+    if let Some(parent) = destination.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let issuer = extract_keypair(
+        sign_config.issuer.clone(),
+        Some(provider_path_buf.to_string_lossy().to_string()),
+        sign_config.keys_directory.clone(),
+        KeyPairType::Account,
+        sign_config.disable_keygen,
+        OutputKind::Json,
+    )?;
+    let subject = extract_keypair(
+        sign_config.subject.clone(),
+        Some(provider_path_buf.to_string_lossy().to_string()),
+        sign_config.keys_directory.clone(),
+        KeyPairType::Service,
+        sign_config.disable_keygen,
+        OutputKind::Json,
+    )?;
+    par.write(destination.as_path(), &issuer, &subject, true)
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+
+    Ok(if destination.is_absolute() {
+        destination
+    } else {
+        common_config.path.join(destination)
+    })
+}

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -247,7 +247,6 @@ impl ProviderMetadata {
             version: self
                 .version
                 .or(Some(project_config.common.version.to_string())),
-            capid: self.capid.or(Some(provider_config.capability_id)),
             vendor: self.vendor.or(Some(provider_config.vendor)),
             ..self
         }
@@ -1567,8 +1566,13 @@ mod test {
         assert_eq!(
             project_config.project_type,
             TypeConfig::Provider(ProviderConfig {
-                capability_id: "wasmcloud:httpserver".into(),
-                vendor: "wayne-industries".into()
+                vendor: "wayne-industries".into(),
+                os: std::env::consts::OS.to_string(),
+                arch: std::env::consts::ARCH.to_string(),
+                key_directory: PathBuf::from("./keys"),
+                wit_world: None,
+                rust_target: None,
+                bin_name: None,
             })
         );
 

--- a/crates/wash-lib/src/cli/dev.rs
+++ b/crates/wash-lib/src/cli/dev.rs
@@ -19,16 +19,17 @@ pub async fn run_dev_loop(
     ctl_client: &Client,
     sign_cfg: Option<SignConfig>,
 ) -> Result<()> {
-    let built_artifact_path = build_project(project_cfg, sign_cfg)?.canonicalize()?;
+    let built_artifact_path = build_project(project_cfg, sign_cfg.as_ref())
+        .await?
+        .canonicalize()?;
 
     // Restart the artifact so that changes can be observed
     match project_cfg.project_type {
-        TypeConfig::Interface(_) | TypeConfig::Provider(_) => {
+        TypeConfig::Provider(_) => {
             eprintln!(
                 "{} {}",
                 emoji::WARN,
-                style("`wash build` interfaces and providers are not yet supported, skipping...")
-                    .bold(),
+                style("`wash build` providers are not yet supported for dev, skipping...").bold(),
             );
         }
         TypeConfig::Actor(_) => {

--- a/crates/wash-lib/src/cli/par.rs
+++ b/crates/wash-lib/src/cli/par.rs
@@ -2,6 +2,11 @@ use anyhow::{anyhow, Context, Result};
 use provider_archive::ProviderArchive;
 use std::path::PathBuf;
 
+/// Helper function for detecting the arch used by the current machine
+pub fn detect_arch() -> String {
+    format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS)
+}
+
 pub struct ParCreateArgs {
     pub capid: String,
     pub vendor: String,
@@ -12,7 +17,7 @@ pub struct ParCreateArgs {
     pub arch: String,
 }
 
-pub async fn create_provider_archive(
+pub fn create_provider_archive(
     ParCreateArgs {
         capid,
         vendor,


### PR DESCRIPTION
## Feature or Problem
This PR implements wash building a capability provider archive just for the local arch/os target. In the future I'd love to add support for multiple other architectures as well with predefined paths, but `wash build` won't ever be responsible for cross compiling (something something sure would be nice if we had a platform agnostic binary target to compile to)

## Related Issues
I added two TODOs re: #1624 because I found out why we're generating keys to `./keys`

## Release Information
next minor wash-cli
next minor wash-lib

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I verified this worked for a provider that will soon be an example 😄 
