### PR TITLE
chore(messaging-nats): bump to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6035,7 +6035,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/crates/provider-messaging-nats/Cargo.toml
+++ b/crates/provider-messaging-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.19.0"
+version = "0.20.0"
 description = """
 A capability provider that satisfies the 'wasmcloud:messaging' contract using NATS as a backend.
 """


### PR DESCRIPTION
## Feature or Problem
This PR bumps the messaging NATS provider to 0.20.0 for release since it's had some breaking changes that we want to have in a non-canary release.

## Related Issues
#1965

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
