### PR TITLE
chore: add observability-maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,11 +30,11 @@ Cargo.* @wasmCloud/host-maintainers
 # shared crates
 crates/control-interface @wasmCloud/control-interface-maintainers
 crates/core @wasmCloud/org-maintainers
-crates/opentelemetry-nats @thomastaylor312 @connorsmith256
+crates/opentelemetry-nats @wasmcloud/observability-maintainers
 crates/provider-archive @wasmCloud/capability-provider-maintainers
 crates/provider-sdk @wasmCloud/capability-provider-sdk-maintainers
 crates/provider-wit-bindgen @wasmCloud/capability-provider-wit-bindgen-maintainers
-crates/tracing @thomastaylor312 @connorsmith256
+crates/tracing @wasmcloud/observability-maintainers
 crates/wascap @wasmCloud/wascap-maintainers
 
 # projects


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
This PR adds one more team to the reviewers list, @wasmcloud/observability-maintainers. This now allows us to fully manage allowed reviewers via GitHub teams instead of a hardcoded list.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
