### PR TITLE
chore(wascap): bump to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3562,7 +3562,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tar",
- "wascap 0.13.0",
+ "wascap 0.14.0",
 ]
 
 [[package]]
@@ -4623,7 +4623,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "wascap 0.13.0",
+ "wascap 0.14.0",
  "wasmcloud-component-adapters",
  "wit-component",
 ]
@@ -5336,22 +5336,6 @@ dependencies = [
 [[package]]
 name = "wascap"
 version = "0.13.0"
-dependencies = [
- "data-encoding",
- "humantime",
- "nkeys",
- "nuid 0.4.1",
- "ring",
- "serde",
- "serde_json",
- "wasm-encoder 0.203.0",
- "wasm-gen",
- "wasmparser 0.202.0",
-]
-
-[[package]]
-name = "wascap"
-version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802ee1beca185fd4d61bcfd937360d1dddacc88fefa39b08209e875d99c95711"
 dependencies = [
@@ -5366,6 +5350,22 @@ dependencies = [
  "wasm-encoder 0.41.2",
  "wasm-gen",
  "wasmparser 0.121.2",
+]
+
+[[package]]
+name = "wascap"
+version = "0.14.0"
+dependencies = [
+ "data-encoding",
+ "humantime",
+ "nkeys",
+ "nuid 0.4.1",
+ "ring",
+ "serde",
+ "serde_json",
+ "wasm-encoder 0.203.0",
+ "wasm-gen",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]
@@ -5417,7 +5417,7 @@ dependencies = [
  "url",
  "wadm",
  "warp",
- "wascap 0.13.0",
+ "wascap 0.14.0",
  "wash-lib",
  "wasmcloud-control-interface 1.0.0-alpha.3",
  "wasmcloud-core 0.5.0",
@@ -5480,7 +5480,7 @@ dependencies = [
  "url",
  "wadm",
  "walkdir",
- "wascap 0.13.0",
+ "wascap 0.14.0",
  "wasm-encoder 0.203.0",
  "wasmcloud-component-adapters",
  "wasmcloud-control-interface 1.0.0-alpha.3",
@@ -5673,7 +5673,7 @@ dependencies = [
  "url",
  "uuid",
  "vaultrs",
- "wascap 0.13.0",
+ "wascap 0.14.0",
  "wasmcloud-control-interface 1.0.0-alpha.3",
  "wasmcloud-core 0.5.0",
  "wasmcloud-host",
@@ -5795,7 +5795,7 @@ dependencies = [
  "tracing",
  "ulid",
  "uuid",
- "wascap 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wascap 0.13.0",
  "wrpc-transport 0.22.0",
  "wrpc-transport-nats 0.19.0",
 ]
@@ -5826,7 +5826,7 @@ dependencies = [
  "tracing",
  "ulid",
  "uuid",
- "wascap 0.13.0",
+ "wascap 0.14.0",
  "webpki-roots 0.26.1",
  "wrpc-transport 0.24.2",
  "wrpc-transport-nats 0.21.0",
@@ -5864,7 +5864,7 @@ dependencies = [
  "ulid",
  "url",
  "uuid",
- "wascap 0.13.0",
+ "wascap 0.14.0",
  "wasmcloud-control-interface 1.0.0-alpha.3",
  "wasmcloud-core 0.5.0",
  "wasmcloud-runtime",
@@ -6012,7 +6012,7 @@ dependencies = [
  "async-nats",
  "tokio",
  "tracing",
- "wascap 0.13.0",
+ "wascap 0.14.0",
  "wasmcloud-control-interface 1.0.0-alpha.3",
 ]
 
@@ -6047,7 +6047,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
- "wascap 0.13.0",
+ "wascap 0.14.0",
  "wasmcloud-provider-sdk",
  "wit-bindgen-wrpc",
 ]
@@ -6106,7 +6106,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "wascap 0.13.0",
+ "wascap 0.14.0",
  "wasmcloud-actor",
  "wasmcloud-component-adapters",
  "wasmcloud-core 0.5.0",
@@ -6136,7 +6136,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "wascap 0.13.0",
+ "wascap 0.14.0",
  "wasmcloud-control-interface 1.0.0-alpha.3",
  "wasmcloud-host",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,7 @@ vaultrs = { version = "0.7", default-features = false }
 wadm = { version = "0.11.0-alpha.3", default-features = false }
 walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
-wascap = { version = "0.13", path = "./crates/wascap", default-features = false }
+wascap = { version = "0.14", path = "./crates/wascap", default-features = false }
 wash-cli = { version = "0", path = "./crates/wash-cli", default-features = false }
 wash-lib = { version = "0.20.0-alpha.2", path = "./crates/wash-lib", default-features = false }
 wasm-encoder = { version = "0.203", default-features = false }

--- a/crates/wascap/Cargo.toml
+++ b/crates/wascap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascap"
-version = "0.13.0"
+version = "0.14.0"
 description = "Wascap - wasmCloud Capabilities. Library for extracting, embedding, and validating claims"
 homepage = "https://wasmcloud.com"
 documentation = "https://docs.rs/wascap"


### PR DESCRIPTION
## Feature or Problem
Bumping wascap to 0.14.0 so I can release the breaking change that provider-archive needs to release 0.10.0 so I can release the breaking change that wash-lib needs in order to release alongside wash-cli to crates.io. Yay.

We should definitely get to that cargo smart-releaser spike soon.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
`cargo publish --dry-run` seems to indicate we are okay here.
