### PR TITLE
fix(provider-sdk)!: change inputs to Provider::delete_link_*()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7359,7 +7359,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-azure"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7385,7 +7385,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7403,7 +7403,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7451,7 +7451,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-server"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7475,7 +7475,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-nats"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7493,7 +7493,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7513,7 +7513,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-vault"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7540,7 +7540,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-messaging-kafka"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7557,7 +7557,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7610,7 +7610,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bigdecimal 0.4.5",

--- a/crates/provider-blobstore-azure/Cargo.toml
+++ b/crates/provider-blobstore-azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-azure"
-version = "0.3.0"
+version = "0.4.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/provider-blobstore-azure/src/lib.rs
+++ b/crates/provider-blobstore-azure/src/lib.rs
@@ -16,7 +16,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::{error, instrument, warn};
 use wasmcloud_provider_sdk::{
     get_connection, initialize_observability, load_host_data, propagate_trace_for_ctx,
-    run_provider, serve_provider_exports, Context, HostData, LinkConfig, Provider,
+    run_provider, serve_provider_exports, Context, HostData, LinkConfig, LinkDeleteInfo, Provider,
 };
 
 use config::StorageConfig;
@@ -76,8 +76,10 @@ impl Provider for BlobstoreAzblobProvider {
         Ok(())
     }
 
-    async fn delete_link(&self, source_id: &str) -> anyhow::Result<()> {
-        self.config.write().await.remove(source_id);
+    #[instrument(level = "info", skip_all, fields(source_id = info.get_source_id()))]
+    async fn delete_link_as_target(&self, info: impl LinkDeleteInfo) -> anyhow::Result<()> {
+        let component_id = info.get_source_id();
+        self.config.write().await.remove(component_id);
         Ok(())
     }
 

--- a/crates/provider-blobstore-fs/Cargo.toml
+++ b/crates/provider-blobstore-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.8.0"
+version = "0.9.0"
 description = """
 Blobstore for wasmCloud, leveraging the filesystem. This package provides a capability provider that satisfies the 'wasmcloud:blobstore' contract.
 """

--- a/crates/provider-blobstore-fs/src/lib.rs
+++ b/crates/provider-blobstore-fs/src/lib.rs
@@ -25,7 +25,7 @@ use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info, instrument, trace, warn};
 use wasmcloud_provider_sdk::{
     get_connection, initialize_observability, propagate_trace_for_ctx, run_provider,
-    serve_provider_exports, Context, LinkConfig, Provider,
+    serve_provider_exports, Context, LinkConfig, LinkDeleteInfo, Provider,
 };
 
 use crate::bindings::wrpc::blobstore::types::ContainerMetadata;
@@ -613,8 +613,10 @@ impl Provider for FsProvider {
         Ok(())
     }
 
-    async fn delete_link(&self, source_id: &str) -> anyhow::Result<()> {
-        self.config.write().await.remove(source_id);
+    #[instrument(level = "info", skip_all, fields(source_id = info.get_source_id()))]
+    async fn delete_link_as_target(&self, info: impl LinkDeleteInfo) -> anyhow::Result<()> {
+        let component_id = info.get_source_id();
+        self.config.write().await.remove(component_id);
         Ok(())
     }
 

--- a/crates/provider-blobstore-s3/Cargo.toml
+++ b/crates/provider-blobstore-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.9.0"
+version = "0.10.0"
 description = """
 S3-compatible object store capability provider for wasmcloud, satisfying the 'wasmcloud:blobstore' capability contract.
 """

--- a/crates/provider-blobstore-s3/src/lib.rs
+++ b/crates/provider-blobstore-s3/src/lib.rs
@@ -45,7 +45,7 @@ use wasmcloud_provider_sdk::core::secrets::SecretValue;
 use wasmcloud_provider_sdk::core::tls;
 use wasmcloud_provider_sdk::{
     get_connection, initialize_observability, propagate_trace_for_ctx, run_provider,
-    serve_provider_exports, Context, LinkConfig, Provider,
+    serve_provider_exports, Context, LinkConfig, LinkDeleteInfo, Provider,
 };
 
 mod bindings {
@@ -924,9 +924,11 @@ impl Provider for BlobstoreS3Provider {
     }
 
     /// Handle notification that a link is dropped: close the connection
-    async fn delete_link(&self, source_id: &str) -> anyhow::Result<()> {
+    #[instrument(level = "info", skip_all, fields(source_id = info.get_source_id()))]
+    async fn delete_link_as_target(&self, info: impl LinkDeleteInfo) -> anyhow::Result<()> {
+        let component_id = info.get_source_id();
         let mut aw = self.actors.write().await;
-        aw.remove(source_id);
+        aw.remove(component_id);
         Ok(())
     }
 

--- a/crates/provider-http-server/Cargo.toml
+++ b/crates/provider-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-server"
-version = "0.22.0"
+version = "0.23.0"
 description = "Http server for wasmcloud, using Axum. This package provides a library, and a capability provider"
 
 authors.workspace = true

--- a/crates/provider-keyvalue-nats/Cargo.toml
+++ b/crates/provider-keyvalue-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-nats"
-version = "0.2.0"
+version = "0.3.0"
 description = """
 A capability provider that satisfies the 'wasi:keyvalue' contract using NATS as a backend.
 """

--- a/crates/provider-keyvalue-redis/Cargo.toml
+++ b/crates/provider-keyvalue-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.27.0"
+version = "0.28.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/provider-keyvalue-redis/src/lib.rs
+++ b/crates/provider-keyvalue-redis/src/lib.rs
@@ -20,7 +20,7 @@ use tokio::sync::RwLock;
 use tracing::{debug, error, info, instrument, warn};
 use wasmcloud_provider_sdk::{
     get_connection, load_host_data, propagate_trace_for_ctx, run_provider, Context, LinkConfig,
-    Provider,
+    LinkDeleteInfo, Provider,
 };
 use wasmcloud_provider_sdk::{initialize_observability, serve_provider_exports};
 
@@ -369,17 +369,15 @@ impl Provider for KvRedisProvider {
     }
 
     /// Handle notification that a link is dropped - close the connection
-    #[instrument(level = "info", skip(self))]
-    async fn delete_link(&self, source_id: &str) -> anyhow::Result<()> {
+    #[instrument(level = "info", skip_all, fields(source_id = info.get_source_id()))]
+    async fn delete_link_as_target(&self, info: impl LinkDeleteInfo) -> anyhow::Result<()> {
+        let component_id = info.get_source_id();
         let mut aw = self.sources.write().await;
         // NOTE: ideally we should *not* get rid of all links for a given source here,
         // but delete_link actually does not tell us enough about the link to know whether
         // we're dealing with one link or the other.
-        aw.retain(|(src_id, _link_name), _| src_id != source_id);
-        debug!(
-            component_id = source_id,
-            "closing all redis connections for component"
-        );
+        aw.retain(|(src_id, _link_name), _| src_id != component_id);
+        debug!(component_id, "closing all redis connections for component");
         Ok(())
     }
 

--- a/crates/provider-keyvalue-vault/Cargo.toml
+++ b/crates/provider-keyvalue-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-vault"
-version = "0.10.0"
+version = "0.11.0"
 description = """
 Hashicorp Vault capability provider for the 'wrpc:keyvalue' capability contract
 """

--- a/crates/provider-messaging-kafka/Cargo.toml
+++ b/crates/provider-messaging-kafka/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-messaging-kafka"
-version = "0.4.0"
+version = "0.5.0"
 description = """
 A capability provider that satisfies the 'wasmcloud:messaging' contract using Kafka as a backend.
 """

--- a/crates/provider-messaging-nats/Cargo.toml
+++ b/crates/provider-messaging-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.22.0"
+version = "0.23.0"
 description = """
 A capability provider that satisfies the 'wasmcloud:messaging' contract using NATS as a backend.
 """

--- a/crates/provider-sdk/src/provider.rs
+++ b/crates/provider-sdk/src/provider.rs
@@ -611,12 +611,12 @@ async fn delete_link_for_provider<P>(
 where
     P: Provider,
 {
-    if ld.source_id == *connection.provider_id {
-        if let Err(e) = provider.delete_link_as_source(&ld.target).await {
+    if *ld.source_id == *connection.provider_id {
+        if let Err(e) = provider.delete_link_as_source(&ld).await {
             error!(error = %e, target = &ld.target, "failed to delete link to component");
         }
-    } else if ld.target == *connection.provider_id {
-        if let Err(e) = provider.delete_link_as_target(&ld.source_id).await {
+    } else if *ld.target == *connection.provider_id {
+        if let Err(e) = provider.delete_link_as_target(&ld).await {
             error!(error = %e, source = &ld.source_id, "failed to delete link from component");
         }
     }

--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.3.0"
+version = "0.4.0"
 description = """
 wasmCloud SQL database provider for Postgres
 """

--- a/examples/rust/providers/messaging-nats/src/nats.rs
+++ b/examples/rust/providers/messaging-nats/src/nats.rs
@@ -192,7 +192,7 @@ impl Provider for NatsMessagingProvider {
     }
 
     /// Handle notification that a link is dropped: close the connection which removes all subscriptions
-    async fn delete_link(&self, source_id: &str) -> anyhow::Result<()> {
+    async fn delete_link_as_target(&self, source_id: &str) -> anyhow::Result<()> {
         let mut all_components = self.components.write().await;
 
         if all_components.remove(source_id).is_some() {


### PR DESCRIPTION
This commit introduces new methods to the `Provider` trait for deleting links -- `delete_configured_link_as_source()` and `delete_configured_link_as_target()`.

Thse new methods are meant to address an issue with deleting links in that the name of the link was unavailable -- only the source of the link was provided.

In order to phase out old uses as fast as possible, along with these new methods, the following methods are deprecated:

- delete_link()
- delete_link_as_target()
- delete_link_as_source()

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
