### PR TITLE
Provides Alias for "wash link del <args>" as "wash link delete <args>"

### DIFF
--- a/crates/wash-lib/src/cli/link.rs
+++ b/crates/wash-lib/src/cli/link.rs
@@ -85,7 +85,7 @@ pub enum LinkCommand {
     Put(LinkPutCommand),
 
     /// Delete a link
-    #[clap(name = "del")]
+    #[clap(name = "del", alias = "delete")]
     Del(LinkDelCommand),
 }
 


### PR DESCRIPTION
## Feature
Solves #1991

## Testing
Ran `cargo build` and  `cargo test` in .crates/wash-cli


### Manual Verification
ran `cargo run up` & `cargo run -- link delete source ns package` , got executed in the same way as `cargo run --link del source ns package`
