### PR TITLE
feat(runtime): enable wasmtime gc feature

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -43,6 +43,7 @@ wasmtime = { workspace = true, features = [
     "component-model",
     "coredump",
     "cranelift",
+    "gc",
     "parallel-compilation",
     "pooling-allocator",
 ] }


### PR DESCRIPTION
## Feature or Problem
This PR enables the `gc` feature in our runtime crate which, as per documentation:
```
gc - Enabled by default, this enables support for a number of WebAssembly proposals such as reference-types, function-references, and gc. Note that the implementation of the gc proposal itself is not yet complete at this time.
```

Building a component with `cargo +nightly build --target wasm32-wasip2` requires the reference-types proposal, so enabling this lets us run components that were built directly to the wasm32-wasip2 target.

~As far as I can tell this is the only way to enable this functionality.~

Once we update to wasmtime 25, we can disable this feature again https://github.com/bytecodealliance/wasmtime/pull/9162

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
 After adding this the component worked out of the box
