### PR TITLE
chore(tracing): Update opentelemetry to use reqwest with rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,6 +4513,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry-otlp = { workspace = true, features = [
     "logs",
     "trace",
     "metrics",
-    "reqwest-client",
+    "reqwest-rustls",
 ], optional = true }
 serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true, features = ["log"] }


### PR DESCRIPTION
## Feature or Problem

Given that we're using rustls pretty much everywhere else, it seems like the right thing would be to use rustls with the OpenTelemetry ecosystem as well.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
