### PR TITLE
fix(devcontainer): update devcontainer path and replace unmaintained lsp with maintained one

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,18 +3,15 @@
     "dockerComposeFile": "docker-compose.yml",
     "service": "dev",
     "workspaceFolder": "/workspace",
-
     "userEnvProbe": "loginShell",
     "updateRemoteUserUID": false,
-
     "onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/setup.sh",
-
     "customizations": {
         "vscode": {
             "settings": {
                 "git.alwaysSignOff": true,
                 "nix.enableLanguageServer": true,
-                "nix.serverPath": "rnix-lsp"
+                "nix.serverPath": "nixd"
             },
             "runItOn": {
                 "commands": [
@@ -34,7 +31,7 @@
                 "serayuzgur.crates",
                 "yzhang.markdown-all-in-one",
                 "tamasfe.even-better-toml"
-            ],
+            ]
         }
     }
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -3,9 +3,9 @@ set -xe
 
 nix profile install --inputs-from . \
     'nixpkgs#nix-direnv' \
-    'nixpkgs#rnix-lsp' \
+    'nixpkgs#nixd' \
     'nixpkgs#rust-analyzer' \
-    'nixpkgs#stdenv.cc.cc' \
+    'nixpkgs#gcc' \
     '.#rust'
 
 echo 'source "$HOME/.nix-profile/share/nix-direnv/direnvrc"' > "$HOME/.direnvrc"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 /target/
 target/
 
-.devcontainer
 .envrc
 .github
 .gitignore


### PR DESCRIPTION
## Feature or Problem
The devontainer command/tool failed due to unmaintained nix packages and some other configurations.

## Related Issues
#2070 
## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact


## Testing

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification

```bash

# go to the root folder
# issue the command

devcontainer up --workspace-folder .
```


#### Additional

I changed the watch in the `.envrc` since it gave me errors/warnings. And little do I know about linkers so if someone has better options for the linker (not gcc) please help.

devcontainer -> `0.65.0`
docker -> `Docker version 26.1.3, build b72abbb`
docker compose -> `Docker Compose version v2.27.3`
