### PR TITLE
feat(wash-cli): Add secrets-topic and policy-topic flags to wash up

### DIFF
--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -17,6 +17,8 @@ pub const WASMCLOUD_HOST_VERSION: &str = "v1.1.0";
 pub const WASMCLOUD_LATTICE: &str = "WASMCLOUD_LATTICE";
 pub const DEFAULT_LATTICE: &str = "default";
 pub const WASMCLOUD_JS_DOMAIN: &str = "WASMCLOUD_JS_DOMAIN";
+pub const WASMCLOUD_POLICY_TOPIC: &str = "WASMCLOUD_POLICY_TOPIC";
+pub const WASMCLOUD_SECRETS_TOPIC: &str = "WASMCLOUD_SECRETS_TOPIC";
 // Host / Cluster configuration
 pub const WASMCLOUD_CLUSTER_ISSUERS: &str = "WASMCLOUD_CLUSTER_ISSUERS";
 pub const WASMCLOUD_CLUSTER_SEED: &str = "WASMCLOUD_CLUSTER_SEED";
@@ -87,6 +89,16 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
         WASMCLOUD_MAX_EXECUTION_TIME_MS.to_string(),
         wasmcloud_opts.max_execution_time.to_string(),
     );
+    if let Some(policy_topic) = wasmcloud_opts.policy_topic {
+        host_config.insert(WASMCLOUD_POLICY_TOPIC.to_string(), policy_topic.to_string());
+    }
+
+    if let Some(secrets_topic) = wasmcloud_opts.secrets_topic {
+        host_config.insert(
+            WASMCLOUD_SECRETS_TOPIC.to_string(),
+            secrets_topic.to_string(),
+        );
+    }
 
     if wasmcloud_opts.allow_latest {
         host_config.insert(WASMCLOUD_OCI_ALLOW_LATEST.to_string(), "true".to_string());

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -274,6 +274,14 @@ pub struct WasmcloudOpts {
     /// Defines the Max Execution time (in ms) that the host runtime will execute for
     #[clap(long = "max-execution-time-ms", alias = "max-time-ms", env = WASMCLOUD_MAX_EXECUTION_TIME_MS, default_value = DEFAULT_MAX_EXECUTION_TIME_MS)]
     pub max_execution_time: u64,
+
+    /// If provided, enables interfacing with a secrets backend for secret retrieval over the given topic prefix.
+    #[clap(long = "secrets-topic", env = WASMCLOUD_SECRETS_TOPIC)]
+    pub secrets_topic: Option<String>,
+
+    /// If provided, enables policy checks on start actions and component invocations
+    #[clap(long = "policy-topic", env = WASMCLOUD_POLICY_TOPIC)]
+    pub policy_topic: Option<String>,
 }
 
 impl WasmcloudOpts {
@@ -374,6 +382,8 @@ pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<Comman
         rpc_seed: cmd.wasmcloud_opts.rpc_seed.or(ctx.rpc_seed),
         rpc_credsfile: cmd.wasmcloud_opts.rpc_credsfile.or(ctx.rpc_credsfile),
         max_execution_time: cmd.wasmcloud_opts.max_execution_time,
+        secrets_topic: cmd.wasmcloud_opts.secrets_topic,
+        policy_topic: cmd.wasmcloud_opts.policy_topic,
         cluster_seed: cmd
             .wasmcloud_opts
             .cluster_seed


### PR DESCRIPTION
## Feature or Problem
This PR adds `secrets-topic` and `policy-topic` flags to wash up
facilitating the wasmcloud binary in connecting the pipeline
## Related Issues
#2631 
## Release Information
next
## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Value propogates to wasmcloud host binary, `wash up` run's as expected.