### PR TITLE
refactor(provider-sdk): move wasmbus RPC topic generation to core

### DIFF
--- a/crates/core/src/rpc.rs
+++ b/crates/core/src/rpc.rs
@@ -12,3 +12,34 @@ pub struct HealthCheckResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
+
+/// Generate the wasmbus RPC subject for putting links on a NATS cluster
+///
+/// When messages are published on this subject, hosts set up and update (if necessary) link information,
+/// which may include calling `receive_link_config_*()` functions on relevant providers.
+pub fn link_put_subject(lattice: &str, provider_key: &str) -> String {
+    format!("wasmbus.rpc.{lattice}.{provider_key}.linkdefs.put")
+}
+
+/// Generate the wasmbus RPC subject for deleting links on a NATS cluster
+///
+/// When messages are published on this subject, hosts remove link information,
+/// which may include calling `delete_link()` on relevant providers.
+pub fn link_del_subject(lattice: &str, provider_key: &str) -> String {
+    format!("wasmbus.rpc.{lattice}.{provider_key}.linkdefs.del")
+}
+
+/// Generate the wasmbus RPC subject for retrieving health information for a given provider
+///
+/// When messages are published on this subject, hosts trigger health checks on providers (i.e. a [`HealthCheckRequest`])
+/// and return relevant results (i.e. a [`HealthCheckResponse`]).
+pub fn health_subject(lattice: &str, provider_key: &str) -> String {
+    format!("wasmbus.rpc.{lattice}.{provider_key}.health")
+}
+
+/// Generate the wasmbus RPC subject for shutting down a given provider
+///
+/// When messages are published on this subject, hosts perform shutdown (cleanly if possible).
+pub fn shutdown_subject(lattice: &str, provider_key: &str, link_name: &str) -> String {
+    format!("wasmbus.rpc.{lattice}.{provider_key}.{link_name}.shutdown")
+}

--- a/crates/provider-sdk/src/provider.rs
+++ b/crates/provider-sdk/src/provider.rs
@@ -21,6 +21,7 @@ use tracing::{debug, error, info, instrument, trace, warn, Instrument as _};
 use ulid::Ulid;
 use uuid::Uuid;
 use wasmcloud_core::nats::convert_header_map_to_hashmap;
+use wasmcloud_core::rpc::{health_subject, link_del_subject, link_put_subject, shutdown_subject};
 use wasmcloud_core::{HealthCheckRequest, HealthCheckResponse, HostData, InterfaceLinkDefinition};
 use wrpc_transport::{AcceptedInvocation, Client, Transmitter};
 use wrpc_types::DynamicFunction;
@@ -44,22 +45,6 @@ const WRPC_HEADER_NAME_HOST_ID: &str = "host-id";
 
 static HOST_DATA: OnceCell<HostData> = OnceCell::new();
 static CONNECTION: OnceCell<ProviderConnection> = OnceCell::new();
-
-fn link_put_subject(lattice: &str, provider_key: &str) -> String {
-    format!("wasmbus.rpc.{lattice}.{provider_key}.linkdefs.put")
-}
-
-fn link_del_subject(lattice: &str, provider_key: &str) -> String {
-    format!("wasmbus.rpc.{lattice}.{provider_key}.linkdefs.del")
-}
-
-fn health_subject(lattice: &str, provider_key: &str) -> String {
-    format!("wasmbus.rpc.{lattice}.{provider_key}.health")
-}
-
-fn shutdown_subject(lattice: &str, provider_key: &str, link_name: &str) -> String {
-    format!("wasmbus.rpc.{lattice}.{provider_key}.{link_name}.shutdown")
-}
 
 /// Retrieves the currently configured connection to the lattice. DO NOT call this method until
 /// after the provider is running (meaning [`start_provider`] or [`run_provider`] have been called)


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit moves the topic generation functions that were used for wasmbus RPC topics from `provider-sdk` to `core` so that they can be used/referred to more widely.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
