### PR TITLE
feat(wash-cli): add secrets subcommand for managing secrets references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6719,6 +6719,7 @@ dependencies = [
  "wasmcloud-control-interface 1.0.0",
  "wasmcloud-core 0.7.0",
  "wasmcloud-provider-sdk",
+ "wasmcloud-secrets-types",
  "weld-codegen",
  "which",
  "wrpc-interface-http",

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -39,7 +39,6 @@ regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
 rmp-serde = { workspace = true }
 rmpv = { workspace = true }
-wasmcloud-secrets-types = { workspace = true }
 sanitize-filename = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -80,6 +79,7 @@ wash-lib = { workspace = true, features = [
 wasmcloud-control-interface = { workspace = true }
 wasmcloud-core = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true }
+wasmcloud-secrets-types = { workspace = true }
 weld-codegen = { workspace = true, features = ["wasmbus"] }
 which = { workspace = true }
 wrpc-interface-http = { workspace = true }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -39,6 +39,7 @@ regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
 rmp-serde = { workspace = true }
 rmpv = { workspace = true }
+wasmcloud-secrets-types = { workspace = true }
 sanitize-filename = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -77,6 +77,7 @@ Iterate:
   call         Invoke a simple function on a component running in a wasmCloud host
   label        Label (or un-label) a host with a key=value label pair
   config       Create configuration for components, capability providers and links
+  secrets      Create secret references for components, capability providers and links
 
 Publish:
   pull         Pull an artifact from an OCI compliant registry
@@ -188,7 +189,7 @@ enum CliCommand {
     #[clap(name = "pull")]
     RegPull(RegistryPullCommand),
     /// Manage secret references
-    #[clap(name = "secrets", subcommand)]
+    #[clap(name = "secrets", alias = "secret", subcommand)]
     Secrets(SecretsCliCommand),
     /// Spy on all invocations a component sends and receives
     #[clap(name = "spy")]

--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -19,6 +19,7 @@ use wash_cli::generate::{self, NewCliCommand};
 use wash_cli::keys::{self, KeysCliCommand};
 use wash_cli::par::{self, ParCliCommand};
 use wash_cli::plugin::{self, PluginCommand};
+use wash_cli::secrets::{self, SecretsCliCommand};
 use wash_cli::ui::{self, UiCommand};
 use wash_cli::up::{self, UpCommand};
 use wash_cli::util::ensure_plugin_dir;
@@ -186,6 +187,9 @@ enum CliCommand {
     /// Pull an artifact from an OCI compliant registry
     #[clap(name = "pull")]
     RegPull(RegistryPullCommand),
+    /// Manage secret references
+    #[clap(name = "secrets", subcommand)]
+    Secrets(SecretsCliCommand),
     /// Spy on all invocations a component sends and receives
     #[clap(name = "spy")]
     Spy(SpyCommand),
@@ -407,6 +411,7 @@ async fn main() {
         CliCommand::Scale(scale_cli) => {
             common::scale_cmd::handle_command(scale_cli, output_kind).await
         }
+        CliCommand::Secrets(secrets_cli) => secrets::handle_command(secrets_cli, output_kind).await,
         CliCommand::Start(start_cli) => {
             common::start_cmd::handle_command(start_cli, output_kind).await
         }

--- a/crates/wash-cli/src/config.rs
+++ b/crates/wash-cli/src/config.rs
@@ -56,7 +56,7 @@ pub async fn handle_command(
             name,
             config_values,
         } => {
-            validate_not_secret(&name)?;
+            ensure_not_secret(&name)?;
 
             put_config(
                 opts,
@@ -67,11 +67,11 @@ pub async fn handle_command(
             .await
         }
         ConfigCliCommand::GetCommand { opts, name } => {
-            validate_not_secret(&name)?;
+            ensure_not_secret(&name)?;
             get_config(opts, &name, output_kind).await
         }
         ConfigCliCommand::DelCommand { opts, name } => {
-            validate_not_secret(&name)?;
+            ensure_not_secret(&name)?;
             delete_config(opts, &name, output_kind).await
         }
     }
@@ -111,7 +111,7 @@ pub(crate) async fn put_config(
                 .unwrap_or(name);
             config_type = "Secret";
         };
-        format!("{config_type} {out_name} put successfully.")
+        format!("{config_type} '{out_name}' put successfully.")
     } else {
         config_response
             .message
@@ -189,7 +189,7 @@ pub(crate) async fn delete_config(
                 .strip_prefix(format!("{SECRET_PREFIX}_").as_str())
                 .unwrap_or(name);
         };
-        format!("{config_type} {out_name} deleted successfully.")
+        format!("{config_type} '{out_name}' deleted successfully.")
     } else {
         config_response
             .message
@@ -214,13 +214,13 @@ fn suggest_run_host_error(e: Box<dyn Error + std::marker::Send + Sync>) -> anyho
     }
 }
 
-fn validate_not_secret(name: &str) -> anyhow::Result<()> {
+fn ensure_not_secret(name: &str) -> anyhow::Result<()> {
     if name.starts_with(SECRET_PREFIX) {
         anyhow::bail!("Configuration names cannot start with '{SECRET_PREFIX}'. Did you mean to use the 'secrets' command?");
     }
     Ok(())
 }
 
-fn is_secret(name: &str) -> bool {
+pub(crate) fn is_secret(name: &str) -> bool {
     name.starts_with(SECRET_PREFIX)
 }

--- a/crates/wash-cli/src/config.rs
+++ b/crates/wash-cli/src/config.rs
@@ -7,6 +7,7 @@ use wash_lib::{
     cli::{input_vec_to_hashmap, CliConnectionOpts, CommandOutput, OutputKind},
     config::WashConnectionOptions,
 };
+use wasmcloud_secrets_types::SECRET_PREFIX;
 
 use crate::appearance::spinner::Spinner;
 
@@ -55,6 +56,8 @@ pub async fn handle_command(
             name,
             config_values,
         } => {
+            validate_not_secret(&name)?;
+
             put_config(
                 opts,
                 &name,
@@ -63,21 +66,32 @@ pub async fn handle_command(
             )
             .await
         }
-        ConfigCliCommand::GetCommand { opts, name } => get_config(opts, &name, output_kind).await,
+        ConfigCliCommand::GetCommand { opts, name } => {
+            validate_not_secret(&name)?;
+            get_config(opts, &name, output_kind).await
+        }
         ConfigCliCommand::DelCommand { opts, name } => {
+            validate_not_secret(&name)?;
             delete_config(opts, &name, output_kind).await
         }
     }
 }
 
-async fn put_config(
+pub(crate) async fn put_config(
     opts: CliConnectionOpts,
     name: &str,
     values: HashMap<String, String>,
     output_kind: OutputKind,
 ) -> anyhow::Result<CommandOutput> {
     let sp: Spinner = Spinner::new(&output_kind)?;
-    sp.update_spinner_message("Putting configuration ...".to_string());
+    let is_secret = name.starts_with(SECRET_PREFIX);
+    let msg = if is_secret {
+        "Putting secret configuration ..."
+    } else {
+        "Putting configuration ..."
+    };
+    sp.update_spinner_message(msg.to_string());
+
     let wco: WashConnectionOptions = opts.try_into()?;
     let ctl_client = wco.into_ctl_client(None).await?;
     // Handle no responders by suggesting a host needs to be running
@@ -89,9 +103,19 @@ async fn put_config(
     sp.finish_and_clear();
 
     let message = if config_response.message.is_empty() && config_response.success {
-        format!("Configuration {name} put successfully.")
+        let mut out_name = name;
+        let mut config_type = "Configuration";
+        if is_secret {
+            out_name = out_name
+                .strip_prefix(format!("{SECRET_PREFIX}_").as_str())
+                .unwrap_or(name);
+            config_type = "Secret";
+        };
+        format!("{config_type} {out_name} put successfully.")
     } else {
-        config_response.message
+        config_response
+            .message
+            .replace(format!("{SECRET_PREFIX}_").as_str(), "")
     };
     let json_out = HashMap::from_iter([
         ("success".to_string(), json!(config_response.success)),
@@ -102,13 +126,16 @@ async fn put_config(
     Ok(output)
 }
 
-async fn get_config(
+pub(crate) async fn get_config(
     opts: CliConnectionOpts,
     name: &str,
     output_kind: OutputKind,
 ) -> anyhow::Result<CommandOutput> {
     let sp: Spinner = Spinner::new(&output_kind)?;
-    sp.update_spinner_message("Getting configuration ...".to_string());
+    let is_secret = is_secret(name);
+    let config_type = if is_secret { "secret" } else { "configuration" };
+    sp.update_spinner_message(format!("Getting {config_type}..."));
+
     let wco: WashConnectionOptions = opts.try_into()?;
     let ctl_client = wco.into_ctl_client(None).await?;
 
@@ -120,7 +147,7 @@ async fn get_config(
     sp.finish_and_clear();
 
     if !config_response.message.is_empty() && !config_response.success {
-        error!("Error getting configuration: {}", config_response.message);
+        error!("Error getting {config_type}: {}", config_response.message);
     };
 
     if let Some(config) = config_response.response {
@@ -129,17 +156,22 @@ async fn get_config(
             config.into_iter().map(|(k, v)| (k, json!(v))).collect(),
         ))
     } else {
-        Err(anyhow::anyhow!("No configuration found for name: {}", name))
+        Err(anyhow::anyhow!(
+            "No {config_type} found for name: {}",
+            name.replace(format!("{SECRET_PREFIX}_").as_str(), "")
+        ))
     }
 }
 
-async fn delete_config(
+pub(crate) async fn delete_config(
     opts: CliConnectionOpts,
     name: &str,
     output_kind: OutputKind,
 ) -> anyhow::Result<CommandOutput> {
     let sp: Spinner = Spinner::new(&output_kind)?;
-    sp.update_spinner_message("Deleting configuration ...".to_string());
+    let is_secret = is_secret(name);
+    let config_type = if is_secret { "secret" } else { "configuration" };
+    sp.update_spinner_message("Deleting {config_type}...".to_string());
     let wco: WashConnectionOptions = opts.try_into()?;
     let ctl_client = wco.into_ctl_client(None).await?;
 
@@ -151,9 +183,17 @@ async fn delete_config(
     sp.finish_and_clear();
 
     let message = if config_response.message.is_empty() && config_response.success {
-        format!("Configuration {name} deleted successfully.")
+        let mut out_name = name;
+        if is_secret {
+            out_name = out_name
+                .strip_prefix(format!("{SECRET_PREFIX}_").as_str())
+                .unwrap_or(name);
+        };
+        format!("{config_type} {out_name} deleted successfully.")
     } else {
-        config_response.message
+        config_response
+            .message
+            .replace(format!("{SECRET_PREFIX}_").as_str(), "")
     };
     let json_out = HashMap::from_iter([
         ("success".to_string(), json!(config_response.success)),
@@ -172,4 +212,15 @@ fn suggest_run_host_error(e: Box<dyn Error + std::marker::Send + Sync>) -> anyho
     } else {
         anyhow::anyhow!(e)
     }
+}
+
+fn validate_not_secret(name: &str) -> anyhow::Result<()> {
+    if name.starts_with(SECRET_PREFIX) {
+        anyhow::bail!("Configuration names cannot start with '{SECRET_PREFIX}'. Did you mean to use the 'secrets' command?");
+    }
+    Ok(())
+}
+
+fn is_secret(name: &str) -> bool {
+    name.starts_with(SECRET_PREFIX)
 }

--- a/crates/wash-cli/src/lib.rs
+++ b/crates/wash-cli/src/lib.rs
@@ -14,6 +14,7 @@ pub mod generate;
 pub mod keys;
 pub mod par;
 pub mod plugin;
+pub mod secrets;
 pub mod ui;
 pub mod up;
 pub mod util;

--- a/crates/wash-cli/src/secrets.rs
+++ b/crates/wash-cli/src/secrets.rs
@@ -1,0 +1,78 @@
+use clap::Subcommand;
+use std::collections::HashMap;
+use wash_lib::cli::{CliConnectionOpts, CommandOutput, OutputKind};
+use wasmcloud_secrets_types::{SecretConfig, SECRET_PREFIX, SECRET_TYPE};
+
+use crate::config::{delete_config, get_config, put_config};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum SecretsCliCommand {
+    #[clap(name = "put", alias = "create", about = "Put secret reference")]
+    PutCommand {
+        #[clap(flatten)]
+        opts: CliConnectionOpts,
+        #[clap(name = "name")]
+        name: String,
+        // TODO: we should have a type for all that, since we use it in wadm
+        backend: String,
+        key: String,
+        version: Option<String>,
+    },
+
+    /// Get a secret reference
+    #[clap(name = "get")]
+    GetCommand {
+        #[clap(flatten)]
+        opts: CliConnectionOpts,
+        #[clap(name = "name")]
+        name: String,
+    },
+
+    /// Delete a secret reference
+    #[clap(name = "del", alias = "delete")]
+    DelCommand {
+        #[clap(flatten)]
+        opts: CliConnectionOpts,
+        #[clap(name = "name")]
+        name: String,
+    },
+}
+
+pub async fn handle_command(
+    command: SecretsCliCommand,
+    output_kind: OutputKind,
+) -> anyhow::Result<CommandOutput> {
+    match command {
+        SecretsCliCommand::PutCommand {
+            opts,
+            name,
+            backend,
+            key,
+            version,
+        } => {
+            let cfg = SecretConfig {
+                backend,
+                key,
+                version,
+                secret_type_identifier: SECRET_TYPE.to_string(),
+            };
+            let values: HashMap<String, String> = cfg.try_into()?;
+
+            put_config(opts, &format_secret_name(&name), values, output_kind).await
+        }
+        SecretsCliCommand::GetCommand { opts, name } => {
+            get_config(opts, &format_secret_name(&name), output_kind).await
+        }
+        SecretsCliCommand::DelCommand { opts, name } => {
+            delete_config(opts, &format_secret_name(&name), output_kind).await
+        }
+    }
+}
+
+fn format_secret_name(name: &str) -> String {
+    if !name.starts_with(SECRET_PREFIX) {
+        format!("{SECRET_PREFIX}_{}", name)
+    } else {
+        name.to_string()
+    }
+}

--- a/crates/wash-cli/tests/wash_config.rs
+++ b/crates/wash-cli/tests/wash_config.rs
@@ -1,0 +1,67 @@
+mod common;
+
+use common::TestWashInstance;
+
+use std::collections::HashMap;
+
+use wash_cli::config::ConfigCliCommand;
+use wash_lib::cli::{CliConnectionOpts, OutputKind};
+
+#[tokio::test]
+async fn test_config_put_and_get() -> anyhow::Result<()> {
+    let wash_instance = TestWashInstance::create().await?;
+    // Create a new config
+    let config_values = vec!["key=value".to_string(), "key2=value2".to_string()];
+
+    let command = ConfigCliCommand::PutCommand {
+        opts: CliConnectionOpts {
+            ctl_port: Some(wash_instance.nats_port.to_string()),
+            ..Default::default()
+        },
+        name: "foobar".to_string(),
+        config_values,
+    };
+
+    // Put the config
+    wash_cli::config::handle_command(command, OutputKind::Json).await?;
+
+    // Assert that the retrieved config deserializes as a HashMap
+    let retrieved_config: HashMap<String, serde_json::Value> = wash_cli::config::handle_command(
+        ConfigCliCommand::GetCommand {
+            opts: CliConnectionOpts {
+                ctl_port: Some(wash_instance.nats_port.to_string()),
+                ..Default::default()
+            },
+            name: "foobar".to_string(),
+        },
+        OutputKind::Json,
+    )
+    .await?
+    .map;
+
+    assert_eq!(retrieved_config.len(), 2);
+    assert_eq!(retrieved_config.get("key").unwrap(), "value");
+    assert_eq!(retrieved_config.get("key2").unwrap(), "value2");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_config_secret_name_error() -> anyhow::Result<()> {
+    // Attempt to create a config with a secret name
+    let config_values = vec!["key=value".to_string()];
+
+    let command = ConfigCliCommand::PutCommand {
+        opts: CliConnectionOpts::default(),
+        name: "SECRET_foo".to_string(),
+        config_values,
+    };
+
+    // Put the config and expect an error
+    let result = wash_cli::config::handle_command(command, OutputKind::Json).await;
+
+    // Assert that an error occurred
+    assert!(result.is_err());
+
+    Ok(())
+}

--- a/crates/wash-cli/tests/wash_secrets.rs
+++ b/crates/wash-cli/tests/wash_secrets.rs
@@ -1,0 +1,77 @@
+mod common;
+
+use std::collections::HashMap;
+
+use anyhow::{bail, Context as _};
+use common::TestWashInstance;
+use wash_cli::secrets::SecretsCliCommand;
+use wash_lib::cli::{CliConnectionOpts, OutputKind};
+use wasmcloud_secrets_types::{SECRET_POLICY_TYPE, SECRET_TYPE};
+
+#[tokio::test]
+async fn test_secret_put_and_get() -> anyhow::Result<()> {
+    let wash_instance = TestWashInstance::create().await?;
+    // Create a new secret reference
+    let opts = CliConnectionOpts {
+        ctl_port: Some(wash_instance.nats_port.to_string()),
+        ..Default::default()
+    };
+
+    let basic_secret_command = SecretsCliCommand::PutCommand {
+        opts: opts.clone(),
+        name: "foobar".to_string(),
+        backend: "baobun".to_string(),
+        key: "path/to/secret".to_string(),
+        version: None,
+        policy_properties: vec![],
+    };
+
+    // Put the config
+    wash_cli::secrets::handle_command(basic_secret_command, OutputKind::Json).await?;
+
+    // Assert that the retrieved config deserializes as a HashMap
+    let retrieved_secret: HashMap<String, serde_json::Value> = wash_cli::secrets::handle_command(
+        SecretsCliCommand::GetCommand {
+            opts,
+            name: "foobar".to_string(),
+        },
+        OutputKind::Json,
+    )
+    .await?
+    .map;
+
+    assert_eq!(retrieved_secret.len(), 4);
+
+    assert!(retrieved_secret
+        .get("backend")
+        .is_some_and(|b| b == "baobun"));
+    assert!(retrieved_secret
+        .get("key")
+        .is_some_and(|k| k == "path/to/secret"));
+    assert!(retrieved_secret
+        .get("type")
+        .is_some_and(|v| v == SECRET_TYPE));
+    let serde_json::Value::String(policy) = retrieved_secret
+        .get("policy_properties")
+        .context("policy_properties should exist")?
+    else {
+        bail!("policy_properties should be a string");
+    };
+
+    let policy: HashMap<String, String> =
+        serde_json::from_str(policy).context("policy_properties should be a JSON object")?;
+    assert!(policy.get("type").is_some_and(|t| t == SECRET_POLICY_TYPE));
+    let Some(properties) = policy.get("properties") else {
+        bail!("policy_properties should have a 'properties' field");
+    };
+    let policy_properties: HashMap<String, String> =
+        serde_json::from_str(properties).context("properties should be a JSON object")?;
+    assert_eq!(policy_properties.len(), 1);
+    assert!(policy_properties
+        .get("backend")
+        .is_some_and(|b| b == "baobun"));
+
+    assert!(retrieved_secret.contains_key("version"));
+
+    Ok(())
+}


### PR DESCRIPTION
## Feature or Problem
This adds a set of commands for manually managing secrets references in a wasmCloud deployment. It is effectively a wrapper around configuration that properly formats and writes the data type to the config bucket.

It also attempts to prevent you from interacting with secrets with the config subcommands by checking the name of the configuration key and redirecting you to the correct subcommand.

## Related Issues
Closes #2494.

## Release Information
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tested locally with a wash build
