### PR TITLE
feat(host)!: introduce linkdef_set_failed event

### DIFF
--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -108,6 +108,23 @@ pub fn linkdef_set(
     })
 }
 
+pub fn linkdef_set_failed(
+    link: &wasmcloud_control_interface::InterfaceLinkDefinition,
+    error: &anyhow::Error,
+) -> serde_json::Value {
+    json!({
+        "source_id": link.source_id,
+        "target": link.target,
+        "name": link.name,
+        "wit_namespace": link.wit_namespace,
+        "wit_package": link.wit_package,
+        "interfaces": link.interfaces,
+        "source_config": link.source_config,
+        "target_config": link.target_config,
+        "error": format!("{error:#}"),
+    })
+}
+
 pub fn linkdef_deleted(
     source_id: impl AsRef<str>,
     name: impl AsRef<str>,


### PR DESCRIPTION
## Feature or Problem
This PR introduces an event to the host `linkdef_set_failed` which can be used to let subscribers on the event bus know that a linkdef failed to be deleted. Since link creation is a synchronous command the sender of the command should be able to know that the event failed, but this will ensure that if you were subscribing to the command and event topics that you'd understand what happened.

## Related Issues
I plan to use this in https://github.com/wasmCloud/wadm/pull/379 to make link scalers backoff & report failures to create links in their status.

## Release Information
next wasmCloud

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
