### PR TITLE
chore: Bump oci-distribution to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3349,6 +3349,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-distribution"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95a2c51531af0cb93761f66094044ca6ea879320bccd35ab747ff3fcab3f422"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http 1.1.0",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.12.4",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
 name = "olpc-cjson"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5746,7 +5771,7 @@ dependencies = [
  "nix",
  "nkeys",
  "notify",
- "oci-distribution",
+ "oci-distribution 0.11.0",
  "once_cell",
  "provider-archive",
  "rand 0.8.5",
@@ -5814,7 +5839,7 @@ dependencies = [
  "indicatif",
  "nkeys",
  "normpath",
- "oci-distribution",
+ "oci-distribution 0.11.0",
  "path-absolutize",
  "provider-archive",
  "regex",
@@ -6101,7 +6126,7 @@ dependencies = [
  "bytes",
  "cloudevents-sdk",
  "futures",
- "oci-distribution",
+ "oci-distribution 0.11.0",
  "opentelemetry",
  "opentelemetry_sdk",
  "serde",
@@ -6124,7 +6149,7 @@ dependencies = [
  "bytes",
  "cloudevents-sdk",
  "futures",
- "oci-distribution",
+ "oci-distribution 0.9.4",
  "opentelemetry",
  "opentelemetry_sdk",
  "serde",
@@ -6176,7 +6201,7 @@ dependencies = [
  "hyper-rustls 0.27.0",
  "hyper-util",
  "nkeys",
- "oci-distribution",
+ "oci-distribution 0.11.0",
  "once_cell",
  "reqwest 0.12.4",
  "rustls 0.23.4",
@@ -6212,7 +6237,7 @@ dependencies = [
  "humantime",
  "names",
  "nkeys",
- "oci-distribution",
+ "oci-distribution 0.11.0",
  "opentelemetry-nats",
  "provider-archive",
  "rmp-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ nkeys = { version = "0.3", default-features = false }
 normpath = { version = "1", default-features = false }
 notify = { version = "6", default-features = false }
 nuid = { version = "0.4", default-features = false }
-oci-distribution = { version = "0.9", default-features = false }
+oci-distribution = { version = "0.11", default-features = false }
 once_cell = { version = "1", default-features = false }
 opentelemetry = { version = "0.21", default-features = false }
 opentelemetry-appender-tracing = { version = "0.2", default-features = false }

--- a/crates/host/src/oci.rs
+++ b/crates/host/src/oci.rs
@@ -178,7 +178,7 @@ impl Fetcher {
         } else {
             ClientProtocol::Https
         };
-        let mut c = Client::new(ClientConfig {
+        let c = Client::new(ClientConfig {
             protocol,
             extra_root_certificates: tls::NATIVE_ROOTS_OCI.to_vec(),
             ..Default::default()

--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -130,7 +130,7 @@ pub async fn pull_oci_artifact(url: String, options: OciPullOptions) -> Result<V
         }
     }
 
-    let mut client = Client::new(ClientConfig {
+    let client = Client::new(ClientConfig {
         protocol: if options.insecure {
             ClientProtocol::Http
         } else {
@@ -225,7 +225,7 @@ pub async fn push_oci_artifact(
         annotations: None,
     }];
 
-    let mut client = Client::new(ClientConfig {
+    let client = Client::new(ClientConfig {
         protocol: if options.insecure {
             ClientProtocol::Http
         } else {


### PR DESCRIPTION
## Feature or Problem

We're currently using 0.9.4 from 2022

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
