### PR TITLE
feat(wash-cli): add `wash app validate` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.30.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cdcd97b590e00e635b17126a1a8f3199dd05333a2d6a6d810ab6693bf4f674"
+checksum = "2924dd7efd0112a5a88ec7d1c2dbf371966f018e90f3f45db7c8027ef895662a"
 dependencies = [
  "ahash",
  "aws-credential-types",
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.8"
+version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509e33efbd853e1e670c47e49af2f4df3d2ae0de8b845b068ddbf04636a6700d"
+checksum = "6242d6a54d3b4b83458f4abd7057ba93c4419dc71e8217e9acd3a748d656d99e"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -2171,12 +2171,6 @@ dependencies = [
  "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "finl_unicode"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "flate2"
@@ -5282,13 +5276,13 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stringprep"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
 dependencies = [
- "finl_unicode",
  "unicode-bidi",
  "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -6052,6 +6046,7 @@ checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
 dependencies = [
  "getrandom 0.2.14",
  "rand 0.8.5",
+ "serde",
  "web-time 1.1.0",
 ]
 
@@ -6084,6 +6079,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6195,10 +6196,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
-name = "wadm"
-version = "0.11.2"
+name = "wadm-types"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25c15f591631338229521c5636b4226b29ba8fa13fbebce24d02eb89e0d4e595"
+checksum = "af535df65c0387b6a8ef521aca58a239af817f03ebf676f91e982b9b919bc513"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -6223,6 +6224,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
+ "ulid",
  "uuid 1.8.0",
  "wasmcloud-control-interface 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6364,7 +6366,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "wadm",
+ "wadm-types",
  "warp",
  "wascap 0.14.0",
  "wash-lib",
@@ -6431,7 +6433,7 @@ dependencies = [
  "toml 0.8.13",
  "tracing",
  "url",
- "wadm",
+ "wadm-types",
  "walkdir",
  "wascap 0.14.0",
  "wasm-encoder 0.208.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,7 +291,8 @@ ulid = { version = "1", default-features = false }
 url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
-wadm = { version = "0.11.2", default-features = false }
+wadm = { version = "0.12", default-features = false }
+wadm-types = { version = "0.1", default-features = false }
 walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
 wascap = { version = "0.14", path = "./crates/wascap", default-features = false }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -63,7 +63,7 @@ tracing-subscriber = { workspace = true, features = [
     "std",
 ] }
 url = { workspace = true }
-wadm = { workspace = true }
+wadm-types = { workspace = true }
 warp = { workspace = true }
 wascap = { workspace = true }
 wash-lib = { workspace = true, features = [

--- a/crates/wash-cli/src/app/output.rs
+++ b/crates/wash-cli/src/app/output.rs
@@ -3,7 +3,7 @@ use term_table::{
     table_cell::{Alignment, TableCell},
     Table,
 };
-use wadm::server::{Status, VersionInfo};
+use wadm_types::api::{Status, VersionInfo};
 
 use super::ModelSummary;
 

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -19,7 +19,7 @@ use tokio::{
     process::Child,
 };
 use tracing::{error, warn};
-use wadm::server::{DeployModelResponse, DeployResult};
+use wadm_types::api::{DeployModelResponse, DeployResult};
 use wash_lib::app::{load_app_manifest, AppManifest, AppManifestSource};
 use wash_lib::cli::{CommandOutput, OutputKind};
 use wash_lib::config::{
@@ -627,7 +627,7 @@ async fn deploy_wadm_application(
     lattice: &str,
 ) -> Result<()> {
     let model_name = manifest.name().context("failed to find model name")?;
-    let _ = wash_lib::app::undeploy_model(client, Some(lattice.into()), model_name, false).await;
+    let _ = wash_lib::app::undeploy_model(client, Some(lattice.into()), model_name).await;
     match deploy_model_from_manifest(client, Some(lattice.into()), manifest, None).await {
         // Successful invocation but deploy model failure
         Ok(DeployModelResponse {
@@ -759,7 +759,7 @@ async fn run_wasmcloud_interactive(
                     // If we successfully loaded the manifest, attempt to undeploy the existing model
                     Ok(manifest) => {
                         if let Some(model_name) = manifest.name() {
-                            match wash_lib::app::undeploy_model(&client, Some(lattice), model_name, false).await {
+                            match wash_lib::app::undeploy_model(&client, Some(lattice), model_name).await {
                                 Ok(DeployModelResponse { result: DeployResult::Error, message }) => {
                                     error!("failed to undeploy manifest during cleanup: {message}");
                                     eprintln!("🟨 Failed to undeploy manifest during cleanup");

--- a/crates/wash-cli/tests/fixtures/wadm/manifests/simple.wadm.yaml
+++ b/crates/wash-cli/tests/fixtures/wadm/manifests/simple.wadm.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: sample
+  annotations:
+    version: v0.0.1
+    description: Sample manifest that passes
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: ghcr.io/wasmcloud/component-http-hello-world:0.1.0
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1

--- a/crates/wash-cli/tests/wash_app.rs
+++ b/crates/wash-cli/tests/wash_app.rs
@@ -1,0 +1,30 @@
+use anyhow::{Context, Result};
+use tokio::process::Command;
+use wash_lib::cli::output::AppValidateOutput;
+
+/// Ensure a simple WADM manifest passes validation
+#[tokio::test]
+async fn app_validate_simple() -> Result<()> {
+    let pass = "./tests/fixtures/wadm/simple.wadm.yaml";
+    tokio::fs::try_exists(pass).await?;
+    let output = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args([
+            "app",
+            "validate",
+            "./tests/fixtures/wadm/manifests/simple.wadm.yaml",
+            "--output",
+            "json",
+        ])
+        .kill_on_drop(true)
+        .output()
+        .await
+        .context("failed to execute wash app validate")?;
+
+    let cmd_output: AppValidateOutput =
+        serde_json::from_slice(&output.stdout).context("failed to build JSON from output")?;
+    assert!(cmd_output.valid, "valid output");
+    assert!(cmd_output.errors.is_empty(), "no errors");
+    assert!(cmd_output.warnings.is_empty(), "no warnings");
+
+    Ok(())
+}

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -28,7 +28,7 @@ cli = [
     "indicatif",
     "path-absolutize",
 ]
-nats = ["async-nats", "wadm"]
+nats = ["async-nats", "wadm-types"]
 docs = ["wasmcloud-component-adapters/docs"]
 plugin = ["wasmtime", "wasmtime-wasi", "wasmtime-wasi-http"]
 
@@ -84,7 +84,7 @@ tokio-util = { workspace = true }
 toml = { workspace = true, features = ["parse"] }
 tracing = { workspace = true, features = ["log"] }
 url = { workspace = true }
-wadm = { workspace = true, optional = true }
+wadm-types = { workspace = true, optional = true }
 walkdir = { workspace = true }
 wascap = { workspace = true }
 wasm-encoder = { workspace = true }

--- a/crates/wash-lib/src/app.rs
+++ b/crates/wash-lib/src/app.rs
@@ -8,7 +8,7 @@ use anyhow::{bail, Context, Result};
 use async_nats::{Client, Message};
 use regex::Regex;
 use tracing::warn;
-use wadm::server::{
+use wadm_types::api::{
     DeleteModelRequest, DeleteModelResponse, DeployModelRequest, DeployModelResponse,
     GetModelRequest, GetModelResponse, ModelSummary, PutModelResponse, StatusResponse,
     UndeployModelRequest, VersionResponse,
@@ -197,14 +197,13 @@ pub async fn undeploy_model(
     client: &Client,
     lattice: Option<String>,
     model_name: &str,
-    non_destructive: bool,
 ) -> Result<DeployModelResponse> {
     let res = model_request(
         client,
         ModelOperation::Undeploy,
         lattice,
         Some(model_name),
-        serde_json::to_vec(&UndeployModelRequest { non_destructive })?,
+        serde_json::to_vec(&UndeployModelRequest {})?,
     )
     .await?;
 
@@ -343,17 +342,13 @@ pub async fn delete_model_version(
     lattice: Option<String>,
     model_name: &str,
     version: Option<String>,
-    delete_all: bool,
 ) -> Result<DeleteModelResponse> {
     let res = model_request(
         client,
         ModelOperation::Delete,
         lattice,
         Some(model_name),
-        serde_json::to_vec(&DeleteModelRequest {
-            version: version.unwrap_or_default(),
-            delete_all,
-        })?,
+        serde_json::to_vec(&DeleteModelRequest { version })?,
     )
     .await?;
 

--- a/crates/wash-lib/src/cli/output.rs
+++ b/crates/wash-lib/src/cli/output.rs
@@ -4,6 +4,8 @@ use serde::Deserialize;
 use wasmcloud_control_interface::{Host, HostInventory};
 use wasmcloud_core::{InterfaceLinkDefinition, LinkName};
 
+use wadm_types::validation::ValidationFailure;
+
 /// JSON Output of the `wash start` command
 #[derive(Debug, Deserialize)]
 pub struct StartCommandOutput {
@@ -103,4 +105,12 @@ pub struct UpCommandOutput {
     pub wasmcloud_log: String,
     pub nats_url: String,
     pub deployed_wadm_manifest_path: Option<String>,
+}
+
+/// JSON output representation of the `wash app validate` command
+#[derive(Debug, Deserialize)]
+pub struct AppValidateOutput {
+    pub valid: bool,
+    pub warnings: Vec<ValidationFailure>,
+    pub errors: Vec<ValidationFailure>,
 }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit adds a `wash app validate` subcommand which can be used to check and suggest fixes for WADM manifests.

As the breadth of possible errors with a manifest is wide, it's difficult to enumerate and check every possible error, but validate serves as a starting point in being able to give users proactive advice on WADM manifests.

For now, it checks:
- interface names (ex. typos, misnamed host-supported interfaces)
- dangling providers/components which aren't linked to anything

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

https://github.com/wasmCloud/wasmCloud/issues/2009

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

`next`

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
