### PR TITLE
ci(release): allow passing additional args to smart-release

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -19,6 +19,9 @@ on:
       do-release:
         type: boolean
         description: Leave unchecked to create a pull request with changes for verification, then check to create a release directly with changes
+      additional-args:
+        type: string
+        description: Advanced; Additional arguments to pass to `smart-release`
   push:
     branches:
       - main
@@ -746,7 +749,7 @@ jobs:
         run: |
           git config --global user.email "automation@wasmcloud.com"
           git config --global user.name "wasmCloud automation"
-          cargo smart-release --update-crates-index --no-publish --execute --no-changelog-preview --no-push ${{ inputs.crate }}
+          cargo smart-release --update-crates-index --no-publish --execute --no-changelog-preview --no-push ${{ inputs.additional-args }} ${{ inputs.crate }}
       - name: Create Pull Request
         if: ${{ !inputs.do-release }}
         uses: peter-evans/create-pull-request@v6
@@ -763,4 +766,4 @@ jobs:
         run: |
           git config --global user.email "automation@wasmcloud.com"
           git config --global user.name "wasmCloud automation"
-          cargo smart-release --update-crates-index --execute --no-changelog-preview --no-changelog ${{ inputs.crate }}
+          cargo smart-release --update-crates-index --execute --no-changelog-preview --no-changelog ${{ inputs.additional-args }} ${{ inputs.crate }}


### PR DESCRIPTION
## Feature or Problem
This PR will allow us to specify additional flags during release, e.g. `-d patch`, to override smart-release default behavior if necessary.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
