### PR TITLE
chore(ci): use last 3 versions of wash for washboard e2e tests

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -81,8 +81,6 @@ jobs:
     strategy:
       matrix:
         wash-version:
-          # TODO: Use this once 0.27.0 is released
-          # - 0.26.0
           - current
         template:
           - hello-world-rust

--- a/.github/workflows/washboard.yml
+++ b/.github/workflows/washboard.yml
@@ -21,14 +21,17 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./washboard-ui
     strategy:
       matrix:
-        wash-version:
-          - 0.27.0
+        wash:
+          - version: 0.27.0
+          - version: 0.28.1
+          - version: 0.29.2
+            release: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,7 +73,7 @@ jobs:
       - name: Install wash
         uses: taiki-e/install-action@v2
         with:
-          tool: wash-cli@${{ matrix.wash-version }}
+          tool: wash-cli@${{ matrix.wash.version }}
 
       - name: E2E Tests
         run: yarn run turbo:test:e2e
@@ -82,6 +85,7 @@ jobs:
         run: tar -C ./packages/washboard-ui/dist -zcvf washboard.tar.gz .
 
       - name: Upload Artifact
+        if: ${{ matrix.wash.release }}
         uses: actions/upload-artifact@v4
         with:
           name: washboard
@@ -94,18 +98,22 @@ jobs:
           name: playwright-report
           retention-days: 30
           path: |
-            washboard-ui/packages/washboard-ui/playwright-report
-            washboard-ui/packages/washboard-ui/test-results
+            washboard-ui/packages/washboard-ui/wash-${{ matrix.wash.version }}.playwright-report
+            washboard-ui/packages/washboard-ui/wash-${{ matrix.wash.version }}.test-results
 
   release:
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/washboard-ui-v')
+    strategy:
+      matrix:
+        wash:
+          - version: 0.29.2
     steps:
       - name: Download Asset
         uses: actions/download-artifact@v4
         with:
-          name: washboard
+          name: washboard-${{ matrix.wash.version }}
 
       - name: Create Release
         uses: ncipollo/release-action@v1.14.0


### PR DESCRIPTION
This commit uses the last 3 versions of wash for washboard e2e tests, picking the latest versions available for minor versions 27, 28 and 29.

Resolves #2392 

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
