### PR TITLE
fix(wash-lib,wash-cli): do not dowmload wadm on every invocation of wasm up

### DIFF
--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -846,7 +846,7 @@ async fn run_wasmcloud_interactive(
     });
 
     if output_kind != OutputKind::Json {
-        println!("🏃 Running in interactive mode.",);
+        println!("🏃 Running in interactive mode.");
         if let Some(ref manifest_path) = wadm_manifest {
             println!(
                 "🚀 Deploying WADM manifest at [{}]",

--- a/crates/wash-lib/src/start/wadm.rs
+++ b/crates/wash-lib/src/start/wadm.rs
@@ -74,14 +74,27 @@ where
         // Check version to see if we need to download new one
         if let Ok(output) = Command::new(&wadm_bin_path).arg("--version").output().await {
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-            if stdout.replace("wadm", "").trim() == version.trim_start_matches('v') {
+            println!("👀 Found wadm version on the disk: {}", stdout.trim_end());
+            let re = regex::Regex::new(r"^wadm[^\s]*").unwrap();
+            if re.replace(&stdout, "").to_string().trim() == version.trim_start_matches('v') {
                 // wadm already exists, return early
+                println!("✅ Using wadm version [{}]", &version);
                 return Ok(wadm_bin_path);
             }
         }
     }
     // Download wadm tarball
-    download_binary_from_github(&wadm_url(os, arch, version), dir, WADM_BINARY).await
+    println!(
+        "🎣 Downloading new wadm from {}",
+        &wadm_url(os, arch, version)
+    );
+
+    let res = download_binary_from_github(&wadm_url(os, arch, version), dir, WADM_BINARY).await;
+    if let Ok(ref path) = res {
+        println!("🎯 Saved wadm to {}", path.display());
+    }
+
+    res
 }
 
 /// Downloads the wadm binary for the architecture and operating system of the current host machine.


### PR DESCRIPTION
## Feature or Problem

Using regexp to detect wadm version instead of constant prefix. Also added some messages to the user, so he will know wadm version and download URL for wadm if download occurs.

## Related Issues

Resolves #2308 

## Release Information

next

## Consumer Impact

I think all users are affected by the bug. So please include the fix to the next release.

## Testing

run `wash up` and check messages on console.

### Unit Test(s)

nope

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification

run `cargo run -- up` in the folder `wasmCloud/crates/wash-cli`
