### PR TITLE
Handle disconnected NATS connection better

### DIFF
--- a/washboard-ui/packages/lattice-client-core/package.json
+++ b/washboard-ui/packages/lattice-client-core/package.json
@@ -2,7 +2,7 @@
   "name": "@wasmcloud/lattice-client-core",
   "packageManager": "yarn@4.2.2",
   "license": "Apache-2.0",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Framework-agnostic core package for the wasmCloud Lattice Client",
   "author": "wasmCloud",
   "repository": {


### PR DESCRIPTION
## Feature or Problem
Found that the nats connection wasn't reconnecting if it failed to connect initially, or was disconnected for some reason. This makes the connection attempt to reconnect if a new request is made while it is disconnected/errored.