### PR TITLE
deps(async-nats): upgrade to 0.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,10 +279,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-nats-wrpc"
-version = "0.35.1"
+name = "async-nats"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b90420a99c2fa8e337a0420f4fd684ac464b5a5d3c42fbbccc6261d7ed25bcc"
+checksum = "f71e5a1bab60f46b0b005f4808b8ee83ef6d577608923de938403393c9a30cf8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3892,7 +3892,7 @@ dependencies = [
 name = "opentelemetry-nats"
 version = "0.1.1"
 dependencies = [
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "opentelemetry 0.23.0",
  "opentelemetry_sdk 0.23.0",
  "tracing",
@@ -5183,7 +5183,7 @@ name = "secrets-nats-kv"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "async-trait",
  "backoff",
  "bytes",
@@ -6666,7 +6666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a1dab42d9eb3412b2fcab8189d79de99a9db2f48cf9e48aedf7c3c163b10f07"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.33.0",
  "bytes",
  "futures",
  "nkeys 0.4.3",
@@ -6687,7 +6687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "253b4a5c06d99f8d6768d69a1ba264652731cd298c87fd880077ad0e554840f2"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.33.0",
  "async-trait",
  "base64 0.22.1",
  "bytes",
@@ -6829,8 +6829,8 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "async-compression",
- "async-nats",
- "async-nats-wrpc",
+ "async-nats 0.33.0",
+ "async-nats 0.36.0",
  "bytes",
  "clap",
  "clap-markdown",
@@ -6882,7 +6882,7 @@ dependencies = [
  "warp",
  "wascap 0.15.0",
  "wash-lib",
- "wasmcloud-control-interface 1.0.0",
+ "wasmcloud-control-interface 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmcloud-core 0.9.0",
  "wasmcloud-provider-sdk",
  "wasmcloud-secrets-types 0.4.0",
@@ -6893,7 +6893,7 @@ dependencies = [
  "wit-parser 0.215.0",
  "wrpc-interface-http",
  "wrpc-transport 0.26.7",
- "wrpc-transport-nats 0.22.3",
+ "wrpc-transport-nats 0.23.0",
 ]
 
 [[package]]
@@ -6902,7 +6902,7 @@ version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-compression",
- "async-nats",
+ "async-nats 0.33.0",
  "bytes",
  "cargo_metadata",
  "cargo_toml",
@@ -6955,7 +6955,7 @@ dependencies = [
  "wascap 0.15.0",
  "wasi-preview1-component-adapter-provider",
  "wasm-encoder 0.216.0",
- "wasmcloud-control-interface 1.0.0",
+ "wasmcloud-control-interface 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmcloud-core 0.9.0",
  "wasmparser 0.215.0",
  "wasmtime",
@@ -7188,8 +7188,7 @@ name = "wasmcloud"
 version = "1.2.1"
 dependencies = [
  "anyhow",
- "async-nats",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "base64 0.22.1",
  "bytes",
  "clap",
@@ -7242,7 +7241,7 @@ dependencies = [
  "wasmcloud-tracing",
  "wrpc-interface-http",
  "wrpc-transport 0.26.7",
- "wrpc-transport-nats 0.22.3",
+ "wrpc-transport-nats 0.23.0",
 ]
 
 [[package]]
@@ -7262,7 +7261,7 @@ name = "wasmcloud-control-interface"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.36.0",
  "async-trait",
  "bytes",
  "cloudevents-sdk",
@@ -7285,7 +7284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa9ce0245be791548d153536d4a849f7db9abc9340657bae00250e8a0f7f6bbc"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.33.0",
  "async-trait",
  "bytes",
  "cloudevents-sdk",
@@ -7308,7 +7307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a646a51b5c4410c6bd93aecbcc98f24921c88712de4549ab64617d88fb4acb88"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.33.0",
  "async-trait",
  "bytes",
  "futures",
@@ -7334,7 +7333,7 @@ name = "wasmcloud-core"
 version = "0.9.0"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "async-trait",
  "bytes",
  "futures",
@@ -7367,7 +7366,7 @@ name = "wasmcloud-host"
 version = "0.20.0"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "async-trait",
  "base64 0.22.1",
  "bytes",
@@ -7404,7 +7403,7 @@ dependencies = [
  "wasmcloud-secrets-types 0.4.0",
  "wasmcloud-tracing",
  "wrpc-transport 0.26.7",
- "wrpc-transport-nats 0.22.3",
+ "wrpc-transport-nats 0.23.0",
 ]
 
 [[package]]
@@ -7422,7 +7421,7 @@ name = "wasmcloud-provider-blobstore-azure"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "async-trait",
  "azure_core",
  "azure_storage",
@@ -7514,7 +7513,7 @@ name = "wasmcloud-provider-http-server"
 version = "0.23.0"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "axum 0.7.5",
  "axum-server",
  "base64 0.22.1",
@@ -7544,7 +7543,7 @@ name = "wasmcloud-provider-keyvalue-nats"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "bytes",
  "futures",
  "rustls-pemfile 2.1.3",
@@ -7562,7 +7561,7 @@ name = "wasmcloud-provider-keyvalue-redis"
 version = "0.28.0"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "bytes",
  "redis",
  "tempfile",
@@ -7597,7 +7596,7 @@ name = "wasmcloud-provider-lattice-controller"
 version = "0.13.0"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "tokio",
  "tracing",
  "wascap 0.15.0",
@@ -7626,7 +7625,7 @@ name = "wasmcloud-provider-messaging-nats"
 version = "0.23.0"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "bytes",
  "futures",
  "opentelemetry 0.23.0",
@@ -7648,7 +7647,7 @@ name = "wasmcloud-provider-sdk"
 version = "0.8.0"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "base64 0.22.1",
  "bytes",
  "futures",
@@ -7671,7 +7670,7 @@ dependencies = [
  "wasmcloud-tracing",
  "wrpc-interface-http",
  "wrpc-transport 0.26.7",
- "wrpc-transport-nats 0.22.3",
+ "wrpc-transport-nats 0.23.0",
 ]
 
 [[package]]
@@ -7746,7 +7745,7 @@ dependencies = [
 name = "wasmcloud-secrets-client"
 version = "0.4.0"
 dependencies = [
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "nkeys 0.4.3",
  "serde_json",
  "thiserror",
@@ -7788,7 +7787,7 @@ name = "wasmcloud-test-util"
 version = "0.12.0"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.36.0",
  "cloudevents-sdk",
  "nkeys 0.4.3",
  "rmp-serde",
@@ -9000,7 +8999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7a40219678cc9e65164487ff3540cddc463d2040950f010bd1d8ce27c8c9a6c"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.33.0",
  "bytes",
  "futures",
  "tokio",
@@ -9011,12 +9010,12 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87731a7eb3f5201548239f229c3334341d43afa9a6363cb80546e1e976895f90"
+checksum = "51cc802e79e54fafcf51c36f44391375537698196a12794b7019c2f81b3d4632"
 dependencies = [
  "anyhow",
- "async-nats-wrpc",
+ "async-nats 0.36.0",
  "bytes",
  "futures",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,6 @@ wasmcloud-tracing = { workspace = true, features = ["otel"] }
 
 [dev-dependencies]
 async-nats = { workspace = true, features = ["ring"] }
-async-nats-0_33 = { workspace = true }
 bytes = { workspace = true }
 base64 = { workspace = true }
 futures = { workspace = true }
@@ -191,8 +190,7 @@ anstyle = { version = "1.0.8", default-features = false }
 anyhow = { version = "1", default-features = false }
 assert-json-diff = { version = "2", default-features = false }
 async-compression = { version = "0.3", default-features = false }
-async-nats = { package = "async-nats-wrpc", version = "0.35.1", default-features = false }
-async-nats-0_33 = { package = "async-nats", version = "0.33", default-features = false }
+async-nats = { package = "async-nats", version = "0.36", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 aws-config = { version = "1.5", default-features = false }
 aws-sdk-s3 = { version = "1.34", default-features = false }
@@ -375,4 +373,4 @@ wrpc-interface-blobstore = { version = "0.18", default-features = false }
 wrpc-interface-http = { version = "0.27", default-features = false }
 wrpc-runtime-wasmtime = { version = "0.21", default-features = false }
 wrpc-transport = { version = "0.26.7", default-features = false }
-wrpc-transport-nats = { version = "0.22.3", default-features = false }
+wrpc-transport-nats = { version = "0.23.0", default-features = false }

--- a/crates/control-interface/Cargo.toml
+++ b/crates/control-interface/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-nats = { version = "0.33" } # TODO: Use workspace version once https://github.com/nats-io/nats.rs/pull/1267 resolved to use in wasmCloud
+async-nats = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 cloudevents-sdk = { workspace = true }

--- a/crates/test-util/Cargo.toml
+++ b/crates/test-util/Cargo.toml
@@ -17,7 +17,7 @@ status = "actively-developed"
 
 [dependencies]
 anyhow = { workspace = true }
-async-nats = { version = "0.33" }
+async-nats = { workspace = true }
 cloudevents-sdk = { workspace = true }
 nkeys = { workspace = true }
 rmp-serde = { workspace = true}

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -18,13 +18,8 @@ maintenance = { status = "actively-developed" }
 anstyle = { workspace = true }
 anyhow = { workspace = true, features = ["backtrace"] }
 async-compression = { workspace = true, features = ["tokio", "gzip"] }
-# We use a separate version of async-nats that has some code that isn't upstream
-# to support the needs of wRPC libraries.
-#
-# TODO: Unify upstream async-nats and wrpc-nats if/when https://github.com/nats-io/nats.rs/pull/1267
-# or something similar is implemented
 async-nats = { workspace = true }
-async-nats-0_33 = { workspace = true }
+async-nats-0_33 = { package = "async-nats", version = "0.33", default-features = false }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["cargo", "derive", "env", "std", "string"] }
 clap_complete = { workspace = true }
@@ -86,7 +81,7 @@ wash-lib = { workspace = true, features = [
     "start",
     "plugin",
 ] }
-wasmcloud-control-interface = { workspace = true }
+wasmcloud-control-interface = { version = "1" } # TODO: Revert once wadm is published with async-nats 0.36
 wasmcloud-core = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true }
 wasmcloud-secrets-types = { workspace = true }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -94,7 +94,7 @@ walkdir = { workspace = true }
 wascap = { workspace = true }
 wasi-preview1-component-adapter-provider = { workspace = true }
 wasm-encoder = { workspace = true }
-wasmcloud-control-interface = { workspace = true }
+wasmcloud-control-interface = { version = "1" } # TODO: Revert once wadm is published with async-nats 0.36
 wasmcloud-core = { workspace = true, features = [
     "oci-distribution",
     "reqwest",

--- a/examples/security/secrets/provider-keyvalue-redis-auth/Cargo.toml
+++ b/examples/security/secrets/provider-keyvalue-redis-auth/Cargo.toml
@@ -13,7 +13,7 @@ status = "actively-developed"
 
 [dependencies]
 anyhow = "1.0.82"
-async-nats = { package = "async-nats-wrpc", version = "0.35.1", default-features = false }
+async-nats = { version = "0.36", default-features = false }
 redis = { version = "0.25.4", features = [
     "aio",
     "connection-manager",

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -35,7 +35,7 @@ const PONGER_COMPONENT_ID: &str = "ponger_component";
 #[instrument(skip_all, ret)]
 #[tokio::test(flavor = "multi_thread")]
 async fn config_updates() -> Result<()> {
-    let (nats_server, _, nats_client, _) = start_nats()
+    let (nats_server, _, nats_client) = start_nats()
         .await
         .context("failed to start backing services")?;
 
@@ -139,11 +139,11 @@ async fn config_e2e() -> anyhow::Result<()> {
         .init();
 
     // Start NATS server
-    let (nats_server, nats_url, nats_client, nats_client_0_33) =
+    let (nats_server, nats_url, nats_client) =
         start_nats().await.expect("should be able to start NATS");
 
     // Build client for interacting with the lattice
-    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client_0_33)
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
         .lattice(LATTICE.to_string())
         .build();
     let wrpc_client = wrpc_transport_nats::Client::new(

--- a/tests/example-rust-hello-world.rs
+++ b/tests/example-rust-hello-world.rs
@@ -40,11 +40,11 @@ async fn example_rust_http_hello_world() -> anyhow::Result<()> {
         )
         .init();
 
-    let (nats_server, nats_url, _, nats_client_0_33) =
+    let (nats_server, nats_url, nats_client) =
         start_nats().await.context("failed to start NATS")?;
 
     // Build client for interacting with the lattice
-    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client_0_33)
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client)
         .lattice(LATTICE.to_string())
         .build();
     // Build the host

--- a/tests/example-rust-http-keyvalue-counter.rs
+++ b/tests/example-rust-http-keyvalue-counter.rs
@@ -54,13 +54,13 @@ async fn example_rust_http_keyvalue_counter() -> anyhow::Result<()> {
         )
         .init();
 
-    let ((nats_server, nats_url, _, nats_client_0_33), (redis_server, redis_url)) = try_join!(
+    let ((nats_server, nats_url, nats_client), (redis_server, redis_url)) = try_join!(
         async { start_nats().await.context("failed to start NATS") },
         async { start_redis().await.context("failed to start Redis") },
     )?;
 
     // Build client for interacting with the lattice
-    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client_0_33)
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client)
         .lattice(LATTICE.to_string())
         .build();
     // Build the host

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -53,7 +53,7 @@ async fn interfaces() -> anyhow::Result<()> {
 
     let (
         (minio_server, minio_url),
-        (nats_server, nats_url, _, nats_client_0_33),
+        (nats_server, nats_url, nats_client),
         (redis_server, redis_url),
         (vault_server, vault_url, vault_client),
     ) = try_join!(
@@ -74,7 +74,7 @@ async fn interfaces() -> anyhow::Result<()> {
         .context("failed to construct Redis connection manager")?;
 
     // Build client for interacting with the lattice
-    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client_0_33)
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client)
         .lattice(LATTICE.to_string())
         .build();
     // Build the host

--- a/tests/policy.rs
+++ b/tests/policy.rs
@@ -22,11 +22,11 @@ const LATTICE: &str = "default";
 #[tokio::test]
 async fn policy_always_deny() -> anyhow::Result<()> {
     // Start NATS for communication
-    let (nats_server, nats_url, _, nats_client_0_33) =
+    let (nats_server, nats_url, nats_client) =
         start_nats().await.context("failed to start NATS")?;
 
     // Build client for interacting with the lattice
-    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client_0_33)
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client)
         .lattice(LATTICE.to_string())
         .build();
 


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
Upgrading to async-nats 0.36, unfortunately we have references to the `wadm` crates which depend on the `control-interface` being upgraded, so `wash-lib` and `wash-cli` will need to drop their 0.33 references after `wadm` releases a new version.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
