### PR TITLE
feat(wash-cli): Modify wash drain to avoid clearing downloads cache when host is running

### DIFF
--- a/crates/wash-lib/src/config.rs
+++ b/crates/wash-lib/src/config.rs
@@ -12,6 +12,7 @@ pub const WASH_DIR: &str = ".wash";
 
 pub const DOWNLOADS_DIR: &str = "downloads";
 pub const WASMCLOUD_PID_FILE: &str = "wasmcloud.pid";
+pub const WADM_PID_FILE: &str = "wadm.pid";
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
 pub const DEFAULT_LATTICE: &str = "default";
@@ -43,6 +44,11 @@ pub fn downloads_dir() -> Result<PathBuf> {
 /// The path to the running wasmCloud Host PID file for wash
 pub fn host_pid_file() -> Result<PathBuf> {
     Ok(downloads_dir()?.join(WASMCLOUD_PID_FILE))
+}
+
+/// The path to the running wadm PID file for wash
+pub fn wadm_pid_file() -> Result<PathBuf> {
+    Ok(downloads_dir()?.join(WADM_PID_FILE))
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Feature or Problem
Aborts `drain all` and `drain downloads` if wasmcloud host is active

## Related Issues
#2788 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I started a wasmcloud instance via `cargo run -- up -d` then tried to run `cargo run -- drain all` which resulted in an error
then ran `down --all` and `drain all` which ran as expected