### PR TITLE
ci(github): update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,12 +30,12 @@ Cargo.* @wasmCloud/host-maintainers
 # shared crates
 crates/control-interface @wasmCloud/control-interface-maintainers
 crates/core @wasmCloud/org-maintainers
-crates/opentelemetry-nats @wasmcloud/observability-maintainers
+crates/opentelemetry-nats @wasmCloud/observability-maintainers
 crates/provider-archive @wasmCloud/capability-provider-maintainers
 crates/provider-sdk @wasmCloud/capability-provider-sdk-maintainers
 crates/provider-wit-bindgen @wasmCloud/capability-provider-wit-bindgen-maintainers
 crates/provider-wit-bindgen-macro @wasmCloud/capability-provider-wit-bindgen-maintainers
-crates/tracing @wasmcloud/observability-maintainers
+crates/tracing @wasmCloud/observability-maintainers
 crates/wascap @wasmCloud/wascap-maintainers
 
 # projects


### PR DESCRIPTION
## Feature or Problem
@vados-cosmonic noticed this issue when viewing the `.github/CODEOWNERS` file which I think is caused by a capitalization in the team name. It might not, though, so 🤷‍♂️.
<img width="675" alt="Screenshot 2024-03-27 at 9 57 49 AM" src="https://github.com/wasmCloud/wasmCloud/assets/1687902/a7a5d2f1-b6f9-45ea-92a7-b4896c471e73">