### PR TITLE
chore(provider-*): bump minor version for otel release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.34.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724119d8fd2d2638b9979673f3b5c2979fa388c9ca27815e3cb5ad6234fac3f5"
+checksum = "2924dd7efd0112a5a88ec7d1c2dbf371966f018e90f3f45db7c8027ef895662a"
 dependencies = [
  "ahash",
  "aws-credential-types",
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.5.7"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8508de54f34b8feca6638466c2bd2de9d1df5bf79c578de9a649b72d644006b3"
+checksum = "607e8b53aeb2bc23fb332159d72a69650cd9643c161d76cd3b7f88ac00b5a1bb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -609,7 +609,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.0",
- "httparse",
  "hyper 0.14.28",
  "hyper-rustls 0.24.2",
  "once_cell",
@@ -622,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.6.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6dbabc7629fab4e4467f95f119c2e1a9b00b44c893affa98e23b040a0e2567"
+checksum = "5b7d790d553d163c7d80a4e06e2906bf24b9172c9ebe045fc3a274e9358ab7bb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -639,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.0"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe321a6b21f5d8eabd0ade9c55d3d0335f3c3157fc2b3e87f05f34b539e4df5"
+checksum = "5b6764ba7e1c5ede1c9f9e4046645534f06c2581402461c559b481a420330a83"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -674,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f734808d43702a67e57d478a12e227d4d038d0b90c9005a78c87890d3805922"
+checksum = "02fa328e19c849b20ef7ada4c9b581dd12351ff35ecc7642d06e69de4f98407c"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -6322,7 +6321,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.29.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -6376,7 +6375,7 @@ dependencies = [
  "wascap 0.15.0",
  "wash-lib",
  "wasmcloud-control-interface 1.0.0",
- "wasmcloud-core 0.7.0",
+ "wasmcloud-core 0.6.0",
  "wasmcloud-provider-sdk",
  "weld-codegen",
  "which",
@@ -6387,7 +6386,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.22.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6445,7 +6444,7 @@ dependencies = [
  "wasm-encoder 0.208.1",
  "wasmcloud-component-adapters",
  "wasmcloud-control-interface 1.0.0",
- "wasmcloud-core 0.7.0",
+ "wasmcloud-core 0.6.0",
  "wasmparser 0.202.0",
  "wasmtime",
  "wasmtime-wasi",
@@ -6676,7 +6675,7 @@ dependencies = [
  "vaultrs",
  "wascap 0.15.0",
  "wasmcloud-control-interface 1.0.0",
- "wasmcloud-core 0.7.0",
+ "wasmcloud-core 0.6.0",
  "wasmcloud-host",
  "wasmcloud-provider-blobstore-azure",
  "wasmcloud-provider-blobstore-fs",
@@ -6749,7 +6748,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry 0.24.0",
- "wasmcloud-core 0.7.0",
+ "wasmcloud-core 0.6.0",
 ]
 
 [[package]]
@@ -6805,7 +6804,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-core"
-version = "0.7.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -6871,7 +6870,7 @@ dependencies = [
  "uuid 1.8.0",
  "wascap 0.15.0",
  "wasmcloud-control-interface 1.0.0",
- "wasmcloud-core 0.7.0",
+ "wasmcloud-core 0.6.0",
  "wasmcloud-runtime",
  "wasmcloud-tracing",
  "wasmtime-wasi-http",
@@ -6895,7 +6894,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-azure"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -6921,7 +6920,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6939,7 +6938,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -6963,7 +6962,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-client"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -6983,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-server"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7007,7 +7006,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7026,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-vault"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7052,7 +7051,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-messaging-kafka"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7067,7 +7066,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7089,7 +7088,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sdk"
-version = "0.6.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7111,7 +7110,7 @@ dependencies = [
  "tracing-opentelemetry 0.24.0",
  "ulid",
  "uuid 1.8.0",
- "wasmcloud-core 0.7.0",
+ "wasmcloud-core 0.6.0",
  "wasmcloud-tracing",
  "wrpc-interface-blobstore",
  "wrpc-interface-http",
@@ -7122,7 +7121,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bigdecimal 0.4.3",
@@ -7172,7 +7171,7 @@ dependencies = [
  "wascap 0.15.0",
  "wasmcloud-component",
  "wasmcloud-component-adapters",
- "wasmcloud-core 0.7.0",
+ "wasmcloud-core 0.6.0",
  "wasmparser 0.202.0",
  "wasmtime",
  "wasmtime-wasi",
@@ -7186,7 +7185,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-test-util"
-version = "0.3.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7202,13 +7201,13 @@ dependencies = [
  "url",
  "wascap 0.15.0",
  "wasmcloud-control-interface 1.0.0",
- "wasmcloud-core 0.7.0",
+ "wasmcloud-core 0.6.0",
  "wasmcloud-host",
 ]
 
 [[package]]
 name = "wasmcloud-tracing"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -7222,7 +7221,7 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry 0.24.0",
  "tracing-subscriber",
- "wasmcloud-core 0.7.0",
+ "wasmcloud-core 0.6.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.32.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2924dd7efd0112a5a88ec7d1c2dbf371966f018e90f3f45db7c8027ef895662a"
+checksum = "2ce9a2c2942ae463c652e8295f9258ceb8312bd5313732e50066bdd6615b50f3"
 dependencies = [
  "ahash",
  "aws-credential-types",
@@ -488,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b56f1cbe6fd4d0c2573df72868f20ab1c125ca9c9dbce17927a463433a2e57"
+checksum = "31eed8d45759b2c5fe7fd304dd70739060e9e0de509209036eabea14d0720cce"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.5.4"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607e8b53aeb2bc23fb332159d72a69650cd9643c161d76cd3b7f88ac00b5a1bb"
+checksum = "8508de54f34b8feca6638466c2bd2de9d1df5bf79c578de9a649b72d644006b3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -609,6 +609,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.0",
+ "httparse",
  "hyper 0.14.28",
  "hyper-rustls 0.24.2",
  "once_cell",
@@ -621,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d790d553d163c7d80a4e06e2906bf24b9172c9ebe045fc3a274e9358ab7bb"
+checksum = "aa6dbabc7629fab4e4467f95f119c2e1a9b00b44c893affa98e23b040a0e2567"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -638,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.1.10"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6764ba7e1c5ede1c9f9e4046645534f06c2581402461c559b481a420330a83"
+checksum = "cfe321a6b21f5d8eabd0ade9c55d3d0335f3c3157fc2b3e87f05f34b539e4df5"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -673,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fa328e19c849b20ef7ada4c9b581dd12351ff35ecc7642d06e69de4f98407c"
+checksum = "6f734808d43702a67e57d478a12e227d4d038d0b90c9005a78c87890d3805922"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -6321,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.28.1"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -6375,7 +6376,7 @@ dependencies = [
  "wascap 0.15.0",
  "wash-lib",
  "wasmcloud-control-interface 1.0.0",
- "wasmcloud-core 0.6.0",
+ "wasmcloud-core 0.7.0",
  "wasmcloud-provider-sdk",
  "weld-codegen",
  "which",
@@ -6386,7 +6387,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6444,7 +6445,7 @@ dependencies = [
  "wasm-encoder 0.208.1",
  "wasmcloud-component-adapters",
  "wasmcloud-control-interface 1.0.0",
- "wasmcloud-core 0.6.0",
+ "wasmcloud-core 0.7.0",
  "wasmparser 0.202.0",
  "wasmtime",
  "wasmtime-wasi",
@@ -6675,7 +6676,7 @@ dependencies = [
  "vaultrs",
  "wascap 0.15.0",
  "wasmcloud-control-interface 1.0.0",
- "wasmcloud-core 0.6.0",
+ "wasmcloud-core 0.7.0",
  "wasmcloud-host",
  "wasmcloud-provider-blobstore-azure",
  "wasmcloud-provider-blobstore-fs",
@@ -6748,7 +6749,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry 0.24.0",
- "wasmcloud-core 0.6.0",
+ "wasmcloud-core 0.7.0",
 ]
 
 [[package]]
@@ -6804,7 +6805,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -6870,7 +6871,7 @@ dependencies = [
  "uuid 1.8.0",
  "wascap 0.15.0",
  "wasmcloud-control-interface 1.0.0",
- "wasmcloud-core 0.6.0",
+ "wasmcloud-core 0.7.0",
  "wasmcloud-runtime",
  "wasmcloud-tracing",
  "wasmtime-wasi-http",
@@ -7088,7 +7089,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sdk"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7110,7 +7111,7 @@ dependencies = [
  "tracing-opentelemetry 0.24.0",
  "ulid",
  "uuid 1.8.0",
- "wasmcloud-core 0.6.0",
+ "wasmcloud-core 0.7.0",
  "wasmcloud-tracing",
  "wrpc-interface-blobstore",
  "wrpc-interface-http",
@@ -7171,7 +7172,7 @@ dependencies = [
  "wascap 0.15.0",
  "wasmcloud-component",
  "wasmcloud-component-adapters",
- "wasmcloud-core 0.6.0",
+ "wasmcloud-core 0.7.0",
  "wasmparser 0.202.0",
  "wasmtime",
  "wasmtime-wasi",
@@ -7185,7 +7186,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-test-util"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7201,13 +7202,13 @@ dependencies = [
  "url",
  "wascap 0.15.0",
  "wasmcloud-control-interface 1.0.0",
- "wasmcloud-core 0.6.0",
+ "wasmcloud-core 0.7.0",
  "wasmcloud-host",
 ]
 
 [[package]]
 name = "wasmcloud-tracing"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -7221,7 +7222,7 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry 0.24.0",
  "tracing-subscriber",
- "wasmcloud-core 0.6.0",
+ "wasmcloud-core 0.7.0",
 ]
 
 [[package]]

--- a/crates/provider-blobstore-azure/Cargo.toml
+++ b/crates/provider-blobstore-azure/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "wasmcloud-provider-blobstore-azure"
-version = "0.1.0"
+version = "0.2.0"
+
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/provider-blobstore-fs/Cargo.toml
+++ b/crates/provider-blobstore-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.6.1"
+version = "0.7.0"
 description = """
 Blobstore for wasmCloud, leveraging the filesystem. This package provides a capability provider that satisfies the 'wasmcloud:blobstore' contract.
 """

--- a/crates/provider-blobstore-s3/Cargo.toml
+++ b/crates/provider-blobstore-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.7.0"
+version = "0.8.0"
 description = """
 S3-compatible object store capability provider for wasmcloud, satisfying the 'wasmcloud:blobstore' capability contract.
 """

--- a/crates/provider-http-client/Cargo.toml
+++ b/crates/provider-http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-client"
-version = "0.10.1"
+version = "0.11.0"
 description = """
 HTTP client for wasmCloud, using hyper. This package provides a capability provider that satisfies the 'wrpc:http/outgoing-handler' contract.
 """

--- a/crates/provider-http-server/Cargo.toml
+++ b/crates/provider-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-server"
-version = "0.20.1"
+version = "0.21.0"
 description = "Http server for wasmcloud, using Axum. This package provides a library, and a capability provider"
 
 authors.workspace = true

--- a/crates/provider-keyvalue-redis/Cargo.toml
+++ b/crates/provider-keyvalue-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.24.1"
+version = "0.25.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/provider-keyvalue-vault/Cargo.toml
+++ b/crates/provider-keyvalue-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-vault"
-version = "0.8.0"
+version = "0.9.0"
 description = """
 Hashicorp Vault capability provider for the 'wrpc:keyvalue' capability contract
 """

--- a/crates/provider-messaging-kafka/Cargo.toml
+++ b/crates/provider-messaging-kafka/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-messaging-kafka"
-version = "0.2.1"
+version = "0.3.0"
 description = """
 A capability provider that satisfies the 'wasmcloud:messaging' contract using Kafka as a backend.
 """

--- a/crates/provider-messaging-nats/Cargo.toml
+++ b/crates/provider-messaging-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.20.0"
+version = "0.21.0"
 description = """
 A capability provider that satisfies the 'wasmcloud:messaging' contract using NATS as a backend.
 """

--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.1.0"
+version = "0.2.0"
 description = """
 wasmCloud SQL database provider for Postgres
 """

--- a/src/bin/blobstore-azure-provider/wasmcloud.toml
+++ b/src/bin/blobstore-azure-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Blobstore Azure"
 language = "rust"
 type = "provider"
-version = "0.1.0"
+version = "0.2.0"
 
 [rust]
 target_path = "../../target"

--- a/src/bin/blobstore-fs-provider/wasmcloud.toml
+++ b/src/bin/blobstore-fs-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Blobstore FS"
 language = "rust"
 type = "provider"
-version = "0.6.0"
+version = "0.7.0"
 
 [rust]
 target_dir = "../../"

--- a/src/bin/blobstore-s3-provider/wasmcloud.toml
+++ b/src/bin/blobstore-s3-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "Blobstore S3"
 language = "rust"
-version = "0.7.0"
+version = "0.8.0"
 type = "provider"
 
 [rust]

--- a/src/bin/http-client-provider/wasmcloud.toml
+++ b/src/bin/http-client-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "HTTP Client"
 language = "rust"
-version = "0.10.1"
+version = "0.11.0"
 type = "provider"
 
 [rust]

--- a/src/bin/http-server-provider/wasmcloud.toml
+++ b/src/bin/http-server-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "HTTP Server"
 language = "rust"
-version = "0.20.0"
+version = "0.21.0"
 type = "provider"
 
 [rust]

--- a/src/bin/keyvalue-redis-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-redis-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Redis"
 language = "rust"
 type = "provider"
-version = "0.24.0"
+version = "0.25.0"
 
 [rust]
 target_path = "../../target"

--- a/src/bin/keyvalue-vault-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-vault-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Vault"
 language = "rust"
 type = "provider"
-version = "0.8.0"
+version = "0.9.0"
 
 [rust]
 target_path = "../../target"

--- a/src/bin/messaging-kafka-provider/wasmcloud.toml
+++ b/src/bin/messaging-kafka-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Messaging Kafka"
 language = "rust"
 type = "provider"
-version = "0.2.1"
+version = "0.3.0"
 
 [rust]
 target_dir = "../../"

--- a/src/bin/messaging-nats-provider/wasmcloud.toml
+++ b/src/bin/messaging-nats-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Messaging NATS"
 language = "rust"
 type = "provider"
-version = "0.20.0"
+version = "0.21.0"
 
 [rust]
 target_dir = "../../"

--- a/src/bin/sqldb-postgres-provider/wasmcloud.toml
+++ b/src/bin/sqldb-postgres-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "SQLDB Postgres"
 language = "rust"
 type = "provider"
-version = "0.1.0"
+version = "0.2.0"
 
 [rust]
 target_path = "../../target"


### PR DESCRIPTION
## Feature or Problem
This PR updates each capability provider a minor version bump to bring in the latest changes in the provider-sdk for link directionality, the core crate for fixing OTEL trace exporter URLs, and trace propagation fixes in http/messaging providers.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
`next` minor release of each provider

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
