### PR TITLE
feat(host): add label_changed event for label update/delete

### DIFF
--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -1,6 +1,6 @@
 use core::num::NonZeroUsize;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Context;
 use cloudevents::{EventBuilder, EventBuilderV10};
@@ -226,6 +226,16 @@ pub fn config_set(config_name: impl AsRef<str>) -> serde_json::Value {
 pub fn config_deleted(config_name: impl AsRef<str>) -> serde_json::Value {
     json!({
         "config_name": config_name.as_ref(),
+    })
+}
+
+pub fn labels_changed(
+    host_id: impl AsRef<str>,
+    labels: impl Into<HashMap<String, String>>,
+) -> serde_json::Value {
+    json!({
+        "host_id": host_id.as_ref(),
+        "labels": labels.into(),
     })
 }
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit adds a `label_changed` event that can be listened to in order to be notified of label changes on a host.

The single event handles both updates and deletes.

Resolves #1551

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
