### PR TITLE
feat(*)!: rename actor_scale* events

### DIFF
--- a/crates/control-interface/src/client.rs
+++ b/crates/control-interface/src/client.rs
@@ -621,7 +621,7 @@ impl Client {
     ///                 .timeout(std::time::Duration::from_millis(1000))
     ///                 .auction_timeout(std::time::Duration::from_millis(1000))
     ///                 .build();
-    ///   let mut receiver = client.events_receiver(vec!["actor_scaled".to_string()]).await.unwrap();
+    ///   let mut receiver = client.events_receiver(vec!["component_scaled".to_string()]).await.unwrap();
     ///   while let Some(evt) = receiver.recv().await {
     ///       println!("Event received: {:?}", evt);
     ///   }

--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -35,7 +35,7 @@ fn format_actor_claims(claims: &jwt::Claims<jwt::Component>) -> serde_json::Valu
     }
 }
 
-pub fn actor_scaled(
+pub fn component_scaled(
     claims: Option<&jwt::Claims<jwt::Component>>,
     annotations: &BTreeMap<String, String>,
     host_id: impl AsRef<str>,
@@ -60,11 +60,12 @@ pub fn actor_scaled(
             "image_ref": image_ref.as_ref(),
             "max_instances": max_instances.into(),
             "actor_id": actor_id.as_ref(),
+            "component_id": actor_id.as_ref(),
         })
     }
 }
 
-pub fn actor_scale_failed(
+pub fn component_scale_failed(
     claims: Option<&jwt::Claims<jwt::Component>>,
     annotations: &BTreeMap<String, String>,
     host_id: impl AsRef<str>,

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2286,8 +2286,8 @@ impl Host {
 
         info!(actor_ref, "actor started");
         self.publish_event(
-            "actor_scaled",
-            event::actor_scaled(
+            "component_scaled",
+            event::component_scaled(
                 claims,
                 &annotations,
                 &self.host_key.public_key(),
@@ -2308,8 +2308,8 @@ impl Host {
         actor.calls.abort();
 
         self.publish_event(
-            "actor_scaled",
-            event::actor_scaled(
+            "component_scaled",
+            event::component_scaled(
                 actor.claims(),
                 &actor.annotations,
                 host_id,
@@ -2534,8 +2534,8 @@ impl Host {
                     .await
                 {
                     self.publish_event(
-                        "actor_scale_failed",
-                        event::actor_scale_failed(
+                        "component_scale_failed",
+                        event::component_scale_failed(
                             claims,
                             &annotations,
                             host_id,
@@ -2558,8 +2558,8 @@ impl Host {
                     .context("failed to stop actor in response to scale to zero")
                 {
                     self.publish_event(
-                        "actor_scale_failed",
-                        event::actor_scale_failed(
+                        "component_scale_failed",
+                        event::component_scale_failed(
                             claims,
                             &actor.annotations,
                             host_id,
@@ -2575,8 +2575,8 @@ impl Host {
 
                 info!(actor_ref, "actor stopped");
                 self.publish_event(
-                    "actor_scaled",
-                    event::actor_scaled(
+                    "component_scaled",
+                    event::component_scaled(
                         claims,
                         &actor.annotations,
                         host_id,
@@ -2613,8 +2613,8 @@ impl Host {
                     let publish_result = match actor.max_instances.cmp(&max) {
                         std::cmp::Ordering::Less | std::cmp::Ordering::Greater => {
                             self.publish_event(
-                                "actor_scaled",
-                                event::actor_scaled(
+                                "component_scaled",
+                                event::component_scaled(
                                     actor.claims(),
                                     &actor.annotations,
                                     host_id,
@@ -2722,8 +2722,8 @@ impl Host {
 
             info!(%new_actor_ref, "actor updated");
             self.publish_event(
-                "actor_scaled",
-                event::actor_scaled(
+                "component_scaled",
+                event::component_scaled(
                     new_claims,
                     &actor.annotations,
                     host_id,
@@ -2739,8 +2739,8 @@ impl Host {
                 .await
                 .context("failed to stop old actor")?;
             self.publish_event(
-                "actor_scaled",
-                event::actor_scaled(
+                "component_scaled",
+                event::component_scaled(
                     actor.claims(),
                     &actor.annotations,
                     host_id,

--- a/crates/test-util/src/actor.rs
+++ b/crates/test-util/src/actor.rs
@@ -44,7 +44,7 @@ pub async fn assert_start_actor(
     let ctl_client = ctl_client.into();
 
     let mut receiver = ctl_client
-        .events_receiver(vec!["actor_scaled".into()])
+        .events_receiver(vec!["component_scaled".into()])
         .await
         .map_err(|e| anyhow!(e))?;
 
@@ -91,7 +91,7 @@ pub async fn assert_scale_actor(
     let ctl_client = ctl_client.into();
 
     let mut receiver = ctl_client
-        .events_receiver(vec!["actor_scaled".into()])
+        .events_receiver(vec!["component_scaled".into()])
         .await
         .map_err(|e| anyhow!(e))?;
 

--- a/crates/wash-lib/src/actor.rs
+++ b/crates/wash-lib/src/actor.rs
@@ -7,7 +7,7 @@ use wasmcloud_control_interface::{Client as CtlClient, CtlResponse};
 use crate::{
     common::boxed_err_to_anyhow,
     config::DEFAULT_START_ACTOR_TIMEOUT_MS,
-    wait::{wait_for_actor_scaled_event, FindEventOutcome},
+    wait::{wait_for_component_scaled_event, FindEventOutcome},
 };
 
 /// Information related to a component scale
@@ -69,6 +69,8 @@ pub async fn scale_component(
         .events_receiver(vec![
             "actor_scaled".to_string(),
             "actor_scale_failed".to_string(),
+            "component_scaled".to_string(),
+            "component_scale_failed".to_string(),
         ])
         .await
         .map_err(boxed_err_to_anyhow)
@@ -100,7 +102,7 @@ pub async fn scale_component(
     }
 
     // Wait for the component to start
-    let event = wait_for_actor_scaled_event(
+    let event = wait_for_component_scaled_event(
         &mut receiver,
         Duration::from_millis(timeout_ms),
         host_id.into(),

--- a/crates/wash-lib/src/wait.rs
+++ b/crates/wash-lib/src/wait.rs
@@ -110,7 +110,7 @@ async fn find_event<T>(
 /// with the `FindEventOutcome` enum containing the success or failure state of the event.
 ///
 /// If the timeout is reached or another error occurs, the `Err` variant of the `Result` will be returned.
-pub async fn wait_for_actor_scaled_event(
+pub async fn wait_for_component_scaled_event(
     receiver: &mut Receiver<Event>,
     timeout: Duration,
     host_id: String,
@@ -124,7 +124,7 @@ pub async fn wait_for_actor_scaled_event(
         }
 
         match cloud_event.event_type.as_str() {
-            "com.wasmcloud.lattice.actor_scaled" => {
+            "com.wasmcloud.lattice.component_scaled" | "com.wasmcloud.lattice.actor_scaled" => {
                 let image_ref = get_string_data_from_json(&cloud_event.data, "image_ref")?;
 
                 if image_ref == actor_ref {
@@ -136,7 +136,8 @@ pub async fn wait_for_actor_scaled_event(
                     }));
                 }
             }
-            "com.wasmcloud.lattice.actor_scale_failed" => {
+            "com.wasmcloud.lattice.component_scale_failed"
+            | "com.wasmcloud.lattice.actor_scale_failed" => {
                 let returned_actor_ref = get_string_data_from_json(&cloud_event.data, "image_ref")?;
 
                 if returned_actor_ref == actor_ref {
@@ -335,7 +336,7 @@ pub async fn wait_for_actor_stop_event(
         }
 
         match cloud_event.event_type.as_str() {
-            "com.wasmcloud.lattice.actor_stopped" | "com.wasmcloud.lattice.actor_scaled" => {
+            "com.wasmcloud.lattice.actor_stopped" | "com.wasmcloud.lattice.component_scaled" => {
                 let returned_actor_id = get_string_data_from_json(&cloud_event.data, "public_key")?;
                 if returned_actor_id == actor_id {
                     return Ok(EventCheckOutcome::Success(ActorStoppedInfo {
@@ -345,7 +346,7 @@ pub async fn wait_for_actor_stop_event(
                 }
             }
             "com.wasmcloud.lattice.actor_stop_failed"
-            | "com.wasmcloud.lattice.actor_scale_failed" => {
+            | "com.wasmcloud.lattice.component_scale_failed" => {
                 let returned_actor_id = get_string_data_from_json(&cloud_event.data, "public_key")?;
 
                 if returned_actor_id == actor_id {


### PR DESCRIPTION
## Feature or Problem
This PR renames the `actor_scaled` and `actor_scale_failed` event to `component_scaled` and `component_scale_failed`. It's the last breaking change (that I know of) with the rename that we should do pre-1.0.

In this PR I also adjusted wash + wash-lib to deal with both events to ease the transition.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
Consumers like wadm will need to update their event to instead handle component scaled.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
