### PR TITLE
chore(runtime): reenable `clippy::pedantic`

### DIFF
--- a/crates/runtime/src/actor/component/mod.rs
+++ b/crates/runtime/src/actor/component/mod.rs
@@ -470,16 +470,14 @@ fn instantiate(
             _ => {}
         }
 
-        let item = match item {
-            component::types::ComponentItem::ComponentInstance(item) => item,
-            _ => continue,
+        let component::types::ComponentItem::ComponentInstance(item) = item else {
+            continue;
         };
         let exports = item.exports(engine);
         let mut instance = HashMap::with_capacity(exports.len());
         for (func_name, item) in exports {
-            let ty = match item {
-                component::types::ComponentItem::ComponentFunc(ty) => ty,
-                _ => continue,
+            let component::types::ComponentItem::ComponentFunc(ty) = item else {
+                continue;
             };
             instance.insert(func_name.to_string(), ty.results().collect());
         }
@@ -604,6 +602,7 @@ impl Component {
     /// Returns a map of dynamic function export types.
     /// Top level map is keyed by the instance name.
     /// Inner map is keyed by exported function name.
+    #[must_use]
     pub fn exports(&self) -> &Arc<HashMap<String, HashMap<String, DynamicFunction>>> {
         &self.exports
     }
@@ -611,6 +610,7 @@ impl Component {
     /// Returns a map of dynamic polyfilled function import types.
     /// Top level map is keyed by the instance name.
     /// Inner map is keyed by exported function name.
+    #[must_use]
     pub fn polyfilled_imports(&self) -> &Arc<HashMap<String, HashMap<String, DynamicFunction>>> {
         &self.polyfilled_imports
     }

--- a/crates/runtime/src/capability/provider/mem/keyvalue.rs
+++ b/crates/runtime/src/capability/provider/mem/keyvalue.rs
@@ -124,8 +124,7 @@ impl KeyValueAtomic for KeyValue {
         match bucket.get(&key).context("key not found")? {
             Entry::Atomic(value) => Ok(value
                 .compare_exchange(old, new, Ordering::Relaxed, Ordering::Relaxed)
-                .map(|value| value == old)
-                .unwrap_or_default()),
+                .is_ok_and(|value| value == old)),
             Entry::Blob(_) => bail!("invalid entry type"),
         }
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,5 +1,6 @@
 //! wasmCloud runtime library
 
+#![warn(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 #![warn(missing_docs)]
 #![forbid(clippy::unwrap_used)]


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Reenable `clippy::pedantic` in the runtime and address warnings introduced in the time it was missing

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

fixup https://github.com/wasmCloud/wasmCloud/commit/42d069eee87d1b5befff1a95b49973064f1a1d1b, where this clippy lint was removed with no explanation

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
