### PR TITLE
feat: Add support for configuring grpc protocol with OpenTelemetry

### DIFF
--- a/crates/core/src/otel.rs
+++ b/crates/core/src/otel.rs
@@ -1,8 +1,16 @@
 //! Core reusable logic around [OpenTelemetry ("OTEL")](https://opentelemetry.io/) support
 
+use std::str::FromStr;
+
+use anyhow::bail;
 use serde::{Deserialize, Serialize};
 
 use crate::wit::WitMap;
+
+// We redefine the upstream variables here since they are not exported by the opentelemetry-otlp crate:
+// https://github.com/open-telemetry/opentelemetry-rust/blob/opentelemetry-0.23.0/opentelemetry-otlp/src/exporter/mod.rs#L57-L60
+const OTEL_EXPORTER_OTLP_GRPC_ENDPOINT_DEFAULT: &str = "http://localhost:4317";
+const OTEL_EXPORTER_OTLP_HTTP_ENDPOINT_DEFAULT: &str = "http://localhost:4318";
 
 /// Configuration values for OpenTelemetry
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -23,6 +31,79 @@ pub struct OtelConfig {
     pub metrics_endpoint: Option<String>,
     /// Overrides the OpenTelemetry endpoint for logs.
     pub logs_endpoint: Option<String>,
+    /// Determines whether http or grpc will be used for exporting the telemetry.
+    pub protocol: OtelProtocol,
+}
+
+impl OtelConfig {
+    pub fn logs_endpoint(&self) -> String {
+        self.logs_endpoint.clone().unwrap_or_else(|| {
+            self.observability_endpoint
+                .clone()
+                .unwrap_or_else(|| self.default_endpoint().to_string())
+        })
+    }
+
+    pub fn metrics_endpoint(&self) -> String {
+        self.metrics_endpoint.clone().unwrap_or_else(|| {
+            self.observability_endpoint
+                .clone()
+                .unwrap_or_else(|| self.default_endpoint().to_string())
+        })
+    }
+
+    pub fn traces_endpoint(&self) -> String {
+        self.traces_endpoint.clone().unwrap_or_else(|| {
+            self.observability_endpoint
+                .clone()
+                .unwrap_or_else(|| self.default_endpoint().to_string())
+        })
+    }
+
+    pub fn logs_enabled(&self) -> bool {
+        self.enable_logs.unwrap_or(self.enable_observability)
+    }
+
+    pub fn metrics_enabled(&self) -> bool {
+        self.enable_metrics.unwrap_or(self.enable_observability)
+    }
+
+    pub fn traces_enabled(&self) -> bool {
+        self.enable_traces.unwrap_or(self.enable_observability)
+    }
+
+    fn default_endpoint(&self) -> &str {
+        match self.protocol {
+            OtelProtocol::Grpc => OTEL_EXPORTER_OTLP_GRPC_ENDPOINT_DEFAULT,
+            OtelProtocol::Http => OTEL_EXPORTER_OTLP_HTTP_ENDPOINT_DEFAULT,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum OtelProtocol {
+    Grpc,
+    Http,
+}
+
+impl Default for OtelProtocol {
+    fn default() -> Self {
+        Self::Http
+    }
+}
+
+impl FromStr for OtelProtocol {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "http" => Ok(Self::Http),
+            "grpc" => Ok(Self::Grpc),
+            protocol => {
+                bail!("unsupported protocol: {protocol:?}, did you mean 'http' or 'grpc'?")
+            }
+        }
+    }
 }
 
 /// Environment settings for initializing a capability provider

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2159,6 +2159,7 @@ impl Host {
                 traces_endpoint: self.host_config.otel_config.traces_endpoint.clone(),
                 metrics_endpoint: self.host_config.otel_config.metrics_endpoint.clone(),
                 logs_endpoint: self.host_config.otel_config.logs_endpoint.clone(),
+                protocol: self.host_config.otel_config.protocol,
             };
             let config_generator = self.config_generator.clone();
 

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -36,13 +36,9 @@ pub fn configure_observability(
     use_structured_logging: bool,
     log_level_override: Option<&Level>,
 ) -> anyhow::Result<()> {
-    let enable_metrics = otel_config
-        .enable_metrics
-        .unwrap_or(otel_config.enable_observability);
-
     let normalized_service_name = service_name.to_kebab_case();
 
-    if enable_metrics {
+    if otel_config.metrics_enabled() {
         metrics::configure_metrics(&normalized_service_name, otel_config)?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use tokio::time::{timeout, timeout_at};
 use tokio::{select, signal};
 use tracing::{warn, Level as TracingLogLevel};
 use wasmcloud_core::logging::Level as WasmcloudLogLevel;
-use wasmcloud_core::OtelConfig;
+use wasmcloud_core::{OtelConfig, OtelProtocol};
 use wasmcloud_host::oci::Config as OciConfig;
 use wasmcloud_host::url::Url;
 use wasmcloud_host::wasmbus::host_config::PolicyService as PolicyServiceConfig;
@@ -241,6 +241,14 @@ struct Args {
     /// Overrides the OpenTelemetry endpoint used for emitting logs. This can also be set with `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`.
     #[clap(long = "override-logs-endpoint", hide = true)]
     logs_endpoint: Option<String>,
+
+    /// Configures whether grpc or http will be used for exporting the enabled telemetry. This defaults to 'http'.
+    #[clap(
+        long = "observability-protocol",
+        env = "WASMCLOUD_OBSERVABILITY_PROTOCOL",
+        hide = true
+    )]
+    observability_protocol: Option<OtelProtocol>,
 }
 
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
@@ -259,6 +267,7 @@ async fn main() -> anyhow::Result<()> {
         traces_endpoint: args.traces_endpoint,
         metrics_endpoint: args.metrics_endpoint,
         logs_endpoint: args.logs_endpoint,
+        protocol: args.observability_protocol.unwrap_or_default(),
     };
     let log_level = WasmcloudLogLevel::from(args.log_level);
 


### PR DESCRIPTION
## Feature or Problem

We need to support OpenTelemetry's gRPC protocol in the exporter configuration as [there can be benefits](https://github.com/open-telemetry/oteps/blob/main/text/0035-opentelemetry-protocol.md#otlp-over-grpc) to using it over the (default) HTTP-based binary protocol.

This makes it possible to pass in `--observability-protocol=grpc` or `WASMCLOUD_OBSERVABILITY_PROTOCOL=grpc` to enable it.

The default is still kept with the HTTP-based binary protocol.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
