### PR TITLE
feat(wash-cli): Add --watch flag to view live changes in host inventory

### DIFF
--- a/crates/wash-cli/src/common/get_cmd.rs
+++ b/crates/wash-cli/src/common/get_cmd.rs
@@ -1,12 +1,22 @@
 use anyhow::Result;
+use crossterm::{
+    cursor, execute,
+    terminal::{Clear, ClearType},
+};
+use std::{collections::HashMap, io::Write, time::Duration};
+use tokio::time::sleep;
 use wash_lib::cli::claims::get_claims;
-use wash_lib::cli::get::{get_host_inventories, get_hosts, GetCommand, GetLinksCommand};
+use wash_lib::cli::get::{
+    get_host_inventories, get_hosts, GetCommand, GetHostInventoriesCommand, GetLinksCommand,
+};
 use wash_lib::cli::link::{LinkCommand, LinkQueryCommand};
 use wash_lib::cli::{CommandOutput, OutputKind};
 
 use crate::appearance::spinner::Spinner;
 use crate::common::link_cmd::handle_command as handle_link_command;
-use crate::ctl::{get_claims_output, get_host_inventories_output, get_hosts_output};
+use crate::ctl::{
+    get_claims_output, get_host_inventories_output, get_hosts_output, host_inventories_table,
+};
 
 pub async fn handle_command(command: GetCommand, output_kind: OutputKind) -> Result<CommandOutput> {
     let sp: Spinner = Spinner::new(&output_kind)?;
@@ -30,10 +40,85 @@ pub async fn handle_command(command: GetCommand, output_kind: OutputKind) -> Res
             } else {
                 sp.update_spinner_message(" Retrieving hosts for inventory query ...".to_string());
             }
-            let invs = get_host_inventories(cmd).await?;
-            get_host_inventories_output(invs)
+            get_inventory_handler(cmd, sp).await?
         }
     };
 
     Ok(out)
+}
+
+async fn get_inventory_handler(
+    cmd: GetHostInventoriesCommand,
+    sp: Spinner,
+) -> Result<CommandOutput> {
+    if cmd.watch.is_some() {
+        watch_inventory(cmd, sp).await?;
+        Ok(CommandOutput::new(
+            "Completed Watching Inventory".to_string(),
+            HashMap::new(),
+        ))
+    } else {
+        let invs = get_host_inventories(cmd).await?;
+        Ok(get_host_inventories_output(invs))
+    }
+}
+
+async fn watch_inventory(cmd: GetHostInventoriesCommand, sp: Spinner) -> Result<()> {
+    let mut stdout = std::io::stdout();
+    let invs = get_host_inventories(cmd.clone()).await?;
+    sp.finish_and_clear();
+    execute!(stdout, Clear(ClearType::FromCursorUp), cursor::MoveTo(0, 0))
+        .map_err(|e| anyhow::anyhow!("Failed to clear terminal: {}", e))?;
+    let output = host_inventories_table(invs);
+    stdout
+        .write_all(output.as_bytes())
+        .map_err(|e| anyhow::anyhow!("Failed to write inventory to stdout: {}", e))?;
+
+    let mut ctrlc = std::pin::pin!(tokio::signal::ctrl_c());
+    let watch_interval = cmd.watch.unwrap_or(Duration::from_millis(5000));
+
+    loop {
+        let invs = tokio::select! {
+            res = get_host_inventories(cmd.clone()) => res?,
+            res = &mut ctrlc => {
+                res?;
+                execute!(stdout, Clear(ClearType::Purge),Clear(ClearType::FromCursorUp), cursor::MoveTo(0, 0), cursor::Show)
+                    .map_err(|e| anyhow::anyhow!("Failed to execute terminal commands: {}", e))?;
+                stdout.flush()
+                    .map_err(|e| anyhow::anyhow!("Failed to flush stdout: {}", e))?;
+                return Ok(());
+            }
+        };
+
+        execute!(stdout, Clear(ClearType::Purge), cursor::MoveTo(0, 0))
+            .map_err(|e| anyhow::anyhow!("Failed to execute terminal commands: {}", e))?;
+
+        let output = host_inventories_table(invs);
+        stdout
+            .write_all(output.as_bytes())
+            .map_err(|e| anyhow::anyhow!("Failed to write inventory to stdout: {}", e))?;
+
+        stdout
+            .flush()
+            .map_err(|e| anyhow::anyhow!("Failed to flush stdout: {}", e))?;
+
+        execute!(
+            stdout,
+            Clear(ClearType::CurrentLine),
+            Clear(ClearType::FromCursorDown),
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to clear terminal: {}", e))?;
+
+        tokio::select! {
+            _ = sleep(watch_interval) => continue,
+            res = &mut ctrlc => {
+                res?;
+                execute!(stdout, Clear(ClearType::Purge),Clear(ClearType::FromCursorUp), cursor::MoveTo(0, 0), cursor::Show)
+                    .map_err(|e| anyhow::anyhow!("Failed to execute terminal commands: {}", e))?;
+                stdout.flush()
+                    .map_err(|e| anyhow::anyhow!("Failed to flush stdout: {}", e))?;
+                return Ok(());
+            }
+        }
+    }
 }

--- a/crates/wash-cli/src/ctl/mod.rs
+++ b/crates/wash-cli/src/ctl/mod.rs
@@ -218,6 +218,7 @@ mod test {
             CtlCliCommand::Get(CtlGetCommand::HostInventories(GetHostInventoriesCommand {
                 opts,
                 host_id,
+                watch: _,
             })) => {
                 assert_eq!(&opts.ctl_host.unwrap(), CTL_HOST);
                 assert_eq!(&opts.ctl_port.unwrap(), CTL_PORT);

--- a/crates/wash-cli/src/ctl/output.rs
+++ b/crates/wash-cli/src/ctl/output.rs
@@ -55,8 +55,10 @@ pub fn link_del_output(
     }
 }
 
-/// Helper function to transform a LinkDefinitionList into a table string for printing
-pub fn links_table(list: Vec<InterfaceLinkDefinition>) -> String {
+pub fn links_table(mut list: Vec<InterfaceLinkDefinition>) -> String {
+    // Sort the list based on the `source_id` field in ascending order
+    list.sort_by(|a, b| a.source_id.cmp(&b.source_id));
+
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table, 4);
 
@@ -84,7 +86,10 @@ pub fn links_table(list: Vec<InterfaceLinkDefinition>) -> String {
 }
 
 /// Helper function to transform a Host list into a table string for printing
-pub fn hosts_table(hosts: Vec<Host>) -> String {
+pub fn hosts_table(mut hosts: Vec<Host>) -> String {
+    // Sort hosts by uptime_seconds in descending order
+    hosts.sort_by(|a, b| b.uptime_seconds.cmp(&a.uptime_seconds));
+
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table, 4);
 
@@ -93,6 +98,7 @@ pub fn hosts_table(hosts: Vec<Host>) -> String {
         TableCell::new_with_alignment("Friendly name", 1, Alignment::Left),
         TableCell::new_with_alignment("Uptime (seconds)", 1, Alignment::Left),
     ]));
+
     hosts.iter().for_each(|h| {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment(h.id.clone(), 2, Alignment::Left),
@@ -105,11 +111,14 @@ pub fn hosts_table(hosts: Vec<Host>) -> String {
 }
 
 /// Helper function to transform a HostInventory into a table string for printing
-pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
+pub fn host_inventories_table(mut invs: Vec<HostInventory>) -> String {
     let mut table = Table::new();
     crate::util::configure_table_style(&mut table, 3);
 
-    invs.into_iter().for_each(|inv| {
+    // Sort the host inventories alphabetically by host_id
+    invs.sort_by(|a, b| a.host_id.cmp(&b.host_id));
+
+    invs.into_iter().for_each(|mut inv| {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment("Host ID", 2, Alignment::Left),
             TableCell::new_with_alignment("Friendly name", 1, Alignment::Left),
@@ -119,7 +128,11 @@ pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
             TableCell::new_with_alignment(inv.friendly_name.clone(), 1, Alignment::Left),
         ]));
 
-        if !inv.labels.is_empty() {
+        // Sort the labels alphabetically by key
+        let mut sorted_labels: Vec<_> = inv.labels.iter().collect();
+        sorted_labels.sort_by(|a, b| a.0.cmp(b.0));
+
+        if !sorted_labels.is_empty() {
             table.add_row(Row::new(vec![TableCell::new_with_alignment(
                 "",
                 3,
@@ -130,7 +143,7 @@ pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
                 1,
                 Alignment::Left,
             )]));
-            inv.labels.iter().for_each(|(k, v)| {
+            sorted_labels.into_iter().for_each(|(k, v)| {
                 table.add_row(Row::new(vec![
                     TableCell::new_with_alignment(k, 1, Alignment::Left),
                     TableCell::new_with_alignment(v, 1, Alignment::Left),
@@ -149,6 +162,10 @@ pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
             4,
             Alignment::Center,
         )]));
+
+        // Sort the components alphabetically by name
+        inv.components.sort_by(|a, b| a.name.cmp(&b.name));
+
         if !inv.components.is_empty() {
             table.add_row(Row::new(vec![
                 TableCell::new_with_alignment("Component ID", 1, Alignment::Left),
@@ -170,11 +187,16 @@ pub fn host_inventories_table(invs: Vec<HostInventory>) -> String {
                 Alignment::Left,
             )]));
         }
+
         table.add_row(Row::new(vec![TableCell::new_with_alignment(
             "",
             4,
             Alignment::Left,
         )]));
+
+        // Sort the providers alphabetically by name
+        inv.providers.sort_by(|a, b| a.name.cmp(&b.name));
+
         if !inv.providers.is_empty() {
             table.add_row(Row::new(vec![
                 TableCell::new_with_alignment("Provider ID", 1, Alignment::Left),

--- a/crates/wash-lib/src/cli/get.rs
+++ b/crates/wash-lib/src/cli/get.rs
@@ -24,6 +24,10 @@ pub struct GetHostInventoriesCommand {
     /// Host ID to retrieve inventory for. If not provided, wash will query the inventories of all running hosts.
     #[clap(name = "host-id", value_parser)]
     pub host_id: Option<ServerId>,
+
+    /// Switches to a real-time, live-updating host inventory
+    #[clap(long, num_args = 0..=1, default_missing_value = "5000", value_parser = parse_watch_interval)]
+    pub watch: Option<std::time::Duration>,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -101,4 +105,9 @@ pub async fn get_hosts(cmd: GetHostsCommand) -> Result<Vec<Host>> {
                 .collect::<Vec<_>>()
         })
         .context("Was able to connect to NATS, but failed to get hosts.")
+}
+
+fn parse_watch_interval(arg: &str) -> Result<std::time::Duration, std::num::ParseIntError> {
+    let milis = arg.parse::<u64>()?;
+    Ok(std::time::Duration::from_millis(milis))
 }


### PR DESCRIPTION
(2/2) done [ie -- watch flag has been implemented]
#2772 is also addressed in this PR

## Feature or Problem
Programatic implementation of unix's `watch` but with multi-platform support.

## Related Issues
#2512 

## Release Information
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
