### PR TITLE
feat(host): support auctioning components with ram limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8366,7 +8366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core 0.54.0",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8379,13 +8379,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -8404,27 +8423,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.4",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
-dependencies = [
- "windows-targets 0.52.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,7 +3014,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -5732,16 +5732,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.27.8"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
+checksum = "d4115055da5f572fff541dd0c4e61b0262977f453cc9fe04be83aba25a89bdab"
 dependencies = [
- "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -7389,6 +7388,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sha2",
+ "sysinfo",
  "time",
  "tokio",
  "tokio-stream",
@@ -8360,6 +8360,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8396,6 +8406,25 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
+dependencies = [
+ "windows-targets 0.52.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,7 @@ serde_with = { version = "3", default-features = false }
 serde_yaml = { version = "0.9", default-features = false }
 serial_test = { version = "0.9", default-features = false }
 sha2 = { version = "0.10", default-features = false }
-sysinfo = { version = "0.27", default-features = false }
+sysinfo = { version = "0.31", default-features = false }
 tempfile = { version = "3", default-features = false }
 term-table = { version = "=1.3.2", default-features = false }
 termcolor = { version = "1", default-features = false }

--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -19,13 +19,13 @@ pub mod client;
 pub use client::{collect_sub_timeout, Client, ClientBuilder};
 
 mod types;
+pub use types::auction::*;
 pub use types::component::*;
 pub use types::ctl::*;
 pub use types::host::*;
-pub use types::link::InterfaceLinkDefinition;
+pub use types::link::*;
 pub use types::provider::*;
 pub use types::registry::*;
-pub use types::rpc::*;
 
 /// Identifier of one or more entities on the lattice used for addressing. May take many forms, such as:
 /// - component public key
@@ -83,7 +83,7 @@ fn assert_non_empty_string(input: impl AsRef<str>, message: impl AsRef<str>) -> 
 enum IdentifierKind {
     HostId,
     ComponentId,
-    ActorRef,
+    ComponentRef,
     ProviderRef,
     LinkName,
 }
@@ -97,8 +97,8 @@ fn parse_identifier<T: AsRef<str>>(kind: &IdentifierKind, value: T) -> Result<St
         IdentifierKind::ComponentId => {
             assert_non_empty_string(value, "Component ID cannot be empty")
         }
-        IdentifierKind::ActorRef => {
-            assert_non_empty_string(value, "Actor OCI reference cannot be empty")
+        IdentifierKind::ComponentRef => {
+            assert_non_empty_string(value, "Component OCI reference cannot be empty")
         }
         IdentifierKind::ProviderRef => {
             assert_non_empty_string(value, "Provider OCI reference cannot be empty")

--- a/crates/control-interface/src/types/component.rs
+++ b/crates/control-interface/src/types/component.rs
@@ -31,6 +31,7 @@ pub struct ComponentDescription {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
 pub struct ComponentInstance {
     /// The annotations that were used in the start request that produced
     /// this component instance

--- a/crates/control-interface/src/types/host.rs
+++ b/crates/control-interface/src/types/host.rs
@@ -47,7 +47,6 @@ pub struct Host {
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct HostInventory {
     /// Components running on this host.
-    #[serde(alias = "actors")]
     pub components: Vec<ComponentDescription>,
     /// Providers running on this host
     pub providers: Vec<ProviderDescription>,

--- a/crates/control-interface/src/types/link.rs
+++ b/crates/control-interface/src/types/link.rs
@@ -33,6 +33,21 @@ pub struct InterfaceLinkDefinition {
     pub target_config: Vec<KnownConfigName>,
 }
 
+/// A request to remove a link definition and detach the relevant component
+/// from the given provider
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DeleteInterfaceLinkDefinitionRequest {
+    /// The source component's identifier.
+    pub source_id: ComponentId,
+    /// Name of the link. Not providing this is equivalent to specifying Some("default")
+    #[serde(default = "default_link_name")]
+    pub name: LinkName,
+    /// WIT namespace of the link, e.g. `wasi` in `wasi:keyvalue/readwrite.get`
+    pub wit_namespace: WitNamespace,
+    /// WIT package of the link, e.g. `keyvalue` in `wasi:keyvalue/readwrite.get`
+    pub wit_package: WitPackage,
+}
+
 /// Helper function to provide a default link name
 pub(crate) fn default_link_name() -> LinkName {
     "default".to_string()

--- a/crates/control-interface/src/types/mod.rs
+++ b/crates/control-interface/src/types/mod.rs
@@ -1,9 +1,9 @@
 //! Collection of types that are commonly used/necessary in control interface operations
 
+pub mod auction;
 pub mod component;
 pub mod ctl;
 pub mod host;
 pub mod link;
 pub mod provider;
 pub mod registry;
-pub mod rpc;

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -36,6 +36,7 @@ secrecy = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
+sysinfo = { workspace = true, features = ["system"] }
 sha2 = { workspace = true }
 time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true, features = [
@@ -52,7 +53,7 @@ ulid = { workspace = true, features = ["std"] }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["serde"] }
 wascap = { workspace = true }
-wasmcloud-control-interface = { workspace = true }
+wasmcloud-control-interface = { workspace = true, features = ["v2alpha1"] }
 wasmcloud-core = { workspace = true, features = [
     "oci-distribution",
     "otel",

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -53,7 +53,7 @@ ulid = { workspace = true, features = ["std"] }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["serde"] }
 wascap = { workspace = true }
-wasmcloud-control-interface = { workspace = true, features = ["v2alpha1"] }
+wasmcloud-control-interface = { workspace = true }
 wasmcloud-core = { workspace = true, features = [
     "oci-distribution",
     "otel",

--- a/crates/host/src/wasmbus/host_config.rs
+++ b/crates/host/src/wasmbus/host_config.rs
@@ -115,7 +115,7 @@ impl Default for Host {
             secrets_topic_prefix: None,
             version: env!("CARGO_PKG_VERSION").to_string(),
             max_execution_time: Duration::from_millis(10 * 60 * 1000),
-            // 10 MB
+            // 256 MB
             max_linear_memory: MAX_LINEAR_MEMORY,
             // 50 MB
             max_component_size: MAX_COMPONENT_SIZE,

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -200,16 +200,6 @@ struct Component {
     max_memory_size: Option<usize>,
 }
 
-impl Component {
-    /// Returns the maximum amount of memory this component could use if all instances were running
-    /// and using the maximum amount of memory at once. If the maximum memory is not set, returns 0.
-    pub(crate) fn max_memory(&self) -> usize {
-        self.max_memory_size
-            .map(|m| m * self.max_instances.get())
-            .unwrap_or(0)
-    }
-}
-
 impl Deref for Component {
     type Target = wasmcloud_runtime::Component<Handler>;
 
@@ -1113,12 +1103,8 @@ impl Host {
     /// the maximum memory of all running components
     async fn get_free_memory(&self) -> u64 {
         self.system_info.read().await.free_memory()
-            - self
-                .components
-                .read()
-                .await
-                .iter()
-                .fold(0, |acc, (_, c)| acc + c.max_memory()) as u64
+        // NOTE(brooksmtownsend): If desired, we can subtract the memory of all
+        // running components here.
     }
 
     #[instrument(level = "debug", skip_all)]

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -43,18 +43,16 @@ use tokio_stream::wrappers::IntervalStream;
 use tracing::{debug, error, info, instrument, trace, warn, Instrument as _};
 use uuid::Uuid;
 use wascap::{jwt, prelude::ClaimsBuilder};
-use wasmcloud_control_interface::v2alpha1::auction::{
-    ComponentAuctionAck, ComponentAuctionRequest,
-};
 use wasmcloud_control_interface::{
-    ComponentDescription, CtlResponse, DeleteInterfaceLinkDefinitionRequest, HostInventory,
-    HostLabel, InterfaceLinkDefinition, ProviderAuctionAck, ProviderAuctionRequest,
-    ProviderDescription, RegistryCredential, ScaleComponentCommand, StartProviderCommand,
-    StopHostCommand, StopProviderCommand, UpdateComponentCommand,
+    ComponentAuctionAck, ComponentAuctionRequest, ComponentDescription, CtlResponse,
+    DeleteInterfaceLinkDefinitionRequest, HostInventory, HostLabel, InterfaceLinkDefinition,
+    ProviderAuctionAck, ProviderAuctionRequest, ProviderDescription, RegistryCredential,
+    ScaleComponentCommand, StartProviderCommand, StopHostCommand, StopProviderCommand,
+    UpdateComponentCommand,
 };
 use wasmcloud_core::{
     provider_config_update_subject, ComponentId, HealthCheckResponse, HostData, OtelConfig,
-    CTL_API_VERSION_1, CTL_API_VERSION_2_ALPHA_1,
+    CTL_API_VERSION_1,
 };
 use wasmcloud_runtime::capability::secrets::store::SecretValue;
 use wasmcloud_runtime::component::WrpcServeEvent;
@@ -168,10 +166,6 @@ impl Queue {
                 format!("{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.config.>"),
                 format!("{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.config"),
             )),
-            // v2alpha1
-            Either::Left(nats.subscribe(format!(
-                "{topic_prefix}.{CTL_API_VERSION_2_ALPHA_1}.{lattice}.*.auction",
-            ))),
         ])
         .await
         .into_iter()

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1436,6 +1436,15 @@ impl Host {
             return Ok(None);
         }
 
+        if auction.max_instances > self.host_config.max_components {
+            debug!(
+                max_instances = auction.max_instances,
+                max_components = self.host_config.max_components,
+                "component max instances requested exceeds host max components"
+            );
+            return Ok(None);
+        }
+
         let requested_ram_amount = auction.max_memory * auction.max_instances as u64;
         self.refresh_ram_usage().await;
 

--- a/crates/runtime/src/component/http.rs
+++ b/crates/runtime/src/component/http.rs
@@ -134,7 +134,12 @@ where
         let scheme = wrpc_interface_http::bindings::wrpc::http::types::Scheme::from(scheme).into();
 
         let (tx, rx) = oneshot::channel();
-        let mut store = new_store(&self.engine, self.handler.clone(), self.max_execution_time);
+        let mut store = new_store(
+            &self.engine,
+            self.handler.clone(),
+            self.max_execution_time,
+            self.max_memory_size,
+        );
         let pre = incoming_http_bindings::IncomingHttpPre::new(self.pre.clone())
             .context("failed to pre-instantiate `wasi:http/incoming-handler`")?;
         let bindings = pre

--- a/crates/runtime/src/component/messaging.rs
+++ b/crates/runtime/src/component/messaging.rs
@@ -102,7 +102,12 @@ where
             reply_to,
         }: wrpc_handler_bindings::wasmcloud::messaging::types::BrokerMessage,
     ) -> anyhow::Result<Result<(), String>> {
-        let mut store = new_store(&self.engine, self.handler.clone(), self.max_execution_time);
+        let mut store = new_store(
+            &self.engine,
+            self.handler.clone(),
+            self.max_execution_time,
+            self.max_memory_size,
+        );
         let pre = wasmtime_handler_bindings::MessagingHandlerPre::new(self.pre.clone())
             .context("failed to pre-instantiate `wasmcloud:messaging/handler`")?;
         let bindings = pre.instantiate_async(&mut store).await?;

--- a/crates/test-util/src/host.rs
+++ b/crates/test-util/src/host.rs
@@ -1,5 +1,6 @@
 //! Utilities for managing wasmCloud hosts locally or remotely via the lattice
 
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::time::Duration;
 use std::{future::Future, sync::Arc};
@@ -101,6 +102,7 @@ impl WasmCloudTestHost {
             provider_shutdown_delay: Some(Duration::from_millis(300)),
             allow_file_load: true,
             secrets_topic_prefix,
+            labels: HashMap::from([("wasmcloud_test".to_string(), "true".to_string())]),
             ..Default::default()
         };
         if let Some(psc) = policy_service_config {

--- a/crates/test-util/src/provider.rs
+++ b/crates/test-util/src/provider.rs
@@ -50,7 +50,7 @@ pub async fn assert_start_provider(
         client,
         lattice,
         host_key,
-        provider_key,
+        provider_key: _,
         provider_id,
         url,
         config,
@@ -74,10 +74,7 @@ pub async fn assert_start_provider(
 
     let res = pin!(IntervalStream::new(interval(Duration::from_secs(1)))
         .take(30)
-        .then(|_| rpc_client.request(
-            health_subject(lattice, &provider_key.public_key()),
-            "".into(),
-        ))
+        .then(|_| rpc_client.request(health_subject(lattice, provider_id), "".into(),))
         .filter_map(|res| {
             match res {
                 Err(error) => {

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = { workspace = true, features = ["raw_value"] }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
-sysinfo = { workspace = true }
+sysinfo = { workspace = true, features = ["system"] }
 tempfile = { workspace = true }
 term-table = { workspace = true }
 termcolor = { workspace = true }

--- a/crates/wash-cli/src/up/mod.rs
+++ b/crates/wash-cli/src/up/mod.rs
@@ -11,7 +11,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use sysinfo::{System, SystemExt};
+use sysinfo::{ProcessesToUpdate, System};
 use tokio::fs::create_dir_all;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
@@ -706,7 +706,7 @@ fn is_process_running(pid: &str) -> bool {
     match pid.parse() {
         Ok(pid) => {
             let mut sys = System::new_all();
-            sys.refresh_processes();
+            sys.refresh_processes(ProcessesToUpdate::All);
             sys.processes().get(&pid).is_some()
         }
         Err(_) => false,

--- a/crates/wash-cli/tests/common/mod.rs
+++ b/crates/wash-cli/tests/common/mod.rs
@@ -10,7 +10,7 @@ use std::{
 use anyhow::{bail, ensure, Context, Result};
 use oci_distribution::Reference;
 use rand::{distributions::Alphanumeric, Rng};
-use sysinfo::{ProcessExt, SystemExt};
+use sysinfo::ProcessesToUpdate;
 use tempfile::TempDir;
 use tokio::{
     fs::File,
@@ -684,11 +684,12 @@ pub async fn wait_until_process_has_count(
 
     tokio::time::timeout(timeout, async move {
         loop {
-            info.refresh_processes();
+            info.refresh_processes(ProcessesToUpdate::All);
             let count = info
                 .processes()
                 .values()
-                .map(|p| p.exe().to_string_lossy())
+                .filter_map(|p| p.exe())
+                .map(|p| p.to_string_lossy())
                 .filter(|name| name.contains(filter))
                 .count();
             if predicate(count) {

--- a/tests/auction.rs
+++ b/tests/auction.rs
@@ -1,0 +1,256 @@
+//! This module contains tests for the host's ability to handle and respond to auctions
+
+use core::str;
+use std::collections::HashMap;
+
+use anyhow::Context as _;
+use test_components::RUST_HTTP_HELLO_WORLD;
+use tracing::instrument;
+use wasmcloud_control_interface::ComponentAuctionRequestBuilder;
+use wasmcloud_test_util::{
+    assert_scale_component, assert_start_provider, host::WasmCloudTestHost,
+    provider::StartProviderArgs,
+};
+
+pub mod common;
+use common::{nats::start_nats, providers};
+
+const LATTICE: &str = "auctions";
+const COMPONENT_REF: &str = "ghcr.io/wasmcloud/hello:1.0.0";
+const COMPONENT_ID: &str = "http_hello_world";
+const PROVIDER_ID: &str = "http_server";
+
+/// Auction components and ensure the host properly handles the auction
+#[instrument(skip_all, ret)]
+#[tokio::test]
+async fn components() -> anyhow::Result<()> {
+    let (nats_server, nats_url, nats_client) =
+        start_nats().await.context("failed to start NATS")?;
+
+    // Build client for interacting with the lattice
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
+        .lattice(LATTICE.to_string())
+        .build();
+    // Build the host
+    let host = WasmCloudTestHost::start(&nats_url, LATTICE)
+        .await
+        .context("failed to start test host")?;
+
+    let auction = ctl_client
+        .perform_component_auction(
+            ComponentAuctionRequestBuilder::new(COMPONENT_REF, COMPONENT_ID).build(),
+        )
+        .await;
+    assert!(
+        auction.is_ok(),
+        "failed to perform component auction: {:?}",
+        auction
+    );
+    assert_eq!(auction.unwrap().len(), 1, "unexpected number of responses");
+
+    let auction_with_constraints = ctl_client
+        .perform_component_auction(
+            ComponentAuctionRequestBuilder::new(COMPONENT_REF, COMPONENT_ID)
+                // This label is hardcoded on the test hosts
+                .constraints(HashMap::from([(
+                    "wasmcloud_test".to_string(),
+                    "true".to_string(),
+                )]))
+                .build(),
+        )
+        .await;
+    assert!(
+        auction_with_constraints.is_ok(),
+        "failed to perform component auction: {:?}",
+        auction_with_constraints
+    );
+    assert_eq!(
+        auction_with_constraints.unwrap().len(),
+        1,
+        "unexpected number of responses"
+    );
+
+    let auction_with_resource_limits = ctl_client
+        .perform_component_auction(
+            ComponentAuctionRequestBuilder::new(COMPONENT_REF, COMPONENT_ID)
+                // If the host has less than 50 bytes of RAM available, we have other problems
+                .max_memory(5)
+                .max_instances(10)
+                .build(),
+        )
+        .await;
+    assert!(
+        auction_with_resource_limits.is_ok(),
+        "failed to perform component auction: {:?}",
+        auction_with_resource_limits
+    );
+    assert_eq!(
+        auction_with_resource_limits.unwrap().len(),
+        1,
+        "unexpected number of responses"
+    );
+
+    let auction_with_excessive_resource_limits = ctl_client
+        .perform_component_auction(
+            // Exceeding the host's max linear memory (256 MiB by default)
+            ComponentAuctionRequestBuilder::new(COMPONENT_REF, COMPONENT_ID)
+                // In total, requesting 300 MiB of memory
+                .max_memory(300 * 1024 * 1024)
+                .build(),
+        )
+        .await;
+    assert!(
+        auction_with_excessive_resource_limits.is_ok(),
+        "failed to perform component auction: {:?}",
+        auction_with_excessive_resource_limits
+    );
+    assert_eq!(
+        auction_with_excessive_resource_limits.unwrap().len(),
+        0,
+        "unexpected number of responses"
+    );
+
+    let auction_too_many_components = ctl_client
+        .perform_component_auction(
+            // Exceeding the host's max components (10000 by default)
+            ComponentAuctionRequestBuilder::new(COMPONENT_REF, COMPONENT_ID)
+                .max_instances(10001)
+                .build(),
+        )
+        .await;
+    assert!(
+        auction_too_many_components.is_ok(),
+        "failed to perform component auction: {:?}",
+        auction_too_many_components
+    );
+    assert_eq!(
+        auction_too_many_components.unwrap().len(),
+        0,
+        "unexpected number of responses"
+    );
+
+    // Start a component with the previously auctioned component ID
+    assert_scale_component(
+        &ctl_client,
+        &host.host_key(),
+        format!("file://{RUST_HTTP_HELLO_WORLD}"),
+        COMPONENT_ID,
+        None,
+        5,
+        Vec::new(),
+    )
+    .await
+    .context("failed to scale `rust-http-hello-world` component")?;
+
+    let auction_no_response = ctl_client
+        .perform_component_auction(
+            ComponentAuctionRequestBuilder::new(COMPONENT_REF, COMPONENT_ID).build(),
+        )
+        .await;
+    assert!(
+        auction_no_response.is_ok(),
+        "failed to perform component auction: {:?}",
+        auction_no_response
+    );
+    // The auction should be successful, but the host shouldn't respond
+    // because a component with that ID is already running
+    assert!(
+        auction_no_response.unwrap().is_empty(),
+        "unexpected number of responses"
+    );
+
+    nats_server.stop().await.context("failed to stop NATS")?;
+    Ok(())
+}
+
+/// Auction providers and ensure the host properly handles the auction
+#[instrument(skip_all, ret)]
+#[tokio::test]
+async fn providers() -> anyhow::Result<()> {
+    let (nats_server, nats_url, nats_client) =
+        start_nats().await.context("failed to start NATS")?;
+
+    // Build client for interacting with the lattice
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
+        .lattice(LATTICE.to_string())
+        .build();
+    // Build the host
+    let host = WasmCloudTestHost::start(&nats_url, LATTICE)
+        .await
+        .context("failed to start test host")?;
+
+    let auction = ctl_client
+        .perform_provider_auction(COMPONENT_REF, PROVIDER_ID, HashMap::new())
+        .await;
+    assert!(
+        auction.is_ok(),
+        "failed to perform provider auction: {:?}",
+        auction
+    );
+    assert_eq!(auction.unwrap().len(), 1, "unexpected number of responses");
+
+    let auction_with_constraints = ctl_client
+        .perform_provider_auction(
+            COMPONENT_REF,
+            PROVIDER_ID,
+            HashMap::from([("wasmcloud_test".to_string(), "true".to_string())]),
+        )
+        .await;
+    assert!(
+        auction_with_constraints.is_ok(),
+        "failed to perform provider auction: {:?}",
+        auction_with_constraints
+    );
+    assert_eq!(
+        auction_with_constraints.unwrap().len(),
+        1,
+        "unexpected number of responses"
+    );
+
+    let auction_with_mismatched_constraints = ctl_client
+        .perform_provider_auction(
+            COMPONENT_REF,
+            PROVIDER_ID,
+            HashMap::from([("foo".to_string(), "bar".to_string())]),
+        )
+        .await;
+    assert!(
+        auction_with_mismatched_constraints.is_ok(),
+        "failed to perform provider auction: {:?}",
+        auction_with_mismatched_constraints
+    );
+    assert_eq!(
+        auction_with_mismatched_constraints.unwrap().len(),
+        0,
+        "unexpected number of responses"
+    );
+
+    let http_server = providers::rust_http_server().await;
+
+    assert_start_provider(StartProviderArgs {
+        client: &ctl_client,
+        lattice: LATTICE,
+        host_key: &host.host_key(),
+        provider_key: &http_server.subject,
+        provider_id: PROVIDER_ID,
+        url: &http_server.url(),
+        config: vec![],
+    })
+    .await
+    .context("failed to start provider")?;
+
+    // Now that the provider is running, the host should not respond to the auction
+    let auction = ctl_client
+        .perform_provider_auction(COMPONENT_REF, PROVIDER_ID, HashMap::new())
+        .await;
+    assert!(
+        auction.is_ok(),
+        "failed to perform provider auction: {:?}",
+        auction
+    );
+    assert_eq!(auction.unwrap().len(), 0, "unexpected number of responses");
+
+    nats_server.stop().await.context("failed to stop NATS")?;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR is in draft to ensure that I can get feedback on the changes to the control interface crate, as I want to ensure I'm using a good pattern there for adding additional features as non-breaking changes.

Additionally, I'd like feedback on the "reservation" mechanism where we will only respond to auctions of memory + instances if there's enough memory for _all_ of those instances to be at max capacity.

## Feature or Problem
~This PR adds support to the control interface crate for a `v2alpha1` version of the control interface protocol. The first inclusion in this new protocol version is an updated `ComponentAuctionRequest` (complete with the #[non_exhaustive] and builder implementations to assist with backwards compatibility) that are only turned on by enabling a new cargo feature. This is technically completely backwards compatible, but since the control-interface crate is v1.0.0, adding the new members (even privately) would be a breaking change.~

After an initial round of feedback, I yanked the control interface v2alpha1 concepts in favor of just accepting there are already breaking changes in the control interface and we need to publish a v2.0.0

This PR also adds support to the host to understand how much memory is available on the system, and respond to an auction according to the requested memory amount ~* component instances~.

To lay this out in concrete terms, let's say we issue an auction for a component and request a max 2mb of memory, with 100 max instances. If all instances were running and consuming memory, this would be 200mb of RAM that we need to "reserve" for this component.

- Host A, having 100mb free RAM to use, will not respond
- Host B, having 250mb free RAM to use, will respond
- ~Host C, having 2gb free RAM to use and another component with 100mb max memory and 19 max instances (1.9gb total), will not respond~ This scenario has been scrapped as it leads to the necessity to massively underprovision a host.

TODO
- [x] Still need to accept the max memory on the component scale command

**We won't be able to offer this same feature for native capability providers, since they are spawned processes. If you're looking to constrain the memory of a provider, I'd recommend running a separate host with the capability provider and using a container to constrain that specific provider** 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
Added a suite of auction tests to demonstrate different scenarios where a host should and shouldn't respond.

### Manual Verification
I manually verified a few of these scenarios with the NATS CLI
