### PR TITLE
feat(wash-lib)!: support building go providers

### DIFF
--- a/crates/wash-lib/src/build/component.rs
+++ b/crates/wash-lib/src/build/component.rs
@@ -65,13 +65,18 @@ pub fn build_actor(
                 };
                 actor_wasm_path
             }
-            LanguageConfig::Other(_) if component_config.build_command.is_some() => {
+            LanguageConfig::Go(_) | LanguageConfig::Other(_)
+                if component_config.build_command.is_some() =>
+            {
                 // SAFETY: We checked that the build command is not None above
                 build_custom_actor(
                     common_config,
                     component_config,
                     component_config.build_command.as_ref().unwrap(),
                 )?
+            }
+            LanguageConfig::Go(_) => {
+                bail!("build command is required for unsupported language go");
             }
             LanguageConfig::Other(other) => {
                 bail!("build command is required for unsupported language {other}");
@@ -272,7 +277,7 @@ fn build_tinygo_actor(
     // While wasmcloud and its tooling is WIT-first, it is possible to build preview1/preview2
     // components that are *not* WIT enabled. To determine whether the project is WIT-enabled
     // we check for the `wit` directory which would be passed through to bindgen.
-    if component_config.wit_world.is_some() {
+    if component_config.wit_world.is_some() && !tinygo_config.disable_go_generate {
         generate_tinygo_bindgen(
             &output_dir,
             common_config.path.join("wit"),

--- a/crates/wash-lib/tests/parser/files/tinygo_component_module.toml
+++ b/crates/wash-lib/tests/parser/files/tinygo_component_module.toml
@@ -14,3 +14,4 @@ call_alias = "testcomponent"
 
 [tinygo]
 tinygo_path = "path/to/tinygo"
+go_path = "path/to/go"

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -120,6 +120,7 @@ fn tinygo_component_module() {
         config.language,
         LanguageConfig::TinyGo(TinyGoConfig {
             tinygo_path: Some("path/to/tinygo".into()),
+            disable_go_generate: false,
         })
     );
 


### PR DESCRIPTION
## Feature or Problem
This PR adds support for `wash build` to compile and package a capability provider written in Go.

Since Go doesn't have a manifest file that easily lets us determine the binary name (please correct me if I'm wrong!) the `bin_name` is required metadata for the wasmcloud.toml. For example:

```toml
name = "KeyValue Go"
language = "go"
type = "provider"
version = "0.1.0"

[provider]
bin_name = "keyvalue-inmemory"
vendor = "wasmCloud"
```

## Related Issues
Enables #2215 to work better!

## Release Information
next minor wash-lib
next minor wash-cli

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
Modified example toml to fit new support for overriding the go binary

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Manually verified this working well with the above config and the example in the provider-sdk-go
