### PR TITLE
Add Ubuntu 23.10 and 24.04 build

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -486,7 +486,7 @@ jobs:
       - name: Push `deb`
         working-directory: ./crates/wash-cli
         run: |
-          debs=(35 203 206 207 210 215 219 220 221 233 235 237 261 266)
+          debs=(35 203 206 207 210 215 219 220 221 233 235 237 261 266 278 284)
           for distro_version in "${debs[@]}"; do
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_amd64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash_*_arm64.deb)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;


### PR DESCRIPTION
## Feature or Problem

The issue #1715 also exists for Ubuntu, the packages for latest Ubuntu versions aren't generated and pushed to Packagecloud. 

This PR adds Ubuntu 23.10 (id 278 in Packagecloud) and 24.04 (id 284 in Packagecloud) as targets for packagecloud.io

## Related Issues

It's related to the issue https://github.com/wasmCloud/wasmCloud/issues/1715

## Release Information

Next release

## Consumer Impact

No consumer impact

## Testing

I can't test, as I have no access to Packagecloud site for the project.
I have recovered the information to define the targets from Packagecloud


### Manual Verification

Build the project, launch the action and see the image appear on Packagecloud site
