### PR TITLE
feat(providers): custom inbox prefix for NATS messaging provider

### DIFF
--- a/crates/provider-messaging-nats/src/connection.rs
+++ b/crates/provider-messaging-nats/src/connection.rs
@@ -10,6 +10,7 @@ const CONFIG_NATS_URI: &str = "cluster_uris";
 const CONFIG_NATS_CLIENT_JWT: &str = "client_jwt";
 const CONFIG_NATS_CLIENT_SEED: &str = "client_seed";
 const CONFIG_NATS_TLS_CA: &str = "tls_ca";
+const CONFIG_NATS_CUSTOM_INBOX_PREFIX: &str = "custom_inbox_prefix";
 
 /// Configuration for connecting a nats client.
 /// More options are available if you use the json than variables in the values string map.
@@ -31,15 +32,21 @@ pub struct ConnectionConfig {
     #[serde(default)]
     pub auth_seed: Option<String>,
 
+    /// TLS Certificate Authority, encoded as a string
     #[serde(default)]
     pub tls_ca: Option<String>,
 
+    /// TLS Certifiate Authority, as a path on disk
     #[serde(default)]
     pub tls_ca_file: Option<String>,
 
-    /// ping interval in seconds
+    /// Ping interval in seconds
     #[serde(default)]
     pub ping_interval_sec: Option<u16>,
+
+    /// Inbox prefix to use (by default
+    #[serde(default)]
+    pub custom_inbox_prefix: Option<String>,
 }
 
 impl ConnectionConfig {
@@ -71,6 +78,9 @@ impl ConnectionConfig {
         if extra.ping_interval_sec.is_some() {
             out.ping_interval_sec = extra.ping_interval_sec;
         }
+        if extra.custom_inbox_prefix.is_some() {
+            out.custom_inbox_prefix = extra.custom_inbox_prefix.clone();
+        }
         out
     }
 }
@@ -79,12 +89,13 @@ impl Default for ConnectionConfig {
     fn default() -> ConnectionConfig {
         ConnectionConfig {
             subscriptions: vec![],
-            cluster_uris: vec![DEFAULT_NATS_URI.to_string()],
+            cluster_uris: vec![DEFAULT_NATS_URI.into()],
             auth_jwt: None,
             auth_seed: None,
             tls_ca: None,
             tls_ca_file: None,
             ping_interval_sec: None,
+            custom_inbox_prefix: None,
         }
     }
 }
@@ -101,6 +112,9 @@ impl ConnectionConfig {
         }
         if let Some(url) = values.get(CONFIG_NATS_URI) {
             config.cluster_uris = url.split(',').map(String::from).collect();
+        }
+        if let Some(custom_inbox_prefix) = values.get(CONFIG_NATS_CUSTOM_INBOX_PREFIX) {
+            config.custom_inbox_prefix = Some(custom_inbox_prefix.clone());
         }
         if let Some(jwt) = values.get(CONFIG_NATS_CLIENT_JWT) {
             config.auth_jwt = Some(jwt.clone());


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
This commit enables a custom inbox prefix for the NATS messaging provider.

Resolves https://github.com/wasmCloud/wasmCloud/issues/1195

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
