### PR TITLE
chore(provider-sqldb-postgres): Remove the rustls option and enable rustls features by default

### DIFF
--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -11,10 +11,6 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
-[features]
-default = [ "rustls" ]
-rustls = [ "dep:tokio-postgres-rustls" ]
-
 [dependencies]
 anyhow = { workspace = true }
 bigdecimal = { workspace = true }
@@ -32,7 +28,7 @@ rustls = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = { workspace = true, features = [ "runtime", "with-serde_json-1", "with-chrono-0_4", "with-uuid-0_8", "with-geo-types-0_7", "array-impls", "with-bit-vec-0_6", "with-uuid-1" ]  }
-tokio-postgres-rustls = { workspace = true, optional = true }
+tokio-postgres-rustls = { workspace = true }
 tracing = { workspace = true }
 ulid = { workspace = true }
 uuid = { workspace = true }

--- a/crates/provider-sqldb-postgres/src/lib.rs
+++ b/crates/provider-sqldb-postgres/src/lib.rs
@@ -301,7 +301,6 @@ impl bindings::prepared::Handler<Option<Context>> for PostgresProvider {
     }
 }
 
-#[cfg(feature = "rustls")]
 fn create_tls_pool(
     cfg: deadpool_postgres::Config,
     runtime: Option<deadpool_postgres::Runtime>,
@@ -315,12 +314,4 @@ fn create_tls_pool(
         ),
     )
     .context("failed to create TLS-enabled connection pool")
-}
-
-#[cfg(not(feature = "rustls"))]
-fn create_tls_pool(
-    _cfg: deadpool_postgres::Config,
-    _runtime: Option<deadpool_postgres::Runtime>,
-) -> Result<Pool> {
-    anyhow::bail!("cannot build TLS connections without rustls feature")
 }


### PR DESCRIPTION
## Feature or Problem

Turns out the `rustls` feature is a bit superfluous, because it gets [turned off by default](https://github.com/wasmCloud/wasmCloud/blob/main/Cargo.toml#L347) and [not enabled subsequently](https://github.com/wasmCloud/wasmCloud/blob/main/Cargo.toml#L128) even though we absolutely want to ship the provider with it enabled, so rather than juggling that, let's just remove the feature flag and always compile it in.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
