### PR TITLE
ci: add explicit content read allowance

### DIFF
--- a/.github/workflows/comment-cc.yml
+++ b/.github/workflows/comment-cc.yml
@@ -21,6 +21,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Explain conventional commits in comment

--- a/.github/workflows/lint-cc.yml
+++ b/.github/workflows/lint-cc.yml
@@ -9,6 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -24,130 +24,131 @@ jobs:
   package:
     runs-on: ubuntu-22.04-16-cores
     permissions:
+      contents: read
       packages: write
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-    - name: Extract tag context
-      id: ctx
-      run: |
-        sha_short=$(git rev-parse --short HEAD)
-        echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
-        echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Extract tag context
+        id: ctx
+        run: |
+          sha_short=$(git rev-parse --short HEAD)
+          echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+          echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"
 
-        if [[ ${GITHUB_REF} == refs/tags/provider-${{ inputs.name }}-v* ]]; then
-          version=${GITHUB_REF_NAME#provider-${{ inputs.name }}-v}
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "tagged version is ${version}"
-          if [[ $version == *"-"* ]]; then
-            echo "tagged version ${version} is a pre-release"
+          if [[ ${GITHUB_REF} == refs/tags/provider-${{ inputs.name }}-v* ]]; then
+            version=${GITHUB_REF_NAME#provider-${{ inputs.name }}-v}
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
+            echo "tagged version is ${version}"
+            if [[ $version == *"-"* ]]; then
+              echo "tagged version ${version} is a pre-release"
+              echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            version=$(cargo metadata --manifest-path "./crates/provider-${{ inputs.name }}/Cargo.toml" --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "wasmcloud-provider-${{ inputs.name }}") | .version')
+            echo "untagged version is ${version}"
+            echo "untagged version ${version} is a pre-release"
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           fi
-        else
-          version=$(cargo metadata --manifest-path "./crates/provider-${{ inputs.name }}/Cargo.toml" --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "wasmcloud-provider-${{ inputs.name }}") | .version')
-          echo "untagged version is ${version}"
-          echo "untagged version ${version} is a pre-release"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "prerelease=true" >> "$GITHUB_OUTPUT"
-        fi
 
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-      with:
-        path: artifacts
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          path: artifacts
 
-    - run: chmod +x "./artifacts/wasmcloud-aarch64-apple-darwin/bin/${{ inputs.name }}-provider"
-    - run: chmod +x "./artifacts/wasmcloud-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
-    - run: chmod +x "./artifacts/wasmcloud-x86_64-apple-darwin/bin/${{ inputs.name }}-provider"
-    - run: chmod +x "./artifacts/wasmcloud-x86_64-pc-windows-msvc/bin/${{ inputs.name }}-provider.exe"
-    - run: chmod +x "./artifacts/wasmcloud-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
+      - run: chmod +x "./artifacts/wasmcloud-aarch64-apple-darwin/bin/${{ inputs.name }}-provider"
+      - run: chmod +x "./artifacts/wasmcloud-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
+      - run: chmod +x "./artifacts/wasmcloud-x86_64-apple-darwin/bin/${{ inputs.name }}-provider"
+      - run: chmod +x "./artifacts/wasmcloud-x86_64-pc-windows-msvc/bin/${{ inputs.name }}-provider.exe"
+      - run: chmod +x "./artifacts/wasmcloud-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
 
-    - run: mv "./artifacts/wasmcloud-x86_64-unknown-linux-musl/bin/wash" wash
-    - run: chmod +x wash
+      - run: mv "./artifacts/wasmcloud-x86_64-unknown-linux-musl/bin/wash" wash
+      - run: chmod +x wash
 
-    - run: |
-        if [ "${{ secrets.issuer }}" != '' ]; then
-          export WASH_ISSUER_KEY="${{ secrets.issuer }}"
-        fi
-        if [ "${{ secrets.subject }}" != '' ]; then
-          export WASH_SUBJECT_KEY="${{ secrets.subject }}"
-        fi
-        ./wash par create \
-              --binary "./artifacts/wasmcloud-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider" \
-              --compress \
-              --destination "${{ inputs.name }}.par.gz" \
-              --name "${{ inputs.name }}-provider" \
-              --vendor wasmcloud \
-              --version ${{ steps.ctx.outputs.version }}
-        ./wash par insert --arch aarch64-linux  --binary "./artifacts/wasmcloud-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
-        ./wash par insert --arch aarch64-macos  --binary "./artifacts/wasmcloud-aarch64-apple-darwin/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
-        ./wash par insert --arch x86_64-macos   --binary "./artifacts/wasmcloud-x86_64-apple-darwin/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
-        ./wash par insert --arch x86_64-windows --binary "./artifacts/wasmcloud-x86_64-pc-windows-msvc/bin/${{ inputs.name }}-provider.exe" "${{ inputs.name }}.par.gz"
-        ./wash par inspect "${{ inputs.name }}.par.gz"
+      - run: |
+          if [ "${{ secrets.issuer }}" != '' ]; then
+            export WASH_ISSUER_KEY="${{ secrets.issuer }}"
+          fi
+          if [ "${{ secrets.subject }}" != '' ]; then
+            export WASH_SUBJECT_KEY="${{ secrets.subject }}"
+          fi
+          ./wash par create \
+                --binary "./artifacts/wasmcloud-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider" \
+                --compress \
+                --destination "${{ inputs.name }}.par.gz" \
+                --name "${{ inputs.name }}-provider" \
+                --vendor wasmcloud \
+                --version ${{ steps.ctx.outputs.version }}
+          ./wash par insert --arch aarch64-linux  --binary "./artifacts/wasmcloud-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
+          ./wash par insert --arch aarch64-macos  --binary "./artifacts/wasmcloud-aarch64-apple-darwin/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
+          ./wash par insert --arch x86_64-macos   --binary "./artifacts/wasmcloud-x86_64-apple-darwin/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
+          ./wash par insert --arch x86_64-windows --binary "./artifacts/wasmcloud-x86_64-pc-windows-msvc/bin/${{ inputs.name }}-provider.exe" "${{ inputs.name }}.par.gz"
+          ./wash par inspect "${{ inputs.name }}.par.gz"
 
-    - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
-      with:
-        name: ${{ inputs.name }}.par.gz
-        path: ${{ inputs.name }}.par.gz
+      - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
+        with:
+          name: ${{ inputs.name }}.par.gz
+          path: ${{ inputs.name }}.par.gz
 
-    # GitHub Container Registry
+      # GitHub Container Registry
 
-    - name: Push `${{ inputs.name }}` provider `${{ github.sha }}` tag to GitHub Container Registry
-      if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name)) || github.ref == 'refs/heads/main'
-      run: ./wash push ghcr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ github.sha }} "${{ inputs.name }}.par.gz"
-      env:
-        WASH_REG_USER: ${{ github.repository_owner }}
-        WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push `${{ inputs.name }}` provider `${{ github.sha }}` tag to GitHub Container Registry
+        if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name)) || github.ref == 'refs/heads/main'
+        run: ./wash push ghcr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ github.sha }} "${{ inputs.name }}.par.gz"
+        env:
+          WASH_REG_USER: ${{ github.repository_owner }}
+          WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push `${{ inputs.name }}` provider `${{ steps.ctx.outputs.sha_short }}` tag to GitHub Container Registry
-      if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name)) || github.ref == 'refs/heads/main'
-      run: ./wash push ghcr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ steps.ctx.outputs.sha_short }} "${{ inputs.name }}.par.gz"
-      env:
-        WASH_REG_USER: ${{ github.repository_owner }}
-        WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push `${{ inputs.name }}` provider `${{ steps.ctx.outputs.sha_short }}` tag to GitHub Container Registry
+        if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name)) || github.ref == 'refs/heads/main'
+        run: ./wash push ghcr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ steps.ctx.outputs.sha_short }} "${{ inputs.name }}.par.gz"
+        env:
+          WASH_REG_USER: ${{ github.repository_owner }}
+          WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push `${{ inputs.name }}` provider `canary` tag to GitHub Container Registry
-      if: github.ref == 'refs/heads/main'
-      run: ./wash push ghcr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:canary "${{ inputs.name }}.par.gz"
-      env:
-        WASH_REG_USER: ${{ github.repository_owner }}
-        WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push `${{ inputs.name }}` provider `canary` tag to GitHub Container Registry
+        if: github.ref == 'refs/heads/main'
+        run: ./wash push ghcr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:canary "${{ inputs.name }}.par.gz"
+        env:
+          WASH_REG_USER: ${{ github.repository_owner }}
+          WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push `${{ inputs.name }}` provider version tag to GitHub Container Registry
-      if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name))
-      run: ./wash push ghcr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ steps.ctx.outputs.version }} "${{ inputs.name }}.par.gz"
-      env:
-        WASH_REG_USER: ${{ github.repository_owner }}
-        WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push `${{ inputs.name }}` provider version tag to GitHub Container Registry
+        if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name))
+        run: ./wash push ghcr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ steps.ctx.outputs.version }} "${{ inputs.name }}.par.gz"
+        env:
+          WASH_REG_USER: ${{ github.repository_owner }}
+          WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
-    # wasmCloud AzureCR
+      # wasmCloud AzureCR
 
-    - name: Push `${{ inputs.name }}` provider `${{ github.sha }}` tag to wasmCloud Azure Container Registry
-      if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name)) || github.ref == 'refs/heads/main'
-      continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
-      run: ./wash push wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ github.sha }} "${{ inputs.name }}.par.gz"
-      env:
-        WASH_REG_USER: ${{ secrets.azurecr_username }}
-        WASH_REG_PASSWORD: ${{ secrets.azurecr_password }}
+      - name: Push `${{ inputs.name }}` provider `${{ github.sha }}` tag to wasmCloud Azure Container Registry
+        if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name)) || github.ref == 'refs/heads/main'
+        continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
+        run: ./wash push wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ github.sha }} "${{ inputs.name }}.par.gz"
+        env:
+          WASH_REG_USER: ${{ secrets.azurecr_username }}
+          WASH_REG_PASSWORD: ${{ secrets.azurecr_password }}
 
-    - name: Push `${{ inputs.name }}` provider `${{ steps.ctx.outputs.sha_short }}` tag to wasmCloud Azure Container Registry
-      if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name)) || github.ref == 'refs/heads/main'
-      continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
-      run: ./wash push wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ steps.ctx.outputs.sha_short }} "${{ inputs.name }}.par.gz"
-      env:
-        WASH_REG_USER: ${{ secrets.azurecr_username }}
-        WASH_REG_PASSWORD: ${{ secrets.azurecr_password }}
+      - name: Push `${{ inputs.name }}` provider `${{ steps.ctx.outputs.sha_short }}` tag to wasmCloud Azure Container Registry
+        if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name)) || github.ref == 'refs/heads/main'
+        continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
+        run: ./wash push wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ steps.ctx.outputs.sha_short }} "${{ inputs.name }}.par.gz"
+        env:
+          WASH_REG_USER: ${{ secrets.azurecr_username }}
+          WASH_REG_PASSWORD: ${{ secrets.azurecr_password }}
 
-    - name: Push `${{ inputs.name }}` provider `canary` tag to wasmCloud Azure Container Registry
-      if: github.ref == 'refs/heads/main'
-      continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
-      run: ./wash push wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:canary "${{ inputs.name }}.par.gz"
-      env:
-        WASH_REG_USER: ${{ secrets.azurecr_username }}
-        WASH_REG_PASSWORD: ${{ secrets.azurecr_password }}
+      - name: Push `${{ inputs.name }}` provider `canary` tag to wasmCloud Azure Container Registry
+        if: github.ref == 'refs/heads/main'
+        continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
+        run: ./wash push wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:canary "${{ inputs.name }}.par.gz"
+        env:
+          WASH_REG_USER: ${{ secrets.azurecr_username }}
+          WASH_REG_PASSWORD: ${{ secrets.azurecr_password }}
 
-    - name: Push `${{ inputs.name }}` provider version tag to wasmCloud Azure Container Registry
-      if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name))
-      continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
-      run: ./wash push wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ steps.ctx.outputs.version }} "${{ inputs.name }}.par.gz"
-      env:
-        WASH_REG_USER: ${{ secrets.azurecr_username }}
-        WASH_REG_PASSWORD: ${{ secrets.azurecr_password }}
+      - name: Push `${{ inputs.name }}` provider version tag to wasmCloud Azure Container Registry
+        if: startswith(github.ref, format('refs/tags/provider-{0}-v', inputs.name))
+        continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
+        run: ./wash push wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ inputs.name }}:${{ steps.ctx.outputs.version }} "${{ inputs.name }}.par.gz"
+        env:
+          WASH_REG_USER: ${{ secrets.azurecr_username }}
+          WASH_REG_PASSWORD: ${{ secrets.azurecr_password }}

--- a/.github/workflows/wasmcloud-chart.yml
+++ b/.github/workflows/wasmcloud-chart.yml
@@ -56,6 +56,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: validate
     permissions:
+      contents: read
       packages: write
 
     steps:

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -332,6 +332,7 @@ jobs:
       - build-windows
       - test-linux
     permissions:
+      contents: read
       packages: write
     uses: ./.github/workflows/provider.yml
     with:
@@ -346,6 +347,7 @@ jobs:
     runs-on: ubuntu-22.04-16-cores
     needs: build-doc
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:
@@ -390,6 +392,7 @@ jobs:
 
     runs-on: ubuntu-22.04-16-cores
     permissions:
+      contents: read
       packages: write
     needs:
       - build-bin


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
This PR fixes an issue where even if you specify top-level permissions for a workflow, you must specify all appropriate permissions for a workflow where you add a `permissions` block. It doesn't seem to make sense that it works this way, but the wasmCloud workflow was not running when only `packages: write` was specified.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
