### PR TITLE
ci(washboard): remove matrix version from release artifact

### DIFF
--- a/.github/workflows/washboard.yml
+++ b/.github/workflows/washboard.yml
@@ -108,15 +108,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/washboard-ui-v')
-    strategy:
-      matrix:
-        wash:
-          - version: 0.29.2
+
     steps:
       - name: Download Asset
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
-          name: washboard-${{ matrix.wash.version }}
+          name: washboard
 
       - name: Create Release
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5


### PR DESCRIPTION
The [previous release](https://github.com/wasmCloud/wasmCloud/actions/runs/9977762485) failed because the wash version was tacked onto the artifact name which is actually always just `washboard`. This corrects that.
