### PR TITLE
fix(wash)!: Removes need for world flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,9 +3622,9 @@ dependencies = [
 
 [[package]]
 name = "oci-wasm"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1930a0cc13337feec6dfcc223d51707b0228189c1c9ac27fab0cf38487acb8"
+checksum = "a91502e5352f927156f2b6a28d2558cc59558b1f441b681df3f706ced6937e07"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,7 @@ notify = { version = "6", default-features = false }
 nuid = { version = "0.4", default-features = false }
 num = { version = "0.4", default-features = false }
 oci-distribution = { version = "0.11", default-features = false }
-oci-wasm = { version = "0.0.3", default-features = false }
+oci-wasm = { version = "0.0.4", default-features = false }
 once_cell = { version = "1", default-features = false }
 opentelemetry = { version = "0.23", default-features = false }
 opentelemetry-appender-tracing = { version = "0.4", default-features = false }

--- a/crates/wash-cli/src/common/registry_cmd.rs
+++ b/crates/wash-cli/src/common/registry_cmd.rs
@@ -134,7 +134,6 @@ pub async fn registry_push(
             insecure: cmd.opts.insecure,
             insecure_skip_tls_verify: cmd.opts.insecure_skip_tls_verify,
             annotations,
-            world_name: cmd.world,
         },
     )
     .await?;

--- a/crates/wash-lib/src/cli/registry.rs
+++ b/crates/wash-lib/src/cli/registry.rs
@@ -93,11 +93,6 @@ pub struct RegistryPushCommand {
     #[clap(short = 'a', long = "annotation", name = "annotations")]
     pub annotations: Option<Vec<String>>,
 
-    /// World name of the component you are pushing. This is only used if you are pushing a binary
-    /// wit component that may contain multiple worlds.
-    #[clap(long = "world", env = "WASH_REG_WORLD")]
-    pub world: Option<String>,
-
     #[clap(flatten)]
     pub opts: AuthOpts,
 }

--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -59,8 +59,6 @@ pub struct OciPushOptions {
     pub insecure_skip_tls_verify: bool,
     /// Optional annotations you'd like to add to the pushed artifact
     pub annotations: Option<HashMap<String, String>>,
-    /// Optional world name to use when pushing a binary wit component
-    pub world_name: Option<String>,
 }
 
 /// The types of artifacts that wash supports
@@ -199,27 +197,26 @@ pub async fn push_oci_artifact(
         .with_context(|| format!("failed to open artifact [{}]", artifact.as_ref().display()))?;
     f.read_to_end(&mut artifact_buf).await?;
 
-    let (config, layer, is_wasm) =
-        match parse_and_validate_artifact(&artifact_buf, options.world_name).await? {
-            SupportedArtifacts::Wasm(conf, layer) => (conf, layer, true),
-            SupportedArtifacts::Par(mut conf, layer) => {
-                let mut config_buf = vec![];
-                match options.config {
-                    Some(config_file) => {
-                        let mut f = File::open(&config_file).await.with_context(|| {
-                            format!("failed to open config file [{}]", config_file.display())
-                        })?;
-                        f.read_to_end(&mut config_buf).await?;
-                    }
-                    None => {
-                        // If no config provided, send blank config
-                        config_buf = b"{}".to_vec();
-                    }
-                };
-                conf.data = config_buf;
-                (conf, layer, false)
-            }
-        };
+    let (config, layer, is_wasm) = match parse_and_validate_artifact(&artifact_buf).await? {
+        SupportedArtifacts::Wasm(conf, layer) => (conf, layer, true),
+        SupportedArtifacts::Par(mut conf, layer) => {
+            let mut config_buf = vec![];
+            match options.config {
+                Some(config_file) => {
+                    let mut f = File::open(&config_file).await.with_context(|| {
+                        format!("failed to open config file [{}]", config_file.display())
+                    })?;
+                    f.read_to_end(&mut config_buf).await?;
+                }
+                None => {
+                    // If no config provided, send blank config
+                    config_buf = b"{}".to_vec();
+                }
+            };
+            conf.data = config_buf;
+            (conf, layer, false)
+        }
+    };
 
     let layers = vec![layer];
 
@@ -264,14 +261,11 @@ pub async fn push_oci_artifact(
 
 /// Helper function to determine artifact type and parse it into a config and layer ready for use in
 /// pushing to OCI
-pub async fn parse_and_validate_artifact(
-    artifact: &[u8],
-    world_name: Option<String>,
-) -> Result<SupportedArtifacts> {
+pub async fn parse_and_validate_artifact(artifact: &[u8]) -> Result<SupportedArtifacts> {
     // NOTE(thomastaylor312): I don't like having to clone here, but we need to either clone here or
     // later when calling parse_component/parse_provider_archive. If this gets to be a
     // problem, we can always change this, but it is a CLI, so _shrug_
-    match parse_component(artifact.to_owned(), world_name) {
+    match parse_component(artifact.to_owned()) {
         Ok(art) => Ok(art),
         Err(_) => match parse_provider_archive(artifact).await {
             Ok(art) => Ok(art),
@@ -293,8 +287,8 @@ pub async fn identify_artifact(artifact: &[u8]) -> Result<ArtifactType> {
 }
 
 /// Attempts to parse the wit from a component. Fails if it isn't a component
-fn parse_component(artifact: Vec<u8>, world_name: Option<String>) -> Result<SupportedArtifacts> {
-    let (conf, layer) = WasmConfig::from_raw_component(artifact, world_name.as_deref(), None)?;
+fn parse_component(artifact: Vec<u8>) -> Result<SupportedArtifacts> {
+    let (conf, layer) = WasmConfig::from_raw_component(artifact, None)?;
     Ok(SupportedArtifacts::Wasm(conf.to_config()?, layer))
 }
 


### PR DESCRIPTION
Based on feedback from users, we found out that the world isn't actually needed for pushing binary wit. This was updated in the oci-wasm library that was also updated in this PR. This removes the world flag as it is no longer needed