### PR TITLE
chore(tests): temporarily disable windows wash CLI tests

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -43,6 +43,10 @@ jobs:
         working-directory: ./crates/wash-cli
 
       - name: Run all wash & wash-lib unit tests
+        # TODO(vados-cosmonic): executing wash on windows from the scripts
+        # we use is currently causing stack oveflows -- while that is being fixed
+        # we can rely on the linux and macos tests.
+        if: ${{ matrix.os != 'windows-latest-8-cores' }}
         run: make test-wash-ci
         working-directory: ./crates/wash-cli
 

--- a/crates/wash-lib/src/start/github.rs
+++ b/crates/wash-lib/src/start/github.rs
@@ -194,7 +194,7 @@ shutdown_lifetime 1 seconds
             .await
             .unwrap();
 
-        let container = GenericImage::new("chainguard/squid-proxy", "latest")
+        let container = GenericImage::new("cgr.dev/chainguard/squid-proxy", "latest")
             .with_exposed_port(3128)
             .with_mount(Mount::bind_mount(
                 squid_config_path.to_string_lossy().to_string(),


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit disables windows wash CLI tests due to stack overflowing, even on the windows-latest-8-cores machines.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
