### PR TITLE
chore(tracing): gate import behind feature

### DIFF
--- a/crates/tracing/src/traces.rs
+++ b/crates/tracing/src/traces.rs
@@ -14,7 +14,9 @@ use tracing_subscriber::layer::{Layered, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{EnvFilter, Layer, Registry};
 use wasmcloud_core::logging::Level;
-use wasmcloud_core::{OtelConfig, OtelProtocol};
+use wasmcloud_core::OtelConfig;
+#[cfg(feature = "otel")]
+use wasmcloud_core::OtelProtocol;
 
 struct LockedWriter<'a> {
     stderr: StderrLock<'a>,


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
This PR fixes a small issue where an import was only used behind the `otel` feature flag, so it failed to release.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I did verify this passes a publish dry run, the provider-sdk and wash-cli both pass all lints so shouldn't be an issue on the release retry
