### PR TITLE
feat(providers): allow missing default connection for redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/crates/provider-keyvalue-redis/Cargo.toml
+++ b/crates/provider-keyvalue-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.24.0"
+version = "0.24.1"
 
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Without a default connection the redis KV provider would normally fail to start -- this can be quite confusing considering usually a connetion is not expected to be made yet.

This commit refactors the conenction logic to allow running a provider without a pre-made default connection, and creates one upon the first connection of an actor that relies on the default
connection (i.e. doesn't have a connection specified via link config).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
