### PR TITLE
feat(example): set outgoing response before writing

### DIFF
--- a/examples/golang/components/http-hello-world/hello.go
+++ b/examples/golang/components/http-hello-world/hello.go
@@ -25,13 +25,13 @@ func (h HttpServer) Handle(request HttpRequest, responseWriter HttpResponseWrite
 	httpResponse.SetStatusCode(200)
 	body := httpResponse.Body().Unwrap()
 	bodyWrite := body.Write().Unwrap()
-	bodyWrite.BlockingWriteAndFlush([]uint8("Hello from Go!\n")).Unwrap()
 
 	// Send HTTP response
 	okResponse := http.Ok[HttpOutgoingResponse, HttpError](httpResponse)
+	http.StaticResponseOutparamSet(responseWriter, okResponse)
+	bodyWrite.BlockingWriteAndFlush([]uint8("Hello from Go!\n")).Unwrap()
 	bodyWrite.Drop()
 	http.StaticOutgoingBodyFinish(body, http.None[http.WasiHttp0_2_0_TypesTrailers]())
-	http.StaticResponseOutparamSet(responseWriter, okResponse)
 }
 
 //go:generate wit-bindgen tiny-go wit --out-dir=gen --gofmt

--- a/examples/python/components/http-hello-world/app.py
+++ b/examples/python/components/http-hello-world/app.py
@@ -11,9 +11,9 @@ class IncomingHandler(exports.IncomingHandler):
         outgoingResponse = OutgoingResponse(Fields.from_list([]))
         # Set the status code to OK
         outgoingResponse.set_status_code(200)
-        outgoingBody = outgoingResponse.body()
+        # Set the HTTP response
+        ResponseOutparam.set(response_out, Ok(outgoingResponse))
         # Write our Hello World message to the response body
+        outgoingBody = outgoingResponse.body()
         outgoingBody.write().blocking_write_and_flush(bytes("Hello from Python!\n", "utf-8"))
         OutgoingBody.finish(outgoingBody, None)
-        # Set and send the HTTP response
-        ResponseOutparam.set(response_out, Ok(outgoingResponse))

--- a/examples/typescript/components/http-hello-world/http-hello-world.ts
+++ b/examples/typescript/components/http-hello-world/http-hello-world.ts
@@ -4,7 +4,7 @@ import {
   OutgoingBody,
   OutgoingResponse,
   Fields,
-} from "wasi:http/types@0.2.0";
+} from 'wasi:http/types@0.2.0';
 
 // Implementation of wasi-http incoming-handler
 //
@@ -13,6 +13,9 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
   // Start building an outgoing response
   const outgoingResponse = new OutgoingResponse(new Fields());
 
+  // Set the created response
+  ResponseOutparam.set(resp, { tag: 'ok', val: outgoingResponse });
+
   // Access the outgoing response body
   let outgoingBody = outgoingResponse.body();
   {
@@ -20,7 +23,7 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
     let outputStream = outgoingBody.write();
     // Write hello world to the response stream
     outputStream.blockingWriteAndFlush(
-      new Uint8Array(new TextEncoder().encode("Hello from Typescript!\n"))
+      new Uint8Array(new TextEncoder().encode('Hello from Typescript!\n'))
     );
     // @ts-ignore: This is required in order to dispose the stream before we return
     outputStream[Symbol.dispose]();
@@ -30,8 +33,6 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
   outgoingResponse.setStatusCode(200);
   // Finish the response body
   OutgoingBody.finish(outgoingBody, undefined);
-  // Set the created response
-  ResponseOutparam.set(resp, { tag: "ok", val: outgoingResponse });
 }
 
 export const incomingHandler = {


### PR DESCRIPTION
## Feature or Problem
This PR changes the ordering in our example HTTP components to ensure we are setting the response outparam _before_ writing bytes to the body.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
