### PR TITLE
WIP: feat: improves helm charts to allow better integration with kubernetes

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -39,15 +39,26 @@ $ helm install wasmcloud oci://ghcr.io/wasmcloud/wasmcloud-chart --version 0.7.2
 This will get you up and going with a wasmCloud Host and NATS server so you can kick the tires and
 try things out.
 
-In order to access the dashboard and NATS, you'll need to forward the ports locally
+In order to access NATS locally, you'll need to forward the port
 (using the `RELEASE_NAME` you chose above as the `RELEASE_NAME` below)
 
 ```console
 # In a second terminal
-$ kubectl port-forward deployment/${RELEASE_NAME} 4222
+$ kubectl port-forward deployment/${RELEASE_NAME}-wasmcloud-chart 4222
 ```
 
+If you also want to see the wasmCloud host from Kubernetes in your local dashboard, you need to set `nats.insecureWebhook.enabled: true` in [`values.yaml`][values-yaml] (please note that this should only be done for testing/development purposes), and you'll need to forward the websocket port locally
+(using the `RELEASE_NAME` you chose above as the `RELEASE_NAME` below)
+
+```console
+# In a third terminal
+$ kubectl port-forward deployment/${RELEASE_NAME}-wasmcloud-chart 4001
+```
+
+If your dashboard is not showing the Kubernetes wasmCloud host, it might be that you have no local version of [wadm](wadm) running. You can spin it up in Kubernetes by setting `wadm.enabled: true` in [`values.yaml`][values-yaml]. This also allows you to execute commands like `wash app deploy [...]` from your local machine to deploy to the Kubernetes wasmCloud host.
+
 [artifacthub-wasmcloud]: https://artifacthub.io/packages/helm/wasmcloud-chart/wasmcloud-chart
+[wadm]: https://github.com/wasmCloud/wadm
 [wasmcloud-v0.81.0]: https://github.com/wasmCloud/wasmCloud/tree/v0.81.0
 [wasmcloud-docker-tags]: https://hub.docker.com/r/wasmcloud/wasmcloud/tags
 [values-yaml]: ./values.yaml

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -43,12 +43,21 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Selector labels wasmcloud_host
 */}}
 {{- define "wasmcloud_host.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "wasmcloud_host.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Selector labels wadm
+*/}}
+{{- define "wadm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wasmcloud_host.name" . }}
+app.kubernetes.io/instance: wadm
+{{- end }}
+
 
 {{/*
 Create the name of the service account to use

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nats.leafnode.enabled -}}
+{{- if or .Values.nats.leafnode.enabled .Values.nats.insecureWebsocket.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,6 +7,7 @@ metadata:
     {{- include "wasmcloud_host.labels" . | nindent 4 }}
 data:
   nats.conf: |-
+    {{ if .Values.nats.leafnode.enabled -}}
     {{ if .Values.nats.jetstreamDomain -}}
     jetstream {
       domain: {{ .Values.nats.jetstreamDomain }}
@@ -20,14 +21,17 @@ data:
         },
       ]
     }
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "wasmcloud_host.fullname" . }}-nats
-  labels:
-    {{- include "wasmcloud_host.labels" . | nindent 4 }}
-data:
-  nats.creds: |-
-    {{ required "Credentials are required for a leafnode" .Values.nats.leafnode.credentials | b64enc }}
+    {{- end }}
+    {{- if and (not .Values.nats.leafnode.enabled) .Values.nats.insecureWebsocket.enabled -}}
+    port: 4222
+    monitor_port: 8222
+    server_name: "wasmcloud"
+
+    jetstream {}
+
+    websocket {
+      port: 4001
+      no_tls: true
+    }
+    {{- end }}
 {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -189,7 +189,7 @@ spec:
           imagePullPolicy: {{ .Values.nats.image.pullPolicy }}
           args:
             - "-js"
-            {{- if .Values.nats.leafnode.enabled }}
+            {{- if or .Values.nats.leafnode.enabled .Values.nats.insecureWebsocket.enabled }}
             - "-c"
             - "/nats/nats.conf"
             {{- end }}
@@ -200,8 +200,13 @@ spec:
               containerPort: 6222
             - name: management
               containerPort: 8222
-          {{- if .Values.nats.leafnode.enabled }}
+            {{- if and (not .Values.nats.leafnode.enabled) .Values.nats.insecureWebsocket.enabled }}
+            - name: websocket
+              containerPort: 4001
+            {{- end}}
+          {{- if or .Values.nats.leafnode.enabled .Values.nats.insecureWebsocket.enabled }}
           volumeMounts:
+            {{- if .Values.nats.leafnode.enabled }}˚
             - name: leafnode-config
               mountPath: /nats/nats.conf
               subPath: nats.conf
@@ -210,18 +215,32 @@ spec:
               mountPath: /nats/nats.creds
               subPath: nats.creds
               readOnly: true
+            {{- end }}
+            {{- if and (not .Values.nats.leafnode.enabled) .Values.nats.insecureWebsocket.enabled }}
+            - name: websocket-config
+              mountPath: /nats/nats.conf
+              subPath: nats.conf
+              readOnly: true
+            {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.nats.resources | nindent 12 }}
         {{- end }}
-      {{- if .Values.nats.leafnode.enabled }}
+      {{- if or .Values.nats.leafnode.enabled .Values.nats.insecureWebsocket.enabled }}
       volumes:
+        {{- if .Values.nats.leafnode.enabled }}
         - name: leafnode-config
           configMap:
             name: {{ include "wasmcloud_host.fullname" . }}
         - name: leafnode-creds
           secret:
             secretName: {{ include "wasmcloud_host.fullname" . }}-nats
+        {{- end }}
+        {{- if and (not .Values.nats.leafnode.enabled) .Values.nats.insecureWebsocket.enabled }}
+        - name: websocket-config
+          configMap:
+            name: {{ include "wasmcloud_host.fullname" . }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -22,3 +22,15 @@ data:
   registryPassword: {{ .Values.wasmcloud.config.registry.password | b64enc }}
   {{- end }}
 {{- end }}
+---
+{{- if .Values.nats.leafnode.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wasmcloud_host.fullname" . }}-nats
+  labels:
+    {{- include "wasmcloud_host.labels" . | nindent 4 }}
+data:
+  nats.creds: |-
+    {{ required "Credentials are required for a leafnode" .Values.nats.leafnode.credentials | b64enc }}
+{{- end }}

--- a/chart/templates/wadm.yaml
+++ b/chart/templates/wadm.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.wadm.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wadm
+  labels:
+    {{- include "wasmcloud_host.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.wadm.replicas }}
+  selector:
+    matchLabels:
+      {{- include "wadm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "wadm.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: wadm
+          image: "{{ .Values.wadm.image.repository }}:{{ .Values.wadm.image.tag }}"
+          imagePullPolicy: {{ .Values.wadm.image.pullPolicy }}
+          env:
+            - name: WADM_NATS_SERVER
+              value: {{ .Values.wadm.natsServer | default (printf "%s:%v" (include "wasmcloud_host.fullname" .) (.Values.service.natsPort)) }}
+          resources:
+            {{- toYaml .Values.wadm.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.wadm.securityContext | nindent 12 }}
+      {{- with .Values.wadm.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wadm.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wadm.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -84,6 +84,12 @@ nats:
     clusterURL: "nats-leaf://connect.ngs.global"
     # Credentials to use
     credentials: ""
+  # Enables websocket support but TLS is disabled. This is mainly intended for testing purposes in
+  # conjunction with the washboard. Please do not enable for production.
+  # Note: Does not have any effect if nats.leafnode.enabled is true.
+  insecureWebsocket:
+    enabled: true
+  
 
   image:
     repository: nats
@@ -136,3 +142,37 @@ affinity: {}
 # Whether or not to expose the host and its NATS server as a service. This defaults to true for ease
 # of "kick the tires" use. For real deployments, this should likely be turned off
 useService: true
+
+# wadm specific configurations
+wadm:
+  # Specifies whether wadm should be deployed.
+  enabled: false
+  # The NATS cluster to connect to. This defaults to the wasmCloud service and port 8080 for ease of "kick the tires" use (`useService: true` and `nats.enabled: true`
+  # should be set).
+  natsServer: ""
+  
+  replicas: 1
+  
+  image:
+    repository: ghcr.io/wasmcloud/wadm
+    pullPolicy: IfNotPresent
+    tag: "v0.10.0"
+  
+  resources: {}
+  
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - "ALL"
+    seccompProfile:
+      type: "RuntimeDefault"
+  
+  nodeSelector: {}
+  
+  tolerations: []
+  
+  affinity: {}


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
At the moment the documentation for the helm chart is misleading in terms of what to do to access the Kubernetes wasmCloud and NATS deployment from your local machine and local washboard. To make this experience smoother I have added the possibility to configure and expose websocket for NATS and also the possibility to deploy wadm with the helm chart.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
https://github.com/wasmCloud/wasmCloud/issues/1672

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->
The added configuration possibilities should only be used for testing, not production.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
I have deployed the helm chart in a local Kubernetes cluster and made sure that applications can be successfully deployed to the Kubernetes wasmCloud host and that the washboard shows the expected host, components, providers and links.
