### PR TITLE
feat(*): add utility method for accessing link name

### DIFF
--- a/crates/provider-sdk/src/lib.rs
+++ b/crates/provider-sdk/src/lib.rs
@@ -104,6 +104,24 @@ pub struct Context {
     pub tracing: HashMap<String, String>,
 }
 
+impl Context {
+    /// Get link name from the request.
+    ///
+    /// While link name should in theory *always* be present, it is not natively included in [`Context`] yet,
+    /// so we must retrieve it from headers on the request.
+    ///
+    /// Note that in certain (older) versions of wasmCloud it is possible for the link name to be missing
+    /// though incredibly unlikely (basically, due to a bug). In the event that the link name was *not*
+    /// properly stored on the context 'default' (the default link name) is returned as the link name.
+    #[must_use]
+    pub fn link_name(&self) -> &str {
+        self.tracing
+            .get("link-name")
+            .map(String::as_str)
+            .unwrap_or("default")
+    }
+}
+
 /// Configuration of a link that is passed to a provider
 #[non_exhaustive]
 pub struct LinkConfig<'a> {


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This PR:
- Adds `Context::link_name()` utility method to easily retrieve link names
- Uses the new method from the KV redis provider

Resolves #2371 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
