### PR TITLE
Adding missing 'handler' to go provider template

### DIFF
--- a/examples/golang/providers/custom-template/main.go
+++ b/examples/golang/providers/custom-template/main.go
@@ -108,7 +108,7 @@ func handleDelTargetLink(handler *Handler, link provider.InterfaceLinkDefinition
 	return nil
 }
 
-func handleHealthCheck(_ *Handler) string {
+func handleHealthCheck(handler *Handler) string {
 	handler.provider.Logger.Info("Handling health check")
 	return "provider healthy"
 }


### PR DESCRIPTION
```
❯ ./run.sh
./main.go:112:2: undefined: handler
```

