### PR TITLE
feat(wash-cli): basic wasi:cli/run style wrpc invocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5065,6 +5065,8 @@ dependencies = [
  "wasmcloud-provider-sdk",
  "weld-codegen",
  "which",
+ "wrpc-transport",
+ "wrpc-types",
 ]
 
 [[package]]

--- a/crates/core/src/wit.rs
+++ b/crates/core/src/wit.rs
@@ -2,8 +2,11 @@
 
 use std::collections::HashMap;
 
+use anyhow::Context;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize, Serializer};
+
+use crate::{WitFunction, WitInterface, WitNamespace, WitPackage};
 
 // I don't know if these would be generated or if we'd just include them in the library and then use them in the generated code, but they work around the lack of a map type in wit
 
@@ -35,4 +38,102 @@ where
 {
     let values = HashMap::<String, T>::deserialize(deserializer)?;
     Ok(values.into_iter().collect())
+}
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+/// Call target identifier, which is equivalent to a WIT specification, which
+/// can identify an interface being called and optionally a specific function on that interface.
+pub struct CallTargetInterface {
+    /// WIT namespace (ex. `wasi` in `wasi:keyvalue/readwrite.get`)
+    pub namespace: String,
+    /// WIT package name (ex. `keyvalue` in `wasi:keyvalue/readwrite.get`)
+    pub package: String,
+    /// WIT interface (ex. `readwrite` in `wasi:keyvalue/readwrite.get`)
+    pub interface: String,
+    // TODO(brooksmtownsend): I'm almost certain we do not need this.
+    /// WIT package name (ex. `get` in `wasi:keyvalue/readwrite.get`)
+    pub function: Option<String>,
+}
+
+impl CallTargetInterface {
+    /// Returns the 3-tuple of (namespace, package, interface) for this interface
+    #[must_use]
+    pub fn as_parts(&self) -> (&str, &str, &str, Option<&str>) {
+        (
+            &self.namespace,
+            &self.package,
+            &self.interface,
+            self.function.as_deref(),
+        )
+    }
+
+    /// Build a [`TargetInterface`] from constituent parts
+    #[must_use]
+    pub fn from_parts(parts: (&str, &str, &str, Option<&str>)) -> Self {
+        let (ns, pkg, iface, function) = parts;
+        Self {
+            namespace: ns.into(),
+            package: pkg.into(),
+            interface: iface.into(),
+            function: function.map(String::from),
+        }
+    }
+
+    /// Build a target interface from a given operation
+    pub fn from_operation(operation: impl AsRef<str>) -> anyhow::Result<Self> {
+        let operation = operation.as_ref();
+        let (wit_ns, wit_pkg, wit_iface, wit_fn) = parse_wit_meta_from_operation(operation)?;
+        Ok(CallTargetInterface::from_parts((
+            &wit_ns,
+            &wit_pkg,
+            &wit_iface,
+            wit_fn.as_deref(),
+        )))
+    }
+}
+
+/// Parse a sufficiently specified WIT operation/method into constituent parts.
+///
+///
+/// # Errors
+///
+/// Returns `Err` if the operation is not of the form "<package>:<ns>/<interface>.<function>"
+///
+/// # Example
+///
+/// ```
+/// let (wit_ns, wit_pkg, wit_iface, wit_fn) = parse_wit_meta_from_operation(("wasmcloud:bus/guest-config"));
+/// #assert_eq!(wit_ns, "wasmcloud")
+/// #assert_eq!(wit_pkg, "bus")
+/// #assert_eq!(wit_iface, "iface")
+/// #assert_eq!(wit_fn, None)
+/// let (wit_ns, wit_pkg, wit_iface, wit_fn) = parse_wit_meta_from_operation(("wasmcloud:bus/guest-config.get"));
+/// #assert_eq!(wit_ns, "wasmcloud")
+/// #assert_eq!(wit_pkg, "bus")
+/// #assert_eq!(wit_iface, "iface")
+/// #assert_eq!(wit_fn, Some("get"))
+/// ```
+pub fn parse_wit_meta_from_operation(
+    operation: impl AsRef<str>,
+) -> anyhow::Result<(WitNamespace, WitPackage, WitInterface, Option<WitFunction>)> {
+    let operation = operation.as_ref();
+    let (ns_and_pkg, interface_and_func) = operation
+        .rsplit_once('/')
+        .context("failed to parse operation")?;
+    let (wit_iface, wit_fn) = interface_and_func
+        .split_once('.')
+        .context("interface and function should be specified")?;
+    let (wit_ns, wit_pkg) = ns_and_pkg
+        .rsplit_once(':')
+        .context("failed to parse operation for WIT ns/pkg")?;
+    Ok((
+        wit_ns.into(),
+        wit_pkg.into(),
+        wit_iface.into(),
+        if wit_fn.is_empty() {
+            None
+        } else {
+            Some(wit_fn.into())
+        },
+    ))
 }

--- a/crates/core/src/wrpc.rs
+++ b/crates/core/src/wrpc.rs
@@ -132,7 +132,7 @@ impl Client {
     ///
     /// ## Arguments
     /// * `nats` - The NATS client to use for communication.
-    /// * `lattice` - The lattice to use for communication.
+    /// * `prefix` - The lattice and component ID to use for communication, e.g. "default.echo".
     /// * `headers` - The headers to include with each outbound invocation.
     pub fn new(
         nats: impl Into<Arc<async_nats::Client>>,

--- a/crates/core/src/wrpc.rs
+++ b/crates/core/src/wrpc.rs
@@ -128,19 +128,24 @@ pub struct Client {
 }
 
 impl Client {
-    /// Create a new wRPC [Client] with the given NATS client, lattice, and headers.
+    /// Create a new wRPC [Client] with the given NATS client, lattice, component ID, and headers.
     ///
     /// ## Arguments
     /// * `nats` - The NATS client to use for communication.
-    /// * `prefix` - The lattice and component ID to use for communication, e.g. "default.echo".
+    /// * `lattice` - The lattice ID to use for communication.
+    /// * `prefix` - The component ID to use for communication.
     /// * `headers` - The headers to include with each outbound invocation.
     pub fn new(
         nats: impl Into<Arc<async_nats::Client>>,
-        lattice: String,
+        lattice: impl AsRef<str>,
+        component_id: impl AsRef<str>,
         headers: HeaderMap,
     ) -> Self {
         Self {
-            inner: wrpc_transport_nats::Client::new(nats, lattice),
+            inner: wrpc_transport_nats::Client::new(
+                nats,
+                format!("{}.{}", lattice.as_ref(), component_id.as_ref()),
+            ),
             headers,
         }
     }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -628,13 +628,10 @@ impl Bus for Handler {
             let injector = TraceContextInjector::default_with_span();
             let mut headers = injector_to_headers(&injector);
             headers.insert("source-id", self.component_id.as_str());
-            let (results, tx) = wasmcloud_core::wrpc::Client::new(
-                self.nats.clone(),
-                format!("{}.{id}", self.lattice),
-                headers,
-            )
-            .invoke_dynamic(instance, name, DynamicTuple(params), results)
-            .await?;
+            let (results, tx) =
+                wasmcloud_core::wrpc::Client::new(self.nats.clone(), &self.lattice, id, headers)
+                    .invoke_dynamic(instance, name, DynamicTuple(params), results)
+                    .await?;
             tx.await.context("failed to transmit parameters")?;
             Ok(results)
         } else {
@@ -2107,7 +2104,8 @@ impl Host {
 
         let wrpc = wasmcloud_core::wrpc::Client::new(
             self.rpc_nats.clone(),
-            format!("{}.{actor_id}", self.host_config.lattice),
+            &self.host_config.lattice,
+            &actor_id,
             // NOTE(brooksmtownsend): We only use this client for serving functions,
             // and the headers will be set by the incoming invocation.
             async_nats::HeaderMap::new(),

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -3954,6 +3954,8 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-nats",
+ "async-trait",
+ "bytes",
  "futures",
  "hex",
  "nkeys",

--- a/crates/runtime/src/actor/component/bus.rs
+++ b/crates/runtime/src/actor/component/bus.rs
@@ -1,10 +1,10 @@
 use super::{Ctx, Instance, TableResult};
 
-use crate::capability::builtin::CallTargetInterface;
 use crate::capability::bus::{guest_config, lattice};
 use crate::capability::Bus;
 
 use std::sync::Arc;
+use wasmcloud_core::CallTargetInterface;
 
 use anyhow::Context as _;
 use async_trait::async_trait;

--- a/crates/runtime/src/actor/component/mod.rs
+++ b/crates/runtime/src/actor/component/mod.rs
@@ -1,5 +1,4 @@
 use crate::actor::claims;
-use crate::capability::builtin::CallTargetInterface;
 use crate::capability::{builtin, Bus, Interfaces};
 use crate::Runtime;
 
@@ -17,6 +16,7 @@ use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite};
 use tokio::sync::Mutex;
 use tracing::{error, instrument, trace, warn};
 use wascap::jwt;
+use wasmcloud_core::CallTargetInterface;
 use wasmtime::component::{
     self, types, InstancePre, Linker, ResourceTable, ResourceTableError, Type, Val,
 };

--- a/crates/runtime/src/capability/mod.rs
+++ b/crates/runtime/src/capability/mod.rs
@@ -9,7 +9,7 @@ pub use builtin::{
 };
 
 // NOTE: this import is used below in bindgen
-pub use builtin::CallTargetInterface;
+pub use wasmcloud_core::CallTargetInterface;
 
 #[allow(clippy::doc_markdown)]
 #[allow(missing_docs)]

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -72,6 +72,8 @@ wasmcloud-core = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true }
 weld-codegen = { workspace = true, features = ["wasmbus"] }
 which = { workspace = true }
+wrpc-transport = { workspace = true }
+wrpc-types = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 notify = { workspace = true, features = ["macos_fsevent"] }

--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -70,7 +70,7 @@ Iterate:
   stop         Stop an actor or provider, or host
   update       Update an actor running in a host to a newer version
   link         Link an actor and a provider
-  call         Invoke a wasmCloud actor
+  call         Invoke a simple function on a component running in a wasmCloud host
   ctl          Interact with a wasmCloud control interface (deprecated, use above commands)
   label        Label (or un-label) a host with a key=value label pair
 
@@ -134,7 +134,7 @@ enum CliCommand {
     /// Build (and sign) a wasmCloud actor, provider, or interface
     #[clap(name = "build")]
     Build(BuildCommand),
-    /// Invoke a wasmCloud actor
+    /// Invoke a simple function on a component running in a wasmCloud host
     #[clap(name = "call")]
     Call(CallCli),
     /// Capture and debug cluster invocations and state

--- a/crates/wash-cli/src/call.rs
+++ b/crates/wash-cli/src/call.rs
@@ -220,10 +220,10 @@ pub async fn handle_call(
 
     let out_str = match result {
         Ok((values, _tx)) => {
-            if let Some(wrpc_transport::Value::String(result)) = values.get(0) {
+            if let Some(wrpc_transport::Value::String(result)) = values.first() {
                 result.to_string()
             } else {
-                bail!("Got something other than a string from the component")
+                bail!("Response from a component was not a String, ensure the function {function} returns a String.")
             }
         }
         Err(e) if e.to_string().contains("transmission failed") => bail!("No component responsed to your request, ensure component {component_id} is running in lattice {lattice}"),

--- a/crates/wash-cli/src/dev.rs
+++ b/crates/wash-cli/src/dev.rs
@@ -258,7 +258,8 @@ pub async fn handle_command(
     );
 
     // Build the project
-    let artifact_path = build_project(&project_cfg, sign_cfg.clone())
+    let artifact_path = build_project(&project_cfg, sign_cfg.as_ref())
+        .await
         .context("failed to build project")?
         .canonicalize()
         .context("failed to canonicalize path")?;

--- a/crates/wash-lib/src/build/mod.rs
+++ b/crates/wash-lib/src/build/mod.rs
@@ -1,0 +1,88 @@
+//! Build (and sign) a wasmCloud actor, or provider. Depends on the "cli" feature
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::info;
+use wit_parser::{Resolve, WorldId};
+
+use crate::parser::{ProjectConfig, TypeConfig};
+
+mod component;
+pub use component::*;
+mod provider;
+use provider::*;
+
+/// This tag indicates that a Wasm module uses experimental features of wasmCloud
+/// and/or the surrounding ecosystem.
+///
+/// This tag is normally embedded in a Wasm module as a custom section
+const WASMCLOUD_WASM_TAG_EXPERIMENTAL: &str = "wasmcloud.com/experimental";
+
+/// Configuration for signing an artifact (actor or provider) including issuer and subject key, the path to where keys can be found, and an option to
+/// disable automatic key generation if keys cannot be found.
+#[derive(Debug, Clone, Default)]
+pub struct SignConfig {
+    /// Location of key files for signing
+    pub keys_directory: Option<PathBuf>,
+
+    /// Path to issuer seed key (account). If this flag is not provided, the seed will be sourced from ($HOME/.wash/keys) or generated for you if it cannot be found.
+    pub issuer: Option<String>,
+
+    /// Path to subject seed key (module or service). If this flag is not provided, the seed will be sourced from ($HOME/.wash/keys) or generated for you if it cannot be found.
+    pub subject: Option<String>,
+
+    /// Disables autogeneration of keys if seed(s) are not provided
+    pub disable_keygen: bool,
+}
+
+/// Using a [ProjectConfig], usually parsed from a `wasmcloud.toml` file, build the project
+/// with the installed language toolchain. This will delegate to [build_actor] when the project is an actor,
+/// or [build_provider] when the project is a provider.
+///
+/// This function returns the path to the compiled artifact, a signed Wasm component or signed provider archive.
+///
+/// # Usage
+/// ```no_run
+/// use wash_lib::{build::build_project, parser::get_config};
+/// let config = get_config(None, Some(true))?;
+/// let artifact_path = build_project(config)?;
+/// println!("Here is the signed artifact: {}", artifact_path.to_string_lossy());
+/// ```
+/// # Arguments
+/// * `config`: [ProjectConfig] for required information to find, build, and sign an actor
+/// * `signing`: Optional [SignConfig] with information for signing the project artifact. If omitted, the artifact will only be built
+pub async fn build_project(
+    config: &ProjectConfig,
+    signing: Option<&SignConfig>,
+) -> Result<PathBuf> {
+    match &config.project_type {
+        TypeConfig::Actor(actor_config) => {
+            build_actor(actor_config, &config.language, &config.common, signing)
+        }
+        TypeConfig::Provider(provider_config) => {
+            build_provider(provider_config, &config.language, &config.common, signing).await
+        }
+    }
+}
+
+/// Build a [`wit_parser::Resolve`] from a provided directory
+/// and select a given world
+fn convert_wit_dir_to_world(
+    dir: impl AsRef<Path>,
+    world: impl AsRef<str>,
+) -> Result<(Resolve, WorldId)> {
+    // Resolve the WIT directory packages & worlds
+    let mut resolve = wit_parser::Resolve::default();
+    let (package_id, _paths) = resolve
+        .push_dir(dir.as_ref())
+        .with_context(|| format!("failed to add WIT directory @ [{}]", dir.as_ref().display()))?;
+    info!("successfully loaded WIT @ [{}]", dir.as_ref().display());
+
+    // Select the target world that was specified by the user
+    let world_id = resolve
+        .select_world(package_id, world.as_ref().into())
+        .context("failed to select world from built resolver")?;
+
+    Ok((resolve, world_id))
+}

--- a/crates/wash-lib/src/build/provider.rs
+++ b/crates/wash-lib/src/build/provider.rs
@@ -1,0 +1,134 @@
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::process;
+
+use anyhow::{anyhow, bail, Context, Result};
+use nkeys::KeyPairType;
+use tracing::warn;
+
+use crate::build::SignConfig;
+use crate::cli::par::{create_provider_archive, detect_arch, ParCreateArgs};
+use crate::cli::{extract_keypair, OutputKind};
+use crate::parser::{CommonConfig, LanguageConfig, ProviderConfig};
+
+/// Build a capability provider for the current machine's architecture
+/// and operating system using provided configuration.
+pub(crate) async fn build_provider(
+    provider_config: &ProviderConfig,
+    language_config: &LanguageConfig,
+    common_config: &CommonConfig,
+    signing_config: Option<&SignConfig>,
+) -> Result<PathBuf> {
+    let LanguageConfig::Rust(rust_config) = language_config else {
+        bail!("Unsupported language for provider: {:?}", language_config)
+    };
+    let mut command = match rust_config.cargo_path.as_ref() {
+        Some(path) => process::Command::new(path),
+        None => process::Command::new("cargo"),
+    };
+
+    // Change directory into the project directory
+    std::env::set_current_dir(&common_config.path)?;
+
+    // Build for a specified target if provided, or the default rust target
+    let mut build_args = Vec::with_capacity(4);
+    build_args.extend_from_slice(&["build", "--release"]);
+    if let Some(override_target) = &provider_config.rust_target {
+        build_args.extend_from_slice(&["--target", override_target]);
+    };
+
+    let result = command.args(build_args).status().map_err(|e| {
+        if e.kind() == ErrorKind::NotFound {
+            anyhow!("{:?} command is not found", command.get_program())
+        } else {
+            anyhow!(e)
+        }
+    })?;
+
+    if !result.success() {
+        bail!("Compiling provider failed: {result}")
+    }
+
+    let metadata = cargo_metadata::MetadataCommand::new().no_deps().exec()?;
+    let bin_name = if let Some(bin_name) = &provider_config.bin_name {
+        bin_name.to_string()
+    } else {
+        // Discover the binary name from the metadata
+        metadata
+            .packages
+            .iter()
+            .find_map(|p| {
+                p.targets.iter().find_map(|t| {
+                    if t.kind.iter().any(|k| k == "bin") {
+                        Some(t.name.clone())
+                    } else {
+                        None
+                    }
+                })
+            }).context("Could not infer provider binary name in metadata, please specify under provider.bin_name")?
+    };
+    let mut provider_path_buf = rust_config
+        .target_path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(metadata.target_directory.as_std_path()));
+    if let Some(override_target) = &provider_config.rust_target {
+        provider_path_buf.push(override_target);
+    }
+    provider_path_buf.push("release");
+    provider_path_buf.push(&bin_name);
+
+    let provider_bytes = tokio::fs::read(&provider_path_buf).await?;
+
+    let mut par = create_provider_archive(
+        ParCreateArgs {
+            capid: provider_config.wit_world.clone().unwrap_or_default(),
+            vendor: provider_config.vendor.to_string(),
+            revision: Some(common_config.revision),
+            version: Some(common_config.version.to_string()),
+            schema: None,
+            name: common_config.name.to_string(),
+            arch: detect_arch(),
+        },
+        &provider_bytes,
+    )
+    .context("failed to create initial provider archive with built provider")?;
+
+    // If no signing config supplied, just return the path to the provider
+    let Some(sign_config) = signing_config else {
+        warn!("No signing configuration supplied, could only build provider");
+        return Ok(provider_path_buf);
+    };
+
+    let destination = common_config
+        .path
+        .join("build")
+        .join(format!("{bin_name}.par.gz"));
+    if let Some(parent) = destination.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let issuer = extract_keypair(
+        sign_config.issuer.clone(),
+        Some(provider_path_buf.to_string_lossy().to_string()),
+        sign_config.keys_directory.clone(),
+        KeyPairType::Account,
+        sign_config.disable_keygen,
+        OutputKind::Json,
+    )?;
+    let subject = extract_keypair(
+        sign_config.subject.clone(),
+        Some(provider_path_buf.to_string_lossy().to_string()),
+        sign_config.keys_directory.clone(),
+        KeyPairType::Service,
+        sign_config.disable_keygen,
+        OutputKind::Json,
+    )?;
+    par.write(destination.as_path(), &issuer, &subject, true)
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+
+    Ok(if destination.is_absolute() {
+        destination
+    } else {
+        common_config.path.join(destination)
+    })
+}

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -247,7 +247,6 @@ impl ProviderMetadata {
             version: self
                 .version
                 .or(Some(project_config.common.version.to_string())),
-            capid: self.capid.or(Some(provider_config.capability_id)),
             vendor: self.vendor.or(Some(provider_config.vendor)),
             ..self
         }
@@ -1567,8 +1566,13 @@ mod test {
         assert_eq!(
             project_config.project_type,
             TypeConfig::Provider(ProviderConfig {
-                capability_id: "wasmcloud:httpserver".into(),
-                vendor: "wayne-industries".into()
+                vendor: "wayne-industries".into(),
+                os: std::env::consts::OS.to_string(),
+                arch: std::env::consts::ARCH.to_string(),
+                key_directory: PathBuf::from("./keys"),
+                wit_world: None,
+                rust_target: None,
+                bin_name: None,
             })
         );
 

--- a/crates/wash-lib/src/cli/dev.rs
+++ b/crates/wash-lib/src/cli/dev.rs
@@ -19,16 +19,17 @@ pub async fn run_dev_loop(
     ctl_client: &Client,
     sign_cfg: Option<SignConfig>,
 ) -> Result<()> {
-    let built_artifact_path = build_project(project_cfg, sign_cfg)?.canonicalize()?;
+    let built_artifact_path = build_project(project_cfg, sign_cfg.as_ref())
+        .await?
+        .canonicalize()?;
 
     // Restart the artifact so that changes can be observed
     match project_cfg.project_type {
-        TypeConfig::Interface(_) | TypeConfig::Provider(_) => {
+        TypeConfig::Provider(_) => {
             eprintln!(
                 "{} {}",
                 emoji::WARN,
-                style("`wash build` interfaces and providers are not yet supported, skipping...")
-                    .bold(),
+                style("`wash build` providers are not yet supported for dev, skipping...").bold(),
             );
         }
         TypeConfig::Actor(_) => {

--- a/crates/wash-lib/src/cli/par.rs
+++ b/crates/wash-lib/src/cli/par.rs
@@ -2,6 +2,11 @@ use anyhow::{anyhow, Context, Result};
 use provider_archive::ProviderArchive;
 use std::path::PathBuf;
 
+/// Helper function for detecting the arch used by the current machine
+pub fn detect_arch() -> String {
+    format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS)
+}
+
 pub struct ParCreateArgs {
     pub capid: String,
     pub vendor: String,
@@ -12,7 +17,7 @@ pub struct ParCreateArgs {
     pub arch: String,
 }
 
-pub async fn create_provider_archive(
+pub fn create_provider_archive(
     ParCreateArgs {
         capid,
         vendor,


### PR DESCRIPTION
Draft PR as it branches off of #1628 

## Feature or Problem
This PR implements a very basic `wash call` functionality that allows developers to invoke a component that exports an interface function that takes no arguments and returns a String. It's very basic, but it will allow manual invocation of a component over wRPC and we can extend this in the future by passing in WIT files 😄 

For example, a component WIT world like:
```wit
package wasmcloud:hello;

interface easy {
  call: func() -> string;
}
```

Can be invoked like:
```bash
wash call <component_id> wasmcloud:hello/easy.call
```

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next wash-cli

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
This works great! I attempted to include basic error handling around timeouts and no responders errors. 
