### PR TITLE
feat(host,provider-sdk): support provider config updates

### DIFF
--- a/crates/core/src/rpc.rs
+++ b/crates/core/src/rpc.rs
@@ -56,3 +56,13 @@ pub fn health_subject(lattice: &str, provider_key: &str) -> String {
 pub fn shutdown_subject(lattice: &str, provider_key: &str, link_name: &str) -> String {
     format!("wasmbus.rpc.{lattice}.{provider_key}.{link_name}.shutdown")
 }
+
+/// Generate the wasmbus RPC subject for delivering config updates to a given provider
+///
+/// When messages are published on this subject, providers up the perform shutdown (cleanly if possible).
+///
+/// NOTE that the NATS message body limits (default 1MiB) apply to these messages
+#[must_use]
+pub fn provider_config_update_subject(lattice: &str, provider_key: &str) -> String {
+    format!("wasmbus.rpc.{lattice}.{provider_key}.config.update")
+}

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2424,10 +2424,13 @@ impl Host {
             let config_update_task = spawn(async move {
                 let subject = provider_config_update_subject(&lattice, &provider_id);
                 trace!(provider_id, "starting config update listener");
-                let mut update_config = update_config.write().await;
                 loop {
+                    let mut update_config = update_config.write().await;
                     select! {
-                        update = update_config.changed() => {
+                        maybe_update = update_config.changed() => {
+                            let Ok(update) = maybe_update else {
+                                break;
+                            };
                             trace!(provider_id, "provider config bundle changed");
                             let bytes = match serde_json::to_vec(&*update) {
                                 Ok(bytes) => bytes,

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2491,10 +2491,7 @@ impl Host {
             return Ok(CtlResponse::error("provider with that ID is not running"));
         };
         let Provider {
-            ref health_check_task,
-            ref config_update_task,
-            ref annotations,
-            ..
+            ref annotations, ..
         } = entry.remove();
 
         // Send a request to the provider, requesting a graceful shutdown
@@ -2523,8 +2520,6 @@ impl Host {
                 "provider did not gracefully shut down in time, shutting down forcefully"
             );
         }
-        health_check_task.abort();
-        config_update_task.abort();
         info!(provider_id, "provider stopped");
         self.publish_event(
             "provider_stopped",

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -35,7 +35,7 @@ use secrecy::Secret;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tokio::sync::{mpsc, watch, RwLock, Semaphore};
+use tokio::sync::{broadcast, mpsc, watch, RwLock, Semaphore};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::{interval_at, timeout_at, Instant};
 use tokio::{process, select, spawn};
@@ -50,7 +50,10 @@ use wasmcloud_control_interface::{
     ScaleComponentCommand, StartProviderCommand, StopHostCommand, StopProviderCommand,
     UpdateComponentCommand,
 };
-use wasmcloud_core::{ComponentId, HealthCheckResponse, HostData, OtelConfig, CTL_API_VERSION_1};
+use wasmcloud_core::{
+    provider_config_update_subject, ComponentId, HealthCheckResponse, HostData, OtelConfig,
+    CTL_API_VERSION_1,
+};
 use wasmcloud_runtime::capability::secrets::store::SecretValue;
 use wasmcloud_runtime::component::WrpcServeEvent;
 use wasmcloud_runtime::Runtime;
@@ -317,13 +320,17 @@ impl wrpc_transport::Serve for WrpcServer {
     }
 }
 
+/// An Provider instance
 #[derive(Debug)]
 struct Provider {
-    child: JoinHandle<()>,
-    annotations: Annotations,
     image_ref: String,
     claims_token: Option<jwt::Token<jwt::CapabilityProvider>>,
     xkey: XKey,
+    annotations: Annotations,
+    /// Task that continuously performs health checks against the provider
+    health_check_task: JoinHandle<()>,
+    /// Task that continuously forwards configuration updates to the provider
+    config_update_task: JoinHandle<()>,
 }
 
 /// wasmCloud Host
@@ -2084,8 +2091,7 @@ impl Host {
         self.store_component_spec(&provider_id, &component_specification)
             .await?;
 
-        // TODO(#1648): Implement redelivery of changed configuration when `config.changed()` is true
-        let (config, secrets) = self
+        let (mut config, secrets) = self
             .fetch_config_and_secrets(
                 config,
                 claims_token.as_ref().map(|t| &t.jwt),
@@ -2257,6 +2263,26 @@ impl Host {
                 .context("failed to write newline")?;
             stdin.shutdown().await.context("failed to close stdin")?;
 
+            // Create a channel for watching for child process exit
+            let (exit_tx, exit_rx) = broadcast::channel::<()>(1);
+            spawn(async move {
+                match child.wait().await {
+                    Ok(status) => {
+                        debug!("provider @ [{}] exited with `{status:?}`", path.display());
+                    }
+                    Err(e) => {
+                        error!(
+                            "failed to wait for provider @ [{}] to execute: {e}",
+                            path.display()
+                        );
+                    }
+                }
+                if let Err(err) = exit_tx.send(()) {
+                    warn!(%err, "failed to send exit tx");
+                }
+            });
+            let mut exit_health_rx = exit_rx.resubscribe();
+
             // TODO: Change method receiver to Arc<Self> and `move` into the closure
             let rpc_nats = self.rpc_nats.clone();
             let ctl_nats = self.ctl_nats.clone();
@@ -2265,7 +2291,7 @@ impl Host {
             let health_lattice = self.host_config.lattice.clone();
             let health_host_id = host_id.to_string();
             let health_provider_id = provider_id.to_string();
-            let child = spawn(async move {
+            let health_check_task = spawn(async move {
                 // Check the health of the provider every 30 seconds
                 let mut health_check = tokio::time::interval(Duration::from_secs(30));
                 let mut previous_healthy = false;
@@ -2355,15 +2381,11 @@ impl Host {
                                     warn!(provider_id = health_provider_id, "failed to request provider health, retrying in 30 seconds");
                                 }
                         }
-                        exit_status = child.wait() => match exit_status {
-                            Ok(status) => {
-                                debug!("`{}` exited with `{status:?}`", path.display());
-                                break;
+                        exit = exit_health_rx.recv() => {
+                            if let Err(err) = exit {
+                                warn!(%err, provider_id = health_provider_id, "failed to receive exit in health check task");
                             }
-                            Err(e) => {
-                                warn!("failed to wait for `{}` to execute: {e}", path.display());
-                                break;
-                            }
+                            break;
                         }
                     }
                 }
@@ -2380,8 +2402,46 @@ impl Host {
                 ),
             )
             .await?;
+
+            // Spawn off a task to watch for config bundle updates and forward them to
+            // the provider that we're spawning and managing
+            let mut exit_config_tx = exit_rx;
+            let provider_id = provider_id.to_string();
+            let lattice = self.host_config.lattice.to_string();
+            let client = self.rpc_nats.clone();
+            let config_update_task = spawn(async move {
+                let subject = provider_config_update_subject(&lattice, &provider_id);
+                trace!(provider_id, "starting config update listener");
+                loop {
+                    select! {
+                        config = config.changed() => {
+                            trace!(provider_id, "provider config bundle changed");
+                            let bytes = match serde_json::to_vec(&*config) {
+                                Ok(bytes) => bytes,
+                                Err(err) => {
+                                    error!(%err, provider_id, lattice, "failed to serialize configuration update ");
+                                    continue;
+                                }
+                            };
+                            trace!(provider_id, subject, "publishing config bundle bytes");
+                            if let Err(err) = client.publish(subject.clone(), Bytes::from(bytes)).await {
+                                error!(%err, provider_id, lattice, "failed to publish configuration update bytes to component");
+                            }
+                        }
+                        exit = exit_config_tx.recv() => {
+                            if let Err(err) = exit {
+                                warn!(%err, provider_id, "failed to receive exit in config update task");
+                            }
+                            break;
+                        }
+                    }
+                }
+            });
+
+            // Add the provider
             entry.insert(Provider {
-                child,
+                health_check_task,
+                config_update_task,
                 annotations,
                 claims_token,
                 image_ref: provider_ref.to_string(),
@@ -2390,6 +2450,7 @@ impl Host {
         } else {
             bail!("provider is already running with that ID")
         }
+
         Ok(())
     }
 
@@ -2413,7 +2474,10 @@ impl Host {
             return Ok(CtlResponse::error("provider with that ID is not running"));
         };
         let Provider {
-            child, annotations, ..
+            health_check_task,
+            config_update_task,
+            annotations,
+            ..
         } = entry.remove();
 
         // Send a request to the provider, requesting a graceful shutdown
@@ -2442,7 +2506,8 @@ impl Host {
                 "provider did not gracefully shut down in time, shutting down forcefully"
             );
         }
-        child.abort();
+        health_check_task.abort();
+        config_update_task.abort();
         info!(provider_id, "provider stopped");
         self.publish_event(
             "provider_stopped",

--- a/src/bin/keyvalue-redis-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-redis-provider/wasmcloud.toml
@@ -4,7 +4,7 @@ type = "provider"
 version = "0.27.0"
 
 [rust]
-target_path = "../../target"
+target_path = "../../../target"
 
 [provider]
 bin_name = "keyvalue-redis-provider"


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This PR introduces a scheme for supporting provider config updates by using the `CONFIGDATA_<lattice>` KV bucket. 

- When a provider makes a config bundle, it picks an ID (UUID v7, could add host ID)
- When the config bundle the host is maintaining updates, we push the value to the key in the KV bucket
- The host passes the key relevant to the config bundle to the provider at startup
- When the provider starts, `provider-sdk` listens independently on NATS for updates to the relevant key, and observes config updates that match it's bundle.
- The provider can implement `on_config_update()` to respond to config updates.

Resolves https://github.com/wasmCloud/wasmCloud/issues/1648

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
