### PR TITLE
chore: update secrets integration to use the updated config structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7572,7 +7572,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-secrets-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/host/src/secrets.rs
+++ b/crates/host/src/secrets.rs
@@ -26,6 +26,8 @@ pub(crate) struct SecretReference {
     /// The version of the secret to retrieve. If not supplied, the latest version will be used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// The policy that defines configuration options for the backend.
+    pub policy_properties: String,
 }
 
 #[derive(Debug)]
@@ -148,13 +150,17 @@ impl Manager {
                 let secrets_client = self
                     .get_or_create_secrets_client(&secret_ref.backend)
                     .await?;
+                let application = Application{
+                    name: application.cloned().unwrap_or_default(),
+                    policy: secret_ref.policy_properties.clone(),
+                };
                 let request = SecretRequest {
                     name: secret_ref.key.clone(),
                     version: secret_ref.version.clone(),
                     context: Context {
                         entity_jwt: entity_jwt.to_string(),
                         host_jwt: host_jwt.to_string(),
-                        application: application.cloned().map(|name| Application { name }),
+                        application,
                     },
                 };
                 secrets_client

--- a/crates/secrets-nats-kv/tests/api.rs
+++ b/crates/secrets-nats-kv/tests/api.rs
@@ -6,7 +6,7 @@ use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secrets_nats_kv::{Api, PutSecretResponse};
 use std::collections::HashMap;
 use wascap::jwt::{Claims, ClaimsBuilder, Component, Host};
-use wasmcloud_secrets_types::{Context, Secret, SecretRequest, WASMCLOUD_HOST_XKEY};
+use wasmcloud_secrets_types::{Application, Context, Secret, SecretRequest, WASMCLOUD_HOST_XKEY};
 
 const SUBJECT_BASE: &str = "kvstore_test";
 const NAME_BASE: &str = "nats-kv";
@@ -147,7 +147,10 @@ async fn integration_test_kvstore_put_secret() -> anyhow::Result<()> {
         context: Context {
             entity_jwt: encoded,
             host_jwt: claims.encode(&account)?,
-            application: None,
+            application: Application {
+                name: "test".to_string(),
+                policy: "".to_string(),
+            },
         },
         version: None,
     };
@@ -252,7 +255,10 @@ async fn integration_test_kvstore_version() -> anyhow::Result<()> {
         context: Context {
             entity_jwt: encoded,
             host_jwt: claims.encode(&account)?,
-            application: None,
+            application: Application {
+                name: "test".to_string(),
+                policy: "".to_string(),
+            },
         },
         version: Some("1".to_string()),
     };

--- a/crates/secrets-types/Cargo.toml
+++ b/crates/secrets-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-secrets-types"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/secrets-types/src/lib.rs
+++ b/crates/secrets-types/src/lib.rs
@@ -34,13 +34,21 @@ pub struct Context {
     pub host_jwt: String,
     /// The application the entity belongs to.
     /// TODO: should this also be a JWT, but signed by the host?
-    pub application: Option<Application>,
+    pub application: Application,
 }
 
 /// The application that the entity belongs to.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct Application {
+    /// The name of the application.
+    #[serde(default)]
     pub name: String,
+
+    /// The policy used define the application's access to secrets.
+    /// This meant to be a JSON string that can be deserialized by a secrets backend
+    /// implementation.
+    #[serde(default)]
+    pub policy: String,
 }
 
 impl Context {

--- a/crates/test-util/src/lattice/config.rs
+++ b/crates/test-util/src/lattice/config.rs
@@ -30,8 +30,12 @@ pub async fn assert_put_secret_reference(
     version: Option<String>,
 ) -> Result<()> {
     let mut config = HashMap::from([
-        ("key".to_string(), key.to_string()),
         ("backend".to_string(), backend.to_string()),
+        ("key".to_string(), key.to_string()),
+        (
+            "policy_properties".to_string(),
+            serde_json::json!({"type": "policy.secrets.wasmcloud.dev", "properties": {"configuration": "value"}}).to_string(),
+        ),
     ]);
     if let Some(version) = version {
         config.insert("version".to_string(), version.to_string());


### PR DESCRIPTION
## Feature or Problem
Update the secrets integration in a wasmCloud host to include information about the policy that determines which backend to communicate with. This is a change that comes in from wadm where the policy block now contains the information about which backend to use.

This also passes any propertes defined on the policy to the correct backend, which are stored as a versioned string-encoded JSON object.


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
