### PR TITLE
refactor(secrets-client): add usage of thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7560,6 +7560,7 @@ dependencies = [
  "async-nats-wrpc",
  "nkeys 0.4.1",
  "serde_json",
+ "thiserror",
  "wasmcloud-secrets-types",
 ]
 

--- a/crates/secrets-client/Cargo.toml
+++ b/crates/secrets-client/Cargo.toml
@@ -14,4 +14,5 @@ status = "actively-developed"
 async-nats = { workspace = true, features = ["ring", "server_2_10"] }
 nkeys = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 wasmcloud-secrets-types = { workspace = true }


### PR DESCRIPTION
This commit introduces `thiserror` for the errors in the `secrets-client` crate.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
