### PR TITLE
fix(wash-cli): use config version in error output

### DIFF
--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -430,7 +430,8 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
                 }
             }
             Err(e) => {
-                eprintln!("🟨 Couldn't download wadm {WADM_VERSION}: {e}");
+                let wadm_version: String = cmd.wadm_opts.wadm_version.clone();
+                eprintln!("🟨 Couldn't download wadm {wadm_version}: {e}");
                 None
             }
         }


### PR DESCRIPTION
## Feature or Problem
Error output was using the static version for wadm even when `--wadm-version` is set.

## Related Issues
None

## Release Information
`next`

## Consumer Impact
Better DX