### PR TITLE
chore(examples): remove redundant world spec

### DIFF
--- a/examples/rust/components/blobby/src/lib.rs
+++ b/examples/rust/components/blobby/src/lib.rs
@@ -1,9 +1,7 @@
 #![allow(clippy::missing_safety_doc)]
 // ^^^ This is for clippy complaining about something that wit bindgen is generating
 
-wit_bindgen::generate!({
-    world: "blobby",
-});
+wit_bindgen::generate!();
 
 use std::io::{Read, Write};
 

--- a/examples/rust/components/echo-messaging/src/lib.rs
+++ b/examples/rust/components/echo-messaging/src/lib.rs
@@ -1,6 +1,4 @@
-wit_bindgen::generate!({
-    world: "hello",
-});
+wit_bindgen::generate!();
 
 use exports::wasmcloud::messaging::handler::Guest;
 use wasi::logging::logging::*;

--- a/examples/rust/components/http-hello-world/src/lib.rs
+++ b/examples/rust/components/http-hello-world/src/lib.rs
@@ -1,6 +1,4 @@
-wit_bindgen::generate!({
-    world: "hello",
-});
+wit_bindgen::generate!();
 
 use exports::wasi::http::incoming_handler::Guest;
 use wasi::http::types::*;

--- a/examples/rust/components/http-jsonify/src/lib.rs
+++ b/examples/rust/components/http-jsonify/src/lib.rs
@@ -22,9 +22,7 @@
 
 use anyhow::{anyhow, bail, Result};
 
-wit_bindgen::generate!({
-    world: "component"
-});
+wit_bindgen::generate!();
 
 /// Implementation of the 'component' world in wit/world.wit will hang off of this struct
 struct Component;

--- a/examples/rust/components/http-keyvalue-counter/src/lib.rs
+++ b/examples/rust/components/http-keyvalue-counter/src/lib.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::missing_safety_doc)]
-wit_bindgen::generate!({
-    world: "hello",
-});
+wit_bindgen::generate!();
 
 use exports::wasi::http::incoming_handler::Guest;
 use wasi::http::types::*;


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Remove the redundant `world` specification for `wit-bindgen` invocations. It's not necessary when there's only one world in the package

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
