### PR TITLE
feat(*): Updates wash and host to support new oci wasm manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "oci-wasm"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae01dd353e18899d28ab88855ea12531897f356f606fb8f4a95fc5f9cff1197"
+checksum = "9616e709ad2bebc019a369791e3933e5d302314c30912ddc79e73d6c8ed82bb7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6273,6 +6273,7 @@ dependencies = [
  "names",
  "nkeys",
  "oci-distribution 0.11.0",
+ "oci-wasm",
  "opentelemetry-nats",
  "provider-archive",
  "rmp-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3374,6 +3374,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-wasm"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae01dd353e18899d28ab88855ea12531897f356f606fb8f4a95fc5f9cff1197"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "oci-distribution 0.11.0",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "wit-component 0.207.0",
+ "wit-parser 0.207.0",
+]
+
+[[package]]
 name = "olpc-cjson"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5002,7 +5019,7 @@ dependencies = [
  "tokio",
  "wascap 0.14.0",
  "wasmcloud-component-adapters",
- "wit-component",
+ "wit-component 0.202.0",
 ]
 
 [[package]]
@@ -5772,6 +5789,7 @@ dependencies = [
  "nkeys",
  "notify",
  "oci-distribution 0.11.0",
+ "oci-wasm",
  "once_cell",
  "provider-archive",
  "rand 0.8.5",
@@ -5840,6 +5858,7 @@ dependencies = [
  "nkeys",
  "normpath",
  "oci-distribution 0.11.0",
+ "oci-wasm",
  "path-absolutize",
  "provider-archive",
  "regex",
@@ -5880,8 +5899,8 @@ dependencies = [
  "weld-codegen",
  "wit-bindgen-core",
  "wit-bindgen-go",
- "wit-component",
- "wit-parser",
+ "wit-component 0.202.0",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
@@ -6013,6 +6032,22 @@ dependencies = [
  "spdx",
  "wasm-encoder 0.202.0",
  "wasmparser 0.202.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c44e62d325ce9253f88c01f0f67be121356767d12f2f13e701fdcd99e1f5b0"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.207.0",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]
@@ -6530,8 +6565,8 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
- "wit-component",
- "wit-parser",
+ "wit-component 0.202.0",
+ "wit-parser 0.202.0",
  "wrpc-runtime-wasmtime",
  "wrpc-transport",
  "wrpc-types",
@@ -6596,6 +6631,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
 dependencies = [
  "bitflags 2.5.0",
+ "indexmap 2.2.6",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
+dependencies = [
+ "ahash",
+ "bitflags 2.5.0",
+ "hashbrown 0.14.3",
  "indexmap 2.2.6",
  "semver",
 ]
@@ -6693,7 +6741,7 @@ dependencies = [
  "syn 2.0.58",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
@@ -6914,7 +6962,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap 2.2.6",
- "wit-parser",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
@@ -7282,9 +7330,9 @@ dependencies = [
  "anyhow",
  "heck 0.4.1",
  "wasm-encoder 0.202.0",
- "wasm-metadata",
+ "wasm-metadata 0.202.0",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.202.0",
 ]
 
 [[package]]
@@ -7294,7 +7342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b67e11c950041849a10828c7600ea62a4077c01e8af72e8593253575428f91b"
 dependencies = [
  "anyhow",
- "wit-parser",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
@@ -7327,9 +7375,9 @@ dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap 2.2.6",
- "wasm-metadata",
+ "wasm-metadata 0.202.0",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.202.0",
 ]
 
 [[package]]
@@ -7402,9 +7450,28 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.202.0",
- "wasm-metadata",
+ "wasm-metadata 0.202.0",
  "wasmparser 0.202.0",
- "wit-parser",
+ "wit-parser 0.202.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a411ff9c471737091b2c1a738a25031029fc4d0b8f1a60bef0e68906e9f6534b"
+dependencies = [
+ "anyhow",
+ "bitflags 2.5.0",
+ "indexmap 2.2.6",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.207.0",
+ "wasm-metadata 0.207.0",
+ "wasmparser 0.207.0",
+ "wit-parser 0.207.0",
 ]
 
 [[package]]
@@ -7423,6 +7490,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.202.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c83dab33a9618d86cfe3563cc864deffd08c17efc5db31a3b7cd1edeffe6e1"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.2.6",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]
@@ -7518,7 +7603,7 @@ checksum = "0b5304f4c3000b643bb56d405c5e29efd940f529b898288c65cd3861e24cca71"
 dependencies = [
  "anyhow",
  "tracing",
- "wit-parser",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,7 @@ normpath = { version = "1", default-features = false }
 notify = { version = "6", default-features = false }
 nuid = { version = "0.4", default-features = false }
 oci-distribution = { version = "0.11", default-features = false }
+oci-wasm = { version = "0.0.1", default-features = false }
 once_cell = { version = "1", default-features = false }
 opentelemetry = { version = "0.21", default-features = false }
 opentelemetry-appender-tracing = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,7 @@ normpath = { version = "1", default-features = false }
 notify = { version = "6", default-features = false }
 nuid = { version = "0.4", default-features = false }
 oci-distribution = { version = "0.11", default-features = false }
-oci-wasm = { version = "0.0.1", default-features = false }
+oci-wasm = { version = "0.0.2", default-features = false }
 once_cell = { version = "1", default-features = false }
 opentelemetry = { version = "0.21", default-features = false }
 opentelemetry-appender-tracing = { version = "0.2", default-features = false }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -27,6 +27,7 @@ humantime = { workspace = true }
 names = { workspace = true }
 nkeys = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"] }
+oci-wasm = { workspace = true, features = ["rustls-tls"] }
 opentelemetry-nats = { workspace = true }
 provider-archive = { workspace = true }
 rmp-serde = { workspace = true }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -31,6 +31,7 @@ nix = { workspace = true, features = ["signal"] }
 nkeys = { workspace = true }
 notify = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"] }
+oci-wasm = { workspace = true, features = ["rustls-tls"] }
 once_cell = { workspace = true }
 provider-archive = { workspace = true }
 regex = { workspace = true }

--- a/crates/wash-cli/src/common/registry_cmd.rs
+++ b/crates/wash-cli/src/common/registry_cmd.rs
@@ -7,8 +7,8 @@ use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use tracing::warn;
 use wash_lib::registry::{
-    pull_oci_artifact, push_oci_artifact, validate_artifact, OciPullOptions, OciPushOptions,
-    SupportedArtifacts,
+    parse_and_validate_artifact, pull_oci_artifact, push_oci_artifact, OciPullOptions,
+    OciPushOptions, SupportedArtifacts,
 };
 use wash_lib::{
     cli::{
@@ -44,7 +44,7 @@ pub async fn registry_pull(
     }?;
 
     let artifact = pull_oci_artifact(
-        image.whole(),
+        &image,
         OciPullOptions {
             digest: cmd.digest,
             allow_latest: cmd.allow_latest,
@@ -73,9 +73,9 @@ pub async fn write_artifact(
     image: &Reference,
     output: Option<String>,
 ) -> Result<String> {
-    let file_extension = match validate_artifact(artifact).await? {
-        SupportedArtifacts::Par => PROVIDER_ARCHIVE_FILE_EXTENSION,
-        SupportedArtifacts::Wasm => WASM_FILE_EXTENSION,
+    let file_extension = match parse_and_validate_artifact(artifact.to_vec()).await? {
+        SupportedArtifacts::Par(..) => PROVIDER_ARCHIVE_FILE_EXTENSION,
+        SupportedArtifacts::Wasm(..) => WASM_FILE_EXTENSION,
     };
     // Output to provided file, or use artifact_name.file_extension
     let outfile = output.unwrap_or_else(|| {

--- a/crates/wash-cli/src/plugin.rs
+++ b/crates/wash-cli/src/plugin.rs
@@ -165,7 +165,7 @@ pub async fn handle_install(
 
             // TODO: Add support for pulling via stream to wash_lib
             let image_data = pull_oci_artifact(
-                image.whole(),
+                &image,
                 OciPullOptions {
                     digest: cmd.digest.clone(),
                     allow_latest: cmd.allow_latest,

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -57,6 +57,7 @@ indicatif = { workspace = true, optional = true }
 nkeys = { workspace = true }
 normpath = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"] }
+oci-wasm = { workspace = true, features = ["rustls-tls"] }
 path-absolutize = { workspace = true, features = [
     "once_cell_cache",
 ], optional = true }


### PR DESCRIPTION
This PR contains two commits: one of them updates wash to only push the new type of wasm manifest, but supports pulling both types of manifest. This is technically a small breaking change for wash, but see the commit message for more details. The second commit updates the host to support the new wasm type as well as the old manifest type. This backwards compatibility will be in place until at least wasmCloud 2.0. 

Closes #2038 
