### PR TITLE
chore(host): Make wasmcloud host heartbeat interval configurable

### DIFF
--- a/crates/host/src/wasmbus/host_config.rs
+++ b/crates/host/src/wasmbus/host_config.rs
@@ -63,6 +63,8 @@ pub struct Host {
     pub version: String,
     /// The Max Execution time for Host runtime
     pub max_execution_time: Duration,
+    /// The interval at which the Host will send heartbeats
+    pub heartbeat_interval: Option<Duration>,
 }
 
 /// Configuration for wasmCloud policy service
@@ -106,6 +108,7 @@ impl Default for Host {
             secrets_topic_prefix: None,
             version: env!("CARGO_PKG_VERSION").to_string(),
             max_execution_time: Duration::from_millis(10 * 60 * 1000),
+            heartbeat_interval: None,
         }
     }
 }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -641,7 +641,7 @@ async fn merge_registry_config(
 }
 
 impl Host {
-    const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+    const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 
     const NAME_ADJECTIVES: &'static str = "
     autumn hidden bitter misty silent empty dry dark summer
@@ -763,11 +763,13 @@ impl Host {
 
         let start_at = Instant::now();
 
+        let heartbeat_interval = config
+            .heartbeat_interval
+            .unwrap_or(Self::DEFAULT_HEARTBEAT_INTERVAL);
         let heartbeat_start_at = start_at
-            .checked_add(Self::HEARTBEAT_INTERVAL)
+            .checked_add(heartbeat_interval)
             .context("failed to compute heartbeat start time")?;
-        let heartbeat =
-            IntervalStream::new(interval_at(heartbeat_start_at, Self::HEARTBEAT_INTERVAL));
+        let heartbeat = IntervalStream::new(interval_at(heartbeat_start_at, heartbeat_interval));
 
         let (stop_tx, stop_rx) = watch::channel(None);
 


### PR DESCRIPTION
## Feature or Problem

For integration testing, it would be nice to make the host heartbeat interval configurable so that it can be shortened in an integration testing that uses the heartbeats.

In the future being able to adjust the host heartbeat frequency would also open up the possibility of reducing the amount of heartbeat traffic in a large deployment, though this likely necessitates changes in other components of the system as well (i.e. adjusting the wadm side of things appropriately as well).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
