### PR TITLE
feat(component): add join helper

### DIFF
--- a/crates/component/src/wrappers/io.rs
+++ b/crates/component/src/wrappers/io.rs
@@ -119,6 +119,21 @@ impl Default for StdioStream<'_> {
     }
 }
 
+/// Similar to [`crate::wasi::io::poll::poll`], but polls all `pollables` until they are all ready.
+///
+/// Poll for completion on a set of pollables.
+///
+/// This function takes a list of pollables, which identify I/O sources of interest, and waits until all of the events are ready for I/O.
+pub fn join(pollables: &[&crate::wasi::io::poll::Pollable]) {
+    let mut pollables = pollables.to_vec();
+    while !pollables.is_empty() {
+        let ready_indices = crate::wasi::io::poll::poll(&pollables);
+        ready_indices.iter().rev().for_each(|&i| {
+            pollables.swap_remove(i as usize);
+        });
+    }
+}
+
 #[cfg(feature = "futures")]
 impl futures::AsyncRead for StdioStream<'_> {
     fn poll_read(


### PR DESCRIPTION
## Feature or Problem
I was doing some experimentation with sending off multiple HTTP requests, and I created this little helper that polls a set of pollables to completion. Is there an appetite to including this in our component library?

I'm fine with closing this, refactoring, etc, but it does seem useful for creating polling multiple futures to completion.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
