### PR TITLE
feat: Add support for supplying additional CA certificates to OCI and OpenTelemetry clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "ring",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
  "rustls-webpki 0.102.5",
  "serde",
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -778,7 +778,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -846,7 +846,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
@@ -1095,7 +1095,7 @@ dependencies = [
  "home",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "hyper-named-pipe",
  "hyper-rustls 0.26.0",
  "hyper-util",
@@ -1103,7 +1103,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "rustls 0.22.4",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -1218,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d00bd8d26c4270d950eaaa837387964a2089a1c3c349a690a1fa03221d29531"
+checksum = "00172660727e2d7f808e7cc2bfffd093fdb3ea2ff2ef819289418a3c3ffab5ac"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -1245,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19eb8e3d71996828751c1ed3908a439639752ac6bdc874e41469ef7fc15fbd7f"
+checksum = "8cd9187bb3f7478a4c135ea10473a41a5f029d2ac800c1adf64f35ec7d4c8603"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -1379,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1389,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1401,18 +1401,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.8"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4be9c4c4b1f30b78d8a750e0822b6a6102d97e62061c583a6c1dea2dfb33ae"
+checksum = "d2020fa13af48afc65a9a87335bda648309ab3d154cd03c7ff95b378c7ed39c4"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2822,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2848,7 +2848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2896,11 +2896,11 @@ checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "hyper-util",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -2915,10 +2915,10 @@ checksum = "736f15a50e749d033164c56c09783b6102c4ff8da79ad77dbddbbaea0f8567f7"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "hyper-util",
  "rustls 0.23.11",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2949,7 +2949,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2966,7 +2966,7 @@ checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4617,7 +4617,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.22.4",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "ryu",
@@ -4783,7 +4783,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "hyper-rustls 0.27.0",
  "hyper-util",
  "ipnet",
@@ -4985,9 +4985,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.1.2",
@@ -5186,9 +5186,9 @@ checksum = "224e328af6e080cddbab3c770b1cf50f0351ba0577091ef2410c3951d835ff87"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -5223,9 +5223,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5234,9 +5234,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -5800,18 +5800,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.62"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.62"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6997,7 +6997,7 @@ dependencies = [
  "clap",
  "futures",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "hyper-util",
  "nkeys 0.4.1",
  "once_cell",
@@ -7166,7 +7166,8 @@ dependencies = [
  "once_cell",
  "reqwest 0.12.5",
  "rustls 0.23.11",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.2",
  "serde",
  "serde_bytes",
  "sha2",
@@ -7317,7 +7318,7 @@ dependencies = [
  "hyper-rustls 0.27.0",
  "hyper-util",
  "rustls 0.23.11",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
  "tokio",
  "tracing",
@@ -7609,6 +7610,7 @@ dependencies = [
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk 0.23.0",
+ "reqwest 0.11.27",
  "serde",
  "tracing",
  "tracing-appender",
@@ -7915,7 +7917,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "rustls 0.22.4",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -8543,7 +8545,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.3.1",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8708,9 +8710,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,6 +257,11 @@ rand = { version = "0.8", default-features = false }
 redis = { version = "0.25", default-features = false }
 regex = { version = "1", default-features = false }
 reqwest = { version = "0.12", default-features = false }
+# reqwest 0.11 is required by `wasmcloud-tracing` to allow customization of
+# the HttpClient trait implementation for reqwest defined in `opentelemetry-http`,
+# which is then used in `opentelemetry-otlp` to customize the http client used for
+# interacting with OTEL collectors.
+reqwest-0_11 = { package = "reqwest", version = "0.11", default-features = false }
 ring = { version = "0.17", default-features = false }
 rmp-serde = { version = "1", default-features = false }
 rmpv = { version = "1", default-features = false }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -38,6 +38,7 @@ once_cell = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"], optional = true }
 rustls = { workspace = true, features = ["std"] }
 rustls-native-certs = { workspace = true, optional = true }
+rustls-pemfile = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }

--- a/crates/core/src/otel.rs
+++ b/crates/core/src/otel.rs
@@ -2,7 +2,7 @@
 //!
 //! [otel]: https://opentelemetry.io
 
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
@@ -40,6 +40,9 @@ pub struct OtelConfig {
     /// Determines whether http or grpc will be used for exporting the telemetry.
     #[serde(default)]
     pub protocol: OtelProtocol,
+    /// Additional CAs to include in the OpenTelemetry client configuration
+    #[serde(default)]
+    pub additional_ca_paths: Vec<PathBuf>,
 }
 
 impl OtelConfig {

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -110,6 +110,7 @@ impl ResourceRef<'_> {
 pub async fn fetch_component(
     component_ref: &str,
     allow_file_load: bool,
+    additional_ca_paths: &Vec<PathBuf>,
     registry_config: &HashMap<String, RegistryConfig>,
 ) -> anyhow::Result<Vec<u8>> {
     match ResourceRef::try_from(component_ref)? {
@@ -127,6 +128,7 @@ pub async fn fetch_component(
             .and_then(|authority| registry_config.get(authority))
             .map(oci::Fetcher::from)
             .unwrap_or_default()
+            .with_additional_ca_paths(additional_ca_paths)
             .fetch_component(component_ref)
             .await
             .with_context(|| {

--- a/crates/host/src/registry.rs
+++ b/crates/host/src/registry.rs
@@ -11,6 +11,8 @@ pub struct Config {
     pub allow_latest: bool,
     /// Whether or not to allow downloading artifacts over HTTP
     pub allow_insecure: bool,
+    /// Additional CAs to include in the OCI client configuration
+    pub additional_ca_paths: Vec<std::path::PathBuf>,
 }
 
 /// The type of a registry
@@ -54,6 +56,7 @@ impl From<wasmcloud_control_interface::RegistryCredential> for Config {
             },
             allow_latest: false,
             allow_insecure: false,
+            additional_ca_paths: Vec::default(),
         }
     }
 }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -586,6 +586,7 @@ async fn merge_registry_config(
 ) -> () {
     let mut registry_config = registry_config.write().await;
     let allow_latest = oci_opts.allow_latest;
+    let additional_ca_paths = oci_opts.additional_ca_paths;
 
     // update auth for specific registry, if provided
     if let Some(reg) = oci_opts.oci_registry {
@@ -625,6 +626,9 @@ async fn merge_registry_config(
 
     // update allow_latest for all registries
     registry_config.iter_mut().for_each(|(url, config)| {
+        if !additional_ca_paths.is_empty() {
+            config.additional_ca_paths.clone_from(&additional_ca_paths);
+        }
         if allow_latest {
             debug!(oci_registry_url = %url, "set allow_latest");
         }
@@ -1421,6 +1425,7 @@ impl Host {
         fetch_component(
             component_ref,
             self.host_config.allow_file_load,
+            &self.host_config.oci_opts.additional_ca_paths,
             &registry_config,
         )
         .await
@@ -2068,6 +2073,7 @@ impl Host {
                 metrics_endpoint: self.host_config.otel_config.metrics_endpoint.clone(),
                 logs_endpoint: self.host_config.otel_config.logs_endpoint.clone(),
                 protocol: self.host_config.otel_config.protocol,
+                additional_ca_paths: self.host_config.otel_config.additional_ca_paths.clone(),
             };
 
             // Prepare startup links by generating the source and target configs. Note that because the provider may be the source

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -39,6 +39,7 @@ opentelemetry-otlp = { workspace = true, features = [
     "metrics",
     "reqwest-client",
 ], optional = true }
+reqwest-0_11 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true, features = ["log"] }
 tracing-appender = { workspace = true }


### PR DESCRIPTION
## Feature or Problem

This adds the support for providing additional CA certificates to be loaded at host initialization time, which are then configured in the OCI and OpenTelemetry clients.

It's intended for use inside of environments where there may be non-WebPKI certificates in use, such as an in-house CA.

## Related Issues

Fixes #2460 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
