### PR TITLE
fix: Make wash push returned digest based on the pushed manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5827,6 +5827,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "term-table",
  "test-case",

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -87,6 +87,7 @@ notify = { workspace = true, features = ["macos_fsevent"] }
 [dev-dependencies]
 assert-json-diff = { workspace = true }
 rand = { workspace = true }
+reqwest = { workspace = true }
 serial_test = { workspace = true }
 sysinfo = { workspace = true }
 

--- a/crates/wash-cli/src/common/registry_cmd.rs
+++ b/crates/wash-cli/src/common/registry_cmd.rs
@@ -149,7 +149,10 @@ pub async fn registry_push(
         _ => resolve_registry_credentials(image.registry()).await,
     }?;
 
-    let annotations = input_vec_to_hashmap(cmd.annotations.unwrap_or_default())?;
+    let annotations = match cmd.annotations {
+        Some(annotations) => input_vec_to_hashmap(annotations).ok(),
+        None => None,
+    };
 
     let (maybe_tag, digest) = push_oci_artifact(
         artifact_url.clone(),
@@ -160,7 +163,7 @@ pub async fn registry_push(
             user: credentials.username,
             password: credentials.password,
             insecure: cmd.opts.insecure,
-            annotations: Some(annotations),
+            annotations,
         },
     )
     .await?;

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -71,6 +71,7 @@ serde_cbor = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["macros"] }
 serde_yaml = { workspace = true }
+sha2 = { workspace = true }
 tempfile = { workspace = true }
 term-table = { workspace = true, optional = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
## Feature or Problem

This addresses a couple of problems:
1. `wash push` was returning the manifest from the manifest-attached config, not the manifest itself.
2. `wash push` was passing in an empty hashmap for `annotations` even if there were none, which resulted in an empty `"annotations": {}` being stored on the registry, when it really should've just been omitted altogether

In addition, it adds logic to calculate the manifest digest locally based on an alphabetically sorted set of bytes to match the behavior of the most commonly available/widely deployed registry, [distribution](https://github.com/distribution/distribution).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
