### PR TITLE
Prepare wash 0.27.0-alpha.2 for wasmCloud 1.0 release candidate testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5263,8 +5263,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wadm"
-version = "0.11.0-alpha.1"
-source = "git+https://github.com/wasmcloud/wadm?branch=chore/v0.11.0-alpha.1#1068dc35ea1918f08ad9e9326ad7e1be0d3549dc"
+version = "0.11.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86a2fc81038e2d2a90c30a49237973224ee76ed0b11d0d714d027798ad5eb565"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5290,7 +5291,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "uuid",
- "wasmcloud-control-interface 1.0.0-alpha.3 (git+https://github.com/wasmcloud/wasmcloud?branch=main)",
+ "wasmcloud-control-interface 1.0.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5358,23 +5359,25 @@ dependencies = [
 [[package]]
 name = "wascap"
 version = "0.13.0"
-source = "git+https://github.com/wasmcloud/wasmcloud?branch=main#804d67665fac39c08a536b0902a65a85035e685e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "802ee1beca185fd4d61bcfd937360d1dddacc88fefa39b08209e875d99c95711"
 dependencies = [
  "data-encoding",
  "humantime",
+ "log",
  "nkeys",
  "nuid 0.4.1",
  "ring",
  "serde",
  "serde_json",
- "wasm-encoder 0.202.0",
+ "wasm-encoder 0.41.2",
  "wasm-gen",
- "wasmparser 0.202.0",
+ "wasmparser 0.121.2",
 ]
 
 [[package]]
 name = "wash-cli"
-version = "0.27.0-alpha.1"
+version = "0.27.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -5428,13 +5431,13 @@ dependencies = [
  "wasmcloud-provider-sdk",
  "weld-codegen",
  "which",
- "wrpc-transport",
- "wrpc-types",
+ "wrpc-transport 0.24.2",
+ "wrpc-types 0.6.0",
 ]
 
 [[package]]
 name = "wash-lib"
-version = "0.19.0"
+version = "0.20.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -5572,6 +5575,15 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
+version = "0.41.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972f97a5d8318f908dded23594188a90bcd09365986b1163e66d70170e5287ae"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9c7d2731df60006819b013f64ccc2019691deccf6e11a1804bc850cd6748f1a"
@@ -5676,9 +5688,9 @@ dependencies = [
  "wasmcloud-test-util",
  "wasmcloud-tracing",
  "wrpc-interface-http",
- "wrpc-transport",
- "wrpc-transport-nats",
- "wrpc-types",
+ "wrpc-transport 0.24.2",
+ "wrpc-transport-nats 0.21.0",
+ "wrpc-types 0.6.0",
 ]
 
 [[package]]
@@ -5738,7 +5750,8 @@ dependencies = [
 [[package]]
 name = "wasmcloud-control-interface"
 version = "1.0.0-alpha.3"
-source = "git+https://github.com/wasmcloud/wasmcloud?branch=main#804d67665fac39c08a536b0902a65a85035e685e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc87e84c68d31d65d4070cf70548f5d27e2c9c75d2768ea52ce60416c048e9a6"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5754,7 +5767,35 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
- "wasmcloud-core 0.5.0 (git+https://github.com/wasmcloud/wasmcloud?branch=main)",
+ "wasmcloud-core 0.4.0",
+]
+
+[[package]]
+name = "wasmcloud-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9384bec7161ea7763f6665c49b9282323065e3edd0247cca9f679180bd14d86"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "bytes",
+ "futures",
+ "hex",
+ "nkeys",
+ "once_cell",
+ "rustls 0.23.4",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "tokio",
+ "tower",
+ "tracing",
+ "ulid",
+ "uuid",
+ "wascap 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wrpc-transport 0.22.0",
+ "wrpc-transport-nats 0.19.0",
 ]
 
 [[package]]
@@ -5785,35 +5826,8 @@ dependencies = [
  "uuid",
  "wascap 0.13.0",
  "webpki-roots 0.26.1",
- "wrpc-transport",
- "wrpc-transport-nats",
-]
-
-[[package]]
-name = "wasmcloud-core"
-version = "0.5.0"
-source = "git+https://github.com/wasmcloud/wasmcloud?branch=main#804d67665fac39c08a536b0902a65a85035e685e"
-dependencies = [
- "anyhow",
- "async-nats",
- "async-trait",
- "bytes",
- "futures",
- "hex",
- "nkeys",
- "once_cell",
- "rustls 0.23.4",
- "serde",
- "serde_bytes",
- "sha2",
- "tokio",
- "tower",
- "tracing",
- "ulid",
- "uuid",
- "wascap 0.13.0 (git+https://github.com/wasmcloud/wasmcloud?branch=main)",
- "wrpc-transport",
- "wrpc-transport-nats",
+ "wrpc-transport 0.24.2",
+ "wrpc-transport-nats 0.21.0",
 ]
 
 [[package]]
@@ -5857,9 +5871,9 @@ dependencies = [
  "wrpc-interface-blobstore",
  "wrpc-interface-http",
  "wrpc-interface-keyvalue",
- "wrpc-transport",
- "wrpc-transport-nats",
- "wrpc-types",
+ "wrpc-transport 0.24.2",
+ "wrpc-transport-nats 0.21.0",
+ "wrpc-types 0.6.0",
 ]
 
 [[package]]
@@ -5887,7 +5901,7 @@ dependencies = [
  "tracing",
  "wasmcloud-provider-sdk",
  "wrpc-interface-blobstore",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
 ]
 
 [[package]]
@@ -5912,7 +5926,7 @@ dependencies = [
  "tracing",
  "wasmcloud-provider-sdk",
  "wrpc-interface-blobstore",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
 ]
 
 [[package]]
@@ -5927,7 +5941,7 @@ dependencies = [
  "tracing",
  "wasmcloud-provider-sdk",
  "wrpc-interface-http",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
 ]
 
 [[package]]
@@ -5973,7 +5987,7 @@ dependencies = [
  "wasmcloud-provider-sdk",
  "wasmcloud-test-util",
  "wrpc-interface-keyvalue",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
 ]
 
 [[package]]
@@ -5994,7 +6008,7 @@ dependencies = [
  "vaultrs",
  "wasmcloud-provider-sdk",
  "wrpc-interface-keyvalue",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
 ]
 
 [[package]]
@@ -6074,9 +6088,9 @@ dependencies = [
  "wrpc-interface-blobstore",
  "wrpc-interface-http",
  "wrpc-interface-keyvalue",
- "wrpc-transport",
- "wrpc-transport-nats",
- "wrpc-types",
+ "wrpc-transport 0.24.2",
+ "wrpc-transport-nats 0.21.0",
+ "wrpc-types 0.6.0",
 ]
 
 [[package]]
@@ -6111,8 +6125,8 @@ dependencies = [
  "wit-component",
  "wit-parser 0.202.0",
  "wrpc-runtime-wasmtime",
- "wrpc-transport",
- "wrpc-types",
+ "wrpc-transport 0.24.2",
+ "wrpc-types 0.6.0",
 ]
 
 [[package]]
@@ -6152,6 +6166,17 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "wasmcloud-core 0.5.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
+dependencies = [
+ "bitflags 2.5.0",
+ "indexmap 2.2.6",
+ "semver",
 ]
 
 [[package]]
@@ -6948,7 +6973,7 @@ dependencies = [
  "tokio",
  "tracing",
  "wit-bindgen-wrpc-rust-macro",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
 ]
 
 [[package]]
@@ -7042,7 +7067,7 @@ dependencies = [
  "bytes",
  "futures",
  "tracing",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
 ]
 
 [[package]]
@@ -7063,7 +7088,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "wasmtime-wasi-http",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
 ]
 
 [[package]]
@@ -7076,7 +7101,7 @@ dependencies = [
  "bytes",
  "futures",
  "tracing",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
 ]
 
 [[package]]
@@ -7090,7 +7115,26 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
+]
+
+[[package]]
+name = "wrpc-transport"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551cf90e43a1a331ec13af1ad244c9605956fd2c3d535ff857f5978ae963518"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "bytes",
+ "futures",
+ "leb128",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "wrpc-types 0.5.0",
 ]
 
 [[package]]
@@ -7109,7 +7153,23 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tracing",
- "wrpc-types",
+ "wrpc-types 0.6.0",
+]
+
+[[package]]
+name = "wrpc-transport-nats"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d7401a0771e00936b57519e5c1627a174ae05d979a5f8a961e264f0e6f99f1"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "bytes",
+ "futures",
+ "tokio",
+ "tower",
+ "tracing",
+ "wrpc-transport 0.22.0",
 ]
 
 [[package]]
@@ -7125,7 +7185,18 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "wrpc-transport",
+ "wrpc-transport 0.24.2",
+]
+
+[[package]]
+name = "wrpc-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052dd3b6e5a936407695801656660badc5d0ddeaff482ac266669bfd47e6457e"
+dependencies = [
+ "anyhow",
+ "tracing",
+ "wit-parser 0.201.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,16 +3132,6 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk 0.20.0",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
@@ -3163,8 +3153,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c4bd073648dae8ac45cfc81588d74b3dc5f334119ac08567ddcbfe16f2d809"
 dependencies = [
  "once_cell",
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.2",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -3179,7 +3169,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 0.2.12",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "reqwest",
 ]
 
@@ -3188,10 +3178,10 @@ name = "opentelemetry-nats"
 version = "0.1.0"
 dependencies = [
  "async-nats",
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.2",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "tracing",
- "tracing-opentelemetry 0.22.0",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -3203,11 +3193,11 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http 0.2.12",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.21.2",
+ "opentelemetry_sdk",
  "prost",
  "reqwest",
  "thiserror",
@@ -3221,8 +3211,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.2",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
 ]
@@ -3233,42 +3223,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
- "opentelemetry 0.21.0",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api",
- "ordered-float 3.9.2",
- "percent-encoding",
- "rand",
- "thiserror",
+ "opentelemetry",
 ]
 
 [[package]]
@@ -3284,23 +3239,14 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.21.0",
- "ordered-float 4.2.0",
+ "opentelemetry",
+ "ordered-float",
  "percent-encoding",
  "rand",
  "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "ordered-float"
-version = "3.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -3616,7 +3562,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tar",
- "wascap",
+ "wascap 0.13.0",
 ]
 
 [[package]]
@@ -4684,7 +4630,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-component-adapters",
  "wit-component",
 ]
@@ -5110,27 +5056,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc09e402904a5261e42cf27aea09ccb7d5318c6717a9eec3d8e2e65c56b18f19"
-dependencies = [
- "once_cell",
- "opentelemetry 0.20.0",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.2",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -5330,9 +5263,8 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wadm"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde964607c5c094365ba1694d1213f6db06b101213cc3c83e289489f53725517"
+version = "0.11.0-alpha.1"
+source = "git+https://github.com/wasmcloud/wadm?branch=chore/v0.11.0-alpha.1#1068dc35ea1918f08ad9e9326ad7e1be0d3549dc"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5358,7 +5290,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "uuid",
- "wasmcloud-control-interface 0.32.1",
+ "wasmcloud-control-interface 1.0.0-alpha.3 (git+https://github.com/wasmcloud/wasmcloud?branch=main)",
 ]
 
 [[package]]
@@ -5424,6 +5356,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "wascap"
+version = "0.13.0"
+source = "git+https://github.com/wasmcloud/wasmcloud?branch=main#804d67665fac39c08a536b0902a65a85035e685e"
+dependencies = [
+ "data-encoding",
+ "humantime",
+ "nkeys",
+ "nuid 0.4.1",
+ "ring",
+ "serde",
+ "serde_json",
+ "wasm-encoder 0.202.0",
+ "wasm-gen",
+ "wasmparser 0.202.0",
+]
+
+[[package]]
 name = "wash-cli"
 version = "0.27.0-alpha.1"
 dependencies = [
@@ -5472,10 +5421,10 @@ dependencies = [
  "url",
  "wadm",
  "warp",
- "wascap",
+ "wascap 0.13.0",
  "wash-lib",
  "wasmcloud-control-interface 1.0.0-alpha.3",
- "wasmcloud-core",
+ "wasmcloud-core 0.5.0",
  "wasmcloud-provider-sdk",
  "weld-codegen",
  "which",
@@ -5535,11 +5484,11 @@ dependencies = [
  "url",
  "wadm",
  "walkdir",
- "wascap",
+ "wascap 0.13.0",
  "wasm-encoder 0.202.0",
  "wasmcloud-component-adapters",
  "wasmcloud-control-interface 1.0.0-alpha.3",
- "wasmcloud-core",
+ "wasmcloud-core 0.5.0",
  "wasmparser 0.202.0",
  "wat",
  "weld-codegen",
@@ -5710,9 +5659,9 @@ dependencies = [
  "url",
  "uuid",
  "vaultrs",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-control-interface 1.0.0-alpha.3",
- "wasmcloud-core",
+ "wasmcloud-core 0.5.0",
  "wasmcloud-host",
  "wasmcloud-provider-blobstore-fs",
  "wasmcloud-provider-blobstore-s3",
@@ -5767,26 +5716,6 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158ad8ec71616b82465ba2eb3f6a431a9b5a6c1b59630ec10730924b6019f806"
-dependencies = [
- "anyhow",
- "async-nats",
- "bytes",
- "cloudevents-sdk",
- "futures",
- "oci-distribution",
- "opentelemetry 0.20.0",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-opentelemetry 0.20.0",
-]
-
-[[package]]
-name = "wasmcloud-control-interface"
 version = "1.0.0-alpha.3"
 dependencies = [
  "anyhow",
@@ -5796,14 +5725,36 @@ dependencies = [
  "cloudevents-sdk",
  "futures",
  "oci-distribution",
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.2",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "tracing-opentelemetry 0.22.0",
- "wasmcloud-core",
+ "tracing-opentelemetry",
+ "wasmcloud-core 0.5.0",
+]
+
+[[package]]
+name = "wasmcloud-control-interface"
+version = "1.0.0-alpha.3"
+source = "git+https://github.com/wasmcloud/wasmcloud?branch=main#804d67665fac39c08a536b0902a65a85035e685e"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "bytes",
+ "cloudevents-sdk",
+ "futures",
+ "oci-distribution",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "wasmcloud-core 0.5.0 (git+https://github.com/wasmcloud/wasmcloud?branch=main)",
 ]
 
 [[package]]
@@ -5832,8 +5783,35 @@ dependencies = [
  "tracing",
  "ulid",
  "uuid",
- "wascap",
+ "wascap 0.13.0",
  "webpki-roots 0.26.1",
+ "wrpc-transport",
+ "wrpc-transport-nats",
+]
+
+[[package]]
+name = "wasmcloud-core"
+version = "0.5.0"
+source = "git+https://github.com/wasmcloud/wasmcloud?branch=main#804d67665fac39c08a536b0902a65a85035e685e"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "bytes",
+ "futures",
+ "hex",
+ "nkeys",
+ "once_cell",
+ "rustls 0.23.4",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "tokio",
+ "tower",
+ "tracing",
+ "ulid",
+ "uuid",
+ "wascap 0.13.0 (git+https://github.com/wasmcloud/wasmcloud?branch=main)",
  "wrpc-transport",
  "wrpc-transport-nats",
 ]
@@ -5870,9 +5848,9 @@ dependencies = [
  "ulid",
  "url",
  "uuid",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-control-interface 1.0.0-alpha.3",
- "wasmcloud-core",
+ "wasmcloud-core 0.5.0",
  "wasmcloud-runtime",
  "wasmcloud-tracing",
  "wasmtime-wasi-http",
@@ -6027,7 +6005,7 @@ dependencies = [
  "async-nats",
  "tokio",
  "tracing",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-control-interface 1.0.0-alpha.3",
 ]
 
@@ -6053,7 +6031,7 @@ dependencies = [
  "async-nats",
  "bytes",
  "futures",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "opentelemetry-nats",
  "rustls-pemfile 2.1.2",
  "serde",
@@ -6061,8 +6039,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry 0.22.0",
- "wascap",
+ "tracing-opentelemetry",
+ "wascap 0.13.0",
  "wasmcloud-provider-sdk",
  "wit-bindgen-wrpc",
 ]
@@ -6078,7 +6056,7 @@ dependencies = [
  "futures",
  "nkeys",
  "once_cell",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "rmp-serde",
  "serde",
  "serde_bytes",
@@ -6088,10 +6066,10 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry 0.22.0",
+ "tracing-opentelemetry",
  "ulid",
  "uuid",
- "wasmcloud-core",
+ "wasmcloud-core 0.5.0",
  "wasmcloud-tracing",
  "wrpc-interface-blobstore",
  "wrpc-interface-http",
@@ -6122,10 +6100,10 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-actor",
  "wasmcloud-component-adapters",
- "wasmcloud-core",
+ "wasmcloud-core 0.5.0",
  "wasmparser 0.202.0",
  "wasmtime",
  "wasmtime-wasi",
@@ -6152,7 +6130,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "wascap",
+ "wascap 0.13.0",
  "wasmcloud-control-interface 1.0.0-alpha.3",
  "wasmcloud-host",
 ]
@@ -6164,16 +6142,16 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "once_cell",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.21.2",
+ "opentelemetry_sdk",
  "serde",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry 0.22.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
- "wasmcloud-core",
+ "wasmcloud-core 0.5.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,12 +267,12 @@ walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
 wascap = { version = "0.13", path = "./crates/wascap", default-features = false }
 wash-cli = { version = "0", path = "./crates/wash-cli", default-features = false }
-wash-lib = { version = "0.19", path = "./crates/wash-lib", default-features = false }
+wash-lib = { version = "0.20.0-alpha.1", path = "./crates/wash-lib", default-features = false }
 wasm-encoder = { version = "0.202", default-features = false }
 wasm-gen = { version = "0.1", default-features = false }
 wasmcloud-actor = { version = "0", path = "./crates/actor", default-features = false }
 wasmcloud-component-adapters = { version = "0.9", default-features = false }
-wasmcloud-control-interface = { version = "1.0.0-alpha.1", path = "./crates/control-interface", default-features = false }
+wasmcloud-control-interface = { version = "1.0.0-alpha.3", path = "./crates/control-interface", default-features = false }
 wasmcloud-core = { version = "0.5", path = "./crates/core", default-features = false }
 wasmcloud-host = { version = "0", path = "./crates/host", default-features = false }
 wasmcloud-provider-blobstore-fs = { version = "*", path = "./crates/provider-blobstore-fs", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ ulid = { version = "1", default-features = false }
 url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
-wadm = { version = "0.10", default-features = false }
+wadm = { version = "0.11.0-alpha.2", default-features = false }
 walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
 wascap = { version = "0.13", path = "./crates/wascap", default-features = false }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.27.0-alpha.1"
+version = "0.27.0-alpha.2"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) CLI tool"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-cli/src/build.rs
+++ b/crates/wash-cli/src/build.rs
@@ -72,7 +72,7 @@ pub async fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
                 })
             };
 
-            let actor_path = if command.sign_only {
+            let component_path = if command.sign_only {
                 std::env::set_current_dir(&config.common.path)?;
                 let actor_wasm_path = if let Some(path) = actor_config.build_artifact.clone() {
                     path
@@ -92,17 +92,17 @@ pub async fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
             };
 
             let json_output = HashMap::from([
-                ("actor_path".to_string(), json!(actor_path)),
+                ("component_path".to_string(), json!(component_path)),
                 ("built".to_string(), json!(!command.sign_only)),
                 ("signed".to_string(), json!(!command.build_only)),
             ]);
             Ok(CommandOutput::new(
                 if command.build_only {
-                    format!("Actor built and can be found at {actor_path:?}")
+                    format!("Component built and can be found at {component_path:?}")
                 } else if command.sign_only {
-                    format!("Actor signed and can be found at {actor_path:?}")
+                    format!("Component signed and can be found at {component_path:?}")
                 } else {
-                    format!("Actor built and signed and can be found at {actor_path:?}")
+                    format!("Component built and signed and can be found at {component_path:?}")
                 },
                 json_output,
             ))

--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -9,9 +9,9 @@ pub const NATS_SERVER_VERSION: &str = "v2.10.7";
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
 // wadm configuration values
-pub const WADM_VERSION: &str = "v0.10.0";
+pub const WADM_VERSION: &str = "v0.11.0-alpha.2";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub const WASMCLOUD_HOST_VERSION: &str = "v1.0.0-alpha.5";
+pub const WASMCLOUD_HOST_VERSION: &str = "v1.0.0-rc.1";
 // NATS isolation configuration variables
 pub const WASMCLOUD_LATTICE: &str = "WASMCLOUD_LATTICE";
 pub const DEFAULT_LATTICE: &str = "default";

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.19.0"
+version = "0.20.0-alpha.1"
 categories = ["wasm", "wasmcloud"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]


### PR DESCRIPTION
## Feature or Problem
This PR bumps a couple of crates (control-interface, wash-lib, wadm, wash-cli) in preparation for release candidate testing. Largely these components were compatible with each other already, with the exception of wadm, but this PR brings them all together in the same `wash` bundle for easy testing.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wash-lib v0.20.0-alpha.1
wash-cli v0.27.0-alpha.2

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
