### PR TITLE
chore(wash-cli): bump wasmCloud and wadm bin versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5265,9 +5265,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wadm"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bd11670372017a613ba62dc4f46e4db75f635d1d6a0ec7cc4f43ab2fc78d97"
+checksum = "30b69c7042256e72a806ee35053cee4e74a188b22b2449c4e2a1383074cf8ac8"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,7 @@ ulid = { version = "1", default-features = false }
 url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
-wadm = { version = "0.11.0", default-features = false }
+wadm = { version = "0.11.1", default-features = false }
 walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
 wascap = { version = "0.14", path = "./crates/wascap", default-features = false }

--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -10,9 +10,9 @@ pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
 pub const DEFAULT_NATS_WEBSOCKET_PORT: &str = "4223";
 // wadm configuration values
-pub const WADM_VERSION: &str = "v0.11.0";
+pub const WADM_VERSION: &str = "v0.11.1";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub const WASMCLOUD_HOST_VERSION: &str = "v1.0.0";
+pub const WASMCLOUD_HOST_VERSION: &str = "v1.0.1";
 // NATS isolation configuration variables
 pub const WASMCLOUD_LATTICE: &str = "WASMCLOUD_LATTICE";
 pub const DEFAULT_LATTICE: &str = "default";


### PR DESCRIPTION
## Feature or Problem
This PR bumps wasmCloud and wadm inside of wash to their latest versions.

We should consider an automatic way to do this, or to pull patch releases automatically :D

## Related Issues
https://github.com/wasmCloud/wasmCloud/issues/2032 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
