### PR TITLE
feature: prevent component update if image reference unchanged

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1865,6 +1865,11 @@ impl Host {
                 .context("component not found")?;
             let annotations = annotations.unwrap_or_default().into_iter().collect();
 
+            if existing_component.image_reference == new_component_ref {
+                info!(%component_id, %new_component_ref, "component already updated");
+                return Ok(());
+            }
+
             let new_component = self.fetch_component(new_component_ref).await?;
             let new_claims = new_component.claims();
             if let Some(claims) = new_claims.cloned() {

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1843,7 +1843,7 @@ impl Host {
             )));
         };
 
-        // If the component image reference is the same or not found, respond with an appropriate message
+        // If the component image reference is the same, respond with an appropriate message
         if component_ref == new_component_ref {
             return Ok(CtlResponse {
                 success: true,

--- a/crates/wash-cli/tests/wash_update.rs
+++ b/crates/wash-cli/tests/wash_update.rs
@@ -175,8 +175,8 @@ async fn integration_update_actor_serial() -> Result<()> {
         .context("failed to update actor")?;
 
     assert!(
-        !output.status.success(),
-        "update with same image ref should fail"
+        output.status.success(),
+        "update with same image ref should still succeed"
     );
 
     Ok(())

--- a/crates/wash-cli/tests/wash_update.rs
+++ b/crates/wash-cli/tests/wash_update.rs
@@ -153,5 +153,28 @@ async fn integration_update_actor_serial() -> Result<()> {
         }
     }
     
+    // Check update with the same image ref
+    let output = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args([
+            "update",
+            "component",
+            "--host-id",
+            wash_instance.host_id.as_str(),
+            "hello",
+            HELLO_OCI_REF,
+            "--output",
+            "json",
+            "--timeout-ms",
+            "40000",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
+        ])
+        .kill_on_drop(true)
+        .output()
+        .await
+        .context("failed to update actor")?;
+
+    assert!(!output.status.success(), "update with same image ref should fail");
+
     Ok(())
 }

--- a/crates/wash-cli/tests/wash_update.rs
+++ b/crates/wash-cli/tests/wash_update.rs
@@ -15,9 +15,6 @@ const OLD_HELLO_OCI_REF: &str = "ghcr.io/brooksmtownsend/http-hello-world-rust:0
     not(can_reach_wasmcloud_azurecr_io),
     ignore = "wasmcloud.azurecr.io is not reachable"
 )]
-#[ignore]
-// TODO: reenable after #1649 merges and v1.0.0-alpha.2 is released
-// This test's issue was fixed in 019c975ecf5e0dde0e7b392787ff3e89d607770f
 async fn integration_update_actor_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
@@ -155,6 +152,6 @@ async fn integration_update_actor_serial() -> Result<()> {
             break;
         }
     }
-
+    
     Ok(())
 }

--- a/crates/wash-cli/tests/wash_update.rs
+++ b/crates/wash-cli/tests/wash_update.rs
@@ -152,7 +152,7 @@ async fn integration_update_actor_serial() -> Result<()> {
             break;
         }
     }
-    
+
     // Check update with the same image ref
     let output = Command::new(env!("CARGO_BIN_EXE_wash"))
         .args([
@@ -174,7 +174,10 @@ async fn integration_update_actor_serial() -> Result<()> {
         .await
         .context("failed to update actor")?;
 
-    assert!(!output.status.success(), "update with same image ref should fail");
+    assert!(
+        !output.status.success(),
+        "update with same image ref should fail"
+    );
 
     Ok(())
 }

--- a/crates/wash-lib/src/cli/update.rs
+++ b/crates/wash-lib/src/cli/update.rs
@@ -76,6 +76,15 @@ pub async fn handle_update_actor(cmd: UpdateComponentCommand) -> Result<CommandO
         );
     };
 
+    if component_ref == cmd.new_component_ref {
+        bail!(
+            "Host [{}] is already running component [{}] with reference [{}]",
+            host_id,
+            cmd.component_id,
+            cmd.new_component_ref
+        );
+    }
+
     let ack = update_actor(&client, &host_id, &cmd.component_id, &cmd.new_component_ref).await?;
     if !ack.success {
         bail!("Operation failed: {}", ack.message);

--- a/crates/wash-lib/src/cli/update.rs
+++ b/crates/wash-lib/src/cli/update.rs
@@ -80,12 +80,13 @@ pub async fn handle_update_actor(cmd: UpdateComponentCommand) -> Result<CommandO
     };
 
     if component_ref == cmd.new_component_ref {
-        bail!(
-            "Component {} already updated to {} on host [{}]",
-            cmd.component_id,
-            cmd.new_component_ref,
-            host_id
-        );
+        return Ok(CommandOutput::from_key_and_text(
+            "result",
+            format!(
+                "Component {} already updated to {} on host [{}]",
+                cmd.component_id, cmd.new_component_ref, host_id
+            ),
+        ));
     }
 
     let ack = update_actor(&client, &host_id, &cmd.component_id, &cmd.new_component_ref).await?;


### PR DESCRIPTION
## Feature or Problem
Skip component update if the currently running component for the component id has the same image reference.

If not skipped, `component_scaled` event is emitted asserting that the component with the new image reference is started, then another `component_scaled` event that asserts a component with the same id and image reference is scaled to 0. Thus, it is difficult to tell if it scaled to 0 or was actually updated with an image of the same reference.

## Related Issues
#1972 

## Release Information
next wasmCloud v1 minor or patch release

## Consumer Impact
- Updating a host's running component with the same image reference in `wash-cli` results in an error.
- If wasmCloud host receives a request to update a component and the component image reference did not change, the component update process is skipped
- Changed wash output messages for component update command

## Testing

### Unit Test(s)
No changes to unit testing

### Acceptance or Integration
- Enabled `integration_update_actor_serial` test for `wash-cli`
- Modified `integration_update_actor_serial` to check an update with the same image reference

### Manual Verification
Start wasmCloud and:
1. `wash start component wasmcloud.azurecr.io/http-hello-world:0.1.0 test`
2. `wash update component test wasmcloud.azurecr.io/http-hello-world:0.1.0`
3. Observe wasmCloud host logs and see `INFO wasmcloud_host::wasmbus: component already updated component_id=testnew_component_ref=wasmcloud.azurecr.io/http-hello-world:0.1.0`
