### PR TITLE
feat(control-interface)!: support static named config for providers

### DIFF
--- a/crates/control-interface/src/client.rs
+++ b/crates/control-interface/src/client.rs
@@ -501,6 +501,8 @@ impl Client {
     /// OCI registry, indicating either a validation failure or success. If a client needs
     /// deterministic guarantees that the provider has completed its startup process, such a client
     /// needs to monitor the control event stream for the appropriate event.
+    ///
+    /// The `provider_configuration` parameter is a list of named configs to use for this provider. It is not required to specify a config.
     #[instrument(level = "debug", skip_all)]
     pub async fn start_provider(
         &self,
@@ -508,7 +510,7 @@ impl Client {
         provider_ref: &str,
         provider_id: &str,
         annotations: Option<HashMap<String, String>>,
-        provider_configuration: Option<String>,
+        provider_configuration: Vec<String>,
     ) -> Result<CtlResponse<()>> {
         let host_id = parse_identifier(&IdentifierKind::HostId, host_id)?;
         let subject =
@@ -519,7 +521,7 @@ impl Client {
             provider_ref: parse_identifier(&IdentifierKind::ProviderRef, provider_ref)?,
             provider_id: parse_identifier(&IdentifierKind::ComponentId, provider_id)?,
             annotations,
-            configuration: provider_configuration,
+            config: provider_configuration,
         })?;
 
         match self.request_timeout(subject, bytes, self.timeout).await {
@@ -825,7 +827,7 @@ mod tests {
         let (provider_ref, provider_id) = (&auction_ack.provider_ref, &auction_ack.provider_id);
         // Provider Start
         let start_response = client
-            .start_provider(&host.id, provider_ref, provider_id, None, None)
+            .start_provider(&host.id, provider_ref, provider_id, None, vec![])
             .await
             .expect("should be able to start provider");
         assert!(start_response.success);

--- a/crates/control-interface/src/types/ctl.rs
+++ b/crates/control-interface/src/types/ctl.rs
@@ -90,11 +90,13 @@ pub struct StartProviderCommand {
     pub annotations: Option<HashMap<String, String>>,
     /// Unique identifier of the provider to start.
     pub provider_id: ComponentId,
-    /// Optional provider configuration in the form of an opaque string. Many
-    /// providers prefer base64-encoded JSON here, though that data should never
-    /// exceed 500KB
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub configuration: Option<String>,
+    /// A list of named configs to use for this provider. It is not required to specify a config.
+    /// Configs are merged together before being given to the provider, with values from the right-most
+    /// config in the list taking precedence. For example, given ordered configs foo {a: 1, b: 2},
+    /// bar {b: 3, c: 4}, and baz {c: 5, d: 6}, the resulting config will be: {a: 1, b: 3, c: 5, d:
+    /// 6}
+    #[serde(default)]
+    pub config: Vec<String>,
     /// The host ID on which to start the provider
     #[serde(default)]
     pub host_id: String,

--- a/crates/core/src/host.rs
+++ b/crates/core/src/host.rs
@@ -1,5 +1,7 @@
 //! Core reusable functionality related to hosts
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::lattice::ClusterIssuerKey;
@@ -41,10 +43,9 @@ pub struct HostData {
     pub link_definitions: Vec<InterfaceLinkDefinition>,
     /// list of cluster issuers
     pub cluster_issuers: Vec<ClusterIssuerKey>,
-    /// Optional configuration JSON sent to a given link name of a provider
-    /// without an actor context
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub config_json: Option<String>,
+    /// Merged named configuration set for this provider at runtime
+    #[serde(default)]
+    pub config: HashMap<String, String>,
     /// Host-wide default RPC timeout for rpc messages, in milliseconds.  Defaults to 2000.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_rpc_timeout_ms: Option<u64>,

--- a/crates/provider-sdk/src/provider.rs
+++ b/crates/provider-sdk/src/provider.rs
@@ -373,7 +373,7 @@ async fn init_provider(name: &str) -> ProviderInitResult<ProviderInitState> {
         instance_id,
         link_definitions,
         cluster_issuers: _,
-        config_json: _,
+        config: _,
         default_rpc_timeout_ms: _,
         structured_logging,
         log_level,

--- a/crates/providers/kv-redis/src/bin/kvredis.rs
+++ b/crates/providers/kv-redis/src/bin/kvredis.rs
@@ -23,8 +23,6 @@ use tracing::{error, info, instrument, warn};
 
 use wasmcloud_provider_wit_bindgen::deps::{
     async_trait::async_trait,
-    serde::Deserialize,
-    serde_json,
     wasmcloud_provider_sdk::{load_host_data, start_provider, Context, InterfaceLinkDefinition},
 };
 
@@ -310,8 +308,7 @@ fn retrieve_default_url(config: &HashMap<String, String>) -> String {
     let config_supplied_url = config
         .keys()
         .find(|k| k.eq_ignore_ascii_case(CONFIG_REDIS_URL_KEY))
-        .map(|url_key| config.get(url_key))
-        .flatten();
+        .and_then(|url_key| config.get(url_key));
 
     if let Some(url) = config_supplied_url {
         info!(url, "Using Redis URL from config");

--- a/crates/providers/kv-redis/src/bin/kvredis.rs
+++ b/crates/providers/kv-redis/src/bin/kvredis.rs
@@ -40,35 +40,10 @@ const DEFAULT_CONNECT_URL: &str = "redis://127.0.0.1:6379/";
 /// Configuration key that will be used to search for Redis config
 const CONFIG_REDIS_URL_KEY: &str = "URL";
 
-#[derive(Deserialize)]
-#[serde(crate = "wasmcloud_provider_wit_bindgen::deps::serde")]
-struct KvRedisConfig {
-    /// Default URL to connect when actor doesn't provide one on a link
-    #[serde(alias = "URL", alias = "Url")]
-    url: String,
-}
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let hd = load_host_data()?;
 
-    let default_connect_url = if let Some(raw_config) = hd.config_json.as_ref() {
-        match serde_json::from_str(raw_config) {
-            Ok(KvRedisConfig { url }) => {
-                info!(url, "Using Redis URL from config");
-                url
-            }
-            Err(err) => {
-                warn!(
-                    DEFAULT_CONNECT_URL,
-                    "Failed to parse `config_json`: {err}\nUsing default configuration"
-                );
-                DEFAULT_CONNECT_URL.to_string()
-            }
-        }
-    } else {
-        info!(DEFAULT_CONNECT_URL, "Using default Redis URL");
-        DEFAULT_CONNECT_URL.to_string()
-    };
+    let default_connect_url = retrieve_default_url(&hd.config);
 
     start_provider(
         KvRedisProvider::new(&default_connect_url),
@@ -328,36 +303,41 @@ impl KvRedisProvider {
     }
 }
 
+/// Fetch the default URL to use for connecting to Redis from the configuration, defaulting
+/// to `DEFAULT_CONNECT_URL` if no URL is found in the configuration.
+fn retrieve_default_url(config: &HashMap<String, String>) -> String {
+    // To aid in user experience, find the URL key in the config that matches "URL" in a case-insensitive manner
+    let config_supplied_url = config
+        .keys()
+        .find(|k| k.eq_ignore_ascii_case(CONFIG_REDIS_URL_KEY))
+        .map(|url_key| config.get(url_key))
+        .flatten();
+
+    if let Some(url) = config_supplied_url {
+        info!(url, "Using Redis URL from config");
+        url.to_string()
+    } else {
+        info!(DEFAULT_CONNECT_URL, "Using default Redis URL");
+        DEFAULT_CONNECT_URL.to_string()
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::KvRedisConfig;
-    use crate::serde_json;
+    use std::collections::HashMap;
+
+    use crate::retrieve_default_url;
 
     const PROPER_URL: &str = "redis://127.0.0.1:6379";
 
     #[test]
     fn can_deserialize_config_case_insensitive() {
-        let lowercase_config = format!("{{\"url\": \"{}\"}}", PROPER_URL);
-        let uppercase_config = format!("{{\"URL\": \"{}\"}}", PROPER_URL);
-        let initial_caps_config = format!("{{\"Url\": \"{}\"}}", PROPER_URL);
+        let lowercase_config = HashMap::from_iter([("url".to_string(), PROPER_URL.to_string())]);
+        let uppercase_config = HashMap::from_iter([("URL".to_string(), PROPER_URL.to_string())]);
+        let initial_caps_config = HashMap::from_iter([("Url".to_string(), PROPER_URL.to_string())]);
 
-        assert_eq!(
-            PROPER_URL,
-            serde_json::from_str::<KvRedisConfig>(&lowercase_config)
-                .unwrap()
-                .url
-        );
-        assert_eq!(
-            PROPER_URL,
-            serde_json::from_str::<KvRedisConfig>(&uppercase_config)
-                .unwrap()
-                .url
-        );
-        assert_eq!(
-            PROPER_URL,
-            serde_json::from_str::<KvRedisConfig>(&initial_caps_config)
-                .unwrap()
-                .url
-        );
+        assert_eq!(PROPER_URL, retrieve_default_url(&lowercase_config));
+        assert_eq!(PROPER_URL, retrieve_default_url(&uppercase_config));
+        assert_eq!(PROPER_URL, retrieve_default_url(&initial_caps_config));
     }
 }

--- a/crates/providers/messaging-nats/src/connection.rs
+++ b/crates/providers/messaging-nats/src/connection.rs
@@ -6,10 +6,10 @@ use wasmcloud_provider_wit_bindgen::deps::serde::{Deserialize, Serialize};
 
 const DEFAULT_NATS_URI: &str = "0.0.0.0:4222";
 
-const ENV_NATS_SUBSCRIPTION: &str = "SUBSCRIPTION";
-const ENV_NATS_URI: &str = "URI";
-const ENV_NATS_CLIENT_JWT: &str = "CLIENT_JWT";
-const ENV_NATS_CLIENT_SEED: &str = "CLIENT_SEED";
+const CONFIG_NATS_SUBSCRIPTION: &str = "subscriptions";
+const CONFIG_NATS_URI: &str = "cluster_uris";
+const CONFIG_NATS_CLIENT_JWT: &str = "client_jwt";
+const CONFIG_NATS_CLIENT_SEED: &str = "client_seed";
 
 /// Configuration for connecting a nats client.
 /// More options are available if you use the json than variables in the values string map.
@@ -81,18 +81,18 @@ impl ConnectionConfig {
     pub fn from_map(values: &HashMap<String, String>) -> Result<ConnectionConfig> {
         let mut config = ConnectionConfig::default();
 
-        if let Some(sub) = values.get(ENV_NATS_SUBSCRIPTION) {
+        if let Some(sub) = values.get(CONFIG_NATS_SUBSCRIPTION) {
             config
                 .subscriptions
                 .extend(sub.split(',').map(|s| s.to_string()));
         }
-        if let Some(url) = values.get(ENV_NATS_URI) {
+        if let Some(url) = values.get(CONFIG_NATS_URI) {
             config.cluster_uris = url.split(',').map(String::from).collect();
         }
-        if let Some(jwt) = values.get(ENV_NATS_CLIENT_JWT) {
+        if let Some(jwt) = values.get(CONFIG_NATS_CLIENT_JWT) {
             config.auth_jwt = Some(jwt.clone());
         }
-        if let Some(seed) = values.get(ENV_NATS_CLIENT_SEED) {
+        if let Some(seed) = values.get(CONFIG_NATS_CLIENT_SEED) {
             config.auth_seed = Some(seed.clone());
         }
         if config.auth_jwt.is_some() && config.auth_seed.is_none() {

--- a/crates/providers/messaging-nats/wasmcloud.toml
+++ b/crates/providers/messaging-nats/wasmcloud.toml
@@ -1,0 +1,6 @@
+name = "Messaging NATS"
+language = "rust"
+type = "provider"
+
+[provider]
+vendor = "wasmCloud"

--- a/crates/test-util/src/lattice/config.rs
+++ b/crates/test-util/src/lattice/config.rs
@@ -2,18 +2,18 @@
 use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
+use wasmcloud_control_interface::{Client as WasmCloudCtlClient, CtlResponse};
 
 /// Put a configuration value, ensuring that the put succeeded
 pub async fn assert_config_put(
-    client: impl AsRef<wasmcloud_control_interface::Client>,
+    client: impl Into<&WasmCloudCtlClient>,
     name: impl AsRef<str>,
     config: HashMap<String, String>,
-) -> Result<()> {
-    let client = client.as_ref();
+) -> Result<CtlResponse<()>> {
+    let client = client.into();
     let name = name.as_ref();
     client
         .put_config(name, config)
         .await
-        .map(|_| ())
         .map_err(|e| anyhow!(e).context("failed to put config"))
 }

--- a/crates/test-util/src/provider.rs
+++ b/crates/test-util/src/provider.rs
@@ -26,7 +26,7 @@ pub struct StartProviderArgs<'a> {
     pub provider_key: &'a KeyPair,
     pub provider_id: &'a str,
     pub url: &'a Url,
-    pub configuration: Option<String>,
+    pub config: Vec<String>,
 }
 
 /// Response expected from a successful healthcheck
@@ -52,7 +52,7 @@ pub async fn assert_start_provider(
         provider_key,
         provider_id,
         url,
-        configuration,
+        config,
     }: StartProviderArgs<'_>,
 ) -> Result<()> {
     let rpc_client = client.nats_client();
@@ -64,7 +64,7 @@ pub async fn assert_start_provider(
             url.as_ref(),
             provider_id,
             None,
-            configuration,
+            config,
         )
         .await
         .map_err(|e| anyhow!(e).context("failed to start provider"))?;

--- a/crates/wash-lib/src/build/provider.rs
+++ b/crates/wash-lib/src/build/provider.rs
@@ -4,7 +4,7 @@ use std::process;
 
 use anyhow::{anyhow, bail, Context, Result};
 use nkeys::KeyPairType;
-use tracing::warn;
+use tracing::{trace, warn};
 
 use crate::build::SignConfig;
 use crate::cli::par::{create_provider_archive, detect_arch, ParCreateArgs};
@@ -29,6 +29,7 @@ pub(crate) async fn build_provider(
 
     // Change directory into the project directory
     std::env::set_current_dir(&common_config.path)?;
+    trace!("Building provider in {:?}", common_config.path);
 
     // Build for a specified target if provided, or the default rust target
     let mut build_args = Vec::with_capacity(4);
@@ -76,6 +77,8 @@ pub(crate) async fn build_provider(
     }
     provider_path_buf.push("release");
     provider_path_buf.push(&bin_name);
+
+    trace!("Retrieving provider binary from {:?}", provider_path_buf);
 
     let provider_bytes = tokio::fs::read(&provider_path_buf).await?;
 

--- a/tests/kv-vault.rs
+++ b/tests/kv-vault.rs
@@ -86,7 +86,7 @@ async fn kv_vault_suite() -> Result<()> {
         provider_key: &messaging_nats_provider_key,
         provider_id: &messaging_nats_provider_key.public_key(),
         url: &messaging_nats_provider_url,
-        configuration: None,
+        config: vec![],
     })
     .await?;
 
@@ -98,7 +98,7 @@ async fn kv_vault_suite() -> Result<()> {
         provider_key: &kv_vault_provider_key,
         provider_id: &kv_vault_provider_key.public_key(),
         url: &kv_vault_provider_url,
-        configuration: None,
+        config: vec![],
     })
     .await?;
 
@@ -114,13 +114,10 @@ async fn kv_vault_suite() -> Result<()> {
         vec![],
         // NOTE: this should be temporary, rather than using a named config,
         // we are stuffing credentials into the target_config
-        vec![format!(
-            "config_json={}",
-            serde_json::to_string(&json!({
-                "subscriptions": [ test_subject ],
-                "cluster_uris": [ nats_url ],
-            }))?
-        )],
+        vec![
+            format!("subscriptions={test_subject}"),
+            format!("cluster_uris={nats_url}"),
+        ],
     )
     .await
     .context("should advertise link")?;


### PR DESCRIPTION
## Feature or Problem
This PR implements the change to the start provider logic in the control interface and host to, instead of accepting a single config string, accept a list of named configurations in order to build the provider configuration. At runtime now we will pass a `HashMap<String, String>` to the provider which will be its configuration (built from all of the named configs).

In a followup issue, which I'll create shortly, we should support reloading this config.

## Related Issues
https://github.com/wasmCloud/wasmCloud/issues/1648

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I verified this worked by creating configuration and having NATS communicate on a different URI than supplied 😄 