### PR TITLE
fix(examples): Add logging to TS deps on 0.82-examples

### DIFF
--- a/examples/typescript/actors/http-hello-world/wit/deps/logging/logging.wit
+++ b/examples/typescript/actors/http-hello-world/wit/deps/logging/logging.wit
@@ -1,0 +1,35 @@
+/// WASI Logging is a logging API intended to let users emit log messages with
+/// simple priority levels and context values.
+interface logging {
+    /// A log level, describing a kind of message.
+    enum level {
+       /// Describes messages about the values of variables and the flow of
+       /// control within a program.
+       trace,
+
+       /// Describes messages likely to be of interest to someone debugging a
+       /// program.
+       debug,
+
+       /// Describes messages likely to be of interest to someone monitoring a
+       /// program.
+       info,
+
+       /// Describes messages indicating hazardous situations.
+       warn,
+
+       /// Describes messages indicating serious errors.
+       error,
+
+       /// Describes messages indicating fatal errors.
+       critical,
+    }
+
+    /// Emit a log message.
+    ///
+    /// A log message has a `level` describing what kind of message is being
+    /// sent, a context, which is an uninterpreted string meant to help
+    /// consumers group similar messages, and a string containing the message
+    /// text.
+    log: func(level: level, context: string, message: string);
+}

--- a/examples/typescript/actors/http-hello-world/wit/deps/logging/world.wit
+++ b/examples/typescript/actors/http-hello-world/wit/deps/logging/world.wit
@@ -1,0 +1,5 @@
+package wasi:logging;
+
+world imports {
+    import logging;
+}


### PR DESCRIPTION
The TypeScript http-hello-world template is missing WIT definitions for wasi:logging and fails on build. This PR fixes the issue on the 0.82-examples branch used by v0.82 docs.