### PR TITLE
feat: use native TLS roots along webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,20 +2331,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "736f15a50e749d033164c56c09783b6102c4ff8da79ad77dbddbbaea0f8567f7"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.2.0",
  "hyper-util",
- "rustls 0.22.2",
+ "rustls 0.23.4",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -4006,6 +4005,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4d6d8ad9f2492485e13453acbb291dd08f64441b6609c491f1c2cd2c6b4fe1"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4843,6 +4856,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.2",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.4",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5785,7 +5809,14 @@ dependencies = [
  "bytes",
  "futures",
  "hex",
+ "hyper-rustls 0.27.0",
+ "hyper-util",
  "nkeys",
+ "oci-distribution",
+ "once_cell",
+ "reqwest",
+ "rustls 0.23.4",
+ "rustls-native-certs 0.7.0",
  "serde",
  "serde_bytes",
  "sha2",
@@ -5795,6 +5826,7 @@ dependencies = [
  "ulid",
  "uuid",
  "wascap",
+ "webpki-roots 0.26.1",
  "wrpc-transport",
  "wrpc-transport-nats",
 ]
@@ -5819,7 +5851,6 @@ dependencies = [
  "oci-distribution",
  "opentelemetry-nats",
  "provider-archive",
- "reqwest",
  "rmp-serde",
  "serde",
  "serde_bytes",
@@ -5891,6 +5922,7 @@ dependencies = [
  "futures",
  "hyper-rustls 0.25.0",
  "rand",
+ "rustls 0.22.2",
  "serde",
  "serde_json",
  "simple_env_load",
@@ -5908,7 +5940,6 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "futures",
- "hyper-rustls 0.26.0",
  "hyper-util",
  "tokio",
  "tracing",
@@ -5938,7 +5969,6 @@ dependencies = [
  "toml 0.8.12",
  "tower-http",
  "tracing",
- "wasmcloud-core",
  "wasmcloud-provider-sdk",
  "wrpc-interface-http",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,11 +125,7 @@ redis = { workspace = true, features = [
     "connection-manager",
     "tokio-comp",
 ] }
-reqwest = { workspace = true, features = [
-    "rustls-tls",
-    "json",
-    "rustls-tls-manual-roots",
-] }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 rmp-serde = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
@@ -150,6 +146,10 @@ uuid = { workspace = true }
 vaultrs = { workspace = true, features = ["rustls"] }
 wascap = { workspace = true }
 wasmcloud-control-interface = { workspace = true }
+wasmcloud-core = { workspace = true, features = [
+    "reqwest",
+    "rustls-native-certs",
+] }
 wasmcloud-test-util = { workspace = true }
 wrpc-interface-http = { workspace = true, features = ["hyper"] }
 wrpc-transport = { workspace = true }
@@ -196,7 +196,7 @@ http-body = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 humantime = { version = "2", default-features = false }
 hyper = { version = "1", default-features = false }
-hyper-rustls = { version = "0.26", default-features = false }
+hyper-rustls = { version = "0.27", default-features = false }
 hyper-util = { version = "0.1", default-features = false }
 ignore = { version = "0.4", default-features = false }
 indicatif = { version = "0.17", default-features = false }
@@ -226,6 +226,8 @@ ring = { version = "0.17", default-features = false }
 rmp-serde = { version = "1", default-features = false }
 rmpv = { version = "1", default-features = false }
 rskafka = { version = "0.5", default-features = false }
+rustls = { version = "0.23", default-features = false }
+rustls-native-certs = { version = "0.7", default-features = false }
 rustls-pemfile = { version = "2", default-features = false }
 sanitize-filename = { version = "0.4", default-features = false }
 semver = { version = "1", default-features = false }
@@ -297,6 +299,7 @@ wasmtime-wasi = { version = "19", default-features = false }
 wasmtime-wasi-http = { version = "19", default-features = false }
 wasmtime-wit-bindgen = { version = "19", default-features = false }
 wat = { version = "1", default-features = false }
+webpki-roots = { version = "0.26", default-features = false }
 weld-codegen = { version = "0.7", default-features = false }
 which = { version = "4", default-features = false }
 wit-bindgen = { version = "0.22", default-features = false }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,7 +10,14 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = []
+default = [
+    "hyper-rustls",
+    "oci-distribution",
+    "reqwest",
+    "rustls-native-certs",
+    "webpki-roots",
+]
+hyper-rustls = ["dep:hyper-rustls", "dep:hyper-util"]
 otel = []
 
 [dependencies]
@@ -20,7 +27,17 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true, features = ["std"] }
+hyper-rustls = { workspace = true, features = [
+    "http2",
+    "ring",
+], optional = true }
+hyper-util = { workspace = true, optional = true }
 nkeys = { workspace = true }
+oci-distribution = { workspace = true, optional = true }
+once_cell = { workspace = true }
+reqwest = { workspace = true, features = ["rustls-tls"], optional = true }
+rustls = { workspace = true, features = ["std"] }
+rustls-native-certs = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }
@@ -30,5 +47,6 @@ tracing = { workspace = true }
 ulid = { workspace = true, features = ["std"] }
 uuid = { workspace = true, features = ["serde"] }
 wascap = { workspace = true }
+webpki-roots = { workspace = true, optional = true }
 wrpc-transport = { workspace = true }
 wrpc-transport-nats = { workspace = true }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod chunking;
 pub mod logging;
 pub mod nats;
+pub mod tls;
 
 pub mod host;
 pub use host::*;

--- a/crates/core/src/tls.rs
+++ b/crates/core/src/tls.rs
@@ -1,0 +1,85 @@
+use std::sync::Arc;
+
+use once_cell::sync::Lazy;
+
+#[cfg(feature = "rustls-native-certs")]
+pub static NATIVE_ROOTS: Lazy<Arc<[rustls::pki_types::CertificateDer<'static>]>> =
+    Lazy::new(|| match rustls_native_certs::load_native_certs() {
+        Ok(certs) => certs.into(),
+        Err(err) => {
+            tracing::warn!(?err, "failed to load native root certificate store");
+            Arc::new([])
+        }
+    });
+
+#[cfg(all(feature = "rustls-native-certs", feature = "oci-distribution"))]
+pub static NATIVE_ROOTS_OCI: Lazy<Arc<[oci_distribution::client::Certificate]>> = Lazy::new(|| {
+    NATIVE_ROOTS
+        .iter()
+        .map(|cert| oci_distribution::client::Certificate {
+            encoding: oci_distribution::client::CertificateEncoding::Der,
+            data: cert.to_vec(),
+        })
+        .collect()
+});
+
+#[cfg(all(feature = "rustls-native-certs", feature = "reqwest"))]
+pub static NATIVE_ROOTS_REQWEST: Lazy<Arc<[reqwest::tls::Certificate]>> = Lazy::new(|| {
+    NATIVE_ROOTS
+        .iter()
+        .filter_map(|cert| reqwest::tls::Certificate::from_der(cert.as_ref()).ok())
+        .collect()
+});
+
+pub static DEFAULT_ROOTS: Lazy<Arc<rustls::RootCertStore>> = Lazy::new(|| {
+    #[allow(unused_mut)]
+    let mut ca = rustls::RootCertStore::empty();
+    #[cfg(feature = "rustls-native-certs")]
+    {
+        let (added, ignored) = ca.add_parsable_certificates(NATIVE_ROOTS.iter().cloned());
+        tracing::debug!(added, ignored, "loaded native root certificate store");
+    }
+    #[cfg(feature = "webpki-roots")]
+    ca.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    Arc::new(ca)
+});
+
+pub static DEFAULT_CLIENT_CONFIG: Lazy<rustls::ClientConfig> = Lazy::new(|| {
+    rustls::ClientConfig::builder()
+        .with_root_certificates(Arc::clone(&DEFAULT_ROOTS))
+        .with_no_client_auth()
+});
+
+#[cfg(feature = "hyper-rustls")]
+pub static DEFAULT_HYPER_CONNECTOR: Lazy<
+    hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+> = Lazy::new(|| {
+    hyper_rustls::HttpsConnectorBuilder::new()
+        .with_tls_config(DEFAULT_CLIENT_CONFIG.clone())
+        .https_or_http()
+        .enable_all_versions()
+        .build()
+});
+
+#[cfg(all(feature = "reqwest", feature = "rustls-native-certs"))]
+pub static DEFAULT_REQWEST_CLIENT: Lazy<reqwest::Client> = Lazy::new(|| {
+    reqwest::ClientBuilder::default()
+        .with_native_certificates()
+        .build()
+        .expect("failed to build HTTP client")
+});
+
+#[cfg(feature = "rustls-native-certs")]
+pub trait NativeRootsExt {
+    fn with_native_certificates(self) -> Self;
+}
+
+#[cfg(all(feature = "reqwest", feature = "rustls-native-certs"))]
+impl NativeRootsExt for reqwest::ClientBuilder {
+    fn with_native_certificates(self) -> Self {
+        NATIVE_ROOTS_REQWEST
+            .iter()
+            .cloned()
+            .fold(self, reqwest::ClientBuilder::add_root_certificate)
+    }
+}

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -24,12 +24,11 @@ hex = { workspace = true, features = ["std"] }
 http = { workspace = true }
 http-body = { workspace = true }
 humantime = { workspace = true }
-oci-distribution = { workspace = true, features = ["rustls-tls"] }
 names = { workspace = true }
 nkeys = { workspace = true }
+oci-distribution = { workspace = true, features = ["rustls-tls"] }
 opentelemetry-nats = { workspace = true }
 provider-archive = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
 rmp-serde = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true, features = ["std"] }
@@ -51,7 +50,11 @@ url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["serde"] }
 wascap = { workspace = true }
 wasmcloud-control-interface = { workspace = true }
-wasmcloud-core = { workspace = true, features = ["otel"] }
+wasmcloud-core = { workspace = true, features = [
+    "oci-distribution",
+    "otel",
+    "rustls-native-certs",
+] }
 wasmcloud-runtime = { workspace = true }
 wasmcloud-tracing = { workspace = true, features = ["otel"] }
 wasmtime-wasi-http = { workspace = true }

--- a/crates/host/src/oci.rs
+++ b/crates/host/src/oci.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use wascap::jwt;
+use wasmcloud_core::tls;
 
 const PROVIDER_ARCHIVE_MEDIA_TYPE: &str = "application/vnd.wasmcloud.provider.archive.layer.v1+par";
 const WASM_MEDIA_TYPE: &str = "application/vnd.module.wasm.content.layer.v1+wasm";
@@ -177,11 +178,11 @@ impl Fetcher {
         } else {
             ClientProtocol::Https
         };
-        let config = ClientConfig {
+        let mut c = Client::new(ClientConfig {
             protocol,
+            extra_root_certificates: tls::NATIVE_ROOTS_OCI.to_vec(),
             ..Default::default()
-        };
-        let mut c = Client::new(config);
+        });
 
         // In case of a cache miss where the file does not exist, pull a fresh OCI Image
         if fs::metadata(&cache_file).await.is_ok() {

--- a/crates/provider-blobstore-s3/Cargo.toml
+++ b/crates/provider-blobstore-s3/Cargo.toml
@@ -29,6 +29,7 @@ hyper-rustls = { version = "0.25", features = [
     "ring",
     "webpki-tokio",
 ], default-features = false } # Downgrade for `aws-smithy-runtime` compatibility
+rustls = { version = "0.22", default-features = false } # Downgrade for `aws-smithy-runtime` compatibility
 serde = { workspace = true }
 serde_json = { workspace = true }
 simple_env_load = { workspace = true }

--- a/crates/provider-http-client/Cargo.toml
+++ b/crates/provider-http-client/Cargo.toml
@@ -18,11 +18,6 @@ status = "actively-developed"
 anyhow = { workspace = true }
 futures = { workspace = true }
 hyper-util = { workspace = true, features = ["client-legacy"] }
-hyper-rustls = { workspace = true, features = [
-    "http2",
-    "ring",
-    "webpki-tokio",
-] }
 tokio = { workspace = true, features = ["macros"] }
 tracing = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true, features = ["otel"] }

--- a/crates/provider-http-server/Cargo.toml
+++ b/crates/provider-http-server/Cargo.toml
@@ -30,6 +30,5 @@ tokio = { workspace = true, features = ["macros"] }
 toml = { workspace = true, features = ["parse"] }
 tower-http = { workspace = true, features = ["cors"] }
 tracing = { workspace = true }
-wasmcloud-core = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true, features = ["otel"] }
 wrpc-interface-http = { workspace = true, features = ["http-body"] }

--- a/crates/provider-http-server/src/lib.rs
+++ b/crates/provider-http-server/src/lib.rs
@@ -46,7 +46,7 @@ use axum_server::tls_rustls::RustlsConfig;
 use tokio::{spawn, time};
 use tower_http::cors::{self, CorsLayer};
 use tracing::{debug, error, info, instrument, trace};
-use wasmcloud_core::LatticeTarget;
+use wasmcloud_provider_sdk::core::LatticeTarget;
 use wasmcloud_provider_sdk::{
     get_connection, LinkConfig, ProviderHandler, ProviderOperationResult,
 };
@@ -151,7 +151,7 @@ pub struct HttpServerCore {
 
 #[derive(Clone, Debug)]
 struct RequestContext {
-    wrpc: Arc<wasmcloud_core::wrpc::Client>,
+    wrpc: Arc<wasmcloud_provider_sdk::core::wrpc::Client>,
     settings: Arc<ServiceSettings>,
     scheme: http::uri::Scheme,
 }

--- a/crates/provider-sdk/Cargo.toml
+++ b/crates/provider-sdk/Cargo.toml
@@ -33,7 +33,12 @@ tracing-futures = { workspace = true, features = ["default"] }
 tracing-opentelemetry = { workspace = true, optional = true }
 ulid = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-wasmcloud-core = { workspace = true, features = ["otel"] }
+wasmcloud-core = { workspace = true, features = [
+    "hyper-rustls",
+    "otel",
+    "rustls-native-certs",
+    "webpki-roots",
+] }
 wasmcloud-tracing = { workspace = true, features = ["otel"] }
 wrpc-transport = { workspace = true }
 wrpc-transport-nats = { workspace = true }

--- a/crates/wash-cli/src/ui/mod.rs
+++ b/crates/wash-cli/src/ui/mod.rs
@@ -12,6 +12,7 @@ use wash_lib::{
     cli::{CommandOutput, OutputKind},
     config::downloads_dir,
 };
+use wasmcloud_core::tls;
 
 const DEFAULT_WASHBOARD_VERSION: &str = "v0.1.0";
 
@@ -67,7 +68,9 @@ async fn download_washboard(version: &str, install_dir: &PathBuf) -> Result<()> 
     );
 
     // Download tarball
-    let resp = reqwest::get(release_url)
+    let resp = tls::DEFAULT_REQWEST_CLIENT
+        .get(&release_url)
+        .send()
         .await
         .context("failed to request washboard tarball")?;
 

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -87,7 +87,11 @@ wascap = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmcloud-component-adapters = { workspace = true }
 wasmcloud-control-interface = { workspace = true }
-wasmcloud-core = { workspace = true }
+wasmcloud-core = { workspace = true, features = [
+    "oci-distribution",
+    "reqwest",
+    "rustls-native-certs",
+] }
 wasmparser = { workspace = true }
 wat = { workspace = true }
 weld-codegen = { workspace = true, features = ["wasmbus"] }

--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -16,6 +16,7 @@ use provider_archive::ProviderArchive;
 use regex::RegexBuilder;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
+use wasmcloud_core::tls;
 
 const PROVIDER_ARCHIVE_MEDIA_TYPE: &str = "application/vnd.wasmcloud.provider.archive.layer.v1+par";
 const PROVIDER_ARCHIVE_CONFIG_MEDIA_TYPE: &str =
@@ -126,6 +127,7 @@ pub async fn pull_oci_artifact(url: String, options: OciPullOptions) -> Result<V
         } else {
             ClientProtocol::Https
         },
+        extra_root_certificates: tls::NATIVE_ROOTS_OCI.to_vec(),
         ..Default::default()
     });
 

--- a/crates/wash-lib/src/start/github.rs
+++ b/crates/wash-lib/src/start/github.rs
@@ -9,6 +9,7 @@ use std::{ffi::OsStr, io::Cursor};
 use tokio::fs::{create_dir_all, metadata, File};
 use tokio_stream::StreamExt;
 use tokio_tar::Archive;
+use wasmcloud_core::tls;
 
 /// Reusable function to download a release tarball from GitHub and extract an embedded binary to a specified directory
 ///
@@ -34,7 +35,7 @@ where
 {
     let bin_path = dir.as_ref().join(bin_name);
     // Download release tarball
-    let body = match reqwest::get(url).await {
+    let body = match tls::DEFAULT_REQWEST_CLIENT.get(url).send().await {
         Ok(resp) => resp.bytes().await?,
         Err(e) => bail!("Failed to request release tarball: {:?}", e),
     };

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -7,6 +7,7 @@ use tokio::process::{Child, Command};
 use tokio_stream::StreamExt;
 use tokio_util::io::StreamReader;
 use tracing::warn;
+use wasmcloud_core::tls;
 
 #[cfg(target_family = "unix")]
 use std::os::unix::prelude::PermissionsExt;
@@ -148,7 +149,7 @@ where
     let url = wasmcloud_url(version);
     // NOTE(brooksmtownsend): This seems like a lot of work when I really just want to use AsyncRead
     // to pipe the response body into a file. I'm not sure if there's a better way to do this.
-    let download_response = reqwest::get(url.clone()).await?;
+    let download_response = tls::DEFAULT_REQWEST_CLIENT.get(&url).send().await?;
     if download_response.status() != StatusCode::OK {
         bail!(
             "failed to download wasmCloud host from {}. Status code: {}",

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -17,6 +17,7 @@ use tokio::time::sleep;
 use tokio::{join, try_join};
 use tracing_subscriber::prelude::*;
 use uuid::Uuid;
+use wasmcloud_core::tls::NativeRootsExt as _;
 use wasmcloud_test_util::lattice::config::assert_config_put;
 use wasmcloud_test_util::provider::{assert_start_provider, StartProviderArgs};
 use wasmcloud_test_util::{
@@ -444,6 +445,7 @@ async fn interfaces() -> anyhow::Result<()> {
     .context("failed to set `foo` key in Vault")?;
 
     let http_client = reqwest::Client::builder()
+        .with_native_certificates()
         .timeout(Duration::from_secs(20))
         .connect_timeout(Duration::from_secs(20))
         .build()


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Include both webpki and native OS root certificates by default for TLS. This ensures that outgoing connections work *everywhere* - be it a `FROM scratch` Docker container, consumer OS behind a corporate firewall, an embedded device or anything in-between.

Eventually we should standardize TLS setup in providers and have a way to switch between the CA pools, but for now we should focus on getting things working.

~The specified `reqwest` feature set ensures both bundles are included https://github.com/seanmonstar/reqwest/blob/14e46ff8cb7550473c950f3471d049ad2e139d3f/src/async_impl/client.rs#L501-L529~ this fails when the OS bundle is missing, so simply load the native certs ourselves and log if we failed to load the native bundle

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

May fix - https://github.com/wasmCloud/wasmCloud/issues/1433

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
