### PR TITLE
ci(examples): push golang oci examples

### DIFF
--- a/.github/workflows/examples-components.yml
+++ b/.github/workflows/examples-components.yml
@@ -194,6 +194,13 @@ jobs:
         wash-version:
           - 0.29.2
         project:
+          # Go example components (to publish)
+          - lang: "golang"
+            lang_version: "1.20"
+            name: "http-echo-tinygo"
+          - lang: "golang"
+            lang_version: "1.20"
+            name: "http-hello-world"  
           # Rust example components (to publish)
           - name: "blobby"
             lang: "rust"

--- a/examples/golang/components/http-echo-tinygo/wasmcloud.toml
+++ b/examples/golang/components/http-echo-tinygo/wasmcloud.toml
@@ -6,15 +6,8 @@
 # WebAssembly Interface Types[1] ("WIT") bindings to generate the 
 # higher level interface definitions that the WebAssembly uses.
 #
-# As of 2023, components are cutting edge WebAssembly, and are thus experimental
-# features in wasmCloud. 
-#
-# That said, this example *should* compile and run on wasmCloud:
-#
 # 1. Build the project with `wash build`
 # 2. Deploy the project with `wash app deploy wadm.yaml` 
-#
-# Please file an issue if you encounter any friction (https://github.com/wasmCloud/wasmcloud/issues/new)
 #
 # [0]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
 # [1]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md


### PR DESCRIPTION
Add two golang examples to the list of examples to push to OCI. Golang will be one of the first examples used in a new Ingress example for routing between Rust and Go.