### PR TITLE
Add support for debug build for rust providers #2298

### DIFF
--- a/crates/wash-cli/tests/common/mod.rs
+++ b/crates/wash-cli/tests/common/mod.rs
@@ -627,6 +627,45 @@ pub async fn init_component_from_template(
     Ok(project_dir)
 }
 
+#[allow(dead_code)]
+pub async fn init_provider(provider_name: &str, template_name: &str) -> Result<TestSetup> {
+    let test_dir = TempDir::new()?;
+    std::env::set_current_dir(&test_dir)?;
+    let project_dir = init_provider_from_template(provider_name, template_name).await?;
+    std::env::set_current_dir(&project_dir)?;
+    Ok(TestSetup {
+        test_dir,
+        project_dir,
+    })
+}
+
+/// Initializes a new provider from a template provider template
+#[allow(dead_code)]
+pub async fn init_provider_from_template(
+    provider_name: &str,
+    template_name: &str,
+) -> Result<PathBuf> {
+    let status = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args([
+            "new",
+            "provider",
+            provider_name,
+            "--template-name",
+            template_name,
+            "--silent",
+            "--no-git-init",
+        ])
+        .kill_on_drop(true)
+        .status()
+        .await
+        .context("Failed to generate provider")?;
+
+    assert!(status.success());
+
+    let project_dir = std::env::current_dir()?.join(provider_name);
+    Ok(project_dir)
+}
+
 /// Wait until a process has a given count on the current machine
 #[allow(dead_code)]
 pub async fn wait_until_process_has_count(

--- a/crates/wash-lib/src/build/provider.rs
+++ b/crates/wash-lib/src/build/provider.rs
@@ -110,7 +110,7 @@ fn build_rust_provider(
     if !rust_config.debug {
         build_args.push("--release");
     }
-    
+
     if let Some(override_target) = &provider_config.rust_target {
         build_args.extend_from_slice(&["--target", override_target]);
     };
@@ -153,7 +153,11 @@ fn build_rust_provider(
         provider_path_buf.push(override_target);
     }
 
-    provider_path_buf.push("release");
+    if rust_config.debug {
+        provider_path_buf.push("debug");
+    } else {
+        provider_path_buf.push("release");
+    }
     provider_path_buf.push(&bin_name);
 
     Ok((provider_path_buf, bin_name))

--- a/crates/wash-lib/src/build/provider.rs
+++ b/crates/wash-lib/src/build/provider.rs
@@ -105,7 +105,12 @@ fn build_rust_provider(
 
     // Build for a specified target if provided, or the default rust target
     let mut build_args = Vec::with_capacity(4);
-    build_args.extend_from_slice(&["build", "--release"]);
+    build_args.push("build");
+
+    if !rust_config.debug {
+        build_args.push("--release");
+    }
+    
     if let Some(override_target) = &provider_config.rust_target {
         build_args.extend_from_slice(&["--target", override_target]);
     };

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -1214,7 +1214,8 @@ mod test {
             project_config.language,
             LanguageConfig::Rust(RustConfig {
                 cargo_path: Some("./cargo".into()),
-                target_path: Some("./target".into())
+                target_path: Some("./target".into()),
+                debug: false,
             })
         );
 
@@ -1354,7 +1355,8 @@ mod test {
             project_config.language,
             LanguageConfig::Rust(RustConfig {
                 cargo_path: Some("./cargo".into()),
-                target_path: Some("./target".into())
+                target_path: Some("./target".into()),
+                debug: false,
             })
         );
 

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -223,8 +223,8 @@ struct RawRustConfig {
     pub cargo_path: Option<PathBuf>,
     /// Path to cargo/rust's `target` directory. Optional, defaults to `./target`.
     pub target_path: Option<PathBuf>,
-    // Whether to build in debug mode. Defaults to false.
-    pub debug: bool,
+    /// Whether to build in debug mode. Defaults to false.
+    pub debug: Option<bool>,
 }
 
 impl TryFrom<RawRustConfig> for RustConfig {
@@ -234,7 +234,7 @@ impl TryFrom<RawRustConfig> for RustConfig {
         Ok(Self {
             cargo_path: raw_config.cargo_path,
             target_path: raw_config.target_path,
-            debug: raw_config.debug,
+            debug: raw_config.debug.unwrap_or_default(),
         })
     }
 }

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -213,6 +213,8 @@ pub struct RustConfig {
     pub cargo_path: Option<PathBuf>,
     /// Path to cargo/rust's `target` directory. Optional, defaults to the cargo target directory for the workspace or project.
     pub target_path: Option<PathBuf>,
+    // Whether to build in debug mode. Defaults to false.
+    pub debug: bool,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Default, Clone)]
@@ -221,6 +223,8 @@ struct RawRustConfig {
     pub cargo_path: Option<PathBuf>,
     /// Path to cargo/rust's `target` directory. Optional, defaults to `./target`.
     pub target_path: Option<PathBuf>,
+    // Whether to build in debug mode. Defaults to false.
+    pub debug: bool,
 }
 
 impl TryFrom<RawRustConfig> for RustConfig {
@@ -230,6 +234,7 @@ impl TryFrom<RawRustConfig> for RustConfig {
         Ok(Self {
             cargo_path: raw_config.cargo_path,
             target_path: raw_config.target_path,
+            debug: raw_config.debug,
         })
     }
 }

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -20,7 +20,8 @@ fn rust_component() {
         config.language,
         LanguageConfig::Rust(RustConfig {
             cargo_path: Some("./cargo".into()),
-            target_path: Some("./target".into())
+            target_path: Some("./target".into()),
+            debug: false,
         })
     );
 
@@ -70,7 +71,8 @@ fn rust_component_with_revision() {
         config.language,
         LanguageConfig::Rust(RustConfig {
             cargo_path: Some("./cargo".into()),
-            target_path: Some("./target".into())
+            target_path: Some("./target".into()),
+            debug: false,
         })
     );
 
@@ -190,7 +192,8 @@ fn folder_path() {
         config.language,
         LanguageConfig::Rust(RustConfig {
             cargo_path: Some("./cargo".into()),
-            target_path: Some("./target".into())
+            target_path: Some("./target".into()),
+            debug: false,
         })
     );
 }
@@ -336,6 +339,7 @@ fn minimal_rust_component() {
         LanguageConfig::Rust(RustConfig {
             cargo_path: None,
             target_path: None,
+            debug: false,
         })
     );
 
@@ -389,6 +393,7 @@ fn cargo_toml_component() {
         LanguageConfig::Rust(RustConfig {
             cargo_path: None,
             target_path: None,
+            debug: false,
         })
     );
 


### PR DESCRIPTION

**Support for debug build for rust providers**

This changes aims to enable building a rust provider in debug mode by enabling debug mode in the wasmcloud.toml
file like this.

```
[rust]
target_dir = "../../"

debug = true
```

