### PR TITLE
feat(wash-cli)!: wash config put/get/del implementation

### DIFF
--- a/crates/wash-cli/src/common/registry_cmd.rs
+++ b/crates/wash-cli/src/common/registry_cmd.rs
@@ -16,7 +16,7 @@ use wash_lib::registry::{
 };
 use wash_lib::{
     cli::{
-        labels_vec_to_hashmap,
+        input_vec_to_hashmap,
         registry::{RegistryPingCommand, RegistryPullCommand, RegistryPushCommand},
         CommandOutput, OutputKind,
     },
@@ -150,7 +150,7 @@ pub async fn registry_push(
         _ => resolve_registry_credentials(image.registry()).await,
     }?;
 
-    let annotations = labels_vec_to_hashmap(cmd.annotations.unwrap_or_default())?;
+    let annotations = input_vec_to_hashmap(cmd.annotations.unwrap_or_default())?;
 
     push_oci_artifact(
         artifact_url.clone(),

--- a/crates/wash-cli/src/config.rs
+++ b/crates/wash-cli/src/config.rs
@@ -1,0 +1,175 @@
+use std::{collections::HashMap, error::Error};
+
+use clap::Subcommand;
+use serde_json::json;
+use tracing::error;
+use wash_lib::{
+    cli::{input_vec_to_hashmap, CliConnectionOpts, CommandOutput, OutputKind},
+    config::WashConnectionOptions,
+};
+
+use crate::appearance::spinner::Spinner;
+
+#[derive(Debug, Clone, Subcommand)]
+#[allow(clippy::enum_variant_names)]
+pub enum ConfigCliCommand {
+    /// Put a named configuration
+    #[clap(name = "put", alias = "create", about = "Put named configuration")]
+    PutCommand {
+        #[clap(flatten)]
+        opts: CliConnectionOpts,
+        /// The name of the configuration to put
+        #[clap(name = "name")]
+        name: String,
+        /// The configuration values to put, in the form of `key=value`. Can be specified multiple times, but must be specified at least once.
+        #[clap(name = "config_value", required = true)]
+        config_values: Vec<String>,
+    },
+    /// Get a named configuration
+    #[clap(name = "get")]
+    GetCommand {
+        #[clap(flatten)]
+        opts: CliConnectionOpts,
+        /// The name of the configuration to get
+        #[clap(name = "name")]
+        name: String,
+    },
+    /// Delete a named configuration
+    #[clap(name = "del", alias = "delete")]
+    DelCommand {
+        #[clap(flatten)]
+        opts: CliConnectionOpts,
+        /// The name of the configuration to delete
+        #[clap(name = "name")]
+        name: String,
+    },
+}
+
+pub async fn handle_command(
+    command: ConfigCliCommand,
+    output_kind: OutputKind,
+) -> anyhow::Result<CommandOutput> {
+    match command {
+        ConfigCliCommand::PutCommand {
+            opts,
+            name,
+            config_values,
+        } => {
+            put_config(
+                opts,
+                &name,
+                input_vec_to_hashmap(config_values)?,
+                output_kind,
+            )
+            .await
+        }
+        ConfigCliCommand::GetCommand { opts, name } => get_config(opts, &name, output_kind).await,
+        ConfigCliCommand::DelCommand { opts, name } => {
+            delete_config(opts, &name, output_kind).await
+        }
+    }
+}
+
+async fn put_config(
+    opts: CliConnectionOpts,
+    name: &str,
+    values: HashMap<String, String>,
+    output_kind: OutputKind,
+) -> anyhow::Result<CommandOutput> {
+    let sp: Spinner = Spinner::new(&output_kind)?;
+    sp.update_spinner_message("Putting configuration ...".to_string());
+    let wco: WashConnectionOptions = opts.try_into()?;
+    let ctl_client = wco.into_ctl_client(None).await?;
+    // Handle no responders by suggesting a host needs to be running
+    let config_response = ctl_client
+        .put_config(name, values)
+        .await
+        .map_err(suggest_run_host_error)?;
+
+    sp.finish_and_clear();
+
+    let message = if config_response.message.is_empty() && config_response.success {
+        format!("Configuration {name} put successfully.")
+    } else {
+        config_response.message
+    };
+    let json_out = HashMap::from_iter([
+        ("success".to_string(), json!(config_response.success)),
+        ("message".to_string(), json!(message)),
+    ]);
+    let output = CommandOutput::new(message, json_out);
+
+    Ok(output)
+}
+
+async fn get_config(
+    opts: CliConnectionOpts,
+    name: &str,
+    output_kind: OutputKind,
+) -> anyhow::Result<CommandOutput> {
+    let sp: Spinner = Spinner::new(&output_kind)?;
+    sp.update_spinner_message("Getting configuration ...".to_string());
+    let wco: WashConnectionOptions = opts.try_into()?;
+    let ctl_client = wco.into_ctl_client(None).await?;
+
+    let config_response = ctl_client
+        .get_config(name)
+        .await
+        .map_err(suggest_run_host_error)?;
+
+    sp.finish_and_clear();
+
+    if !config_response.message.is_empty() && !config_response.success {
+        error!("Error getting configuration: {}", config_response.message);
+    };
+
+    if let Some(config) = config_response.response {
+        Ok(CommandOutput::new(
+            format!("{:?}", config),
+            config.into_iter().map(|(k, v)| (k, json!(v))).collect(),
+        ))
+    } else {
+        Err(anyhow::anyhow!("No configuration found for name: {}", name))
+    }
+}
+
+async fn delete_config(
+    opts: CliConnectionOpts,
+    name: &str,
+    output_kind: OutputKind,
+) -> anyhow::Result<CommandOutput> {
+    let sp: Spinner = Spinner::new(&output_kind)?;
+    sp.update_spinner_message("Deleting configuration ...".to_string());
+    let wco: WashConnectionOptions = opts.try_into()?;
+    let ctl_client = wco.into_ctl_client(None).await?;
+
+    let config_response = ctl_client
+        .delete_config(name)
+        .await
+        .map_err(suggest_run_host_error)?;
+
+    sp.finish_and_clear();
+
+    let message = if config_response.message.is_empty() && config_response.success {
+        format!("Configuration {name} deleted successfully.")
+    } else {
+        config_response.message
+    };
+    let json_out = HashMap::from_iter([
+        ("success".to_string(), json!(config_response.success)),
+        ("message".to_string(), json!(message)),
+    ]);
+    let output = CommandOutput::new(message, json_out);
+
+    Ok(output)
+}
+
+/// Simple helper function to suggest running a host if no responders are found
+fn suggest_run_host_error(e: Box<dyn Error + std::marker::Send + Sync>) -> anyhow::Error {
+    let err_str = e.to_string();
+    if err_str.contains("no responders") {
+        anyhow::anyhow!("No responders found for config put request. Is a host running?")
+    } else {
+        anyhow::anyhow!(e)
+    }
+}

--- a/crates/wash-cli/src/lib.rs
+++ b/crates/wash-cli/src/lib.rs
@@ -4,6 +4,7 @@ pub mod build;
 pub mod call;
 pub mod common;
 pub mod completions;
+pub mod config;
 pub mod ctl;
 pub mod ctx;
 pub mod dev;

--- a/crates/wash-cli/src/util.rs
+++ b/crates/wash-cli/src/util.rs
@@ -119,7 +119,7 @@ mod test {
             "config_b64".to_string(),
             "eyJhZGRyZXNzIjogIjAuMC4wLjA6ODA4MCJ9Cg==".to_string(),
         );
-        let output = wash_lib::cli::labels_vec_to_hashmap(vec![base64_option]).unwrap();
+        let output = wash_lib::cli::input_vec_to_hashmap(vec![base64_option]).unwrap();
         assert_eq!(expected, output);
     }
 }

--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -329,16 +329,16 @@ pub fn extract_keypair(
     }
 }
 
-/// Transforms a list of labels in the form of (label=value) to a hashmap
-pub fn labels_vec_to_hashmap(constraints: Vec<String>) -> Result<HashMap<String, String>> {
+/// Transforms a list of key in the form of (key=value) to a hashmap
+pub fn input_vec_to_hashmap(values: Vec<String>) -> Result<HashMap<String, String>> {
     let mut hm: HashMap<String, String> = HashMap::new();
-    for constraint in constraints {
+    for constraint in values {
         match constraint.split_once('=') {
             Some((key, value)) => {
                 hm.insert(key.to_string(), value.to_string());
             }
             None => {
-                anyhow::bail!("Constraints were not properly formatted. Ensure they are formatted as label=value")
+                anyhow::bail!("Input values were not properly formatted. Ensure they are formatted as key=value")
             }
         };
     }

--- a/crates/wash-lib/src/cli/scale.rs
+++ b/crates/wash-lib/src/cli/scale.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 use crate::{
     actor::{scale_component, ScaleComponentArgs},
-    cli::{labels_vec_to_hashmap, CliConnectionOpts, CommandOutput},
+    cli::{input_vec_to_hashmap, CliConnectionOpts, CommandOutput},
     common::find_host_id,
     config::WashConnectionOptions,
 };
@@ -49,7 +49,7 @@ pub async fn handle_scale_component(cmd: ScaleComponentCommand) -> Result<Comman
     let wco: WashConnectionOptions = cmd.opts.try_into()?;
     let client = wco.into_ctl_client(None).await?;
 
-    let annotations = labels_vec_to_hashmap(cmd.annotations)?;
+    let annotations = input_vec_to_hashmap(cmd.annotations)?;
 
     scale_component(ScaleComponentArgs {
         client: &client,

--- a/crates/wash-lib/src/cli/start.rs
+++ b/crates/wash-lib/src/cli/start.rs
@@ -6,7 +6,7 @@ use tokio::time::Duration;
 
 use crate::{
     actor::{scale_component, ComponentScaledInfo, ScaleComponentArgs},
-    cli::{labels_vec_to_hashmap, CliConnectionOpts, CommandOutput},
+    cli::{input_vec_to_hashmap, CliConnectionOpts, CommandOutput},
     common::{boxed_err_to_anyhow, find_host_id},
     config::{
         WashConnectionOptions, DEFAULT_NATS_TIMEOUT_MS, DEFAULT_START_ACTOR_TIMEOUT_MS,
@@ -99,7 +99,7 @@ pub async fn handle_start_component(cmd: StartComponentCommand) -> Result<Comman
                 .perform_actor_auction(
                     &component_ref,
                     &cmd.component_id,
-                    labels_vec_to_hashmap(cmd.constraints.unwrap_or_default())?,
+                    input_vec_to_hashmap(cmd.constraints.unwrap_or_default())?,
                 )
                 .await
                 .map_err(boxed_err_to_anyhow)
@@ -227,7 +227,7 @@ pub async fn handle_start_provider(cmd: StartProviderCommand) -> Result<CommandO
                 .perform_provider_auction(
                     &provider_ref,
                     &cmd.link_name,
-                    labels_vec_to_hashmap(cmd.constraints.unwrap_or_default())?,
+                    input_vec_to_hashmap(cmd.constraints.unwrap_or_default())?,
                 )
                 .await
                 .map_err(boxed_err_to_anyhow)


### PR DESCRIPTION
## Feature or Problem
This PR implements the `wash config` subcommand, including `get`, `put`, and `del`.

I had to make a change in the host to actually watch the config data bucket to get updates on config, so tests for this feature in wash will have to wait for the next alpha wasmcloud release.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wasmcloud v1.0.0-alpha.2
next wash

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I manually made sure all of this worked! I also included a special case to ensure we aren't inserting `success:true` when people fetch JSON config, might conflict with their keys and/or cause confusion.
