### PR TITLE
fix(wash-cli): remove help about deprecated wash reg #2404

### DIFF
--- a/crates/wash-cli/README.md
+++ b/crates/wash-cli/README.md
@@ -124,7 +124,6 @@ Iterate:
 Publish:
   pull         Pull an artifact from an OCI compliant registry
   push         Push an artifact to an OCI compliant registry
-  reg          Perform operations on an OCI registry
 
 Configure:
   completions  Generate shell completions for wash

--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -80,7 +80,6 @@ Iterate:
 Publish:
   pull         Pull an artifact from an OCI compliant registry
   push         Push an artifact to an OCI compliant registry
-  reg          Perform operations on an OCI registry
 
 Configure:
   completions  Generate shell completions for wash

--- a/crates/wash-cli/src/common/registry_cmd.rs
+++ b/crates/wash-cli/src/common/registry_cmd.rs
@@ -230,18 +230,18 @@ mod tests {
 
     #[test]
     /// Enumerates multiple options of the `pull` command to ensure API doesn't
-    /// change between versions. This test will fail if `wash reg pull`
+    /// change between versions. This test will fail if `wash pull`
     /// changes syntax, ordering of required elements, or flags.
     fn test_pull_comprehensive() -> Result<()> {
         // test basic `wash reg pull`
         let pull_basic: Cmd = Parser::try_parse_from(["wash", "pull", ECHO_WASM])
-            .context("failed to perform reg pull")?;
+            .context("failed to perform wash pull")?;
         ensure!(matches!(
             pull_basic.sub,
             RegistryCommand::Pull(RegistryPullCommand { url, .. }) if url == ECHO_WASM,
         ));
 
-        // test `wash reg pull`
+        // test `wash pull`
         let pull_all_flags: Cmd =
             Parser::try_parse_from(["wash", "pull", ECHO_WASM, "--allow-latest", "--insecure"])
                 .context("failed to pull with all flags")?;
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     /// Enumerates multiple options of the `push` command to ensure API doesn't
-    /// change between versions. This test will fail if `wash reg push`
+    /// change between versions. This test will fail if `wash push`
     /// changes syntax, ordering of required elements, or flags.
     fn test_push_comprehensive() {
         // Not explicitly used, just a placeholder for a directory
@@ -317,7 +317,7 @@ mod tests {
                 assert_eq!(artifact, format!("{TESTDIR}/echopush.wasm"));
                 assert!(opts.insecure);
             }
-            _ => panic!("`reg push` constructed incorrect command"),
+            _ => panic!("`wash push` constructed incorrect command"),
         };
 
         // Push logging.par.gz and pull from local registry
@@ -344,7 +344,7 @@ mod tests {
                 assert!(opts.insecure);
                 assert!(allow_latest);
             }
-            _ => panic!("`reg push` constructed incorrect command"),
+            _ => panic!("`wash push` constructed incorrect command"),
         };
 
         // Push logging.par.gz to different tag and pull to confirm successful push
@@ -384,7 +384,7 @@ mod tests {
                 assert_eq!(opts.user.unwrap(), "localuser");
                 assert_eq!(opts.password.unwrap(), "supers3cr3t");
             }
-            _ => panic!("`reg push` constructed incorrect command"),
+            _ => panic!("`wash push` constructed incorrect command"),
         };
     }
 }


### PR DESCRIPTION
## Feature or Problem

#2404 

## Related Issues

## Release Information

next

## Consumer Impact

Just changed help output text

## Testing

### Unit Test(s)

no changes

### Acceptance or Integration


### Manual Verification

run `wash help` and see no info about `reg` command is present.
