### PR TITLE
fix(http-server): Improve reuse of underlying TCP socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7350,7 +7350,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-server"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",

--- a/crates/provider-http-server/Cargo.toml
+++ b/crates/provider-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-server"
-version = "0.21.0"
+version = "0.21.1"
 description = "Http server for wasmcloud, using Axum. This package provides a library, and a capability provider"
 
 authors.workspace = true

--- a/src/bin/http-server-provider/wasmcloud.toml
+++ b/src/bin/http-server-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "HTTP Server"
 language = "rust"
-version = "0.21.0"
+version = "0.21.1"
 type = "provider"
 
 [rust]


### PR DESCRIPTION
After digging around in the `wasmtime serve` code, I found this neat little trick around reuseaddr which works on any linux or unix-like system (sorry Windows!). In my testing, this increased HTTP throughput by 10-15%