### PR TITLE
chore(ci): use static version for publishing example components

### DIFF
--- a/.github/workflows/examples-components.yml
+++ b/.github/workflows/examples-components.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         wash-version:
-          - 0.27.0
+          - 0.28.1
           - current
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         wash-version:
-          - 0.27.0
+          - 0.28.1
           - current
         project:
           # Golang example components
@@ -177,7 +177,7 @@ jobs:
       fail-fast: false
       matrix:
         wash-version:
-          - current
+          - 0.28.1
         project:
           # Rust example components (to publish)
           - name: "blobby"


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit changes the `examples-components` CI workflow to use a static (updated) version of `wash` to publish components, ahead of the release of wash 0.29.0.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
