### PR TITLE
ci(wash-cli): trigger repository dispatch in proper repo

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -535,6 +535,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/wash-cli-v')
         with:
           token: ${{ secrets.HOMEBREW_CHOCOLATEY_DISPATCH_TOKEN }}
+          repository: wasmCloud/homebrew-wasmcloud
           event-type: brew-formula-update
           client-payload: |
             {"tag_prefix": "wash-cli", "tag_version": "${{ env.wash_version }}"}
@@ -543,6 +544,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/wash-cli-v')
         with:
           token: ${{ secrets.HOMEBREW_CHOCOLATEY_DISPATCH_TOKEN }}
+          repository: wasmCloud/chocolatey-wash
           event-type: choco-formula-update
           client-payload: |
             {"wash_version": "${{ env.wash_version }}"}


### PR DESCRIPTION
## Feature or Problem
When writing this action, I forgot to ensure that we're triggering the repository dispatch in the _other_ repository, not this one. At least the PAT protections are in place and prevent triggering actions in this repo.

## Related Issues
https://github.com/wasmCloud/wasmCloud/actions/runs/9005487474/job/24741562902

## Release Information
N/A, just next wash-cli release

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
