### PR TITLE
feat(wash-cli): limit terminal to width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5764,6 +5764,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "termsize"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f11ff5c25c172608d5b85e2fb43ee9a6d683a7f4ab7f96ae07b3d8b590368fd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "test-case"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6795,6 +6805,7 @@ dependencies = [
  "tempfile",
  "term-table",
  "termcolor",
+ "termsize",
  "thiserror",
  "tokio",
  "tokio-tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,6 +289,7 @@ sysinfo = { version = "0.27", default-features = false }
 tempfile = { version = "3", default-features = false }
 term-table = { version = "=1.3.2", default-features = false }
 termcolor = { version = "1", default-features = false }
+termsize = { version = "0.1", default-features = false }
 # TODO(joonas): point testcontainers to a real version once 0.16.8 is released
 # so that https://github.com/testcontainers/testcontainers-rs/pull/633 is included.
 testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs.git", rev = "cb65ec251ba1fadca33d5dfc810c34bef3b5528b", default-features = false }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -57,6 +57,7 @@ sysinfo = { workspace = true }
 tempfile = { workspace = true }
 term-table = { workspace = true }
 termcolor = { workspace = true }
+termsize = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-tar = { workspace = true }

--- a/crates/wash-cli/src/app/output.rs
+++ b/crates/wash-cli/src/app/output.rs
@@ -9,7 +9,7 @@ use super::ModelSummary;
 
 pub fn list_revisions_table(revisions: Vec<VersionInfo>) -> String {
     let mut table = Table::new();
-    crate::util::configure_table_style(&mut table);
+    crate::util::configure_table_style(&mut table, 2);
 
     table.add_row(Row::new(vec![
         TableCell::new_with_alignment("Version", 1, Alignment::Left),
@@ -28,19 +28,16 @@ pub fn list_revisions_table(revisions: Vec<VersionInfo>) -> String {
 
 pub fn list_models_table(models: Vec<ModelSummary>) -> String {
     let mut table = Table::new();
-    crate::util::configure_table_style(&mut table);
+    crate::util::configure_table_style(&mut table, 3);
 
     table.add_row(Row::new(vec![
         TableCell::new_with_alignment("Name", 1, Alignment::Left),
-        TableCell::new_with_alignment("Latest Version", 1, Alignment::Left),
         TableCell::new_with_alignment("Deployed Version", 1, Alignment::Left),
-        TableCell::new_with_alignment("Deploy Status", 1, Alignment::Right),
-        TableCell::new_with_alignment("Description", 1, Alignment::Left),
+        TableCell::new_with_alignment("Status", 1, Alignment::Left),
     ]));
     models.iter().for_each(|m| {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment(m.name.clone(), 1, Alignment::Left),
-            TableCell::new_with_alignment(m.version.clone(), 1, Alignment::Left),
             TableCell::new_with_alignment(
                 m.deployed_version
                     .clone()
@@ -48,13 +45,16 @@ pub fn list_models_table(models: Vec<ModelSummary>) -> String {
                 1,
                 Alignment::Left,
             ),
-            TableCell::new_with_alignment(format!("{:?}", m.status), 1, Alignment::Right),
-            TableCell::new_with_alignment(
-                m.description.clone().unwrap_or_else(|| "N/A".to_string()),
-                1,
+            TableCell::new_with_alignment(format!("{:?}", m.status), 1, Alignment::Left),
+        ]));
+
+        if let Some(description) = m.description.as_ref() {
+            table.add_row(Row::new(vec![TableCell::new_with_alignment(
+                format!("  └ {}", description),
+                3,
                 Alignment::Left,
-            ),
-        ]))
+            )]));
+        }
     });
 
     table.render()
@@ -62,7 +62,7 @@ pub fn list_models_table(models: Vec<ModelSummary>) -> String {
 
 pub fn status_table(model_name: String, status: Status) -> String {
     let mut table = Table::new();
-    crate::util::configure_table_style(&mut table);
+    crate::util::configure_table_style(&mut table, 4);
 
     table.add_row(Row::new(vec![
         TableCell::new_with_alignment("Name", 1, Alignment::Left),

--- a/crates/wash-cli/src/ctl/output.rs
+++ b/crates/wash-cli/src/ctl/output.rs
@@ -58,7 +58,7 @@ pub fn link_del_output(
 /// Helper function to transform a LinkDefinitionList into a table string for printing
 pub fn links_table(list: Vec<InterfaceLinkDefinition>) -> String {
     let mut table = Table::new();
-    crate::util::configure_table_style(&mut table);
+    crate::util::configure_table_style(&mut table, 4);
 
     table.add_row(Row::new(vec![
         TableCell::new_with_alignment("Source ID", 1, Alignment::Left),
@@ -86,18 +86,18 @@ pub fn links_table(list: Vec<InterfaceLinkDefinition>) -> String {
 /// Helper function to transform a Host list into a table string for printing
 pub fn hosts_table(hosts: Vec<Host>) -> String {
     let mut table = Table::new();
-    crate::util::configure_table_style(&mut table);
+    crate::util::configure_table_style(&mut table, 4);
 
     table.add_row(Row::new(vec![
-        TableCell::new_with_alignment("Host ID", 1, Alignment::Left),
-        TableCell::new_with_alignment("Uptime (seconds)", 1, Alignment::Left),
+        TableCell::new_with_alignment("Host ID", 2, Alignment::Left),
         TableCell::new_with_alignment("Friendly name", 1, Alignment::Left),
+        TableCell::new_with_alignment("Uptime (seconds)", 1, Alignment::Left),
     ]));
     hosts.iter().for_each(|h| {
         table.add_row(Row::new(vec![
-            TableCell::new_with_alignment(h.id.clone(), 1, Alignment::Left),
-            TableCell::new_with_alignment(format!("{}", h.uptime_seconds), 1, Alignment::Left),
+            TableCell::new_with_alignment(h.id.clone(), 2, Alignment::Left),
             TableCell::new_with_alignment(h.friendly_name.clone(), 1, Alignment::Left),
+            TableCell::new_with_alignment(format!("{}", h.uptime_seconds), 1, Alignment::Left),
         ]))
     });
 
@@ -107,22 +107,22 @@ pub fn hosts_table(hosts: Vec<Host>) -> String {
 /// Helper function to transform a HostInventory into a table string for printing
 pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
     let mut table = Table::new();
-    crate::util::configure_table_style(&mut table);
+    crate::util::configure_table_style(&mut table, 3);
 
     invs.into_iter().for_each(|inv| {
         table.add_row(Row::new(vec![
-            TableCell::new_with_alignment("Host ID", 1, Alignment::Left),
+            TableCell::new_with_alignment("Host ID", 2, Alignment::Left),
             TableCell::new_with_alignment("Friendly name", 1, Alignment::Left),
         ]));
         table.add_row(Row::new(vec![
-            TableCell::new_with_alignment(inv.host_id.clone(), 1, Alignment::Left),
+            TableCell::new_with_alignment(inv.host_id.clone(), 2, Alignment::Left),
             TableCell::new_with_alignment(inv.friendly_name.clone(), 1, Alignment::Left),
         ]));
 
         if !inv.labels.is_empty() {
             table.add_row(Row::new(vec![TableCell::new_with_alignment(
                 "",
-                2,
+                3,
                 Alignment::Left,
             )]));
             table.add_row(Row::new(vec![TableCell::new_with_alignment(
@@ -207,7 +207,7 @@ pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
 /// Helper function to transform a ClaimsList into a table string for printing
 pub fn claims_table(list: Vec<HashMap<String, String>>) -> String {
     let mut table = Table::new();
-    crate::util::configure_table_style(&mut table);
+    crate::util::configure_table_style(&mut table, 2);
 
     table.add_row(Row::new(vec![TableCell::new_with_alignment(
         "Claims",
@@ -277,14 +277,13 @@ pub fn claims_table(list: Vec<HashMap<String, String>>) -> String {
 /// Helper function to transform a list of plugin metadata into a table string for printing
 pub fn plugins_table(list: Vec<&Metadata>) -> String {
     let mut table = Table::new();
-    crate::util::configure_table_style(&mut table);
+    crate::util::configure_table_style(&mut table, 4);
 
     table.add_row(Row::new(vec![
         TableCell::new_with_alignment("Name", 1, Alignment::Left),
         TableCell::new_with_alignment("ID", 1, Alignment::Left),
         TableCell::new_with_alignment("Version", 1, Alignment::Left),
         TableCell::new_with_alignment("Author", 1, Alignment::Left),
-        TableCell::new_with_alignment("Description", 1, Alignment::Left),
     ]));
     list.into_iter().for_each(|metadata| {
         table.add_row(Row::new(vec![
@@ -292,8 +291,14 @@ pub fn plugins_table(list: Vec<&Metadata>) -> String {
             TableCell::new_with_alignment(&metadata.id, 1, Alignment::Left),
             TableCell::new_with_alignment(&metadata.version, 1, Alignment::Left),
             TableCell::new_with_alignment(&metadata.author, 1, Alignment::Left),
-            TableCell::new_with_alignment(&metadata.description, 1, Alignment::Left),
         ]));
+        if !metadata.description.is_empty() {
+            table.add_row(Row::new(vec![TableCell::new_with_alignment(
+                format!("  └ {}", metadata.description),
+                4,
+                Alignment::Left,
+            )]));
+        }
     });
 
     table.render()

--- a/crates/wash-cli/src/util.rs
+++ b/crates/wash-cli/src/util.rs
@@ -11,6 +11,8 @@ use wash_lib::{
     plugin::{subcommand::SubcommandRunner, PLUGIN_DIR},
 };
 
+const MAX_TERMINAL_WIDTH: usize = 120;
+
 pub fn format_optional(value: Option<String>) -> String {
     value.unwrap_or_else(|| "N/A".into())
 }
@@ -142,9 +144,16 @@ pub fn msgpack_to_json_val(msg: Vec<u8>, bin_str: char) -> serde_json::Value {
     }
 }
 
-pub fn configure_table_style(table: &mut Table<'_>) {
+pub fn configure_table_style(table: &mut Table<'_>, num_rows: usize) {
     table.style = empty_table_style();
     table.separate_rows = false;
+
+    // Sets the max column width to ensure the table evenly fills the terminal width
+    table.max_column_width = termsize::get()
+        // Just slightly reducing the terminal width to account for padding
+        .map(|size| size.cols.saturating_sub(4) as usize)
+        .unwrap_or(MAX_TERMINAL_WIDTH)
+        / num_rows;
 }
 
 fn empty_table_style() -> TableStyle {


### PR DESCRIPTION
## Feature or Problem
This PR introduces the `termwidth` dependency and ensures that our terminal commands don't overflow the width.

Some examples of the before and after terminal displays:

`wash app list`
<img width="1697" alt="image" src="https://github.com/user-attachments/assets/a2acb169-734a-41c1-84d6-66a1e628df25">

`wash plugin list`
<img width="1674" alt="image" src="https://github.com/user-attachments/assets/774ac4d9-b158-4b08-95fa-72ea47d56f00">

`wash get hosts`
<img width="1422" alt="image" src="https://github.com/user-attachments/assets/823d37fc-d53f-4edd-9e19-81fff290c388">

## Related Issues
Fixes #2660 

## Release Information
wash-cli 0.31.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
