### PR TITLE
fix(wash-lib): use resolved component ref for start

### DIFF
--- a/crates/wash-lib/src/cli/scale.rs
+++ b/crates/wash-lib/src/cli/scale.rs
@@ -9,6 +9,7 @@ use crate::component::{scale_component, ScaleComponentArgs};
 use crate::config::WashConnectionOptions;
 use crate::context::default_component_operation_timeout_ms;
 
+use super::start::resolve_ref;
 use super::validate_component_id;
 
 #[derive(Debug, Clone, Parser)]
@@ -65,6 +66,7 @@ pub async fn handle_scale_component(cmd: ScaleComponentCommand) -> Result<Comman
     let client = wco.into_ctl_client(None).await?;
 
     let annotations = input_vec_to_hashmap(cmd.annotations)?;
+    let component_ref = resolve_ref(&cmd.component_ref).await?;
 
     let info = scale_component(ScaleComponentArgs {
         client: &client,
@@ -72,7 +74,7 @@ pub async fn handle_scale_component(cmd: ScaleComponentCommand) -> Result<Comman
         // prompt the user to choose if more than one thing matches
         host_id: &find_host_id(&cmd.host_id, &client).await?.0,
         component_id: &cmd.component_id,
-        component_ref: &cmd.component_ref,
+        component_ref: &component_ref,
         max_instances: cmd.max_instances,
         annotations: Some(annotations),
         config: cmd.config,

--- a/crates/wash-lib/src/cli/start.rs
+++ b/crates/wash-lib/src/cli/start.rs
@@ -79,7 +79,7 @@ pub struct StartComponentCommand {
 }
 
 /// Utility function for resolving component and provider references
-async fn resolve_ref(s: impl AsRef<str>) -> Result<String> {
+pub(crate) async fn resolve_ref(s: impl AsRef<str>) -> Result<String> {
     let resolved = match s.as_ref() {
         s if s.starts_with('/') => {
             format!("file://{}", &s) // prefix with file:// if it's an absolute path
@@ -166,7 +166,7 @@ pub async fn handle_start_component(cmd: StartComponentCommand) -> Result<Comman
     } = scale_component(ScaleComponentArgs {
         client: &client,
         host_id: &host,
-        component_ref: &cmd.component_ref,
+        component_ref: &component_ref,
         component_id: &cmd.component_id,
         max_instances: cmd.max_instances,
         skip_wait: cmd.skip_wait,


### PR DESCRIPTION
## Feature or Problem
This PR is a small fix to ensure that when we resolve the component_ref for a start or scale command, we use it both for the auction and the actual start.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next wash

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
