### PR TITLE
chore(provider-bindgen): remove contract_id

### DIFF
--- a/crates/provider-lattice-controller/src/lib.rs
+++ b/crates/provider-lattice-controller/src/lib.rs
@@ -30,7 +30,6 @@
 
 // wasmcloud_provider_wit_bindgen::generate!({
 //     impl_struct: LatticeControllerProvider,
-//     contract: "wasmcloud:latticecontrol",
 //     replace_witified_maps: true,
 //     wit_bindgen_cfg: "provider"
 // });

--- a/crates/provider-messaging-kafka/src/lib.rs
+++ b/crates/provider-messaging-kafka/src/lib.rs
@@ -18,7 +18,6 @@ use wasmcloud_provider_wit_bindgen::deps::{
 
 wasmcloud_provider_wit_bindgen::generate!({
     impl_struct: KafkaMessagingProvider,
-    contract: "wasmcloud:messaging",
     wit_bindgen_cfg: "provider-messaging-kafka"
 });
 

--- a/crates/provider-messaging-nats/src/lib.rs
+++ b/crates/provider-messaging-nats/src/lib.rs
@@ -24,7 +24,6 @@ use connection::ConnectionConfig;
 
 wasmcloud_provider_wit_bindgen::generate!({
     impl_struct: NatsMessagingProvider,
-    contract: "wasmcloud:messaging",
     wit_bindgen_cfg: "provider-messaging-nats"
 });
 

--- a/crates/provider-wit-bindgen-macro/src/wit.rs
+++ b/crates/provider-wit-bindgen-macro/src/wit.rs
@@ -381,21 +381,14 @@ pub(crate) fn translate_export_fn_for_lattice(
 /// Note that the lists do not necessarily match, for example an interface with only one method with no arguments,
 /// there is no extra structs that need to be made, but there is one function (the method) that needs to be crafted.
 pub(crate) fn translate_import_fn_for_lattice(
-    iface: &wit_parser::Interface,
-    iface_fn_name: &String,
+    interface_id: &str,
+    iface_name: &str,
+    iface_fn_name: &str,
     iface_fn: &wit_parser::Function,
     cfg: &ProviderBindgenConfig,
 ) -> anyhow::Result<TokenStream> {
     let fn_name = Ident::new(iface_fn_name.to_snake_case().as_str(), Span::call_site());
-    // Derive the WIT instance (<ns>:<pkg>/<iface>) & fn name
-    let iface_name = iface
-        .name
-        .clone()
-        .context("unexpectedly missing iface name")?;
-    let instance_lit_str = LitStr::new(
-        format!("{}/{iface_name}", cfg.contract).as_str(),
-        Span::call_site(),
-    );
+    let instance_lit_str = LitStr::new(interface_id, Span::call_site());
     let fn_name_lit_str = LitStr::new(iface_fn_name, Span::call_site());
 
     // Convert the WIT result type into a Rust type
@@ -404,8 +397,7 @@ pub(crate) fn translate_import_fn_for_lattice(
     } else {
         iface_fn.results.to_rust_type(cfg).with_context(|| {
             format!(
-                "Failed to convert WIT function results (returns) while parsing interface [{}]",
-                iface.name.clone().unwrap_or("<unknown>".into()),
+                "Failed to convert WIT function results (returns) while parsing interface [{iface_name}]",
             )
         })?
     };


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

While we have yet to figure out exactly how we expose WIT related metadata about the provider to the
host (see: https://github.com/wasmCloud/wasmCloud/issues/1780), we won't be needing the wasmcloud contract specific code that was necessary before.

This commit removes `contract_id()` as a requirement for providers.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
