### PR TITLE
Washboard and websockets

### DIFF
--- a/crates/wash-cli/src/ui/mod.rs
+++ b/crates/wash-cli/src/ui/mod.rs
@@ -34,7 +34,8 @@ pub async fn handle_command(command: UiCommand, output_kind: OutputKind) -> Resu
 }
 
 pub async fn handle_ui(cmd: UiCommand, _output_kind: OutputKind) -> Result<()> {
-    let washboard_assets = ensure_washboard(&cmd.version, downloads_dir()?).await?;
+    let washboard_path = downloads_dir()?.join("washboard");
+    let washboard_assets = ensure_washboard(&cmd.version, washboard_path).await?;
     let static_files = warp::fs::dir(washboard_assets);
 
     let cors = warp::cors()

--- a/crates/wash-cli/src/ui/mod.rs
+++ b/crates/wash-cli/src/ui/mod.rs
@@ -14,7 +14,7 @@ use wash_lib::{
 };
 use wasmcloud_core::tls;
 
-const DEFAULT_WASHBOARD_VERSION: &str = "v0.1.0";
+const DEFAULT_WASHBOARD_VERSION: &str = "v0.2.1";
 
 #[derive(Parser, Debug, Clone)]
 pub struct UiCommand {

--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -8,6 +8,7 @@ use crate::up::{credsfile::parse_credsfile, WasmcloudOpts};
 pub const NATS_SERVER_VERSION: &str = "v2.10.7";
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
+pub const DEFAULT_NATS_WEBSOCKET_PORT: &str = "4223";
 // wadm configuration values
 pub const WADM_VERSION: &str = "v0.11.0-alpha.2";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -92,7 +92,7 @@ pub struct NatsOpts {
     #[clap(
         long = "nats-websocket-port",
         env = "NATS_WEBSOCKET_PORT",
-        default_value_t = 4001
+        default_value = DEFAULT_NATS_WEBSOCKET_PORT
     )]
     pub nats_websocket_port: u16,
 
@@ -118,7 +118,7 @@ impl From<NatsOpts> for NatsConfig {
             js_domain: other.nats_js_domain,
             remote_url: other.nats_remote_url,
             credentials: other.nats_credsfile,
-            websocket_port: Some(other.nats_websocket_port),
+            websocket_port: other.nats_websocket_port,
         }
     }
 }
@@ -370,7 +370,7 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
             js_domain: cmd.nats_opts.nats_js_domain,
             remote_url: cmd.nats_opts.nats_remote_url,
             credentials: cmd.nats_opts.nats_credsfile.clone(),
-            websocket_port: Some(cmd.nats_opts.nats_websocket_port),
+            websocket_port: cmd.nats_opts.nats_websocket_port,
         };
         start_nats(&install_dir, &nats_binary, nats_config).await?;
         Some(nats_binary)
@@ -609,9 +609,7 @@ async fn run_wasmcloud_interactive(
 
     if output_kind != OutputKind::Json {
         println!("🏃 Running in interactive mode.",);
-        println!(
-            "🎛️  If you enabled --nats-websocket-port, start the dashboard by executing `wash ui`"
-        );
+        println!("🎛️ To start the dashboard, run `wash ui`");
         println!("🚪 Press `CTRL+c` at any time to exit");
     }
 

--- a/crates/wash-lib/src/start/nats.rs
+++ b/crates/wash-lib/src/start/nats.rs
@@ -124,7 +124,7 @@ pub struct NatsConfig {
     pub js_domain: Option<String>,
     pub remote_url: Option<String>,
     pub credentials: Option<PathBuf>,
-    pub websocket_port: Option<u16>,
+    pub websocket_port: u16,
 }
 
 /// Returns a standalone NATS config with the following values:
@@ -133,6 +133,7 @@ pub struct NatsConfig {
 /// * `js_domain`: `Some("core")`
 /// * `remote_url`: `None`
 /// * `credentials`: `None`
+/// * `websocket_port`: `4223`
 impl Default for NatsConfig {
     fn default() -> Self {
         NatsConfig {
@@ -142,7 +143,7 @@ impl Default for NatsConfig {
             js_domain: Some("core".to_string()),
             remote_url: None,
             credentials: None,
-            websocket_port: None,
+            websocket_port: 4223,
         }
     }
 }
@@ -166,7 +167,7 @@ impl NatsConfig {
         js_domain: Option<String>,
         remote_url: String,
         credentials: PathBuf,
-        websocket_port: Option<u16>,
+        websocket_port: u16,
     ) -> Self {
         NatsConfig {
             host: host.to_owned(),
@@ -225,17 +226,15 @@ leafnodes {{
         } else {
             String::new()
         };
-        let websocket_section = match self.websocket_port {
-            Some(port) => format!(
-                r#"
+        let websocket_port = self.websocket_port;
+        let websocket_section = format!(
+            r#"
 websocket {{
-    port: {port}
+    port: {websocket_port}
     no_tls: true
 }}
                 "#
-            ),
-            _ => String::new(),
-        };
+        );
         let config = format!(
             r#"
 jetstream {{
@@ -444,7 +443,7 @@ mod test {
             None,
             "connect.ngs.global".to_string(),
             creds.clone(),
-            Some(4204),
+            4204,
         );
 
         config.write_to_path(creds.clone()).await?;

--- a/examples/docker/docker-compose-websockets.yml
+++ b/examples/docker/docker-compose-websockets.yml
@@ -1,5 +1,5 @@
 # This docker-compose file starts an entire wasmCloud ecosystem, including:
-#   a NATS server (with websocket open on port 4001)
+#   a NATS server (with websocket open on port 4223)
 #   a local OCI registry
 #   grafana + tempo for tracing
 #   a wasmCloud host
@@ -13,7 +13,7 @@ services:
       - "4222:4222"
       - "6222:6222"
       - "8222:8222"
-      - "4001:4001"
+      - "4223:4223"
     command:
       - "-c=/etc/nats/nats-server.conf"
     volumes:

--- a/examples/docker/nats.websocket.conf
+++ b/examples/docker/nats.websocket.conf
@@ -5,6 +5,6 @@ server_name: "wasmcloud"
 jetstream {}
 
 websocket {
-  port: 4001
+  port: 4223
   no_tls: true
 }

--- a/washboard-ui/CONTRIBUTING.md
+++ b/washboard-ui/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Enable `corepack` and install `yarn` using the following commands:
 corepack enable
 yarn install
 ```
- 
+
 ### Start a local UI development server
 
 Run the following command to start a local frontend development server:
@@ -39,7 +39,7 @@ yarn run dev
 Run the following command to start the wasmCloud host using the wash CLI:
 
 ```bash
-wash up --nats-websocket-port 4001
+wash up
 ```
 
 ### Explanations
@@ -49,18 +49,31 @@ wash up --nats-websocket-port 4001
 `wasmcloud` uses [NATS](https://nats.io/) as its message broker. The `wash` CLI can be used to start a local NATS
 or connect to an existing NATS server.
 
-The Washboard UI connects to a NATS server at [ws://localhost:4001 by default][0], although this can be overridden via
+The Washboard UI connects to a NATS server at [ws://localhost:4223 by default][0], although this can be overridden via
 the UI.
 
-In case you use `wash up` to spawn up the Nats server, you can control the websocket port using the
-`--nats-websocket-port` flag or `NATS_WEBSOCKET_PORT` environment variable. For example:
+You can spawn the NATS server with a wasmCloud Host and wadm with the `wash` cli tool. See the documentation for [installation instructions][1].
 
 ```bash
-wash up --nats-websocket-port 4001
+wash up
 ```
 
-Otherwise, verify the port you are using to connect to the NATS server. Visit [NATS Websocket Configuration][1] for more
+You can change the NATS websocket port using the
+`--nats-websocket-port` flag or `NATS_WEBSOCKET_PORT` environment variable. Note that you must stop the NATS Server to make this change. For example:
+
+```bash
+# 1. Make sure NATS is stopped
+wash down
+
+# 2. Start NATS with the new port
+wash up --nats-websocket-port 4001
+# or
+NATS_WEBSOCKET_PORT=4001 wash up
+```
+
+Otherwise, verify the port you are using to connect to the NATS server. Visit [NATS Websocket Configuration][2] for more
 information.
 
-[0]: https://github.com/wasmCloud/wasmCloud/blob/5fbc982aea164a738b9254952ca91b0a5fd3bb82/washboard-ui/src/lattice/lattice-service.ts#L70
-[1]: https://docs.nats.io/running-a-nats-service/configuration/websocket/websocket_conf
+[0]: https://github.com/wasmCloud/wasmCloud/blob/28699dc8e891df34888935e8ace31c718da9f590/washboard-ui/src/lattice/lattice-service.ts#L70
+[1]: https://wasmcloud.com/docs/installation
+[2]: https://docs.nats.io/running-a-nats-service/configuration/websocket/websocket_conf

--- a/washboard-ui/packages/washboard-ui/.env.development
+++ b/washboard-ui/packages/washboard-ui/.env.development
@@ -1,1 +1,1 @@
-VITE_NATS_WEBSOCKET_URL=ws://localhost:4001
+VITE_NATS_WEBSOCKET_URL=ws://localhost:4223

--- a/washboard-ui/packages/washboard-ui/package.json
+++ b/washboard-ui/packages/washboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wasmcloud/washboard-ui",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/washboard-ui/packages/washboard-ui/src/app/components/app-lattice-client-provider.tsx
+++ b/washboard-ui/packages/washboard-ui/src/app/components/app-lattice-client-provider.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 const client = new LatticeClient({
   config: {
-    latticeUrl: import.meta.env.VITE_NATS_WEBSOCKET_URL || 'ws://localhost:4222',
+    latticeUrl: import.meta.env.VITE_NATS_WEBSOCKET_URL || 'ws://localhost:4223',
   },
 });
 


### PR DESCRIPTION
## Feature or Problem
- Enable Websocket by default
- Update Default Websocket Port to `4223`
- Change washboard-ui to use new default port and bump version

## Release Information
`washboard-ui@0.2.1`
`wash@next`

## Testing
### Manual Verification

Tested locally against current version of washboard