### PR TITLE
fix: Ensure file exists before attempting to remove

### DIFF
--- a/crates/wash-cli/src/dev.rs
+++ b/crates/wash-cli/src/dev.rs
@@ -15,7 +15,7 @@ use wash_lib::{
     cli::dev::run_dev_loop,
     cli::{sanitize_component_id, CommandOutput},
     component::{scale_component, ScaleComponentArgs},
-    config::{downloads_dir, WASMCLOUD_PID_FILE},
+    config::host_pid_file,
     generate::emoji,
     id::{ModuleId, ServerId},
     parser::get_config,
@@ -93,7 +93,7 @@ pub async fn handle_command(
     output_kind: wash_lib::cli::OutputKind,
 ) -> Result<CommandOutput> {
     // Check if host is running
-    let pid_file = downloads_dir()?.join(WASMCLOUD_PID_FILE);
+    let pid_file = host_pid_file()?;
     let existing_instance = tokio::fs::metadata(pid_file).await.is_ok();
 
     let mut host_subprocess: Option<HostSubprocess> = None;

--- a/crates/wash-cli/src/down/mod.rs
+++ b/crates/wash-cli/src/down/mod.rs
@@ -10,8 +10,8 @@ use tokio::process::Command;
 use tracing::warn;
 use wash_lib::cli::{stop::stop_hosts, CommandOutput, OutputKind};
 use wash_lib::config::{
-    create_nats_client_from_opts, downloads_dir, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT,
-    WASMCLOUD_PID_FILE,
+    create_nats_client_from_opts, downloads_dir, host_pid_file, DEFAULT_NATS_HOST,
+    DEFAULT_NATS_PORT,
 };
 use wash_lib::id::ServerId;
 use wash_lib::start::{nats_pid_path, NATS_SERVER_BINARY, WADM_PID};
@@ -132,7 +132,7 @@ pub async fn handle_down(cmd: DownCommand, output_kind: OutputKind) -> Result<Co
             );
             return Ok(CommandOutput::new(out_text, out_json));
         } else {
-            let wasmcloud_pid_file_path = install_dir.join(WASMCLOUD_PID_FILE);
+            let wasmcloud_pid_file_path = host_pid_file()?;
             // Failing to find the pid file is not an error that should prevent stopping other resources
             if let Err(e) = tokio::fs::remove_file(&wasmcloud_pid_file_path)
                 .await

--- a/crates/wash-cli/tests/common/mod.rs
+++ b/crates/wash-cli/tests/common/mod.rs
@@ -23,7 +23,7 @@ use wash_lib::cli::output::{
     CallCommandOutput, GetHostsCommandOutput, PullCommandOutput, StartCommandOutput,
     StopCommandOutput, UpCommandOutput,
 };
-use wash_lib::config::{downloads_dir, WASMCLOUD_PID_FILE};
+use wash_lib::config::host_pid_file;
 use wash_lib::start::{ensure_nats_server, start_nats_server, NatsConfig, WASMCLOUD_HOST_BIN};
 use wasmcloud_control_interface::Host;
 
@@ -802,7 +802,7 @@ pub async fn wait_for_no_hosts() -> Result<()> {
     )
     .await
     .context("number of hosts running is still non-zero")?;
-    let lockfile = downloads_dir().map(|p| p.join(WASMCLOUD_PID_FILE))?;
+    let lockfile = host_pid_file()?;
     if wait_for_file_to_be_removed(&lockfile).await.is_err() {
         // If the PID file wasn't removed, attempt to delete it manually
         tokio::fs::remove_file(&lockfile).await.with_context(|| {

--- a/crates/wash-lib/src/cli/stop.rs
+++ b/crates/wash-lib/src/cli/stop.rs
@@ -244,7 +244,8 @@ pub async fn stop_host(cmd: StopHostCommand) -> Result<CommandOutput> {
     let install_dir = downloads_dir()?;
 
     let (_, hosts_remain) = stop_hosts(client, Some(&cmd.host_id), false).await?;
-    if !hosts_remain {
+    let pid_file_exists = tokio::fs::try_exists(install_dir.join(WASMCLOUD_PID_FILE)).await?;
+    if !hosts_remain && pid_file_exists {
         tokio::fs::remove_file(install_dir.join(WASMCLOUD_PID_FILE)).await?;
     }
 

--- a/crates/wash-lib/src/config.rs
+++ b/crates/wash-lib/src/config.rs
@@ -40,6 +40,11 @@ pub fn downloads_dir() -> Result<PathBuf> {
     Ok(cfg_dir()?.join(DOWNLOADS_DIR))
 }
 
+/// The path to the running wasmCloud Host PID file for wash
+pub fn host_pid_file() -> Result<PathBuf> {
+    Ok(downloads_dir()?.join(WASMCLOUD_PID_FILE))
+}
+
 #[derive(Clone)]
 /// Connection options for a Wash instance
 pub struct WashConnectionOptions {


### PR DESCRIPTION
## Feature or Problem

This addresses the root cause for https://github.com/wasmCloud/wadm/actions/runs/10208903476/job/28246069141?pr=367#step:8:159 when the host is told to stop, but it's not running on the same machine as `wash` (in the Actions example above, it's running inside of a Docker Container).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
