### PR TITLE
chore(host): Bumps host version to rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 description = "wasmCloud host runtime"
 default-run = "wasmcloud"
 

--- a/crates/host/src/wasmbus/host_config.rs
+++ b/crates/host/src/wasmbus/host_config.rs
@@ -56,6 +56,9 @@ pub struct Host {
     pub otel_config: OtelConfig,
     /// configuration for wasmCloud policy service
     pub policy_service_config: PolicyService,
+    /// The semver version of the host. This is used by a consumer of this crate to indicate the
+    /// host version (which may differ from the crate version)
+    pub version: String,
 }
 
 /// Configuration for wasmCloud policy service
@@ -96,6 +99,7 @@ impl Default for Host {
             config_service_enabled: false,
             otel_config: OtelConfig::default(),
             policy_service_config: PolicyService::default(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
         }
     }
 }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -794,7 +794,7 @@ impl Host {
             "friendly_name": friendly_name,
             "labels": labels,
             "uptime_seconds": 0,
-            "version": env!("CARGO_PKG_VERSION"),
+            "version": config.version,
         });
 
         let ((ctl_nats, queue), rpc_nats) = try_join!(
@@ -898,11 +898,11 @@ impl Host {
 
         let meter = global::meter_with_version(
             "wasmcloud-host",
-            Some(env!("CARGO_PKG_VERSION")),
+            Some(config.version.clone()),
             None::<&str>,
             Some(vec![
                 KeyValue::new("host.id", host_key.public_key()),
-                KeyValue::new("host.version", env!("CARGO_PKG_VERSION")),
+                KeyValue::new("host.version", config.version.clone()),
             ]),
         );
         let metrics = HostMetrics::new(
@@ -1175,7 +1175,7 @@ impl Host {
             labels: self.labels.read().await.clone(),
             uptime_human: human_friendly_uptime(uptime),
             uptime_seconds: uptime.as_secs(),
-            version: env!("CARGO_PKG_VERSION").to_string(),
+            version: self.host_config.version.clone(),
             host_id: self.host_key.public_key(),
         }
     }
@@ -2665,7 +2665,7 @@ impl Host {
             friendly_name: self.friendly_name.clone(),
             uptime_seconds: uptime.as_secs(),
             uptime_human: Some(human_friendly_uptime(uptime)),
-            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            version: Some(self.host_config.version.clone()),
             js_domain: self.host_config.js_domain.clone(),
             ctl_host: Some(self.host_config.ctl_nats_url.to_string()),
             rpc_host: Some(self.host_config.rpc_nats_url.to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,6 +370,7 @@ async fn main() -> anyhow::Result<()> {
         enable_structured_logging: args.enable_structured_logging,
         otel_config,
         policy_service_config,
+        version: env!("CARGO_PKG_VERSION").to_string(),
     }))
     .await
     .context("failed to initialize host")?;


### PR DESCRIPTION
While I was here, I fixed the issue where we were using the host crate version instead of the top level binary host version in our events and ctl API responses