### PR TITLE
chore(http-client): bump to v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6952,7 +6952,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-client"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "futures",

--- a/crates/provider-http-client/Cargo.toml
+++ b/crates/provider-http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-client"
-version = "0.10.0"
+version = "0.10.1"
 description = """
 HTTP client for wasmCloud, using hyper. This package provides a capability provider that satisfies the 'wrpc:http/outgoing-handler' contract.
 """

--- a/src/bin/http-client-provider/wasmcloud.toml
+++ b/src/bin/http-client-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "HTTP Client"
 language = "rust"
-version = "0.10.0"
+version = "0.10.1"
 type = "provider"
 
 [rust]


### PR DESCRIPTION
## Feature or Problem
This PR bumps http-client to release with the protocol fix since the provider is failing to instantiate on v1.0.2.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
http-client v0.10.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
