### PR TITLE
Fix: exclude crates/providers folder from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ wrpc-types = { workspace = true }
 
 [workspace]
 members = ["crates/*"]
+exclude = ["crates/providers"]
 
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }


### PR DESCRIPTION
## Feature or Problem
A [previous PR](https://github.com/wasmCloud/wasmCloud/commit/005b7073e6896f68aa64348fef44ae69305acaf7#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L91) that made providers part of the workspace removed a line that excluded the `crates/providers` folder from the workspace. This removal leads Cargo to expect a `Cargo.toml` file in that folder. Cargo fails with

```
> cargo metadata
error: failed to load manifest for workspace member `/Users/jocrau/Code/wasmCloud/crates/providers`

Caused by:
  failed to read `/Users/jocrau/Code/wasmCloud/crates/providers/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
```  

The failure breaks the `rust-analyzer`, which I use in VS Code.

## Release Information
Targets the next release.

## Testing

### Manual Verification
I simply ran `cargo metadata` with and without the line.
