### PR TITLE
feat(wash-cli): `wash up --wadm-manifest`

### DIFF
--- a/crates/wash-cli/tests/fixtures/wadm/component-only.wadm.yaml
+++ b/crates/wash-cli/tests/fixtures/wadm/component-only.wadm.yaml
@@ -1,0 +1,20 @@
+#
+# This is a test WADM file used mostly for testing
+#
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: example
+  annotations:
+    description: example WADM file with a single component (http-hello-world-rust) and no providers
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1

--- a/crates/wash-lib/src/app.rs
+++ b/crates/wash-lib/src/app.rs
@@ -66,6 +66,30 @@ impl AppManifest {
         }
         Ok(())
     }
+
+    /// Retrieve the name of a given [`AppManifest`]
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            AppManifest::ModelName(name) => Some(name),
+            AppManifest::SerializedModel(manifest) => manifest
+                .get("metadata")?
+                .get("name")
+                .and_then(|v| v.as_str()),
+        }
+    }
+
+    /// Retrieve the version of a given [`AppManifest`], returning None if the manifest
+    /// does not contain a version (or is not the type to contain a version)
+    pub fn version(&self) -> Option<&str> {
+        match self {
+            AppManifest::ModelName(_) => None,
+            AppManifest::SerializedModel(manifest) => manifest
+                .get("metadata")?
+                .get("annotations")?
+                .get("version")
+                .and_then(|v| v.as_str()),
+        }
+    }
 }
 
 /// Resolve the relative paths in a YAML value, given a base path (directory)

--- a/crates/wash-lib/src/cli/output.rs
+++ b/crates/wash-lib/src/cli/output.rs
@@ -94,3 +94,13 @@ pub struct LabelHostCommandOutput {
     pub deleted: bool,
     pub processed: Vec<(String, String)>,
 }
+
+/// JSON output representation of the `wash up` command
+#[derive(Debug, Clone, Deserialize)]
+pub struct UpCommandOutput {
+    pub success: bool,
+    pub kill_cmd: String,
+    pub wasmcloud_log: String,
+    pub nats_url: String,
+    pub deployed_wadm_manifest_path: Option<String>,
+}


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit introduces the functionality for `wash up --wadm-manifest <path to manifest>`, which starts a host and immediately deploys an application defined in a WADM manifest, cleaning it up when the `Ctrl+C` is hit, along with normal host termination.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
