### PR TITLE
fix(custom-template-go): print instead of log

### DIFF
--- a/examples/golang/providers/custom-template/main.go
+++ b/examples/golang/providers/custom-template/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -82,36 +83,36 @@ func run() error {
 }
 
 func handleNewSourceLink(handler *Handler, link provider.InterfaceLinkDefinition) error {
-	handler.provider.Logger.Info("Handling new source link", "link", link)
+	fmt.Println("Handling new source link", "link", link)
 	handler.linkedTo[link.SourceID] = link.SourceConfig
 	return nil
 }
 
 func handleNewTargetLink(handler *Handler, link provider.InterfaceLinkDefinition) error {
-	handler.provider.Logger.Info("Handling new target link", "link", link)
+	fmt.Println("Handling new target link", "link", link)
 	handler.linkedFrom[link.Target] = link.TargetConfig
 	return nil
 }
 
 func handleDelSourceLink(handler *Handler, link provider.InterfaceLinkDefinition) error {
-	handler.provider.Logger.Info("Handling del source link", "link", link)
+	fmt.Println("Handling del source link", "link", link)
 	delete(handler.linkedTo, link.SourceID)
 	return nil
 }
 
 func handleDelTargetLink(handler *Handler, link provider.InterfaceLinkDefinition) error {
-	handler.provider.Logger.Info("Handling del target link", "link", link)
+	fmt.Println("Handling del target link", "link", link)
 	delete(handler.linkedFrom, link.Target)
 	return nil
 }
 
-func handleHealthCheck(handler *Handler) string {
-	handler.provider.Logger.Info("Handling health check")
+func handleHealthCheck(_ *Handler) string {
+	fmt.Println("Handling health check")
 	return "provider healthy"
 }
 
 func handleShutdown(handler *Handler) error {
-	handler.provider.Logger.Info("Handling shutdown")
+	fmt.Println("Handling shutdown")
 	clear(handler.linkedFrom)
 	clear(handler.linkedTo)
 	return nil


### PR DESCRIPTION
## Feature or Problem
This PR is a temporary workaround for a segfault that occurs when accessing the `provider` struct during the handler initialization functions.

## Related Issues
#2374

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
