### PR TITLE
refactor(ci): create lint comment from secondary action

### DIFF
--- a/.github/workflows/comment-cc.yml
+++ b/.github/workflows/comment-cc.yml
@@ -1,47 +1,36 @@
-name: lint-conventional-commits
+#
+# Commenting on a conventional commit lint failure is done in a separate workflow
+# to fix the permission issues with workflows run from forks.
+#
+# This workflow runs only when the other workflow runs (including if it fails)
+#
+name: comment-cc
 
-on: [pull_request]
+on:
+  workflow_run:
+    workflows:
+      - lint-cc
+    types:
+      - completed
 
+# Leave a comment on PRs that fail conventional commits
 jobs:
-  lint:
+  comment:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # - uses: taiki-e/cache-cargo-install-action@v2
-      #   with:
-      #     tool: convco
-
-      # - name: Check conventional commits formatting
-      #   id: cc-lint
-      #   continue-on-error: true
-      #   shell: bash
-      #   run: |
-      #     convco check '${{ github.event.pull_request.base.sha }}'..'${{ github.event.pull_request.head.sha }}'
-
-      - name: Install commitsar
-        uses: jaxxstorm/action-install-gh-release@25d5e2dd555cd74f1fab9ac1e6ea117acde2c0c4
-        with:
-          repo: aevea/commitsar
-          tag: v0.20.2
-          cache: enable
-
-      - name: Check commits
-        id: cc-lint
-        continue-on-error: true
-        run: |
-          commitsar -v -s=false
-
       - name: Explain conventional commits in comment
         uses: marocchino/sticky-pull-request-comment@5ec44f8ee5ecf07ea2e7410866738fb7890eb756
         with:
+          # Since lint-conventional-commits runs on pull requests, we should have exactly one
+          # pull request on the original workflow run, which we can reference the number of
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
           header: tip-conventional-commits
-          delete: ${{ steps.cc-lint.outcome == 'success' }}
-          recreate: ${{ steps.cc-lint.outcome != 'success' }}
+          # If the workflow is now successful, we can delete the original message
+          delete: ${{ github.event.workflow_run.conclusion == 'success' }}
+          # If the workflow failed, we should create the message
+          recreate: ${{ github.event.workflow_run.conclusion != 'success' }}
           message: |
             <h3>
 
@@ -63,8 +52,3 @@ jobs:
 
             [cc]: https://www.conventionalcommits.org/en/v1.0.0
             [wasmcloud]: https://github.com/wasmCloud
-
-      - name: Propagate lint failure
-        if: ${{ steps.cc-lint.outcome != 'success' }}
-        run: |
-          exit -1

--- a/.github/workflows/lint-cc.yml
+++ b/.github/workflows/lint-cc.yml
@@ -1,0 +1,25 @@
+name: lint-cc
+
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install commitsar
+        uses: jaxxstorm/action-install-gh-release@25d5e2dd555cd74f1fab9ac1e6ea117acde2c0c4
+        with:
+          repo: aevea/commitsar
+          tag: v0.20.2
+          cache: enable
+
+      - name: Check commits
+        id: cc-lint
+        run: |
+          commitsar -v -s=false


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit refactors the conventional commit lint to create comments from another secondary action, `comment-conventional-commits`.

Since `comment-conventional-commits` is triggered by a `workflow_run` (which refers to `lint-conventional-commits`), it is safe from the permission issues that forks run into.

What's better is that we don't have to rely on the forks at all to provide PR details (and thus avoid a security worry).

The approach is laid out by Github's research team here:

https://securitylab.github.com/research/github-actions-preventing-pwn-requests


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
