### PR TITLE
chore(wash-cli): bump wasmcloud v1.0.2

### DIFF
--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -12,7 +12,7 @@ pub const DEFAULT_NATS_WEBSOCKET_PORT: &str = "4223";
 // wadm configuration values
 pub const WADM_VERSION: &str = "v0.11.1";
 // wasmCloud configuration values, https://wasmcloud.dev/reference/host-runtime/host_configure/
-pub const WASMCLOUD_HOST_VERSION: &str = "v1.0.1";
+pub const WASMCLOUD_HOST_VERSION: &str = "v1.0.2";
 // NATS isolation configuration variables
 pub const WASMCLOUD_LATTICE: &str = "WASMCLOUD_LATTICE";
 pub const DEFAULT_LATTICE: &str = "default";

--- a/crates/wash-cli/tests/wash_reg.rs
+++ b/crates/wash-cli/tests/wash_reg.rs
@@ -352,7 +352,7 @@ async fn integration_reg_config() -> Result<()> {
     assert!(cmd.status.success());
     let output = get_json_output(cmd).unwrap();
     let expected_url = format!("{LOCAL_REGISTRY}/{push_url}");
-    let expected_json = json!({"url": expected_url, "success": true});
+    let expected_json = json!({"url": expected_url, "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a", "success": true, "tag": "0.2.0", "url": "localhost:5001/hello:0.2.0"});
     assert_eq!(output, expected_json);
 
     //===== case: Push (with a repository url) to test env vars


### PR DESCRIPTION
## Feature or Problem
This PR bumps the included wasmcloud version in wash 0.28 to be the latest and include patch fixes for small devices.

## Related Issues
Fixes #1961
Wouldn't have to create this PR if #2032 was done :)

## Release Information
wash-cli v0.28.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
