### PR TITLE
fix(wash-cli): wash dev on non-xkeys component IDs

### DIFF
--- a/crates/wash-lib/src/cli/dev.rs
+++ b/crates/wash-lib/src/cli/dev.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use console::style;
 use wasmcloud_control_interface::Client;
 
@@ -6,16 +6,16 @@ use crate::{
     build::{build_project, SignConfig},
     component::update_component,
     generate::emoji,
-    id::{ModuleId, ServerId},
+    id::ServerId,
     parser::{ProjectConfig, TypeConfig},
 };
 
 /// Perform a single execution of the dev loop for an artifact
 pub async fn run_dev_loop(
     project_cfg: &ProjectConfig,
-    component_id: ModuleId,
+    component_id: &str,
     component_ref: &str,
-    host_id: ServerId,
+    host_id: &ServerId,
     ctl_client: &Client,
     sign_cfg: Option<SignConfig>,
 ) -> Result<()> {
@@ -43,7 +43,9 @@ pub async fn run_dev_loop(
                 .bold(),
             );
 
-            update_component(ctl_client, &host_id, &component_id, component_ref).await?;
+            update_component(ctl_client, host_id, component_id, component_ref)
+                .await
+                .context("failed to update component during dev loop")?;
         }
     }
 


### PR DESCRIPTION
This commit fixes an issue wher `wash dev` assumed that component IDs had to be `ModuleId`s (i.e. nkeys).

While in the past component IDs *were* nkeys, they are no longer required to be, and can be user-friendly names.

Resolves #2887 

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
