### PR TITLE
fix(tests): increase windows stack size

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -43,10 +43,6 @@ jobs:
         working-directory: ./crates/wash-cli
 
       - name: Run all wash & wash-lib unit tests
-        # TODO(vados-cosmonic): executing wash on windows from the scripts
-        # we use is currently causing stack oveflows -- while that is being fixed
-        # we can rely on the linux and macos tests.
-        if: ${{ matrix.os != 'windows-latest-8-cores' }}
         run: make test-wash-ci
         working-directory: ./crates/wash-cli
 

--- a/crates/wash-cli/build.rs
+++ b/crates/wash-cli/build.rs
@@ -22,6 +22,18 @@ async fn record_reachability(host: &str) {
 
 #[tokio::main]
 async fn main() {
+    // On Windows, `clap` can overflow the stack in debug mode due to small default stack size
+    //
+    // This generally triggers during the `integration_help_subcommand_check` which checks the help
+    // command (i.e. walking the entire arg tree)
+    //
+    // see:
+    // - https://github.com/clap-rs/clap/issues/5134
+    // - https://github.com/clap-rs/clap/issues/4516
+    if std::env::var_os("CARGO_CFG_WINDOWS").is_some() {
+        println!("cargo:rustc-link-arg=/stack:{}", 8 * 1024 * 1024);
+    }
+
     join!(
         record_reachability("github.com"),
         record_reachability("ghcr.io"),


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

`clap` has a few bugs that cause stacks to overflow on windows when doing commands like walking the full arg tree (i.e. `--help`).

Adopting a fix from one of the
issues (https://github.com/clap-rs/clap/issues/5134), we increase the size of stack during build.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
