### PR TITLE
fix: improve errors in wash-cli

### DIFF
--- a/crates/wash-cli/src/call.rs
+++ b/crates/wash-cli/src/call.rs
@@ -605,7 +605,9 @@ async fn create_client_from_opts_wrpc(opts: &ConnectionOpts) -> Result<async_nat
                 .require_tls(true);
         }
 
-        opts.connect(&nats_url).await.with_context(|| format!("Failed to connect to NATS {}\nNo credentials file was provided, you may need one to connect.", &nats_url))?
+        opts.connect(&nats_url)
+            .await
+            .with_context(|| format!("Failed to connect to NATS {}", &nats_url))?
     };
     Ok(nc)
 }

--- a/crates/wash-lib/src/config.rs
+++ b/crates/wash-lib/src/config.rs
@@ -252,7 +252,9 @@ pub async fn create_nats_client_from_opts(
             opts = opts.add_root_certificates(ca_file).require_tls(true);
         }
 
-        opts.connect(&nats_url).await.with_context(|| format!("Failed to connect to NATS {}\nNo credentials file was provided, you may need one to connect.", &nats_url))?
+        opts.connect(&nats_url)
+            .await
+            .with_context(|| format!("Failed to connect to NATS {}", &nats_url))?
     };
     Ok(nc)
 }


### PR DESCRIPTION
- **fix(wash-cli): remove misleading creds error message**
- **feat: give a nicer error to wash app for no responders**

## Feature or Problem
This PR improves one misleading error and one unhelpful error, ensuring that we aren't suggesting people we use credentials files for the former. For the latter, all `wash app` commands will now output a nicer error message in the case where no wadm server responded to the API request instead of just `no responders`.

The helper to ensure we output a nicer error for no responders could be replicated in a few places around the code IMO

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
