### PR TITLE
fix(host): allow overwriting provider reference

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2028,26 +2028,11 @@ impl Host {
             "policy denied request to start provider `{request_id}`: `{message:?}`",
         );
 
-        let component_specification = if let Ok(Some(mut spec)) =
-            self.get_component_spec(provider_id).await
-        {
-            // If the component didn't start yet, the URL will be empty but the spec may contain links.
-            // Populate the URL and store the updated spec.
-            if spec.url.is_empty() {
-                spec.url = provider_ref.to_string();
-            } else if spec.url != provider_ref {
-                // Ensure there isn't another component already claiming this ID
-                bail!(
-                        "existing component specification URL [{}] for provider ID [{}] does not match provider reference [{}] (you may need to pick a new ID)",
-                        spec.url,
-                        provider_id,
-                        provider_ref
-                    );
-            }
-            spec
-        } else {
-            ComponentSpecification::new(provider_ref)
-        };
+        let component_specification = self
+            .get_component_spec(provider_id)
+            .await?
+            .unwrap_or_else(|| ComponentSpecification::new(provider_ref));
+
         self.store_component_spec(&provider_id, &component_specification)
             .await?;
 


### PR DESCRIPTION
## Feature or Problem
This PR allows overwriting the provider reference in the component specification for a given ID if that provider is not running on this host. This primarily solves a developer experience issue where a provider is no longer running and it cannot be updated without deleting the component spec manually.

## Related Issues
Implemented for components in https://github.com/wasmCloud/wasmCloud/pull/1829

## Release Information
1.0.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
