### PR TITLE
feat(wash) use wadm-client crate, update CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6180,6 +6180,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "wadm-client"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7323280a9b69ac1bd9a3ebc829f24a7b03de974b67531026341f89cf7271584c"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "bytes",
+ "nkeys 0.3.2",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "wadm-types",
+]
+
+[[package]]
 name = "wadm-types"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6350,6 +6371,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wadm-client",
  "wadm-types",
  "warp",
  "wascap 0.15.0",
@@ -6417,6 +6439,7 @@ dependencies = [
  "toml 0.8.14",
  "tracing",
  "url",
+ "wadm-client",
  "wadm-types",
  "walkdir",
  "wascap 0.15.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,6 +292,7 @@ url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
 wadm = { version = "0.12", default-features = false }
+wadm-client = { version = "0.1", default-features = false }
 wadm-types = { version = "0.1", default-features = false }
 walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -63,6 +63,7 @@ tracing-subscriber = { workspace = true, features = [
     "std",
 ] }
 url = { workspace = true }
+wadm-client = { workspace = true }
 wadm-types = { workspace = true }
 warp = { workspace = true }
 wascap = { workspace = true }

--- a/crates/wash-cli/src/app/mod.rs
+++ b/crates/wash-cli/src/app/mod.rs
@@ -1,13 +1,11 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Context};
 use clap::{Args, Subcommand};
 use serde_json::json;
-use wadm_types::api::{
-    DeleteModelResponse, DeployModelResponse, GetModelResponse, GetResult, ModelSummary,
-    PutModelResponse, PutResult, StatusResponse, VersionResponse,
-};
+use wadm_client::Result;
+use wadm_types::api::ModelSummary;
 use wadm_types::validation::{validate_manifest_file, ValidationFailure, ValidationOutput};
 use wash_lib::app::{load_app_manifest, AppManifest};
 use wash_lib::cli::{CliConnectionOpts, CommandOutput, OutputKind};
@@ -19,22 +17,22 @@ mod output;
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum AppCliCommand {
-    /// List application specifications available within the lattice
+    /// List all applications available within the lattice
     #[clap(name = "list")]
     List(ListCommand),
-    /// Retrieve the details for a specific version of an app specification
+    /// Get the application manifest for a specific version of an application
     #[clap(name = "get")]
     Get(GetCommand),
-    /// Retrieve the status of a given model within the lattice
+    /// Get the current status of a given application
     #[clap(name = "status")]
     Status(StatusCommand),
-    /// Retrieve the version history of a given model within the lattice
+    /// Get the version history of a given application
     #[clap(name = "history")]
     History(HistoryCommand),
-    /// Delete a model version
+    /// Delete an application version
     #[clap(name = "delete", alias = "del")]
     Delete(DeleteCommand),
-    /// Puts a model version into the store
+    /// Create an application version by putting the manifest into the wadm store
     #[clap(name = "put")]
     Put(PutCommand),
     /// Deploy an application to the lattice
@@ -56,9 +54,9 @@ pub struct ListCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct UndeployCommand {
-    /// Name of the app specification to undeploy
+    /// Name of the application to undeploy
     #[clap(name = "name")]
-    model_name: String,
+    app_name: String,
 
     #[clap(flatten)]
     opts: CliConnectionOpts,
@@ -68,9 +66,9 @@ pub struct UndeployCommand {
 pub struct DeployCommand {
     /// Name of the application to deploy, if it was already `put`, or a path to a file containing the application manifest
     #[clap(name = "application")]
-    application: Option<String>,
+    app_name: Option<String>,
 
-    /// Version of the app specification to deploy, defaults to the latest created version
+    /// Version of the application to deploy, defaults to the latest created version
     #[clap(name = "version")]
     version: Option<String>,
 
@@ -84,11 +82,11 @@ pub struct DeployCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct DeleteCommand {
-    /// Name of the app specification to delete, or a path to a WADM Application Manifest
+    /// Name of the application to delete, or a path to a Wadm Application Manifest
     #[clap(name = "name")]
-    model_name: String,
+    app_name: String,
 
-    /// Version of the app specification to delete. Not required if --delete-all is supplied
+    /// Version of the application to delete. If not supplied, all versions are deleted
     #[clap(name = "version")]
     version: Option<String>,
 
@@ -98,7 +96,7 @@ pub struct DeleteCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct PutCommand {
-    /// Possible sources: file from fs, remote file http url,  or stdin. if no source is provided (or arg marches '-'), stdin is used.
+    /// The source of the application manifest, either a file path, remote file http url, or stdin. If no source is provided (or arg marches '-'), stdin is used.
     source: Option<String>,
 
     #[clap(flatten)]
@@ -107,11 +105,11 @@ pub struct PutCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct GetCommand {
-    /// The name of the app spec to retrieve
+    /// The name of the application to retrieve
     #[clap(name = "name")]
-    model_name: String,
+    app_name: String,
 
-    /// The version of the app spec to retrieve. If left empty, retrieves the latest version
+    /// The version of the application to retrieve. If left empty, retrieves the latest version
     #[clap(name = "version")]
     version: Option<String>,
 
@@ -121,9 +119,9 @@ pub struct GetCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct StatusCommand {
-    /// The name of the app spec
+    /// The name of the application
     #[clap(name = "name")]
-    model_name: String,
+    app_name: String,
 
     #[clap(flatten)]
     opts: CliConnectionOpts,
@@ -131,9 +129,9 @@ pub struct StatusCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct HistoryCommand {
-    /// The name of the app spec
+    /// The name of the application
     #[clap(name = "name")]
-    model_name: String,
+    app_name: String,
 
     #[clap(flatten)]
     opts: CliConnectionOpts,
@@ -149,56 +147,47 @@ pub struct ValidateCommand {
 pub async fn handle_command(
     command: AppCliCommand,
     output_kind: OutputKind,
-) -> Result<CommandOutput> {
+) -> anyhow::Result<CommandOutput> {
     use AppCliCommand::*;
     let sp: Spinner = Spinner::new(&output_kind)?;
     let out: CommandOutput = match command {
         List(cmd) => {
-            sp.update_spinner_message("Querying app spec list ...".to_string());
-            let results = get_models(cmd).await?;
-            list_models_output(results)
+            sp.update_spinner_message("Listing applications ...".to_string());
+            get_applications(cmd).await?
         }
         Get(cmd) => {
-            sp.update_spinner_message("Querying app spec details ... ".to_string());
-            let results = get_model_details(cmd).await?;
-            show_model_output(results)
+            sp.update_spinner_message("Getting application manifest ... ".to_string());
+            get_manifest(cmd).await?
         }
         Status(cmd) => {
-            sp.update_spinner_message("Querying app status ... ".to_string());
-            let model_name = cmd.model_name.clone();
-            let results = get_model_status(cmd).await?;
-            show_model_status(model_name, results)
+            sp.update_spinner_message("Getting application status ... ".to_string());
+            get_model_status(cmd).await?
         }
         History(cmd) => {
-            sp.update_spinner_message("Querying app revision history ... ".to_string());
-            let results = get_model_history(cmd).await?;
-            show_model_history(results)
+            sp.update_spinner_message("Getting application version history ... ".to_string());
+            get_application_versions(cmd).await?
         }
         Delete(cmd) => {
-            sp.update_spinner_message("Deleting app version ... ".to_string());
-            let results = delete_model_version(cmd).await?;
-            show_del_results(results)
+            sp.update_spinner_message("Deleting application version ... ".to_string());
+            delete_application_version(cmd).await?
         }
         Put(cmd) => {
-            sp.update_spinner_message("Uploading app specification ... ".to_string());
-            let results = put_model(cmd).await?;
-            show_put_results(results)
+            sp.update_spinner_message("Creating application version ... ".to_string());
+            put_model(cmd).await?
         }
         Deploy(cmd) => {
             sp.update_spinner_message("Deploying application ... ".to_string());
-            let results = deploy_model(cmd).await?;
-            show_deploy_results(results)
+            deploy_model(cmd).await?
         }
         Undeploy(cmd) => {
             sp.update_spinner_message("Undeploying application ... ".to_string());
-            let results = undeploy_model(cmd).await?;
-            show_undeploy_results(results)
+            undeploy_model(cmd).await?
         }
         Validate(cmd) => {
             sp.update_spinner_message("Validating application manifest ... ".to_string());
             let (_manifest, validation_results) = validate_manifest_file(&cmd.application)
                 .await
-                .context("failed to validate WADM manifest")?;
+                .context("failed to validate Wadm manifest")?;
             show_validate_manifest_results(validation_results)
         }
     };
@@ -207,24 +196,29 @@ pub async fn handle_command(
     Ok(out)
 }
 
-async fn undeploy_model(cmd: UndeployCommand) -> Result<DeployModelResponse> {
+async fn undeploy_model(cmd: UndeployCommand) -> Result<CommandOutput> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
     let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
-    wash_lib::app::undeploy_model(&client, lattice, &cmd.model_name).await
+    wash_lib::app::undeploy_model(&client, lattice, &cmd.app_name).await?;
+
+    let message = format!("Undeployed application: {}", cmd.app_name);
+    let mut map = HashMap::new();
+    map.insert("results".to_string(), json!(message));
+    Ok(CommandOutput::new(message, map))
 }
 
-async fn deploy_model(cmd: DeployCommand) -> Result<DeployModelResponse> {
+async fn deploy_model(cmd: DeployCommand) -> Result<CommandOutput> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
     let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
-    let app_manifest = match cmd.application {
+    let app_manifest = match cmd.app_name {
         Some(source) => load_app_manifest(source.parse()?).await?,
         None => load_app_manifest("-".parse()?).await?,
     };
@@ -249,31 +243,36 @@ pub(crate) async fn deploy_model_from_manifest(
     lattice: Option<String>,
     manifest: AppManifest,
     version: Option<String>,
-) -> Result<DeployModelResponse> {
-    match manifest {
+) -> Result<CommandOutput> {
+    let (name, version) = match manifest {
         AppManifest::SerializedModel(manifest) => {
-            let put_res = wash_lib::app::put_model(
+            wash_lib::app::put_and_deploy_model(
                 client,
-                lattice.clone(),
+                lattice,
                 serde_yaml::to_string(&manifest)
                     .context("failed to convert manifest to string")?
                     .as_ref(),
             )
-            .await?;
-
-            let model_name = match put_res.result {
-                PutResult::Created | PutResult::NewVersion => put_res.name,
-                _ => bail!("Could not put manifest to deploy {}", put_res.message),
-            };
-            wash_lib::app::deploy_model(client, lattice, &model_name, version).await
+            .await
         }
         AppManifest::ModelName(model_name) => {
-            wash_lib::app::deploy_model(client, lattice, &model_name, version).await
+            wash_lib::app::deploy_model(client, lattice, &model_name, version.clone())
+                .await
+                .map(|_| (model_name.to_string(), version.unwrap_or_default()))
         }
-    }
+    }?;
+
+    let mut map = HashMap::new();
+    map.insert("deployed".to_string(), json!(true));
+    map.insert("model_name".to_string(), json!(name));
+    map.insert("model_version".to_string(), json!(version));
+    Ok(CommandOutput::new(
+        format!("Deployed application \"{name}\", version \"{version}\""),
+        map,
+    ))
 }
 
-async fn put_model(cmd: PutCommand) -> Result<PutModelResponse> {
+async fn put_model(cmd: PutCommand) -> anyhow::Result<CommandOutput> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
     let lattice = Some(connection_opts.get_lattice());
@@ -285,54 +284,81 @@ async fn put_model(cmd: PutCommand) -> Result<PutModelResponse> {
         None => load_app_manifest("-".parse()?).await?,
     };
 
-    match app_manifest {
-        AppManifest::SerializedModel(manifest) => {
-            wash_lib::app::put_model(
-                &client,
-                lattice,
-                serde_yaml::to_string(&manifest)
-                    .context("failed to convert manifest to string")?
-                    .as_ref(),
-            )
-            .await
-        }
+    let (name, version) = match app_manifest {
+        AppManifest::SerializedModel(manifest) => wash_lib::app::put_model(
+            &client,
+            lattice,
+            serde_yaml::to_string(&manifest)
+                .context("failed to convert manifest to string")?
+                .as_ref(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!(e)),
         AppManifest::ModelName(_) => {
             bail!("failed to retrieve manifest at `{:?}`", cmd.source)
         }
-    }
+    }?;
+
+    let mut map = HashMap::new();
+    map.insert("deployed".to_string(), json!(true));
+    map.insert("model_name".to_string(), json!(name));
+    map.insert("model_version".to_string(), json!(version));
+    Ok(CommandOutput::new(
+        format!("Put application \"{name}\", version \"{version}\""),
+        map,
+    ))
 }
 
-async fn get_model_history(cmd: HistoryCommand) -> Result<VersionResponse> {
+async fn get_application_versions(cmd: HistoryCommand) -> Result<CommandOutput> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
     let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
-    wash_lib::app::get_model_history(&client, lattice, &cmd.model_name).await
+    let versions = wash_lib::app::get_model_history(&client, lattice, &cmd.app_name).await?;
+    let mut map = HashMap::new();
+    map.insert("revisions".to_string(), json!(versions));
+    Ok(CommandOutput::new(
+        output::list_revisions_table(versions),
+        map,
+    ))
 }
 
-async fn get_model_status(cmd: StatusCommand) -> Result<StatusResponse> {
+async fn get_model_status(cmd: StatusCommand) -> Result<CommandOutput> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
     let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
-    wash_lib::app::get_model_status(&client, lattice, &cmd.model_name).await
+    let status = wash_lib::app::get_model_status(&client, lattice, &cmd.app_name).await?;
+
+    let mut map = HashMap::new();
+    map.insert("status".to_string(), json!(status));
+    Ok(CommandOutput::new(
+        output::status_table(cmd.app_name, status),
+        map,
+    ))
 }
 
-async fn get_model_details(cmd: GetCommand) -> Result<GetModelResponse> {
+async fn get_manifest(cmd: GetCommand) -> Result<CommandOutput> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
     let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
 
-    wash_lib::app::get_model_details(&client, lattice, &cmd.model_name, cmd.version).await
+    let manifest =
+        wash_lib::app::get_model_details(&client, lattice, &cmd.app_name, cmd.version).await?;
+
+    let mut map = HashMap::new();
+    map.insert("application".to_string(), json!(manifest));
+    let yaml = serde_yaml::to_string(&manifest).unwrap();
+    Ok(CommandOutput::new(yaml, map))
 }
 
-async fn delete_model_version(cmd: DeleteCommand) -> Result<DeleteModelResponse> {
+async fn delete_application_version(cmd: DeleteCommand) -> Result<CommandOutput> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
     let lattice = Some(connection_opts.get_lattice());
@@ -341,13 +367,13 @@ async fn delete_model_version(cmd: DeleteCommand) -> Result<DeleteModelResponse>
 
     // If we have received a valid path to a model file, then read and extract the model name,
     // otherwise use the supplied name as a model name
-    let (model_name, version): (String, Option<String>) = if tokio::fs::try_exists(&cmd.model_name)
+    let (model_name, version): (String, Option<String>) = if tokio::fs::try_exists(&cmd.app_name)
         .await
         .is_ok_and(|exists| exists)
     {
-        let manifest = load_app_manifest(cmd.model_name.parse()?)
+        let manifest = load_app_manifest(cmd.app_name.parse()?)
             .await
-            .with_context(|| format!("failed to load app manifest at [{}]", cmd.model_name))?;
+            .with_context(|| format!("failed to load app manifest at [{}]", cmd.app_name))?;
         (
             manifest
                 .name()
@@ -356,75 +382,33 @@ async fn delete_model_version(cmd: DeleteCommand) -> Result<DeleteModelResponse>
             manifest.version().map(Into::into),
         )
     } else {
-        (cmd.model_name, cmd.version)
+        (cmd.app_name, cmd.version)
     };
 
-    wash_lib::app::delete_model_version(&client, lattice, &model_name, version).await
+    let deleted =
+        wash_lib::app::delete_model_version(&client, lattice, &model_name, version).await?;
+
+    let mut map = HashMap::new();
+    map.insert("deleted".to_string(), json!(deleted));
+    let message = if deleted {
+        format!("Deleted application version: {model_name}")
+    } else {
+        format!("Already deleted application version: {model_name}")
+    };
+    Ok(CommandOutput::new(message, map))
 }
 
-async fn get_models(cmd: ListCommand) -> Result<Vec<ModelSummary>> {
+async fn get_applications(cmd: ListCommand) -> Result<CommandOutput> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
     let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
-    wash_lib::app::get_models(&client, lattice).await
-}
+    let models = wash_lib::app::get_models(&client, lattice).await?;
 
-fn list_models_output(results: Vec<ModelSummary>) -> CommandOutput {
     let mut map = HashMap::new();
-    map.insert("apps".to_string(), json!(results));
-    CommandOutput::new(output::list_models_table(results), map)
-}
-
-fn show_model_output(md: GetModelResponse) -> CommandOutput {
-    let mut map = HashMap::new();
-    map.insert("model".to_string(), json!(md));
-    if md.result == GetResult::Success {
-        let yaml = serde_yaml::to_string(&md.manifest).unwrap();
-        CommandOutput::new(yaml, map)
-    } else {
-        CommandOutput::new(md.message, map)
-    }
-}
-
-fn show_put_results(results: PutModelResponse) -> CommandOutput {
-    let mut map = HashMap::new();
-    map.insert("results".to_string(), json!(results));
-    CommandOutput::new(results.message, map)
-}
-
-fn show_undeploy_results(results: DeployModelResponse) -> CommandOutput {
-    let mut map = HashMap::new();
-    map.insert("results".to_string(), json!(results));
-    CommandOutput::new(results.message, map)
-}
-
-fn show_del_results(results: DeleteModelResponse) -> CommandOutput {
-    let mut map = HashMap::new();
-    map.insert("deleted".to_string(), json!(results));
-    CommandOutput::new(results.message, map)
-}
-
-fn show_deploy_results(results: DeployModelResponse) -> CommandOutput {
-    let mut map = HashMap::new();
-    map.insert("acknowledged".to_string(), json!(results));
-    CommandOutput::new(results.message, map)
-}
-
-fn show_model_history(results: VersionResponse) -> CommandOutput {
-    let mut map = HashMap::new();
-    map.insert("revisions".to_string(), json!(results));
-    CommandOutput::new(output::list_revisions_table(results.versions), map)
-}
-
-fn show_model_status(model_name: String, results: StatusResponse) -> CommandOutput {
-    let mut map = HashMap::new();
-    map.insert("status".to_string(), json!(results));
-    CommandOutput::new(
-        output::status_table(model_name, results.status.unwrap_or_default()),
-        map,
-    )
+    map.insert("applications".to_string(), json!(models));
+    Ok(CommandOutput::new(output::list_models_table(models), map))
 }
 
 fn show_validate_manifest_results(messages: impl AsRef<[ValidationFailure]>) -> CommandOutput {

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -19,7 +19,6 @@ use tokio::{
     process::Child,
 };
 use tracing::{error, warn};
-use wadm_types::api::{DeployModelResponse, DeployResult};
 use wash_lib::app::{load_app_manifest, AppManifest, AppManifestSource};
 use wash_lib::cli::{CommandOutput, OutputKind};
 use wash_lib::config::{
@@ -638,13 +637,6 @@ async fn deploy_wadm_application(
     let model_name = manifest.name().context("failed to find model name")?;
     let _ = wash_lib::app::undeploy_model(client, Some(lattice.into()), model_name).await;
     match deploy_model_from_manifest(client, Some(lattice.into()), manifest, None).await {
-        // Successful invocation but deploy model failure
-        Ok(DeployModelResponse {
-            result: DeployResult::Error | DeployResult::NotFound,
-            message,
-        }) => {
-            bail!("failed to deploy WADM model: {message}",);
-        }
         // Ignore if the model is already deployed
         Err(e) if e.to_string().contains("already exists") => {}
         // All other failures are unexpected
@@ -769,16 +761,9 @@ async fn run_wasmcloud_interactive(
                     // If we successfully loaded the manifest, attempt to undeploy the existing model
                     Ok(manifest) => {
                         if let Some(model_name) = manifest.name() {
-                            match wash_lib::app::undeploy_model(&client, Some(lattice), model_name).await {
-                                Ok(DeployModelResponse { result: DeployResult::Error, message }) => {
-                                    error!("failed to undeploy manifest during cleanup: {message}");
-                                    eprintln!("🟨 Failed to undeploy manifest during cleanup");
-                                },
-                                Err(e) => {
-                                    error!("failed to complete undeploy operation during cleanup: {e}");
-                                    eprintln!("🟨 Failed to undeploy manifest during cleanup");
-                                }
-                                _ => {},
+                            if let Err(e) = wash_lib::app::undeploy_model(&client, Some(lattice), model_name).await {
+                                error!("failed to complete undeploy operation during cleanup: {}", e.to_string());
+                                eprintln!("🟨 Failed to undeploy manifest during cleanup");
                             }
                         }
                     },

--- a/crates/wash-cli/tests/common/mod.rs
+++ b/crates/wash-cli/tests/common/mod.rs
@@ -554,7 +554,7 @@ impl TestWashInstance {
                 "--timeout-ms",
                 DEFAULT_WASH_INVOCATION_TIMEOUT_MS_ARG,
                 "--ctl-port",
-                &self.nats_port.to_string().as_ref(),
+                self.nats_port.to_string().as_ref(),
             ])
             .kill_on_drop(true)
             .output()

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -87,6 +87,7 @@ url = { workspace = true }
 wadm-types = { workspace = true, optional = true }
 walkdir = { workspace = true }
 wascap = { workspace = true }
+wadm-client = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmcloud-component-adapters = { workspace = true }
 wasmcloud-control-interface = { workspace = true }


### PR DESCRIPTION
- **feat(wash-lib)!: wrap new wadm-client**
- **feat(wash-cli)!: use new wadm-client**

## Feature or Problem
This PR updates `wash-lib` and `wash-cli` to use the new wadm-client crate which provides better strongly typed methods for managing applications. It also gives us much nicer error formatting, so I was able to do a good bit of refactoring on the wash-cli side. I kept the wash-lib API as similar as possible to reduce breaking changes with dependents, but in general using the wadm-client crate directly is recommended.

While I was in there, I noticed something that has bugged me for a bit around our use of "app spec" and "model" when it could be a whole lot simpler to talk about. I updated the help text and some variable names to standardize on CRUDdy operations and the management of "applications" rather than dealing with specs and models and versions and apps. Feedback welcome.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next minor wash-lib and wash-cli.

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I took a look at the help texts but I need to manually verify these work as expected.
