### PR TITLE
fix(provider-blobstore-fs): make ROOT configuration case-insensitive

### DIFF
--- a/crates/provider-blobstore-fs/src/lib.rs
+++ b/crates/provider-blobstore-fs/src/lib.rs
@@ -698,7 +698,7 @@ impl Provider for FsProvider {
         }
 
         // Determine the root path value
-        let root_val: PathBuf = match config.iter().find(|(key, _)| **key == "ROOT") {
+        let root_val: PathBuf = match config.iter().find(|(key, _)| key.to_uppercase() == "ROOT") {
             None => "/tmp".into(),
             Some((_, value)) => value.into(),
         };


### PR DESCRIPTION
This PR adjusts the ROOT path value matching behavior to convert all keys to uppercase. This makes the relevant value case-insensitive.

## Feature or Problem
When configuring the value of ROOT for blobstore-fs, the only allowable spelling of the key to configure the value is "ROOT" — case sensitive.

## Related Issues

## Release Information

## Consumer Impact

## Testing

### Unit Test(s)

### Acceptance or Integration

### Manual Verification
