### PR TITLE
fix: resource future table blobstore

### DIFF
--- a/crates/runtime/src/capability.rs
+++ b/crates/runtime/src/capability.rs
@@ -9,8 +9,7 @@ mod wasmtime_bindings {
 
     mod blobstore {
         pub type Container = std::sync::Arc<str>;
-        pub type IncomingValue =
-            core::pin::Pin<Box<dyn futures::Stream<Item = bytes::Bytes> + Send>>;
+        pub type IncomingValue = crate::component::HostInputStreamer;
         pub type OutgoingValue = crate::io::AsyncVec;
         pub type StreamObjectNames = crate::io::BufferedIncomingStream<String>;
     }

--- a/crates/runtime/src/component/blobstore.rs
+++ b/crates/runtime/src/component/blobstore.rs
@@ -99,7 +99,14 @@ where
             (Ok(stream), io) => {
                 if let Some(io) = io {
                     // TODO: Move this into the runtime
-                    io.await.context("failed to perform async I/O")?;
+                    let handle = tokio::spawn(async move {
+                        if let Err(e) = io.await {
+                            tracing::error!("Error awaiting async IO: {:?}", e);
+                        }
+                    });
+                    self.table
+                        .push(handle)
+                        .context("failed to push async I/O")?;
                 }
                 let value = self
                     .table

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -21,6 +21,7 @@ use wrpc_runtime_wasmtime::{
     collect_component_resources, link_item, ServeExt as _, SharedResourceTable, WrpcView,
 };
 
+pub use blobstore::HostInputStreamer;
 pub use bus::Bus;
 pub use config::Config;
 pub use logging::Logging;

--- a/examples/rust/components/blobby/src/lib.rs
+++ b/examples/rust/components/blobby/src/lib.rs
@@ -3,18 +3,16 @@
 
 wit_bindgen::generate!();
 
-use std::io::{Read, Write};
-
 use http::{
     header::{ALLOW, CONTENT_LENGTH},
     StatusCode,
 };
 
 use exports::wasi::http::incoming_handler::Guest;
-use wasi::blobstore::blobstore;
 use wasi::http::types::*;
 use wasi::logging::logging::{log, Level};
-use wrapper::OutputStreamWriter;
+use wasi::{blobstore::blobstore, io::streams::InputStream};
+use wrapper::stream_input_to_output;
 
 mod wrapper;
 
@@ -68,11 +66,10 @@ fn send_response_error(response_out: ResponseOutparam, error: Error) {
         .set_status_code(error.status_code.as_u16())
         .expect("Unable to set status code");
     let response_body = response.body().expect("body called more than once");
-    let mut writer = response_body.write().expect("should only call write once");
+    let writer = response_body.write().expect("should only call write once");
 
-    let mut stream = OutputStreamWriter::from(&mut writer);
-
-    if let Err(e) = stream.write_all(error.message.as_bytes()) {
+    // It's highly unlikely our error message will be more than 4096 bytes
+    if let Err(e) = writer.blocking_write_and_flush(error.message.as_bytes()) {
         log(
             Level::Error,
             "handle",
@@ -158,42 +155,15 @@ impl Guest for Blobby {
                     .set_status_code(StatusCode::OK.as_u16())
                     .expect("Unable to set status code");
                 let response_body = response.body().unwrap();
-                let mut stream = response_body.write().expect("Unable to get stream");
-                let mut outstream = OutputStreamWriter::from(&mut stream);
-                if let Err(e) = outstream.write_all(&data) {
-                    log(
-                        Level::Error,
-                        "handle",
-                        format!("Failed to write to stream: {}", e).as_str(),
-                    );
-                    send_response_error(
-                        response_out,
-                        Error {
-                            status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                            message: "Unable to send data to client".to_string(),
-                        },
-                    );
-                    return;
-                }
-                if let Err(e) = outstream.flush() {
-                    log(
-                        Level::Error,
-                        "handle",
-                        format!("Failed to flush stream: {}", e).as_str(),
-                    );
-                    send_response_error(
-                        response_out,
-                        Error {
-                            status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                            message: "Unable to flush data to client".to_string(),
-                        },
-                    );
-                    return;
-                }
-                // This MUST be dropped to free the resource
-                drop(stream);
-                let response = OutgoingBody::finish(response_body, None)
-                    .map(|_| response)
+                ResponseOutparam::set(response_out, Ok(response));
+                log(Level::Debug, "handle", "Writing data to stream");
+                stream_input_to_output(
+                    data,
+                    response_body.write().expect("Unable to get stream"),
+                    None,
+                )
+                .expect("failed to stream blob to http response body");
+                OutgoingBody::finish(response_body, None)
                     .map_err(|e| {
                         log(
                             Level::Error,
@@ -201,8 +171,9 @@ impl Guest for Blobby {
                             format!("Failed to finish response body: {}", e).as_str(),
                         );
                         e
-                    });
-                ResponseOutparam::set(response_out, response);
+                    })
+                    .expect("failed to finish outgoing body");
+
                 return;
             }
             Method::Post | Method::Put => {
@@ -221,12 +192,8 @@ impl Guest for Blobby {
                         return;
                     }
                 };
-                let mut stream = body
-                    .stream()
-                    .expect("Unable to get stream from request body");
                 // HACK(thomastaylor312): We are requiring the content length header to be set so we
-                // can splice the stream properly. This should be better with wasi 0.2.2 which will
-                // introduce a stream forward function
+                // can limit the bytes when splicing the stream.
                 let raw_header = request.headers().get(&CONTENT_LENGTH.to_string());
                 // Yep, wasi http really is gross. The way the `get` function works is that it
                 // returns an empty vec if the header is not set, but a vec with one empty vec if
@@ -272,31 +239,10 @@ impl Guest for Blobby {
                     }
                 };
 
-                // Only read up to the exact amount of bytes we need. This is to prevent a bad component
-                // from sending infinite data
-                let mut buf = vec![
-                    0u8;
-                    content_length
-                        .try_into()
-                        .expect("Too much data to read into component")
-                ];
-                if let Err(e) = stream.read_exact(&mut buf) {
-                    log(
-                        Level::Error,
-                        "handle",
-                        format!("Failed to read request body: {}", e).as_str(),
-                    );
-                    send_response_error(
-                        response_out,
-                        Error {
-                            status_code: StatusCode::BAD_REQUEST,
-                            message: "Failed to read request body".to_string(),
-                        },
-                    );
-                    return;
-                }
-
-                put_object(&container_id, &file_name, buf)
+                let stream = body
+                    .stream()
+                    .expect("Unable to get stream from request body");
+                put_object(&container_id, &file_name, stream, content_length)
             }
             Method::Delete => delete_object(&container_id, &file_name),
             _ => {
@@ -333,7 +279,7 @@ impl Guest for Blobby {
 // HACK(thomastaylor312): We are returning the full object in memory because there isn't really a
 // way to glue in the streams to each other right now. This should get better in wasi 0.2.2 with the
 // stream forward function
-fn get_object(container_name: &String, object_name: &String) -> Result<Vec<u8>> {
+fn get_object(container_name: &String, object_name: &String) -> Result<InputStream> {
     // Check that the object exists first. If it doesn't return the proper http response
     let container =
         blobstore::get_container(container_name).map_err(Error::from_blobstore_error)?;
@@ -350,7 +296,7 @@ fn get_object(container_name: &String, object_name: &String) -> Result<Vec<u8>> 
     let incoming = container
         .get_data(object_name, 0, metadata.size)
         .map_err(Error::from_blobstore_error)?;
-    let body = wasi::blobstore::types::IncomingValue::incoming_value_consume_sync(incoming)
+    let body = wasi::blobstore::types::IncomingValue::incoming_value_consume_async(incoming)
         .map_err(Error::from_blobstore_error)?;
 
     log(Level::Info, "get_object", "successfully got object stream");
@@ -367,43 +313,22 @@ fn delete_object(container_name: &String, object_name: &String) -> Result<Status
         .map_err(Error::from_blobstore_error)
 }
 
-// HACK(thomastaylor312): We are passing the full object in memory because there isn't really a way
-// to glue in the streams to each other right now. This should get better in wasi 0.2.2 with the
-// stream forward function
-fn put_object(container_name: &String, object_name: &String, data: Vec<u8>) -> Result<StatusCode> {
+fn put_object(
+    container_name: &String,
+    object_name: &String,
+    data: InputStream,
+    content_length: u64,
+) -> Result<StatusCode> {
     let container =
         blobstore::get_container(container_name).map_err(Error::from_blobstore_error)?;
     let result_value = wasi::blobstore::types::OutgoingValue::new_outgoing_value();
 
-    let mut body = result_value
+    let body = result_value
         .outgoing_value_write_body()
         .expect("failed to get outgoing value output stream");
 
-    let mut out = OutputStreamWriter::from(&mut body);
-
-    if let Err(e) = out.write_all(&data) {
-        log(
-            Level::Error,
-            "put_object",
-            &format!("Failed to write data to blobstore: {}", e),
-        );
-        return Err(Error {
-            status_code: StatusCode::INTERNAL_SERVER_ERROR,
-            message: format!("Failed to write data to blobstore: {}", e),
-        });
-    }
-
-    if let Err(e) = out.flush() {
-        log(
-            Level::Error,
-            "put_object",
-            &format!("Failed to flush data to blobstore: {}", e),
-        );
-        return Err(Error {
-            status_code: StatusCode::INTERNAL_SERVER_ERROR,
-            message: format!("Failed to flush data to blobstore: {}", e),
-        });
-    }
+    stream_input_to_output(data, body, Some(content_length))
+        .expect("failed to stream data from http response to blobstore");
 
     if let Err(e) = container.write_data(object_name, &result_value) {
         log(

--- a/examples/rust/components/blobby/src/wrapper.rs
+++ b/examples/rust/components/blobby/src/wrapper.rs
@@ -2,111 +2,38 @@
 // something we should probably make part of wit-bindgen or something else since this will be a
 // common thing people will need in Rust
 
-use std::io;
-use std::io::Read;
+use crate::wasi::{
+    io::streams::{InputStream, OutputStream, StreamError},
+    logging::logging::{log, Level},
+};
 
-use crate::wasi::io::streams::StreamError;
-
-impl Read for crate::wasi::io::streams::InputStream {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let n = buf
-            .len()
-            .try_into()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-        match self.blocking_read(n) {
-            Ok(chunk) => {
-                let n = chunk.len();
-                if n > buf.len() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "more bytes read than requested",
-                    ));
+/// Helper function to read all the data from the input stream and write it to the output stream
+/// Optionally takes a length to limit the number of bytes read from the input stream
+pub fn stream_input_to_output(
+    data: InputStream,
+    out: OutputStream,
+    len: Option<u64>,
+) -> Result<(), StreamError> {
+    let mut total_len = len.unwrap_or(u64::MAX);
+    loop {
+        match out.blocking_splice(&data, total_len) {
+            Ok(bytes_spliced) => match total_len.checked_sub(bytes_spliced) {
+                Some(0) | None => return Ok(()),
+                Some(new_len) => total_len = new_len,
+            },
+            Err(e) => match e {
+                StreamError::Closed => {
+                    return Ok(());
                 }
-                buf[..n].copy_from_slice(&chunk);
-                Ok(n)
-            }
-            Err(StreamError::Closed) => Ok(0),
-            Err(StreamError::LastOperationFailed(e)) => {
-                Err(io::Error::new(io::ErrorKind::Other, e.to_debug_string()))
-            }
+                StreamError::LastOperationFailed(e) => {
+                    log(
+                        Level::Error,
+                        "stream_input_to_output",
+                        format!("last operation failed: {:?}", e).as_str(),
+                    );
+                    return Err(StreamError::LastOperationFailed(e));
+                }
+            },
         }
-    }
-}
-
-// NOTE(thomastaylor312): This is soooo weird. So for some reason if I make sure to explicitly call
-// write (crate::wasi::io::streams::OutputStream::write), it never writes the bytes successfully,
-// but if we use the wrapper below (copied directly from `wasmcloud-component`), it works. To make it
-// even worse, when we were using it to write to the http response, it worked, but not for the
-// blobstore. There is probably some sort of simple thing that could fix this but I don't know what.
-
-// impl Write for crate::wasi::io::streams::OutputStream {
-//     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-//         let n = match self.check_write().map(std::num::NonZeroU64::new) {
-//             Ok(Some(n)) => n,
-//             Ok(None) | Err(StreamError::Closed) => return Ok(0),
-//             Err(StreamError::LastOperationFailed(e)) => {
-//                 return Err(io::Error::new(io::ErrorKind::Other, e.to_debug_string()))
-//             }
-//         };
-//         let n = n
-//             .get()
-//             .try_into()
-//             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-//         let n = buf.len().min(n);
-//         log(Level::Info, "write", &format!("n: {}", n));
-//         crate::wasi::io::streams::OutputStream::write(self.borrow(), &buf[..n]).map_err(
-//             |e| match e {
-//                 StreamError::Closed => io::ErrorKind::UnexpectedEof.into(),
-//                 StreamError::LastOperationFailed(e) => {
-//                     io::Error::new(io::ErrorKind::Other, e.to_debug_string())
-//                 }
-//             },
-//         )?;
-//         Ok(n)
-//     }
-
-//     fn flush(&mut self) -> std::io::Result<()> {
-//         self.blocking_flush()
-//             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
-//     }
-// }
-
-pub struct OutputStreamWriter<'a> {
-    stream: &'a mut crate::wasi::io::streams::OutputStream,
-}
-
-impl<'a> From<&'a mut crate::wasi::io::streams::OutputStream> for OutputStreamWriter<'a> {
-    fn from(stream: &'a mut crate::wasi::io::streams::OutputStream) -> Self {
-        Self { stream }
-    }
-}
-
-impl std::io::Write for OutputStreamWriter<'_> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let n = match self.stream.check_write().map(std::num::NonZeroU64::new) {
-            Ok(Some(n)) => n,
-            Ok(None) | Err(StreamError::Closed) => return Ok(0),
-            Err(StreamError::LastOperationFailed(e)) => {
-                return Err(io::Error::new(io::ErrorKind::Other, e.to_debug_string()))
-            }
-        };
-        let n = n
-            .get()
-            .try_into()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-        let n = buf.len().min(n);
-        self.stream.write(&buf[..n]).map_err(|e| match e {
-            StreamError::Closed => io::ErrorKind::UnexpectedEof.into(),
-            StreamError::LastOperationFailed(e) => {
-                io::Error::new(io::ErrorKind::Other, e.to_debug_string())
-            }
-        })?;
-        Ok(n)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.stream
-            .blocking_flush()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
     }
 }

--- a/examples/rust/components/blobby/wadm.yaml
+++ b/examples/rust/components/blobby/wadm.yaml
@@ -69,4 +69,4 @@ spec:
     - name: blobstore
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/blobstore-fs:0.7.0
+        image: ghcr.io/wasmcloud/blobstore-fs:0.8.0

--- a/tests/components/rust/interfaces-reactor/src/lib.rs
+++ b/tests/components/rust/interfaces-reactor/src/lib.rs
@@ -80,7 +80,7 @@ pub fn run_test(body: &[u8]) -> (Vec<u8>, String) {
         "guid": HostRng::generate_guid(),
         "random_32": HostRng::random32(),
         "random_in_range": HostRng::random_in_range(min, max),
-        "long_value": "1234567890".repeat(1000),
+        "long_value": "1234567890".repeat(10000),
         "config_value": config::runtime::get(&config_key).expect("failed to get config value"),
         "all_config": config::runtime::get_all().expect("failed to get all config values"),
         "ping": pong,
@@ -89,7 +89,6 @@ pub fn run_test(body: &[u8]) -> (Vec<u8>, String) {
         "is_same": is_same,
         "archie": is_good_boy,
     });
-    eprintln!("response: `{res:?}`");
 
     let body = serde_json::to_vec(&res).expect("failed to encode response to JSON");
 

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -43,7 +43,7 @@ async fn interfaces() -> anyhow::Result<()> {
         .with(tracing_subscriber::fmt::layer().compact().without_time())
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")
+                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=debug")
             }),
         )
         .init();
@@ -509,7 +509,7 @@ async fn interfaces() -> anyhow::Result<()> {
     ensure!(config_value.is_none());
     ensure!(all_config == []);
     ensure!(ping == "pong");
-    ensure!(long_value == "1234567890".repeat(1000));
+    ensure!(long_value == "1234567890".repeat(10000));
     ensure!(meaning_of_universe == 42);
     ensure!(split == ["hi", "there", "friend"]);
     ensure!(is_same);


### PR DESCRIPTION
This PR is meant to spur a little discussion, and it contains two fixes.

1. Awaiting the blobstore `get_container_data` async I/O future inside of a tokio task, and storing that task in the resource table of the component
2. Setting blobby's `ResponseOutparam` before trying to write the body of the file.
	1. This fix isn't complete yet and contains some commented out code where blobby attempts to send back 500 errors when we hit component issues, which is good 

## Feature or Problem
Without either of these fixes, using wasmCloud 1.1.0 and blobstore-fs 0.8.0, any object that is bigger than 524kb ends up hanging at the `get_container_data` async I/O future and never returns. This is, of course, a problem, but it is isolated to the component.

With the fix of awaiting the blobstore future inside of a task, and putting that future inside of the resource table (which I believe is what @rvolosatovs alluded to as a need but I might be misinterpreting) I can download blobs of ~1.2Mb

~With the blobby fix, I can download blobs of ~2Mb before I fail to write all the data. Depending on how inefficient blobby is, this might just approach the memory limit we have set for components /shrug.~

After the most recent force push, I've updated the code to use `splice`, which streams data directly instead of reading it entirely into memory. With this I've been able to use blobby to stream a 890megabyte file.

This is all strange because, with a pure HTTP component, I've been able to stream hundreds of megabytes through a component without any issues. So I believe this is either a bug in how we're transmitting data, or a lack of streaming in blobby specifically. If it's the latter, I'd like to fix the issue so that we can show examples of the right usage here.

## Related Issues
Attempting to address https://github.com/wasmCloud/wasmCloud/issues/2475

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Here's the blobby component uploading & downloading a 2.3Gb file
```bash
➜ curl -H 'Content-Type: application/gzip' -v 'http://127.0.0.1:8080/container.tar.gz' -T big.tar.gz -X POST
*   Trying 127.0.0.1:8080...
* Connected to 127.0.0.1 (127.0.0.1) port 8080
> POST /container.tar.gz HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Type: application/gzip
> Content-Length: 2292479488
> Expect: 100-continue
>
< HTTP/1.1 100 Continue
<
* upload completely sent off: 2292479488 bytes
< HTTP/1.1 201 Created
< vary: origin, access-control-request-method, access-control-request-headers
< access-control-allow-origin: *
< access-control-expose-headers: *
< transfer-encoding: chunked
< date: Thu, 08 Aug 2024 14:42:15 GMT
<
* Connection #0 to host 127.0.0.1 left intact

➜ curl 'http://127.0.0.1:8080/container.tar.gz' --output big2.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2186M    0 2186M    0     0   110M      0 --:--:--  0:00:19 --:--:--  113M

# no difference
➜ diff big.tar.gz big2.tar.gz
🛁 wash 0.30.0 took 9s
```
