### PR TITLE
fix(blobstore-fs): Creates a subdirectory when no root is specified

### DIFF
--- a/crates/provider-blobstore-fs/README.md
+++ b/crates/provider-blobstore-fs/README.md
@@ -1,19 +1,22 @@
 # `blobstore-fs` capability provider
 
-This capability provider implements the `wasmcloud:blobstore` capability for Unix and Windows file systems. 
+This capability provider implements the `wasmcloud:blobstore` capability for Unix and Windows file
+systems. 
 
-The provider will store files and folders on the host where the provider executes, and expose those folders and files within as a blobstore (AKA object storage).
+The provider will store files and folders on the host where the provider executes, and expose those
+folders and files within as a blobstore (AKA object storage).
 
 ## Configuration
 
-Similar to other wasmcloud providers, this provider is configured wiht link configuration values:
+Similar to other wasmcloud providers, this provider is configured with link configuration values:
 
-| Link value | Default | Example            | Description                               |
-|------------|---------|--------------------|-------------------------------------------|
-| `ROOT`     | `/tmp`  | `/tmp/your-folder` | The root folder where data will be stored |
+| Link value | Default               | Example            | Description                               |
+| ---------- | --------------------- | ------------------ | ----------------------------------------- |
+| `ROOT`     | `/tmp/<component-id>` | `/tmp/your-folder` | The root folder where data will be stored |
+
+The default value will create a folder in the `/tmp` directory with the name of the component ID so
+as to avoid collision when linking multiple components
 
 > [!NOTE]
 > The provider must have read and write access to the disk location specified by `ROOT`
->
-> Each component's files will be stored under the path `$ROOT/<component id>`
 

--- a/src/bin/blobstore-fs-provider/wasmcloud.toml
+++ b/src/bin/blobstore-fs-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Blobstore FS"
 language = "rust"
 type = "provider"
-version = "0.8.0"
+version = "0.9.0"
 
 [rust]
 target_dir = "../../"


### PR DESCRIPTION
We we refactored the provider last, we left some code that created the proper subdirectory, but then didn't do anything with that directory.

This gives things a reasonable default. If a `ROOT` is specified, then we use that without creating a subpath. If we are defaulting, we create a subdir with the component ID to avoid collision