### PR TITLE
fix(host): propagate traces through components

### DIFF
--- a/crates/host/src/wasmbus/handler.rs
+++ b/crates/host/src/wasmbus/handler.rs
@@ -82,9 +82,8 @@ impl Handler {
         }
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn wrpc_client(&self, target: &str) -> wasmcloud_core::wrpc::Client {
-        // TODO: store injector in handler, then use it?
         let injector = TraceContextInjector::default_with_span();
         let mut headers = injector_to_headers(&injector);
         headers.insert("source-id", self.component_id.as_str());
@@ -102,6 +101,7 @@ impl Handler {
         *self.trace_ctx.write().await = trace_ctx;
     }
 
+    #[instrument(level = "trace", skip(self))]
     async fn wrpc_blobstore_blobstore(&self) -> anyhow::Result<wasmcloud_core::wrpc::Client> {
         let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
@@ -114,7 +114,7 @@ impl Handler {
         Ok(self.wrpc_client(&id))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(level = "trace", skip(self))]
     async fn wrpc_http_outgoing_handler(&self) -> anyhow::Result<wasmcloud_core::wrpc::Client> {
         let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
@@ -127,6 +127,7 @@ impl Handler {
         Ok(self.wrpc_client(&id))
     }
 
+    #[instrument(level = "trace", skip(self))]
     async fn wrpc_keyvalue_atomics(&self) -> anyhow::Result<wasmcloud_core::wrpc::Client> {
         let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
@@ -137,6 +138,7 @@ impl Handler {
         Ok(self.wrpc_client(&id))
     }
 
+    #[instrument(level = "trace", skip(self))]
     async fn wrpc_keyvalue_store(&self) -> anyhow::Result<wasmcloud_core::wrpc::Client> {
         let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
@@ -147,6 +149,7 @@ impl Handler {
         Ok(self.wrpc_client(&id))
     }
 
+    #[instrument(level = "trace", skip(self))]
     async fn wrpc_messaging_consumer(&self) -> anyhow::Result<wasmcloud_core::wrpc::Client> {
         let LatticeInterfaceTarget { id, .. } = self
             .identify_wrpc_target(&CallTargetInterface::from_parts((
@@ -795,7 +798,7 @@ impl Messaging for Handler {
 
 #[async_trait]
 impl OutgoingHttp for Handler {
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle(
         &self,
         request: wasmtime_wasi_http::types::OutgoingRequest,

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -39,7 +39,7 @@ use tokio::task::JoinHandle;
 use tokio::time::{interval_at, timeout, timeout_at, Instant};
 use tokio::{process, select, spawn};
 use tokio_stream::wrappers::IntervalStream;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn, Instrument as _};
 use uuid::Uuid;
 use wascap::{jwt, prelude::ClaimsBuilder};
 use wasmcloud_control_interface::{
@@ -292,7 +292,6 @@ impl Component {
                 })
                 .collect::<Vec<(String, String)>>();
             wasmcloud_tracing::context::attach_span_context(&trace_context);
-            self.handler.set_trace_context(trace_context).await;
         }
 
         // Instantiate component with expected handlers
@@ -319,6 +318,14 @@ impl Component {
             KeyValue::new("host", self.metrics.host_id.clone()),
         ];
 
+        // Associate the current context with the span
+        let injector = TraceContextInjector::default_with_span();
+        let trace_context = injector
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        self.handler.set_trace_context(trace_context).await;
+
         let start_at = Instant::now();
         match params {
             InvocationParams::Custom {
@@ -328,6 +335,7 @@ impl Component {
             } => {
                 let res = component
                     .call(&instance, &name, params)
+                    .instrument(tracing::trace_span!("call_component"))
                     .await
                     .context("failed to call component");
                 let elapsed = u64::try_from(start_at.elapsed().as_nanos()).unwrap_or_default();
@@ -356,7 +364,8 @@ impl Component {
                             .handle(request, response_tx)
                             .await
                             .context("failed to call `wasi:http/incoming-handler.handle`")
-                    },
+                    }
+                    .instrument(tracing::trace_span!("wasi:http/incoming-handler.handle")),
                     async {
                         let res = match response_rx.await.context("failed to receive response")? {
                             Ok(resp) => {
@@ -376,6 +385,7 @@ impl Component {
                             .await
                             .context("failed to transmit response")
                     }
+                    .instrument(tracing::trace_span!("transmit_response"))
                 );
                 let elapsed = u64::try_from(start_at.elapsed().as_nanos()).unwrap_or_default();
                 attributes.push(KeyValue::new(
@@ -404,6 +414,9 @@ impl Component {
                         body,
                         reply_to,
                     })
+                    .instrument(tracing::trace_span!(
+                        "wasmcloud:messaging/handler.handle-message"
+                    ))
                     .await
                     .context("failed to call `wasmcloud:messaging/handler.handle-message`");
                 let elapsed = u64::try_from(start_at.elapsed().as_nanos()).unwrap_or_default();
@@ -1212,7 +1225,7 @@ impl Host {
         .await
     }
 
-    /// Instantiate an component
+    /// Instantiate a component
     #[allow(clippy::too_many_arguments)] // TODO: refactor into a config struct
     #[instrument(level = "debug", skip_all)]
     async fn instantiate_component(

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2462,7 +2462,7 @@ impl Host {
         Ok(CtlResponse::ok(inventory))
     }
 
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     async fn handle_claims(&self) -> anyhow::Result<CtlResponse<Vec<HashMap<String, String>>>> {
         trace!("handling claims");
 
@@ -2480,9 +2480,9 @@ impl Host {
         ))
     }
 
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     async fn handle_links(&self) -> anyhow::Result<Vec<u8>> {
-        debug!("handling links");
+        trace!("handling links");
 
         let links = self.links.read().await;
         let links: Vec<&InterfaceLinkDefinition> = links.values().flatten().collect();

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -292,6 +292,7 @@ impl Component {
                 })
                 .collect::<Vec<(String, String)>>();
             wasmcloud_tracing::context::attach_span_context(&trace_context);
+            self.handler.set_trace_context(trace_context).await;
         }
 
         // Instantiate component with expected handlers
@@ -1465,6 +1466,7 @@ impl Host {
             lattice: self.host_config.lattice.clone(),
             component_id: component_id.clone(),
             targets: Arc::default(),
+            trace_ctx: Arc::default(),
             interface_links: Arc::new(RwLock::new(component_import_links(&component_spec.links))),
             polyfills: Arc::clone(component.polyfills()),
             invocation_timeout: Duration::from_secs(10), // TODO: Make this configurable

--- a/crates/provider-http-client/src/lib.rs
+++ b/crates/provider-http-client/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use futures::StreamExt;
 use hyper_util::rt::TokioExecutor;
 use tokio::spawn;
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, instrument, Instrument};
 
 use wasmcloud_provider_sdk::core::tls;
 use wasmcloud_provider_sdk::interfaces::http::OutgoingHandler;
@@ -90,7 +90,7 @@ impl HttpClientProvider {
 }
 
 impl OutgoingHandler for HttpClientProvider {
-    #[instrument(level = "trace", skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn serve_handle<Tx: wrpc_transport::Transmitter>(
         &self,
         AcceptedInvocation {
@@ -120,6 +120,7 @@ impl OutgoingHandler for HttpClientProvider {
         let res = match self
             .client
             .request(req)
+            .instrument(tracing::debug_span!("http_request"))
             .await
             .map(try_http_to_outgoing_response)
         {

--- a/crates/provider-http-server/src/lib.rs
+++ b/crates/provider-http-server/src/lib.rs
@@ -154,7 +154,7 @@ struct RequestContext {
     scheme: http::uri::Scheme,
 }
 
-#[instrument]
+#[instrument(level = "debug")]
 async fn handle_request(
     extract::State(RequestContext {
         target,

--- a/crates/provider-messaging-nats/src/connection.rs
+++ b/crates/provider-messaging-nats/src/connection.rs
@@ -55,31 +55,32 @@ impl ConnectionConfig {
     pub fn merge(&self, extra: &ConnectionConfig) -> ConnectionConfig {
         let mut out = self.clone();
         if !extra.subscriptions.is_empty() {
-            out.subscriptions = extra.subscriptions.clone();
+            out.subscriptions.clone_from(&extra.subscriptions);
         }
         // If the default configuration has a URL in it, and then the link definition
         // also provides a URL, the assumption is to replace/override rather than combine
         // the two into a potentially incompatible set of URIs
         if !extra.cluster_uris.is_empty() {
-            out.cluster_uris = extra.cluster_uris.clone();
+            out.cluster_uris.clone_from(&extra.cluster_uris);
         }
         if extra.auth_jwt.is_some() {
-            out.auth_jwt = extra.auth_jwt.clone();
+            out.auth_jwt.clone_from(&extra.auth_jwt);
         }
         if extra.auth_seed.is_some() {
-            out.auth_seed = extra.auth_seed.clone();
+            out.auth_seed.clone_from(&extra.auth_seed);
         }
         if extra.tls_ca.is_some() {
-            out.tls_ca = extra.tls_ca.clone();
+            out.tls_ca.clone_from(&extra.tls_ca);
         }
         if extra.tls_ca_file.is_some() {
-            out.tls_ca_file = extra.tls_ca_file.clone();
+            out.tls_ca_file.clone_from(&extra.tls_ca_file);
         }
         if extra.ping_interval_sec.is_some() {
             out.ping_interval_sec = extra.ping_interval_sec;
         }
         if extra.custom_inbox_prefix.is_some() {
-            out.custom_inbox_prefix = extra.custom_inbox_prefix.clone();
+            out.custom_inbox_prefix
+                .clone_from(&extra.custom_inbox_prefix);
         }
         out
     }

--- a/crates/runtime/src/actor/component/http.rs
+++ b/crates/runtime/src/actor/component/http.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use async_trait::async_trait;
 use tokio::sync::{oneshot, Mutex};
+use tracing::instrument;
 use wasmtime::component::{Resource, ResourceTable};
 use wasmtime_wasi_http::body::{HyperIncomingBody, HyperOutgoingBody};
 use wasmtime_wasi_http::types::{
@@ -104,6 +105,7 @@ impl Instance {
 
 #[async_trait]
 impl IncomingHttp for InterfaceInstance<incoming_http_bindings::IncomingHttp> {
+    #[instrument(skip_all)]
     async fn handle(
         &self,
         request: http::Request<HyperIncomingBody>,

--- a/crates/runtime/src/actor/component/mod.rs
+++ b/crates/runtime/src/actor/component/mod.rs
@@ -730,7 +730,7 @@ impl Instance {
     }
 
     /// Invoke an operation on an [Instance] producing a result.
-    #[instrument(skip(self, params, instance, name), fields(interface = instance, function = name))]
+    #[instrument(level = "debug", skip(self, params, instance, name), fields(interface = instance, function = name))]
     pub async fn call(
         &mut self,
         instance: &str,

--- a/examples/rust/components/dog-fetcher/wadm.yaml
+++ b/examples/rust/components/dog-fetcher/wadm.yaml
@@ -5,7 +5,7 @@ metadata:
   name: dog-fetcher
   annotations:
     version: v0.0.1
-    description: "HTTP hello world demo in Rust, showing use of the server and client providers"
+    description: 'HTTP hello world demo in Rust, showing use of the server and client providers'
 spec:
   components:
     - name: http-component


### PR DESCRIPTION
## Feature or Problem
This PR adds a `trace_ctx` parameter to a component's `Handler` which is set as invocations are received and used as invocations are sent in order to propagate the current trace context throughout a component's lifecycle.

## Related Issues
Fixes #2263 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

Traces reconnected (on trace logging so _VERY_ verbose) but not quite at the right level. Fine tuning instrumentation...
![image](https://github.com/wasmCloud/wasmCloud/assets/12040685/7f62da45-4eb5-419e-973f-182d326d1e74)

Traces reconnected at the debug level:
![image](https://github.com/wasmCloud/wasmCloud/assets/12040685/1e22a2fa-4620-4f11-894f-1d339813dca4)
