### PR TITLE
chore(charts): Refresh wasmcloud-host chart

### DIFF
--- a/.github/workflows/wasmcloud-host-chart.yml
+++ b/.github/workflows/wasmcloud-host-chart.yml
@@ -1,0 +1,97 @@
+name: wasmcloud-host-chart
+
+on:
+  push:
+    tags:
+      - 'wasmcloud-host-chart-v[0-9].[0-9]+.[0-9]+'
+  pull_request:
+    paths:
+      - 'charts/wasmcloud-host/**'
+      - '.github/workflows/wasmcloud-host-chart.yml'
+
+permissions:
+  contents: read
+
+env:
+  HELM_VERSION: v3.13.3
+
+jobs:
+  validate:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Set up Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      # Used by helm chart-testing below
+      - name: Set up Python
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f
+        with:
+          python-version: '3.12.0'
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992
+        with:
+          version: v3.9.0
+          yamllint_version: 1.32.0
+          yamale_version: 4.0.4
+
+      - name: Run chart-testing (lint)
+        run: |
+          ct lint --config charts/wasmcloud-host/ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde
+
+      - name: Install nats in the test cluster
+        run: |
+          helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+          helm repo update
+          helm install nats nats/nats -f charts/ci/nats-values.yaml
+
+      - name: Run chart-testing (install)
+        run: ct install --config charts/wasmcloud-host/ct.yaml
+
+  publish:
+    if: ${{ startsWith(github.ref, 'refs/tags/wasmcloud-host-chart-v') }}
+    runs-on: ubuntu-22.04
+    needs: validate
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Set up Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Package
+        run: |
+          helm package charts/wasmcloud-host -d .helm-charts
+
+      - name: Login to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase the organization name for ghcr.io
+        run: |
+          echo "GHCR_REPO_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+
+      - name: Publish
+        run: |
+          for chart in .helm-charts/*; do
+            if [ -z "${chart:-}" ]; then
+              break
+            fi
+            helm push "${chart}" "oci://ghcr.io/${{ env.GHCR_REPO_NAMESPACE }}/charts"
+          done

--- a/charts/ci/nats-values.yaml
+++ b/charts/ci/nats-values.yaml
@@ -1,0 +1,10 @@
+config:
+  leafnodes:
+    enabled: true
+  jetstream:
+    enabled: true
+    fileStore:
+      pvc:
+        enabled: false
+    merge:
+      domain: default

--- a/charts/wasmcloud-host/.helmignore
+++ b/charts/wasmcloud-host/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/wasmcloud-host/Chart.yaml
+++ b/charts/wasmcloud-host/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: wasmcloud-host
+description: A Helm chart for deploying wasmCloud hosts on Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.8.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.2.0"

--- a/charts/wasmcloud-host/ct.yaml
+++ b/charts/wasmcloud-host/ct.yaml
@@ -1,0 +1,3 @@
+charts:
+  - charts/wasmcloud-host
+validate-maintainers: false

--- a/charts/wasmcloud-host/templates/_helpers.tpl
+++ b/charts/wasmcloud-host/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "wasmcloud-host.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "wasmcloud-host.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "wasmcloud-host.nats-config-name" -}}
+{{- .Release.Name | trunc 51 | trimSuffix "-" }}-nats-config
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "wasmcloud-host.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "wasmcloud-host.labels" -}}
+helm.sh/chart: {{ include "wasmcloud-host.chart" . }}
+{{ include "wasmcloud-host.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "wasmcloud-host.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wasmcloud-host.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "wasmcloud-host.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "wasmcloud-host.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "wasmcloud-host.allowed-insecure" -}}
+{{- $list := list }}
+{{- range .Values.config.allowedInsecure }}
+{{- $list = append $list . }}
+{{- end }}
+{{- join "," $list }}
+{{- end }}

--- a/charts/wasmcloud-host/templates/configmap.yaml
+++ b/charts/wasmcloud-host/templates/configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wasmcloud-host.nats-config-name" . }}
+  labels:
+    {{- include "wasmcloud-host.labels" . | nindent 4 }}
+data:
+  nats.conf: |
+    jetstream {
+        domain={{ .Values.config.leafNodeDomain | quote }}
+        store_dir="/tmp/nats-leaf-jetstream"
+    }
+
+    listen: "127.0.0.1:4222"
+    leafnodes {
+        remotes = [
+            {
+              url: {{ .Values.config.natsAddress | quote }}
+              {{- if .Values.config.natsCredentialsSecret }}
+              credentials: "/nats/nats.creds"
+              {{- end }}
+            },
+        ]
+    }

--- a/charts/wasmcloud-host/templates/deployment.yaml
+++ b/charts/wasmcloud-host/templates/deployment.yaml
@@ -1,0 +1,182 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wasmcloud-host.fullname" . }}
+  labels:
+    {{- include "wasmcloud-host.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "wasmcloud-host.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "wasmcloud-host.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: wasmcloud-host
+          command: ["wasmcloud"]
+        {{- if or (eq .Values.config.observability.enable true) (eq .Values.config.observability.traces.enable true) (eq .Values.config.observability.metrics.enable true) (eq .Values.config.observability.logs.enable true) }}
+          arg:
+          {{- if .Values.config.observability.enable }}
+            - --enable-observability
+          {{- end }}
+          {{- if .Values.config.observability.endpoint }}
+            - --override-observability-endpoint
+            - {{ .Values.config.observability.endpoint }}
+          {{- end }}
+          {{- if .Values.config.observability.protocol }}
+            - --observability-protocol
+            - {{ .Values.config.observability.protocol }}
+          {{- end }}
+          {{- if .Values.config.observability.traces.enable }}
+            - --enable-traces
+          {{ end }}
+          {{- if .Values.config.observability.traces.endpoint }}
+            - --override-traces-endpoint
+            - {{ .Values.config.observability.traces.endpoint }}
+          {{- end }}
+          {{- if .Values.config.observability.metrics.enable }}
+            - --enable-metrics
+          {{ end }}
+          {{- if .Values.config.observability.metrics.endpoint }}
+            - --override-metrics-endpoint
+            - {{ .Values.config.observability.metrics.endpoint }}
+          {{- end }}
+          {{- if .Values.config.observability.logs.enable }}
+            - --enable-logs
+          {{ end }}
+          {{- if .Values.config.observability.logs.endpoint }}
+            - --override-logs-endpoint
+            - {{ .Values.config.observability.logs.endpoint }}
+          {{- end }}
+        {{- end }}
+          env:
+          {{- if .Values.config.enableStructuredLogging }}
+          - name: WASMCLOUD_STRUCTURED_LOGGING_ENABLED
+            value: "true"
+          {{- end }}
+          - name: WASMCLOUD_LOG_LEVEL
+            value: {{ .Values.config.logLevel | upper | quote }}
+          - name: WASMCLOUD_JS_DOMAIN
+            value: {{ .Values.config.jetstreamDomain | quote }}
+          - name: WASMCLOUD_LATTICE
+            value: {{ .Values.config.lattice | quote }}
+          - name: WASMCLOUD_NATS_HOST
+            value: "127.0.0.1"
+          - name: WASMCLOUD_NATS_PORT
+            value: "4222"
+          - name: WASMCLOUD_RPC_TIMEOUT_MS
+            value: "4000"
+          {{- if .Values.config.controlTopicPrefix }}
+          - name: WASMCLOUD_CTL_TOPIC_PREFIX
+            value: {{ .Values.config.controlTopicPrefix }}
+          {{- end }}
+          {{- if .Values.config.configServiceEnabled }}
+          - name: WASMCLOUD_CONFIG_SERVICE
+            value: "true"
+          {{- end }}
+          {{- if .Values.config.allowLatest }}
+          - name: WASMCLOUD_OCI_ALLOW_LATEST
+            value: "true"
+          {{- end }}
+          {{- if .Values.config.allowedInsecure }}
+          - name: WASMCLOUD_OCI_ALLOWED_INSECURE
+            value: {{ include "wasmcloud-host.allowed-insecure" . }}
+          {{- end }}
+        {{- if .Values.config.policyService.enable }}
+          {{- if .Values.config.policyService.topic }}
+          - name: WASMCLOUD_POLICY_TOPIC
+            value: {{ .Values.config.policyService.topic | quote }}
+          {{- end }}
+          {{- if .Values.config.policyService.changesTopic }}
+          - name: WASMCLOUD_POLICY_CHANGES_TOPIC
+            value: {{ .Values.config.policyService.changesTopic | quote }}
+          {{- end }}
+          {{- if .Values.config.policyService.timeoutMs }}
+          - name: WASMCLOUD_POLICY_TIMEOUT
+            value: {{ .Values.config.policyService.timeoutMs | quote }}
+          {{- end }}
+        {{- end }}
+          {{- if .Values.config.secrets_topic_prefix }}
+          - name: WASMCLOUD_SECRETS_TOPIC
+            value: {{ .Values.config.secrets_topic_prefix | quote }}
+          {{- end }}
+          {{- if .Values.config.maxLinearMemoryBytes }}
+          - name: WASMCLOUD_MAX_LINEAR_MEMORY
+            value: {{ .Values.config.maxLinearMemoryBytes | int64 }}
+          {{- end }}
+        {{- if .Values.config.hostLabels }}
+          {{- range $key, $value := .Values.config.hostLabels }}
+            {{- if $value }}
+          - name: WASMCLOUD_LABEL_{{ $key | lower }}
+            value: {{ $value }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+          - name: WASMCLOUD_LABEL_kubernetes
+            value: "true"
+          - name: WASMCLOUD_LABEL_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: WASMCLOUD_LABEL_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources.wasmcloud | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+        - name: nats-leaf
+          image: "{{ .Values.image.natsLeaf.repository }}:{{ .Values.image.natsLeaf.tag }}"
+          imagePullPolicy: {{ .Values.image.natsLeaf.pullPolicy }}
+          args:
+            - -js
+            - --config
+            - /nats/nats.conf
+          resources:
+            {{- toYaml .Values.resources.natsLeaf | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: {{ include "wasmcloud-host.nats-config-name" . }}
+              mountPath: /nats/nats.conf
+              subPath: "nats.conf"
+              readOnly: true
+          {{- if .Values.config.natsCredentialsSecret }}
+            - name: {{ .Values.config.natsCredentialsSecret }}
+              mountPath: /nats/nats.creds
+              subPath: "nats.creds"
+              readOnly: true
+          {{- end }}
+      volumes:
+        - name: {{ include "wasmcloud-host.nats-config-name" . }}
+          configMap:
+            name: {{ include "wasmcloud-host.nats-config-name" . }}
+      {{- if .Values.config.natsCredentialsSecret }}
+        - name: {{ .Values.config.natsCredentialsSecret }}
+          secret: /nats/nats.creds
+            secretName: {{ .Values.config.natsCredentialsSecret }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/wasmcloud-host/values.yaml
+++ b/charts/wasmcloud-host/values.yaml
@@ -1,0 +1,97 @@
+replicas: 1
+nameOverride: ""
+
+image:
+  repository: "ghcr.io/wasmcloud/wasmcloud"
+  pullPolicy: "IfNotPresent"
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+  # Optional: The image to use for the NATS leaf that is deployed alongside the wasmCloud host.
+  # If not provided, the default upstream image will be used.
+  natsLeaf:
+    repository: "nats"
+    pullPolicy: "IfNotPresent"
+    tag: "2.10-alpine"
+
+config:
+  # Required: The lattice to connect the hosts to.
+  lattice: "default"
+  # Optional: Additional labels to apply to the host other than the defaults set by the host
+  hostLabels: {}
+  # Optional. The name of a secret containing a set of NATS credentials under 'nats.creds' key.
+  natsCredentialsSecret: ""
+  # Optional: The name of a secret containing the registry credentials.
+  # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line
+  registryCredentialsSecret: "wasmcloud-pull-secret"
+  # Optional: Enable structured logging for host logs. Defaults to "false".
+  enableStructuredLogging: false
+  # Optional: The control topic prefix to use for the host. Defaults to "wasmbus.ctl"
+  controlTopicPrefix: ""
+  # Optional: The Jetstream domain to use for the NATS sidecar. Defaults to "default".
+  jetstreamDomain: "default"
+  # Optional: The leaf node domain to use for the NATS sidecar. Defaults to "leaf".
+  leafNodeDomain: "leaf"
+  # Optional: Enable the config service for this host. Defaults to "false".
+  # Makes wasmCloud host issue requests to a config service on startup.
+  configServiceEnabled: false
+  # Optional: The log level to use for the host. Defaults to "INFO".
+  logLevel: "INFO"
+  # Optional: The address of the NATS server to connect to. Defaults to "nats://nats.default.svc.cluster.local".
+  natsAddress: "nats://nats.default.svc.cluster.local"
+  # Optional: Allow the host to deploy using the latest tag on OCI components or providers. Defaults to "false".
+  allowLatest: false
+  # Optional: Allow the host to pull artifacts from OCI registries insecurely.
+  allowedInsecure: []
+  # Optional: Policy service configuration.
+  policyService:
+    # Whether or not policy service is enabled
+    enable: false
+    # If provided, enables policy checks on start actions and component invocations.
+    topic: "wasmcloud.policy"
+    # If provided, allows the host to subscribe to updates on past policy decisions. Requires 'topic' above to be set.
+    changesTopic: "wasmcloud.policy.changes"
+    # If provided, allows setting a custom timeout for requesting policy decisions. Defaults to 1000. Requires 'topic' to be set.
+    timeoutMs: 1000
+  # Optional: Observability options for configuring the OpenTelemetry integration.
+  observability:
+    # NOTE: Enables all signals (logs/metrics/traces) at once. Set it to 'false' and enable each signal individually in case you don't need all of them.
+    enable: false
+    endpoint: ""
+    # Either 'grpc' or 'http'
+    protocol: ""
+    logs:
+      enable: false
+      endpoint: ""
+    metrics:
+      enable: false
+      endpoint: ""
+    traces:
+      enable: false
+      endpoint: ""
+  # Optional: Subject prefix that will be used by the host to query for wasmCloud Secrets.
+  # See https://wasmcloud.com/docs/concepts/secrets for more context
+  secretsTopicPrefix: "wasmcloud.secrets"
+  # Optional: The maximum amount of memory bytes that a component can allocate. Defaults to 10485760 (10mb).
+  maxLinearMemoryBytes:
+  # Optional: Additional options to control how the underlying wasmCloud hosts are scheduled in Kubernetes.
+  # This includes setting resource requirements for the nats and wasmCloud host
+  # containers along with any additional pot template settings.
+
+imagePullSecrets: []
+podSecurityContext: {}
+# fsGroup: 2000
+
+securityContext: {}
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
+resources:
+  wasmcloud: {}
+  natsLeaf: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Feature or Problem

This refreshes the `wasmcloud-host` helm chart to be compatible with wasmCloud 1.0+ (defaulting to `1.2.0`).

I've left the deprecation of the old chart as a follow-up exercise once we've published this one.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
