### PR TITLE
wadm 0.14.0, wasmcloud v1.2.0-rc.1, long version

### DIFF
--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -25,7 +25,7 @@ async-compression = { workspace = true, features = ["tokio", "gzip"] }
 async-nats = { workspace = true }
 async-nats-0_33 = { workspace = true }
 bytes = { workspace = true }
-clap = { workspace = true, features = ["std", "derive", "env", "string"] }
+clap = { workspace = true, features = ["cargo", "derive", "env", "std", "string"] }
 clap_complete = { workspace = true }
 cloudevents-sdk = { workspace = true }
 console = { workspace = true }

--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -21,7 +21,7 @@ use wash_cli::par::{self, ParCliCommand};
 use wash_cli::plugin::{self, PluginCommand};
 use wash_cli::secrets::{self, SecretsCliCommand};
 use wash_cli::ui::{self, UiCommand};
-use wash_cli::up::{self, UpCommand};
+use wash_cli::up::{self, UpCommand, NATS_SERVER_VERSION, WADM_VERSION, WASMCLOUD_HOST_VERSION};
 use wash_cli::util::ensure_plugin_dir;
 use wash_lib::cli::capture::{CaptureCommand, CaptureSubcommand};
 use wash_lib::cli::claims::ClaimsCliCommand;
@@ -98,8 +98,19 @@ Options:
   -V, --version          Print version
 ";
 
+/// Helper function to display the version of all the binaries wash runs
+fn version() -> String {
+    format!(
+        "         v{}\n├ nats-server {}\n├ wadm        {}\n└ wasmcloud   {}",
+        clap::crate_version!(),
+        NATS_SERVER_VERSION,
+        WADM_VERSION,
+        WASMCLOUD_HOST_VERSION
+    )
+}
+
 #[derive(Debug, Clone, Parser)]
-#[clap(name = "wash", version, override_help = HELP)]
+#[clap(name = "wash", version = version(), override_help = HELP)]
 struct Cli {
     #[clap(
         short = 'o',

--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -10,9 +10,9 @@ pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
 pub const DEFAULT_NATS_WEBSOCKET_PORT: &str = "4223";
 // wadm configuration values
-pub const WADM_VERSION: &str = "v0.13.0";
+pub const WADM_VERSION: &str = "v0.14.0";
 // wasmCloud configuration values, https://wasmcloud.com/docs/reference/host-config
-pub const WASMCLOUD_HOST_VERSION: &str = "v1.1.0";
+pub const WASMCLOUD_HOST_VERSION: &str = "v1.2.0-rc.1";
 // NATS isolation configuration variables
 pub const WASMCLOUD_LATTICE: &str = "WASMCLOUD_LATTICE";
 pub const DEFAULT_LATTICE: &str = "default";


### PR DESCRIPTION
## Feature or Problem
This PR updates the wadm and wasmCloud version in wash for testing in preparation for a release.

While I was here, I also added a custom version implementation.

## Related Issues
Fixes #2642

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
Consumers of the starship plugin for `wash` (poke @jordan-rash ) should update their starship config to something like the following:
```toml
[custom.wash_ver]
symbol = "🛁"
when = "true"
command = "wash -V | grep wash | awk '{print $1, $2}'"
format = "[$symbol $output]($style) "
style = "bold fg:#00C389"
```

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
The new `-V` or `--version` looks like this:
```
cargo run -- --version
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.62s
     Running `/Users/brooks/github.com/wasmcloud/wasmcloud/target/debug/wash --version`
wash          v0.30.0
├ nats-server v2.10.18
├ wadm        v0.14.0
└ wasmcloud   v1.2.0-rc.1
```

<img width="946" alt="image" src="https://github.com/user-attachments/assets/fd72786a-43cc-409c-9413-16bc5422d35b">
