### PR TITLE
feat(http-client): provide configuration options for http-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6679,9 +6679,13 @@ dependencies = [
  "http 1.1.0",
  "hyper-rustls 0.27.0",
  "hyper-util",
+ "rustls 0.23.5",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.2",
  "tokio",
  "tracing",
  "wasmcloud-provider-sdk",
+ "webpki-roots 0.26.1",
  "wrpc-interface-http",
  "wrpc-transport",
 ]

--- a/crates/provider-http-client/Cargo.toml
+++ b/crates/provider-http-client/Cargo.toml
@@ -20,8 +20,12 @@ futures = { workspace = true }
 http = { workspace = true }
 hyper-rustls = { workspace = true, features = ["native-tokio", "tls12"] }
 hyper-util = { workspace = true, features = ["client-legacy"] }
-tokio = { workspace = true, features = ["macros"] }
+rustls = { workspace = true, features = ["std"] }
+rustls-pemfile = { workspace = true }
+rustls-native-certs = { workspace = true }
+tokio = { workspace = true, features = ["macros", "io-util"] }
 tracing = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true, features = ["otel"] }
+webpki-roots = { workspace = true }
 wrpc-interface-http = { workspace = true, features = ["http-body"] }
 wrpc-transport = { workspace = true }

--- a/crates/provider-http-client/README.md
+++ b/crates/provider-http-client/README.md
@@ -4,5 +4,36 @@ This capability provider implements the `wasi:http/outgoing-handler` interface, 
 
 This capability provider is multi-threaded and can handle concurrent requests from multiple components.
 
+## Configuration
+
+| Key                 | Value                | Description                                                                                                                                                                                | Default |
+| ------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `load_native_certs` | "true" / "false"     | Use the platform's native certificate store at runtime. Any value other than "true" will be assumed as "false"                                                                             | "true"  |
+| `load_webpki_certs` | "true" / "false"     | Uses a compiled-in set of root certificates trusted by Mozilla. Any value other than "true" will be assumed as "false"                                                                     | "true"  |
+| `ssl_certs_file`    | "/path/to/certs.pem" | Path to a file available on the machine where the HTTP client runs that contains one or more root certificates to trust. The provider will fail to instantiate if the file is not present. | N/A     |
+
+An example of starting this provider with all of the configuration values looks like this in `wash`:
+
+```bash
+wash config put http-client-config load_native_certs=true load_webpki_certs=true ssl_certs_file=/tmp/certs.pem
+wash start provider ghcr.io/wasmcloud/http-client:0.10.0 http-client --config http-client-config
+```
+
+An example of starting this provider with all of the configuration values looks like this in `wadm`:
+
+```yaml
+- name: httpclient
+  type: capability
+  properties:
+    image: ghcr.io/wasmcloud/http-client:0.10.0
+    config:
+      - name: http-client-config
+        properties:
+          load_native_certs: 'true'
+          load_webpki_certs: 'true'
+          ssl_certs_file: /tmp/certs.pem
+```
+
 ## Link Definition Values
+
 This capability provider does not have any link definition configuration values.

--- a/src/bin/http-client-provider/main.rs
+++ b/src/bin/http-client-provider/main.rs
@@ -1,12 +1,16 @@
 use anyhow::Context as _;
 use wasmcloud_provider_http_client::HttpClientProvider;
-use wasmcloud_provider_sdk::interfaces::http::run_outgoing_handler;
+use wasmcloud_provider_sdk::{interfaces::http::run_outgoing_handler, load_host_data};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    run_outgoing_handler(HttpClientProvider::default(), "http-client-provider")
-        .await
-        .context("failed to run provider")?;
+    let host_data = load_host_data()?;
+    run_outgoing_handler(
+        HttpClientProvider::new(&host_data.config).await?,
+        "http-client-provider",
+    )
+    .await
+    .context("failed to run provider")?;
     eprintln!("HttpClient provider exiting");
     Ok(())
 }


### PR DESCRIPTION
## Feature or Problem
While we're enabling additional functionality for the HTTP client, I wanted to ensure we could preserve the same behavior from rustls-native-certs's SSL_CERT_FILE environment variable as config for the http client. This PR adds three completely optional configuration values to disable loading native certificates, disable loading webpki certificates, and to load additional certificates from a file on disk.

## Related Issues
Followup to #2193

## Release Information
http-client v0.10.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
