### PR TITLE
fix(wash-lib): serialize manifest to deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6387,7 +6387,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.22.0"
+version = "0.22.1"
 categories = ["wasm", "wasmcloud"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-lib/src/app.rs
+++ b/crates/wash-lib/src/app.rs
@@ -219,7 +219,8 @@ pub async fn put_model(
         client.clone(),
     );
 
-    wadm_client.put_manifest(model).await
+    let manifest = model.as_bytes();
+    wadm_client.put_manifest(manifest).await
 }
 
 /// Deploy a model, instructing wadm to manage the application
@@ -242,7 +243,8 @@ pub async fn put_and_deploy_model(
         client.clone(),
     );
 
-    wadm_client.put_and_deploy_manifest(model).await
+    let manifest = model.as_bytes();
+    wadm_client.put_and_deploy_manifest(manifest).await
 }
 
 /// Query wadm for the history of a given model name


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
This Pr serializes wadm manifest when putting it instead of passing a string, which is interpreted as a filepath and attempted to load as a file.

## Related Issues
Fixes #2312 

## Release Information
wash-lib v0.22.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
