### PR TITLE
feat(wash-cli): re-add wash call tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,9 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.2.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938a142ab806f18b88a97b0dea523d39e0fd730a064b035726adcfc58a8a5188"
+checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
 dependencies = [
  "byteorder 1.5.0",
  "rmp",
@@ -4140,9 +4140,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -4177,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4188,9 +4188,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -5383,6 +5383,7 @@ dependencies = [
  "console",
  "dirs",
  "futures",
+ "http 1.1.0",
  "indicatif",
  "nix",
  "nkeys",
@@ -5424,6 +5425,7 @@ dependencies = [
  "wasmcloud-provider-sdk",
  "weld-codegen",
  "which",
+ "wrpc-interface-http",
  "wrpc-transport",
  "wrpc-types",
 ]

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -25,6 +25,7 @@ cloudevents-sdk = { workspace = true }
 console = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
+http = { workspace = true }
 indicatif = { workspace = true }
 nix = { workspace = true, features = ["signal"] }
 nkeys = { workspace = true }
@@ -68,6 +69,7 @@ wasmcloud-core = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true }
 weld-codegen = { workspace = true, features = ["wasmbus"] }
 which = { workspace = true }
+wrpc-interface-http = { workspace = true }
 wrpc-transport = { workspace = true }
 wrpc-types = { workspace = true }
 

--- a/crates/wash-cli/tests/wash_call.rs
+++ b/crates/wash-cli/tests/wash_call.rs
@@ -1,0 +1,50 @@
+use anyhow::{Context, Result};
+use serial_test::serial;
+
+use wash_lib::cli::output::StartCommandOutput;
+
+mod common;
+use common::{TestWashInstance, HTTP_JSONIFY_OCI_REF};
+
+use crate::common::wait_for_no_hosts;
+
+/// Ensure that wash call works
+#[tokio::test]
+#[serial]
+#[cfg_attr(not(can_reach_github_com), ignore = "github.com is not reachable")]
+async fn integration_call() -> Result<()> {
+    wait_for_no_hosts()
+        .await
+        .context("unexpected wasmcloud instance(s) running")?;
+
+    let instance = TestWashInstance::create().await?;
+
+    // Pre-emptively pull the OCI ref for the component to ensure we don't run into the
+    // default testing timeout when attempting to start the component
+    let _ = instance
+        .pull(HTTP_JSONIFY_OCI_REF)
+        .await
+        .context("failed to pull component")?;
+
+    // Start an echo component
+    let StartCommandOutput { component_id, .. } = instance
+        .start_component(HTTP_JSONIFY_OCI_REF, "http-jsonify")
+        .await
+        .context("failed to start component")?;
+    let component_id = component_id.context("component ID not present after starting component")?;
+
+    // Call the component
+    let cmd_output = instance
+        .call_component(
+            &component_id,
+            "wasi:http/incoming-handler.handle",
+            "body-data-goes-here",
+        )
+        .await
+        .context("failed to call component")?;
+
+    assert!(cmd_output.success, "call command succeeded");
+    assert_eq!(cmd_output.response["status"], 200, "status code is 200");
+
+    Ok(())
+}

--- a/crates/wash-cli/tests/wash_start.rs
+++ b/crates/wash-cli/tests/wash_start.rs
@@ -15,7 +15,7 @@ async fn integration_start_stop_actor_serial() -> Result<()> {
 
     // Start the actor via OCI ref
     wash_instance
-        .start_actor(HELLO_OCI_REF, "hello_actor_id")
+        .start_component(HELLO_OCI_REF, "hello_actor_id")
         .await?;
 
     wash_instance.stop_actor("hello_actor_id", None).await?;

--- a/crates/wash-cli/tests/wash_stop.rs
+++ b/crates/wash-cli/tests/wash_stop.rs
@@ -22,7 +22,7 @@ async fn integration_stop_actor_serial() -> Result<()> {
         success,
         ..
     } = wash_instance
-        .start_actor(HELLO_OCI_REF, "hello_actor_id_from_start")
+        .start_component(HELLO_OCI_REF, "hello_actor_id_from_start")
         .await?;
     assert!(success, "start command returned success");
 

--- a/crates/wash-lib/src/cli/output.rs
+++ b/crates/wash-lib/src/cli/output.rs
@@ -79,3 +79,10 @@ pub struct CallCommandOutput {
     pub success: bool,
     pub response: serde_json::Value,
 }
+
+/// JSON output representation of the `wash pull` command
+#[derive(Debug, Deserialize)]
+pub struct PullCommandOutput {
+    pub success: bool,
+    pub file: String,
+}


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit re-adds the missing `wash call` tests to the codebase, enhancing `wash call` to be able to invoke incoming HTTP handlers along the way.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
