### PR TITLE
feat(provider-sdk): add support for init()

### DIFF
--- a/crates/provider-sdk/src/error.rs
+++ b/crates/provider-sdk/src/error.rs
@@ -6,7 +6,8 @@ pub type ProviderInitResult<T> = Result<T, ProviderInitError>;
 /// Result form for [`ProviderHandler`] trait methods
 pub type ProviderOperationResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
-/// All errors that that can be returned by a provider when it is being initialized
+/// All errors that that can be returned by a provider when it is being initialized,
+/// primarily from internal provider-sdk code
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderInitError {
     /// Errors when connecting to the lattice NATS cluster


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit adds support for a implementer-provided provider initialization hook that `provider-sdk` can call during initialization.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
