### PR TITLE
fix(examples): daemonscale http provider in all examples

### DIFF
--- a/examples/golang/components/http-client-tinygo/wadm.yaml
+++ b/examples/golang/components/http-client-tinygo/wadm.yaml
@@ -55,6 +55,9 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1
 
     - name: httpclient
       type: capability

--- a/examples/golang/components/http-echo-tinygo/wadm.yaml
+++ b/examples/golang/components/http-echo-tinygo/wadm.yaml
@@ -52,3 +52,6 @@ spec:
               - name: default-http
                 properties:
                   port: '8080'
+        - type: daemonscaler
+          properties:
+            replicas: 1

--- a/examples/golang/components/http-hello-world/wadm.yaml
+++ b/examples/golang/components/http-hello-world/wadm.yaml
@@ -45,3 +45,6 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1

--- a/examples/python/components/http-hello-world/wadm.yaml
+++ b/examples/python/components/http-hello-world/wadm.yaml
@@ -45,3 +45,6 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1

--- a/examples/rust/components/blobby/wadm.yaml
+++ b/examples/rust/components/blobby/wadm.yaml
@@ -66,6 +66,9 @@ spec:
               - name: default-http
                 properties:
                   address: 0.0.0.0:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1
     - name: blobstore
       type: capability
       properties:

--- a/examples/rust/components/dog-fetcher/wadm.yaml
+++ b/examples/rust/components/dog-fetcher/wadm.yaml
@@ -58,6 +58,9 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1
 
     - name: httpclient
       type: capability

--- a/examples/rust/components/http-blobstore/wadm.yaml
+++ b/examples/rust/components/http-blobstore/wadm.yaml
@@ -66,6 +66,9 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1
 
     # Capability provider that exposes a blobstore with the filesystem
     - name: blobstore-fs

--- a/examples/rust/components/http-hello-world/wadm.yaml
+++ b/examples/rust/components/http-hello-world/wadm.yaml
@@ -15,6 +15,8 @@ spec:
     - name: http-component
       type: component
       properties:
+        # NOTE: this example is used in the quickstart guide,
+        # we keep the local file ref enabled instead of OCI like other examples.
         image: file://./build/http_hello_world_s.wasm
         # To use the a precompiled version of this component, use the line below instead:
         # image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
@@ -44,3 +46,6 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1

--- a/examples/rust/components/http-jsonify/wadm.yaml
+++ b/examples/rust/components/http-jsonify/wadm.yaml
@@ -50,3 +50,6 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1

--- a/examples/rust/components/http-keyvalue-counter/wadm.yaml
+++ b/examples/rust/components/http-keyvalue-counter/wadm.yaml
@@ -69,3 +69,6 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1

--- a/examples/rust/composition/http-hello/wadm.yaml
+++ b/examples/rust/composition/http-hello/wadm.yaml
@@ -35,3 +35,6 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1

--- a/examples/rust/composition/http-hello2/wadm.yaml
+++ b/examples/rust/composition/http-hello2/wadm.yaml
@@ -51,3 +51,6 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1

--- a/examples/rust/composition/wadm.yaml
+++ b/examples/rust/composition/wadm.yaml
@@ -35,3 +35,6 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1

--- a/examples/security/secrets/wadm.yaml
+++ b/examples/security/secrets/wadm.yaml
@@ -97,3 +97,6 @@ spec:
                 - name: default-http
                   properties:
                     address: 0.0.0.0:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1

--- a/examples/typescript/components/http-hello-world/wadm.yaml
+++ b/examples/typescript/components/http-hello-world/wadm.yaml
@@ -47,3 +47,6 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1


### PR DESCRIPTION
At least until spreadscaled http providers are supported by the
operator to generate service endpoints, we should make all of the
examples use the Daemonscaler. This allows examples to work with
a simple kind deploy by default.

https://github.com/wasmCloud/wasmCloud-operator?tab=readme-ov-file#automatically-syncing-kubernetes-service

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Adds daemonscaler to all HTTP provider examples so that examples work OOTB with k8s deploys.
