### PR TITLE
feat(wash-lib): Support configuring proxy credentials for HTTP(S)_PROXY when downloading artifacts

### DIFF
--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -7,7 +7,6 @@ use tokio::process::{Child, Command};
 use tokio_stream::StreamExt;
 use tokio_util::io::StreamReader;
 use tracing::warn;
-use wasmcloud_core::tls;
 
 #[cfg(target_family = "unix")]
 use std::os::unix::prelude::PermissionsExt;
@@ -16,6 +15,8 @@ use std::process::Stdio;
 
 #[cfg(target_family = "unix")]
 use command_group::AsyncCommandGroup;
+
+use super::get_download_client;
 
 const WASMCLOUD_GITHUB_RELEASE_URL: &str =
     "https://github.com/wasmCloud/wasmCloud/releases/download";
@@ -149,7 +150,7 @@ where
     let url = wasmcloud_url(version);
     // NOTE(brooksmtownsend): This seems like a lot of work when I really just want to use AsyncRead
     // to pipe the response body into a file. I'm not sure if there's a better way to do this.
-    let download_response = tls::DEFAULT_REQWEST_CLIENT.get(&url).send().await?;
+    let download_response = get_download_client()?.get(&url).send().await?;
     if download_response.status() != StatusCode::OK {
         bail!(
             "failed to download wasmCloud host from {}. Status code: {}",


### PR DESCRIPTION
## Feature or Problem

This makes it possible to specify basic authentication credentials to be used with the configured `HTTP(S)_PROXY` (or `http(s)_proxy`) environment variables by way of specifying `WASH_PROXY_USERNAME` and `WASH_PROXY_PASSWORD` environment variables.

If we think this is a reasonable approach, I'm also happy to extend this to the [`wash ui` command](https://github.com/wasmCloud/wasmCloud/blob/main/crates/wash-cli/src/ui/mod.rs#L66-L76)

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
