### PR TITLE
fix(wash-cli): transposed args in call.rs

### DIFF
--- a/crates/wash-cli/src/call.rs
+++ b/crates/wash-cli/src/call.rs
@@ -174,8 +174,8 @@ pub async fn handle_command(
         _ => {
             wrpc_invoke_simple(
                 wrpc_client,
-                &component_id,
                 &lattice,
+                &component_id,
                 &instance,
                 &name,
                 opts.timeout_ms,


### PR DESCRIPTION
Noticed these were transposed when the output of the `No component responded to your request...` error
message claimed the lattice was the component and the component was the lattice.

## Feature or Problem
https://github.com/wasmCloud/wasmCloud/blob/27a5005460269436d91c3e889873a93fddef704c/crates/wash-cli/src/call.rs#L175-L181 puts component_id before lattice, but lattice comes first in https://github.com/wasmCloud/wasmCloud/blob/27a5005460269436d91c3e889873a93fddef704c/crates/wash-cli/src/call.rs#L448-L454

## Related Issues
N/A

## Release Information
`next`

## Consumer Impact
Fortunately, this only seems to affect the contents of human readable error messages in that function.

## Testing
I ran `cargo test` (oof those initial rust builds take a long time on my laptop!).
Most tests passed, including `test call::test::test_rpc_comprehensive ... ok` which I'm guessing is the main test related to this code. There were a few failures but I think they're unrelated:
```
failures:
    integration_build_provider_debug_mode
    integration_build_rust_component_in_workspace_unsigned
    integration_build_rust_component_signed
    integration_build_rust_component_signed_with_signing_keys_directory_configuration
    integration_build_rust_component_unsigned
    integration_build_tinygo_component_signed
    integration_build_tinygo_component_unsigned
```

### Unit Test(s)
No changes.

### Acceptance or Integration
No changes.

### Manual Verification

While I appear to be doing something else wrong, at least the error message knows which is which now :)

```
$ cargo run -- call -x 83a5b52e-17cf-4080-bac8-f844099f142e rust_hello_world-httpserver wasi:http/incoming-handler@0.2.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.74s
     Running `/home/mtaufen/projects/wasmCloud/target/debug/wash call -x 83a5b52e-17cf-4080-bac8-f844099f142e rust_hello_world-httpserver 'wasi:http/incoming-handler@0.2.0'`

Error invoking component: timed out invoking component, is component [rust_hello_world-httpserver] running in lattice [83a5b52e-17cf-4080-bac8-f844099f142e]?
```

Granted, the original error message I got was slightly different, so while I believe this fixes the bug I don't know why the behavior slightly differs. This was the original error message:

```
$ wash call -x 83a5b52e-17cf-4080-bac8-f844099f142e rust_hello_world-httpserver wasi:http/incoming-handler@0.2.0

No component responsed to your request, ensure component 83a5b52e-17cf-4080-bac8-f844099f142e is running in lattice rust_hello_world-httpserver
```
