### PR TITLE
ci: Enable workflow_dispatch action smart-release

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -11,13 +11,14 @@ on:
         options:
           - wasmcloud
           - wasmcloud-core
+          - wasmcloud-test-util
           - wasmcloud-tracing
           - wash-cli
           - wash-lib
           - wascap
-      execute:
+      do-release:
         type: boolean
-        description: check this box to release, leave unchecked to compute changes and PR
+        description: check this box to push changes and create release directly, leave unchecked to create a pull request with changes for verification
   push:
     branches:
       - main
@@ -687,15 +688,17 @@ jobs:
       - name: install smart-release
         env:
           RUSTFLAGS: ''
+        # NOTE(brooksmtownsend): Installing from my fork as updating workspace dependencies is not yet supported in the mainline
+        # PR to follow: https://github.com/Byron/cargo-smart-release/pull/17
         run: cargo install cargo-smart-release --git https://github.com/brooksmtownsend/cargo-smart-release --branch feat/update-workspace-dependencies
       - name: dry run release
-        if: ${{ !inputs.execute }}
+        if: ${{ !inputs.do-release }}
         run: |
           git config --global user.email "automation@wasmcloud.com"
           git config --global user.name "wasmCloud automation"
           cargo smart-release --update-crates-index --no-publish --execute --no-changelog-preview --no-push ${{ inputs.crate }}
       - name: Create Pull Request
-        if: ${{ !inputs.execute }}
+        if: ${{ !inputs.do-release }}
         uses: peter-evans/create-pull-request@v6
         with:
           signoff: true
@@ -703,7 +706,7 @@ jobs:
           commit-message: 'release(${{ inputs.crate }}): release and update CHANGELOG'
 
       - name: release
-        if: ${{ inputs.execute }}
+        if: ${{ inputs.do-release }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -18,7 +18,7 @@ on:
           - wascap
       do-release:
         type: boolean
-        description: check this box to push changes and create release directly, leave unchecked to create a pull request with changes for verification
+        description: Leave unchecked to create a pull request with changes for verification, then check to create a release directly with changes
   push:
     branches:
       - main
@@ -712,4 +712,4 @@ jobs:
         run: |
           git config --global user.email "automation@wasmcloud.com"
           git config --global user.name "wasmCloud automation"
-          cargo smart-release --update-crates-index --execute --no-changelog-preview ${{ inputs.crate }}
+          cargo smart-release --update-crates-index --execute --no-changelog-preview --no-changelog ${{ inputs.crate }}

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -4,6 +4,20 @@ on:
   pull_request:
   merge_group:
   workflow_dispatch:
+    inputs:
+      crate:
+        type: choice
+        description: crate to smart-release
+        options:
+          - wasmcloud
+          - wasmcloud-core
+          - wasmcloud-tracing
+          - wash-cli
+          - wash-lib
+          - wascap
+      execute:
+        type: boolean
+        description: check this box to release, leave unchecked to compute changes and PR
   push:
     branches:
       - main
@@ -655,3 +669,44 @@ jobs:
         continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
         run: cargo publish --token ${{ secrets.CRATES_PUBLISH_TOKEN }}
         working-directory: ./crates/${{ matrix.crate }}
+
+  smart-release:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      - name: Install cmake for smart-release
+        run: sudo apt update && sudo apt install cmake -y
+
+      - name: install smart-release
+        env:
+          RUSTFLAGS: ''
+        run: cargo install cargo-smart-release --git https://github.com/brooksmtownsend/cargo-smart-release --branch feat/update-workspace-dependencies
+      - name: dry run release
+        if: ${{ !inputs.execute }}
+        run: |
+          git config --global user.email "automation@wasmcloud.com"
+          git config --global user.name "wasmCloud automation"
+          cargo smart-release --update-crates-index --no-publish --execute --no-changelog-preview --no-push ${{ inputs.crate }}
+      - name: Create Pull Request
+        if: ${{ !inputs.execute }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          signoff: true
+          title: Release ${{ inputs.crate }}
+          commit-message: 'release(${{ inputs.crate }}): release and update CHANGELOG'
+
+      - name: release
+        if: ${{ inputs.execute }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config --global user.email "automation@wasmcloud.com"
+          git config --global user.name "wasmCloud automation"
+          cargo smart-release --update-crates-index --execute --no-changelog-preview ${{ inputs.crate }}


### PR DESCRIPTION
## Feature or Problem
When releasing a crate or one of our main binaries, wash-cli or wasmcloud, currently it can be very difficult to properly predict:
1. What crates need to be released
2. What order crates need to be released
3. Whether to patch bump, minor bump, or leave as-is and release

Not only that, but we should be keeping up with a changelog as well. I chose to use cargo smart-release (with workspace-deps support https://github.com/Byron/cargo-smart-release/pull/17) in order to take care of the above actions automatically.

This PR adds a workflow_dispatch trigger to our `wasmcloud` action (if desired, I can migrate to a new action since I know that the workflow_dispatch wasn't release specific before) and lets you specify a crate to release. You can either directly release the crate, or leave the checkbox blank and the action will create a PR with the changes.

I attempted to capture the steps to use this action in https://github.com/wasmCloud/wasmCloud/wiki/Release-Runbook, which we should be able to keep updated so that all maintainers can reuse this for new releases.

## Related Issues
Fixes #2036 

## Release Information
N/A

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
You can see an example successful run of this in my fork:
1. Trigger action for `wasmcloud-core` without execute checked https://github.com/brooksmtownsend/wasmCloud/actions/runs/8973489750/job/24643786588
2. PR created: https://github.com/brooksmtownsend/wasmCloud/pull/3
3. PR merged, action triggered with execute checked
4. Action runs, creating tags and releases https://github.com/brooksmtownsend/wasmCloud/actions/runs/8973533429/job/24643936734, https://github.com/brooksmtownsend/wasmCloud/releases/tag/wasmcloud-core-v0.6.0

Additionally, by running directly on `main` with execute checked
1. Trigger action for `wasmcloud-tracing`, execute checked, all changes are reflected and pushed skipping 1,2,3 above https://github.com/brooksmtownsend/wasmCloud/actions/runs/8973902728/job/24645072545 (it _would_ pass but I want to avoid deleting old tags so that the above step shows fully what happened)
