### PR TITLE
ci(dco): pass dco in merge group

### DIFF
--- a/.github/workflows/dco-merge-group.yml
+++ b/.github/workflows/dco-merge-group.yml
@@ -1,0 +1,12 @@
+# Mostly copied from https://github.com/onnx/onnx/blob/main/.github/workflows/dco_merge_group.yml
+# Because of https://github.com/dcoapp/app/issues/199
+
+name: DCO
+on:
+  merge_group:
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "dummy DCO workflow (it won't run any check actually) to trigger by merge_group in order to enable merge queue"


### PR DESCRIPTION
## Feature or Problem
This PR adds a dummy check that only runs in the merge group that passes DCO. Our checks will always require DCO before a PR gets into the merge group itself, so this is simply an enabler for us to keep the check as required.

## Related Issues
https://github.com/dcoapp/app/issues/199

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
