### PR TITLE
refactor(providers): enable consumer groups with kafka provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,6 +1661,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32c"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3098,12 +3113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924df4f0e24e2e7f9cdd90babb0b96f93b20f3ecfa949ea9e6613756b8c8e1bf"
-
-[[package]]
 name = "io-extras"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,6 +3228,21 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+]
+
+[[package]]
+name = "kafka"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054ba4edcb4dcda4209e138c7e88caf26d4a325b3db76fbdb6ca5eecc23e426"
+dependencies = [
+ "byteorder 1.5.0",
+ "crc",
+ "fnv",
+ "ref_slice",
+ "thiserror",
+ "tracing",
+ "twox-hash",
 ]
 
 [[package]]
@@ -4635,6 +4659,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref_slice"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ed1d73fb92eba9b841ba2aef69533a060ccc0d3ec71c90aeda5996d4afb7a9"
+
+[[package]]
 name = "regalloc2"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4829,26 +4859,6 @@ checksum = "e540282f11751956c82bc5529a7fb71b871b998fbf9cf06c2419b22e1b4350df"
 dependencies = [
  "num-traits",
  "rmp",
-]
-
-[[package]]
-name = "rskafka"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132ecfa3cd9c3825208524a80881f115337762904ad3f0174e87975b2d79162c"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "crc32c",
- "futures",
- "integer-encoding",
- "parking_lot",
- "pin-project-lite",
- "rand 0.8.5",
- "thiserror",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -5507,6 +5517,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -6296,6 +6312,17 @@ dependencies = [
  "futures",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand 0.8.5",
+ "static_assertions",
 ]
 
 [[package]]
@@ -7383,8 +7410,9 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "rskafka",
+ "kafka",
  "tokio",
+ "tokio-stream",
  "tracing",
  "wasmcloud-provider-sdk",
  "wasmcloud-tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,7 +258,7 @@ reqwest = { version = "0.12", default-features = false }
 ring = { version = "0.17", default-features = false }
 rmp-serde = { version = "1", default-features = false }
 rmpv = { version = "1", default-features = false }
-rskafka = { version = "0.5", default-features = false }
+kafka = { version = "0.10", default-features = false }
 rustls = { version = "0.23.11", default-features = false }
 rustls-native-certs = { version = "0.7", default-features = false }
 rustls-pemfile = { version = "2", default-features = false }

--- a/crates/provider-messaging-kafka/Cargo.toml
+++ b/crates/provider-messaging-kafka/Cargo.toml
@@ -19,8 +19,9 @@ anyhow = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 futures = { workspace = true }
-rskafka = { workspace = true }
+kafka = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true, features = [ "otel" ] }
 wasmcloud-tracing = { workspace = true }

--- a/crates/provider-messaging-kafka/README.md
+++ b/crates/provider-messaging-kafka/README.md
@@ -12,10 +12,16 @@ It exposes publish and subscribe functionality to components to operate on Kafka
 
 ## Named Config Settings
 
-| Property | Description                                                                                                                                                                                                                                                                |
-| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `hosts`  | A comma-separated list of bootstrap server hosts. For example, `HOSTS=127.0.0.1:9092,127.0.0.1:9093`. A single value is accepted as well, and the default value is the Kafka default of `127.0.0.1:9092`. This will be used for both the consumer and producer connections |
-| `topic`  | The Kafka topic you wish to consume. Any messages on this topic will be forwarded to this component for processing                                                                                                                                                         |
+| Property              | Description                                                                                                                                                                                                                                                                |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `hosts`               | A comma-separated list of bootstrap server hosts. For example, `HOSTS=127.0.0.1:9092,127.0.0.1:9093`. A single value is accepted as well, and the default value is the Kafka default of `127.0.0.1:9092`. This will be used for both the consumer and producer connections |
+| `topic`               | The Kafka topic you wish to consume. Any messages on this topic will be forwarded to this component for processing                                                                                                                                                         |
+| `consumer_group`      | Consumer group to use when consuming messages                                                                                                                                                                                                                              |
+| `consumer_partitions` | Comma delimited list of partitions to use when subscribing to the topic specified by the link.                                                                                                                                                                             |
+| `producer_partitions` | Comma delimited list of partitions to use when handling `publish` calls from components (unrelated to the subscription topic)                                                                                                                                              |
+
+
+                                                                                                         |
 
 ## Limitations
 

--- a/crates/provider-messaging-kafka/messaging-kafka-demo.wadm.yaml
+++ b/crates/provider-messaging-kafka/messaging-kafka-demo.wadm.yaml
@@ -13,8 +13,7 @@ spec:
     - name: echo
       type: component
       properties:
-        # NOTE: make sure to `wash build` the echo messaging example!
-        image: file://../../examples/rust/components/echo-messaging/build/echo_messaging_s.wasm
+        image: ghcr.io/wasmcloud/components/echo-messaging-rust:0.1.0
       traits:
         # Govern the spread/scheduling of the component
         - type: spreadscaler
@@ -22,7 +21,7 @@ spec:
             replicas: 1
         - type: link
           properties:
-            target: nats
+            target: kafka
             namespace: wasmcloud
             package: messaging
             interfaces: [consumer]
@@ -30,9 +29,19 @@ spec:
               - name: simple-subscription
                 properties:
                   topic: wasmcloud.echo
+                  # consumer_group: "your-group-name-here"
+                  # consumer_partitions: "0,1,2,3"
+                  # producer_partitions: "0,1,2,3"
 
     # Add a capability provider that implements `wasmcloud:messaging` using KAFKA
     - name: kafka
       type: capability
       properties:
+        # To use the locally built version of this provider,
+        #
+        # - build it with (`cargo build`)
+        # - create a provider archive (`wash par create`)
+        # - uncomment the line below
+        #
+        # image: file://../../messaging-kafka-provider.par.gz
         image: ghcr.io/wasmcloud/messaging-kafka:canary

--- a/crates/provider-messaging-kafka/src/client.rs
+++ b/crates/provider-messaging-kafka/src/client.rs
@@ -1,0 +1,125 @@
+use anyhow::{Context as _, Result};
+use futures::Stream;
+use kafka::client::KafkaClient;
+use kafka::consumer::{Builder as ConsumerBuilder, Consumer, Message};
+use tokio::sync::oneshot::Sender;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tracing::{error, trace};
+
+/// An Async Kafka Client built on the [`tokio`] runtime
+pub(crate) struct AsyncKafkaClient(pub(crate) KafkaClient);
+
+impl AsyncKafkaClient {
+    /// Build an [`AsyncKafkaClient`] for a list of hosts
+    pub async fn from_hosts(hosts: Vec<String>) -> Result<Self> {
+        Self::from_client(KafkaClient::new(hosts)).await
+    }
+
+    /// Build an [`AsyncKafkaClient`] from an existing [`KafkaClient`]
+    pub async fn from_client(mut kc: KafkaClient) -> Result<Self> {
+        let kc = tokio::task::spawn_blocking(move || {
+            kc.load_metadata_all().context("failed to load metadata")?;
+            Ok::<KafkaClient, anyhow::Error>(kc)
+        })
+        .await
+        .context("failed to perform spawn blocking")?
+        .context("failed to load metadata")?;
+        Ok(Self(kc))
+    }
+}
+
+/// An wrapper for easily using a [`kafka::consumer::Consumer`] asynchronously
+pub(crate) struct AsyncKafkaConsumer(Consumer);
+
+/// A fetched message from a remote Kafka broker for a particular topic & partition.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) struct KafkaMessage {
+    /// The offset at which this message resides in the remote kafka
+    /// broker topic partition.
+    pub offset: i64,
+
+    /// The "key" data of this message.  Empty if there is no such
+    /// data for this message.
+    pub key: Vec<u8>,
+
+    /// The value data of this message.  Empty if there is no such
+    /// data for this message.
+    pub value: Vec<u8>,
+}
+
+impl<'a> From<&Message<'a>> for KafkaMessage {
+    fn from(Message { offset, key, value }: &Message<'a>) -> Self {
+        Self {
+            offset: *offset,
+            key: Vec::<u8>::from(*key),
+            value: Vec::<u8>::from(*value),
+        }
+    }
+}
+
+impl AsyncKafkaConsumer {
+    /// Build from an [`AsyncKafkaClient`] which is guaranteed to have had metadata loaded at least once (during construction).
+    pub async fn from_async_client(
+        ac: AsyncKafkaClient,
+        builder_fn: impl FnOnce(ConsumerBuilder) -> ConsumerBuilder,
+    ) -> Result<Self> {
+        let builder = builder_fn(Consumer::from_client(ac.0));
+        let consumer = builder.create().context("failed to create consumer")?;
+        Ok(Self(consumer))
+    }
+
+    /// Produce an unending stream of messages based on the inner consumer, with a mechanism for stopping
+    pub async fn messages(self) -> Result<(impl Stream<Item = KafkaMessage>, Sender<()>)> {
+        let mut consumer = self.0;
+        let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let (msg_tx, msg_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        // Listen forever for new messages with the consumer
+        tokio::task::spawn_blocking(move || {
+            loop {
+                match consumer.poll() {
+                    // If we received message sets, process them
+                    Ok(message_sets) => {
+                        for message_set in message_sets.iter() {
+                            for message in message_set.messages() {
+                                trace!(
+                                    topic = message_set.topic(),
+                                    partition = message_set.partition(),
+                                    offset = message.offset,
+                                    "received message",
+                                );
+                                if let Err(e) = msg_tx
+                                    .send(KafkaMessage::from(message))
+                                    .context("failed to send kafka message")
+                                {
+                                    error!("failed to send kafka message: {e}");
+                                }
+                            }
+                            if let Err(e) = consumer.consume_messageset(message_set) {
+                                error!("failed to consume message set: {e}");
+                            }
+                        }
+                        // Commit all consumed stuff, but only if we're in a group
+                        if !consumer.group().is_empty() {
+                            if let Err(e) = consumer.commit_consumed() {
+                                error!("failed to commit consumed messages: {e}");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!("failed to poll: {e}");
+                    }
+                }
+
+                // If we've been told to stop, then we should stop
+                if let Ok(()) = stop_rx.try_recv() {
+                    trace!("received stop, shutting down consuming thread...");
+                    return Ok(()) as Result<()>;
+                }
+            }
+        });
+
+        Ok((UnboundedReceiverStream::new(msg_rx), stop_tx))
+    }
+}

--- a/crates/provider-sdk/src/provider.rs
+++ b/crates/provider-sdk/src/provider.rs
@@ -763,6 +763,7 @@ pub fn invocation_context(headers: &HeaderMap) -> Context {
     }
 }
 
+#[derive(Clone)]
 pub struct WrpcClient {
     nats: wrpc_transport_nats::Client,
     timeout: Duration,


### PR DESCRIPTION
This commit enables consumer groups via link time configuration in the kafka provider.

The native Rust ecosystem for Kafka is somewhat immature, so to do this we must switch to a different crate
`kafka-rs` (https://crates.io/crates/kafka), which implements consumer groups but is otherwise missing some features.

With this branch, one can specify CONSUMER_GROUP in link configuration to control the consumer group that is used for Kafka consumers (whose incoming messages will trigger downstream components).

Resolves #1442 

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
