### PR TITLE
feat(host,cli): max_execution_time config flag support for host runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6683,6 +6683,7 @@ dependencies = [
  "dirs",
  "futures",
  "http 1.1.0",
+ "humantime",
  "indicatif",
  "nix",
  "nkeys 0.4.1",

--- a/crates/host/src/wasmbus/host_config.rs
+++ b/crates/host/src/wasmbus/host_config.rs
@@ -61,6 +61,8 @@ pub struct Host {
     /// The semver version of the host. This is used by a consumer of this crate to indicate the
     /// host version (which may differ from the crate version)
     pub version: String,
+    /// The Max Execution time for Host runtime
+    pub max_execution_time: Duration,
 }
 
 /// Configuration for wasmCloud policy service
@@ -103,6 +105,7 @@ impl Default for Host {
             policy_service_config: PolicyService::default(),
             secrets_topic_prefix: None,
             version: env!("CARGO_PKG_VERSION").to_string(),
+            max_execution_time: Duration::from_millis(10 * 60 * 1000),
         }
     }
 }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -769,6 +769,7 @@ impl Host {
 
         // TODO: Configure
         let (runtime, epoch, epoch_end) = Runtime::builder()
+            .max_execution_time(config.max_execution_time)
             .build()
             .context("failed to build runtime")?;
         let event_builder = EventBuilderV10::new().source(host_key.public_key());
@@ -840,6 +841,8 @@ impl Host {
 
         let config_generator = BundleGenerator::new(config_data.clone());
 
+        let max_execution_time_ms = config.max_execution_time;
+
         let host = Host {
             components: RwLock::default(),
             event_builder,
@@ -869,7 +872,7 @@ impl Host {
             component_claims: Arc::default(),
             provider_claims: Arc::default(),
             metrics: Arc::new(metrics),
-            max_execution_time: Duration::from_secs(10 * 60),
+            max_execution_time: max_execution_time_ms,
         };
 
         let host = Arc::new(host);

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -26,6 +26,7 @@ console = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+humantime.workspace = true
 indicatif = { workspace = true }
 nix = { workspace = true, features = ["signal"] }
 nkeys = { workspace = true }

--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -21,6 +21,8 @@ pub const WASMCLOUD_JS_DOMAIN: &str = "WASMCLOUD_JS_DOMAIN";
 pub const WASMCLOUD_CLUSTER_ISSUERS: &str = "WASMCLOUD_CLUSTER_ISSUERS";
 pub const WASMCLOUD_CLUSTER_SEED: &str = "WASMCLOUD_CLUSTER_SEED";
 pub const WASMCLOUD_HOST_SEED: &str = "WASMCLOUD_HOST_SEED";
+pub const WASMCLOUD_MAX_EXECUTION_TIME_MS: &str = "WASMCLOUD_MAX_EXECUTION_TIME_MS";
+pub const DEFAULT_MAX_EXECUTION_TIME_MS: &str = "600000";
 // NATS RPC connection configuration
 pub const WASMCLOUD_RPC_HOST: &str = "WASMCLOUD_RPC_HOST";
 pub const WASMCLOUD_RPC_PORT: &str = "WASMCLOUD_RPC_PORT";
@@ -81,6 +83,10 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
             cluster_issuers.join(","),
         );
     }
+    host_config.insert(
+        WASMCLOUD_MAX_EXECUTION_TIME_MS.to_string(),
+        wasmcloud_opts.max_execution_time.to_string(),
+    );
 
     if wasmcloud_opts.allow_latest {
         host_config.insert(WASMCLOUD_OCI_ALLOW_LATEST.to_string(), "true".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,9 @@ struct Args {
         requires = "policy_topic"
     )]
     policy_changes_topic: Option<String>,
+    /// If provided, allows to set a custom Max Execution time for the Host in ms.
+    #[clap(long = "max-execution-time-ms", default_value = "600000", env = "WASMCLOUD_MAX_EXECUTION_TIME_MS", value_parser = parse_duration)]
+    max_execution_time: Duration,
     /// If provided, allows setting a custom timeout for requesting policy decisions. Defaults to one second. Requires `policy_topic` to be set.
     #[clap(
         long = "policy-timeout-ms",
@@ -417,6 +420,7 @@ async fn main() -> anyhow::Result<()> {
         policy_service_config,
         secrets_topic_prefix: args.secrets_topic_prefix,
         version: env!("CARGO_PKG_VERSION").to_string(),
+        max_execution_time: args.max_execution_time,
     }))
     .await
     .context("failed to initialize host")?;


### PR DESCRIPTION
## Feature or Problem
Adds a `--max-execution-time` flag to `wash up` for configuring the host's max execution time implemented in #2002 and #2015 

## Related Issues
(1/2) of  #2016 
## Release Information
next
## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Ran `cargo run -- up --max-execution-time <humantime>` to which `wash -up` ran as usual, value propagation and time duration formatting works.