### PR TITLE
fix(wash-lib): Setup extra_root_certificates for OCI push client

### DIFF
--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -231,6 +231,7 @@ pub async fn push_oci_artifact(
         } else {
             ClientProtocol::Https
         },
+        extra_root_certificates: tls::NATIVE_ROOTS_OCI.to_vec(),
         ..Default::default()
     });
 


### PR DESCRIPTION
## Feature or Problem

Looking through the OCI push and pull code, I noticed that the client we set up for [pull has `extra_root_certificates` configured](https://github.com/wasmCloud/wasmCloud/blob/main/crates/wash-lib/src/registry.rs#L133-L141), but the one for push did not, so I felt like that would be worth remedying.

Presumably we'll want the same behavior in both cases.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
