### PR TITLE
[FEAT] Add trace_level option to configure trace level separate from logs

### DIFF
--- a/crates/core/src/host.rs
+++ b/crates/core/src/host.rs
@@ -59,9 +59,6 @@ pub struct HostData {
     /// The log level providers should log at
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_level: Option<Level>,
-    /// The trace level providers should instrument at
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub trace_level: Option<Level>,
     #[serde(default)]
     pub otel_config: OtelConfig,
 }

--- a/crates/core/src/host.rs
+++ b/crates/core/src/host.rs
@@ -59,6 +59,9 @@ pub struct HostData {
     /// The log level providers should log at
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_level: Option<Level>,
+    /// The trace level providers should instrument at
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_level: Option<Level>,
     #[serde(default)]
     pub otel_config: OtelConfig,
 }

--- a/crates/core/src/logging.rs
+++ b/crates/core/src/logging.rs
@@ -28,3 +28,9 @@ impl From<tracing::Level> for Level {
         }
     }
 }
+
+impl Default for Level {
+    fn default() -> Self {
+        Self::Info
+    }
+}

--- a/crates/core/src/otel.rs
+++ b/crates/core/src/otel.rs
@@ -8,7 +8,7 @@ use anyhow::bail;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::wit::WitMap;
+use crate::{logging::Level, wit::WitMap};
 
 /// Configuration values for OpenTelemetry
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -43,6 +43,13 @@ pub struct OtelConfig {
     /// Additional CAs to include in the OpenTelemetry client configuration
     #[serde(default)]
     pub additional_ca_paths: Vec<PathBuf>,
+    /// The level of tracing to enable.
+    #[serde(default = "default_trace_level")]
+    pub trace_level: Level,
+}
+
+fn default_trace_level() -> Level {
+    Level::Debug
 }
 
 impl OtelConfig {

--- a/crates/core/src/otel.rs
+++ b/crates/core/src/otel.rs
@@ -49,7 +49,7 @@ pub struct OtelConfig {
 }
 
 fn default_trace_level() -> Level {
-    Level::Debug
+    Level::Info
 }
 
 impl OtelConfig {

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2141,7 +2141,6 @@ impl Host {
                 cluster_issuers: vec![],
                 default_rpc_timeout_ms,
                 log_level: Some(self.host_config.log_level.clone()),
-                trace_level: Some(self.host_config.otel_config.trace_level.clone()),
                 structured_logging: self.host_config.enable_structured_logging,
                 otel_config,
             };

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2074,6 +2074,7 @@ impl Host {
                 logs_endpoint: self.host_config.otel_config.logs_endpoint.clone(),
                 protocol: self.host_config.otel_config.protocol,
                 additional_ca_paths: self.host_config.otel_config.additional_ca_paths.clone(),
+                trace_level: self.host_config.otel_config.trace_level.clone(),
             };
 
             // Prepare startup links by generating the source and target configs. Note that because the provider may be the source
@@ -2140,6 +2141,7 @@ impl Host {
                 cluster_issuers: vec![],
                 default_rpc_timeout_ms,
                 log_level: Some(self.host_config.log_level.clone()),
+                trace_level: Some(self.host_config.otel_config.trace_level.clone()),
                 structured_logging: self.host_config.enable_structured_logging,
                 otel_config,
             };

--- a/crates/provider-sdk/src/otel.rs
+++ b/crates/provider-sdk/src/otel.rs
@@ -42,7 +42,7 @@ macro_rules! propagate_trace_for_ctx {
 #[macro_export]
 macro_rules! initialize_observability {
     ($provider_name:expr, $maybe_flamegraphs_path:expr) => {
-        let __observability__guard = {
+        let __observability_guard = {
             use $crate::anyhow::Context as _;
             use $crate::tracing_subscriber::util::SubscriberInitExt as _;
             let $crate::HostData {
@@ -50,6 +50,7 @@ macro_rules! initialize_observability {
                 otel_config,
                 structured_logging,
                 log_level,
+                trace_level,
                 ..
             } = $crate::provider::load_host_data().context("failed to load host data")?;
 
@@ -63,6 +64,7 @@ macro_rules! initialize_observability {
                 *structured_logging,
                 $maybe_flamegraphs_path,
                 log_level.as_ref(),
+                trace_level.as_ref(),
             )
             .context("failed to configure observability")?;
             dispatch

--- a/crates/provider-sdk/src/otel.rs
+++ b/crates/provider-sdk/src/otel.rs
@@ -50,7 +50,6 @@ macro_rules! initialize_observability {
                 otel_config,
                 structured_logging,
                 log_level,
-                trace_level,
                 ..
             } = $crate::provider::load_host_data().context("failed to load host data")?;
 
@@ -64,7 +63,7 @@ macro_rules! initialize_observability {
                 *structured_logging,
                 $maybe_flamegraphs_path,
                 log_level.as_ref(),
-                trace_level.as_ref(),
+                Some(&otel_config.trace_level),
             )
             .context("failed to configure observability")?;
             dispatch

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -48,6 +48,7 @@ pub fn configure_observability(
     use_structured_logging: bool,
     flame_graph: Option<impl AsRef<Path>>,
     log_level_override: Option<&Level>,
+    trace_level_override: Option<&Level>,
 ) -> anyhow::Result<(tracing::Dispatch, traces::FlushGuard)> {
     let normalized_service_name = service_name.to_kebab_case();
 
@@ -61,6 +62,7 @@ pub fn configure_observability(
         use_structured_logging,
         flame_graph,
         log_level_override,
+        trace_level_override,
     )
 }
 

--- a/crates/tracing/src/traces.rs
+++ b/crates/tracing/src/traces.rs
@@ -176,12 +176,14 @@ pub fn configure_tracing(
                 fmt.event_format(JsonOrNot::Json(Format::default().json()))
                     .fmt_fields(JsonFields::new())
                     .with_filter(log_level_filter),
-            ).into()
+            )
+            .into()
     } else {
         registry
             .with(
                 fmt.event_format(JsonOrNot::Not(Format::default()))
-                    .fmt_fields(DefaultFields::new()).with_filter(log_level_filter),
+                    .fmt_fields(DefaultFields::new())
+                    .with_filter(log_level_filter),
             )
             .into()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use wasmcloud_tracing::configure_observability;
 #[command(version, about, long_about = None)]
 struct Args {
     /// Controls the verbosity of traces emitted from the wasmCloud host
-    #[clap(long = "trace-level", default_value_t = TracingLogLevel::DEBUG, env = "WASMCLOUD_TRACE_LEVEL")]
+    #[clap(long = "trace-level", default_value_t = TracingLogLevel::INFO, env = "WASMCLOUD_TRACE_LEVEL")]
     pub trace_level: TracingLogLevel,
     /// Controls the verbosity of logs from the wasmCloud host
     #[clap(long = "log-level", alias = "structured-log-level", default_value_t = TracingLogLevel::INFO, env = "WASMCLOUD_LOG_LEVEL")]


### PR DESCRIPTION
- **feat(core)!: add trace_level option**
- **feat(tracing)!: add trace_level option**
- **feat(provider-sdk)!: configure observability with trace_level option**
- **feat(host)!: configure observability with trace_level option**
- **feat(wasmcloud)!: add --trace-level option**

## Feature or Problem
This PR adds a `--trace-level` option to wasmCloud which allows configuring traces and logging separately, defaulting trace level to INFO and log level to INFO. This should resolve an issue where you needed to set the log level to a fairly verbose level of debug in order to see many valuable traces.

## Related Issues
Fixes #1932

## Release Information
next minor tracing
next minor provider-sdk
next minor core
wasmcloud 1.1

## Consumer Impact
This is a backwards compatible breaking change, and operators of wasmCloud should be aware that as of 1.1 the default trace verbosity will be at a debug level.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
