### PR TITLE
chore(secrets-types): Add variant to represent error processing policy

### DIFF
--- a/crates/secrets-types/src/errors.rs
+++ b/crates/secrets-types/src/errors.rs
@@ -38,6 +38,8 @@ pub enum GetSecretError {
     InvalidPayload,
     #[error("Invalid headers")]
     InvalidHeaders,
+    #[error("Error processing policies: ${0}")]
+    PolicyError(String),
     #[error("Encountered an unknown error fetching secret: {0}")]
     Other(String),
 }


### PR DESCRIPTION
## Feature or Problem

I'd like to have an error variant that represents an error with processing the policy that was provided in a given `SecretRequest`.

While this is not applicable to all backends, other backends that are dependent on specific configuration being present in the policy properties should have a way to communicate about that being the specific issue.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
