### PR TITLE
chore: prefix NATS_PORT and NATS_URL with WASMCLOUD

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,9 +35,9 @@ spec:
           image: "{{ .Values.wasmcloud.image.repository }}:{{ .Values.wasmcloud.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.wasmcloud.image.pullPolicy }}
           env:
-            - name: NATS_HOST
+            - name: WASMCLOUD_NATS_HOST
               value: {{ .Values.wasmcloud.config.natsHost | quote }}
-            - name: NATS_PORT
+            - name: WASMCLOUD_NATS_PORT
               value: {{ .Values.wasmcloud.config.natsPort | quote }}
             {{- if .Values.wasmcloud.config.natsJwt }}
             - name: NATS_JWT

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,18 @@ struct Args {
     #[clap(long = "log-level", alias = "structured-log-level", default_value_t = TracingLogLevel::INFO, env = "WASMCLOUD_LOG_LEVEL")]
     pub log_level: TracingLogLevel,
     /// NATS server host to connect to
-    #[clap(long = "nats-host", default_value = "127.0.0.1", env = "NATS_HOST")]
+    #[clap(
+        long = "nats-host",
+        default_value = "127.0.0.1",
+        env = "WASMCLOUD_NATS_HOST"
+    )]
     nats_host: String,
     /// NATS server port to connect to
-    #[clap(long = "nats-port", default_value_t = 4222, env = "NATS_PORT")]
+    #[clap(
+        long = "nats-port",
+        default_value_t = 4222,
+        env = "WASMCLOUD_NATS_PORT"
+    )]
     nats_port: u16,
     /// A user JWT to use to authenticate to NATS
     #[clap(long = "nats-jwt", env = "WASMCLOUD_NATS_JWT", requires = "nats_seed")]


### PR DESCRIPTION
## Feature or Problem
This adds a `WASMCLOUD` prefix to both the `NATS_PORT` and `NATS_URL` env vars, since there are potentially conficts with those variables in other systems. Specifically this would play badly deploying in Kubernetes with a service named `nats` running in the same namespace, since a `NATS_PORT` env var is automatically injected in that case which stops the wasmcloud binary from starting. It is also a good practice to have all of our environment variables using the same prefix.

This is a breaking change to wasmCloud CLI args for the host.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
