### PR TITLE
chore(wash-cli): Add an explicit note about leftover wadm processes

### DIFF
--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -447,6 +447,9 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
             Err(e) => {
                 let wadm_version: String = cmd.wadm_opts.wadm_version.clone();
                 eprintln!("🟨 Couldn't download wadm {wadm_version}: {e}");
+                if e.to_string().contains("Text file busy") {
+                    eprintln!("🛟 Please ensure there aren't any leftover wadm processes");
+                }
                 None
             }
         }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Sometimes, if a wadm process is leftover after a host exits, it can block the usage of wadm in future starts of an existing host. The symptom for this is wadm failing during wash startup with a "Couldn't download wadm: Text file busy" error.

The quickest fix for this issue is stopping the running wadm processes, but it's hard to *know* that might be the problem without intuiting what text file might be busy/what might be wrong.

This commit adds a message to the failure to download just in case this specific case occurs.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
