### PR TITLE
chore(wash-cli): update NATS to 2.10.18

### DIFF
--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use crate::up::{credsfile::parse_credsfile, WasmcloudOpts};
 
 // NATS configuration values
-pub const NATS_SERVER_VERSION: &str = "v2.10.7";
+pub const NATS_SERVER_VERSION: &str = "v2.10.18";
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
 pub const DEFAULT_NATS_WEBSOCKET_PORT: &str = "4223";


### PR DESCRIPTION
## Feature or Problem
This PR updates the version of NATS to download in wash to 2.10.18. With testing with the new blobstore streaming fixes, I would get slow consumer issues when running with 2.10.7.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
