### PR TITLE
fix(providers): remove deserialize trait

### DIFF
--- a/crates/providers/blobstore-fs/src/lib.rs
+++ b/crates/providers/blobstore-fs/src/lib.rs
@@ -19,7 +19,6 @@ use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt as _, TryStreamExt as _};
 use path_clean::PathClean;
-use serde::Deserialize;
 use tokio::fs::{self, create_dir_all, File};
 use tokio::io::AsyncSeekExt as _;
 use tokio::sync::RwLock;
@@ -40,7 +39,7 @@ const FIRST_SEQ_NBR: u64 = 0;
 
 pub type ChunkOffsetKey = (String, usize);
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone)]
 struct FsProviderConfig {
     root: Arc<PathBuf>,
 }


### PR DESCRIPTION
Fixes error with provider where deserialize cannot be derived on an Arc.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

```bash
  Compiling wasmcloud-provider-blobstore-fs v0.4.0 (/Users/bhayes/repos/wasmCloud/wasmCloud/crates/providers/blobstore-fs)
error[E0277]: the trait bound `Arc<PathBuf>: Deserialize<'_>` is not satisfied
    --> blobstore-fs/src/lib.rs:45:11
     |
45   |     root: Arc<PathBuf>,
     |           ^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `Arc<PathBuf>`
     |
     = help: the following other types implement trait `Deserialize<'de>`:
               <bool as Deserialize<'de>>
               <char as Deserialize<'de>>
               <isize as Deserialize<'de>>
               <i8 as Deserialize<'de>>
               <i16 as Deserialize<'de>>
               <i32 as Deserialize<'de>>
               <i64 as Deserialize<'de>>
               <i128 as Deserialize<'de>>
             and 244 others
note: required by a bound in `next_element`
    --> /Users/bhayes/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.196/src/de/mod.rs:1726:12
     |
1724 |     fn next_element<T>(&mut self) -> Result<Option<T>, Self::Error>
     |        ------------ required by a bound in this associated function
1725 |     where
1726 |         T: Deserialize<'de>,
     |            ^^^^^^^^^^^^^^^^ required by this bound in `SeqAccess::next_element`

error[E0277]: the trait bound `Arc<PathBuf>: Deserialize<'_>` is not satisfied
    --> blobstore-fs/src/lib.rs:45:11
     |
45   |     root: Arc<PathBuf>,
     |           ^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `Arc<PathBuf>`
     |
     = help: the following other types implement trait `Deserialize<'de>`:
               <bool as Deserialize<'de>>
               <char as Deserialize<'de>>
               <isize as Deserialize<'de>>
               <i8 as Deserialize<'de>>
               <i16 as Deserialize<'de>>
               <i32 as Deserialize<'de>>
               <i64 as Deserialize<'de>>
               <i128 as Deserialize<'de>>
             and 244 others
note: required by a bound in `next_value`
    --> /Users/bhayes/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.196/src/de/mod.rs:1865:12
     |
1863 |     fn next_value<V>(&mut self) -> Result<V, Self::Error>
     |        ---------- required by a bound in this associated function
1864 |     where
1865 |         V: Deserialize<'de>,
     |            ^^^^^^^^^^^^^^^^ required by this bound in `MapAccess::next_value`

error[E0277]: the trait bound `Arc<PathBuf>: Deserialize<'_>` is not satisfied
  --> blobstore-fs/src/lib.rs:45:5
   |
45 |     root: Arc<PathBuf>,
   |     ^^^^ the trait `Deserialize<'_>` is not implemented for `Arc<PathBuf>`
   |
   = help: the following other types implement trait `Deserialize<'de>`:
             <bool as Deserialize<'de>>
             <char as Deserialize<'de>>
             <isize as Deserialize<'de>>
             <i8 as Deserialize<'de>>
             <i16 as Deserialize<'de>>
             <i32 as Deserialize<'de>>
             <i64 as Deserialize<'de>>
             <i128 as Deserialize<'de>>
           and 244 others
note: required by a bound in `_serde::__private::de::missing_field`
  --> /Users/bhayes/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.196/src/private/de.rs:25:8
   |
23 | pub fn missing_field<'de, V, E>(field: &'static str) -> Result<V, E>
   |        ------------- required by a bound in this function
24 | where
25 |     V: Deserialize<'de>,
   |        ^^^^^^^^^^^^^^^^ required by this bound in `missing_field`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `wasmcloud-provider-blobstore-fs` (lib) due to 3 previous errors
```

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
Re-ran cargo build for the 