### PR TITLE
chore/provider wrpc release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7258,7 +7258,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-azure"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7284,7 +7284,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7302,7 +7302,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7350,7 +7350,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-server"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7374,7 +7374,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-nats"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7392,7 +7392,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-vault"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7439,7 +7439,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-messaging-kafka"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7456,7 +7456,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7509,7 +7509,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bigdecimal 0.4.5",

--- a/crates/provider-blobstore-azure/Cargo.toml
+++ b/crates/provider-blobstore-azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-azure"
-version = "0.2.0"
+version = "0.3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/provider-blobstore-fs/Cargo.toml
+++ b/crates/provider-blobstore-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.7.0"
+version = "0.8.0"
 description = """
 Blobstore for wasmCloud, leveraging the filesystem. This package provides a capability provider that satisfies the 'wasmcloud:blobstore' contract.
 """

--- a/crates/provider-blobstore-s3/Cargo.toml
+++ b/crates/provider-blobstore-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.8.0"
+version = "0.9.0"
 description = """
 S3-compatible object store capability provider for wasmcloud, satisfying the 'wasmcloud:blobstore' capability contract.
 """

--- a/crates/provider-http-client/Cargo.toml
+++ b/crates/provider-http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-client"
-version = "0.11.0"
+version = "0.12.0"
 description = """
 HTTP client for wasmCloud, using hyper. This package provides a capability provider that satisfies the 'wrpc:http/outgoing-handler' contract.
 """

--- a/crates/provider-http-server/Cargo.toml
+++ b/crates/provider-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-server"
-version = "0.21.1"
+version = "0.22.0"
 description = "Http server for wasmcloud, using Axum. This package provides a library, and a capability provider"
 
 authors.workspace = true

--- a/crates/provider-keyvalue-nats/Cargo.toml
+++ b/crates/provider-keyvalue-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-nats"
-version = "0.1.0"
+version = "0.2.0"
 description = """
 A capability provider that satisfies the 'wasi:keyvalue' contract using NATS as a backend.
 """

--- a/crates/provider-keyvalue-redis/Cargo.toml
+++ b/crates/provider-keyvalue-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.26.0"
+version = "0.27.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/provider-keyvalue-vault/Cargo.toml
+++ b/crates/provider-keyvalue-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-vault"
-version = "0.9.0"
+version = "0.10.0"
 description = """
 Hashicorp Vault capability provider for the 'wrpc:keyvalue' capability contract
 """

--- a/crates/provider-messaging-kafka/Cargo.toml
+++ b/crates/provider-messaging-kafka/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-messaging-kafka"
-version = "0.3.0"
+version = "0.4.0"
 description = """
 A capability provider that satisfies the 'wasmcloud:messaging' contract using Kafka as a backend.
 """

--- a/crates/provider-messaging-nats/Cargo.toml
+++ b/crates/provider-messaging-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.21.0"
+version = "0.22.0"
 description = """
 A capability provider that satisfies the 'wasmcloud:messaging' contract using NATS as a backend.
 """

--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.2.0"
+version = "0.3.0"
 description = """
 wasmCloud SQL database provider for Postgres
 """

--- a/src/bin/blobstore-azure-provider/wasmcloud.toml
+++ b/src/bin/blobstore-azure-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Blobstore Azure"
 language = "rust"
 type = "provider"
-version = "0.2.0"
+version = "0.3.0"
 
 [rust]
 target_path = "../../target"

--- a/src/bin/blobstore-fs-provider/wasmcloud.toml
+++ b/src/bin/blobstore-fs-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Blobstore FS"
 language = "rust"
 type = "provider"
-version = "0.7.0"
+version = "0.8.0"
 
 [rust]
 target_dir = "../../"

--- a/src/bin/blobstore-s3-provider/wasmcloud.toml
+++ b/src/bin/blobstore-s3-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "Blobstore S3"
 language = "rust"
-version = "0.8.0"
+version = "0.9.0"
 type = "provider"
 
 [rust]

--- a/src/bin/http-client-provider/wasmcloud.toml
+++ b/src/bin/http-client-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "HTTP Client"
 language = "rust"
-version = "0.11.0"
+version = "0.12.0"
 type = "provider"
 
 [rust]

--- a/src/bin/http-server-provider/wasmcloud.toml
+++ b/src/bin/http-server-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "HTTP Server"
 language = "rust"
-version = "0.21.1"
+version = "0.22.0"
 type = "provider"
 
 [rust]

--- a/src/bin/keyvalue-nats-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-nats-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Nats"
 language = "rust"
 type = "provider"
-version = "0.1.0"
+version = "0.2.0"
 
 [rust]
 target_path = "../../../target"

--- a/src/bin/keyvalue-redis-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-redis-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Redis"
 language = "rust"
 type = "provider"
-version = "0.25.0"
+version = "0.27.0"
 
 [rust]
 target_path = "../../target"

--- a/src/bin/keyvalue-vault-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-vault-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Vault"
 language = "rust"
 type = "provider"
-version = "0.9.0"
+version = "0.10.0"
 
 [rust]
 target_path = "../../target"

--- a/src/bin/messaging-kafka-provider/wasmcloud.toml
+++ b/src/bin/messaging-kafka-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Messaging Kafka"
 language = "rust"
 type = "provider"
-version = "0.3.0"
+version = "0.4.0"
 
 [rust]
 target_dir = "../../"

--- a/src/bin/messaging-nats-provider/wasmcloud.toml
+++ b/src/bin/messaging-nats-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Messaging NATS"
 language = "rust"
 type = "provider"
-version = "0.21.0"
+version = "0.22.0"
 
 [rust]
 target_dir = "../../"

--- a/src/bin/sqldb-postgres-provider/wasmcloud.toml
+++ b/src/bin/sqldb-postgres-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "SQLDB Postgres"
 language = "rust"
 type = "provider"
-version = "0.2.0"
+version = "0.3.0"
 
 [rust]
 target_path = "../../target"


### PR DESCRIPTION
- **chore(provider-*): bump minor version for wrpc update**
- **deps: update Cargo.lock with provider bumps**

## Feature or Problem
This PR updates all providers a minor version to use an updated wrpc version.

## Related Issues
#2478 

## Release Information
next minor all providers

## Consumer Impact
Consumers of wasmCloud capability providers should all update to use the versions mentioned in this PR, aka the latest versions. The update for async streams in wRPC is backwards compatible but not forwards compatible, so v1.1.0 hosts will **not** be able to make use of the 

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
