### PR TITLE
feat: add field to secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7576,7 +7576,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-secrets-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-nats-wrpc",
  "nkeys 0.4.3",
@@ -7587,7 +7587,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-secrets-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,8 +343,8 @@ wasmcloud-provider-messaging-nats = { version = "*", path = "./crates/provider-m
 wasmcloud-provider-sdk = { version = "^0.6.0", path = "./crates/provider-sdk", default-features = false }
 wasmcloud-provider-sqldb-postgres = { version = "*", path = "./crates/provider-sqldb-postgres", default-features = false }
 wasmcloud-runtime = { version = "0", path = "./crates/runtime", default-features = false }
-wasmcloud-secrets-client = { version = "0.1", path = "./crates/secrets-client", default-features = false }
-wasmcloud-secrets-types = { version = "0.1", path = "./crates/secrets-types", default-features = false }
+wasmcloud-secrets-client = { version = "0.2", path = "./crates/secrets-client", default-features = false }
+wasmcloud-secrets-types = { version = "0.2", path = "./crates/secrets-types", default-features = false }
 wasmcloud-test-util = { version = "^0.12.0", path = "./crates/test-util", default-features = false }
 wasmcloud-tracing = { version = "^0.5.0", path = "./crates/tracing", default-features = false }
 wasmparser = { version = "0.212", default-features = false }

--- a/crates/host/src/secrets.rs
+++ b/crates/host/src/secrets.rs
@@ -123,7 +123,7 @@ impl Manager {
                     Ok(Some(secret)) => serde_json::from_slice::<SecretConfig>(&secret)
                         .with_context(|| format!("failed to deserialize secret reference from config store, ensure {secret_name} is a secret reference and not configuration")),
                     Ok(None) => bail!(
-                        "Secret reference {secret_name} not found in config store"
+                        "Secret config {secret_name} not found in config store, could not create secret request"
                     ),
                     Err(e) => bail!(e),
                 }

--- a/crates/secrets-client/Cargo.toml
+++ b/crates/secrets-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmcloud-secrets-client"
 description = "Client library for interacting with wasmCloud secrets backends"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/secrets-client/src/lib.rs
+++ b/crates/secrets-client/src/lib.rs
@@ -30,7 +30,7 @@ pub enum SecretClientError {
     OpenSecretResponse(nkeys::error::Error),
     #[error("failed to deserialize secret response: {0}")]
     DeserializeSecretResponse(serde_json::error::Error),
-    #[error("unexpected server error: {0}")]
+    #[error("server error: {0}")]
     Server(String),
     #[error("missing secret: {0}")]
     MissingSecret(String),
@@ -160,7 +160,7 @@ impl Client {
         sr.secret.ok_or_else(|| {
             SecretClientError::MissingSecret(format!(
                 "no secret found with name [{}]",
-                secret_request.name
+                secret_request.key
             ))
         })
     }

--- a/crates/secrets-nats-kv/src/api.rs
+++ b/crates/secrets-nats-kv/src/api.rs
@@ -622,7 +622,7 @@ impl SecretsServer for Api {
         let values: HashSet<String> = serde_json::from_slice(&entry.unwrap())
             .map_err(|e| GetSecretError::UpstreamError(e.to_string()))?;
 
-        if !values.contains(&request.name) {
+        if !values.contains(&request.key) {
             return Err(GetSecretError::Unauthorized);
         }
 
@@ -634,16 +634,16 @@ impl SecretsServer for Api {
 
         let entry = match &request.version {
             Some(v) => {
-                let revision = str::parse::<u64>(v).unwrap();
+                let revision = str::parse::<u64>(v).map_err(|_| GetSecretError::InvalidRequest)?;
 
                 let mut key_hist = secrets
-                    .history(&request.name)
+                    .history(&request.key)
                     .await
                     .map_err(|e| GetSecretError::UpstreamError(e.to_string()))?;
                 find_key_rev(&mut key_hist, revision).await
             }
             None => secrets
-                .entry(&request.name)
+                .entry(&request.key)
                 .await
                 .map_err(|e| GetSecretError::UpstreamError(e.to_string()))?,
         };

--- a/crates/secrets-nats-kv/src/api.rs
+++ b/crates/secrets-nats-kv/src/api.rs
@@ -149,7 +149,7 @@ impl Api {
             }
         };
 
-        let secret: Secret = match serde_json::from_slice(&payload) {
+        let secret: PutSecretRequest = match serde_json::from_slice(&payload) {
             Ok(s) => s,
             Err(e) => {
                 let _ = self.client.publish(reply, e.to_string().into()).await;
@@ -184,7 +184,7 @@ impl Api {
             return;
         };
 
-        match store.put(secret.name, encrypted_value.into()).await {
+        match store.put(secret.key, encrypted_value.into()).await {
             Ok(revision) => {
                 let resp = PutSecretResponse::from(revision);
                 let _ = self
@@ -655,7 +655,6 @@ impl SecretsServer for Api {
         let entry = entry.unwrap();
 
         let mut secret = Secret {
-            name: entry.key,
             version: entry.revision.to_string(),
             ..Default::default()
         };

--- a/crates/secrets-nats-kv/src/client.rs
+++ b/crates/secrets-nats-kv/src/client.rs
@@ -4,7 +4,7 @@ use anyhow::{ensure, Context};
 
 pub const SECRETS_API_VERSION: &str = "v1alpha1";
 
-use crate::{PutSecretError, PutSecretResponse};
+use crate::{PutSecretError, PutSecretRequest, PutSecretResponse};
 
 /// Helper function wrapper around [`put_secret`] that allows putting multiple secrets in the secret store.
 /// See the documentation for [`put_secret`] for more information.
@@ -14,7 +14,7 @@ pub async fn put_secrets(
     nats_client: &async_nats::Client,
     subject_base: &str,
     transit_xkey: &nkeys::XKey,
-    secrets: Vec<wasmcloud_secrets_types::Secret>,
+    secrets: Vec<PutSecretRequest>,
 ) -> Vec<anyhow::Result<()>> {
     futures::future::join_all(
         secrets
@@ -35,7 +35,7 @@ pub async fn put_secret(
     nats_client: &async_nats::Client,
     subject_base: &str,
     transit_xkey: &nkeys::XKey,
-    secret: wasmcloud_secrets_types::Secret,
+    secret: PutSecretRequest,
 ) -> anyhow::Result<()> {
     ensure!(
         !(secret.binary_secret.is_some() && secret.string_secret.is_some()),

--- a/crates/secrets-nats-kv/src/main.rs
+++ b/crates/secrets-nats-kv/src/main.rs
@@ -7,6 +7,7 @@ use secrets_nats_kv::client::SECRETS_API_VERSION;
 use secrets_nats_kv::Api;
 
 use secrets_nats_kv::client;
+use secrets_nats_kv::PutSecretRequest;
 
 #[derive(Parser)]
 #[command(about, version, name = "secrets-nats-kv")]
@@ -184,8 +185,8 @@ async fn put(args: PutCommand) -> anyhow::Result<()> {
         .transpose()?;
 
     let name = args.name.clone();
-    let secret = wasmcloud_secrets_types::Secret {
-        name,
+    let secret = PutSecretRequest {
+        key: name,
         version: args.version.unwrap_or_default(),
         // NOTE: The clap parser will ensure that one and only one of these is present
         string_secret: args.string,

--- a/crates/secrets-nats-kv/src/types.rs
+++ b/crates/secrets-nats-kv/src/types.rs
@@ -2,6 +2,14 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[derive(Serialize, Deserialize, Default)]
+pub struct PutSecretRequest {
+    pub key: String,
+    pub version: String,
+    pub string_secret: Option<String>,
+    pub binary_secret: Option<Vec<u8>>,
+}
+
 /// The response to a `put_secret` operation.
 /// This response contains the revision number of the secret that was just written.
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/crates/secrets-nats-kv/tests/api.rs
+++ b/crates/secrets-nats-kv/tests/api.rs
@@ -143,7 +143,8 @@ async fn integration_test_kvstore_put_secret() -> anyhow::Result<()> {
         .build();
 
     let request = SecretRequest {
-        name: "test".to_string(),
+        key: "test".to_string(),
+        field: None,
         context: Context {
             entity_jwt: encoded,
             host_jwt: claims.encode(&account)?,
@@ -251,7 +252,8 @@ async fn integration_test_kvstore_version() -> anyhow::Result<()> {
         .build();
 
     let request = SecretRequest {
-        name: "test".to_string(),
+        key: "test".to_string(),
+        field: None,
         context: Context {
             entity_jwt: encoded,
             host_jwt: claims.encode(&account)?,

--- a/crates/secrets-nats-kv/tests/api.rs
+++ b/crates/secrets-nats-kv/tests/api.rs
@@ -3,10 +3,10 @@ use std::collections::HashSet;
 use async_nats::{jetstream, Client};
 use nkeys::{KeyPair, XKey};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use secrets_nats_kv::{Api, PutSecretResponse};
+use secrets_nats_kv::{Api, PutSecretRequest, PutSecretResponse};
 use std::collections::HashMap;
 use wascap::jwt::{Claims, ClaimsBuilder, Component, Host};
-use wasmcloud_secrets_types::{Application, Context, Secret, SecretRequest, WASMCLOUD_HOST_XKEY};
+use wasmcloud_secrets_types::{Application, Context, SecretRequest, WASMCLOUD_HOST_XKEY};
 
 const SUBJECT_BASE: &str = "kvstore_test";
 const NAME_BASE: &str = "nats-kv";
@@ -94,8 +94,8 @@ async fn integration_test_kvstore_put_secret() -> anyhow::Result<()> {
     // Give the server some time to start
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    let value = Secret {
-        name: "test".to_string(),
+    let value = PutSecretRequest {
+        key: "test".to_string(),
         string_secret: Some("value".to_string()),
         ..Default::default()
     };
@@ -192,8 +192,8 @@ async fn integration_test_kvstore_version() -> anyhow::Result<()> {
     // Give the server some time to start
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    let value = Secret {
-        name: "test".to_string(),
+    let value = PutSecretRequest {
+        key: "test".to_string(),
         string_secret: Some("value".to_string()),
         ..Default::default()
     };

--- a/crates/secrets-types/Cargo.toml
+++ b/crates/secrets-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-secrets-types"
-version = "0.1.0"
+version = "0.2.0"
 description = "Types, traits, and structs for interacting with secrets in wasmCloud"
 authors.workspace = true
 categories.workspace = true

--- a/crates/secrets-types/src/lib.rs
+++ b/crates/secrets-types/src/lib.rs
@@ -145,11 +145,6 @@ pub struct SecretResponse {
 /// A secret that can be either a string or binary value.
 #[derive(Serialize, Deserialize, Default)]
 pub struct Secret {
-    /// An identifier of the secret as stored in the secret store.
-    ///
-    /// A `Secret` can be a key, path, or any other identifier that the secret store uses to
-    /// retrieve the secret.
-    pub name: String,
     pub version: String,
     pub string_secret: Option<String>,
     pub binary_secret: Option<Vec<u8>>,

--- a/crates/test-util/src/lattice/config.rs
+++ b/crates/test-util/src/lattice/config.rs
@@ -27,6 +27,7 @@ pub async fn assert_put_secret_reference(
     name: impl AsRef<str>,
     key: &str,
     backend: &str,
+    field: Option<String>,
     version: Option<String>,
     properties: HashMap<String, String>,
 ) -> Result<()> {
@@ -34,6 +35,7 @@ pub async fn assert_put_secret_reference(
         name.as_ref().to_string(),
         backend.to_string(),
         key.to_string(),
+        field,
         version,
         properties.into_iter().map(|(k, v)| (k, v.into())).collect(),
     );

--- a/crates/wash-cli/src/secrets.rs
+++ b/crates/wash-cli/src/secrets.rs
@@ -21,6 +21,9 @@ pub enum SecretsCliCommand {
         /// The key to use for retrieving the secret from the backend.
         #[clap(name = "key")]
         key: String,
+        /// The field to use for retrieving the secret from the backend.
+        #[clap(long = "field")]
+        field: Option<String>,
         /// The version of the secret to retrieve. If not supplied, the latest version will be used.
         #[clap(short = 'v', long = "version")]
         version: Option<String>,
@@ -58,6 +61,7 @@ pub async fn handle_command(
             name,
             backend,
             key,
+            field,
             version,
             policy_properties,
         } => {
@@ -67,6 +71,7 @@ pub async fn handle_command(
                 secret_name,
                 backend,
                 key,
+                field,
                 version,
                 policy_property_map
                     .into_iter()

--- a/crates/wash-cli/tests/wash_secrets.rs
+++ b/crates/wash-cli/tests/wash_secrets.rs
@@ -22,6 +22,7 @@ async fn test_secret_put_and_get() -> anyhow::Result<()> {
         name: "foobar".to_string(),
         backend: "baobun".to_string(),
         key: "path/to/secret".to_string(),
+        field: None,
         version: None,
         policy_properties: vec![],
     };
@@ -92,6 +93,7 @@ async fn test_secret_put_and_get_complex() -> anyhow::Result<()> {
         name: "mysecret".to_string(),
         backend: "baobuns".to_string(),
         key: "secrets/path/v2/mine".to_string(),
+        field: Some("myfield".to_string()),
         version: Some("v1.0.0".to_string()),
         policy_properties: vec!["role=operator".to_string(), "app_id=1234".to_string()],
     };
@@ -110,7 +112,7 @@ async fn test_secret_put_and_get_complex() -> anyhow::Result<()> {
     .await?
     .map;
 
-    assert_eq!(retrieved_secret.len(), 6);
+    assert_eq!(retrieved_secret.len(), 7);
     assert!(retrieved_secret
         .get("name")
         .is_some_and(|n| n == "mysecret"));
@@ -120,6 +122,9 @@ async fn test_secret_put_and_get_complex() -> anyhow::Result<()> {
     assert!(retrieved_secret
         .get("key")
         .is_some_and(|k| k == "secrets/path/v2/mine"));
+    assert!(retrieved_secret
+        .get("field")
+        .is_some_and(|f| f == "myfield"));
     assert!(retrieved_secret
         .get("version")
         .is_some_and(|k| k == "v1.0.0"));

--- a/tests/common/secrets.rs
+++ b/tests/common/secrets.rs
@@ -1,8 +1,7 @@
 use anyhow::{Context, Result};
 use async_nats::Client;
+use secrets_nats_kv::PutSecretRequest;
 use std::{collections::HashSet, process::Output, time::Duration};
-
-use wasmcloud_secrets_types::Secret;
 
 use super::BackgroundServer;
 
@@ -42,7 +41,7 @@ impl NatsKvSecretsBackend {
         res.map_err(|e| anyhow::anyhow!(e))
     }
 
-    pub async fn put_secret(&self, secret: Secret) -> Result<()> {
+    pub async fn put_secret(&self, secret: PutSecretRequest) -> Result<()> {
         secrets_nats_kv::client::put_secret(
             &self.nats_client,
             &self.subject_base,

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -8,6 +8,7 @@ use async_nats::jetstream;
 use common::secrets::NatsKvSecretsBackend;
 use hyper_util::rt::TokioExecutor;
 use hyper_util::rt::TokioIo;
+use secrets_nats_kv::PutSecretRequest;
 use test_components::{
     RUST_PINGER_CONFIG_COMPONENT_PREVIEW2_SIGNED, RUST_PONGER_CONFIG_COMPONENT_PREVIEW2_SIGNED,
 };
@@ -173,8 +174,8 @@ async fn config_e2e() -> anyhow::Result<()> {
     nats_kv_secrets_backend.ensure_build().await?;
     let secrets_backend_server = nats_kv_secrets_backend.start().await?;
     nats_kv_secrets_backend
-        .put_secret(wasmcloud_secrets_types::Secret {
-            name: "ponger".to_string(),
+        .put_secret(PutSecretRequest {
+            key: "ponger".to_string(),
             string_secret: Some("sup3rs3cr3t-v4lu3".to_string()),
             ..Default::default()
         })

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -239,6 +239,7 @@ async fn config_e2e() -> anyhow::Result<()> {
         "ponger",
         "nats-kv",
         None,
+        None,
         HashMap::with_capacity(0),
     )
     .await?;


### PR DESCRIPTION
## Feature or Problem
This PR adds the `field` parameter to the `SecretRequest` and `SecretConfig` types, allowing secrets backends that support indexed secrets inside of an individual key to only return the desired field.

An example of this is vault, where secrets are addressable by a path (which we use the `key` parameter) and then contained in that path are multiple key=value pairs.

This PR also removes the unneeded `name` field from the Secret, since the backend doesn't actually need this value and returning the key/field arbitrarily would just increase bytes sent/encrypted.

## Related Issues
Upcoming wadm issue to support this.

## Release Information
1.1.0-beta.2

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
