### PR TITLE
chore(wasmcloud): bump to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7095,7 +7095,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "1.1.0"
+version = "1.1.1"
 description = "wasmCloud host runtime"
 default-run = "wasmcloud"
 readme = "README.md"


### PR DESCRIPTION
## Feature or Problem
Bumping to 1.1.1 since I want to release https://github.com/wasmCloud/wasmCloud/pull/2674

## Related Issues
https://github.com/wasmCloud/wasmCloud/pull/2674

## Release Information
wasmcloud 1.1.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
