### PR TITLE
fix(charts): Fix secrets topic prefix naming and max linear memory bytes rendering

### DIFF
--- a/charts/wasmcloud-host/Chart.yaml
+++ b/charts/wasmcloud-host/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wasmcloud-host/templates/deployment.yaml
+++ b/charts/wasmcloud-host/templates/deployment.yaml
@@ -105,13 +105,13 @@ spec:
             value: {{ .Values.config.policyService.timeoutMs | quote }}
           {{- end }}
         {{- end }}
-          {{- if .Values.config.secrets_topic_prefix }}
+          {{- if .Values.config.secretsTopicPrefix }}
           - name: WASMCLOUD_SECRETS_TOPIC
-            value: {{ .Values.config.secrets_topic_prefix | quote }}
+            value: {{ .Values.config.secretsTopicPrefix | quote }}
           {{- end }}
           {{- if .Values.config.maxLinearMemoryBytes }}
           - name: WASMCLOUD_MAX_LINEAR_MEMORY
-            value: {{ .Values.config.maxLinearMemoryBytes | int64 }}
+            value: {{ .Values.config.maxLinearMemoryBytes | int64 | quote }}
           {{- end }}
         {{- if .Values.config.hostLabels }}
           {{- range $key, $value := .Values.config.hostLabels }}
@@ -123,11 +123,11 @@ spec:
         {{- end }}
           - name: WASMCLOUD_LABEL_kubernetes
             value: "true"
-          - name: WASMCLOUD_LABEL_pod_name
+          - name: WASMCLOUD_LABEL_kubernetes_pod_name
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: WASMCLOUD_LABEL_node_name
+          - name: WASMCLOUD_LABEL_kubernetes_node_name
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName


### PR DESCRIPTION
## Feature or Problem

The secrets topic prefix naming had slipped through as not following the appropriate naming convention, and for some reason Helm did not like max linear bytes being passed in as a number instead of a string, so I'm adding some quoting to it.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
