### PR TITLE
feat(http-client): Add default User-Agent header to requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6622,6 +6622,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "futures",
+ "http 1.1.0",
  "hyper-rustls 0.27.0",
  "hyper-util",
  "tokio",

--- a/crates/provider-http-client/Cargo.toml
+++ b/crates/provider-http-client/Cargo.toml
@@ -17,6 +17,7 @@ status = "actively-developed"
 [dependencies]
 anyhow = { workspace = true }
 futures = { workspace = true }
+http = { workspace = true }
 hyper-rustls = { workspace = true }
 hyper-util = { workspace = true, features = ["client-legacy"] }
 tokio = { workspace = true, features = ["macros"] }


### PR DESCRIPTION
## Feature or Problem

In the interest of keeping https://github.com/wasmCloud/wasmCloud/pull/2164 focused on just the wasmcloud-internal client, this implements the suggestion of adding a default User-Agent if one isn't set in the `http-client` provider.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
