### PR TITLE
chore(deps): update rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,7 @@ ring = { version = "0.17", default-features = false }
 rmp-serde = { version = "1", default-features = false }
 rmpv = { version = "1", default-features = false }
 kafka = { version = "0.10", default-features = false }
-rustls = { version = "0.23.11", default-features = false }
+rustls = { version = "0.23.12", default-features = false }
 rustls-native-certs = { version = "0.7", default-features = false }
 rustls-pemfile = { version = "2", default-features = false }
 rustversion = { version = "1.0", default-features = false }

--- a/crates/provider-blobstore-s3/Cargo.toml
+++ b/crates/provider-blobstore-s3/Cargo.toml
@@ -22,12 +22,16 @@ aws-smithy-runtime = { workspace = true, features = ["client", "tls-rustls"] }
 base64 = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
+# Intentionally stale version for `aws-smithy-runtime` compatibility
+# see: https://github.com/smithy-lang/smithy-rs/issues/3710
 hyper-rustls = { version = "0.25", features = [
     "http2",
     "ring",
     "webpki-tokio",
-], default-features = false } # Downgrade for `aws-smithy-runtime` compatibility
-rustls = { version = "0.22", default-features = false } # Downgrade for `aws-smithy-runtime` compatibility
+], default-features = false }
+# Intentionally stale version for `aws-smithy-runtime` compatibility
+# see: https://github.com/smithy-lang/smithy-rs/issues/3710
+rustls = { version = "0.22", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
This commit updates rustls at the top level *only* and improves the comment regarding the older versions being used intentionally in provider-blobstore-s3

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
