### PR TITLE
ci(examples): validate app wadm.yaml

### DIFF
--- a/.github/workflows/examples-components.yml
+++ b/.github/workflows/examples-components.yml
@@ -180,11 +180,13 @@ jobs:
           npm install -g @bytecodealliance/jco
           npm install -g @bytecodealliance/componentize-js
 
-      # Validate example wadm.yaml if the example has one
+      # Validate example [local.]wadm.yaml if present
       - name: validate wadm.yaml
-        if: ${{ hashFiles(format('examples/{0}/{1}/components/wadm.yaml', matrix.project.lang, matrix.project.name)) != '' }}
-        run: wash app validate wadm.yaml
         working-directory: examples/${{ matrix.project.lang }}/components/${{ matrix.project.name }}
+        shell: bash
+        run: |
+          [[ ! -f wadm.yaml ]] || wash app validate wadm.yaml
+          [[ ! -f local.wadm.yaml ]] || wash app validate local.wadm.yaml
 
       # Build example project(s)
       - name: build project


### PR DESCRIPTION
This adds an additional step to building example components.

## Feature or Problem
Ensure `wash app validate` passes for example `wadm.yaml`.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
#2697

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
Review of GH CI
