### PR TITLE
Configure reqwest with user-agent

### DIFF
--- a/crates/core/src/tls.rs
+++ b/crates/core/src/tls.rs
@@ -64,10 +64,14 @@ pub static DEFAULT_HYPER_CONNECTOR: Lazy<
 #[cfg(all(feature = "reqwest", feature = "rustls-native-certs"))]
 pub static DEFAULT_REQWEST_CLIENT: Lazy<reqwest::Client> = Lazy::new(|| {
     reqwest::ClientBuilder::default()
+        .user_agent(REQWEST_USER_AGENT)
         .with_native_certificates()
         .build()
         .expect("failed to build HTTP client")
 });
+
+pub static REQWEST_USER_AGENT: &str =
+    concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 #[cfg(feature = "rustls-native-certs")]
 pub trait NativeRootsExt {


### PR DESCRIPTION
## Feature or Problem

Certain proxies will require authentication to be provided if the User-Agent header is missing when establishing a tunnel, so we should set a reasonable default here (`wasmcloud-core/<crate-version>` for now, we can adjust it later if need be) to enable usage in networks that are behind such proxies.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
