### PR TITLE
fix(host): always publish component_scale event

### DIFF
--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -1,5 +1,3 @@
-use core::num::NonZeroUsize;
-
 use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Context;
@@ -70,7 +68,7 @@ pub fn component_scale_failed(
     host_id: impl AsRef<str>,
     image_ref: impl AsRef<str>,
     component_id: impl AsRef<str>,
-    max_instances: NonZeroUsize,
+    max_instances: u32,
     error: &anyhow::Error,
 ) -> serde_json::Value {
     if let Some(claims) = claims {


### PR DESCRIPTION
## Feature or Problem
I noticed that if a component fails to scale because of an issue with OCI downloads, claims extraction, or policy server denial, we don't publish the `component_scale_failed` event. This PR ensures:
1. Any error during component scaling is reflected as an event
1. Any scale operation, even if a no-op (e.g. requested scale that's already running) publishes an event to ensure the idempotency of the command. This helps consumers like wash always know their request completed successfully.

- [ ] It doesn't have to happen in this PR, but it might be nice to ensure that the provider & update commands also reflect this idempotency

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
