### PR TITLE
feat(providers): implement wasmcloud:postgres@0.1.1-draft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bigdecimal 0.4.5",

--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.4.0"
+version = "0.5.0"
 description = """
 wasmCloud SQL database provider for Postgres
 """

--- a/crates/provider-sqldb-postgres/src/bindings.rs
+++ b/crates/provider-sqldb-postgres/src/bindings.rs
@@ -25,9 +25,9 @@ use uuid::Uuid;
 // Bindgen happens here
 wit_bindgen_wrpc::generate!({
   with: {
-      "wasmcloud:postgres/types@0.1.0-draft": generate,
-      "wasmcloud:postgres/query@0.1.0-draft": generate,
-      "wasmcloud:postgres/prepared@0.1.0-draft": generate,
+      "wasmcloud:postgres/types@0.1.1-draft": generate,
+      "wasmcloud:postgres/query@0.1.1-draft": generate,
+      "wasmcloud:postgres/prepared@0.1.1-draft": generate,
   },
 });
 

--- a/crates/provider-sqldb-postgres/wit/deps.lock
+++ b/crates/provider-sqldb-postgres/wit/deps.lock
@@ -1,4 +1,4 @@
 [postgres]
-url = "https://github.com/wasmCloud/wasmCloud/releases/download/wit-wasmcloud-postgres-v0.1.0-draft/wit-wasmcloud-postgres-0.1.0-draft.tar.gz"
-sha256 = "dc180a915c3716a5f2f41ceee0d312baa75c9ae2b2fa429ad99ab5bced83e4b1"
-sha512 = "5954c6f59c804ae32d3c619f442273b749e60181c0154c50aba54c20a2d3dff4f31f714ee6c347cea053ac88101e63b8761c17b37ba88c0d9bc2209cbc132930"
+path = "../../../wit/postgres/wit"
+sha256 = "0d08fe1fc4574ea6407a148612b14807323168b51748af1ef5ecc6049eff7739"
+sha512 = "cb2f23d9922a15027002d9b7383aa87a55501da111f0c428fef3c09e2a459710072d82687af015034e4e52e6dad5656440971e302bb00bafae6ab1ca86bc9355"

--- a/crates/provider-sqldb-postgres/wit/deps.toml
+++ b/crates/provider-sqldb-postgres/wit/deps.toml
@@ -1,1 +1,1 @@
-postgres = "https://github.com/wasmCloud/wasmCloud/releases/download/wit-wasmcloud-postgres-v0.1.0-draft/wit-wasmcloud-postgres-0.1.0-draft.tar.gz"
+postgres = "../../../wit/postgres/wit"

--- a/crates/provider-sqldb-postgres/wit/deps/postgres/query.wit
+++ b/crates/provider-sqldb-postgres/wit/deps/postgres/query.wit
@@ -1,11 +1,11 @@
-package wasmcloud:postgres@0.1.0-draft;
+package wasmcloud:postgres@0.1.1-draft;
 
 /// Interface for querying a Postgres database
 interface query {
   use types.{pg-value, result-row, query-error};
 
   /// Query a Postgres database, leaving connection/session management
-  /// to the callee/implementer of this interface (normally a provider configured with conneciton credentials)
+  /// to the callee/implementer of this interface (normally a provider configured with connection credentials)
   ///
   /// Queries *must* be parameterized, with named arguments in the form of `$<integer>`, for example:
   ///
@@ -14,6 +14,16 @@ interface query {
   /// ```
   ///
   query: func(query: string, params: list<pg-value>) -> result<list<result-row>, query-error>;
+
+  /// Perform a batch query (which could contain multiple statements) against a Postgres database,
+  /// leaving connection/session management to the callee/implementer of this interface
+  /// (normally a provider configured with connection credentials)
+  ///
+  /// No user-provided or untrusted data should be used with this query -- parameters are not allowed
+  ///
+  /// This query *can* be used to execute multi-statement queries (common in migrations).
+  ///
+  query-batch: func(query: string) -> result<_, query-error>;
 }
 
 /// Interface for querying a Postgres database with prepared statements

--- a/crates/provider-sqldb-postgres/wit/deps/postgres/types.wit
+++ b/crates/provider-sqldb-postgres/wit/deps/postgres/types.wit
@@ -1,4 +1,4 @@
-package wasmcloud:postgres@0.1.0-draft;
+package wasmcloud:postgres@0.1.1-draft;
 
 /// Types used by components and providers of a SQLDB Postgres interface
 interface types {

--- a/crates/provider-sqldb-postgres/wit/provider.wit
+++ b/crates/provider-sqldb-postgres/wit/provider.wit
@@ -1,6 +1,6 @@
 package wasmcloud:providers;
 
 world provider-sqldb-postgres {
-    export wasmcloud:postgres/query@0.1.0-draft;
-    export wasmcloud:postgres/prepared@0.1.0-draft;
+    export wasmcloud:postgres/query@0.1.1-draft;
+    export wasmcloud:postgres/prepared@0.1.1-draft;
 }

--- a/wit/postgres/wit/types.wit
+++ b/wit/postgres/wit/types.wit
@@ -1,4 +1,4 @@
-package wasmcloud:postgres@0.1.0-draft;
+package wasmcloud:postgres@0.1.1-draft;
 
 /// Types used by components and providers of a SQLDB Postgres interface
 interface types {


### PR DESCRIPTION
This commit implements wasmcloud:postgres@0.1.1-draft for as-yet-unreleased the upcoming version of the wasmcloud postgres provider

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
