### PR TITLE
feat(wash): add feedback message to 1st run message

### DIFF
--- a/crates/wash-cli/src/completions.rs
+++ b/crates/wash-cli/src/completions.rs
@@ -12,11 +12,19 @@ use wash_lib::config::cfg_dir;
 const TOKEN_FILE: &str = ".completion_suggested";
 const COMPLETION_DOC_URL: &str =
     "https://github.com/wasmCloud/wasmCloud/blob/main/crates/wash-cli/Completions.md";
+const SLACK_URL: &str = "https://slack.wasmcloud.com";
 
 fn instructions() -> String {
     format!(
-        "For instructions on setting up auto-complete for your shell, please see '{}'",
+        "🐚 Autocomplete available! To configure autocomplete with your shell, follow the instructions at\n   {}",
         COMPLETION_DOC_URL
+    )
+}
+
+fn feedback() -> String {
+    format!(
+        "📝 Feedback wanted! If you want to suggest an improvement or would like assistance, join the community at\n   {}",
+        SLACK_URL
     )
 }
 
@@ -57,8 +65,9 @@ pub fn first_run_suggestion() -> Result<Option<String>> {
         )
     })?;
     Ok(Some(format!(
-        "Congratulations on installing wash!  Shell auto-complete is available. {}",
-        instructions()
+        "Congratulations on installing wash!\n\n{}\n\n{}",
+        instructions(),
+        feedback(),
     )))
 }
 


### PR DESCRIPTION
## Feature or Problem
Adjust message on first run of `wash` to include callout to check out the slack community.

## Release Information
`next`

## Consumer Impact
No impact here since it's just developer messaging.

## Testing
This is what the message looks like now:
<img width="759" alt="Screenshot 2024-04-08 at 4 33 46 PM" src="https://github.com/wasmCloud/wasmCloud/assets/1687902/ad51602f-b51d-4ea7-9f6e-feeda404e965">
