### PR TITLE
fix(docs): fix incorrect links to rust examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,11 +26,11 @@ You can get started quickly by trying out of our example projects:
 | Golang ([TinyGo][tinygo]) | [`./golang/components/http-hello-world`](./golang/components/http-hello-world)         |                                                                 |
 | Golang ([TinyGo][tinygo]) | [`./golang/components/http-echo-tinygo`](./golang/components/http-echo-tinygo)         |                                                                 |
 | [Python][python]          | [`./python/components/http-hello-world`](./golang/components/http-hello-world)         |                                                                 |
-| [Rust][rust]              | [`./rust/components/echo-messaging`](./golang/components/echo-messaging)               | `ghcr.io/wasmcloud/components/echo-messaging-rust:0.1.0`        |
-| [Rust][rust]              | [`./rust/components/blobby`](./golang/components/blobby)                               | `ghcr.io/wasmcloud/components/blobby-rust:0.4.0`                |
-| [Rust][rust]              | [`./rust/components/http-hello-world`](./golang/components/http-hello-world)           | `ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0`      |
-| [Rust][rust]              | [`./rust/components/http-jsonify`](./golang/components/http-jsonify)                   | `ghcr.io/wasmcloud/components/http-jsonify-rust:0.1.1`          |
-| [Rust][rust]              | [`./rust/components/http-keyvalue-counter`](./golang/components/http-keyvalue-counter) | `ghcr.io/wasmcloud/components/http-keyvalue-counter-rust:0.1.0` |
+| [Rust][rust]              | [`./rust/components/echo-messaging`](./rust/components/echo-messaging)               | `ghcr.io/wasmcloud/components/echo-messaging-rust:0.1.0`        |
+| [Rust][rust]              | [`./rust/components/blobby`](./rust/components/blobby)                               | `ghcr.io/wasmcloud/components/blobby-rust:0.4.0`                |
+| [Rust][rust]              | [`./rust/components/http-hello-world`](./rust/components/http-hello-world)           | `ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0`      |
+| [Rust][rust]              | [`./rust/components/http-jsonify`](./rust/components/http-jsonify)                   | `ghcr.io/wasmcloud/components/http-jsonify-rust:0.1.1`          |
+| [Rust][rust]              | [`./rust/components/http-keyvalue-counter`](./rust/components/http-keyvalue-counter) | `ghcr.io/wasmcloud/components/http-keyvalue-counter-rust:0.1.0` |
 
 Start components with `wash`, either from file or OCI reference (if available):
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

These links to Rust examples were pointing to the Go or 404.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
