### PR TITLE
fix(wash-ui): type mismatch number input and schema

### DIFF
--- a/washboard-ui/packages/washboard-ui/src/app/components/lattice-settings.tsx
+++ b/washboard-ui/packages/washboard-ui/src/app/components/lattice-settings.tsx
@@ -22,7 +22,7 @@ const formSchema = z.object({
     ),
   latticeId: z.string(),
   ctlTopicPrefix: z.string(),
-  retryCount: z.number().min(0),
+  retryCount: z.number().or(z.string()).pipe(z.coerce.number().min(0)),
 });
 
 type LatticeFormInput = z.input<typeof formSchema>;


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
For events dispatched by an HTMLInputElement, regardless of the type "number" attribute used, the target.value type is string. The html5 input element though will only ever send strings that are trivially parsable as Number(event.target.value). This uses a zod coercion to preprocess the data by passing it through a Number constructor and filling the form field data on change properly.
## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
closes [BUG] Washboard UI retryCount cannot be changed  #2354
## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
ran the washboard ui locally and was able to update the retryCount and have form success before drawer close