### PR TITLE
WIP: [issue#1624-modified the default key_directory for wash build]

### DIFF
--- a/crates/wash-cli/src/build.rs
+++ b/crates/wash-cli/src/build.rs
@@ -58,7 +58,6 @@ pub async fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
 
     match config.project_type {
         TypeConfig::Actor(ref actor_config) => {
-            print!("Inside wash build of an actor");
             let sign_config = if command.build_only {
                 None
             } else {

--- a/crates/wash-cli/src/build.rs
+++ b/crates/wash-cli/src/build.rs
@@ -58,6 +58,7 @@ pub async fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
 
     match config.project_type {
         TypeConfig::Actor(ref actor_config) => {
+            print!("Inside wash build of an actor");
             let sign_config = if command.build_only {
                 None
             } else {

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -1555,6 +1555,10 @@ mod test {
 
         let project_config = assert_ok!(result);
 
+        let mut expected_default_key_dir = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
+        expected_default_key_dir.push(".wash/keys");
+
         assert_eq!(
             project_config.language,
             LanguageConfig::Rust(RustConfig {
@@ -1569,7 +1573,7 @@ mod test {
                 vendor: "wayne-industries".into(),
                 os: std::env::consts::OS.to_string(),
                 arch: std::env::consts::ARCH.to_string(),
-                key_directory: PathBuf::from("./keys"),
+                key_directory: expected_default_key_dir,
                 wit_world: Some("wasmcloud:httpserver".to_string()),
                 rust_target: None,
                 bin_name: None,

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -116,7 +116,7 @@ impl TryFrom<RawActorConfig> for ActorConfig {
             // TODO(#1624): Default to ~/.wash/keys
             key_directory: raw_config
                 .key_directory
-                .unwrap_or_else(|| PathBuf::from("./keys")),
+                .unwrap_or_else(|| PathBuf::from("~/.wash/keys")),
             wasm_target: raw_config
                 .wasm_target
                 .map(WasmTarget::from)
@@ -186,7 +186,7 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
             // TODO(#1624): Default to ~/.wash/keys
             key_directory: raw_config
                 .key_directory
-                .unwrap_or_else(|| PathBuf::from("./keys")),
+                .unwrap_or_else(|| PathBuf::from("~/.wash/keys")),
         })
     }
 }

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -110,7 +110,7 @@ impl TryFrom<RawActorConfig> for ActorConfig {
     type Error = anyhow::Error;
 
     fn try_from(raw_config: RawActorConfig) -> Result<Self, Self::Error> {
-        let key_dir = if let Some(key_directory) = raw_config.key_directory {
+        let key_directory = if let Some(key_directory) = raw_config.key_directory {
             key_directory
         } else {
             let home_dir = dirs::home_dir()
@@ -120,7 +120,7 @@ impl TryFrom<RawActorConfig> for ActorConfig {
         Ok(Self {
             claims: raw_config.claims.unwrap_or_default(),
             push_insecure: raw_config.push_insecure.unwrap_or(false),
-            key_directory: key_dir,
+            key_directory,
             wasm_target: raw_config
                 .wasm_target
                 .map(WasmTarget::from)
@@ -176,7 +176,7 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
     type Error = anyhow::Error;
 
     fn try_from(raw_config: RawProviderConfig) -> Result<Self, Self::Error> {
-        let key_dir = if let Some(key_directory) = raw_config.key_directory {
+        let key_directory = if let Some(key_directory) = raw_config.key_directory {
             key_directory
         } else {
             let home_dir = dirs::home_dir()
@@ -194,7 +194,7 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
             rust_target: raw_config.rust_target,
             bin_name: raw_config.bin_name,
             wit_world: raw_config.wit_world,
-            key_directory: key_dir,
+            key_directory,
         })
     }
 }

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -109,14 +109,19 @@ struct RawActorConfig {
 impl TryFrom<RawActorConfig> for ActorConfig {
     type Error = anyhow::Error;
 
-    fn try_from(raw_config: RawActorConfig) -> Result<Self> {
+    fn try_from(raw_config: RawActorConfig) -> Result<Self, Self::Error> {
+        let key_dir = if let Some(key_directory) = raw_config.key_directory {
+            key_directory
+        } else {
+            let home_dir = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
+            home_dir.join(".wash/keys")
+        };
+        print!("User's key directory: {}", key_dir.display());
         Ok(Self {
             claims: raw_config.claims.unwrap_or_default(),
             push_insecure: raw_config.push_insecure.unwrap_or(false),
-            // TODO(#1624): Default to ~/.wash/keys
-            key_directory: raw_config
-                .key_directory
-                .unwrap_or_else(|| PathBuf::from("~/.wash/keys")),
+            key_directory: key_dir,
             wasm_target: raw_config
                 .wasm_target
                 .map(WasmTarget::from)
@@ -171,7 +176,14 @@ struct RawProviderConfig {
 impl TryFrom<RawProviderConfig> for ProviderConfig {
     type Error = anyhow::Error;
 
-    fn try_from(raw_config: RawProviderConfig) -> Result<Self> {
+    fn try_from(raw_config: RawProviderConfig) -> Result<Self, Self::Error> {
+        let key_dir = if let Some(key_directory) = raw_config.key_directory {
+            key_directory
+        } else {
+            let home_dir = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
+            home_dir.join(".wash/keys")
+        };
         Ok(Self {
             vendor: raw_config.vendor.unwrap_or_else(|| "NoVendor".to_string()),
             os: raw_config
@@ -183,10 +195,7 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
             rust_target: raw_config.rust_target,
             bin_name: raw_config.bin_name,
             wit_world: raw_config.wit_world,
-            // TODO(#1624): Default to ~/.wash/keys
-            key_directory: raw_config
-                .key_directory
-                .unwrap_or_else(|| PathBuf::from("~/.wash/keys")),
+            key_directory: key_dir,
         })
     }
 }

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -117,7 +117,6 @@ impl TryFrom<RawActorConfig> for ActorConfig {
                 .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
             home_dir.join(".wash/keys")
         };
-        print!("User's key directory: {}", key_dir.display());
         Ok(Self {
             claims: raw_config.claims.unwrap_or_default(),
             push_insecure: raw_config.push_insecure.unwrap_or(false),

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -328,6 +328,10 @@ fn minimal_rust_actor() {
 
     let config = assert_ok!(result);
 
+    let mut expected_key_dir =
+        dirs::home_dir().expect("Unable to determine the user's home directory");
+    expected_key_dir.push(".wash/keys");
+
     assert_eq!(
         config.language,
         LanguageConfig::Rust(RustConfig {
@@ -342,7 +346,7 @@ fn minimal_rust_actor() {
             claims: vec!["wasmcloud:httpserver".to_string()],
 
             push_insecure: false,
-            key_directory: PathBuf::from("./keys"),
+            key_directory: expected_key_dir,
             destination: None,
             call_alias: None,
             wasi_preview2_adapter_path: None,
@@ -377,6 +381,10 @@ fn cargo_toml_actor() {
 
     let config = assert_ok!(result);
 
+    let mut expected_default_key_dir =
+        dirs::home_dir().expect("Unable to determine the user's home directory");
+    expected_default_key_dir.push(".wash/keys");
+
     assert_eq!(
         config.language,
         LanguageConfig::Rust(RustConfig {
@@ -391,7 +399,7 @@ fn cargo_toml_actor() {
             claims: vec!["wasmcloud:httpserver".to_string()],
 
             push_insecure: false,
-            key_directory: PathBuf::from("./keys"),
+            key_directory: expected_default_key_dir,
             destination: None,
             call_alias: None,
             wasi_preview2_adapter_path: None,
@@ -427,11 +435,16 @@ fn minimal_rust_actor_preview2() {
     );
 
     let config = assert_ok!(result);
+
+    let mut expected_default_key_dir =
+        dirs::home_dir().expect("Unable to determine the user's home directory");
+    expected_default_key_dir.push(".wash/keys");
+
     assert_eq!(
         config.project_type,
         TypeConfig::Actor(ActorConfig {
             claims: vec!["wasmcloud:httpserver".to_string()],
-            key_directory: PathBuf::from("./keys"),
+            key_directory: expected_default_key_dir,
             wasm_target: WasmTarget::WasiPreview2,
             wit_world: Some("test-world".to_string()),
             ..Default::default()


### PR DESCRIPTION
## Feature or Problem
`wash build` always generates keys in the local folder instead of `$HOME/.wash/keys

## Testing
this is a draft PR with some work still in progress.

### Manual Verification
modified the default key_directory for `wash build`. tried to run wasmCloud locally to see if the changes are being resonated while creating a new actor.
