### PR TITLE
chore/update wadm client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6192,9 +6192,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wadm-client"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54dff43b877842c657447e073a87b9d636fac74b1b97cc3032e946fbd637760c"
+checksum = "422db00d06cf461d6410396dd5a2653bcf21bccb883659f39173756b91f3f477"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -6399,7 +6399,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6334,7 +6334,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.29.1"
+version = "0.29.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -6399,7 +6399,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.22.2"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.29.1"
+version = "0.29.2"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) CLI tool"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.22.1"
+version = "0.22.2"
 categories = ["wasm", "wasmcloud"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.22.2"
+version = "0.22.1"
 categories = ["wasm", "wasmcloud"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]


### PR DESCRIPTION
- **chore: update wadm-client to v0.1.2 in lock**
- **chore(wash-cli): bump to v0.29.2 for wadm-client**

## Feature or Problem
Apparently I did not fully update the Cargo.lock to bring in the last fix for wadm-client for the delete subject, so this updates that and sets up a new version of wash-cli to go out. Originally this PR included an update to wash-lib as well, but I removed it since libraries can just update.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
