### PR TITLE
Wash up should be idempotent.

### DIFF
--- a/crates/wash-cli/src/dev.rs
+++ b/crates/wash-cli/src/dev.rs
@@ -10,14 +10,13 @@ use notify::{event::EventKind, Event as NotifyEvent, RecursiveMode, Watcher};
 use tokio::task::JoinHandle;
 use tokio::time::{timeout, Duration};
 use tokio::{select, sync::mpsc};
-use wash_lib::actor::ScaleComponentArgs;
-use wash_lib::generate::emoji;
 use wash_lib::{
-    actor::scale_component,
+    actor::{scale_component, ScaleComponentArgs},
     build::{build_project, SignConfig},
     cli::dev::run_dev_loop,
     cli::{sanitize_component_id, CommandOutput},
     config::downloads_dir,
+    generate::emoji,
     id::{ModuleId, ServerId},
     parser::get_config,
 };
@@ -25,7 +24,7 @@ use wasmcloud_control_interface::Host;
 
 use crate::{
     down::{handle_down, DownCommand},
-    up::{handle_up, NatsOpts, UpCommand, WadmOpts, WasmcloudOpts, DOWNLOADS_DIR},
+    up::{handle_up, NatsOpts, UpCommand, WadmOpts, WasmcloudOpts},
 };
 
 #[derive(Debug, Clone, Parser)]
@@ -94,7 +93,7 @@ pub async fn handle_command(
     output_kind: wash_lib::cli::OutputKind,
 ) -> Result<CommandOutput> {
     // Check if host is running
-    let pid_file = downloads_dir()?.join(DOWNLOADS_DIR);
+    let pid_file = downloads_dir()?;
     let existing_instance = tokio::fs::metadata(pid_file).await.is_ok();
 
     let mut host_subprocess: Option<HostSubprocess> = None;

--- a/crates/wash-cli/src/dev.rs
+++ b/crates/wash-cli/src/dev.rs
@@ -15,7 +15,7 @@ use wash_lib::{
     build::{build_project, SignConfig},
     cli::dev::run_dev_loop,
     cli::{sanitize_component_id, CommandOutput},
-    config::downloads_dir,
+    config::{downloads_dir, WASMCLOUD_PID_FILE},
     generate::emoji,
     id::{ModuleId, ServerId},
     parser::get_config,
@@ -93,7 +93,7 @@ pub async fn handle_command(
     output_kind: wash_lib::cli::OutputKind,
 ) -> Result<CommandOutput> {
     // Check if host is running
-    let pid_file = downloads_dir()?;
+    let pid_file = downloads_dir()?.join(WASMCLOUD_PID_FILE);
     let existing_instance = tokio::fs::metadata(pid_file).await.is_ok();
 
     let mut host_subprocess: Option<HostSubprocess> = None;

--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -4,8 +4,6 @@ use anyhow::{anyhow, Result};
 
 use crate::up::{credsfile::parse_credsfile, WasmcloudOpts};
 
-pub const DOWNLOADS_DIR: &str = "downloads";
-pub const WASMCLOUD_PID_FILE: &str = "wasmcloud.pid";
 // NATS configuration values
 pub const NATS_SERVER_VERSION: &str = "v2.10.7";
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -384,10 +384,10 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
     // If this fails, we should return early since wasmCloud wouldn't be able to connect either
     nats_client_from_wasmcloud_opts(&wasmcloud_opts).await?;
 
-    if tokio::fs::try_exists(install_dir.join(WASMCLOUD_PID_FILE))
-        .await
-        .is_ok_and(|exists| exists)
-        && !cmd.wasmcloud_opts.multi_local
+    if !cmd.wasmcloud_opts.multi_local
+        && tokio::fs::try_exists(install_dir.join(WASMCLOUD_PID_FILE))
+            .await
+            .is_ok_and(|exists| exists)
     {
         bail!("Pid file {:?} exists. There are still hosts running, please stop them before starting new ones or use --multi-local to start more",
             install_dir.join(WASMCLOUD_PID_FILE));

--- a/crates/wash-cli/tests/common/mod.rs
+++ b/crates/wash-cli/tests/common/mod.rs
@@ -491,6 +491,7 @@ impl TestWashInstance {
             .output()
             .await
             .context("failed to stop host")?;
+        // Remove the lock file if it exists
         let install_dir = downloads_dir()?;
         let lock_file_exists = tokio::fs::try_exists(install_dir.join(WASMCLOUD_PID_FILE)).await?;
         if lock_file_exists {

--- a/crates/wash-cli/tests/wash_stop.rs
+++ b/crates/wash-cli/tests/wash_stop.rs
@@ -1,8 +1,8 @@
 mod common;
 
-use common::{TestWashInstance, HELLO_OCI_REF, PROVIDER_HTTPSERVER_OCI_REF};
+use common::{wait_for_no_hosts, TestWashInstance, HELLO_OCI_REF, PROVIDER_HTTPSERVER_OCI_REF};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serial_test::serial;
 use wash_lib::cli::output::StartCommandOutput;
 
@@ -75,6 +75,10 @@ async fn integration_stop_provider_serial() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn integration_stop_host_serial() -> Result<()> {
+    println!("stop host");
+    wait_for_no_hosts()
+        .await
+        .context("unexpected wasmcloud instance(s) running")?;
     let wash_instance = TestWashInstance::create().await?;
     wash_instance.stop_host().await?;
     Ok(())

--- a/crates/wash-cli/tests/wash_stop.rs
+++ b/crates/wash-cli/tests/wash_stop.rs
@@ -75,7 +75,6 @@ async fn integration_stop_provider_serial() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn integration_stop_host_serial() -> Result<()> {
-    println!("stop host");
     wait_for_no_hosts()
         .await
         .context("unexpected wasmcloud instance(s) running")?;

--- a/crates/wash-cli/tests/wash_up.rs
+++ b/crates/wash-cli/tests/wash_up.rs
@@ -271,3 +271,19 @@ async fn integration_up_works_with_labels() -> Result<()> {
 
     Ok(())
 }
+
+/// Cannot start a host when one is already running
+#[tokio::test]
+#[serial]
+async fn integration_up_cannot_start_multiple_hosts() -> Result<()> {
+    TestWashInstance::create().await?;
+    let instance1 = TestWashInstance::create().await;
+    assert!(
+        instance1.is_err(),
+        "should not be able to start a second host"
+    );
+    // Second instance should start with --scale
+    TestWashInstance::create_with_extra_args(vec!["--scale"]).await?;
+
+    Ok(())
+}

--- a/crates/wash-cli/tests/wash_up.rs
+++ b/crates/wash-cli/tests/wash_up.rs
@@ -271,19 +271,3 @@ async fn integration_up_works_with_labels() -> Result<()> {
 
     Ok(())
 }
-
-/// Cannot start a host when one is already running
-#[tokio::test]
-#[serial]
-async fn integration_up_cannot_start_multiple_hosts() -> Result<()> {
-    TestWashInstance::create().await?;
-    let instance1 = TestWashInstance::create().await;
-    assert!(
-        instance1.is_err(),
-        "should not be able to start a second host"
-    );
-    // Second instance should start with --scale
-    TestWashInstance::create_with_extra_args(vec!["--scale"]).await?;
-
-    Ok(())
-}

--- a/crates/wash-lib/src/config.rs
+++ b/crates/wash-lib/src/config.rs
@@ -10,7 +10,8 @@ use crate::context::WashContext;
 
 pub const WASH_DIR: &str = ".wash";
 
-const DOWNLOADS_DIR: &str = "downloads";
+pub const DOWNLOADS_DIR: &str = "downloads";
+pub const WASMCLOUD_PID_FILE: &str = "wasmcloud.pid";
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
 pub const DEFAULT_LATTICE: &str = "default";


### PR DESCRIPTION
If a wasmcloud host is runnning, `wash up` will not start an additional host unless `--scale` is passed.

When starting multiple hosts, NATS should be run independently of wasmcloud, otherwise killing the original `wash up` will also stop NATS.

## Feature or Problem
Wash up should be idempotent https://github.com/wasmCloud/wasmCloud/issues/846

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
This will change how users start multiple wasmCloud hosts on the same machine

## Testing
Integration test added.

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
