### PR TITLE
fix(http-client)!: use platform native system certs, enable tls 1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,6 +2698,7 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "rustls 0.23.5",
+ "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -6671,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "futures",

--- a/crates/provider-http-client/Cargo.toml
+++ b/crates/provider-http-client/Cargo.toml
@@ -18,7 +18,7 @@ status = "actively-developed"
 anyhow = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
-hyper-rustls = { workspace = true, features = ["native-tokio"] }
+hyper-rustls = { workspace = true, features = ["native-tokio", "tls12"] }
 hyper-util = { workspace = true, features = ["client-legacy"] }
 tokio = { workspace = true, features = ["macros"] }
 tracing = { workspace = true }

--- a/crates/provider-http-client/Cargo.toml
+++ b/crates/provider-http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-client"
-version = "0.9.0"
+version = "0.10.0"
 description = """
 HTTP client for wasmCloud, using hyper. This package provides a capability provider that satisfies the 'wrpc:http/outgoing-handler' contract.
 """
@@ -18,7 +18,7 @@ status = "actively-developed"
 anyhow = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
-hyper-rustls = { workspace = true }
+hyper-rustls = { workspace = true, features = ["native-tokio"] }
 hyper-util = { workspace = true, features = ["client-legacy"] }
 tokio = { workspace = true, features = ["macros"] }
 tracing = { workspace = true }

--- a/src/bin/http-client-provider/wasmcloud.toml
+++ b/src/bin/http-client-provider/wasmcloud.toml
@@ -1,10 +1,10 @@
 name = "HTTP Client"
 language = "rust"
-version = "0.9.0"
+version = "0.10.0"
 type = "provider"
 
 [rust]
-target_dir = "../../"
+target_dir = "../../../"
 
 [provider]
 bin_name = "http-client-provider"


### PR DESCRIPTION
## Feature or Problem
This PR enables the HTTP client provider to use the platform's native certificate store at runtime, as specified in https://crates.io/crates/hyper-rustls via rustls-native-certs. As far as I know this doesn't introduce any platform specific dependencies, but it can fail in platform specific ways.

Worth noting this would also enable loading a set of certs using the `SSL_CERT_FILE` environment variable, however we don't pass environment variables to providers by default. We may need to consider adding that as a separate feature.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
http-client v0.10.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Draft pending verification this fixes an issue on machines with additional certificates
