### PR TITLE
fix(wash-cli): re-adding the changes to make sure tests pass sucessfully

### DIFF
--- a/crates/wash-cli/tests/wash_build.rs
+++ b/crates/wash-cli/tests/wash_build.rs
@@ -87,9 +87,16 @@ async fn integration_build_rust_actor_signed_with_signing_keys_directory_configu
         .context("test command failed to run and complete")?;
 
     assert!(output.status.success());
-    let output =
-        String::from_utf8(output.stderr).context("Failed to convert output bytes to String")?;
-    assert!(output.contains(expected_default_key_dir.to_str().unwrap()));
+
+    // Ensure that the key was generated in the default directory
+    let generated_key = expected_default_key_dir.join("http_hello_world_module.nk");
+    assert!(
+        std::fs::metadata(&generated_key).is_ok(),
+        "Key should be present and accessible in ~/.wash/keys"
+    );
+
+    // assert ./keys directory is not created for generated keys
+    assert!(std::fs::metadata(project_dir.join("keys")).is_err());
 
     // case: keys directory configured via cli arg --keys-directory
     let key_directory = project_dir.join("batmankeys").to_string_lossy().to_string();

--- a/crates/wash-cli/tests/wash_build.rs
+++ b/crates/wash-cli/tests/wash_build.rs
@@ -70,6 +70,10 @@ async fn integration_build_rust_actor_signed_with_signing_keys_directory_configu
     env::set_var("RUST_LOG", "debug");
 
     // base case: no keys directory configured
+    let mut expected_default_key_dir = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
+    expected_default_key_dir.push(".wash/keys");
+
     let cmd = Command::new(env!("CARGO_BIN_EXE_wash"))
         .args(["build"])
         .stderr(std::process::Stdio::piped())
@@ -85,7 +89,7 @@ async fn integration_build_rust_actor_signed_with_signing_keys_directory_configu
     assert!(output.status.success());
     let output =
         String::from_utf8(output.stderr).context("Failed to convert output bytes to String")?;
-    assert!(output.contains("hello/keys/http_hello_world_module.nk"));
+    assert!(output.contains(expected_default_key_dir.to_str().unwrap()));
 
     // case: keys directory configured via cli arg --keys-directory
     let key_directory = project_dir.join("batmankeys").to_string_lossy().to_string();

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -1190,6 +1190,10 @@ mod test {
 
         let project_config = assert_ok!(result);
 
+        let mut expected_default_key_dir = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
+        expected_default_key_dir.push(".wash/keys");
+
         assert_eq!(
             project_config.language,
             LanguageConfig::Rust(RustConfig {
@@ -1206,7 +1210,7 @@ mod test {
                     "wasmcloud:httpclient".to_string(),
                     "lexcorp:quantum-simulator".to_string()
                 ],
-                key_directory: PathBuf::from("./keys"),
+                key_directory: expected_default_key_dir,
                 destination: Some(PathBuf::from("./build/testactor.wasm".to_string())),
                 call_alias: Some("test-actor".to_string()),
                 tags: Some(HashSet::from([
@@ -1325,6 +1329,10 @@ mod test {
 
         let project_config = assert_ok!(result);
 
+        let mut expected_default_key_dir = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
+        expected_default_key_dir.push(".wash/keys");
+
         assert_eq!(
             project_config.language,
             LanguageConfig::Rust(RustConfig {
@@ -1339,7 +1347,7 @@ mod test {
                 vendor: "wayne-industries".into(),
                 os: std::env::consts::OS.to_string(),
                 arch: std::env::consts::ARCH.to_string(),
-                key_directory: PathBuf::from("./keys"),
+                key_directory: expected_default_key_dir,
                 wit_world: Some("wasmcloud:httpserver".to_string()),
                 rust_target: None,
                 bin_name: None,

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -1190,10 +1190,6 @@ mod test {
 
         let project_config = assert_ok!(result);
 
-        let mut expected_default_key_dir = dirs::home_dir()
-            .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
-        expected_default_key_dir.push(".wash/keys");
-
         assert_eq!(
             project_config.language,
             LanguageConfig::Rust(RustConfig {
@@ -1210,7 +1206,7 @@ mod test {
                     "wasmcloud:httpclient".to_string(),
                     "lexcorp:quantum-simulator".to_string()
                 ],
-                key_directory: expected_default_key_dir,
+                key_directory: PathBuf::from("./keys"),
                 destination: Some(PathBuf::from("./build/testactor.wasm".to_string())),
                 call_alias: Some("test-actor".to_string()),
                 tags: Some(HashSet::from([

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -117,13 +117,17 @@ impl TryFrom<RawComponentConfig> for ComponentConfig {
     type Error = anyhow::Error;
 
     fn try_from(raw_config: RawComponentConfig) -> Result<Self> {
+        let key_directory = if let Some(key_directory) = raw_config.key_directory {
+            key_directory
+        } else {
+            let home_dir = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
+            home_dir.join(".wash/keys")
+        };
         Ok(Self {
             claims: raw_config.claims.unwrap_or_default(),
             push_insecure: raw_config.push_insecure.unwrap_or(false),
-            // TODO(#1624): Default to ~/.wash/keys
-            key_directory: raw_config
-                .key_directory
-                .unwrap_or_else(|| PathBuf::from("./keys")),
+            key_directory,
             wasm_target: raw_config
                 .wasm_target
                 .map(WasmTarget::from)
@@ -179,6 +183,13 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
     type Error = anyhow::Error;
 
     fn try_from(raw_config: RawProviderConfig) -> Result<Self> {
+        let key_directory = if let Some(key_directory) = raw_config.key_directory {
+            key_directory
+        } else {
+            let home_dir = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("Unable to determine the user's home directory"))?;
+            home_dir.join(".wash/keys")
+        };
         Ok(Self {
             vendor: raw_config.vendor.unwrap_or_else(|| "NoVendor".to_string()),
             os: raw_config
@@ -190,10 +201,7 @@ impl TryFrom<RawProviderConfig> for ProviderConfig {
             rust_target: raw_config.rust_target,
             bin_name: raw_config.bin_name,
             wit_world: raw_config.wit_world,
-            // TODO(#1624): Default to ~/.wash/keys
-            key_directory: raw_config
-                .key_directory
-                .unwrap_or_else(|| PathBuf::from("./keys")),
+            key_directory,
         })
     }
 }

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -328,6 +328,10 @@ fn minimal_rust_actor() {
 
     let config = assert_ok!(result);
 
+    let mut expected_key_dir =
+        dirs::home_dir().expect("Unable to determine the user's home directory");
+    expected_key_dir.push(".wash/keys");
+
     assert_eq!(
         config.language,
         LanguageConfig::Rust(RustConfig {
@@ -342,7 +346,7 @@ fn minimal_rust_actor() {
             claims: vec!["wasmcloud:httpserver".to_string()],
 
             push_insecure: false,
-            key_directory: PathBuf::from("./keys"),
+            key_directory: expected_key_dir,
             destination: None,
             call_alias: None,
             wasi_preview2_adapter_path: None,
@@ -377,6 +381,10 @@ fn cargo_toml_actor() {
 
     let config = assert_ok!(result);
 
+    let mut expected_key_dir =
+        dirs::home_dir().expect("Unable to determine the user's home directory");
+    expected_key_dir.push(".wash/keys");
+
     assert_eq!(
         config.language,
         LanguageConfig::Rust(RustConfig {
@@ -391,7 +399,7 @@ fn cargo_toml_actor() {
             claims: vec!["wasmcloud:httpserver".to_string()],
 
             push_insecure: false,
-            key_directory: PathBuf::from("./keys"),
+            key_directory: expected_key_dir,
             destination: None,
             call_alias: None,
             wasi_preview2_adapter_path: None,
@@ -427,11 +435,16 @@ fn minimal_rust_actor_preview2() {
     );
 
     let config = assert_ok!(result);
+
+    let mut expected_default_key_dir =
+        dirs::home_dir().expect("Unable to determine the user's home directory");
+    expected_default_key_dir.push(".wash/keys");
+
     assert_eq!(
         config.project_type,
         TypeConfig::Component(ComponentConfig {
             claims: vec!["wasmcloud:httpserver".to_string()],
-            key_directory: PathBuf::from("./keys"),
+            key_directory: expected_default_key_dir,
             wasm_target: WasmTarget::WasiPreview2,
             wit_world: Some("test-world".to_string()),
             ..Default::default()


### PR DESCRIPTION
## Feature or Problem
Modified the default key generation directory


## Consumer Impact
Upon actor creation, the keys get generated by default in the user's `$HOME` directory


### Manual Verification
Tested successfully with 2 scenarios - with and without specifying "key_directory" attribute in the wasmcloud.toml of the actor
