### PR TITLE
feat(wash-cli): add CLI styling to wash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6825,6 +6825,7 @@ dependencies = [
 name = "wash-cli"
 version = "0.31.0"
 dependencies = [
+ "anstyle",
  "anyhow",
  "assert-json-diff",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ wrpc-transport-nats = { workspace = true }
 members = ["crates/*"]
 
 [workspace.dependencies]
+anstyle = { version = "1.0.8", default-features = false }
 anyhow = { version = "1", default-features = false }
 assert-json-diff = { version = "2", default-features = false }
 async-compression = { version = "0.3", default-features = false }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -15,12 +15,13 @@ repository.workspace = true
 maintenance = { status = "actively-developed" }
 
 [dependencies]
+anstyle = { workspace = true }
 anyhow = { workspace = true, features = ["backtrace"] }
 async-compression = { workspace = true, features = ["tokio", "gzip"] }
 # We use a separate version of async-nats that has some code that isn't upstream
 # to support the needs of wRPC libraries.
 #
-# TODO: Unify upstream async-nats and wrpc-nats if/when https://github.com/nats-io/nats.rs/pull/1267 
+# TODO: Unify upstream async-nats and wrpc-nats if/when https://github.com/nats-io/nats.rs/pull/1267
 # or something similar is implemented
 async-nats = { workspace = true }
 async-nats-0_33 = { workspace = true }

--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -3,27 +3,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::bail;
 use clap::{self, Arg, Command, FromArgMatches, Parser, Subcommand};
-
 use serde_json::json;
 use tracing_subscriber::EnvFilter;
-use wash_cli::app::{self, AppCliCommand};
-use wash_cli::build::{self, BuildCommand};
-use wash_cli::call::{self, CallCli};
-use wash_cli::common;
-use wash_cli::completions::{self, CompletionOpts};
-use wash_cli::config::{self, ConfigCliCommand};
-use wash_cli::ctx::{self, CtxCommand};
-use wash_cli::dev::{self, DevCommand};
-use wash_cli::down::{self, DownCommand};
-use wash_cli::drain;
-use wash_cli::generate::{self, NewCliCommand};
-use wash_cli::keys::{self, KeysCliCommand};
-use wash_cli::par::{self, ParCliCommand};
-use wash_cli::plugin::{self, PluginCommand};
-use wash_cli::secrets::{self, SecretsCliCommand};
-use wash_cli::ui::{self, UiCommand};
-use wash_cli::up::{self, UpCommand, NATS_SERVER_VERSION, WADM_VERSION, WASMCLOUD_HOST_VERSION};
-use wash_cli::util::ensure_plugin_dir;
 use wash_lib::cli::capture::{CaptureCommand, CaptureSubcommand};
 use wash_lib::cli::claims::ClaimsCliCommand;
 use wash_lib::cli::get::GetCommand;
@@ -39,6 +20,26 @@ use wash_lib::cli::update::UpdateCommand;
 use wash_lib::cli::{CommandOutput, OutputKind};
 use wash_lib::drain::Drain as DrainSelection;
 use wash_lib::plugin::subcommand::{DirMapping, SubcommandRunner};
+
+use wash_cli::app::{self, AppCliCommand};
+use wash_cli::build::{self, BuildCommand};
+use wash_cli::call::{self, CallCli};
+use wash_cli::common;
+use wash_cli::completions::{self, CompletionOpts};
+use wash_cli::config::{self, ConfigCliCommand};
+use wash_cli::ctx::{self, CtxCommand};
+use wash_cli::dev::{self, DevCommand};
+use wash_cli::down::{self, DownCommand};
+use wash_cli::drain;
+use wash_cli::generate::{self, NewCliCommand};
+use wash_cli::keys::{self, KeysCliCommand};
+use wash_cli::par::{self, ParCliCommand};
+use wash_cli::plugin::{self, PluginCommand};
+use wash_cli::secrets::{self, SecretsCliCommand};
+use wash_cli::style::WASH_CLI_STYLE;
+use wash_cli::ui::{self, UiCommand};
+use wash_cli::up::{self, UpCommand, NATS_SERVER_VERSION, WADM_VERSION, WASMCLOUD_HOST_VERSION};
+use wash_cli::util::ensure_plugin_dir;
 
 const HELP: &str = r"
 _________________________________________________________________________________
@@ -112,6 +113,7 @@ fn version() -> String {
 
 #[derive(Debug, Clone, Parser)]
 #[clap(name = "wash", version = version(), override_help = HELP)]
+#[command(styles = WASH_CLI_STYLE)]
 struct Cli {
     #[clap(
         short = 'o',

--- a/crates/wash-cli/src/lib.rs
+++ b/crates/wash-cli/src/lib.rs
@@ -15,6 +15,7 @@ pub mod keys;
 pub mod par;
 pub mod plugin;
 pub mod secrets;
+pub mod style;
 pub mod ui;
 pub mod up;
 pub mod util;

--- a/crates/wash-cli/src/style.rs
+++ b/crates/wash-cli/src/style.rs
@@ -1,0 +1,23 @@
+//! Styling for wash CLI
+//!
+//! These are originally the same styles used by clap_cargo as of v0.14.1
+//! see: https://docs.rs/clap-cargo/0.14.1/src/clap_cargo/style.rs.html
+
+use anstyle::{AnsiColor, Effects, Style};
+
+const HEADER: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
+const USAGE: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
+const LITERAL: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+const PLACEHOLDER: Style = AnsiColor::Cyan.on_default();
+const ERROR: Style = AnsiColor::Red.on_default().effects(Effects::BOLD);
+const VALID: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+const INVALID: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
+
+pub const WASH_CLI_STYLE: clap::builder::styling::Styles = clap::builder::styling::Styles::styled()
+    .header(HEADER)
+    .usage(USAGE)
+    .literal(LITERAL)
+    .placeholder(PLACEHOLDER)
+    .error(ERROR)
+    .valid(VALID)
+    .invalid(INVALID);


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Adopt styling similar to cargo for wash CLI commands. This doesn't change our overridden help-text, but it does affect commands individually. We might want to consider changing/updating our overridden help/maybe not overriding it as well (or colorizing it ourselves).

### Before

![before](https://github.com/user-attachments/assets/cab0e032-c5ba-4275-9c15-12e2da685f31)

### After

![after](https://github.com/user-attachments/assets/38464270-b430-492b-9eff-631a4c7bdf5f)




## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
