### PR TITLE
chore(secrets-client): Update default secrets API version to match the latest changes

### DIFF
--- a/.github/workflows/secrets-nats-kv.yml
+++ b/.github/workflows/secrets-nats-kv.yml
@@ -3,6 +3,7 @@ name: secrets-nats-kv
 on:
   push:
     branches: [main]
+  merge_group:
   pull_request:
     branches: [main]
     paths:
@@ -10,6 +11,7 @@ on:
       - Cargo.lock
       - Cargo.toml
       - crates/secrets-nats-kv/**
+      - crates/secrets-client/**
       - crates/secrets-types/**
 
 permissions:

--- a/crates/secrets-client/src/lib.rs
+++ b/crates/secrets-client/src/lib.rs
@@ -5,7 +5,7 @@ use wasmcloud_secrets_types::{
 };
 
 /// Default API version of the secrets API implementation in wasmCloud
-const DEFAULT_API_VERSION: &str = "v0";
+const DEFAULT_API_VERSION: &str = "v1alpha1";
 
 /// Errors that can be returned during creation/use of a [`Client`]
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## Feature or Problem

Since we've landed on `v1alpha1` instead of `v0`, let's update the `secrets-client` to default to that as well.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
