### PR TITLE
Cleanup reg ping remnants

### DIFF
--- a/crates/wash-lib/src/cli/registry.rs
+++ b/crates/wash-lib/src/cli/registry.rs
@@ -35,9 +35,6 @@ pub enum RegistryCommand {
     /// Push an artifact to an OCI compliant registry
     #[clap(name = "push")]
     Push(RegistryPushCommand),
-    /// Ping (test url) to see if the OCI url has an artifact
-    #[clap(name = "ping")]
-    Ping(RegistryPingCommand),
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -91,20 +88,6 @@ pub struct RegistryPushCommand {
     /// Optional set of annotations to apply to the OCI artifact manifest
     #[clap(short = 'a', long = "annotation", name = "annotations")]
     pub annotations: Option<Vec<String>>,
-
-    #[clap(flatten)]
-    pub opts: AuthOpts,
-}
-
-#[derive(Parser, Debug, Clone)]
-pub struct RegistryPingCommand {
-    /// URL of artifact
-    #[clap(name = "url")]
-    pub url: String,
-
-    /// Registry of artifact. This is only needed if the URL is not a full (OCI) artifact URL (ie, missing the registry fragment)
-    #[clap(short = 'r', long = "registry", env = "WASH_REG_URL")]
-    pub registry: Option<String>,
 
     #[clap(flatten)]
     pub opts: AuthOpts,


### PR DESCRIPTION
## Feature or Problem

`wash reg ping` was removed in https://github.com/wasmcloud/wasmcloud/commit/e6ee3de780ec5bc6a6cc0ec3a15457278978bca6 as part of https://github.com/wasmCloud/wasmCloud/pull/1649, but this code was left over from that.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
