### PR TITLE
feat(wascap): add Host entity type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4256,7 +4256,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tar",
- "wascap 0.14.0",
+ "wascap 0.15.0",
 ]
 
 [[package]]
@@ -5519,7 +5519,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "wascap 0.14.0",
+ "wascap 0.15.0",
  "wasmcloud-component-adapters",
  "wit-component 0.202.0",
 ]
@@ -6317,7 +6317,7 @@ dependencies = [
 
 [[package]]
 name = "wascap"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "data-encoding",
  "humantime",
@@ -6383,7 +6383,7 @@ dependencies = [
  "url",
  "wadm-types",
  "warp",
- "wascap 0.14.0",
+ "wascap 0.15.0",
  "wash-lib",
  "wasmcloud-control-interface 1.0.0",
  "wasmcloud-core 0.6.0",
@@ -6450,7 +6450,7 @@ dependencies = [
  "url",
  "wadm-types",
  "walkdir",
- "wascap 0.14.0",
+ "wascap 0.15.0",
  "wasm-encoder 0.208.1",
  "wasmcloud-component-adapters",
  "wasmcloud-control-interface 1.0.0",
@@ -6674,7 +6674,7 @@ dependencies = [
  "url",
  "uuid 1.8.0",
  "vaultrs",
- "wascap 0.14.0",
+ "wascap 0.15.0",
  "wasmcloud-control-interface 1.0.0",
  "wasmcloud-core 0.6.0",
  "wasmcloud-host",
@@ -6829,7 +6829,7 @@ dependencies = [
  "tracing",
  "ulid",
  "uuid 1.8.0",
- "wascap 0.14.0",
+ "wascap 0.15.0",
  "webpki-roots 0.26.1",
  "wrpc-transport",
  "wrpc-transport-nats",
@@ -6868,7 +6868,7 @@ dependencies = [
  "ulid",
  "url",
  "uuid 1.8.0",
- "wascap 0.14.0",
+ "wascap 0.15.0",
  "wasmcloud-control-interface 1.0.0",
  "wasmcloud-core 0.6.0",
  "wasmcloud-runtime",
@@ -7045,7 +7045,7 @@ dependencies = [
  "async-nats",
  "tokio",
  "tracing",
- "wascap 0.14.0",
+ "wascap 0.15.0",
  "wasmcloud-control-interface 1.0.0",
 ]
 
@@ -7081,7 +7081,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry 0.24.0",
- "wascap 0.14.0",
+ "wascap 0.15.0",
  "wasmcloud-provider-sdk",
  "wit-bindgen-wrpc",
 ]
@@ -7168,7 +7168,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid 1.8.0",
- "wascap 0.14.0",
+ "wascap 0.15.0",
  "wasmcloud-component",
  "wasmcloud-component-adapters",
  "wasmcloud-core 0.6.0",
@@ -7199,7 +7199,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "wascap 0.14.0",
+ "wascap 0.15.0",
  "wasmcloud-control-interface 1.0.0",
  "wasmcloud-core 0.6.0",
  "wasmcloud-host",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,7 +295,7 @@ wadm = { version = "0.12", default-features = false }
 wadm-types = { version = "0.1", default-features = false }
 walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
-wascap = { version = "0.14", path = "./crates/wascap", default-features = false }
+wascap = { version = "0.15", path = "./crates/wascap", default-features = false }
 wash-cli = { version = "0", path = "./crates/wash-cli", default-features = false }
 wash-lib = { version = "^0.21.0", path = "./crates/wash-lib", default-features = false }
 wasm-encoder = { version = "0.208", default-features = false }

--- a/crates/wascap/Cargo.toml
+++ b/crates/wascap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascap"
-version = "0.14.0"
+version = "0.15.0"
 description = "Wascap - wasmCloud Capabilities. Library for extracting, embedding, and validating claims"
 homepage = "https://wasmcloud.com"
 documentation = "https://docs.rs/wascap"

--- a/crates/wascap/src/jwt.rs
+++ b/crates/wascap/src/jwt.rs
@@ -138,6 +138,15 @@ pub struct Invocation {
     pub invocation_hash: String,
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
+pub struct Host {
+    /// Optional friendly descriptive name for the host
+    pub name: Option<String>,
+    /// Optional labels for the host
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<HashMap<String, String>>,
+}
+
 /// Represents a set of [RFC 7519](https://tools.ietf.org/html/rfc7519) compliant JSON Web Token
 /// claims.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
@@ -283,6 +292,15 @@ impl WascapEntity for Cluster {
 impl WascapEntity for Invocation {
     fn name(&self) -> String {
         self.target_url.to_string()
+    }
+}
+
+impl WascapEntity for Host {
+    fn name(&self) -> String {
+        self.name
+            .as_ref()
+            .unwrap_or(&"Unnamed Host".to_string())
+            .to_string()
     }
 }
 
@@ -547,6 +565,42 @@ impl Claims<Invocation> {
                 target_url: target_url.to_string(),
                 origin_url: origin_url.to_string(),
                 invocation_hash: hash.to_string(),
+            }),
+            expires,
+            id: nuid::next(),
+            issued_at: since_the_epoch().as_secs(),
+            issuer,
+            subject,
+            not_before,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
+        }
+    }
+}
+
+impl Claims<Host> {
+    /// Creates a new non-expiring Claims wrapper for metadata representing a host
+    #[must_use]
+    pub fn new(
+        name: String,
+        issuer: String,
+        subject: String,
+        tags: Option<HashMap<String, String>>,
+    ) -> Self {
+        Self::with_dates(name, issuer, subject, None, None, tags)
+    }
+
+    pub fn with_dates(
+        name: String,
+        issuer: String,
+        subject: String,
+        not_before: Option<u64>,
+        expires: Option<u64>,
+        tags: Option<HashMap<String, String>>,
+    ) -> Claims<Host> {
+        Claims {
+            metadata: Some(Host {
+                name: Some(name),
+                labels: tags,
             }),
             expires,
             id: nuid::next(),
@@ -851,9 +905,19 @@ impl Invocation {
     }
 }
 
+impl Host {
+    #[must_use]
+    pub fn new(name: String, labels: HashMap<String, String>) -> Host {
+        Host {
+            name: Some(name),
+            labels: Some(labels),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::{Account, Claims, Component, ErrorKind, KeyPair, Operator};
+    use super::{Account, Claims, Component, ErrorKind, Host, KeyPair, Operator};
     use crate::jwt::{
         since_the_epoch, validate_token, CapabilityProvider, ClaimsBuilder, Cluster,
         WASCAP_INTERNAL_REVISION,
@@ -1096,7 +1160,7 @@ mod test {
               },
               "easterEgg": {
                 "description": "Indicates whether or not the easter egg should be displayed",
-                "type": "boolean"                
+                "type": "boolean"
               }
             }
           }
@@ -1343,6 +1407,44 @@ mod test {
             validate_token::<Component>(correct_but_wrong).is_err_and(|e| !e
                 .to_string()
                 .contains("invalid token format, expected 3 segments"))
+        );
+    }
+
+    #[test]
+    fn ensure_host_validation() {
+        let signer = KeyPair::new_account();
+        let host = KeyPair::new_server();
+        let mut claims = Claims {
+            metadata: Some(Host::new("test".to_string(), HashMap::new())),
+            expires: None,
+            id: nuid::next(),
+            issued_at: 0,
+            issuer: signer.public_key(),
+            subject: host.public_key().to_string(),
+            not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
+        };
+
+        let encoded = claims.encode(&signer).unwrap();
+        let decoded = Claims::<Host>::decode(&encoded);
+        assert!(decoded.is_ok());
+        let decoded_claims = decoded.unwrap();
+        assert_eq!(
+            decoded_claims.metadata.unwrap().labels,
+            Some(HashMap::new())
+        );
+
+        let validation = validate_token::<Host>(&encoded);
+        assert!(validation.is_ok());
+        assert!(validation.unwrap().signature_valid);
+
+        claims.metadata.as_mut().unwrap().labels =
+            Some(HashMap::from([("test".to_string(), "value".to_string())]));
+        let encoded = claims.encode(&signer).unwrap();
+        let decoded = Claims::<Host>::decode(&encoded).unwrap();
+        assert_eq!(
+            decoded.metadata.unwrap().labels,
+            Some(HashMap::from([("test".to_string(), "value".to_string())]))
         );
     }
 }


### PR DESCRIPTION
## Feature or Problem
Add a `Host` entity type to wascap. This allows us to generate JWTs for hosts that contains assertions about the metadata they were started with. For now this only includes host labels, but this could change in the future.

This is the same change as what was in #2223 but includes the right DCO this time.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
