### PR TITLE
chore: remove "wash new interface"

### DIFF
--- a/crates/wash-cli/src/generate.rs
+++ b/crates/wash-cli/src/generate.rs
@@ -15,10 +15,6 @@ pub enum NewCliCommand {
     #[clap(name = "component", alias = "actor")]
     Component(NewProjectArgs),
 
-    /// Generate a new interface project
-    #[clap(name = "interface")]
-    Interface(NewProjectArgs),
-
     /// Generate a new capability provider project
     #[clap(name = "provider")]
     Provider(NewProjectArgs),
@@ -72,7 +68,6 @@ impl From<NewCliCommand> for Project {
     fn from(cmd: NewCliCommand) -> Project {
         let (args, kind) = match cmd {
             NewCliCommand::Component(args) => (args, ProjectKind::Component),
-            NewCliCommand::Interface(args) => (args, ProjectKind::Interface),
             NewCliCommand::Provider(args) => (args, ProjectKind::Provider),
         };
 

--- a/crates/wash-lib/src/generate/favorites.toml
+++ b/crates/wash-lib/src/generate/favorites.toml
@@ -36,17 +36,11 @@ description = "a hello-world component (in Python) that responds over an HTTP co
 git = "wasmCloud/wasmCloud"
 subfolder = "examples/python/components/http-hello-world"
 
-[[interface]]
-name = "converter-interface"
-description = "an interface for actor-to-actor messages with a single Convert method"
-git = "wasmCloud/project-templates"
-subfolder = "interface/converter-actor"
-
-[[interface]]
-name = "factorial-interface"
-description = "an interface for a capability provider with capability contract"
-git = "wasmCloud/project-templates"
-subfolder = "interface/factorial"
+[[component]]
+name = "echo-messaging"
+description = "a component (in Rust) that echoes a payload received in a message using `wasmcloud:messaging`"
+git = "wasmCloud/wasmCloud"
+subfolder = "examples/rust/components/echo-messaging"
 
 [[provider]]
 name = "messaging-nats"

--- a/crates/wash-lib/src/generate/mod.rs
+++ b/crates/wash-lib/src/generate/mod.rs
@@ -36,7 +36,6 @@ const PROJECT_NAME_REGEX: &str = r"^([a-zA-Z][a-zA-Z0-9_-]+)$";
 pub enum ProjectKind {
     #[default]
     Component,
-    Interface,
     Provider,
 }
 
@@ -47,7 +46,6 @@ impl fmt::Display for ProjectKind {
             "{}",
             match self {
                 ProjectKind::Component => "component",
-                ProjectKind::Interface => "interface",
                 ProjectKind::Provider => "provider",
             }
         )


### PR DESCRIPTION
## Feature or Problem
This PR removes the no-longer-used `wash new interface` functionality as all interfaces now use wit. We may consider this in the future to help generate a WIT file, but likely this should come through WebAssembly tooling.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next minor wash-lib
next minor wash-cli

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
