### PR TITLE
Fix #1715 - Add Fedora 39 and 40 build

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -494,7 +494,7 @@ jobs:
       - name: Push `rpm`
         working-directory: ./crates/wash-cli
         run: |
-          rpms=(194 204 209 216 226 231 236 239 240 244 260 273)
+          rpms=(194 204 209 216 226 231 236 239 240 244 260 273 279 283)
           for distro_version in "${rpms[@]}"; do
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.aarch64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;


### PR DESCRIPTION
## Feature or Problem

This PR fixes the issue #1715 by adding Fedora 39 (id 279 in Packagecloud) and 40 (id 283 in Packagecloud) as targets for packagecloud.io

## Related Issues

It fixes the issue #1715

## Release Information

Next release

## Consumer Impact

No consumer impact

## Testing

I can't test, as I have no access to Packagecloud site for the project.
I have recovered the information to define the targets from Packagecloud

### Manual Verification

Build the project, launch the action and see the image appear on Packagecloud site