### PR TITLE
fix(core): compile with default features

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -33,7 +33,7 @@ hyper-rustls = { workspace = true, features = [
 ], optional = true }
 hyper-util = { workspace = true, optional = true }
 nkeys = { workspace = true }
-oci-distribution = { workspace = true, optional = true }
+oci-distribution = { workspace = true, features = ["rustls-tls"], optional = true }
 once_cell = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"], optional = true }
 rustls = { workspace = true, features = ["std"] }


### PR DESCRIPTION
## Feature or Problem
This PR ensures when `oci-distribution` is used for wasmcloud-core that we use rustls-tls, which fixes a compilation issue with our default features.

## Related Issues
Fixes #2088

## Release Information
next patch release of wasmcloud-core

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
It builds!
