### PR TITLE
ci(wash-cli): trigger homebrew/choco update

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -505,10 +505,32 @@ jobs:
       - uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/wash-cli-v')
         with:
-          draft: true
+          draft: false
           prerelease: true
           generate_release_notes: true
           files: ./wash/*
+
+      - name: Extract version
+        if: startsWith(github.ref, 'refs/tags/wash-cli-v')
+        run: |
+          VERSION=$(echo "${GITHUB_REF##*/}" | sed -e 's/wash-cli-v//')
+          echo "wash_version=$VERSION" >> $GITHUB_ENV
+      - name: Release homebrew
+        uses: peter-evans/repository-dispatch@v3
+        if: startsWith(github.ref, 'refs/tags/wash-cli-v')
+        with:
+          token: ${{ secrets.HOMEBREW_CHOCOLATEY_DISPATCH_TOKEN }}
+          event-type: brew-formula-update
+          client-payload: |
+            {"tag_prefix": "wash-cli", "tag_version": "${{ env.wash_version }}"}
+      - name: Release chocolatey
+        uses: peter-evans/repository-dispatch@v3
+        if: startsWith(github.ref, 'refs/tags/wash-cli-v')
+        with:
+          token: ${{ secrets.HOMEBREW_CHOCOLATEY_DISPATCH_TOKEN }}
+          event-type: choco-formula-update
+          client-payload: |
+            {"wash_version": "${{ env.wash_version }}"}
 
   snapcraft:
     if: startsWith(github.ref, 'refs/tags/wash-cli-v')


### PR DESCRIPTION
## Feature or Problem
This PR sets up the wash-cli release action to trigger a repository dispatch event in https://github.com/wasmCloud/homebrew-wasmcloud and https://github.com/wasmCloud/chocolatey-wash to update the formula automatically.

We'll still need to approve the PRs in those repositories after actions run, but this prevents a bunch of clicks to do a workflow_dispatch modification.

## Related Issues
https://github.com/wasmCloud/chocolatey-wash/commit/fb9151a9663d754fbcca5906e78c5ff575122c72
https://github.com/wasmCloud/homebrew-wasmcloud/pull/61

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
