### PR TITLE
release: v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5256,9 +5256,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wadm"
-version = "0.11.0-alpha.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21615d275ee4725573c92c561cc87346949e82cf04126cfcc46c8194ea9f7d05"
+checksum = "62bd11670372017a613ba62dc4f46e4db75f635d1d6a0ec7cc4f43ab2fc78d97"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5284,7 +5284,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "uuid",
- "wasmcloud-control-interface 1.0.0-alpha.3",
+ "wasmcloud-control-interface 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5424,8 +5424,8 @@ dependencies = [
  "wasmcloud-provider-sdk",
  "weld-codegen",
  "which",
- "wrpc-transport 0.24.2",
- "wrpc-types 0.6.0",
+ "wrpc-transport",
+ "wrpc-types",
 ]
 
 [[package]]
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "1.0.0-rc.2"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5699,9 +5699,9 @@ dependencies = [
  "wasmcloud-test-util",
  "wasmcloud-tracing",
  "wrpc-interface-http",
- "wrpc-transport 0.24.2",
- "wrpc-transport-nats 0.21.0",
- "wrpc-types 0.6.0",
+ "wrpc-transport",
+ "wrpc-transport-nats",
+ "wrpc-types",
 ]
 
 [[package]]
@@ -5739,29 +5739,6 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "1.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc87e84c68d31d65d4070cf70548f5d27e2c9c75d2768ea52ce60416c048e9a6"
-dependencies = [
- "anyhow",
- "async-nats",
- "async-trait",
- "bytes",
- "cloudevents-sdk",
- "futures",
- "oci-distribution",
- "opentelemetry",
- "opentelemetry_sdk",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-opentelemetry",
- "wasmcloud-core 0.4.0",
-]
-
-[[package]]
-name = "wasmcloud-control-interface"
 version = "1.0.0"
 dependencies = [
  "anyhow",
@@ -5782,31 +5759,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmcloud-core"
-version = "0.4.0"
+name = "wasmcloud-control-interface"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9384bec7161ea7763f6665c49b9282323065e3edd0247cca9f679180bd14d86"
+checksum = "fa9ce0245be791548d153536d4a849f7db9abc9340657bae00250e8a0f7f6bbc"
 dependencies = [
  "anyhow",
  "async-nats",
  "async-trait",
  "bytes",
+ "cloudevents-sdk",
  "futures",
- "hex",
- "nkeys",
- "once_cell",
- "rustls 0.23.4",
+ "oci-distribution",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "serde",
- "serde_bytes",
- "sha2",
+ "serde_json",
  "tokio",
- "tower",
  "tracing",
- "ulid",
- "uuid",
- "wascap 0.13.0",
- "wrpc-transport 0.22.0",
- "wrpc-transport-nats 0.19.0",
+ "tracing-opentelemetry",
+ "wasmcloud-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5837,8 +5809,36 @@ dependencies = [
  "uuid",
  "wascap 0.14.0",
  "webpki-roots 0.26.1",
- "wrpc-transport 0.24.2",
- "wrpc-transport-nats 0.21.0",
+ "wrpc-transport",
+ "wrpc-transport-nats",
+]
+
+[[package]]
+name = "wasmcloud-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a646a51b5c4410c6bd93aecbcc98f24921c88712de4549ab64617d88fb4acb88"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "bytes",
+ "futures",
+ "hex",
+ "nkeys",
+ "once_cell",
+ "rustls 0.23.4",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "tokio",
+ "tower",
+ "tracing",
+ "ulid",
+ "uuid",
+ "wascap 0.13.0",
+ "wrpc-transport",
+ "wrpc-transport-nats",
 ]
 
 [[package]]
@@ -5882,9 +5882,9 @@ dependencies = [
  "wit-bindgen-wrpc",
  "wrpc-interface-blobstore",
  "wrpc-interface-http",
- "wrpc-transport 0.24.2",
- "wrpc-transport-nats 0.21.0",
- "wrpc-types 0.6.0",
+ "wrpc-transport",
+ "wrpc-transport-nats",
+ "wrpc-types",
 ]
 
 [[package]]
@@ -5912,7 +5912,7 @@ dependencies = [
  "tracing",
  "wasmcloud-provider-sdk",
  "wrpc-interface-blobstore",
- "wrpc-transport 0.24.2",
+ "wrpc-transport",
 ]
 
 [[package]]
@@ -5937,7 +5937,7 @@ dependencies = [
  "tracing",
  "wasmcloud-provider-sdk",
  "wrpc-interface-blobstore",
- "wrpc-transport 0.24.2",
+ "wrpc-transport",
 ]
 
 [[package]]
@@ -5952,7 +5952,7 @@ dependencies = [
  "tracing",
  "wasmcloud-provider-sdk",
  "wrpc-interface-http",
- "wrpc-transport 0.24.2",
+ "wrpc-transport",
 ]
 
 [[package]]
@@ -6089,9 +6089,9 @@ dependencies = [
  "wasmcloud-tracing",
  "wrpc-interface-blobstore",
  "wrpc-interface-http",
- "wrpc-transport 0.24.2",
- "wrpc-transport-nats 0.21.0",
- "wrpc-types 0.6.0",
+ "wrpc-transport",
+ "wrpc-transport-nats",
+ "wrpc-types",
 ]
 
 [[package]]
@@ -6126,8 +6126,8 @@ dependencies = [
  "wit-component",
  "wit-parser 0.202.0",
  "wrpc-runtime-wasmtime",
- "wrpc-transport 0.24.2",
- "wrpc-types 0.6.0",
+ "wrpc-transport",
+ "wrpc-types",
 ]
 
 [[package]]
@@ -6974,7 +6974,7 @@ dependencies = [
  "tokio",
  "tracing",
  "wit-bindgen-wrpc-rust-macro",
- "wrpc-transport 0.24.2",
+ "wrpc-transport",
 ]
 
 [[package]]
@@ -7068,7 +7068,7 @@ dependencies = [
  "bytes",
  "futures",
  "tracing",
- "wrpc-transport 0.24.2",
+ "wrpc-transport",
 ]
 
 [[package]]
@@ -7089,7 +7089,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "wasmtime-wasi-http",
- "wrpc-transport 0.24.2",
+ "wrpc-transport",
 ]
 
 [[package]]
@@ -7103,26 +7103,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "wrpc-transport 0.24.2",
-]
-
-[[package]]
-name = "wrpc-transport"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551cf90e43a1a331ec13af1ad244c9605956fd2c3d535ff857f5978ae963518"
-dependencies = [
- "anyhow",
- "async-nats",
- "async-trait",
- "bytes",
- "futures",
- "leb128",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
- "wrpc-types 0.5.0",
+ "wrpc-transport",
 ]
 
 [[package]]
@@ -7141,23 +7122,7 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tracing",
- "wrpc-types 0.6.0",
-]
-
-[[package]]
-name = "wrpc-transport-nats"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d7401a0771e00936b57519e5c1627a174ae05d979a5f8a961e264f0e6f99f1"
-dependencies = [
- "anyhow",
- "async-nats",
- "bytes",
- "futures",
- "tokio",
- "tower",
- "tracing",
- "wrpc-transport 0.22.0",
+ "wrpc-types",
 ]
 
 [[package]]
@@ -7173,18 +7138,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "wrpc-transport 0.24.2",
-]
-
-[[package]]
-name = "wrpc-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052dd3b6e5a936407695801656660badc5d0ddeaff482ac266669bfd47e6457e"
-dependencies = [
- "anyhow",
- "tracing",
- "wit-parser 0.201.0",
+ "wrpc-transport",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "1.0.0-rc.2"
+version = "1.0.0"
 description = "wasmCloud host runtime"
 default-run = "wasmcloud"
 
@@ -262,7 +262,7 @@ ulid = { version = "1", default-features = false }
 url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
-wadm = { version = "0.11.0-alpha.4", default-features = false }
+wadm = { version = "0.11.0", default-features = false }
 walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
 wascap = { version = "0.14", path = "./crates/wascap", default-features = false }


### PR DESCRIPTION
# wasmCloud 1.0.0 Release Notes

The 1.0 release is a grand culmination of effort from the [2024 Q1 Roadmap](https://wasmcloud.com/docs/1.0/roadmap/) which focused primarily on standardization of host control interface and RPC protocols, events, and WebAssembly component support. 

## Features

As specified in our 1.0.0 roadmap, these are the major features that wasmCloud brings as a project:

1. [Declarative WebAssembly Orchestration](https://wasmcloud.com/docs/1.0/concepts/applications)
2. [Seamless Distributed Networking](https://wasmcloud.com/docs/1.0/concepts/lattice)
3. [Vendorless Application Components](https://wasmcloud.com/docs/1.0/concepts/components#application-components)
4. [Completely OTEL Observable](https://wasmcloud.com/docs/1.0/category/observability)
5. [Defense-In-Depth Security By Default](https://wasmcloud.com/docs/1.0/category/security)

wasmCloud is a **universal application platform** that helps you build and run globally distributed WebAssembly applications on any cloud and any edge. wasmCloud applications are composed of WebAssembly components and capability providers (executable host plugins). wasmCloud hosts can be clustered together with the technology CNCF NATS to form a distributed mesh network called a [lattice](https://wasmcloud.com/docs/1.0/concepts/lattice), allowing you to seamlessly distribute applications on any architecture, operating system, virtual or physical machine and communicate like it was running on a single computer.

## Compatibility

The v1.0.0 release of wasmCloud is **not** compatible over the lattice with previous versions of wasmCloud, wash, or wadm. There are a few primary breaking changes that make 1.0 incompatible:

1. Topic changes in the control interface for backwards compatibility [https://github.com/wasmCloud/wasmCloud/issues/1108](https://github.com/wasmCloud/wasmCloud/issues/1108)
2. RPC protocol change from wasmbus to wRPC [https://github.com/wasmCloud/wasmCloud/issues/1548](https://github.com/wasmCloud/wasmCloud/issues/1548)
3. Removal of support for Smithy-based modules and wasmCloud contracts in favor of WebAssembly components and [WIT](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)

This includes renaming `actor` to `component` in many places in the code.

For these reasons, it’s recommended to update all wasmCloud hosts that you run to v1.0.0 at the same time. Associated tooling like **wadm** should update to at least version **v0.11.0** as well in order to match the protocol versions.

## Migrating from v0.82

Updating `wash` to **v0.27.0** will include wasmCloud **v1.0.0** and wadm **v0.11.0**, bundling all associated tooling together for a quick upgrade. If you deploy wasmCloud via the helm chart or using the container, updating to wasmCloud v1.0.0 should be all you need.

### If you use wash in your CI/scripts/workflows

The primary changes in `wash` center around the addition of component IDs, and the changes to links and configuration.

1. Any scripts that start, scale, or stop components or providers should update to also include a component ID (`wash start actor myoci.io/echo:0.1.0` → `wash start component myoci.io/echo:0.1.0` )
2. Any scripts that linked an actor to a provider should re-examine the link, and change to support the WIT interface link format. See the [Link changes](https://wasmcloud.com/docs/1.0/ecosystem/wadm/migrating#link-changes) section of the wadm documentation for more information. Configuration that is specified as a link value can now be externalized and specified via `wash config` .

### If you use wadm to deploy your applications

Please see the [Migrating from v0.82](https://wasmcloud.com/docs/1.0/ecosystem/wadm/migrating) section in the wadm documentation for details on updating application manifests.

### If you use Smithy-generated actors or capability providers

These actors and capability providers were deprecated in v0.82, and support is officially removed in v1.0.0. We recommend reaching out using the contact methods below if you need assistance migrating from these interfaces.

## Known Issues

- When using the HTTPServer provider, you may see warnings about failed health checks but this is a false positive [https://github.com/wasmCloud/wasmCloud/issues/1925](https://github.com/wasmCloud/wasmCloud/issues/1925)
- Component_scaled events are published twice when a component stops [https://github.com/wasmCloud/wasmCloud/issues/1888](https://github.com/wasmCloud/wasmCloud/issues/1888)

## Acknowledgements

A huge thank you to the wasmCloud community for participating in design discussions, attending community meetings, testing the release candidate, and helping us make distributed WebAssembly applications easy and fun. Thank you to all of the maintainers of the wasmCloud project for the massive effort coordinating and testing for this release.

## Contact

If you’re testing, updating, or just trying out v1.0.0 for the first time, please reach out to us in the associated GitHub discussion or on our [Slack](https://slack.wasmcloud.com/). Come join the community!
