### PR TITLE
fix(wash): use config option when getting project config

### DIFF
--- a/crates/wash-lib/src/cli/registry.rs
+++ b/crates/wash-lib/src/cli/registry.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 
 #[derive(Parser, Debug, Clone)]
@@ -80,7 +82,7 @@ pub struct RegistryPushCommand {
 
     /// Path to config file, if omitted will default to a blank configuration
     #[clap(short = 'c', long = "config")]
-    pub config: Option<String>,
+    pub config: Option<PathBuf>,
 
     /// Allow latest artifact tags
     #[clap(long = "allow-latest")]


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit fixes the `wash push` command to ensure it uses the `--config` switch if provided when looking up project config.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
