### PR TITLE
feat(examples): add load testing for example components

### DIFF
--- a/.github/workflows/examples-components.yml
+++ b/.github/workflows/examples-components.yml
@@ -19,7 +19,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - .github/workflows/examples.yml
+      - .github/workflows/examples-components.yml
       - crates/wash-lib/**
       - crates/wash-cli/**
       - examples/rust/components/**
@@ -39,7 +39,7 @@ env:
 
 jobs:
   build-wash-cli:
-    name: Build wash CLI
+    name: build wash-cli
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -87,9 +87,11 @@ jobs:
           - lang: "golang"
             lang_version: "1.20"
             name: "http-echo-tinygo"
+            test_deploy: wadm.yaml
           - lang: "golang"
             lang_version: "1.20"
             name: "http-hello-world"
+            test_deploy: wadm.yaml
           # Rust example components
           - name: "blobby"
             lang: "rust"
@@ -97,27 +99,35 @@ jobs:
           - name: "dog-fetcher"
             lang: "rust"
             wasm-bin: "dog_fetcher_s.wasm"
+            test_deploy: local.wadm.yaml
           - name: "echo-messaging"
             lang: "rust"
             wasm-bin: "echo_messaging_s.wasm"
+            test_deploy: local.wadm.yaml
           - name: "ferris-says"
             lang: "rust"
             wasm-bin: "ferris_says_s.wasm"
+            test_deploy: local.wadm.yaml
           - name: "http-blobstore"
             lang: "rust"
             wasm-bin: "http_blobstore_s.wasm"
+            test_deploy: local.wadm.yaml
           - name: "http-hello-world"
             lang: "rust"
             wasm-bin: "http_hello_world_s.wasm"
+            test_deploy: local.wadm.yaml
           - name: "http-jsonify"
             lang: "rust"
             wasm-bin: "http_jsonify_s.wasm"
+            test_deploy: local.wadm.yaml
           - name: "http-keyvalue-counter"
             lang: "rust"
             wasm-bin: "http_keyvalue_counter_s.wasm"
+            test_deploy: local.wadm.yaml
           - name: "keyvalue-messaging"
             lang: "rust"
             wasm-bin: "keyvalue_messaging_s.wasm"
+            test_deploy: local.wadm.yaml
           - name: "sqldb-postgres-query"
             lang: "rust"
             wasm-bin: "sqldb_postgres_query_s.wasm"
@@ -129,6 +139,7 @@ jobs:
           - name: "http-hello-world"
             lang: "typescript"
             lang_version: "20.x"
+            test_deploy: wadm.yaml
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       # Download wash binary & install to path
@@ -168,10 +179,37 @@ jobs:
         run: |
           npm install -g @bytecodealliance/jco
           npm install -g @bytecodealliance/componentize-js
+
       # Build example project(s)
       - name: build project
         run: wash build
         working-directory: examples/${{ matrix.project.lang }}/components/${{ matrix.project.name }}
+
+      # Run the local.wadm that comes with the example
+      - name: test component load
+        if: ${{ matrix.project.test_deploy && matrix.wash-version == 'current' }}
+        shell: bash
+        working-directory: examples/${{ matrix.project.lang }}/components/${{ matrix.project.name }}
+        run: |
+          set -xe
+          wash up &
+          WASH_PID=$!
+          sleep 3;
+          wash app deploy ${{ matrix.project.test_deploy }};
+          TRIES=0
+          while [[ $(wash get inventory --output=json | jq '.inventories[0].components | length') -eq 0 ]] ; do
+            if [[ $TRIES -gt 10 ]]; then
+              echo "❌ failed to find component in inventory output after deploying example manifest";
+              exit -1;
+            fi
+            TRIES=$((TRIES+1));
+            sleep 1;
+          done;
+          echo "✅ successfully started at least one component";
+          wash app delete ${{ matrix.project.test_deploy }};
+          kill $WASH_PID;
+          exit 0;
+
       # Save example as an artifact for later step(s)
       - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029
         if: ${{ startswith(github.ref, format('refs/tags/component-{0}-v', matrix.project.name)) }}

--- a/examples/golang/components/http-client-tinygo/local.wadm.yaml
+++ b/examples/golang/components/http-client-tinygo/local.wadm.yaml
@@ -1,0 +1,62 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: http-client-tinygo
+  annotations:
+    version: v0.0.1
+    description: 'HTTP client world demo in Golang (TinyGo), using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+    wasmcloud.dev/authors: wasmCloud team
+    wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-client-tinygo/wadm.yaml
+    wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-client-tinygo/README.md
+    wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/golang/components/http-client-tinygo
+    wasmcloud.dev/categories: |
+      http,outgoing-http,http-server,tinygo,golang,example
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: file://./build/http_client_tinygo_s.wasm
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+        # Establish a unidirectional link to the outgoing-handler,
+        # so the `http-component` component can make use of outgoing handler functionality
+        # (i.e. making external web requests)
+        - type: link
+          properties:
+            target: httpclient
+            namespace: wasi
+            package: http
+            interfaces: [outgoing-handler]
+
+    # Add a capability provider that enables HTTP access
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.22.0
+      traits:
+        # Link the httpserver to the component, and configure the HTTP server
+        # to listen on port 8080 for incoming requests
+        #
+        # Since the HTTP server calls the `http-component` component, we establish
+        # a unidirectional link from this `httpserver` provider (the "source")
+        # to the `http-component` component (the "target"), so the server can invoke
+        # the component to handle a request.
+        - type: link
+          properties:
+            target: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 127.0.0.1:8080
+
+    - name: httpclient
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-client:0.11.0

--- a/examples/rust/components/dog-fetcher/local.wadm.yaml
+++ b/examples/rust/components/dog-fetcher/local.wadm.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: dog-fetcher
+  annotations:
+    version: v0.0.1
+    description: 'HTTP hello world demo in Rust, showing use of the server and client providers'
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: file://./build/dog_fetcher_s.wasm
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+        # Establish a unidirectional link to the `httpclient` provider,
+        # so the `http-component` (dog-fetching) component can make use of httpclient functionality
+        # (i.e. making external web requests)            
+        - type: link
+          properties:
+            target: httpclient
+            namespace: wasi
+            package: http
+            interfaces: [outgoing-handler]
+
+    # Add a capability provider that enables HTTP access
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.22.0
+      traits:
+        # Link the httpserver to the component, and configure the HTTP server
+        # to listen on port 8080 for incoming requests
+        #
+        # Since the HTTP server calls the `http-component` component, we establish
+        # a unidirectional link from this `httpserver` provider (the "source")
+        # to the `http-component` component (the "target"), so the server can invoke
+        # the component to handle an incoming HTTP request.
+        - type: link
+          properties:
+            target: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 127.0.0.1:8080
+
+    - name: httpclient
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-client:0.11.0

--- a/examples/rust/components/echo-messaging/local.wadm.yaml
+++ b/examples/rust/components/echo-messaging/local.wadm.yaml
@@ -1,0 +1,52 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: rust-echo-messaging
+  annotations:
+    version: v0.0.1
+    description: 'Echo demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+spec:
+  components:
+    - name: echo
+      type: component
+      properties:
+        # To use the locally compiled code in this folder, use the line below instead after running `wash build`:
+        image: file://./build/echo_messaging_s.wasm
+        id: echo
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+        # Establish a unidirectional link to the messaging capability provider (powered by NATS),
+        # so the `echo` component can make use of messaging interface functionality
+        # (i.e. making interacting with the messaging system, in this case NATS)            
+        - type: link
+          properties:
+            target: nats
+            namespace: wasmcloud
+            package: messaging
+            interfaces: [consumer]
+
+    # Add a capability provider that implements `wasmcloud:messaging` using NATS
+    - name: nats
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/messaging-nats:canary
+      traits:
+        # Since the `nats` capability provider calls an component to handle messages 
+        # coming over subscriptions, this provider needs a unidirectional link to the
+        # component that wil be called.
+        # 
+        # Here we link the `nats` provider (the "source"), to the `echo` component (the "target"),
+        # so that so the provider can deliver messages to the component (by invoking the wasmcloud:messaging/handler interface) .
+        - type: link
+          properties:
+            target: echo
+            namespace: wasmcloud
+            package: messaging
+            interfaces: [handler]
+            source_config:
+              - name: simple-subscription
+                properties:
+                  subscriptions: wasmcloud.echo

--- a/examples/rust/components/ferris-says/local.wadm.yaml
+++ b/examples/rust/components/ferris-says/local.wadm.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: ferris-says
+  annotations:
+    version: v0.0.1
+    description: |
+      A simple demo of invocation of a cowsay-like function in wasmCloud, written in Rust
+spec:
+  components:
+    - name: ferris-says
+      type: component
+      properties:
+        # To use the locally compiled code in this folder, use the line below instead after running `wash build`:
+        image: file://./build/ferris_says_s.wasm
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1

--- a/examples/rust/components/http-blobstore/local.wadm.yaml
+++ b/examples/rust/components/http-blobstore/local.wadm.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: rust-http-blobstore
+  annotations:
+    version: v0.0.1
+    description: 'HTTP Blobstore demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+spec:
+  components:
+    # Component that serves the blobstore-over-HTTP abstraction
+    - name: http-blobstore
+      type: component
+      properties:
+        image: file://./build/http_blobstore_s.wasm
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+        # Link to the blobstore provider which provides the underlying storage interface
+        #
+        # Establish a unidirectional link to the `blobstore-fs` (the filesystem-powered blobstore provider),
+        # so the `http-blobstore` component can make use of blobstore functionality provided by the filesystem
+        # (i.e. reading/writing blobs)
+        - type: link
+          properties:
+            target: blobstore-fs
+            namespace: wasi
+            package: blobstore
+            interfaces: [blobstore]
+            target_config:
+              - name: root-directory
+                properties:
+                  root: '/tmp'
+
+    # Capability provider that serves HTTP requests
+    - name: httpserver
+      type: capability
+      properties:
+        # To use a locally compiled provider, uncomment the line below
+        # (and ensure that you've used `wash par crate` to create the par file below)
+        #
+        # image: file://../../../../crates/provider-http-server/provider-http-server.par.gz
+        image: ghcr.io/wasmcloud/http-server:0.22.0
+      traits:
+        # Since this HTTP server capability provider calls the `http-blobstore` component, we establish
+        # a unidirectional link from this `httpserer` provider (the "source")
+        # to the `http-blobstore` component (the "target"), so the server can invoke
+        # the component to handle an incoming HTTP request.
+        - type: link
+          properties:
+            target: http-blobstore
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 127.0.0.1:8080
+
+    # Capability provider that exposes a blobstore with the filesystem
+    - name: blobstore-fs
+      type: capability
+      properties:
+        # To use a locally compiled provider, uncomment the line below
+        # (and ensure that you've used `wash par crate` to create the par file below)
+        #
+        # image: file://../../../../crates/provider-blobstore-fs/provider-blobstore-fs.par.gz
+        image: ghcr.io/wasmcloud/blobstore-fs:0.7.0

--- a/examples/rust/components/http-hello-world/local.wadm.yaml
+++ b/examples/rust/components/http-hello-world/local.wadm.yaml
@@ -1,0 +1,39 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: rust-hello-world
+  annotations:
+    version: v0.0.1
+    description: 'HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: file://./build/http_hello_world_s.wasm
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+
+    # Add a capability provider that enables HTTP access
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.22.0
+      traits:
+        # Establish a unidirectional link from this http server provider (the "source")
+        # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
+        #
+        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8080
+        - type: link
+          properties:
+            target: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 127.0.0.1:8080

--- a/examples/rust/components/http-jsonify/local.wadm.yaml
+++ b/examples/rust/components/http-jsonify/local.wadm.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: rust-http-jsonify
+  annotations:
+    version: v0.0.1
+    description: |
+      A component that turns incoming HTTP requests into a JSON representation
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: file://./build/http_jsonify_s.wasm
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+
+    # Add a capability provider that enables HTTP access
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.22.0
+      traits:
+        # Link the httpserver to the component, and configure the HTTP server
+        # to listen on port 8080 for incoming requests
+        #
+        # Since the HTTP server calls the `http-component` component, we establish
+        # a unidirectional link from this `httpserver` provider (the "source")
+        # to the `http-component` component (the "target"), so the server can invoke
+        # the component to handle a request.
+        - type: link
+          properties:
+            target: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 127.0.0.1:8080

--- a/examples/rust/components/http-keyvalue-counter/local.wadm.yaml
+++ b/examples/rust/components/http-keyvalue-counter/local.wadm.yaml
@@ -1,0 +1,63 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: rust-http-kv
+  annotations:
+    version: v0.0.1
+    description: 'HTTP counter demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+spec:
+  components:
+    - name: counter
+      type: component
+      properties:
+        image: file://./build/http_keyvalue_counter_s.wasm
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+        # Link the component to Redis on the default Redis port
+        #
+        # Establish a unidirectional link to the `kvredis` (the keyvalue capability provider),
+        # so the `counter` component can make use of keyvalue functionality provided by the Redis
+        # (i.e. using a keyvalue cache)            
+        - type: link
+          properties:
+            target: kvredis
+            namespace: wasi
+            package: keyvalue
+            interfaces: [atomics, store]
+            target_config:
+              - name: redis-url
+                properties:
+                  url: redis://127.0.0.1:6379
+
+    # Add a capability provider that enables Redis access
+    - name: kvredis
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.25.0
+
+    # Add a capability provider that enables HTTP access
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.22.0
+      traits:
+        # Link the httpserver to the component, and configure the HTTP server
+        # to listen on port 8080 for incoming requests
+        #
+        # Since the HTTP server calls the `counter` component, we establish
+        # a unidirectional link from this `httpserver` provider (the "source")
+        # to the `counter` component (the "target"), so the server can invoke
+        # the component to handle a request.
+        - type: link
+          properties:
+            target: counter
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 127.0.0.1:8080

--- a/examples/rust/components/keyvalue-messaging/local.wadm.yaml
+++ b/examples/rust/components/keyvalue-messaging/local.wadm.yaml
@@ -1,0 +1,86 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: rust-keyvalue-demo
+  annotations:
+    version: v0.1.0
+    description: "NATS keyvalue demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)"
+spec:
+  components:
+    - name: kv-demo
+      type: component
+      properties:
+        image: file://./build/keyvalue_messaging_s.wasm
+        id: kv-demo
+        config:
+          - name: nats-kv-example
+            properties:
+              link_name1: "bucket-id1"
+              # link_name2: "bucket-id2"
+              pub_subject: "nats.demo"
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+        # Link the component to the local NATS server
+        - type: link
+          properties:
+            name: bucket-id1
+            target: nats-kv
+            namespace: wasi
+            package: keyvalue
+            interfaces: [store, atomics]
+            # NOTE: The following is an example of how to configure the NATS Kv capability provider, for an individual component
+            target_config:
+              - name: wasmcloud
+                properties:
+                  bucket: "WASMCLOUD"
+        # # NOTE: The following is an example of how to configure additional named links to the same capability provider
+        # - type: link
+        #   properties:
+        #     name: bucket-id2
+        #     target: nats-kv
+        #     namespace: wasi
+        #     package: keyvalue
+        #     interfaces: [store, atomics]
+        #     target_config:
+        #       - name: wasmland
+        #         properties:
+        #           bucket: "WASMLAND"
+        - type: link
+          properties:
+            target: nats-msg
+            namespace: wasmcloud
+            package: messaging
+            interfaces: [consumer]
+
+    # Add a capability provider that implements `wasi:keyvalue` using NATS
+    - name: nats-kv
+      type: capability
+      properties:
+        # image: file://../../../../src/bin/keyvalue-nats-provider/build/keyvalue-nats-provider.par.gz
+        image: ghcr.io/wasmcloud/keyvalue-nats:0.1.0
+        # # NOTE: The following is an example of how to provide default/shared configuration, to all components, which do not provide their own NATS connection configuration.
+        # config:
+        #   - name: nats-connection
+        #     properties:
+        #       cluster_uri: "nats://0.0.0.0:4222"
+        #       bucket: "WASMCLOUD"
+
+    # Add a capability provider that implements `wasmcloud:messaging` using NATS
+    - name: nats-msg
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/messaging-nats:canary
+      traits:
+        - type: link
+          properties:
+            target: kv-demo
+            namespace: wasmcloud
+            package: messaging
+            interfaces: [handler]
+            source_config:
+              - name: nats-subscription
+                properties:
+                  subscriptions: nats.atomic.delta


### PR DESCRIPTION
This commit adds a small bash script that loads an example component(s) and attempts to run it with `wash` & `wadm`, and waits until at least one component is running then exits.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
