### PR TITLE
fix(provider-wit-bindgen): handle TypeDef::Enum(_)

### DIFF
--- a/crates/provider-wit-bindgen-macro/src/wit.rs
+++ b/crates/provider-wit-bindgen-macro/src/wit.rs
@@ -238,8 +238,8 @@ pub(crate) fn convert_wit_typedef(
 
         // For records that we encounter, they will be translated to Rust Structs by bindgen
         // we can pretend the struct exists because by the time the macro is done, it will.
-        TypeDefKind::Record(_) => {
-            let struct_name = format_ident!(
+        TypeDefKind::Enum(_) | TypeDefKind::Record(_) => {
+            let name = format_ident!(
                 "{}",
                 type_def
                     .name
@@ -247,7 +247,7 @@ pub(crate) fn convert_wit_typedef(
                     .context("unexpectedly missing name for typedef")?
                     .to_upper_camel_case()
             );
-            Ok(struct_name.to_token_stream())
+            Ok(name.to_token_stream())
         }
 
         _ => bail!("unsupported type kind {type_def:#?}"),


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

In the handling of TypeDefKinds done in `convert_wit_typedef()` Enum was excluded but should have been handled. Since Enums are very similar to Records, the same handling should work for both.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
