### PR TITLE
Feat(wash): Adds flag to [wash up] to allow reading custom nats config

### DIFF
--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -66,6 +66,15 @@ pub struct NatsOpts {
         requires = "nats_remote_url"
     )]
     pub nats_credsfile: Option<PathBuf>,
+    /// Optional path to a NATS config file
+    /// NOTE: If your configuration changes the address or port to listen on from 0.0.0.0:4222, ensure you set --nats-host and --nats-port
+    #[clap(
+        long = "nats-config-file",
+        env = "NATS_CONFIG",
+        requires = "nats_host",
+        requires = "nats_port"
+    )]
+    pub nats_configfile: Option<PathBuf>,
 
     /// Optional remote URL of existing NATS infrastructure to extend.
     #[clap(long = "nats-remote-url", env = "NATS_REMOTE_URL")]
@@ -122,6 +131,7 @@ impl From<NatsOpts> for NatsConfig {
             remote_url: other.nats_remote_url,
             credentials: other.nats_credsfile,
             websocket_port: other.nats_websocket_port,
+            config_path: other.nats_configfile,
         }
     }
 }
@@ -395,6 +405,7 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
             remote_url: cmd.nats_opts.nats_remote_url,
             credentials: cmd.nats_opts.nats_credsfile.clone(),
             websocket_port: cmd.nats_opts.nats_websocket_port,
+            config_path: cmd.nats_opts.nats_configfile,
         };
         start_nats(&install_dir, &nats_binary, nats_config).await?;
         Some(nats_binary)


### PR DESCRIPTION
## Related Issues
Resolves #1405 
## Release Information
Next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
ran `cargo run -- up --nats-config-file ~/Desktop/Wasm/special.conf --nats-host="127.0.0.1" --nats-port=4959` which executed as expected and also exited normally by `cargo run -- down -- all` stopping all components successfully

verified all possible failure cases , such as 
1) Providing directory path instead of file : resulted in `The provided NATS config File ["/home/aditya/Desktop/Wasm/"] is not a valid File`
2) Ommiting `--nats-host` and `--nats-port` : resulted in `the following required arguments were not provided:
  --nats-host <NATS_HOST>`