### PR TITLE
fix(*): Clarifies additional licenses based off of CNCF license list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5220,12 +5220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple_env_load"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062f063a8bb8336fa98ee0eae53115bf6753ca9c83437808bf000c65621ca5e3"
-
-[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6931,7 +6925,6 @@ dependencies = [
  "path-clean",
  "serde",
  "serde_json",
- "simple_env_load",
  "time",
  "tokio",
  "tokio-stream",
@@ -6976,7 +6969,6 @@ dependencies = [
  "rustls 0.22.4",
  "serde",
  "serde_json",
- "simple_env_load",
  "tokio",
  "tokio-util",
  "tracing",
@@ -7050,7 +7042,6 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "simple_env_load",
  "tokio",
  "tracing",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,6 @@ serde_with = { version = "2", default-features = false }
 serde_yaml = { version = "0.9", default-features = false }
 serial_test = { version = "0.9", default-features = false }
 sha2 = { version = "0.10", default-features = false }
-simple_env_load = { version = "0.2", default-features = false }
 sysinfo = { version = "0.27", default-features = false }
 tempfile = { version = "3", default-features = false }
 term-table = { version = "1", default-features = false }

--- a/crates/provider-blobstore-azure/Cargo.toml
+++ b/crates/provider-blobstore-azure/Cargo.toml
@@ -11,16 +11,21 @@ repository.workspace = true
 anyhow = { workspace = true }
 async-nats = { workspace = true }
 async-trait = { workspace = true }
-azure_core = { workspace = true, features = ["enable_reqwest_rustls"], default-features = false }
-azure_storage = { workspace = true, features = ["enable_reqwest_rustls"], default-features = false }
-azure_storage_blobs = { workspace = true, features = ["enable_reqwest_rustls"], default-features = false }
+azure_core = { workspace = true, features = [
+    "enable_reqwest_rustls",
+], default-features = false }
+azure_storage = { workspace = true, features = [
+    "enable_reqwest_rustls",
+], default-features = false }
+azure_storage_blobs = { workspace = true, features = [
+    "enable_reqwest_rustls",
+], default-features = false }
 base64 = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 path-clean = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-simple_env_load = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["fs"] }

--- a/crates/provider-blobstore-s3/Cargo.toml
+++ b/crates/provider-blobstore-s3/Cargo.toml
@@ -30,7 +30,6 @@ hyper-rustls = { version = "0.25", features = [
 rustls = { version = "0.22", default-features = false } # Downgrade for `aws-smithy-runtime` compatibility
 serde = { workspace = true }
 serde_json = { workspace = true }
-simple_env_load = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true }

--- a/crates/provider-blobstore-s3/README.md
+++ b/crates/provider-blobstore-s3/README.md
@@ -25,23 +25,6 @@ from different components configured with different access roles and policies.
   - `AWS_ROLE_EXTERNAL_ID` - (optional) the external id to be associated with the role. This can be used if your auth policy requires a value for externalId
 
 
-### with 'env' file (link definition)
-
-When linking the Blobstore-s3 capability provider to a component, you can use the link parameter `env`
-to specify the name of the file containing configuration settings.
-The value of the `env` parameter should be an absolute path to a text file on disk.
-
-The file should be ascii or UTF-8, and contain one line per variable, with optional comments. The syntax is defined as follows:
-```
-# Comments are ignored
-VAR_NAME = "value"  # sets a string value. spaces around the equals ('=') are optional.
-VAR_NAME = value    # quotes around values are optional. This line has the same effect as the previous line.
-VAR_NAME="value"    # so does this
-```
-
-If a file is used to define settings, and any environment variables are defined for the provider process 
-_and_ defined in the 'env' file, values from the file take precedence.
-
 ### with environment variables
 
 Blobstore-s3 capability provider settings can be passed to the provider through an env file, as

--- a/crates/provider-blobstore-s3/src/lib.rs
+++ b/crates/provider-blobstore-s3/src/lib.rs
@@ -27,7 +27,6 @@ use base64::Engine as _;
 use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt as _, TryStreamExt as _};
 use serde::Deserialize;
-use tokio::fs;
 use tokio::io::AsyncReadExt as _;
 use tokio::sync::RwLock;
 use tokio_util::io::ReaderStream;
@@ -89,13 +88,6 @@ impl StorageConfig {
         } else {
             StorageConfig::default()
         };
-        // load environment variables from file
-        if let Some(env_file) = values.get("env") {
-            let data = fs::read_to_string(env_file)
-                .await
-                .with_context(|| format!("reading env file '{env_file}'"))?;
-            simple_env_load::parse_and_set(&data, |k, v| env::set_var(k, v));
-        }
 
         if let Ok(arn) = env::var("AWS_ROLE_ARN") {
             let mut sts_config = config.sts_config.unwrap_or_default();

--- a/crates/provider-keyvalue-vault/Cargo.toml
+++ b/crates/provider-keyvalue-vault/Cargo.toml
@@ -14,7 +14,6 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
-simple_env_load = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/provider-keyvalue-vault/src/config.rs
+++ b/crates/provider-keyvalue-vault/src/config.rs
@@ -49,13 +49,6 @@ impl Default for Config {
 impl Config {
     /// initialize from linkdef values, environment, and defaults
     pub fn from_values(values: &HashMap<String, String>) -> Result<Config> {
-        // load environment variables from file
-        if let Some(env_file) = values.get("env").or_else(|| values.get("ENV")) {
-            eprintln!("file try read env from file: {env_file}");
-            let data = std::fs::read_to_string(env_file)
-                .with_context(|| format!("reading env file '{env_file}'"))?;
-            simple_env_load::parse_and_set(&data, |k, v| std::env::set_var(k, v));
-        }
         let addr = env::var("VAULT_ADDR")
             .ok()
             .or_else(|| values.get("addr").cloned())

--- a/deny.toml
+++ b/deny.toml
@@ -12,8 +12,6 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "MIT",
-    "MPL-2.0",
-    "OpenSSL",
     "Unicode-DFS-2016",
 ]
 # The confidence threshold for detecting a license from license text.
@@ -23,7 +21,17 @@ allow = [
 confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
-exceptions = [{ name = "simple_env_load", allow = ["0BSD"] }]
+exceptions = [
+    # This license is allowed via exception in the CNCF: https://github.com/cncf/foundation/blob/509ed956a2fb549458f324c7a2962d98b0800fb5/license-exceptions/cncf-exceptions-2022-04-12.spdx#L12
+    { name = "webpki-roots", allow = [
+        "MPL-2.0",
+    ] },
+    # Ring has a...complicated license. However, since it is at the core of a large number of rust
+    # projects, we are manually allowing the OpenSSL part of the license
+    { name = "ring", allow = [
+        "OpenSSL",
+    ] },
+]
 
 [[licenses.clarify]]
 name = "ring"


### PR DESCRIPTION
This involved removing a dependency that we weren't commonly using or wasn't even documented in some cases (file loading a .env file in 2 providers). Things should be good to go now