### PR TITLE
feat(host): add option for normalizing config

### DIFF
--- a/crates/host/src/wasmbus/host_config.rs
+++ b/crates/host/src/wasmbus/host_config.rs
@@ -59,6 +59,8 @@ pub struct Host {
     /// The semver version of the host. This is used by a consumer of this crate to indicate the
     /// host version (which may differ from the crate version)
     pub version: String,
+    /// Whether to normalize provider config keys (by lowercasing them)
+    pub normalize_provider_config_keys: bool,
 }
 
 /// Configuration for wasmCloud policy service
@@ -100,6 +102,7 @@ impl Default for Host {
             otel_config: OtelConfig::default(),
             policy_service_config: PolicyService::default(),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            normalize_provider_config_keys: false,
         }
     }
 }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -907,7 +907,10 @@ impl Host {
             config.lattice.clone(),
         );
 
-        let config_generator = BundleGenerator::new(config_data.clone());
+        let mut config_generator = BundleGenerator::from_store(config_data.clone());
+        if config.normalize_provider_config_keys {
+            config_generator.normalize_keys = true;
+        }
 
         let host = Host {
             components: RwLock::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,6 +249,10 @@ struct Args {
         hide = true
     )]
     observability_protocol: Option<OtelProtocol>,
+
+    /// Configures whether to normalize configuration keys for config passed to providers
+    #[clap(long = "normalize-provider-config-keys")]
+    normalize_provider_config_keys: Option<bool>,
 }
 
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
@@ -379,6 +383,7 @@ async fn main() -> anyhow::Result<()> {
         enable_structured_logging: args.enable_structured_logging,
         otel_config,
         policy_service_config,
+        normalize_provider_config_keys: args.normalize_provider_config_keys.unwrap_or(false),
         version: env!("CARGO_PKG_VERSION").to_string(),
     }))
     .await

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -42,7 +42,7 @@ async fn config_updates() -> Result<()> {
         .await
         .context("Unable to set up NATS KV store for test")?;
 
-    let generator = BundleGenerator::new(store.clone());
+    let generator = BundleGenerator::from_store(store.clone());
 
     // First test that a non-existent config item returns an error
     generator


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit adds an option for normalizing configuration keys that are used/provided by hosts, with a new option `--normalize-config-keys`.

When this option is enabled, config keys that are retrieved and used by the host will all be normalized (for now, lowercased), before use.


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
