### PR TITLE
fix(core): default to http otel protocol if not supplied

### DIFF
--- a/crates/core/src/otel.rs
+++ b/crates/core/src/otel.rs
@@ -32,6 +32,7 @@ pub struct OtelConfig {
     /// Overrides the OpenTelemetry endpoint for logs.
     pub logs_endpoint: Option<String>,
     /// Determines whether http or grpc will be used for exporting the telemetry.
+    #[serde(default)]
     pub protocol: OtelProtocol,
 }
 


### PR DESCRIPTION
## Feature or Problem
This PR defaults the OtelConfig protocol field if not supplied to HTTP, which will preserve forwards compatibility with new providers running on v1.0.2 and earlier versions of the wasmCloud host.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
