### PR TITLE
feat: Allow per-signal enabling to override enable-observability

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -203,11 +203,7 @@ struct Args {
     oci_password: Option<String>,
 
     /// Determines whether observability should be enabled.
-    #[clap(
-        long = "enable-observability",
-        env = "WASMCLOUD_OBSERVABILITY_ENABLED",
-        conflicts_with_all = ["enable_traces", "enable_metrics", "enable_logs"]
-    )]
+    #[clap(long = "enable-observability", env = "WASMCLOUD_OBSERVABILITY_ENABLED")]
     enable_observability: bool,
 
     /// Determines whether traces should be enabled.


### PR DESCRIPTION
## Feature or Problem

Being able to support overriding individual signal whether observability as a whole is enabled or not makes it easier to write code that wraps the host (such as the `wasmcloud-operator`).

I don't see there being really any downsides to this, nor does it seem like breaking any existing contracts, since any previous configurations that might've tried controlling individual signals while also enabling observability as a whole wouldn't have worked.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
