### PR TITLE
feat(wash+ui): Display max instances count in wash get inventory output and washboard output

### DIFF
--- a/crates/wash-cli/src/ctl/output.rs
+++ b/crates/wash-cli/src/ctl/output.rs
@@ -146,6 +146,7 @@ pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
                 TableCell::new_with_alignment("Component ID", 1, Alignment::Left),
                 TableCell::new_with_alignment("Name", 1, Alignment::Left),
                 TableCell::new_with_alignment("Image Reference", 2, Alignment::Left),
+                TableCell::new_with_alignment("Max Count", 1, Alignment::Left),
             ]));
             inv.components.iter().for_each(|a| {
                 let a = a.clone();
@@ -153,6 +154,7 @@ pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
                     TableCell::new_with_alignment(a.id, 1, Alignment::Left),
                     TableCell::new_with_alignment(format_optional(a.name), 1, Alignment::Left),
                     TableCell::new_with_alignment(a.image_ref, 2, Alignment::Left),
+                    TableCell::new_with_alignment(a.max_instances, 1, Alignment::Left),
                 ]))
             });
         } else {

--- a/crates/wash-cli/src/ctl/output.rs
+++ b/crates/wash-cli/src/ctl/output.rs
@@ -144,7 +144,6 @@ pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
         if !inv.components.is_empty() {
             table.add_row(Row::new(vec![
                 TableCell::new_with_alignment("Component ID", 1, Alignment::Left),
-                TableCell::new_with_alignment("Name", 1, Alignment::Left),
                 TableCell::new_with_alignment("Image Reference", 2, Alignment::Left),
                 TableCell::new_with_alignment("Max Count", 1, Alignment::Left),
             ]));
@@ -152,7 +151,6 @@ pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
                 let a = a.clone();
                 table.add_row(Row::new(vec![
                     TableCell::new_with_alignment(a.id, 1, Alignment::Left),
-                    TableCell::new_with_alignment(format_optional(a.name), 1, Alignment::Left),
                     TableCell::new_with_alignment(a.image_ref, 2, Alignment::Left),
                     TableCell::new_with_alignment(a.max_instances, 1, Alignment::Left),
                 ]))

--- a/washboard-ui/CONTRIBUTING.md
+++ b/washboard-ui/CONTRIBUTING.md
@@ -25,7 +25,16 @@ Enable `corepack` and install `yarn` using the following commands:
 corepack enable
 yarn install
 ```
+### Building ts files
 
+Run the following command to build typescript files in @wasmcloud/.. workspace package
+to avoid the following error: 
+
+`Unable to resolve path to module '@wasmcloud/lattice-client-react'  import/no-unresolved`
+
+```bash
+yarn run turbo:lint
+```
 ### Start a local UI development server
 
 Run the following command to start a local frontend development server:

--- a/washboard-ui/CONTRIBUTING.md
+++ b/washboard-ui/CONTRIBUTING.md
@@ -33,7 +33,7 @@ to avoid the following error:
 `Unable to resolve path to module '@wasmcloud/lattice-client-react'  import/no-unresolved`
 
 ```bash
-yarn run turbo:lint
+yarn run turbo:build
 ```
 ### Start a local UI development server
 

--- a/washboard-ui/packages/washboard-ui/src/app/components/components-table.tsx
+++ b/washboard-ui/packages/washboard-ui/src/app/components/components-table.tsx
@@ -92,6 +92,13 @@ const columns = [
       expandedRow: 'empty',
     },
   }),
+  columnHelper.accessor('max_instances', {
+    header: 'Max Count',
+    meta: {
+      baseRow: 'visible',
+      expandedRow: 'empty',
+    },
+  })
 ];
 
 export function ComponentsTable(): ReactElement {

--- a/washboard-ui/packages/washboard-ui/src/app/components/components-table.tsx
+++ b/washboard-ui/packages/washboard-ui/src/app/components/components-table.tsx
@@ -98,7 +98,7 @@ const columns = [
       baseRow: 'visible',
       expandedRow: 'empty',
     },
-  })
+  }),
 ];
 
 export function ComponentsTable(): ReactElement {

--- a/washboard-ui/packages/washboard-ui/src/app/components/components-table.tsx
+++ b/washboard-ui/packages/washboard-ui/src/app/components/components-table.tsx
@@ -35,8 +35,9 @@ const columns = [
       expandedRow: 'empty',
     },
   }),
-  columnHelper.accessor('name', {
-    header: 'Name',
+  columnHelper.accessor('id', {
+    header: 'ID',
+    cell: (info) => <ShortCopy text={info.getValue()} />,
     meta: {
       baseRow: 'visible',
       expandedRow: 'empty',
@@ -82,14 +83,6 @@ const columns = [
       expandedCell: (_hostId: string, instances: string) => () => {
         return instances.length;
       },
-    },
-  }),
-  columnHelper.accessor('id', {
-    header: 'ID',
-    cell: (info) => <ShortCopy text={info.getValue()} />,
-    meta: {
-      baseRow: 'visible',
-      expandedRow: 'empty',
     },
   }),
   columnHelper.accessor('max_instances', {


### PR DESCRIPTION
## Feature or Problem
To enhance the visibility of component concurrency settings by displaying the maximum instances count in both the washboard UI and the wash CLI's inventory output. This addition will help users understand the scale of their components more effectively.
## Related Issues
resolves #2095 
## Release Information
<!---
next
## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Ran local development server for verifying frontend changes, along with deploying custom wadm manifests using `cargo run -- app deploy <name>` and verified wash-cli changes by `cargo run  -- get inventory` which worked as expected and showed max count as the `replicas: x` field from wadm manifests. 