### PR TITLE
Revert "fix(wash-lib): changed the variable name for a cleaner code"

### DIFF
--- a/crates/wash-cli/src/build.rs
+++ b/crates/wash-cli/src/build.rs
@@ -58,7 +58,6 @@ pub async fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
 
     match config.project_type {
         TypeConfig::Actor(ref actor_config) => {
-            print!("Inside wash build of an actor");
             let sign_config = if command.build_only {
                 None
             } else {

--- a/crates/wash-cli/src/build.rs
+++ b/crates/wash-cli/src/build.rs
@@ -58,6 +58,7 @@ pub async fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
 
     match config.project_type {
         TypeConfig::Actor(ref actor_config) => {
+            print!("Inside wash build of an actor");
             let sign_config = if command.build_only {
                 None
             } else {

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -1318,10 +1318,6 @@ mod test {
 
         let project_config = assert_ok!(result);
 
-        let mut expected_default_key_dir = dirs::home_dir()
-            .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
-        expected_default_key_dir.push(".wash/keys");
-
         assert_eq!(
             project_config.language,
             LanguageConfig::Rust(RustConfig {
@@ -1336,7 +1332,7 @@ mod test {
                 vendor: "wayne-industries".into(),
                 os: std::env::consts::OS.to_string(),
                 arch: std::env::consts::ARCH.to_string(),
-                key_directory: expected_default_key_dir,
+                key_directory: PathBuf::from("./keys"),
                 wit_world: Some("wasmcloud:httpserver".to_string()),
                 rust_target: None,
                 bin_name: None,

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -116,7 +116,7 @@ impl TryFrom<RawActorConfig> for ActorConfig {
     type Error = anyhow::Error;
 
     fn try_from(raw_config: RawActorConfig) -> Result<Self, Self::Error> {
-        let key_directory = if let Some(key_directory) = raw_config.key_directory {
+        let key_dir = if let Some(key_directory) = raw_config.key_directory {
             key_directory
         } else {
             let home_dir = dirs::home_dir()
@@ -126,7 +126,7 @@ impl TryFrom<RawActorConfig> for ActorConfig {
         Ok(Self {
             claims: raw_config.claims.unwrap_or_default(),
             push_insecure: raw_config.push_insecure.unwrap_or(false),
-            key_directory,
+            key_directory: key_dir,
             wasm_target: raw_config
                 .wasm_target
                 .map(WasmTarget::from)
@@ -182,7 +182,7 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
     type Error = anyhow::Error;
 
     fn try_from(raw_config: RawProviderConfig) -> Result<Self, Self::Error> {
-        let key_directory = if let Some(key_directory) = raw_config.key_directory {
+        let key_dir = if let Some(key_directory) = raw_config.key_directory {
             key_directory
         } else {
             let home_dir = dirs::home_dir()
@@ -200,7 +200,7 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
             rust_target: raw_config.rust_target,
             bin_name: raw_config.bin_name,
             wit_world: raw_config.wit_world,
-            key_directory,
+            key_directory: key_dir,
         })
     }
 }

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -115,19 +115,14 @@ struct RawActorConfig {
 impl TryFrom<RawActorConfig> for ActorConfig {
     type Error = anyhow::Error;
 
-    fn try_from(raw_config: RawActorConfig) -> Result<Self, Self::Error> {
-        let key_dir = if let Some(key_directory) = raw_config.key_directory {
-            key_directory
-        } else {
-            let home_dir = dirs::home_dir()
-                .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
-            home_dir.join(".wash/keys")
-        };
-        print!("User's key directory: {}", key_dir.display());
+    fn try_from(raw_config: RawActorConfig) -> Result<Self> {
         Ok(Self {
             claims: raw_config.claims.unwrap_or_default(),
             push_insecure: raw_config.push_insecure.unwrap_or(false),
-            key_directory: key_dir,
+            // TODO(#1624): Default to ~/.wash/keys
+            key_directory: raw_config
+                .key_directory
+                .unwrap_or_else(|| PathBuf::from("~/.wash/keys")),
             wasm_target: raw_config
                 .wasm_target
                 .map(WasmTarget::from)
@@ -182,14 +177,7 @@ struct RawProviderConfig {
 impl TryFrom<RawProviderConfig> for ProviderConfig {
     type Error = anyhow::Error;
 
-    fn try_from(raw_config: RawProviderConfig) -> Result<Self, Self::Error> {
-        let key_dir = if let Some(key_directory) = raw_config.key_directory {
-            key_directory
-        } else {
-            let home_dir = dirs::home_dir()
-                .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
-            home_dir.join(".wash/keys")
-        };
+    fn try_from(raw_config: RawProviderConfig) -> Result<Self> {
         Ok(Self {
             vendor: raw_config.vendor.unwrap_or_else(|| "NoVendor".to_string()),
             os: raw_config
@@ -201,7 +189,10 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
             rust_target: raw_config.rust_target,
             bin_name: raw_config.bin_name,
             wit_world: raw_config.wit_world,
-            key_directory: key_dir,
+            // TODO(#1624): Default to ~/.wash/keys
+            key_directory: raw_config
+                .key_directory
+                .unwrap_or_else(|| PathBuf::from("~/.wash/keys")),
         })
     }
 }

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -122,7 +122,7 @@ impl TryFrom<RawActorConfig> for ActorConfig {
             // TODO(#1624): Default to ~/.wash/keys
             key_directory: raw_config
                 .key_directory
-                .unwrap_or_else(|| PathBuf::from("~/.wash/keys")),
+                .unwrap_or_else(|| PathBuf::from("./keys")),
             wasm_target: raw_config
                 .wasm_target
                 .map(WasmTarget::from)
@@ -192,7 +192,7 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
             // TODO(#1624): Default to ~/.wash/keys
             key_directory: raw_config
                 .key_directory
-                .unwrap_or_else(|| PathBuf::from("~/.wash/keys")),
+                .unwrap_or_else(|| PathBuf::from("./keys")),
         })
     }
 }

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -123,6 +123,7 @@ impl TryFrom<RawActorConfig> for ActorConfig {
                 .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
             home_dir.join(".wash/keys")
         };
+        print!("User's key directory: {}", key_dir.display());
         Ok(Self {
             claims: raw_config.claims.unwrap_or_default(),
             push_insecure: raw_config.push_insecure.unwrap_or(false),

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -328,10 +328,6 @@ fn minimal_rust_actor() {
 
     let config = assert_ok!(result);
 
-    let mut expected_key_dir =
-        dirs::home_dir().expect("Unable to determine the user's home directory");
-    expected_key_dir.push(".wash/keys");
-
     assert_eq!(
         config.language,
         LanguageConfig::Rust(RustConfig {
@@ -346,7 +342,7 @@ fn minimal_rust_actor() {
             claims: vec!["wasmcloud:httpserver".to_string()],
 
             push_insecure: false,
-            key_directory: expected_key_dir,
+            key_directory: PathBuf::from("./keys"),
             destination: None,
             call_alias: None,
             wasi_preview2_adapter_path: None,
@@ -381,10 +377,6 @@ fn cargo_toml_actor() {
 
     let config = assert_ok!(result);
 
-    let mut expected_default_key_dir =
-        dirs::home_dir().expect("Unable to determine the user's home directory");
-    expected_default_key_dir.push(".wash/keys");
-
     assert_eq!(
         config.language,
         LanguageConfig::Rust(RustConfig {
@@ -399,7 +391,7 @@ fn cargo_toml_actor() {
             claims: vec!["wasmcloud:httpserver".to_string()],
 
             push_insecure: false,
-            key_directory: expected_default_key_dir,
+            key_directory: PathBuf::from("./keys"),
             destination: None,
             call_alias: None,
             wasi_preview2_adapter_path: None,
@@ -435,16 +427,11 @@ fn minimal_rust_actor_preview2() {
     );
 
     let config = assert_ok!(result);
-
-    let mut expected_default_key_dir =
-        dirs::home_dir().expect("Unable to determine the user's home directory");
-    expected_default_key_dir.push(".wash/keys");
-
     assert_eq!(
         config.project_type,
         TypeConfig::Actor(ActorConfig {
             claims: vec!["wasmcloud:httpserver".to_string()],
-            key_directory: expected_default_key_dir,
+            key_directory: PathBuf::from("./keys"),
             wasm_target: WasmTarget::WasiPreview2,
             wit_world: Some("test-world".to_string()),
             ..Default::default()


### PR DESCRIPTION
This reverts commit edc660d.Reverts wasmCloud/wasmCloud#1685

This was a good change, but it was failing a test. Reverting for now, @siddharthkhonde it should be pretty simple to re-open the change here just with the test fix