### PR TITLE
build(nix): update `nix-direnv`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,6 @@
-if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
 fi
+watch_file rust-toolchain.toml
 use flake
-nix_direnv_watch_file rust-toolchain.toml
 export WASMTIME_BACKTRACE_DETAILS=1


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

- Update vendored `nix-direnv` to a newer version
- Replace deprecated `nix_direnv_watch_file` by `watch_file`
   - Also, reorder as per documentation

Thanks @markkovari for pointing this out in https://github.com/wasmCloud/wasmCloud/pull/2419#discussion_r1662571247!

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
---> 

https://github.com/wasmCloud/wasmCloud/pull/2419#discussion_r1662571247

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
