### PR TITLE
fix(provider-bindgen): fix module path for receive_discriminant call

### DIFF
--- a/crates/wrpc-transport-derive-macro/src/wrpc_transport/receive.rs
+++ b/crates/wrpc-transport-derive-macro/src/wrpc_transport/receive.rs
@@ -203,7 +203,8 @@ fn derive_receive_inner_for_enum(item: syn::Item) -> Result<TokenStream> {
             where
                 T: #crate_path::deps::futures::Stream<Item=#crate_path::deps::anyhow::Result<#crate_path::deps::bytes::Bytes>> + Send + Sync + Unpin + 'static
             {
-                let (discriminant, payload) = wrpc_transport_derive::deps::wrpc_transport::receive_discriminant(payload, rx)
+                use #crate_path::deps::anyhow::Context as _;
+                let (discriminant, payload) = #crate_path::deps::wrpc_transport::receive_discriminant(payload, rx)
                     .await
                     .context("failed to receive enum discriminant")?;
                 match discriminant {


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit fixes the path in provider WIT bindgen for a use of `receive_discriminant` which caused an error when the path was exercised.

Resolves #1671 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

Reproduction was successful (and easy) using the WIT  provided in the issue, thanks @jschilli!
