### PR TITLE
feat(wash-lib): add support for specifying multiple labels

### DIFF
--- a/crates/wash-cli/tests/wash_label.rs
+++ b/crates/wash-cli/tests/wash_label.rs
@@ -1,0 +1,39 @@
+mod common;
+
+use common::TestWashInstance;
+
+use anyhow::{Context, Result};
+use serial_test::serial;
+use tokio::process::Command;
+use wash_lib::cli::output::LabelHostCommandOutput;
+
+#[tokio::test]
+#[serial]
+async fn integration_label_host_serial() -> Result<()> {
+    let wash_instance = TestWashInstance::create().await?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args([
+            "label",
+            &wash_instance.host_id,
+            "key1=value1",
+            "--output",
+            "json",
+            "--ctl-port",
+            &wash_instance.nats_port.to_string(),
+        ])
+        .kill_on_drop(true)
+        .output()
+        .await
+        .context("failed to execute wash label")?;
+
+    let cmd_output: LabelHostCommandOutput = serde_json::from_slice(&output.stdout)?;
+    assert!(cmd_output.success, "command returned success");
+
+    assert!(!cmd_output.deleted);
+    assert_eq!(
+        cmd_output.processed,
+        vec![(String::from("key1"), String::from("value1"))],
+    );
+    Ok(())
+}

--- a/crates/wash-lib/src/cli/label.rs
+++ b/crates/wash-lib/src/cli/label.rs
@@ -1,5 +1,9 @@
-use anyhow::{bail, Result};
+use std::collections::HashMap;
+
+use anyhow::Result;
 use clap::Parser;
+use serde_json::json;
+use tracing::{error, warn};
 
 use crate::{
     common::{boxed_err_to_anyhow, find_host_id},
@@ -24,8 +28,8 @@ pub struct LabelHostCommand {
     pub delete: bool,
 
     /// Host label in the form of a `[key]=[value]` pair, e.g. "cloud=aws". When `--delete` is set, only the key is provided
-    #[clap(name = "label", alias = "label")]
-    pub label: String,
+    #[clap(name = "label", alias = "label", value_delimiter = ',')]
+    pub labels: Vec<String>,
 }
 
 pub async fn handle_label_host(cmd: LabelHostCommand) -> Result<CommandOutput> {
@@ -40,40 +44,117 @@ pub async fn handle_label_host(cmd: LabelHostCommand) -> Result<CommandOutput> {
         friendly_name
     };
 
-    let (key, value) = match cmd.label.split_once('=') {
-        Some((k, v)) => (k, v),
-        None => (cmd.label.as_str(), ""),
-    };
+    let labels = cmd
+        .labels
+        .iter()
+        .map(|orig| match orig.split_once('=') {
+            Some((k, v)) => (k, v),
+            None => (orig.as_str(), ""),
+        })
+        .collect::<Vec<(&str, &str)>>();
 
-    if cmd.delete {
-        let ack = client
-            .delete_label(&host_id, key)
-            .await
-            .map_err(boxed_err_to_anyhow)?;
-        if !ack.success {
-            bail!("Operation failed: {}", ack.message);
+    // Set/Delete the provided labels
+    let mut succeeded = true;
+    let mut processed: Vec<(&str, &str)> = Vec::new();
+    for (key, value) in &labels {
+        let op = if cmd.delete {
+            client
+                .delete_label(&host_id, key)
+                .await
+                .map_err(boxed_err_to_anyhow)
+        } else {
+            client
+                .put_label(&host_id, key, value)
+                .await
+                .map_err(boxed_err_to_anyhow)
+        };
+
+        match op {
+            Ok(ack) => {
+                if !ack.success {
+                    warn!(message = ack.message, "operation failed");
+                    succeeded = false;
+                    break;
+                }
+                processed.push((key, value));
+            }
+            Err(error) => {
+                error!(?error, "failed to set/delete label");
+                succeeded = false;
+                break;
+            }
+        }
+    }
+
+    let output = format!(
+        "Host `{friendly_name}` {} with `{}`",
+        if cmd.delete { "unlabeled" } else { "labeled" },
+        labels
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<String>>()
+            .join(",")
+    );
+
+    Ok(CommandOutput::new(
+        output,
+        HashMap::from([
+            ("success".into(), json!(succeeded)),
+            ("deleted".into(), json!(cmd.delete)),
+            ("processed".into(), json!(processed)),
+        ]),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::LabelHostCommand;
+
+    const HOST_ID: &str = "host-id";
+
+    /// Ensure multiple labels work when specified multiple times
+    #[test]
+    fn test_label_multiple_joined() {
+        #[derive(Parser, Debug)]
+        struct Cmd {
+            #[clap(flatten)]
+            command: LabelHostCommand,
         }
 
-        Ok(CommandOutput::from_key_and_text(
-            "result",
-            format!("Host `{friendly_name}` unlabeled with `{key}`"),
-        ))
-    } else {
-        if value.is_empty() {
-            bail!("No value provided");
+        let expected_labels = vec!["key1=value1", "key2=value2"];
+        let cmd: Cmd =
+            Parser::try_parse_from(["label", HOST_ID, &expected_labels.join(",")]).unwrap();
+        let LabelHostCommand {
+            host_id,
+            delete,
+            labels,
+            ..
+        } = cmd.command;
+        assert_eq!(host_id, HOST_ID);
+        assert!(!delete);
+        assert_eq!(labels, expected_labels);
+    }
+
+    /// Ensure single label works
+    #[test]
+    fn test_label_single() {
+        #[derive(Parser, Debug)]
+        struct Cmd {
+            #[clap(flatten)]
+            command: LabelHostCommand,
         }
 
-        let ack = client
-            .put_label(&host_id, key, value)
-            .await
-            .map_err(boxed_err_to_anyhow)?;
-        if !ack.success {
-            bail!("Operation failed: {}", ack.message);
-        }
-
-        Ok(CommandOutput::from_key_and_text(
-            "result",
-            format!("Host `{friendly_name}` labeled with `{key}={value}`"),
-        ))
+        let cmd: Cmd = Parser::try_parse_from(["label", HOST_ID, "key1=value1"]).unwrap();
+        let LabelHostCommand {
+            host_id,
+            delete,
+            labels,
+            ..
+        } = cmd.command;
+        assert_eq!(host_id, HOST_ID);
+        assert!(!delete);
+        assert_eq!(labels, vec!["key1=value1"]);
     }
 }

--- a/crates/wash-lib/src/cli/output.rs
+++ b/crates/wash-lib/src/cli/output.rs
@@ -86,3 +86,11 @@ pub struct PullCommandOutput {
     pub success: bool,
     pub file: String,
 }
+
+/// JSON output representation of the `wash label` command
+#[derive(Debug, Deserialize)]
+pub struct LabelHostCommandOutput {
+    pub success: bool,
+    pub deleted: bool,
+    pub processed: Vec<(String, String)>,
+}


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit adds support for specifying multiple labels to `wash label`.

Users can use `wash label <host-id> key1=value1,key2=value2` to set multiple labels on the host at the same time, in a best-effort manner

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
