### PR TITLE
ci(wasmcloud): disable docker output artifact

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -365,6 +365,8 @@ jobs:
 
   docker:
     runs-on: ubuntu-22.04-16-cores
+    env:
+      DOCKER_BUILD_RECORD_UPLOAD: false
     needs:
       - build-bin
       - test-linux


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue where downloading artifacts would fail because of the docker build output. I'm not entirely sure why this was happening, but I theorize it's related to https://github.com/actions/download-artifact/issues/339 and the commenter that mentioned that invalid zips/repeated filenames cause issues.

I validated this was the issue with releasing our latest providers / 1.1.0-beta.1 because I deleted the artifact and re-ran the failed workflow and it worked.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
