### PR TITLE
test: test interfaces with 100kb payload

### DIFF
--- a/tests/components/rust/interfaces-reactor/src/lib.rs
+++ b/tests/components/rust/interfaces-reactor/src/lib.rs
@@ -80,7 +80,7 @@ pub fn run_test(body: &[u8]) -> (Vec<u8>, String) {
         "guid": HostRng::generate_guid(),
         "random_32": HostRng::random32(),
         "random_in_range": HostRng::random_in_range(min, max),
-        "long_value": "1234567890".repeat(1000),
+        "long_value": "1234567890".repeat(10000),
         "config_value": config::runtime::get(&config_key).expect("failed to get config value"),
         "all_config": config::runtime::get_all().expect("failed to get all config values"),
         "ping": pong,
@@ -89,9 +89,9 @@ pub fn run_test(body: &[u8]) -> (Vec<u8>, String) {
         "is_same": is_same,
         "archie": is_good_boy,
     });
-    eprintln!("response: `{res:?}`");
 
     let body = serde_json::to_vec(&res).expect("failed to encode response to JSON");
+    eprintln!("response_len: `{}`", body.len());
 
     let tcp4 = tcp_create_socket::create_tcp_socket(network::IpAddressFamily::Ipv4)
         .expect("failed to create an IPv4 TCP socket");

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -509,7 +509,7 @@ async fn interfaces() -> anyhow::Result<()> {
     ensure!(config_value.is_none());
     ensure!(all_config == []);
     ensure!(ping == "pong");
-    ensure!(long_value == "1234567890".repeat(1000));
+    ensure!(long_value == "1234567890".repeat(10000));
     ensure!(meaning_of_universe == 42);
     ensure!(split == ["hi", "there", "friend"]);
     ensure!(is_same);


### PR DESCRIPTION
## Feature or Problem
This is a WIP PR to demonstrate an issue with writing larger (65kb+) payloads to the blobstore output stream when using the OutputStreamWriter.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
https://github.com/wasmCloud/wasmCloud/actions/runs/10308267947/job/28535303371?pr=2715#step:4:2620 is where the error occurs

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
