### PR TITLE
Add option to skip certificate validation for the OCI registry connection

### DIFF
--- a/crates/wash-cli/src/common/registry_cmd.rs
+++ b/crates/wash-cli/src/common/registry_cmd.rs
@@ -51,6 +51,7 @@ pub async fn registry_pull(
             user: credentials.username,
             password: credentials.password,
             insecure: cmd.opts.insecure,
+            insecure_skip_tls_verify: cmd.opts.insecure_skip_tls_verify,
         },
     )
     .await?;
@@ -131,6 +132,7 @@ pub async fn registry_push(
             user: credentials.username,
             password: credentials.password,
             insecure: cmd.opts.insecure,
+            insecure_skip_tls_verify: cmd.opts.insecure_skip_tls_verify,
             annotations,
         },
     )

--- a/crates/wash-cli/src/par.rs
+++ b/crates/wash-cli/src/par.rs
@@ -139,6 +139,10 @@ pub struct InspectCommand {
     #[clap(long = "insecure")]
     insecure: bool,
 
+    /// Skip checking OCI registry's certificate for validity
+    #[clap(long = "insecure-skip-tls-verify")]
+    pub insecure_skip_tls_verify: bool,
+
     /// skip the local OCI cache
     #[clap(long = "no-cache")]
     no_cache: bool,
@@ -201,6 +205,7 @@ impl From<InspectCommand> for inspect::InspectCliCommand {
             user: cmd.user,
             password: cmd.password,
             insecure: cmd.insecure,
+            insecure_skip_tls_verify: cmd.insecure_skip_tls_verify,
             no_cache: cmd.no_cache,
         }
     }
@@ -592,12 +597,14 @@ mod test {
                 user,
                 password,
                 insecure,
+                insecure_skip_tls_verify,
                 no_cache,
             }) => {
                 assert_eq!(archive, LOCAL);
                 assert_eq!(digest.unwrap(), "sha256:blah");
                 assert!(!allow_latest);
                 assert!(!insecure);
+                assert!(!insecure_skip_tls_verify);
                 assert_eq!(user.unwrap(), "name");
                 assert_eq!(password.unwrap(), "secret");
                 assert!(no_cache);
@@ -627,12 +634,14 @@ mod test {
                 user,
                 password,
                 insecure,
+                insecure_skip_tls_verify,
                 no_cache,
             }) => {
                 assert_eq!(archive, REMOTE);
                 assert_eq!(digest.unwrap(), "sha256:blah");
                 assert!(allow_latest);
                 assert!(insecure);
+                assert!(!insecure_skip_tls_verify);
                 assert_eq!(user.unwrap(), "name");
                 assert_eq!(password.unwrap(), "secret");
                 assert!(no_cache);

--- a/crates/wash-cli/src/plugin.rs
+++ b/crates/wash-cli/src/plugin.rs
@@ -172,6 +172,7 @@ pub async fn handle_install(
                     user: cmd.oci_auth.user,
                     password: cmd.oci_auth.password,
                     insecure: cmd.oci_auth.insecure,
+                    insecure_skip_tls_verify: cmd.oci_auth.insecure_skip_tls_verify,
                 },
             )
             .await

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -80,6 +80,10 @@ pub struct InspectCommand {
     #[clap(long = "insecure")]
     pub(crate) insecure: bool,
 
+    /// Skip checking OCI registry's certificate for validity
+    #[clap(long = "insecure-skip-tls-verify")]
+    pub insecure_skip_tls_verify: bool,
+
     /// skip the local OCI cache
     #[clap(long = "no-cache")]
     pub(crate) no_cache: bool,
@@ -333,6 +337,7 @@ impl From<InspectCommand> for inspect::InspectCliCommand {
             user: cmd.user,
             password: cmd.password,
             insecure: cmd.insecure,
+            insecure_skip_tls_verify: cmd.insecure_skip_tls_verify,
             no_cache: cmd.no_cache,
         }
     }
@@ -789,6 +794,7 @@ mod test {
                 user,
                 password,
                 insecure,
+                insecure_skip_tls_verify,
                 no_cache,
                 wit,
             }) => {
@@ -801,6 +807,7 @@ mod test {
                 assert_eq!(password.unwrap(), "opensesame");
                 assert!(allow_latest);
                 assert!(insecure);
+                assert!(!insecure_skip_tls_verify);
                 assert!(jwt_only);
                 assert!(no_cache);
                 assert!(!wit);
@@ -820,6 +827,7 @@ mod test {
             "opensesame",
             "--allow-latest",
             "--insecure",
+            "--insecure-skip-tls-verify",
             "--jwt-only",
             "--no-cache",
         ])
@@ -834,6 +842,7 @@ mod test {
                 user,
                 password,
                 insecure,
+                insecure_skip_tls_verify,
                 no_cache,
                 wit,
             }) => {
@@ -846,6 +855,7 @@ mod test {
                 assert_eq!(password.unwrap(), "opensesame");
                 assert!(allow_latest);
                 assert!(insecure);
+                assert!(insecure_skip_tls_verify);
                 assert!(jwt_only);
                 assert!(no_cache);
                 assert!(!wit);

--- a/crates/wash-lib/src/cli/inspect.rs
+++ b/crates/wash-lib/src/cli/inspect.rs
@@ -62,6 +62,10 @@ pub struct InspectCliCommand {
     #[clap(long = "insecure")]
     pub insecure: bool,
 
+    /// Skip checking OCI registry's certificate for validity
+    #[clap(long = "insecure-skip-tls-verify")]
+    pub insecure_skip_tls_verify: bool,
+
     /// skip the local OCI cache and pull the artifact from the registry to inspect
     #[clap(long = "no-cache")]
     pub no_cache: bool,
@@ -93,6 +97,7 @@ pub async fn handle_command(
                 user: command.user.clone(),
                 password: command.password.clone(),
                 insecure: command.insecure,
+                insecure_skip_tls_verify: command.insecure_skip_tls_verify,
             },
         )
         .await?;
@@ -417,6 +422,7 @@ mod test {
             user,
             password,
             insecure,
+            insecure_skip_tls_verify,
             no_cache,
             wit,
         } = inspect_long.command;
@@ -424,6 +430,7 @@ mod test {
         assert_eq!(digest.unwrap(), "sha256:blah");
         assert!(!allow_latest);
         assert!(!insecure);
+        assert!(!insecure_skip_tls_verify);
         assert_eq!(user.unwrap(), "name");
         assert_eq!(password.unwrap(), "secret");
         assert!(jwt_only);
@@ -453,6 +460,7 @@ mod test {
             user,
             password,
             insecure,
+            insecure_skip_tls_verify,
             no_cache,
             wit,
         } = inspect_short.command;
@@ -460,6 +468,7 @@ mod test {
         assert_eq!(digest.unwrap(), "sha256:blah");
         assert!(allow_latest);
         assert!(insecure);
+        assert!(!insecure_skip_tls_verify);
         assert_eq!(user.unwrap(), "name");
         assert_eq!(password.unwrap(), "secret");
         assert!(jwt_only);
@@ -490,6 +499,7 @@ mod test {
             user,
             password,
             insecure,
+            insecure_skip_tls_verify,
             no_cache,
             wit,
         } = cmd.command;
@@ -502,6 +512,7 @@ mod test {
         assert_eq!(password.unwrap(), "opensesame");
         assert!(allow_latest);
         assert!(insecure);
+        assert!(!insecure_skip_tls_verify);
         assert!(jwt_only);
         assert!(no_cache);
         assert!(!wit);
@@ -517,6 +528,7 @@ mod test {
             "opensesame",
             "--allow-latest",
             "--insecure",
+            "--insecure-skip-tls-verify",
             "--wit",
             "--no-cache",
         ])
@@ -530,6 +542,7 @@ mod test {
             user,
             password,
             insecure,
+            insecure_skip_tls_verify,
             no_cache,
             wit,
         } = short_cmd.command;
@@ -542,6 +555,7 @@ mod test {
         assert_eq!(password.unwrap(), "opensesame");
         assert!(allow_latest);
         assert!(insecure);
+        assert!(insecure_skip_tls_verify);
         assert!(!jwt_only);
         assert!(no_cache);
         assert!(wit);

--- a/crates/wash-lib/src/cli/registry.rs
+++ b/crates/wash-lib/src/cli/registry.rs
@@ -25,6 +25,10 @@ pub struct AuthOpts {
     /// Allow insecure (HTTP) registry connections
     #[clap(long = "insecure")]
     pub insecure: bool,
+
+    /// Skip checking server's certificate for validity
+    #[clap(long = "insecure-skip-tls-verify")]
+    pub insecure_skip_tls_verify: bool,
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -42,6 +42,8 @@ pub struct OciPullOptions {
     pub password: Option<String>,
     /// Whether or not to allow pulling from non-https registries
     pub insecure: bool,
+    /// Whether or not OCI registry's certificate will be checked for validity. This will make your HTTPS connections insecure.
+    pub insecure_skip_tls_verify: bool,
 }
 
 /// Additional options for pushing an OCI artifact
@@ -57,6 +59,8 @@ pub struct OciPushOptions {
     pub password: Option<String>,
     /// Whether or not to allow pulling from non-https registries
     pub insecure: bool,
+    /// Whether or not OCI registry's certificate will be checked for validity. This will make your HTTPS connections insecure.
+    pub insecure_skip_tls_verify: bool,
     /// Optional annotations you'd like to add to the pushed artifact
     pub annotations: Option<HashMap<String, String>>,
 }
@@ -137,6 +141,7 @@ pub async fn pull_oci_artifact(url: String, options: OciPullOptions) -> Result<V
             ClientProtocol::Https
         },
         extra_root_certificates: tls::NATIVE_ROOTS_OCI.to_vec(),
+        accept_invalid_certificates: options.insecure_skip_tls_verify,
         ..Default::default()
     });
 
@@ -232,6 +237,7 @@ pub async fn push_oci_artifact(
             ClientProtocol::Https
         },
         extra_root_certificates: tls::NATIVE_ROOTS_OCI.to_vec(),
+        accept_invalid_certificates: options.insecure_skip_tls_verify,
         ..Default::default()
     });
 


### PR DESCRIPTION
## Feature or Problem

Sometimes it can be easier to simply ignore HTTPS certificate than try to ensure that it's correctly set up correctly in the OS  trust store (such as when you have self-signed certificates), this should make those scenarios easier to use any wash commands that interact with OCI registries.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
