### PR TITLE
fix(wash): registry image URL parsing

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -81,7 +81,8 @@ jobs:
     strategy:
       matrix:
         wash-version:
-          - 0.26.0
+          # TODO: Use this once 0.27.0 is released
+          # - 0.26.0
           - current
         template:
           - hello-world-rust

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -392,7 +392,7 @@ pub fn get_config(opt_path: Option<PathBuf>, use_env: Option<bool>) -> Result<Pr
     let (project_path, wasmcloud_path) = if path.is_dir() {
         let wasmcloud_path = path.join("wasmcloud.toml");
         if !wasmcloud_path.is_file() {
-            bail!("no wasmcloud.toml file found in {}", path.display());
+            bail!("failed to find wasmcloud.toml in [{}]", path.display());
         }
         (path, wasmcloud_path)
     } else if path.is_file() {
@@ -404,7 +404,7 @@ pub fn get_config(opt_path: Option<PathBuf>, use_env: Option<bool>) -> Result<Pr
         )
     } else {
         bail!(
-            "unrecognized path [{}] (neither directory nor file)",
+            "failed to find wasmcloud.toml: path [{}] is not a directory or file",
             path.display()
         );
     };

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -403,7 +403,10 @@ pub fn get_config(opt_path: Option<PathBuf>, use_env: Option<bool>) -> Result<Pr
             path,
         )
     } else {
-        bail!("no wasmcloud.toml file found in {}", path.display());
+        bail!(
+            "unrecognized path [{}] (neither directory nor file)",
+            path.display()
+        );
     };
 
     let mut config = Config::builder().add_source(config::File::from(wasmcloud_path.clone()));

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -266,7 +266,7 @@ fn folder_path_with_no_config() {
     let err = assert_err!(result);
     assert_eq!(
         format!(
-            "no wasmcloud.toml file found in {}",
+            "failed to find wasmcloud.toml in [{}]",
             get_full_path("./tests/parser/files/noconfig")
         ),
         err.to_string().as_str()


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

When URLs are submitted to `wash push` as the first argument, unless a `--registry` is provided, the URL is parsed as an
`oci_distribution::Reference`.

It is possible for a URL like `ghcr.io/wasmCloud/img:v0.1.0` to correctly parse *yet* fail the the `url == image.whole()` test, because the lowercasing of the *supplied* URL was not used throughout `resolve_artifact_ref()`.

This commit performs the lowercasing of the URL and registry (if supplied) consistently in `resolve_artifact_ref()`, ensuring that the comparison works, and `oci_distribution::Reference`s that correctly parse are used.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
