### PR TITLE
chore(examples): add missing manifests, use official images

### DIFF
--- a/.github/workflows/examples-components.yml
+++ b/.github/workflows/examples-components.yml
@@ -8,9 +8,11 @@ on:
       - component-blobby-v[0-9]+.[0-9]+.[0-9]+*
       - component-dog-fetcher-v[0-9]+.[0-9]+.[0-9]+*
       - component-echo-messaging-v[0-9]+.[0-9]+.[0-9]+*
+      - component-http-blobstore-v[0-9]+.[0-9]+.[0-9]+*
       - component-http-hello-world-v[0-9]+.[0-9]+.[0-9]+*
       - component-http-jsonify-v[0-9]+.[0-9]+.[0-9]+*
       - component-http-keyvalue-counter-v[0-9]+.[0-9]+.[0-9]+*
+      - component-sqldb-postgres-query-v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
     branches: [main]
     paths:
@@ -83,32 +85,38 @@ jobs:
             lang_version: "1.20"
             name: "http-hello-world"
           # Rust example components
-          - lang: "rust"
-            name: "blobby"
+          - name: "blobby"
+            lang: "rust"
             wasm-bin: "blobby_s.wasm"
-          - lang: "rust"
-            name: "http-hello-world"
-            wasm-bin: "http_hello_world_s.wasm"
-          - lang: "rust"
-            name: "dog-fetcher"
+          - name: "dog-fetcher"
+            lang: "rust"
             wasm-bin: "dog_fetcher_s.wasm"
-          - lang: "rust"
-            name: "http-jsonify"
-            wasm-bin: "wasmcloud_component_http_jsonify_s.wasm"
-          - lang: "rust"
-            name: "http-keyvalue-counter"
-            wasm-bin: "http_keyvalue_counter_s.wasm"
-          - lang: "rust"
-            name: "echo-messaging"
+          - name: "echo-messaging"
+            lang: "rust"
             wasm-bin: "echo_messaging_s.wasm"
+          - name: "http-blobstore"
+            lang: "rust"
+            wasm-bin: "http_blobstore_s.wasm"
+          - name: "http-hello-world"
+            lang: "rust"
+            wasm-bin: "http_hello_world_s.wasm"
+          - name: "http-jsonify"
+            lang: "rust"
+            wasm-bin: "http_jsonify_s.wasm"
+          - name: "http-keyvalue-counter"
+            lang: "rust"
+            wasm-bin: "http_keyvalue_counter_s.wasm"
+          - name: "sqldb-postgres-query"
+            lang: "rust"
+            wasm-bin: "sqldb_postgres_query_s.wasm"
           # Python example components
-          - lang: "python"
+          - name: "http-hello-world"
+            lang: "python"
             lang_version: "3.10"
-            name: "http-hello-world"
           # Typescript example components
-          - lang: "typescript"
+          - name: "http-hello-world"
+            lang: "typescript"
             lang_version: "20.x"
-            name: "http-hello-world"
     steps:
       - uses: actions/checkout@v4
       # Download wash binary & install to path
@@ -172,24 +180,30 @@ jobs:
           - current
         project:
           # Rust example components (to publish)
-          - lang: "rust"
-            name: "blobby"
+          - name: "blobby"
+            lang: "rust"
             wasm-bin: "blobby_s.wasm"
-          - lang: "rust"
-            name: "http-keyvalue-counter"
-            wasm-bin: "http_keyvalue_counter_s.wasm"
-          - lang: "rust"
-            name: "http-hello-world"
-            wasm-bin: "http_hello_world_s.wasm"
-          - lang: "rust"
-            name: "dog-fetcher"
+          - name: "dog-fetcher"
+            lang: "rust"
             wasm-bin: "dog_fetcher_s.wasm"
-          - lang: "rust"
-            name: "http-jsonify"
-            wasm-bin: "wasmcloud_component_http_jsonify_s.wasm"
-          - lang: "rust"
-            name: "echo-messaging"
+          - name: "echo-messaging"
+            lang: "rust"
             wasm-bin: "echo_messaging_s.wasm"
+          - name: "http-blobstore"
+            lang: "rust"
+            wasm-bin: "http_blobstore_s.wasm"
+          - name: "http-hello-world"
+            lang: "rust"
+            wasm-bin: "http_hello_world_s.wasm"
+          - name: "http-jsonify"
+            lang: "rust"
+            wasm-bin: "http_jsonify_s.wasm"
+          - name: "http-keyvalue-counter"
+            lang: "rust"
+            wasm-bin: "http_keyvalue_counter_s.wasm"
+          - name: "sqldb-postgres-query"
+            lang: "rust"
+            wasm-bin: "sqldb_postgres_query_s.wasm"
     steps:
       - uses: actions/checkout@v4
       # Determine tag version (if this is a release tag), without the 'v'

--- a/crates/provider-sqldb-postgres/README.md
+++ b/crates/provider-sqldb-postgres/README.md
@@ -111,7 +111,7 @@ For example, the following WADM manifest fragment:
     - name: querier
       type: component
       properties:
-        image: file://./build/sqldb_postgres_managed_s.wasm
+        image: file://./build/sqldb_postgres_query_s.wasm
       traits:
         - type: spreadscaler
           properties:

--- a/examples/rust/components/echo-messaging/wadm.yaml
+++ b/examples/rust/components/echo-messaging/wadm.yaml
@@ -10,7 +10,9 @@ spec:
     - name: echo
       type: component
       properties:
-        image: file://./build/echo_messaging_s.wasm
+        # To use the locally compiled code in this folder, use the line below instead after running `wash build`:
+        # image: file://./build/echo_messaging_s.wasm
+        image: ghcr.io/wasmcloud/components/echo-messaging-rust:0.1.0
         id: echo
       traits:
         # Govern the spread/scheduling of the component

--- a/examples/rust/components/http-blobstore/wadm.yaml
+++ b/examples/rust/components/http-blobstore/wadm.yaml
@@ -11,7 +11,9 @@ spec:
     - name: http-blobstore
       type: component
       properties:
-        image: file://./build/http_blobstore_s.wasm
+        # To use the locally compiled code in this folder, use the line below instead after running `wash build`:
+        # image: file://./build/http_blobstore_s.wasm
+        image: ghcr.io/wasmcloud/components/http-blobstore-rust:0.1.0
       traits:
         # Govern the spread/scheduling of the component
         - type: spreadscaler

--- a/examples/rust/components/http-hello-world/wadm.yaml
+++ b/examples/rust/components/http-hello-world/wadm.yaml
@@ -10,7 +10,9 @@ spec:
     - name: http-component
       type: component
       properties:
-        image: file://./build/http_hello_world_s.wasm
+        # To use the locally compiled code in this folder, use the line below instead after running `wash build`:
+        # image: file://./build/http_hello_world_s.wasm
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
       traits:
         # Govern the spread/scheduling of the component
         - type: spreadscaler

--- a/examples/rust/components/http-jsonify/Cargo.toml
+++ b/examples/rust/components/http-jsonify/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wasmcloud-component-http-jsonify"
+name = "http-jsonify"
 version = "0.1.1"
 edition = "2021"
 authors = ["The wasmCloud Team"]

--- a/examples/rust/components/http-jsonify/README.md
+++ b/examples/rust/components/http-jsonify/README.md
@@ -1,0 +1,40 @@
+# HTTP JSONify
+
+This is a simple Rust Wasm example that converts an incoming HTTP request to a JSON representation, and returns that as the response.
+
+## Prerequisites
+
+- `cargo` >=1.75
+- [`wash`](https://wasmcloud.com/docs/installation) >=0.27.0
+- `wasmtime` >=19.0.0 (if running with wasmtime)
+
+## BUilding
+
+```console
+wash build
+```
+
+## Running with wasmtime
+
+You must have wasmtime >=19.0.0 for this to work. Make sure to follow the build step above first.
+
+```bash
+wasmtime serve -Scommon ./build/http_hello_world_s.wasm
+```
+
+## Running with wasmCloud
+
+Ensuring you've built your component with `wash build`, you can launch wasmCloud and deploy the full hello world application with the following commands. 
+
+Once the application reports as **Deployed** in the application list, you can use `curl` to send a request to the running HTTP server.
+
+```shell
+wash up -d
+wash app deploy ./wadm.yaml
+wash app list
+curl http://127.0.0.1:8080
+```
+
+## Adding Capabilities
+
+To learn how to extend this example with additional capabilities, see the [Adding Capabilities](https://wasmcloud.com/docs/tour/adding-capabilities?lang=rust) section of the wasmCloud documentation.

--- a/examples/rust/components/http-jsonify/wadm.yaml
+++ b/examples/rust/components/http-jsonify/wadm.yaml
@@ -2,35 +2,30 @@
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: dog-fetcher
+  name: rust-http-jsonify
   annotations:
     version: v0.0.1
-    description: "HTTP hello world demo in Rust, showing use of the server and client providers"
+    description: |
+      A component that turns incoming HTTP requests into a JSON representation
 spec:
   components:
     - name: http-component
       type: component
       properties:
         # To use the locally compiled code in this folder, use the line below instead after running `wash build`:
-        # image: file://./build/dog_fetcher_s.wasm
-        image: ghcr.io/wasmcloud/components/dog-fetcher:0.1.0
+        # image: file://./build/wasmcloud_component_http_jsonify_s.wasm
+        image: ghcr.io/wasmcloud/components/http-jsonify-rust:0.1.1
       traits:
         # Govern the spread/scheduling of the component
         - type: spreadscaler
           properties:
             replicas: 1
-        - type: link
-          properties:
-            target: httpclient
-            namespace: wasi
-            package: http
-            interfaces: [outgoing-handler]
 
     # Add a capability provider that enables HTTP access
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.0
+        image: ghcr.io/wasmcloud/http-server:0.20.1
       traits:
         # Link the httpserver to the component, and configure the HTTP server
         # to listen on port 8080 for incoming requests
@@ -44,8 +39,3 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
-
-    - name: httpclient
-      type: capability
-      properties:
-        image: ghcr.io/wasmcloud/http-client:0.9.0

--- a/examples/rust/components/http-keyvalue-counter/wadm.yaml
+++ b/examples/rust/components/http-keyvalue-counter/wadm.yaml
@@ -10,8 +10,9 @@ spec:
     - name: counter
       type: component
       properties:
-        # NOTE: If the file at the relative path below is missing, run `wash build`
-        image: file://./build/http_keyvalue_counter_s.wasm
+        # To use the locally compiled code in this folder, use the line below instead after running `wash build`:
+        # image: file://./build/http_keyvalue_counter_s.wasm
+        image: ghcr.io/wasmcloud/components/http-keyvalue-counter-rust:0.1.0
       traits:
         # Govern the spread/scheduling of the component
         - type: spreadscaler

--- a/examples/rust/components/sqldb-postgres-query/Cargo.toml
+++ b/examples/rust/components/sqldb-postgres-query/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "sqldb-postgres-managed"
+name = "sqldb-postgres-query"
 edition = "2021"
 version = "0.1.0"
 description = """
-An example component that performs queries with the wasmcloud-sqldb-postgres provider, using only the wasmcloud:postgres/managed interface.
+An example component that performs queries with the wasmcloud-sqldb-postgres provider, using only the wasmcloud:postgres interface.
 """
 
 [workspace]

--- a/examples/rust/components/sqldb-postgres-query/README.md
+++ b/examples/rust/components/sqldb-postgres-query/README.md
@@ -42,7 +42,7 @@ docker run \
 wash build
 ```
 
-This will create a folder called `build` which contains `sqldb_postgres_managed_s.wasm`.
+This will create a folder called `build` which contains `sqldb_postgres_query_s.wasm`.
 
 > [!NOTE]
 > If you're using a local build of the provider (using `file://...` in `wadm.yaml`) this is a good time to ensure you've built the [provider archive `par.gz`][par] for your provider.
@@ -105,7 +105,7 @@ wash get inventory
 Once the component & provider are deployed, you can invoke the example component with `wash call`:
 
 ```console
-wash call rust_sqldb_postgres_managed-querier wasmcloud:examples/invoke.call
+wash call rust_sqldb_postgres_query-querier wasmcloud:examples/invoke.call
 ```
 
 Note that the name of the component is prefixed with the WADM application, and the interface on it we call is defined in `wit/provider.wit` (the `call` function of the `invoke` interface).

--- a/examples/rust/components/sqldb-postgres-query/wadm.yaml
+++ b/examples/rust/components/sqldb-postgres-query/wadm.yaml
@@ -2,7 +2,7 @@
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: rust-sqldb-postgres-managed
+  name: rust-sqldb-postgres-query
   annotations:
     version: v0.1.0
     description: |
@@ -13,7 +13,7 @@ spec:
       type: component
       properties:
         # NOTE: You must run `wash build` for the WebAssembly binary at the relative path below to be present
-        image: file://./build/sqldb_postgres_managed_s.wasm
+        image: file://./build/sqldb_postgres_query_s.wasm
       traits:
         # Govern the spread/scheduling of the actor
         - type: spreadscaler

--- a/examples/rust/components/sqldb-postgres-query/wadm.yaml
+++ b/examples/rust/components/sqldb-postgres-query/wadm.yaml
@@ -12,8 +12,9 @@ spec:
     - name: querier
       type: component
       properties:
-        # NOTE: You must run `wash build` for the WebAssembly binary at the relative path below to be present
-        image: file://./build/sqldb_postgres_query_s.wasm
+        # To use the locally compiled code in this folder, use the line below instead after running `wash build`:
+        # image: file://./build/sqldb_postgres_query_s.wasm
+        image: ghcr.io/wasmcloud/components/sqldb-postgres-query-rust:0.1.0
       traits:
         # Govern the spread/scheduling of the actor
         - type: spreadscaler

--- a/examples/rust/components/sqldb-postgres-query/wasmcloud.toml
+++ b/examples/rust/components/sqldb-postgres-query/wasmcloud.toml
@@ -1,8 +1,8 @@
-name = "sqldb-postgres-managed"
+name = "sqldb-postgres-query"
 version = "0.1.0"
 language = "rust"
 type = "component"
 
-[actor]
+[component]
 wit_world = "component"
 wasm_target = "wasm32-wasi-preview2"


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit adds WADM manifests for examples that didn't have them, and also updates all manifests to have a line about how to use the local code versus the officially released components

This change *should* make it much easier to pull and run any WADM manifest in an example.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
