### PR TITLE
chore: bump crates to 1.0.0 compatible versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "provider-archive"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-compression",
  "data-encoding",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "wascap"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "data-encoding",
  "humantime",
@@ -5026,7 +5026,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -5079,7 +5079,7 @@ dependencies = [
  "warp-embed",
  "wascap",
  "wash-lib",
- "wasmcloud-control-interface 0.33.0",
+ "wasmcloud-control-interface 1.0.0-alpha.1",
  "wasmcloud-core",
  "wasmcloud-provider-sdk",
  "weld-codegen",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -5143,7 +5143,7 @@ dependencies = [
  "wascap",
  "wasm-encoder 0.41.2",
  "wasmcloud-component-adapters",
- "wasmcloud-control-interface 0.33.0",
+ "wasmcloud-control-interface 1.0.0-alpha.1",
  "wasmcloud-core",
  "wasmparser",
  "wat",
@@ -5311,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "0.82.0"
+version = "1.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -5342,7 +5342,7 @@ dependencies = [
  "uuid 1.7.0",
  "vaultrs",
  "wascap",
- "wasmcloud-control-interface 0.33.0",
+ "wasmcloud-control-interface 1.0.0-alpha.1",
  "wasmcloud-core",
  "wasmcloud-host",
  "wasmcloud-test-util",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.33.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5486,7 +5486,7 @@ dependencies = [
  "url",
  "uuid 1.7.0",
  "wascap",
- "wasmcloud-control-interface 0.33.0",
+ "wasmcloud-control-interface 1.0.0-alpha.1",
  "wasmcloud-core",
  "wasmcloud-runtime",
  "wasmcloud-tracing",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sdk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-test-util"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5630,13 +5630,13 @@ dependencies = [
  "tracing",
  "url",
  "wascap",
- "wasmcloud-control-interface 0.33.0",
+ "wasmcloud-control-interface 1.0.0-alpha.1",
  "wasmcloud-host",
 ]
 
 [[package]]
 name = "wasmcloud-tracing"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "heck 0.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "0.82.0"
+version = "1.0.0-alpha.2"
 description = "wasmCloud host runtime"
 
 authors.workspace = true
@@ -141,7 +141,7 @@ opentelemetry-otlp = { version = "0.14", default-features = false }
 opentelemetry_sdk = { version = "0.21", default-features = false }
 path-absolutize = { version = "3", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
-provider-archive = { version = "0.8", path = "./crates/provider-archive", default-features = false }
+provider-archive = { version = "0.9", path = "./crates/provider-archive", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.8", default-features = false }
 redis = { version = "0.23", default-features = false }
@@ -191,24 +191,24 @@ wadm = { version = "0.10", default-features = false }
 walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
 warp-embed = { version = "0.4", default-features = false }
-wascap = { version = "0.12", path = "./crates/wascap", default-features = false }
+wascap = { version = "0.13", path = "./crates/wascap", default-features = false }
 wash-cli = { version = "0", path = "./crates/wash-cli", default-features = false }
-wash-lib = { version = "0.18", path = "./crates/wash-lib", default-features = false }
+wash-lib = { version = "0.19", path = "./crates/wash-lib", default-features = false }
 wasi-common = { version = "18", default-features = false }
 wasm-encoder = { version = "0.41", default-features = false }
 wasm-gen = { version = "0.1", default-features = false }
 wasmcloud-actor = { version = "0", path = "./crates/actor", default-features = false }
 wasmcloud-actor-macros = { version = "0", path = "./crates/actor/macros", default-features = false }
 wasmcloud-component-adapters = { version = "0.8", default-features = false }
-wasmcloud-control-interface = { version = "0.33", path = "./crates/control-interface", default-features = false }
-wasmcloud-core = { version = "0.2", path = "./crates/core", default-features = false }
+wasmcloud-control-interface = { version = "1.0.0-alpha.1", path = "./crates/control-interface", default-features = false }
+wasmcloud-core = { version = "0.3", path = "./crates/core", default-features = false }
 wasmcloud-host = { version = "0", path = "./crates/host", default-features = false }
-wasmcloud-provider-sdk = { version = "0.2", path = "./crates/provider-sdk", default-features = false }
+wasmcloud-provider-sdk = { version = "0.3", path = "./crates/provider-sdk", default-features = false }
 wasmcloud-provider-wit-bindgen = { version = "0.1", path = "./crates/provider-wit-bindgen", default-features = false }
 wasmcloud-provider-wit-bindgen-macro = { version = "0.1", path = "./crates/provider-wit-bindgen-macro", default-features = false }
 wasmcloud-runtime = { version = "0", path = "./crates/runtime", default-features = false }
-wasmcloud-test-util = { version = "0.0.1", path = "./crates/test-util", default-features = false }
-wasmcloud-tracing = { version = "0.1", path = "./crates/tracing", default-features = false }
+wasmcloud-test-util = { version = "0.1", path = "./crates/test-util", default-features = false }
+wasmcloud-tracing = { version = "0.2", path = "./crates/tracing", default-features = false }
 wasmparser = { version = "0.121", default-features = false }
 wasmtime = { version = "18", default-features = false }
 wasmtime-wasi = { version = "18", default-features = false }

--- a/crates/control-interface/Cargo.toml
+++ b/crates/control-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.33.0"
+version = "1.0.0-alpha.1"
 homepage = "https://wasmcloud.com"
 description = "A client library for communicating with hosts on a wasmCloud lattice"
 documentation = "https://docs.rs/wasmcloud-control-interface"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-core"
-version = "0.2.0"
+version = "0.3.0"
 description = "wasmCloud core functionality shared throughout the ecosystem"
 
 authors.workspace = true

--- a/crates/provider-archive/Cargo.toml
+++ b/crates/provider-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provider-archive"
-version = "0.8.0"
+version = "0.9.0"
 description = "Library for reading and writing wasmCloud capability provider archive files"
 documentation = "https://docs.rs/provider-archive"
 readme = "README.md"

--- a/crates/provider-sdk/Cargo.toml
+++ b/crates/provider-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-sdk"
-version = "0.2.0"
+version = "0.3.0"
 description = "wasmCloud provider SDK"
 
 authors.workspace = true

--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "provider-archive"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-compression",
  "data-encoding",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "wascap"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "data-encoding",
  "humantime",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.33.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4237,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sdk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-test-util"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4589,7 +4589,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-tracing"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "heck",

--- a/crates/test-util/Cargo.toml
+++ b/crates/test-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-test-util"
-version = "0.0.1"
+version = "0.1.0"
 rust-version = "1.75"
 description = """
 Utilities for testing wasmCloud hosts, providers, and actors.

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-tracing"
-version = "0.1.0"
+version = "0.2.0"
 description = "wasmCloud tracing functionality"
 
 authors.workspace = true

--- a/crates/wascap/Cargo.toml
+++ b/crates/wascap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascap"
-version = "0.12.0"
+version = "0.13.0"
 description = "Wascap - wasmCloud Capabilities. Library for extracting, embedding, and validating claims"
 homepage = "https://wasmcloud.com"
 documentation = "https://docs.rs/wascap"

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) CLI tool"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.18.1"
+version = "0.19.0"
 categories = ["wasm", "wasmcloud"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]


### PR DESCRIPTION
## Feature or Problem
This PR bumps quite a few of the crates that changed between the release of `v0.82.0` and the release of `v1.0.0-alpha.1`. The goal of this PR is to update all crates to a version that is compatible with the latest control interface and RPC protocols and 1.0 features, and the end goal after merging this (and #1649) is to cut an alpha version of `wash`

## Related Issues
#1649

## Release Information
wash-cli 0.27.0-alpha.1
wasmcloud 1.0.0-alpha.2
wasmcloud-tracing 0.2.0
wasmcloud-core 0.3.0
wasmcloud-control-interface 1.0.0-alpha.1
provider-archive 0.9
wasmcloud-provider-sdk 0.3
wascap 0.13
wasmcloud-test-util 0.1
wash-lib 0.19

## Consumer Impact
Most of these crates will be incompatible with v0.82 (notably the control interface, core, provider SDK, wash-lib, wash-cli) so it is essential that when updating all the crates are updated to their latest version.

For the vast majority of developers working with wasmCloud, this means updating `wash` to the latest version and automatically getting the latest updates.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>