### PR TITLE
chore/wash cli v0.29.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6322,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "provider-archive"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "async-compression",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,7 +239,7 @@ path-absolutize = { version = "3", default-features = false }
 path-clean = { version = "1", default-features = false }
 pg_bigdecimal = { version = "0.1", default-features = false }
 postgres-types = { version = "0.2", default-features = false }
-provider-archive = { version = "^0.10.2", path = "./crates/provider-archive", default-features = false }
+provider-archive = { version = "^0.11.0", path = "./crates/provider-archive", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.8", default-features = false }
 redis = { version = "0.25", default-features = false }

--- a/crates/provider-archive/Cargo.toml
+++ b/crates/provider-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provider-archive"
-version = "0.10.2"
+version = "0.11.0"
 description = "Library for reading and writing wasmCloud capability provider archive files"
 documentation = "https://docs.rs/provider-archive"
 readme = "README.md"

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.29.0"
+version = "0.29.1"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) CLI tool"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]


### PR DESCRIPTION
- **chore(provider-archive): bump to v0.11.0 for release**
- **chore(wash-cli): bump to v0.29.1 for release**

## Feature or Problem
This pr bumps wash-cli to 0.29.1 for release. It also bumps provider-archive to v0.11.0 to bring in the newest nkeys library and fix the issue where wash couldn't be published to crates.io

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
