### PR TITLE
fix(examples): make annotation links comma delimited strings

### DIFF
--- a/examples/golang/components/http-client-tinygo/wadm.yaml
+++ b/examples/golang/components/http-client-tinygo/wadm.yaml
@@ -9,13 +9,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-client-tinygo/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-client-tinygo/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/golang/components/http-client-tinygo
-    wasmcloud.dev/categories:
-      - http
-      - outgoing-http
-      - http-server
-      - tinygo
-      - golang
-      - example
+    wasmcloud.dev/categories: |
+      http,outgoing-http,http-server,tinygo,golang,example
 spec:
   components:
     - name: http-component

--- a/examples/golang/components/http-echo-tinygo/wadm.yaml
+++ b/examples/golang/components/http-echo-tinygo/wadm.yaml
@@ -20,14 +20,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-echo-tinygo/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-echo-tinygo/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/golang/components/http-echo-tinygo
-    wasmcloud.dev/categories:
-      - http
-      - outgoing-http
-      - http-server
-      - golang
-      - tinygo
-      - example
-      - golang
+    wasmcloud.dev/categories: |
+      http,outgoing-http,http-server,golang,tinygo,example,golang
 spec:
   components:
     - name: http-echo-tinygo

--- a/examples/golang/components/http-hello-world/wadm.yaml
+++ b/examples/golang/components/http-hello-world/wadm.yaml
@@ -9,13 +9,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-hello-world/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-hello-world/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/golang/components/http-hello-world
-    wasmcloud.dev/categories:
-      - http
-      - outgoing-http
-      - http-server
-      - tinygo
-      - golang
-      - example
+    wasmcloud.dev/categories: |
+      http,outgoing-http,http-server,tinygo,golang,example
 spec:
   components:
     - name: http-component

--- a/examples/golang/providers/custom-template/wadm.yaml
+++ b/examples/golang/providers/custom-template/wadm.yaml
@@ -9,14 +9,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/providers/custom-template/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/providers/custom-template/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/golang/providers/custom-template
-    wasmcloud.dev/categories:
-      - capability-provider
-      - provider
-      - template
-      - http-server
-      - tinygo
-      - golang
-      - example
+    wasmcloud.dev/categories: |
+      capability-provider,provider,template,http-server,tinygo,golang,example
 spec:
   components:
     - name: test-component

--- a/examples/python/components/http-hello-world/wadm.yaml
+++ b/examples/python/components/http-hello-world/wadm.yaml
@@ -9,11 +9,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/python/http-hello-world/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/python/http-hello-world/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/python/http-hello-world
-    wasmcloud.dev/categories:
-      - http
-      - http-server
-      - python
-      - example
+    wasmcloud.dev/categories: |
+      http,http-server,python,example
 spec:
   components:
     - name: http-component

--- a/examples/rust/components/blobby/wadm.yaml
+++ b/examples/rust/components/blobby/wadm.yaml
@@ -15,13 +15,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/blobby/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/blobby/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/components/blobby
-    wasmcloud.dev/categories:
-      - http
-      - http-server
-      - rust
-      - object-storage
-      - blobstore
-      - example
+    wasmcloud.dev/categories: |
+      http,http-server,rust,object-storage,blobstore,example
 spec:
   components:
     - name: blobby

--- a/examples/rust/components/dog-fetcher/wadm.yaml
+++ b/examples/rust/components/dog-fetcher/wadm.yaml
@@ -10,12 +10,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/dog-fetcher/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/dog-fetcher/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/components/dog-fetcher
-    wasmcloud.dev/categories:
-      - http
-      - outgoing-http
-      - http-server
-      - rust
-      - example
+    wasmcloud.dev/categories: |
+      http,outgoing-http,http-server,rust,example
 spec:
   components:
     - name: http-component

--- a/examples/rust/components/echo-messaging/wadm.yaml
+++ b/examples/rust/components/echo-messaging/wadm.yaml
@@ -9,12 +9,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/echo-messaging/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/echo-messaging/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/components/echo-messaging
-    wasmcloud.dev/categories:
-      - messaging
-      - echo
-      - nats
-      - rust
-      - example
+    wasmcloud.dev/categories: |
+      messaging,echo,nats,rust,example
 spec:
   components:
     - name: echo

--- a/examples/rust/components/http-hello-world/wadm.yaml
+++ b/examples/rust/components/http-hello-world/wadm.yaml
@@ -9,12 +9,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rusg/components/http-hello-world/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rusg/components/http-hello-world/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/rusg/components/http-hello-world
-    wasmcloud.dev/categories:
-      - http
-      - http-server
-      - rust
-      - hello-world
-      - example
+    wasmcloud.dev/categories: |
+      http,http-server,rust,hello-world,example
 spec:
   components:
     - name: http-component

--- a/examples/rust/components/http-jsonify/wadm.yaml
+++ b/examples/rust/components/http-jsonify/wadm.yaml
@@ -11,11 +11,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/http-jsonify/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/http-jsonify/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/components/http-jsonify
-    wasmcloud.dev/categories:
-      - http
-      - http-server
-      - rust
-      - example
+    wasmcloud.dev/categories: |
+      http,http-server,rust,example
 spec:
   components:
     - name: http-component

--- a/examples/rust/components/http-keyvalue-counter/wadm.yaml
+++ b/examples/rust/components/http-keyvalue-counter/wadm.yaml
@@ -9,13 +9,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/http-keyvalue-counter/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/http-keyvalue-counter/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/components/http-keyvalue-counter
-    wasmcloud.dev/categories:
-      - http
-      - http-server
-      - keyvalue
-      - interactive
-      - rust
-      - example
+    wasmcloud.dev/categories: |
+      http,http-server,keyvalue,interactive,rust,example
 spec:
   components:
     - name: counter

--- a/examples/rust/components/sqldb-postgres-query/wadm.yaml
+++ b/examples/rust/components/sqldb-postgres-query/wadm.yaml
@@ -11,12 +11,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/sqldb-postgres-quer/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/sqldb-postgres-quer/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/components/sqldb-postgres-quer
-    wasmcloud.dev/categories:
-      - database
-      - sqldb
-      - postgres
-      - rust
-      - example
+    wasmcloud.dev/categories: |
+      database,sqldb,postgres,rust,example
 spec:
   components:
     - name: querier

--- a/examples/typescript/components/http-hello-world/wadm.yaml
+++ b/examples/typescript/components/http-hello-world/wadm.yaml
@@ -10,11 +10,8 @@ metadata:
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/typescript/components/http-hello-world/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/typescript/components/http-hello-world/README.md
     wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/typescript/components/http-hello-world
-    wasmcloud.dev/categories:
-      - http
-      - http-server
-      - typescript
-      - example
+    wasmcloud.dev/categories: |
+      http,http-server,typescript,example
 spec:
   components:
     # (Component) A test component that returns a string for any given HTTP request


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Annotations in OAM must be strings, and as we had them they weren't, this commit changes all the wasmcloud.dev/categories annotations to be strings.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
