### PR TITLE
chore(wash-cli): help styling to streamline cli markdown

### DIFF
--- a/crates/wash-cli/src/par.rs
+++ b/crates/wash-cli/src/par.rs
@@ -109,11 +109,11 @@ pub struct InspectCommand {
     #[clap(name = "archive")]
     archive: String,
 
-    /// Digest to verify artifact against (if OCI URL is provided for <archive>)
+    /// Digest to verify artifact against (if OCI URL is provided for `<archive>`)
     #[clap(short = 'd', long = "digest")]
     digest: Option<String>,
 
-    /// Allow latest artifact tags (if OCI URL is provided for <archive>)
+    /// Allow latest artifact tags (if OCI URL is provided for `<archive>`)
     #[clap(long = "allow-latest")]
     allow_latest: bool,
 

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -50,11 +50,11 @@ pub struct InspectCommand {
     #[clap(name = "wit", long = "wit", alias = "world")]
     pub wit: bool,
 
-    /// Digest to verify artifact against (if OCI URL is provided for <component>)
+    /// Digest to verify artifact against (if OCI URL is provided for `<component>`)
     #[clap(short = 'd', long = "digest")]
     pub(crate) digest: Option<String>,
 
-    /// Allow latest artifact tags (if OCI URL is provided for <component>)
+    /// Allow latest artifact tags (if OCI URL is provided for `<component>`)
     #[clap(long = "allow-latest")]
     pub(crate) allow_latest: bool,
 

--- a/crates/wash-lib/src/cli/inspect.rs
+++ b/crates/wash-lib/src/cli/inspect.rs
@@ -32,11 +32,11 @@ pub struct InspectCliCommand {
     )]
     pub wit: bool,
 
-    /// Digest to verify artifact against (if OCI URL is provided for <target>)
+    /// Digest to verify artifact against (if OCI URL is provided for `<target>`)
     #[clap(short = 'd', long = "digest")]
     pub digest: Option<String>,
 
-    /// Allow latest artifact tags (if OCI URL is provided for <target>)
+    /// Allow latest artifact tags (if OCI URL is provided for `<target>`)
     #[clap(long = "allow-latest")]
     pub allow_latest: bool,
 


### PR DESCRIPTION
Teensy PR to streamline CLI doc generation. There are six instances of angle brackets in the wash help that have to be manually wrapped in backticks in order to render the Markdown successfully in Docusaurus. So, proposing to simply wrap the offending items in backticks in the help in order to cut out the extra step (and clear the way for more complete automation down the line).