### PR TITLE
fix(host): remove extra component_scaled events

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1438,7 +1438,7 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn stop_actor(&self, actor: &Actor, host_id: &str) -> anyhow::Result<()> {
+    async fn stop_actor(&self, actor: &Actor, _host_id: &str) -> anyhow::Result<()> {
         trace!(component_id = %actor.id, "stopping component");
 
         // TODO: How to know if abort was successful?

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1441,7 +1441,6 @@ impl Host {
     async fn stop_actor(&self, actor: &Actor, _host_id: &str) -> anyhow::Result<()> {
         trace!(component_id = %actor.id, "stopping component");
 
-        // TODO: How to know if abort was successful?
         actor.calls.abort();
 
         Ok(())
@@ -1895,7 +1894,6 @@ impl Host {
             self.stop_actor(actor, host_id)
                 .await
                 .context("failed to stop old component")?;
-            // TODO: How to differentiate between old and new component if image reference is the same?
             self.publish_event(
                 "component_scaled",
                 event::component_scaled(

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1441,20 +1441,8 @@ impl Host {
     async fn stop_actor(&self, actor: &Actor, host_id: &str) -> anyhow::Result<()> {
         trace!(component_id = %actor.id, "stopping component");
 
+        // TODO: How to know if abort was successful?
         actor.calls.abort();
-
-        self.publish_event(
-            "component_scaled",
-            event::component_scaled(
-                actor.claims(),
-                &actor.annotations,
-                host_id,
-                0_usize,
-                &actor.image_reference,
-                &actor.id,
-            ),
-        )
-        .await?;
 
         Ok(())
     }
@@ -1907,6 +1895,7 @@ impl Host {
             self.stop_actor(actor, host_id)
                 .await
                 .context("failed to stop old component")?;
+            // TODO: How to differentiate between old and new component if image reference is the same?
             self.publish_event(
                 "component_scaled",
                 event::component_scaled(


### PR DESCRIPTION
Signed-off-by: Yerzhan Zhamashev <yerzhan.contribs@novel.systems>

## Problem
> When a component is scaled to a max instances value of 0, we emit two component_scaled events that assert that it was scaled to zero. 

Similarly, an extra `component_scaled` event with `max_instances: 0` is emitted for `wash scale` and `wash update`.

## Related Issues
#1888 

## Release Information
`wasmCloud v1.0`

## Consumer Impact
Extra `component_scaled` event with `max_instances: 0` is no longer emitted when a component is updated or scaled (and scaled to 0 i.e stopped)

## Testing
All tests should work as expected

### Manual Verification
Listening to `wasmbus.evt.>` on NATS while performing `wash start`, `wash scale`, `wash update`, and `wash stop` on a component.
