### PR TITLE
debug: replicate trace with dog fetcher

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -292,6 +292,7 @@ impl Component {
                 })
                 .collect::<Vec<(String, String)>>();
             wasmcloud_tracing::context::attach_span_context(&trace_context);
+            self.handler.set_trace_context(trace_context).await;
         }
 
         // Instantiate component with expected handlers
@@ -1465,6 +1466,7 @@ impl Host {
             lattice: self.host_config.lattice.clone(),
             component_id: component_id.clone(),
             targets: Arc::default(),
+            trace_ctx: Arc::default(),
             interface_links: Arc::new(RwLock::new(component_import_links(&component_spec.links))),
             polyfills: Arc::clone(component.polyfills()),
             invocation_timeout: Duration::from_secs(10), // TODO: Make this configurable

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1212,7 +1212,7 @@ impl Host {
         .await
     }
 
-    /// Instantiate an component
+    /// Instantiate a component
     #[allow(clippy::too_many_arguments)] // TODO: refactor into a config struct
     #[instrument(level = "debug", skip_all)]
     async fn instantiate_component(

--- a/crates/provider-http-client/src/lib.rs
+++ b/crates/provider-http-client/src/lib.rs
@@ -90,7 +90,7 @@ impl HttpClientProvider {
 }
 
 impl OutgoingHandler for HttpClientProvider {
-    #[instrument(level = "trace", skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn serve_handle<Tx: wrpc_transport::Transmitter>(
         &self,
         AcceptedInvocation {

--- a/crates/provider-http-server/src/lib.rs
+++ b/crates/provider-http-server/src/lib.rs
@@ -154,7 +154,7 @@ struct RequestContext {
     scheme: http::uri::Scheme,
 }
 
-#[instrument]
+#[instrument(level = "debug")]
 async fn handle_request(
     extract::State(RequestContext {
         target,

--- a/crates/runtime/src/actor/component/http.rs
+++ b/crates/runtime/src/actor/component/http.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use async_trait::async_trait;
 use tokio::sync::{oneshot, Mutex};
+use tracing::instrument;
 use wasmtime::component::{Resource, ResourceTable};
 use wasmtime_wasi_http::body::{HyperIncomingBody, HyperOutgoingBody};
 use wasmtime_wasi_http::types::{
@@ -104,6 +105,7 @@ impl Instance {
 
 #[async_trait]
 impl IncomingHttp for InterfaceInstance<incoming_http_bindings::IncomingHttp> {
+    #[instrument(skip_all)]
     async fn handle(
         &self,
         request: http::Request<HyperIncomingBody>,

--- a/examples/rust/components/dog-fetcher/wadm.yaml
+++ b/examples/rust/components/dog-fetcher/wadm.yaml
@@ -12,8 +12,8 @@ spec:
       type: component
       properties:
         # To use the locally compiled code in this folder, use the line below instead after running `wash build`:
-        # image: file://./build/dog_fetcher_s.wasm
-        image: ghcr.io/wasmcloud/components/dog-fetcher:0.1.0
+        image: file://./build/dog_fetcher_s.wasm
+        # image: ghcr.io/wasmcloud/components/dog-fetcher:0.1.0
       traits:
         # Govern the spread/scheduling of the component
         - type: spreadscaler
@@ -30,7 +30,8 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.0
+        image: file://../../../../http-server-provider.par.gz
+        #image: ghcr.io/wasmcloud/http-server:0.20.0
       traits:
         # Link the httpserver to the component, and configure the HTTP server
         # to listen on port 8080 for incoming requests
@@ -48,4 +49,5 @@ spec:
     - name: httpclient
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-client:0.9.0
+        image: file://../../../../http-client-provider.par.gz
+        #image: ghcr.io/wasmcloud/http-client:0.9.0

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,19 +227,34 @@ struct Args {
     enable_logs: Option<bool>,
 
     /// Overrides the OpenTelemetry endpoint used for emitting traces, metrics and logs. This can also be set with `OTEL_EXPORTER_OTLP_ENDPOINT`.
-    #[clap(long = "override-observability-endpoint")]
+    #[clap(
+        long = "override-observability-endpoint",
+        env = "WASMCLOUD_OVERRIDE_OBSERVABILITY_ENDPOINT",
+    )]
     observability_endpoint: Option<String>,
 
     /// Overrides the OpenTelemetry endpoint used for emitting traces. This can also be set with `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
-    #[clap(long = "override-traces-endpoint", hide = true)]
+    #[clap(
+        long = "override-traces-endpoint",
+        env = "WASMCLOUD_OVERRIDE_TRACES_ENDPOINT",
+        hide = true
+    )]
     traces_endpoint: Option<String>,
 
     /// Overrides the OpenTelemetry endpoint used for emitting metrics. This can also be set with `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`.
-    #[clap(long = "override-metrics-endpoint", hide = true)]
+    #[clap(
+        long = "override-metrics-endpoint",
+        env = "WASMCLOUD_OVERRIDE_METRICS_ENDPOINT",
+        hide = true,
+    )]
     metrics_endpoint: Option<String>,
 
     /// Overrides the OpenTelemetry endpoint used for emitting logs. This can also be set with `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`.
-    #[clap(long = "override-logs-endpoint", hide = true)]
+    #[clap(
+        long = "override-logs-endpoint",
+        env = "WASMCLOUD_OVERRIDE_METRICS_ENDPOINT",
+        hide = true,
+    )]
     logs_endpoint: Option<String>,
 
     /// Configures whether grpc or http will be used for exporting the enabled telemetry. This defaults to 'http'.


### PR DESCRIPTION
This commit contains experimental code used to debug/replicate the o11y traces for making a call with http-client & http-provider.

Running this requires the following hackery:

- running the docker compose for o11y
- (re) building dog-fetcher
- modifying the WADM w/ dog fetcher (done by this commit)
- build & create PAR for http-client
- build & create PAR for http-server
- set WASMCLOUD_OVERRIDE_TRACES_ENDPOINT before `wash up`
- replacing existing wasmcloud host (in `~/.wash/downloads/v1.0.2`)

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
