### PR TITLE
chore: update component/runtime/host crate READMEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-host"
-version = "0.82.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -7538,7 +7538,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-runtime"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasmcloud"
 version = "1.1.0"
 description = "wasmCloud host runtime"
 default-run = "wasmcloud"
+readme = "README.md"
 
 authors.workspace = true
 categories.workspace = true
@@ -342,7 +343,7 @@ wasmcloud-provider-messaging-kafka = { version = "*", path = "./crates/provider-
 wasmcloud-provider-messaging-nats = { version = "*", path = "./crates/provider-messaging-nats", default-features = false }
 wasmcloud-provider-sdk = { version = "^0.7.0", path = "./crates/provider-sdk", default-features = false }
 wasmcloud-provider-sqldb-postgres = { version = "*", path = "./crates/provider-sqldb-postgres", default-features = false }
-wasmcloud-runtime = { version = "0", path = "./crates/runtime", default-features = false }
+wasmcloud-runtime = { version = "0.1", path = "./crates/runtime", default-features = false }
 wasmcloud-secrets-client = { version = "^0.3.0", path = "./crates/secrets-client", default-features = false }
 wasmcloud-secrets-types = { version = "^0.3.0", path = "./crates/secrets-types", default-features = false }
 wasmcloud-test-util = { version = "^0.12.0", path = "./crates/test-util", default-features = false }

--- a/crates/component/Cargo.toml
+++ b/crates/component/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasmcloud-component"
 version = "0.1.0"
 description = "wasmCloud component library giving access to interfaces provided by wasmCloud host runtime"
+readme = "README.md"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/component/README.md
+++ b/crates/component/README.md
@@ -1,0 +1,83 @@
+# wasmCloud Component
+
+wasmCloud is an open source Cloud Native Computing Foundation (CNCF) project that enables teams to build, manage, and scale polyglot Wasm apps across any cloud, K8s, or edge.
+
+⚠️ This crate is highly experimental and likely to experience breaking changes frequently. The host itself is relatively stable, but the APIs and public members of this crate are not guaranteed to be stable and may change in a backwards-incompatible way.
+
+## Usage
+
+This crate is a collection of `wasi` and `wasmcloud` interfaces that can be used at runtime in a Wasm component running in wasmCloud. It can be imported in a Rust application and used directly rather than generating bindings manually in code.
+
+```rust
+wit_bindgen::generate!({
+    with: {
+        "wasi:http/types@0.2.0": wasmcloud_component::wasi::http::types,
+        "wasi:io/streams@0.2.0": wasmcloud_component::wasi::io::streams,
+    }
+});
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+
+use serde::Deserialize;
+use serde_json::json;
+use test_components::testing::*;
+use wasmcloud_component::wasi::{config, http};
+use wasmcloud_component::{InputStreamReader, OutputStreamWriter};
+
+struct Component;
+
+impl exports::wasi::http::incoming_handler::Guest for Component {
+    fn handle(request: http::types::IncomingRequest, response_out: http::types::ResponseOutparam) {
+        #[derive(Deserialize)]
+        struct Request {
+            config_key: String,
+        }
+
+        let request_body = request
+            .consume()
+            .expect("failed to get incoming request body");
+        let Request { config_key } = {
+            let mut buf = vec![];
+            let mut stream = request_body
+                .stream()
+                .expect("failed to get incoming request stream");
+            InputStreamReader::from(&mut stream)
+                .read_to_end(&mut buf)
+                .expect("failed to read value from incoming request stream");
+            serde_json::from_slice(&buf).expect("failed to decode request body")
+        };
+        let _trailers = http::types::IncomingBody::finish(request_body);
+
+        // No args, return string
+        let pong = pingpong::ping();
+        let pong_secret = pingpong::ping_secret();
+
+        let res = json!({
+            "single_val": config::runtime::get(&config_key).expect("failed to get config value"),
+            "multi_val": config::runtime::get_all().expect("failed to get config value").into_iter().collect::<HashMap<String, String>>(),
+            "pong": pong,
+            "pong_secret": pong_secret,
+        });
+        let body = serde_json::to_vec(&res).expect("failed to encode response to JSON");
+        let response = http::types::OutgoingResponse::new(http::types::Fields::new());
+        let response_body = response
+            .body()
+            .expect("failed to get outgoing response body");
+        {
+            let mut stream = response_body
+                .write()
+                .expect("failed to get outgoing response stream");
+            let mut w = OutputStreamWriter::from(&mut stream);
+            w.write_all(&body)
+                .expect("failed to write body to outgoing response stream");
+            w.flush().expect("failed to flush outgoing response stream");
+        }
+        http::types::OutgoingBody::finish(response_body, None)
+            .expect("failed to finish response body");
+        http::types::ResponseOutparam::set(response_out, Ok(response));
+    }
+}
+
+export!(Component);
+```

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "wasmcloud-host"
-version = "0.82.0"
+version = "0.20.0"
 description = "wasmCloud host library"
+readme = "README.md"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/host/README.md
+++ b/crates/host/README.md
@@ -1,18 +1,9 @@
-# 💻 Distributed computing, _simplified_
+# wasmCloud Host
 
-The wasmCloud runtime is a vessel for running applications in the cloud, at the edge, in the browser, on small devices, and anywhere else you can imagine.
+wasmCloud is an open source Cloud Native Computing Foundation (CNCF) project that enables teams to build, manage, and scale polyglot Wasm apps across any cloud, K8s, or edge.
 
-**Move from concept to production without changing your design, architecture, or your programming environment.**
+⚠️ This crate is highly experimental and likely to experience breaking changes frequently. The host itself is relatively stable, but the APIs and public members of this crate are not guaranteed to be stable.
 
-wasmCloud lets you focus on shipping _features_. Build secure, portable, re-usable components. Get rid of the headaches from being smothered by boilerplate, dependency hell, tight coupling, and designs mandated by your infrastructure.
+## Usage
 
-## Core Tenets
-
-- Dead simple distributed applications
-- Run anywhere
-- Secure by default
-- Productivity for both developers and operations
-
-# wasmCloud Host Runtime
-
-This crate contains the host runtime itself. Check out the [top-level project](https://github.com/wasmCloud/wasmCloud) for information about the wasmCloud ecosystem as a whole.
+This crate can be used to embed a wasmCloud host in a Rust application. You can refer to the [main.rs](https://github.com/wasmCloud/wasmCloud/blob/main/src/main.rs) file of the wasmCloud runtime for an example of this.

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "wasmcloud-runtime"
-version = "0.3.0"
+version = "0.1.0"
 description = "wasmCloud runtime library"
+readme = "README.md"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/runtime/README.md
+++ b/crates/runtime/README.md
@@ -1,0 +1,9 @@
+# wasmCloud Runtime
+
+wasmCloud is an open source Cloud Native Computing Foundation (CNCF) project that enables teams to build, manage, and scale polyglot Wasm apps across any cloud, K8s, or edge.
+
+⚠️ This crate is highly experimental and likely to experience breaking changes frequently. The runtime itself is relatively stable, but the APIs and public members of this crate are not guaranteed to be stable.
+
+## Usage
+
+This crate can be used to embed a wasmCloud runtime in a Rust application. You can refer to the [wasmcloud-host](https://crates.io/crates/wasmcloud-host) crate for an example of how to use the runtime, generally it's recommended to use the host crate instead for embedding in an application as this crate is lower level.


### PR DESCRIPTION
## Feature or Problem
This PR prepares the wasmcloud-component, wasmcloud-runtime, and wasmcloud-host crates for an eventual release. **I don't plan on releasing them quite yet**, and the top-level binary of `wasmcloud` still includes many dependencies on the provider libraries (but we should turn those off?) but this puts us in the right direction for releasing some of these crates that are listed as deprecated on crates.io.

## Related Issues
I thought I had an issue for this but I can't find it /shrug

## Release Information
wasmcloud-component 0.1.0
wasmcloud-runtime 0.1.0
wasmcloud-host 0.20.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
