### PR TITLE
refactor: Use testcontainers and localstack for blobstore-s3 provider testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7477,6 +7477,7 @@ dependencies = [
  "rustls 0.22.4",
  "serde",
  "serde_json",
+ "testcontainers",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/crates/provider-blobstore-s3/Cargo.toml
+++ b/crates/provider-blobstore-s3/Cargo.toml
@@ -40,3 +40,4 @@ wrpc-transport = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+testcontainers = { workspace = true }

--- a/crates/provider-blobstore-s3/README.md
+++ b/crates/provider-blobstore-s3/README.md
@@ -149,22 +149,18 @@ however, the prefix is not required.
 
 
 ## Running the Tests
-To run `make test` successfully, this provider requires either:
-- AWS configuration (see [Configuration](#Configuration) above)
-- A running s3 replacement like minio
 
-To test locally without AWS configuration, you can run minio with:
-```shell
-docker run -p 9000:9000 --name minio \
-    --env MINIO_ROOT_USER="minioadmin" \
-    --env MINIO_ROOT_PASSWORD="minioadmin" bitnami/minio:latest
-```
+To run `cargo test` successfully, this provider requires either:
+1. A local docker setup, so that [testcontainers](https://github.com/testcontainers/testcontainers-rs) can be used to run a [localstack](https://github.com/localstack/localstack) container for S3.
+2. AWS configuration (see [Configuration](#Configuration) above)
 
 Then set your environment variables and run the test
 ```shell
 export AWS_REGION=us-east-1
-export AWS_ACCESS_KEY_ID=minioadmin
-export AWS_SECRET_ACCESS_KEY=minioadmin
-export AWS_ENDPOINT=http://localhost:9000
-make test
+export AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_ACCESS_KEY
+export AWS_ENDPOINT=AWS_ENDPOINT_URL
+cargo test
 ```
+
+Please note that if `AWS_ENDPOINT` environment variable is not set, a [localstack](https://github.com/localstack/localstack) testcontainer will be used instead.


### PR DESCRIPTION
## Feature or Problem

This change adopts localstack via testcontainers instead of Minio as the default testing backend for the `blobstore-s3` provider.

It also fixes a bug that I uncovered in how the client was being set up when no bucket region was provided.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
