### PR TITLE
feat(host)!: allow tuning runtime parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -1373,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "c937d4061031a6d0c8da4b9a4f98a172fc2976dfb1c19213a9cf7d0d3c837e36"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1383,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "85379ba512b21a328adf887e85f7742d12e96eb31f3ef077df4ffc26b506ffed"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.12"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8670053e87c316345e384ca1f3eba3006fc6355ed8b8a1140d104e109e3df34"
+checksum = "aa3c596da3cf0983427b0df0dba359df9182c13bd5b519b585a482b0c351f4e8"
 dependencies = [
  "clap",
 ]
@@ -5216,9 +5216,9 @@ checksum = "224e328af6e080cddbab3c770b1cf50f0351ba0577091ef2410c3951d835ff87"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
 dependencies = [
  "serde_derive",
 ]
@@ -5253,9 +5253,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/host/src/wasmbus/host_config.rs
+++ b/crates/host/src/wasmbus/host_config.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use nkeys::KeyPair;
 use url::Url;
 use wasmcloud_core::{logging::Level as LogLevel, OtelConfig};
+use wasmcloud_runtime::{MAX_COMPONENTS, MAX_COMPONENT_SIZE, MAX_LINEAR_MEMORY};
 
 /// wasmCloud Host configuration
 #[allow(clippy::struct_excessive_bools)]
@@ -61,8 +62,14 @@ pub struct Host {
     /// The semver version of the host. This is used by a consumer of this crate to indicate the
     /// host version (which may differ from the crate version)
     pub version: String,
-    /// The Max Execution time for Host runtime
+    /// The maximum execution time for a component instance
     pub max_execution_time: Duration,
+    /// The maximum linear memory that a component instance can allocate
+    pub max_linear_memory: u64,
+    /// The maximum size of a component binary that can be loaded
+    pub max_component_size: u64,
+    /// The maximum number of components that can be run simultaneously
+    pub max_components: u32,
     /// The interval at which the Host will send heartbeats
     pub heartbeat_interval: Option<Duration>,
 }
@@ -108,6 +115,11 @@ impl Default for Host {
             secrets_topic_prefix: None,
             version: env!("CARGO_PKG_VERSION").to_string(),
             max_execution_time: Duration::from_millis(10 * 60 * 1000),
+            // 10 MB
+            max_linear_memory: MAX_LINEAR_MEMORY,
+            // 50 MB
+            max_component_size: MAX_COMPONENT_SIZE,
+            max_components: MAX_COMPONENTS,
             heartbeat_interval: None,
         }
     }

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -773,9 +773,11 @@ impl Host {
 
         let (stop_tx, stop_rx) = watch::channel(None);
 
-        // TODO: Configure
         let (runtime, epoch, epoch_end) = Runtime::builder()
             .max_execution_time(config.max_execution_time)
+            .max_linear_memory(config.max_linear_memory)
+            .max_components(config.max_components)
+            .max_component_size(config.max_component_size)
             .build()
             .context("failed to build runtime")?;
         let event_builder = EventBuilderV10::new().source(host_key.public_key());

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,19 @@ struct Args {
     /// If provided, allows to set a custom Max Execution time for the Host in ms.
     #[clap(long = "max-execution-time-ms", default_value = "600000", env = "WASMCLOUD_MAX_EXECUTION_TIME_MS", value_parser = parse_duration_millis)]
     max_execution_time: Duration,
+    /// The maximum amount of memory bytes that a component can allocate
+    #[clap(long = "max-linear-memory-bytes", default_value_t = 10 * 1024 * 1024, env = "WASMCLOUD_MAX_LINEAR_MEMORY")]
+    max_linear_memory: u64,
+    /// The maximum byte size of a component binary that can be loaded
+    #[clap(long = "max-component-size-bytes", default_value_t = 50 * 1024 * 1024, env = "WASMCLOUD_MAX_COMPONENT_SIZE")]
+    max_component_size: u64,
+    /// The maximum number of components that can be run simultaneously
+    #[clap(
+        long = "max-components",
+        default_value_t = 10000,
+        env = "WASMCLOUD_MAX_COMPONENTS"
+    )]
+    max_components: u32,
     /// If provided, allows setting a custom timeout for requesting policy decisions. Defaults to one second. Requires `policy_topic` to be set.
     #[clap(
         long = "policy-timeout-ms",
@@ -425,6 +438,9 @@ async fn main() -> anyhow::Result<()> {
         secrets_topic_prefix: args.secrets_topic_prefix,
         version: env!("CARGO_PKG_VERSION").to_string(),
         max_execution_time: args.max_execution_time,
+        max_linear_memory: args.max_linear_memory,
+        max_component_size: args.max_component_size,
+        max_components: args.max_components,
         heartbeat_interval: args.heartbeat_interval,
     }))
     .await


### PR DESCRIPTION
## Feature or Problem
This PR surfaces additional tuning parameters that can be used to control limits on components in the wasmtime runtime, including the max number of component instances, the max size of a component instance, and the maximum amount of memory a component instance could allocate.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
Could argue for a v1.1.2

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
