### PR TITLE
ci(wasmcloud): add azure blobstore to release pipeline

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -40,6 +40,8 @@ on:
       - 'opentelemetry-nats-v[0-9].[0-9]+.[0-9]+-*'
       - 'provider-archive-v[0-9].[0-9]+.[0-9]+'
       - 'provider-archive-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-blobstore-azure-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-blobstore-azure-v[0-9].[0-9]+.[0-9]+-*'
       - 'provider-blobstore-fs-v[0-9].[0-9]+.[0-9]+'
       - 'provider-blobstore-fs-v[0-9].[0-9]+.[0-9]+-*'
       - 'provider-blobstore-s3-v[0-9].[0-9]+.[0-9]+'
@@ -165,6 +167,7 @@ jobs:
       - run: cargo build --release -p wash-cli -p wasmcloud
       - run: mkdir "artifact/bin"
 
+      - run: move "target/release/blobstore-azure-provider.exe" "artifact/bin/blobstore-azure-provider.exe"
       - run: move "target/release/blobstore-fs-provider.exe" "artifact/bin/blobstore-fs-provider.exe"
       - run: move "target/release/blobstore-s3-provider.exe" "artifact/bin/blobstore-s3-provider.exe"
       - run: move "target/release/http-client-provider.exe" "artifact/bin/http-client-provider.exe"
@@ -285,6 +288,9 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: blobstore-azure
+            subject: BLOBSTORE_AZURE_SUBJECT
+
           - name: blobstore-fs
             subject: BLOBSTORE_FS_SUBJECT
 


### PR DESCRIPTION
## Feature or Problem
I noticed when releasing providers that the azure provider didn't have a pipeline associated with it. This adds a release action for blobstore-azure

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
