### PR TITLE
feat(host): gracefully shutdown epoch interrupt thread

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -394,6 +394,7 @@ async fn main() -> anyhow::Result<()> {
         },
         deadline = host.stopped() => deadline?,
     };
+    drop(host);
     if let Some(deadline) = deadline {
         timeout_at(deadline, shutdown)
     } else {


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This ensures that the epoch interrupt thread is gracefully shutdown (which only occurs after there are not more engine (and therefore the host) references) without significantly slowing down the host shutdown.

In particular, this, in overwhelming majority of cases, should prevent the following error (or similar) from ever showing up:
```
Error: failed to shutdown host

Caused by:
    epoch thread has not finished
```

Small change is also that I've removed the requirement for actors to be signed, as was discussed before a few times

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

#2023 #2002 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
