### PR TITLE
chore(*): Bumps version to alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 description = "wasmCloud host runtime"
 default-run = "wasmcloud"
 


### PR DESCRIPTION
We had cut a tag at alpha.3 without bumping the Cargo.toml