### PR TITLE
ci: do not push `latest`

### DIFF
--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -118,13 +118,6 @@ jobs:
         WASH_REG_USER: ${{ github.repository_owner }}
         WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push `${{ inputs.name }}` provider `latest` tag to GitHub Container Registry
-      if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name)) && !steps.ctx.outputs.prerelease
-      run: ./wash push ghcr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:latest "${{ inputs.name }}.par.gz"
-      env:
-        WASH_REG_USER: ${{ github.repository_owner }}
-        WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-
     # wasmCloud AzureCR
 
     - name: Push `${{ inputs.name }}` provider `${{ github.sha }}` tag to wasmCloud Azure Container Registry
@@ -155,14 +148,6 @@ jobs:
       if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name))
       continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
       run: ./wash push wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ steps.ctx.outputs.version }} "${{ inputs.name }}.par.gz"
-      env:
-        WASH_REG_USER: ${{ secrets.azurecr_username }}
-        WASH_REG_PASSWORD: ${{ secrets.azurecr_password }}
-
-    - name: Push `${{ inputs.name }}` provider `latest` tag to wasmCloud Azure Container Registry
-      if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name)) && !steps.ctx.outputs.prerelease
-      continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
-      run: ./wash push wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:latest "${{ inputs.name }}.par.gz"
       env:
         WASH_REG_USER: ${{ secrets.azurecr_username }}
         WASH_REG_PASSWORD: ${{ secrets.azurecr_password }}


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Apparently pushing `latest` is prohibited:

https://github.com/wasmCloud/wasmCloud/actions/runs/8450924701/job/23149190845

```
Run ./wash push ghcr.io/wasmcloud/messaging-nats:latest "messaging-nats.par.gz"

Pushing artifacts with tag 'latest' is prohibited
```

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
