### PR TITLE
fix(wash-lib): build provider tests

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -6,11 +6,11 @@ on:
   pull_request:
     branches: [main]
     paths:
-    - .github/workflows/wash.yml
-    - Cargo.lock
-    - Cargo.toml
-    - crates/wash-cli/**
-    - crates/wash-lib/**
+      - .github/workflows/wash.yml
+      - Cargo.lock
+      - Cargo.toml
+      - crates/wash-cli/**
+      - crates/wash-lib/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: "18.x"
       - uses: actions/checkout@v4.1.1
       - uses: Swatinem/rust-cache@v2
         with:
@@ -54,10 +54,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "ubuntu-22.04-shared-cache"
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.20
       - uses: acifani/setup-tinygo@v2
         with:
-          tinygo-version: '0.27.0'
-          install-binaryen: 'false'
+          tinygo-version: "0.27.0"
+          install-binaryen: "false"
       - name: Add wasm32-unknown-unknown
         run: rustup target add wasm32-unknown-unknown
       - name: Launch integration test services

--- a/crates/host/src/metrics.rs
+++ b/crates/host/src/metrics.rs
@@ -1,4 +1,4 @@
-use wasmcloud_tracing::{Counter, Histogram, Meter, Unit};
+use wasmcloud_tracing::{Counter, Histogram, KeyValue, Meter, Unit};
 
 /// `HostMetrics` encapsulates the set of metrics emitted by the wasmcloud host
 #[derive(Clone, Debug)]
@@ -48,6 +48,21 @@ impl HostMetrics {
             actor_errors: actor_error_count,
             host_id,
             lattice_id,
+        }
+    }
+
+    /// Record the result of invoking a component, including the elapsed time, any attributes, and whether the invocation resulted in an error.
+    pub(crate) fn record_component_invocation(
+        &self,
+        elapsed: u64,
+        attributes: &[KeyValue],
+        error: bool,
+    ) {
+        self.handle_rpc_message_duration_ns
+            .record(elapsed, attributes);
+        self.actor_invocations.add(1, attributes);
+        if error {
+            self.actor_errors.add(1, attributes);
         }
     }
 }

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -1570,7 +1570,7 @@ mod test {
                 os: std::env::consts::OS.to_string(),
                 arch: std::env::consts::ARCH.to_string(),
                 key_directory: PathBuf::from("./keys"),
-                wit_world: None,
+                wit_world: Some("wasmcloud:httpserver".to_string()),
                 rust_target: None,
                 bin_name: None,
             })
@@ -1599,7 +1599,6 @@ mod test {
                 name: Some("testprovider".to_string()),
                 version: Some(Version::parse("0.1.0")?.to_string()),
                 revision: Some(666),
-                capid: Some("wasmcloud:httpserver".into()),
                 vendor: Some("wayne-industries".into()),
                 ..ProviderMetadata::default()
             }

--- a/crates/wash-lib/tests/parser/files/rust_provider_claims_metadata.toml
+++ b/crates/wash-lib/tests/parser/files/rust_provider_claims_metadata.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 revision = 666
 
 [provider]
-capability_id = "wasmcloud:httpserver"
+wit_world = "wasmcloud:httpserver"
 vendor = "wayne-industries"
 
 [rust]

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -251,7 +251,7 @@ fn no_interface_config() {
 
     assert_eq!(
         format!(
-            "missing interface config in {}",
+            "unknown project type: interface in {}",
             get_full_path("./tests/parser/files/no_interface.toml")
         ),
         err.to_string().as_str()


### PR DESCRIPTION
## Feature or Problem
This PR fixes a test failure in `wash-lib` that I didn't catch PR-ing into `feat/wrpc` and pins our Go version to 1.20 which is failing a test in `main`.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
