### PR TITLE
build(nix): include `tinygo` in devshell on aarch64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -436,18 +436,17 @@
           ...
         }:
           extendDerivations {
-            buildInputs =
-              [
-                pkgs.buildah
-                pkgs.cargo-audit
-                pkgs.minio
-                pkgs.nats-server
-                pkgs.protobuf # prost build dependency
-                pkgs.redis
-                pkgs.vault
-                pkgs.wit-deps
-              ]
-              ++ optional (!(pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64)) pkgs.tinygo; # TinyGo currently fails to buid due to GDB not being supported on aarch64-darwin
+            buildInputs = [
+              pkgs.buildah
+              pkgs.cargo-audit
+              pkgs.minio
+              pkgs.nats-server
+              pkgs.protobuf # prost build dependency
+              pkgs.redis
+              pkgs.tinygo
+              pkgs.vault
+              pkgs.wit-deps
+            ];
           }
           devShells;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -171,12 +171,6 @@
                 ++ optional pkgs.stdenv.hostPlatform.isDarwin pkgs.libiconv;
 
               depsBuildBuild = depsBuildBuild';
-
-              nativeBuildInputs =
-                nativeBuildInputs
-                ++ [
-                  pkgs.protobuf # prost build dependency
-                ];
             }
             // optionalAttrs (args ? cargoArtifacts) {
               depsBuildBuild =
@@ -441,7 +435,6 @@
               pkgs.cargo-audit
               pkgs.minio
               pkgs.nats-server
-              pkgs.protobuf # prost build dependency
               pkgs.redis
               pkgs.tinygo
               pkgs.vault


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

- Looks like Darwin support was fixed in https://github.com/NixOS/nixpkgs/pull/251527
- Remove `protobuf` dep, which is not required for build anymore

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
