### PR TITLE
fix(tracing): enable core otel features

### DIFF
--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -17,6 +17,8 @@ otel = [
     "opentelemetry-appender-tracing",
     "tracing-opentelemetry",
     "opentelemetry-otlp",
+    "wasmcloud-core/otel",
+    "wasmcloud-core/rustls-native-certs",
 ]
 
 [dependencies]
@@ -52,4 +54,4 @@ tracing-subscriber = { workspace = true, features = [
     "fmt",
     "json",
 ] }
-wasmcloud-core = { workspace = true, features = ["otel"] }
+wasmcloud-core = { workspace = true }

--- a/crates/tracing/src/traces.rs
+++ b/crates/tracing/src/traces.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 #[cfg(feature = "otel")]
 use std::sync::Arc;
 
+#[cfg(feature = "otel")]
 use anyhow::Context as _;
 #[cfg(feature = "otel")]
 use opentelemetry_otlp::{LogExporterBuilder, SpanExporterBuilder, WithExportConfig};
@@ -17,6 +18,7 @@ use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
+#[cfg(feature = "otel")]
 use tracing_subscriber::Layer;
 use wasmcloud_core::logging::Level;
 use wasmcloud_core::OtelConfig;
@@ -90,19 +92,17 @@ pub fn configure_tracing(
         .with_ansi(ansi);
 
     let dispatch = if use_structured_logging {
-        registry
-            .with(
-                fmt.event_format(JsonOrNot::Json(Format::default().json()))
-                    .fmt_fields(JsonFields::new()),
-            )
-            .into()
+        reg.with(
+            fmt.event_format(JsonOrNot::Json(Format::default().json()))
+                .fmt_fields(JsonFields::new()),
+        )
+        .into()
     } else {
-        registry
-            .with(
-                fmt.event_format(JsonOrNot::Not(Format::default()))
-                    .fmt_fields(DefaultFields::new()),
-            )
-            .into()
+        reg.with(
+            fmt.event_format(JsonOrNot::Not(Format::default()))
+                .fmt_fields(DefaultFields::new()),
+        )
+        .into()
     };
 
     Ok((
@@ -304,6 +304,7 @@ where
     Ok(log_layer)
 }
 
+#[cfg(feature = "otel")]
 fn get_trace_level_filter(trace_level_override: Option<&Level>) -> EnvFilter {
     if let Some(trace_level) = trace_level_override {
         let level = wasi_level_to_tracing_level(trace_level);


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue where the wasmcloud-tracing crate didn't properly gate otel functions + enable otel features in the wasmcloud-core crate

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
