### PR TITLE
feat: Add keyvalue-messaging example to the example components workflow

### DIFF
--- a/.github/workflows/examples-components.yml
+++ b/.github/workflows/examples-components.yml
@@ -12,6 +12,7 @@ on:
       - component-http-hello-world-v[0-9]+.[0-9]+.[0-9]+*
       - component-http-jsonify-v[0-9]+.[0-9]+.[0-9]+*
       - component-http-keyvalue-counter-v[0-9]+.[0-9]+.[0-9]+*
+      - component-keyvalue-messaging-v[0-9]+.[0-9]+.[0-9]+*
       - component-sqldb-postgres-query-v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
     branches: [main]
@@ -109,6 +110,9 @@ jobs:
           - name: "http-keyvalue-counter"
             lang: "rust"
             wasm-bin: "http_keyvalue_counter_s.wasm"
+          - name: "keyvalue-messaging"
+            lang: "rust"
+            wasm-bin: "keyvalue_messaging_s.wasm"
           - name: "sqldb-postgres-query"
             lang: "rust"
             wasm-bin: "sqldb_postgres_query_s.wasm"
@@ -207,6 +211,9 @@ jobs:
           - name: "http-keyvalue-counter"
             lang: "rust"
             wasm-bin: "http_keyvalue_counter_s.wasm"
+          - name: "keyvalue-messaging"
+            lang: "rust"
+            wasm-bin: "keyvalue_messaging_s.wasm"
           - name: "sqldb-postgres-query"
             lang: "rust"
             wasm-bin: "sqldb_postgres_query_s.wasm"

--- a/examples/rust/components/keyvalue-messaging/wadm.yaml
+++ b/examples/rust/components/keyvalue-messaging/wadm.yaml
@@ -11,7 +11,8 @@ spec:
       type: component
       properties:
         # NOTE: If the file at the relative path below is missing, run `wash build`
-        image: file://./build/keyvalue_messaging_s.wasm
+        # image: file://./build/keyvalue_messaging_s.wasm
+        image: ghcr.io/wasmcloud/components/keyvalue-messaging-rust:0.1.0
         id: kv-demo
         config:
           - name: nats-kv-example
@@ -60,9 +61,8 @@ spec:
     - name: nats-kv
       type: capability
       properties:
-        #image: ghcr.io/wasmcloud/provider-keyvalue-nats:0.1.0
-        # NOTE: For the purpose of running this example, prior to the PR merge, a local archive using `wash par create` was used
-        image: file://../../../../src/bin/keyvalue-nats-provider/build/keyvalue-nats-provider.par.gz
+        # image: file://../../../../src/bin/keyvalue-nats-provider/build/keyvalue-nats-provider.par.gz
+        image: ghcr.io/wasmcloud/keyvalue-nats:0.1.0
         # # NOTE: The following is an example of how to provide default/shared configuration, to all components, which do not provide their own NATS connection configuration.
         # config:
         #   - name: nats-connection


### PR DESCRIPTION
## Feature or Problem
The `keyvalue-messaging` example, which is accompanying the `nats-keyvalue-provider` is missing from the `examples-components.yml` workflow; this PR will remediate the omission.
The PR also updates the Wadm manifest of the example to use the published (or to be published) images of the provider and the example.

## Related Issues
#2559 

## Consumer Impact
This should improve the user experience.
