### PR TITLE
chore/control interface actor rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,7 +1323,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wasmtime-types",
 ]
 
@@ -3606,7 +3606,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tar",
- "wascap",
+ "wascap 0.13.0",
 ]
 
 [[package]]
@@ -4674,7 +4674,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-component-adapters",
  "wit-component",
 ]
@@ -5412,7 +5412,26 @@ dependencies = [
  "serde_json",
  "wasm-encoder 0.202.0",
  "wasm-gen",
- "wasmparser",
+ "wasmparser 0.201.0",
+]
+
+[[package]]
+name = "wascap"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "802ee1beca185fd4d61bcfd937360d1dddacc88fefa39b08209e875d99c95711"
+dependencies = [
+ "data-encoding",
+ "humantime",
+ "log",
+ "nkeys",
+ "nuid 0.4.1",
+ "ring",
+ "serde",
+ "serde_json",
+ "wasm-encoder 0.41.2",
+ "wasm-gen",
+ "wasmparser 0.121.2",
 ]
 
 [[package]]
@@ -5464,10 +5483,10 @@ dependencies = [
  "url",
  "wadm",
  "warp",
- "wascap",
+ "wascap 0.13.0",
  "wash-lib",
- "wasmcloud-control-interface 1.0.0-alpha.2",
- "wasmcloud-core",
+ "wasmcloud-control-interface 1.0.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmcloud-core 0.4.0",
  "wasmcloud-provider-sdk",
  "weld-codegen",
  "which",
@@ -5527,12 +5546,12 @@ dependencies = [
  "url",
  "wadm",
  "walkdir",
- "wascap",
+ "wascap 0.13.0",
  "wasm-encoder 0.202.0",
  "wasmcloud-component-adapters",
- "wasmcloud-control-interface 1.0.0-alpha.2",
- "wasmcloud-core",
- "wasmparser",
+ "wasmcloud-control-interface 1.0.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmcloud-core 0.4.0",
+ "wasmparser 0.201.0",
  "wat",
  "weld-codegen",
  "wit-bindgen-core",
@@ -5615,6 +5634,15 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
+version = "0.41.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972f97a5d8318f908dded23594188a90bcd09365986b1163e66d70170e5287ae"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9c7d2731df60006819b013f64ccc2019691deccf6e11a1804bc850cd6748f1a"
@@ -5654,7 +5682,7 @@ dependencies = [
  "serde_json",
  "spdx",
  "wasm-encoder 0.201.0",
- "wasmparser",
+ "wasmparser 0.201.0",
 ]
 
 [[package]]
@@ -5702,9 +5730,9 @@ dependencies = [
  "url",
  "uuid",
  "vaultrs",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-control-interface 1.0.0-alpha.2",
- "wasmcloud-core",
+ "wasmcloud-core 0.4.0",
  "wasmcloud-host",
  "wasmcloud-provider-blobstore-fs",
  "wasmcloud-provider-blobstore-s3",
@@ -5796,7 +5824,30 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry 0.22.0",
- "wasmcloud-core",
+ "wasmcloud-core 0.4.0",
+]
+
+[[package]]
+name = "wasmcloud-control-interface"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "042a574966c368f0e04b9829dd9d1df1965c7c852a2b4880384fe7a2f7ea0cd9"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "bytes",
+ "cloudevents-sdk",
+ "futures",
+ "oci-distribution",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.2",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry 0.22.0",
+ "wasmcloud-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5825,8 +5876,36 @@ dependencies = [
  "tracing",
  "ulid",
  "uuid",
- "wascap",
+ "wascap 0.13.0",
  "webpki-roots 0.26.1",
+ "wrpc-transport",
+ "wrpc-transport-nats",
+]
+
+[[package]]
+name = "wasmcloud-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9384bec7161ea7763f6665c49b9282323065e3edd0247cca9f679180bd14d86"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "bytes",
+ "futures",
+ "hex",
+ "nkeys",
+ "once_cell",
+ "rustls 0.23.4",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "tokio",
+ "tower",
+ "tracing",
+ "ulid",
+ "uuid",
+ "wascap 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wrpc-transport",
  "wrpc-transport-nats",
 ]
@@ -5863,9 +5942,9 @@ dependencies = [
  "ulid",
  "url",
  "uuid",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-control-interface 1.0.0-alpha.2",
- "wasmcloud-core",
+ "wasmcloud-core 0.4.0",
  "wasmcloud-runtime",
  "wasmcloud-tracing",
  "wasmtime-wasi-http",
@@ -6025,7 +6104,7 @@ dependencies = [
  "async-nats",
  "tokio",
  "tracing",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-control-interface 1.0.0-alpha.2",
  "wasmcloud-provider-wit-bindgen",
 ]
@@ -6057,7 +6136,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry 0.22.0",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-provider-wit-bindgen",
 ]
 
@@ -6086,7 +6165,7 @@ dependencies = [
  "tracing-opentelemetry 0.22.0",
  "ulid",
  "uuid",
- "wasmcloud-core",
+ "wasmcloud-core 0.4.0",
  "wasmcloud-tracing",
  "wrpc-interface-blobstore",
  "wrpc-interface-http",
@@ -6154,11 +6233,11 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-actor",
  "wasmcloud-component-adapters",
- "wasmcloud-core",
- "wasmparser",
+ "wasmcloud-core 0.4.0",
+ "wasmparser 0.201.0",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
@@ -6184,7 +6263,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-control-interface 1.0.0-alpha.2",
  "wasmcloud-host",
 ]
@@ -6205,7 +6284,18 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry 0.22.0",
  "tracing-subscriber",
- "wasmcloud-core",
+ "wasmcloud-core 0.4.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
+dependencies = [
+ "bitflags 2.4.2",
+ "indexmap 2.2.5",
+ "semver",
 ]
 
 [[package]]
@@ -6226,7 +6316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67e66da702706ba08729a78e3c0079085f6bfcb1a62e4799e97bbf728c2c265"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.201.0",
 ]
 
 [[package]]
@@ -6257,7 +6347,7 @@ dependencies = [
  "serde_json",
  "target-lexicon",
  "wasm-encoder 0.201.0",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -6340,7 +6430,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
@@ -6380,7 +6470,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-encoder 0.201.0",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -6457,7 +6547,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.201.0",
 ]
 
 [[package]]
@@ -6535,7 +6625,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "winch-codegen",
@@ -6711,7 +6801,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wasmtime-environ",
 ]
 
@@ -6983,7 +7073,7 @@ dependencies = [
  "serde_json",
  "wasm-encoder 0.201.0",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wit-parser",
 ]
 
@@ -7002,7 +7092,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.201.0",
 ]
 
 [[package]]

--- a/crates/control-interface/README.md
+++ b/crates/control-interface/README.md
@@ -1,9 +1,9 @@
 ![Crates.io](https://img.shields.io/crates/v/wasmcloud-control-interface)
-[![Documentation](https://img.shields.io/badge/Docs-Documentation-blue)](https://wasmcloud.dev)
+[![Documentation](https://img.shields.io/badge/Docs-Documentation-blue)](https://wasmcloud.com)
 [![Rustdocs](https://docs.rs/wasmcloud-control-interface/badge.svg)](https://docs.rs/wasmcloud-control-interface)
 
 # wasmCloud Control Interface Client
 
-This library is a convenient API for interacting with the lattice control interface. This is a Rust crate that implements the [lattice control protocol](https://wasmcloud.dev/reference/lattice-protocols/control-interface/) as described in the wasmCloud reference documentation. For a formal definition of the interface protocol, you can also look at the **Smithy** files in the [interface repository](https://github.com/wasmCloud/interfaces/blob/main/lattice-control/lattice-control-interface.smithy).
+This library is a convenient API for interacting with the lattice control interface. This is a Rust crate that implements the [lattice control protocol](https://wasmcloud.com/reference/lattice-protocols/control-interface/) as described in the wasmCloud reference documentation.
 
-The lattice control interface provides a way for clients to interact with the lattice to issue control commands and queries. This interface is a message broker protocol that supports functionality like starting and stopping components and providers, declaring link definitions, monitoring lattice events, holding auctions to determine scheduling compatibility, and much more.
+The lattice control interface provides a way for clients to interact with the lattice to issue control commands and queries. This interface is a message broker protocol that supports functionality like starting and stopping components and providers, declaring link definitions, monitoring lattice events, holding auctions to determine scheduling compatibility, and more.

--- a/crates/control-interface/src/broker.rs
+++ b/crates/control-interface/src/broker.rs
@@ -21,9 +21,9 @@ pub mod v1 {
         )
     }
 
-    pub fn actor_auction_subject(topic_prefix: &Option<String>, lattice: &str) -> String {
+    pub fn component_auction_subject(topic_prefix: &Option<String>, lattice: &str) -> String {
         format!(
-            "{}.actor.auction",
+            "{}.component.auction",
             prefix(topic_prefix, lattice, CTL_API_VERSION_1)
         )
     }
@@ -86,9 +86,13 @@ pub mod v1 {
 
         use super::prefix;
 
-        pub fn scale_actor(topic_prefix: &Option<String>, lattice: &str, host_id: &str) -> String {
+        pub fn scale_component(
+            topic_prefix: &Option<String>,
+            lattice: &str,
+            host_id: &str,
+        ) -> String {
             format!(
-                "{}.actor.scale.{host_id}",
+                "{}.component.scale.{host_id}",
                 prefix(topic_prefix, lattice, CTL_API_VERSION_1)
             )
         }
@@ -115,9 +119,13 @@ pub mod v1 {
             )
         }
 
-        pub fn update_actor(topic_prefix: &Option<String>, lattice: &str, host_id: &str) -> String {
+        pub fn update_component(
+            topic_prefix: &Option<String>,
+            lattice: &str,
+            host_id: &str,
+        ) -> String {
             format!(
-                "{}.actor.update.{host_id}",
+                "{}.component.update.{host_id}",
                 prefix(topic_prefix, lattice, CTL_API_VERSION_1)
             )
         }

--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -19,7 +19,7 @@ pub mod client;
 pub use client::{collect_sub_timeout, Client, ClientBuilder};
 
 mod types;
-pub use types::actor::*;
+pub use types::component::*;
 pub use types::ctl::*;
 pub use types::host::*;
 pub use types::link::InterfaceLinkDefinition;

--- a/crates/control-interface/src/types/component.rs
+++ b/crates/control-interface/src/types/component.rs
@@ -1,4 +1,4 @@
-//! Data types used when dealing with actors on a wasmCloud lattice
+//! Data types used when dealing with components on a wasmCloud lattice
 
 use std::collections::HashMap;
 
@@ -6,23 +6,23 @@ use serde::{Deserialize, Serialize};
 
 use crate::ComponentId;
 
-/// A summary description of an actor within a host inventory
+/// A summary description of an component within a host inventory
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ActorDescription {
-    /// The unique component identifier for this actor
+pub struct ComponentDescription {
+    /// The unique component identifier for this component
     #[serde(default)]
     pub id: ComponentId,
-    /// Image reference for this actor
+    /// Image reference for this component
     #[serde(default)]
     pub image_ref: String,
-    /// Name of this actor, if one exists
+    /// Name of this component, if one exists
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// The annotations that were used in the start request that produced
-    /// this actor instance
+    /// this component instance
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<HashMap<String, String>>,
-    /// The revision number for this actor instance
+    /// The revision number for this component instance
     #[serde(default)]
     pub revision: i32,
     /// The maximum number of concurrent requests this instance can handle
@@ -31,18 +31,18 @@ pub struct ActorDescription {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ActorInstance {
+pub struct ComponentInstance {
     /// The annotations that were used in the start request that produced
-    /// this actor instance
+    /// this component instance
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<HashMap<String, String>>,
-    /// Image reference for this actor
+    /// Image reference for this component
     #[serde(default)]
     pub image_ref: String,
     /// This instance's unique ID (guid)
     #[serde(default)]
     pub instance_id: String,
-    /// The revision number for this actor instance
+    /// The revision number for this component instance
     #[serde(default)]
     pub revision: i32,
     /// The maximum number of concurrent requests this instance can handle

--- a/crates/control-interface/src/types/ctl.rs
+++ b/crates/control-interface/src/types/ctl.rs
@@ -53,26 +53,26 @@ impl CtlResponse<()> {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ScaleActorCommand {
-    /// Image reference for the actor.
+pub struct ScaleComponentCommand {
+    /// Image reference for the component.
     #[serde(default)]
-    pub actor_ref: String,
-    /// Unique identifier of the actor to scale.
-    pub actor_id: ComponentId,
-    /// Optional set of annotations used to describe the nature of this actor scale command. For
+    pub component_ref: String,
+    /// Unique identifier of the component to scale.
+    pub component_id: ComponentId,
+    /// Optional set of annotations used to describe the nature of this component scale command. For
     /// example, autonomous agents may wish to "tag" scale requests as part of a given deployment
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<HashMap<String, String>>,
-    /// The maximum number of concurrent executing instances of this actor. Setting this to `0` will
-    /// stop the actor.
+    /// The maximum number of concurrent executing instances of this component. Setting this to `0` will
+    /// stop the component.
     // NOTE: renaming to `count` lets us remain backwards compatible for a few minor versions
     #[serde(default, alias = "count", rename = "count")]
     pub max_instances: u32,
-    /// Host ID on which to scale this actor
+    /// Host ID on which to scale this component
     #[serde(default)]
     pub host_id: String,
-    /// A list of named configs to use for this actor. It is not required to specify a config.
-    /// Configs are merged together before being given to the actor, with values from the right-most
+    /// A list of named configs to use for this component. It is not required to specify a config.
+    /// Configs are merged together before being given to the component, with values from the right-most
     /// config in the list taking precedence. For example, given ordered configs foo {a: 1, b: 2},
     /// bar {b: 3, c: 4}, and baz {c: 5, d: 6}, the resulting config will be: {a: 1, b: 3, c: 5, d:
     /// 6}
@@ -128,22 +128,22 @@ pub struct StopProviderCommand {
 }
 
 /// A command instructing a specific host to perform a live update
-/// on the indicated actor by supplying a new image reference. Note that
+/// on the indicated component by supplying a new image reference. Note that
 /// live updates are only possible through image references
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct UpdateActorCommand {
-    /// The actor's 56-character unique ID
+pub struct UpdateComponentCommand {
+    /// The component's 56-character unique ID
     #[serde(default)]
-    pub actor_id: ComponentId,
+    pub component_id: ComponentId,
     /// Optional set of annotations used to describe the nature of this
-    /// update request. Only actor instances that have matching annotations
+    /// update request. Only component instances that have matching annotations
     /// will be upgraded, allowing for instance isolation by
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<HashMap<String, String>>,
     /// The host ID of the host to perform the live update
     #[serde(default)]
     pub host_id: String,
-    /// The new image reference of the upgraded version of this actor
+    /// The new image reference of the upgraded version of this component
     #[serde(default)]
-    pub new_actor_ref: String,
+    pub new_component_ref: String,
 }

--- a/crates/control-interface/src/types/host.rs
+++ b/crates/control-interface/src/types/host.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::actor::ActorDescription;
+use crate::types::component::ComponentDescription;
 use crate::types::provider::ProviderDescription;
 
 /// A summary representation of a host
@@ -50,8 +50,9 @@ pub struct Host {
 /// a query. Also used as a payload for the host heartbeat
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct HostInventory {
-    /// Actors running on this host.
-    pub actors: Vec<ActorDescription>,
+    /// Components running on this host.
+    #[serde(alias = "actors")]
+    pub components: Vec<ComponentDescription>,
     /// Providers running on this host
     pub providers: Vec<ProviderDescription>,
     /// The host's unique ID

--- a/crates/control-interface/src/types/mod.rs
+++ b/crates/control-interface/src/types/mod.rs
@@ -1,6 +1,6 @@
 //! Collection of types that are commonly used/necessary in control interface operations
 
-pub mod actor;
+pub mod component;
 pub mod ctl;
 pub mod host;
 pub mod link;

--- a/crates/control-interface/src/types/rpc.rs
+++ b/crates/control-interface/src/types/rpc.rs
@@ -6,16 +6,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::{ComponentId, LinkName, WitNamespace, WitPackage};
 
-/// A host response to a request to start an actor, confirming the host
-/// has enough capacity to start the actor
+/// A host response to a request to start an component, confirming the host
+/// has enough capacity to start the component
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ActorAuctionAck {
-    /// The original actor reference used for the auction
+pub struct ComponentAuctionAck {
+    /// The original component reference used for the auction
     #[serde(default)]
-    pub actor_ref: String,
-    /// The unique component identifier that the auctioner can use for this actor
+    pub component_ref: String,
+    /// The unique component identifier that the auctioner can use for this component
     #[serde(default)]
-    pub actor_id: String,
+    pub component_id: String,
     /// The host ID of the "bidder" for this auction.
     #[serde(default)]
     pub host_id: String,
@@ -24,15 +24,15 @@ pub struct ActorAuctionAck {
     pub constraints: HashMap<String, String>,
 }
 
-/// A request to locate suitable hosts for a given actor
+/// A request to locate suitable hosts for a given component
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ActorAuctionRequest {
-    /// The image reference, file or OCI, for this actor.
+pub struct ComponentAuctionRequest {
+    /// The image reference, file or OCI, for this component.
     #[serde(default)]
-    pub actor_ref: String,
-    /// The unique identifier to be used for this actor. The host will ensure
-    /// that no other actor with the same ID is running on the host
-    pub actor_id: ComponentId,
+    pub component_ref: String,
+    /// The unique identifier to be used for this component. The host will ensure
+    /// that no other component with the same ID is running on the host
+    pub component_id: ComponentId,
     /// The set of constraints that must match the labels of a suitable target host
     pub constraints: HashMap<String, String>,
 }
@@ -71,7 +71,7 @@ pub struct ProviderAuctionRequest {
     pub provider_id: ComponentId,
 }
 
-/// A request to remove a link definition and detach the relevant actor
+/// A request to remove a link definition and detach the relevant component
 /// from the given provider
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct DeleteInterfaceLinkDefinitionRequest {

--- a/crates/host/src/metrics.rs
+++ b/crates/host/src/metrics.rs
@@ -6,10 +6,10 @@ use wasmcloud_tracing::{Counter, Histogram, KeyValue, Meter, Unit};
 pub struct HostMetrics {
     /// Represents the time it took for each handle_rpc_message invocation in nanoseconds.
     pub handle_rpc_message_duration_ns: Histogram<u64>,
-    /// The count of the number of times an actor was invoked.
-    pub actor_invocations: Counter<u64>,
-    /// The count of the number of times an actor invocation resulted in an error.
-    pub actor_errors: Counter<u64>,
+    /// The count of the number of times an component was invoked.
+    pub component_invocations: Counter<u64>,
+    /// The count of the number of times an component invocation resulted in an error.
+    pub component_errors: Counter<u64>,
 
     /// The host's ID.
     // TODO this is actually configured as an InstrumentationScope attribute on the global meter,
@@ -32,20 +32,20 @@ impl HostMetrics {
             .with_unit(Unit::new("nanoseconds"))
             .init();
 
-        let actor_invocation_count = meter
-            .u64_counter("wasmcloud_host.actor.invocations")
-            .with_description("Number of actor invocations")
+        let component_invocation_count = meter
+            .u64_counter("wasmcloud_host.component.invocations")
+            .with_description("Number of component invocations")
             .init();
 
-        let actor_error_count = meter
-            .u64_counter("wasmcloud_host.actor.invocation.errors")
-            .with_description("Number of actor errors")
+        let component_error_count = meter
+            .u64_counter("wasmcloud_host.component.invocation.errors")
+            .with_description("Number of component errors")
             .init();
 
         Self {
             handle_rpc_message_duration_ns: wasmcloud_host_handle_rpc_message_duration_ns,
-            actor_invocations: actor_invocation_count,
-            actor_errors: actor_error_count,
+            component_invocations: component_invocation_count,
+            component_errors: component_error_count,
             host_id,
             lattice_id,
         }
@@ -60,9 +60,9 @@ impl HostMetrics {
     ) {
         self.handle_rpc_message_duration_ns
             .record(elapsed, attributes);
-        self.actor_invocations.add(1, attributes);
+        self.component_invocations.add(1, attributes);
         if error {
-            self.actor_errors.add(1, attributes);
+            self.component_errors.add(1, attributes);
         }
     }
 }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -35,11 +35,11 @@ use tracing::{debug, error, info, instrument, trace, warn};
 use uuid::Uuid;
 use wascap::{jwt, prelude::ClaimsBuilder};
 use wasmcloud_control_interface::{
-    ActorAuctionAck, ActorAuctionRequest, ActorDescription, CtlResponse,
+    ComponentAuctionAck, ComponentAuctionRequest, ComponentDescription, CtlResponse,
     DeleteInterfaceLinkDefinitionRequest, HostInventory, HostLabel, InterfaceLinkDefinition,
     ProviderAuctionAck, ProviderAuctionRequest, ProviderDescription, RegistryCredential,
-    ScaleActorCommand, StartProviderCommand, StopHostCommand, StopProviderCommand,
-    UpdateActorCommand, WitInterface,
+    ScaleComponentCommand, StartProviderCommand, StopHostCommand, StopProviderCommand,
+    UpdateComponentCommand, WitInterface,
 };
 use wasmcloud_core::{HealthCheckResponse, HostData, LatticeTarget, OtelConfig, CTL_API_VERSION_1};
 use wasmcloud_runtime::capability::logging::logging;
@@ -155,7 +155,7 @@ impl Queue {
                 format!("{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.claims"),
             )),
             Either::Left(nats.subscribe(format!(
-                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.actor.*.{host_id}"
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.component.*.{host_id}"
             ))),
             Either::Left(nats.subscribe(format!(
                 "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.provider.*.{host_id}"
@@ -819,7 +819,7 @@ impl Logging for Handler {
             logging::Level::Trace => {
                 tracing::event!(
                     tracing::Level::TRACE,
-                    actor_id = self.component_id,
+                    component_id = self.component_id,
                     ?level,
                     context,
                     "{message}"
@@ -828,7 +828,7 @@ impl Logging for Handler {
             logging::Level::Debug => {
                 tracing::event!(
                     tracing::Level::DEBUG,
-                    actor_id = self.component_id,
+                    component_id = self.component_id,
                     ?level,
                     context,
                     "{message}"
@@ -837,7 +837,7 @@ impl Logging for Handler {
             logging::Level::Info => {
                 tracing::event!(
                     tracing::Level::INFO,
-                    actor_id = self.component_id,
+                    component_id = self.component_id,
                     ?level,
                     context,
                     "{message}"
@@ -846,7 +846,7 @@ impl Logging for Handler {
             logging::Level::Warn => {
                 tracing::event!(
                     tracing::Level::WARN,
-                    actor_id = self.component_id,
+                    component_id = self.component_id,
                     ?level,
                     context,
                     "{message}"
@@ -855,7 +855,7 @@ impl Logging for Handler {
             logging::Level::Error => {
                 tracing::event!(
                     tracing::Level::ERROR,
-                    actor_id = self.component_id,
+                    component_id = self.component_id,
                     ?level,
                     context,
                     "{message}"
@@ -864,7 +864,7 @@ impl Logging for Handler {
             logging::Level::Critical => {
                 tracing::event!(
                     tracing::Level::ERROR,
-                    actor_id = self.component_id,
+                    component_id = self.component_id,
                     ?level,
                     context,
                     "{message}"
@@ -1019,20 +1019,19 @@ type Annotations = BTreeMap<String, String>;
 #[derive(Debug)]
 struct Actor {
     component: wasmcloud_runtime::Component,
-    /// Unique component identifier for this actor
+    /// Unique component identifier for this component
     id: String,
     calls: AbortHandle,
     handler: Handler,
     annotations: Annotations,
-    /// Maximum number of instances of this actor that can be running at once
+    /// Maximum number of instances of this component that can be running at once
     max_instances: NonZeroUsize,
     image_reference: String,
     metrics: Arc<HostMetrics>,
     // TODO(#1220): implement issuer verification
-    /// Cluster issuers that this actor should accept invocations from
+    /// Cluster issuers that this component should accept invocations from
     #[allow(unused)]
     valid_issuers: Vec<String>,
-    // TODO(#1548): ensure we are validating actor start and invocations
     #[allow(unused)]
     policy_manager: Arc<PolicyManager>,
 }
@@ -1073,7 +1072,7 @@ impl std::fmt::Debug for InvocationParams {
 }
 
 impl Actor {
-    /// Handle an incoming wRPC request to invoke an export on this actor instance.
+    /// Handle an incoming wRPC request to invoke an export on this component instance.
     #[instrument(
         level = "info",
         skip(self, context, result_subject, transmitter),
@@ -1140,7 +1139,9 @@ impl Actor {
         }
 
         // Instantiate component with expected handlers
-        let mut actor = self.instantiate().context("failed to instantiate actor")?;
+        let mut actor = self
+            .instantiate()
+            .context("failed to instantiate component")?;
         actor
             .stderr(stderr())
             .await
@@ -1155,7 +1156,7 @@ impl Actor {
 
         // TODO(metrics): insert information about the source once we have concrete context data
         let mut attributes = vec![
-            KeyValue::new("actor.ref", self.image_reference.clone()),
+            KeyValue::new("component.ref", self.image_reference.clone()),
             KeyValue::new("lattice", self.metrics.lattice_id.clone()),
             KeyValue::new("host", self.metrics.host_id.clone()),
         ];
@@ -1170,7 +1171,7 @@ impl Actor {
                 let res = actor
                     .call(&instance, &name, params)
                     .await
-                    .context("failed to call actor");
+                    .context("failed to call component");
                 let elapsed = u64::try_from(start_at.elapsed().as_nanos()).unwrap_or_default();
                 attributes.push(KeyValue::new("operation", format!("{instance}/{name}")));
                 self.metrics
@@ -1261,7 +1262,6 @@ struct Provider {
 
 /// wasmCloud Host
 pub struct Host {
-    // TODO: Clean up actors after stop
     /// The actor map is a map of actor component ID to actor
     actors: RwLock<HashMap<String, Arc<Actor>>>,
     cluster_key: Arc<KeyPair>,
@@ -1959,14 +1959,14 @@ impl Host {
     async fn inventory(&self) -> HostInventory {
         trace!("generating host inventory");
         let actors = self.actors.read().await;
-        let actors: Vec<_> = stream::iter(actors.iter())
+        let components: Vec<_> = stream::iter(actors.iter())
             .filter_map(|(id, actor)| async move {
                 let name = actor
                     .claims()
                     .and_then(|claims| claims.metadata.as_ref())
                     .and_then(|metadata| metadata.name.as_ref())
                     .cloned();
-                Some(ActorDescription {
+                Some(ComponentDescription {
                     id: id.into(),
                     image_ref: actor.image_reference.clone(),
                     annotations: Some(actor.annotations.clone().into_iter().collect()),
@@ -2018,7 +2018,7 @@ impl Host {
             .collect();
         let uptime = self.start_at.elapsed();
         HostInventory {
-            actors,
+            components,
             providers,
             friendly_name: self.friendly_name.clone(),
             labels: self.labels.read().await.clone(),
@@ -2054,18 +2054,18 @@ impl Host {
     async fn instantiate_actor(
         &self,
         annotations: &Annotations,
-        actor_ref: String,
-        actor_id: String,
+        component_ref: String,
+        component_id: String,
         max_instances: NonZeroUsize,
         component: wasmcloud_runtime::Component,
         handler: Handler,
     ) -> anyhow::Result<Arc<Actor>> {
-        trace!(actor_ref, max_instances, "instantiating actor");
+        trace!(component_ref, max_instances, "instantiating component");
 
         let wrpc = wasmcloud_core::wrpc::Client::new(
             self.rpc_nats.clone(),
             &self.host_config.lattice,
-            &actor_id,
+            &component_id,
             // NOTE(brooksmtownsend): We only use this client for serving functions,
             // and the headers will be set by the incoming invocation.
             async_nats::HeaderMap::new(),
@@ -2074,14 +2074,14 @@ impl Host {
         let (calls_abort, calls_abort_reg) = AbortHandle::new_pair();
         let actor = Arc::new(Actor {
             component: component.clone(),
-            id: actor_id,
+            id: component_id,
             calls: calls_abort,
             handler: handler.clone(),
             annotations: annotations.clone(),
             max_instances,
             valid_issuers: self.cluster_issuers.clone(),
             policy_manager: Arc::clone(&self.policy_manager),
-            image_reference: actor_ref,
+            image_reference: component_ref,
             metrics: Arc::clone(&self.metrics),
         });
 
@@ -2223,13 +2223,13 @@ impl Host {
         &self,
         entry: hash_map::VacantEntry<'a, String, Arc<Actor>>,
         component: wasmcloud_runtime::Component,
-        actor_ref: String,
-        actor_id: String,
+        component_ref: String,
+        component_id: String,
         max_instances: NonZeroUsize,
         annotations: impl Into<Annotations>,
         config: ConfigBundle,
     ) -> anyhow::Result<&'a mut Arc<Actor>> {
-        debug!(actor_ref, ?max_instances, "starting new actor");
+        debug!(component_ref, ?max_instances, "starting new component");
 
         let annotations = annotations.into();
         let claims = component.claims();
@@ -2239,24 +2239,25 @@ impl Host {
                 .context("failed to store claims")?;
         }
 
-        let component_spec = if let Ok(Some(mut spec)) = self.get_component_spec(&actor_id).await {
-            // If the component didn't start yet, the URL will be empty but the spec may contain links.
-            // Populate the URL and store the updated spec.
-            if spec.url.is_empty() {
-                spec.url = actor_ref.to_string();
-            } else if spec.url != actor_ref {
-                // Ensure another actor isn't already running with the same ID
-                bail!(
-                    "component spec URL does not match actor reference: {} != {}",
-                    spec.url,
-                    actor_ref
-                );
-            }
-            spec
-        } else {
-            ComponentSpecification::new(&actor_ref)
-        };
-        self.store_component_spec(&actor_id, &component_spec)
+        let component_spec =
+            if let Ok(Some(mut spec)) = self.get_component_spec(&component_id).await {
+                // If the component didn't start yet, the URL will be empty but the spec may contain links.
+                // Populate the URL and store the updated spec.
+                if spec.url.is_empty() {
+                    spec.url = component_ref.to_string();
+                } else if spec.url != component_ref {
+                    // Ensure another actor isn't already running with the same ID
+                    bail!(
+                        "component spec URL does not match component reference: {} != {}",
+                        spec.url,
+                        component_ref
+                    );
+                }
+                spec
+            } else {
+                ComponentSpecification::new(&component_ref)
+            };
+        self.store_component_spec(&component_id, &component_spec)
             .await?;
 
         // Map the imports to pull out the result types of the functions for lookup when invoking them
@@ -2265,7 +2266,7 @@ impl Host {
             nats: Arc::clone(&self.rpc_nats),
             config_data: Arc::new(RwLock::new(config)),
             lattice: self.host_config.lattice.clone(),
-            component_id: actor_id.clone(),
+            component_id: component_id.clone(),
             targets: Arc::default(),
             interface_links: Arc::new(RwLock::new(component_import_links(&component_spec.links))),
             polyfilled_imports: imports,
@@ -2275,16 +2276,16 @@ impl Host {
         let actor = self
             .instantiate_actor(
                 &annotations,
-                actor_ref.clone(),
-                actor_id.clone(),
+                component_ref.clone(),
+                component_id.clone(),
                 max_instances,
                 component.clone(),
                 handler.clone(),
             )
             .await
-            .context("failed to instantiate actor")?;
+            .context("failed to instantiate component")?;
 
-        info!(actor_ref, "actor started");
+        info!(component_ref, "component started");
         self.publish_event(
             "component_scaled",
             event::component_scaled(
@@ -2292,8 +2293,8 @@ impl Host {
                 &annotations,
                 &self.host_key.public_key(),
                 max_instances,
-                &actor_ref,
-                &actor_id,
+                &component_ref,
+                &component_id,
             ),
         )
         .await?;
@@ -2303,7 +2304,7 @@ impl Host {
 
     #[instrument(level = "debug", skip_all)]
     async fn stop_actor(&self, actor: &Actor, host_id: &str) -> anyhow::Result<()> {
-        trace!(actor_id = %actor.id, "stopping actor");
+        trace!(component_id = %actor.id, "stopping component");
 
         actor.calls.abort();
 
@@ -2327,32 +2328,32 @@ impl Host {
     async fn handle_auction_actor(
         &self,
         payload: impl AsRef<[u8]>,
-    ) -> anyhow::Result<Option<CtlResponse<ActorAuctionAck>>> {
-        let ActorAuctionRequest {
-            actor_ref,
-            actor_id,
+    ) -> anyhow::Result<Option<CtlResponse<ComponentAuctionAck>>> {
+        let ComponentAuctionRequest {
+            component_ref,
+            component_id,
             constraints,
         } = serde_json::from_slice(payload.as_ref())
-            .context("failed to deserialize actor auction command")?;
+            .context("failed to deserialize component auction command")?;
 
         info!(
-            actor_ref,
-            actor_id,
+            component_ref,
+            component_id,
             ?constraints,
-            "handling auction for actor"
+            "handling auction for component"
         );
 
         let host_labels = self.labels.read().await;
         let constraints_satisfied = constraints
             .iter()
             .all(|(k, v)| host_labels.get(k).map(|hv| hv == v).unwrap_or(false));
-        let actor_id_running = self.actors.read().await.contains_key(&actor_id);
+        let component_id_running = self.actors.read().await.contains_key(&component_id);
 
         // This host can run the actor if all constraints are satisfied and the actor is not already running
-        if constraints_satisfied && !actor_id_running {
-            Ok(Some(CtlResponse::ok(ActorAuctionAck {
-                actor_ref,
-                actor_id,
+        if constraints_satisfied && !component_id_running {
+            Ok(Some(CtlResponse::ok(ComponentAuctionAck {
+                component_ref,
+                component_id,
                 constraints,
                 host_id: self.host_key.public_key(),
             })))
@@ -2399,17 +2400,20 @@ impl Host {
     }
 
     #[instrument(level = "trace", skip_all)]
-    async fn fetch_actor(&self, actor_ref: &str) -> anyhow::Result<wasmcloud_runtime::Component> {
+    async fn fetch_actor(
+        &self,
+        component_ref: &str,
+    ) -> anyhow::Result<wasmcloud_runtime::Component> {
         let registry_config = self.registry_config.read().await;
         let actor = fetch_actor(
-            actor_ref,
+            component_ref,
             self.host_config.allow_file_load,
             &registry_config,
         )
         .await
-        .context("failed to fetch actor")?;
+        .context("failed to fetch component")?;
         let actor = wasmcloud_runtime::Component::new(&self.runtime, actor)
-            .context("failed to initialize actor")?;
+            .context("failed to initialize component")?;
         Ok(actor)
     }
 
@@ -2447,25 +2451,28 @@ impl Host {
         payload: impl AsRef<[u8]>,
         host_id: &str,
     ) -> anyhow::Result<CtlResponse<()>> {
-        let ScaleActorCommand {
-            actor_ref,
-            actor_id,
+        let ScaleComponentCommand {
+            component_ref,
+            component_id,
             annotations,
             max_instances,
             config,
             ..
         } = serde_json::from_slice(payload.as_ref())
-            .context("failed to deserialize actor scale command")?;
+            .context("failed to deserialize component scale command")?;
 
-        debug!(actor_ref, max_instances, actor_id, "handling scale actor");
+        debug!(
+            component_ref,
+            max_instances, component_id, "handling scale component"
+        );
 
         let host_id = host_id.to_string();
         let annotations: Annotations = annotations.unwrap_or_default().into_iter().collect();
         spawn(async move {
             if let Err(e) = self
                 .handle_scale_actor_task(
-                    &actor_ref,
-                    &actor_id,
+                    &component_ref,
+                    &component_id,
                     &host_id,
                     max_instances,
                     annotations,
@@ -2473,7 +2480,7 @@ impl Host {
                 )
                 .await
             {
-                error!(%actor_ref, %actor_id, err = ?e, "failed to scale actor");
+                error!(%component_ref, %component_id, err = ?e, "failed to scale component");
             }
         });
         Ok(CtlResponse::success())
@@ -2484,32 +2491,38 @@ impl Host {
     /// Supplying `0` will result in stopping that actor instance.
     async fn handle_scale_actor_task(
         &self,
-        actor_ref: &str,
-        actor_id: &str,
+        component_ref: &str,
+        component_id: &str,
         host_id: &str,
         max_instances: u32,
         annotations: Annotations,
         config: Vec<String>,
     ) -> anyhow::Result<()> {
-        trace!(actor_ref, max_instances, "scale actor task");
+        trace!(component_ref, max_instances, "scale component task");
 
-        let actor = self.fetch_actor(actor_ref).await?;
+        let actor = self.fetch_actor(component_ref).await?;
         let claims = actor.claims();
         let resp = self
             .policy_manager
-            .evaluate_start_component(actor_id, actor_ref, max_instances, &annotations, claims)
+            .evaluate_start_component(
+                component_id,
+                component_ref,
+                max_instances,
+                &annotations,
+                claims,
+            )
             .await?;
         if !resp.permitted {
             bail!(
-                "Policy denied request to scale actor `{}`: `{:?}`",
+                "Policy denied request to scale component `{}`: `{:?}`",
                 resp.request_id,
                 resp.message
             )
         };
 
-        let actor_ref = actor_ref.to_string();
+        let component_ref = component_ref.to_string();
         match (
-            self.actors.write().await.entry(actor_id.to_string()),
+            self.actors.write().await.entry(component_id.to_string()),
             NonZeroUsize::new(max_instances as usize),
         ) {
             // No actor is running and we requested to scale to zero, noop
@@ -2525,8 +2538,8 @@ impl Host {
                     .start_actor(
                         entry,
                         actor.clone(),
-                        actor_ref.clone(),
-                        actor_id.to_string(),
+                        component_ref.clone(),
+                        component_id.to_string(),
                         max,
                         annotations.clone(),
                         config,
@@ -2539,8 +2552,8 @@ impl Host {
                             claims,
                             &annotations,
                             host_id,
-                            &actor_ref,
-                            actor_id,
+                            &component_ref,
+                            component_id,
                             max,
                             &e,
                         ),
@@ -2555,7 +2568,7 @@ impl Host {
                 if let Err(err) = self
                     .stop_actor(&actor, host_id)
                     .await
-                    .context("failed to stop actor in response to scale to zero")
+                    .context("failed to stop component in response to scale to zero")
                 {
                     self.publish_event(
                         "component_scale_failed",
@@ -2563,7 +2576,7 @@ impl Host {
                             claims,
                             &actor.annotations,
                             host_id,
-                            actor_ref,
+                            component_ref,
                             &actor.id,
                             actor.max_instances,
                             &err,
@@ -2573,7 +2586,7 @@ impl Host {
                     return Err(err);
                 };
 
-                info!(actor_ref, "actor stopped");
+                info!(component_ref, "component stopped");
                 self.publish_event(
                     "component_scaled",
                     event::component_scaled(
@@ -2602,14 +2615,14 @@ impl Host {
                     let instance = self
                         .instantiate_actor(
                             &annotations,
-                            actor_ref.to_string(),
+                            component_ref.to_string(),
                             actor.id.to_string(),
                             max,
                             actor.component.clone(),
                             handler,
                         )
                         .await
-                        .context("failed to instantiate actor")?;
+                        .context("failed to instantiate component")?;
                     let publish_result = match actor.max_instances.cmp(&max) {
                         std::cmp::Ordering::Less | std::cmp::Ordering::Greater => {
                             self.publish_event(
@@ -2630,9 +2643,9 @@ impl Host {
                     let actor = entry.insert(instance);
                     self.stop_actor(&actor, host_id)
                         .await
-                        .context("failed to stop actor after scaling")?;
+                        .context("failed to stop component after scaling")?;
 
-                    info!(actor_ref, ?max, "actor scaled");
+                    info!(component_ref, ?max, "component scaled");
 
                     // Wait to unwrap the event publish result until after we've processed the instances
                     publish_result?;
@@ -2642,7 +2655,7 @@ impl Host {
         Ok(())
     }
 
-    // TODO(#1548): With actor IDs, new actor references, configuration, etc, we're going to need to do some
+    // TODO(#1548): With component IDs, new actor references, configuration, etc, we're going to need to do some
     // design thinking around how update actor should work. Should it be limited to a single host or latticewide?
     // Should it also update configuration, or is that separate? Should scaling be done via an update?
     #[instrument(level = "debug", skip_all)]
@@ -2651,30 +2664,30 @@ impl Host {
         payload: impl AsRef<[u8]>,
         host_id: &str,
     ) -> anyhow::Result<CtlResponse<()>> {
-        let UpdateActorCommand {
-            actor_id,
+        let UpdateComponentCommand {
+            component_id,
             annotations,
-            new_actor_ref,
+            new_component_ref,
             ..
         } = serde_json::from_slice(payload.as_ref())
-            .context("failed to deserialize actor update command")?;
+            .context("failed to deserialize component update command")?;
 
         debug!(
-            actor_id,
-            new_actor_ref,
+            component_id,
+            new_component_ref,
             ?annotations,
-            "handling update actor"
+            "handling update component"
         );
 
-        let actor_id = actor_id.to_string();
-        let new_actor_ref = new_actor_ref.to_string();
+        let component_id = component_id.to_string();
+        let new_component_ref = new_component_ref.to_string();
         let host_id = host_id.to_string();
         spawn(async move {
             if let Err(e) = self
-                .handle_update_actor_task(&actor_id, &new_actor_ref, &host_id, annotations)
+                .handle_update_actor_task(&component_id, &new_component_ref, &host_id, annotations)
                 .await
             {
-                error!(%new_actor_ref, %actor_id, err = ?e, "failed to update actor");
+                error!(%new_component_ref, %component_id, err = ?e, "failed to update component");
             }
         });
 
@@ -2683,8 +2696,8 @@ impl Host {
 
     async fn handle_update_actor_task(
         &self,
-        actor_id: &str,
-        new_actor_ref: &str,
+        component_id: &str,
+        new_component_ref: &str,
         host_id: &str,
         annotations: Option<HashMap<String, String>>,
     ) -> anyhow::Result<()> {
@@ -2692,10 +2705,10 @@ impl Host {
         // we attempt to grab a write lock.
         let new_actor = {
             let actors = self.actors.read().await;
-            let actor = actors.get(actor_id).context("actor not found")?;
+            let actor = actors.get(component_id).context("component not found")?;
             let annotations = annotations.unwrap_or_default().into_iter().collect();
 
-            let new_actor = self.fetch_actor(new_actor_ref).await?;
+            let new_actor = self.fetch_actor(new_component_ref).await?;
             let new_claims = new_actor.claims();
             if let Some(claims) = new_claims.cloned() {
                 self.store_claims(Claims::Component(claims))
@@ -2709,18 +2722,18 @@ impl Host {
             let Ok(new_actor) = self
                 .instantiate_actor(
                     &annotations,
-                    new_actor_ref.to_string(),
-                    actor_id.to_string(),
+                    new_component_ref.to_string(),
+                    component_id.to_string(),
                     max,
                     new_actor.clone(),
                     handler,
                 )
                 .await
             else {
-                bail!("failed to instantiate actor from new reference");
+                bail!("failed to instantiate component from new reference");
             };
 
-            info!(%new_actor_ref, "actor updated");
+            info!(%new_component_ref, "component updated");
             self.publish_event(
                 "component_scaled",
                 event::component_scaled(
@@ -2728,8 +2741,8 @@ impl Host {
                     &actor.annotations,
                     host_id,
                     max,
-                    new_actor_ref,
-                    actor_id,
+                    new_component_ref,
+                    component_id,
                 ),
             )
             .await?;
@@ -2737,7 +2750,7 @@ impl Host {
             // TODO(#1548): If this errors, we need to rollback
             self.stop_actor(actor, host_id)
                 .await
-                .context("failed to stop old actor")?;
+                .context("failed to stop old component")?;
             self.publish_event(
                 "component_scaled",
                 event::component_scaled(
@@ -2757,7 +2770,7 @@ impl Host {
         self.actors
             .write()
             .await
-            .insert(actor_id.to_string(), new_actor);
+            .insert(component_id.to_string(), new_actor);
         Ok(())
     }
 
@@ -3535,17 +3548,17 @@ impl Host {
         //    should never fail but it's a result we must handle.
         // And finally, the Vec<u8> is the serialized [CtlResponse] that we'll send back to the client
         let ctl_response = match (parts.next(), parts.next(), parts.next(), parts.next()) {
-            // Actor commands
-            (Some("actor"), Some("auction"), None, None) => self
+            // Component commands
+            (Some("component"), Some("auction"), None, None) => self
                 .handle_auction_actor(message.payload)
                 .await
                 .map(serialize_ctl_response),
-            (Some("actor"), Some("scale"), Some(host_id), None) => Arc::clone(&self)
+            (Some("component"), Some("scale"), Some(host_id), None) => Arc::clone(&self)
                 .handle_scale_actor(message.payload, host_id)
                 .await
                 .map(Some)
                 .map(serialize_ctl_response),
-            (Some("actor"), Some("update"), Some(host_id), None) => Arc::clone(&self)
+            (Some("component"), Some("update"), Some(host_id), None) => Arc::clone(&self)
                 .handle_update_actor(message.payload, host_id)
                 .await
                 .map(Some)
@@ -3865,7 +3878,7 @@ impl Host {
         debug!(id, "process component delete");
         // TODO: TBD: stop actor if spec deleted?
         if let Some(_actor) = self.actors.write().await.get(id) {
-            warn!("Component spec deleted but actor {} still running", id);
+            warn!("Component spec deleted but component {} still running", id);
         }
         Ok(())
     }
@@ -4101,7 +4114,7 @@ impl TryFrom<Claims> for StoredClaims {
                     ver,
                     call_alias,
                     ..
-                } = metadata.context("no metadata found on actor claims")?;
+                } = metadata.context("no metadata found on component claims")?;
                 Ok(StoredClaims::Component(StoredComponentClaims {
                     call_alias: call_alias.unwrap_or_default(),
                     issuer,
@@ -4158,7 +4171,7 @@ impl TryFrom<&Claims> for StoredClaims {
                     ..
                 } = metadata
                     .as_ref()
-                    .context("no metadata found on actor claims")?;
+                    .context("no metadata found on component claims")?;
                 Ok(StoredClaims::Component(StoredComponentClaims {
                     call_alias: call_alias.clone().unwrap_or_default(),
                     issuer: issuer.clone(),

--- a/crates/test-util/src/actor.rs
+++ b/crates/test-util/src/actor.rs
@@ -53,7 +53,7 @@ pub async fn assert_start_actor(
     let CtlResponse {
         success, message, ..
     } = ctl_client
-        .scale_actor(
+        .scale_component(
             &host_key.public_key(),
             url.as_ref(),
             actor_id.as_ref(),
@@ -101,7 +101,7 @@ pub async fn assert_scale_actor(
     let CtlResponse {
         success, message, ..
     } = ctl_client
-        .scale_actor(
+        .scale_component(
             &host_key.public_key(),
             url.as_ref(),
             actor_id.as_ref(),

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -63,7 +63,7 @@ wadm = { workspace = true }
 warp = { workspace = true }
 wascap = { workspace = true }
 wash-lib = { workspace = true, features = ["cli", "parser", "nats", "start"] }
-wasmcloud-control-interface = { workspace = true }
+wasmcloud-control-interface = { version = "1.0.0-alpha.2" }
 wasmcloud-core = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true }
 weld-codegen = { workspace = true, features = ["wasmbus"] }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -86,7 +86,7 @@ walkdir = { workspace = true }
 wascap = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmcloud-component-adapters = { workspace = true }
-wasmcloud-control-interface = { workspace = true }
+wasmcloud-control-interface = { version = "1.0.0-alpha.2" }
 wasmcloud-core = { workspace = true, features = [
     "oci-distribution",
     "reqwest",


### PR DESCRIPTION
- **chore(control-interface)!: rename actor to component**
- **chore(host)!: rename ctl actor to component**

## Feature or Problem
This PR renamed the use of `actor` to `component` in the control interface library, and propagates those changes through the host and wash. Note that this doesn't change all code occurrences as those are purely internal, and this PR focuses instead on error messages, NATS topics, and logs.

The notable remaining thing to change from actor to component is the `actor_scaled` and `actor_scale_failed` events.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
Next breaking alpha/rc of wasmcloud and wash

## Consumer Impact
Compatibility with previous alpha versions of wasmCloud and wash will be broken, but it already was with the topic change to include v1 so there shouldn't be too much friction here.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
