### PR TITLE
feat(wit): add WIT for email provider

### DIFF
--- a/wit/email/README.md
+++ b/wit/email/README.md
@@ -1,0 +1,6 @@
+# 📧 Email WIT
+
+This folder contains a [WIT][wit] interface for sending email via [WebAssembly][wasm].
+
+[wasm]: https://webassembly.org
+[wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md

--- a/wit/email/wit/outgoing.wit
+++ b/wit/email/wit/outgoing.wit
@@ -1,0 +1,36 @@
+package wasmcloud:email@0.1.0-draft;
+
+/// Inteface for configuring outgoing email
+interface outgoing-config {
+  /// An opaque token that represents an existing outgoing configuration
+  type outgoing-email-config-token = string;
+
+  /// Retreive and initialize an outgoing email configuration
+  get-configuration: func(name: string) -> option<outgoing-email-config-token>;
+}
+
+/// Interface for sending outgoing email
+interface outgoing-sender {
+  use types.{outgoing-email};
+  use outgoing-config.{outgoing-email-config-token};
+
+  /// Errors that occur while sending emails
+  variant send-email-error {
+    /// Transport sending failure
+    transport-failure(string),
+    /// Failed to parse/use the given email message
+    invalid-outgoing-email(string),
+    /// The configuration that was found was unusable
+    unusable-config(string),
+    /// Failed to find a configuration for sending email
+    no-such-config(string),
+    /// Completely unexpected and possibly lower-level error that has occurred
+    unexpected(string),
+  }
+
+  /// Send a single outgoing email, using a pre-existing outgoing email configuration
+  send-email: func(
+    cfg: outgoing-email-config-token,
+    msg: outgoing-email
+  ) -> result<_, send-email-error>;
+}

--- a/wit/email/wit/types.wit
+++ b/wit/email/wit/types.wit
@@ -1,0 +1,25 @@
+package wasmcloud:email@0.1.0-draft;
+
+/// Types that are used by the email interface
+interface types {
+  /// Alias for an email address
+  type email-address = string;
+
+  /// Record that represents a simple outgoing email whose contents can easily be held in memory.
+  record outgoing-email {
+    /// The email address(es) from which the email will be sent
+    sender: email-address,
+    /// The email address(es) to which the email will be sent
+    recipients: list<email-address>,
+    /// List of email addresses Carbon Copy list
+    cc: option<list<email-address>>,
+    /// List of email address on Blind Carbon Copy list
+    bcc: option<list<email-address>>,
+    /// Subject of the message
+    subject: string,
+    /// Plain text content of the message
+    text: option<string>,
+    /// HTML content of the message
+    html: option<string>,
+  }
+}


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
A while back we did a hackathon where I developed this provider for sending external emails... Would be nice to upstream this and get some support in main for this prototype interface!

This commit adds the WIT interface for the wasmcloud:email provider, particularly the outgoing email sending functionality

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
