### PR TITLE
feat(wash-cli): Add --watch flag to wash app list for displaying live info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "mio 1.0.2",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3471,6 +3496,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -5454,6 +5480,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 1.0.2",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6794,6 +6841,7 @@ dependencies = [
  "clap_complete",
  "cloudevents-sdk",
  "console",
+ "crossterm",
  "dirs",
  "futures",
  "http 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ cloudevents-sdk = { version = "0.7", default-features = false }
 command-group = { version = "5", default-features = false }
 config = { version = "0.13", default-features = false }
 console = { version = "0.15", default-features = false }
+crossterm = {version = "0.28.1",default-features = false }
 dashmap = { version = "5", default-features = false }
 data-encoding = { version = "2", default-features = false }
 deadpool-postgres = { version = "0.13", default-features = false }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -29,6 +29,7 @@ clap = { workspace = true, features = ["std", "derive", "env", "string"] }
 clap_complete = { workspace = true }
 cloudevents-sdk = { workspace = true }
 console = { workspace = true }
+crossterm ={ workspace = true, features = ["events","windows"] }
 dirs = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }

--- a/crates/wash-cli/src/app/mod.rs
+++ b/crates/wash-cli/src/app/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{bail, Context};
 use clap::{Args, Subcommand};
@@ -12,6 +13,12 @@ use wash_lib::cli::{CliConnectionOpts, CommandOutput, OutputKind};
 use wash_lib::config::WashConnectionOptions;
 
 use crate::appearance::spinner::Spinner;
+use crossterm::{
+    cursor, execute,
+    terminal::{Clear, ClearType},
+};
+use std::io::{stdout, Write};
+use tokio::time::sleep;
 
 mod output;
 
@@ -50,6 +57,9 @@ pub enum AppCliCommand {
 pub struct ListCommand {
     #[clap(flatten)]
     opts: CliConnectionOpts,
+    /// Switches to a real-time, live-updating application list
+    #[clap(long)]
+    watch: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -153,7 +163,7 @@ pub async fn handle_command(
     let out: CommandOutput = match command {
         List(cmd) => {
             sp.update_spinner_message("Listing applications ...".to_string());
-            get_applications(cmd).await?
+            get_applications(cmd, &sp).await?
         }
         Get(cmd) => {
             sp.update_spinner_message("Getting application manifest ... ".to_string());
@@ -417,17 +427,81 @@ async fn delete_application_version(cmd: DeleteCommand) -> Result<CommandOutput>
     Ok(CommandOutput::new(message, map))
 }
 
-async fn get_applications(cmd: ListCommand) -> Result<CommandOutput> {
+async fn get_applications(cmd: ListCommand, sp: &Spinner) -> Result<CommandOutput> {
     let connection_opts =
         <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(cmd.opts)?;
     let lattice = Some(connection_opts.get_lattice());
 
     let client = connection_opts.into_nats_client().await?;
-    let models = wash_lib::app::get_models(&client, lattice).await?;
 
-    let mut map = HashMap::new();
-    map.insert("applications".to_string(), json!(models));
-    Ok(CommandOutput::new(output::list_models_table(models), map))
+    if cmd.watch {
+        sp.finish_and_clear();
+        watch_applications(&client, lattice).await?;
+        Ok(CommandOutput::new(
+            "Watching applications (press Ctrl+C to exit)".to_string(),
+            HashMap::new(),
+        ))
+    } else {
+        let models = wash_lib::app::get_models(&client, lattice).await?;
+        let mut map = HashMap::new();
+        map.insert("applications".to_string(), json!(models));
+        Ok(CommandOutput::new(output::list_models_table(models), map))
+    }
+}
+
+async fn watch_applications(
+    client: &async_nats_0_33::Client,
+    lattice: Option<String>,
+) -> Result<()> {
+    let mut stdout = stdout();
+
+    execute!(stdout, Clear(ClearType::FromCursorUp), cursor::MoveTo(0, 0))
+        .map_err(|e| anyhow::anyhow!("Failed to clear terminal: {}", e))?;
+
+    loop {
+        let models = wash_lib::app::get_models(client, lattice.clone()).await?;
+        let table = output::list_models_table(models);
+
+        execute!(stdout, Clear(ClearType::Purge), cursor::MoveTo(0, 0))
+            .map_err(|e| anyhow::anyhow!("Failed to execute terminal commands: {}", e))?;
+
+        stdout
+            .write_all(table.as_bytes())
+            .map_err(|e| anyhow::anyhow!("Failed to write table to stdout: {}", e))?;
+
+        stdout
+            .flush()
+            .map_err(|e| anyhow::anyhow!("Failed to flush stdout: {}", e))?;
+        execute!(
+            stdout,
+            Clear(ClearType::CurrentLine),
+            Clear(ClearType::FromCursorDown),
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to clear terminal: {}", e))?;
+
+        if crossterm::event::poll(Duration::from_millis(800))
+            .map_err(|e| anyhow::anyhow!("Failed to poll for events: {}", e))?
+        {
+            if let Ok(crossterm::event::Event::Key(key)) = crossterm::event::read() {
+                if key.code == crossterm::event::KeyCode::Char('c')
+                    && key
+                        .modifiers
+                        .contains(crossterm::event::KeyModifiers::CONTROL)
+                {
+                    execute!(stdout, Clear(ClearType::Purge), cursor::MoveTo(0, 0)).map_err(
+                        |e| anyhow::anyhow!("Failed to execute terminal commands: {}", e),
+                    )?;
+                    break;
+                }
+            }
+        }
+
+        sleep(Duration::from_millis(800)).await;
+    }
+
+    execute!(stdout, cursor::Show).map_err(|e| anyhow::anyhow!("Failed to show cursor: {}", e))?;
+
+    Ok(())
 }
 
 fn show_validate_manifest_results(messages: impl AsRef<[ValidationFailure]>) -> CommandOutput {

--- a/crates/wash-cli/src/app/output.rs
+++ b/crates/wash-cli/src/app/output.rs
@@ -29,7 +29,6 @@ pub fn list_revisions_table(revisions: Vec<VersionInfo>) -> String {
 pub fn list_models_table(models: Vec<ModelSummary>) -> String {
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table, 3);
-
     table.add_row(Row::new(vec![
         TableCell::new_with_alignment("Name", 1, Alignment::Left),
         TableCell::new_with_alignment("Deployed Version", 1, Alignment::Left),


### PR DESCRIPTION
## Feature or Problem
This flag perpetually displays changes to application status until Ctrl+c is invoked

## Related Issues
#2512 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
