### PR TITLE
fix(*): link uniqueness enforcement, deletes

### DIFF
--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -127,16 +127,31 @@ pub fn linkdef_set_failed(
 
 pub fn linkdef_deleted(
     source_id: impl AsRef<str>,
+    target: Option<&String>,
     name: impl AsRef<str>,
     wit_namespace: impl AsRef<str>,
     wit_package: impl AsRef<str>,
+    interfaces: Option<&Vec<String>>,
 ) -> serde_json::Value {
-    json!({
-        "source_id": source_id.as_ref(),
-        "name": name.as_ref(),
-        "wit_namespace": wit_namespace.as_ref(),
-        "wit_package": wit_package.as_ref(),
-    })
+    // Target and interfaces aren't known if the link didn't exist, so we omit them from the
+    // event data in that case.
+    if let (Some(target), Some(interfaces)) = (target, interfaces) {
+        json!({
+            "source_id": source_id.as_ref(),
+            "target": target,
+            "name": name.as_ref(),
+            "wit_namespace": wit_namespace.as_ref(),
+            "wit_package": wit_package.as_ref(),
+            "interfaces": interfaces,
+        })
+    } else {
+        json!({
+            "source_id": source_id.as_ref(),
+            "name": name.as_ref(),
+            "wit_namespace": wit_namespace.as_ref(),
+            "wit_package": wit_package.as_ref(),
+        })
+    }
 }
 
 pub fn provider_started(

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2791,7 +2791,7 @@ impl Host {
                 .await?;
 
             // Send the link to providers for deletion
-            self.del_provider_link(&link).await?;
+            self.del_provider_link(link).await?;
         }
 
         // For idempotency, we always publish the deleted event, even if the link didn't exist

--- a/crates/provider-http-server/src/path.rs
+++ b/crates/provider-http-server/src/path.rs
@@ -185,8 +185,14 @@ impl Provider for HttpServerProvider {
     }
 
     /// Remove the path for a particular component/link_name pair
-    #[instrument(level = "info", skip_all, fields(target_id = info.get_target_id()))]
+    #[instrument(level = "debug", skip_all, fields(target_id = info.get_target_id()))]
     async fn delete_link_as_source(&self, info: impl LinkDeleteInfo) -> anyhow::Result<()> {
+        debug!(
+            source = info.get_source_id(),
+            target = info.get_target_id(),
+            link = info.get_link_name(),
+            "deleting http path link"
+        );
         let component_id = info.get_target_id();
         let link_name = info.get_link_name();
 

--- a/crates/test-util/src/lattice/link.rs
+++ b/crates/test-util/src/lattice/link.rs
@@ -1,7 +1,7 @@
 //! Utilities for managing lattice links
 
 use anyhow::{anyhow, Result};
-use wasmcloud_control_interface::InterfaceLinkDefinition;
+use wasmcloud_control_interface::{CtlResponse, InterfaceLinkDefinition};
 
 #[allow(clippy::too_many_arguments)]
 pub async fn assert_advertise_link(
@@ -14,7 +14,7 @@ pub async fn assert_advertise_link(
     interfaces: Vec<String>,
     source_config: Vec<String>,
     target_config: Vec<String>,
-) -> Result<()> {
+) -> Result<CtlResponse<()>> {
     let client = client.into();
     let source_id = source_id.as_ref();
     let target = target.as_ref();
@@ -33,8 +33,7 @@ pub async fn assert_advertise_link(
             target_config,
         })
         .await
-        .map_err(|e| anyhow!(e).context("failed to advertise link"))?;
-    Ok(())
+        .map_err(|e| anyhow!(e).context("failed to advertise link"))
 }
 
 pub async fn assert_remove_link(

--- a/crates/wash-cli/src/common/link_cmd.rs
+++ b/crates/wash-cli/src/common/link_cmd.rs
@@ -29,7 +29,7 @@ pub fn link_put_output(
                 map,
             ))
         }
-        Some(f) => bail!("Error advertising link: {}", f),
+        Some(f) => bail!("Error putting link: {f}"),
     }
 }
 
@@ -100,7 +100,11 @@ pub async fn handle_command(
                 },
             )
             .await
-            .map_or_else(|e| Some(format!("{e}")), |_| None);
+            .map_or_else(
+                |e| Some(format!("{e}")),
+                // If the operation was unsuccessful, return the error message
+                |ctl_response| (!ctl_response.success).then_some(ctl_response.message),
+            );
 
             link_put_output(&source_id, &target, failure)?
         }

--- a/crates/wash-cli/src/ctl/output.rs
+++ b/crates/wash-cli/src/ctl/output.rs
@@ -73,30 +73,16 @@ pub fn links_table(mut list: Vec<InterfaceLinkDefinition>) -> String {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment(l.source_id.clone(), 1, Alignment::Left),
             TableCell::new_with_alignment(l.target.clone(), 1, Alignment::Left),
-            if l.interfaces.len() == 1 {
-                TableCell::new_with_alignment(
-                    // SAFETY: We know that there is at least one element in the interfaces vector
-                    format!(
-                        "{}:{}/{}",
-                        l.wit_namespace,
-                        l.wit_package,
-                        l.interfaces.get(0).unwrap()
-                    ),
-                    1,
-                    Alignment::Left,
-                )
-            } else {
-                TableCell::new_with_alignment(
-                    format!(
-                        "{}:{}/{}",
-                        l.wit_namespace,
-                        l.wit_package,
-                        l.interfaces.join(",")
-                    ),
-                    1,
-                    Alignment::Left,
-                )
-            },
+            TableCell::new_with_alignment(
+                format!(
+                    "{}:{}/{}",
+                    l.wit_namespace,
+                    l.wit_package,
+                    l.interfaces.join(",")
+                ),
+                1,
+                Alignment::Left,
+            ),
             TableCell::new_with_alignment(l.name.clone(), 1, Alignment::Left),
         ]))
     });

--- a/crates/wash-cli/src/ctl/output.rs
+++ b/crates/wash-cli/src/ctl/output.rs
@@ -65,20 +65,39 @@ pub fn links_table(mut list: Vec<InterfaceLinkDefinition>) -> String {
     table.add_row(Row::new(vec![
         TableCell::new_with_alignment("Source ID", 1, Alignment::Left),
         TableCell::new_with_alignment("Target", 1, Alignment::Left),
-        TableCell::new_with_alignment("WIT", 1, Alignment::Left),
-        TableCell::new_with_alignment("Interfaces", 1, Alignment::Left),
+        TableCell::new_with_alignment("Interface(s)", 1, Alignment::Left),
+        TableCell::new_with_alignment("Name", 1, Alignment::Left),
     ]));
 
     list.iter().for_each(|l| {
         table.add_row(Row::new(vec![
             TableCell::new_with_alignment(l.source_id.clone(), 1, Alignment::Left),
             TableCell::new_with_alignment(l.target.clone(), 1, Alignment::Left),
-            TableCell::new_with_alignment(
-                format!("{}:{}", l.wit_namespace, l.wit_package),
-                1,
-                Alignment::Left,
-            ),
-            TableCell::new_with_alignment(l.interfaces.join(","), 1, Alignment::Left),
+            if l.interfaces.len() == 1 {
+                TableCell::new_with_alignment(
+                    // SAFETY: We know that there is at least one element in the interfaces vector
+                    format!(
+                        "{}:{}/{}",
+                        l.wit_namespace,
+                        l.wit_package,
+                        l.interfaces.get(0).unwrap()
+                    ),
+                    1,
+                    Alignment::Left,
+                )
+            } else {
+                TableCell::new_with_alignment(
+                    format!(
+                        "{}:{}/{}",
+                        l.wit_namespace,
+                        l.wit_package,
+                        l.interfaces.join(",")
+                    ),
+                    1,
+                    Alignment::Left,
+                )
+            },
+            TableCell::new_with_alignment(l.name.clone(), 1, Alignment::Left),
         ]))
     });
 

--- a/src/bin/http-server-provider/wasmcloud.toml
+++ b/src/bin/http-server-provider/wasmcloud.toml
@@ -4,7 +4,7 @@ version = "0.22.0"
 type = "provider"
 
 [rust]
-target_dir = "../../"
+target_dir = "../../../"
 
 [provider]
 bin_name = "http-server-provider"

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -1,0 +1,548 @@
+//! This module contains tests for the lattice's ability to manage links between components
+//!
+//! The primary goal of these tests are to ensure that creating links, deleting links,
+//! checking link uniqueness, and rejecting invalid links are all functioning as expected.
+
+use core::str;
+use core::time::Duration;
+
+use std::net::Ipv4Addr;
+
+use anyhow::{bail, Context as _};
+use futures::StreamExt;
+use tokio::try_join;
+use tracing::instrument;
+use tracing_subscriber::prelude::*;
+use wasmcloud_control_interface::CtlResponse;
+use wasmcloud_core::tls::NativeRootsExt as _;
+use wasmcloud_test_util::lattice::config::assert_config_put;
+use wasmcloud_test_util::lattice::link::assert_remove_link;
+use wasmcloud_test_util::provider::{assert_start_provider, StartProviderArgs};
+use wasmcloud_test_util::{
+    component::assert_scale_component, host::WasmCloudTestHost,
+    lattice::link::assert_advertise_link,
+};
+
+use test_components::RUST_HTTP_HELLO_WORLD;
+
+pub mod common;
+use common::free_port;
+use common::nats::start_nats;
+use common::providers;
+
+const LATTICE: &str = "links";
+const COMPONENT_ID: &str = "http_hello_world";
+
+/// Create many valid links between a few components, then ensure that links that are invalid
+/// (e.g. a new link with the same source, WIT interface, and link name but different target) are rejected
+#[instrument(skip_all, ret)]
+#[tokio::test]
+async fn link_deletes() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().compact().without_time())
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")
+            }),
+        )
+        .init();
+
+    let (nats_server, nats_url, nats_client) =
+        start_nats().await.context("failed to start NATS")?;
+
+    // Build client for interacting with the lattice
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
+        .lattice(LATTICE.to_string())
+        .build();
+    // Build the host
+    let _host = WasmCloudTestHost::start(&nats_url, LATTICE)
+        .await
+        .context("failed to start test host")?;
+
+    // Set up a few IDs and interfaces for enumerating tests
+    let component_one = "foo";
+    let component_two = "bar";
+    let interface_one = "test1";
+    let interface_two = "test2";
+    let interface_three = "test3";
+    let link_name_one = "one";
+    let link_name_two = "two";
+    let link_name_three = "three";
+
+    // Link one -(one)-> two on all interfaces
+    define_link(
+        &ctl_client,
+        component_one,
+        component_two,
+        link_name_one,
+        vec![interface_one, interface_two, interface_three],
+    )
+    .await?;
+    // Link one -(two)-> three on all interfaces
+    define_link(
+        &ctl_client,
+        component_one,
+        component_two,
+        link_name_two,
+        vec![interface_one, interface_two, interface_three],
+    )
+    .await?;
+    // Link two -(three)-> one on all interfaces
+    define_link(
+        &ctl_client,
+        component_two,
+        component_one,
+        link_name_three,
+        vec![interface_one, interface_two, interface_three],
+    )
+    .await?;
+
+    // Ensure links were validly created
+    let resp = ctl_client
+        .get_links()
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+    assert!(resp.success);
+    assert!(resp.response.is_some());
+    let links = resp.response.unwrap();
+    assert_eq!(links.len(), 3);
+    for link in links.iter() {
+        match (&link.source_id, &link.name) {
+            (id, name) if id == component_one && name == link_name_one => {
+                assert_eq!(link.target, component_two);
+                assert_eq!(link.interfaces.len(), 3);
+            }
+            (id, name) if id == component_one && name == link_name_two => {
+                assert_eq!(link.target, component_two);
+                assert_eq!(link.interfaces.len(), 3);
+            }
+            (id, name) if id == component_two && name == link_name_three => {
+                assert_eq!(link.target, component_one);
+                assert_eq!(link.interfaces.len(), 3);
+            }
+            (id, name) => bail!("unexpected link source {id} with name {name}"),
+        }
+    }
+
+    let mut deleted_events = nats_client
+        .subscribe(format!("wasmbus.evt.{LATTICE}.linkdef_deleted"))
+        .await?;
+    let mut provider_link_deleted_messages = nats_client
+        .subscribe(format!("wasmbus.rpc.{LATTICE}.*.linkdefs.del"))
+        .await?;
+
+    // This link doesn't exist, so we should get an event but no provider message
+    assert_remove_link(
+        &ctl_client,
+        component_one,
+        NAMESPACE,
+        "otherpackage",
+        link_name_one,
+    )
+    .await?;
+    // Link delete events are idempotent, so they're always published
+    let deleted_event = deleted_events.next().await;
+    assert!(deleted_event.is_some());
+    // If the link didn't exist, the provider won't receive a message
+    let provider_deleted_event = tokio::time::timeout(
+        std::time::Duration::from_millis(10),
+        provider_link_deleted_messages.next(),
+    )
+    .await;
+    // timed out because it's not available
+    assert!(provider_deleted_event.is_err());
+
+    // Remove the one -(one)-> two link, designated by the link name
+    assert_remove_link(
+        &ctl_client,
+        component_one,
+        NAMESPACE,
+        PACKAGE,
+        link_name_one,
+    )
+    .await?;
+    // Link delete events are idempotent, so they're always published
+    let deleted_event = deleted_events.next().await;
+    assert!(deleted_event.is_some());
+    // If the link did exist, the provider should receive a message
+    let provider_deleted_event = provider_link_deleted_messages.next().await;
+    assert!(provider_deleted_event.is_some());
+    // We actually publish one for the source and target, so there's two
+    let provider_deleted_event = provider_link_deleted_messages.next().await;
+    assert!(provider_deleted_event.is_some());
+
+    nats_server.stop().await.context("failed to stop NATS")?;
+    Ok(())
+}
+
+/// Ensure that the lattice can create multiple links from the same
+/// source on the same WIT interface to different targets or with different configuration
+/// (in this case, it's the same target, but the same principle applies to different targets)
+#[instrument(skip_all, ret)]
+#[tokio::test]
+async fn link_name_support() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().compact().without_time())
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")
+            }),
+        )
+        .init();
+
+    let (nats_server, nats_url, nats_client) =
+        start_nats().await.context("failed to start NATS")?;
+
+    // Build client for interacting with the lattice
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client)
+        .lattice(LATTICE.to_string())
+        .build();
+    // Build the host
+    let host = WasmCloudTestHost::start(&nats_url, LATTICE)
+        .await
+        .context("failed to start test host")?;
+
+    let http_port = free_port().await?;
+    let rust_http_server = providers::rust_http_server().await;
+    let rust_http_server_id = rust_http_server.subject.public_key();
+
+    let http_server_config_name = "http-server".to_string();
+    assert_config_put(
+        &ctl_client,
+        &http_server_config_name,
+        [
+            (
+                "default_address".to_string(),
+                format!("{}:{http_port}", Ipv4Addr::LOCALHOST),
+            ),
+            ("routing_mode".to_string(), "path".to_string()),
+        ],
+    )
+    .await
+    .context("failed to put configuration")?;
+    try_join!(
+        async {
+            assert_config_put(
+                &ctl_client,
+                "path_one",
+                [("path".to_string(), "/one".to_string())],
+            )
+            .await
+            .context("failed to put configuration")
+        },
+        async {
+            assert_config_put(
+                &ctl_client,
+                "path_two",
+                [("path".to_string(), "/two".to_string())],
+            )
+            .await
+            .context("failed to put configuration")
+        },
+        async {
+            assert_config_put(
+                &ctl_client,
+                "path_three",
+                [("path".to_string(), "/three".to_string())],
+            )
+            .await
+            .context("failed to put configuration")
+        },
+        async {
+            let host_key = host.host_key();
+            let rust_http_server_url = rust_http_server.url();
+            assert_start_provider(StartProviderArgs {
+                client: &ctl_client,
+                lattice: LATTICE,
+                host_key: &host_key,
+                provider_key: &rust_http_server.subject,
+                provider_id: &rust_http_server_id,
+                url: &rust_http_server_url,
+                config: vec![http_server_config_name],
+            })
+            .await
+            .context("failed to start providers")
+        },
+        async {
+            assert_scale_component(
+                &ctl_client,
+                &host.host_key(),
+                format!("file://{RUST_HTTP_HELLO_WORLD}"),
+                COMPONENT_ID,
+                None,
+                5,
+                Vec::new(),
+            )
+            .await
+            .context("failed to scale `rust-http-hello-world` component")
+        }
+    )?;
+
+    assert_advertise_link(
+        &ctl_client,
+        &rust_http_server_id,
+        COMPONENT_ID,
+        "one",
+        "wasi",
+        "http",
+        vec!["incoming-handler".to_string()],
+        vec!["path_one".to_string()],
+        vec![],
+    )
+    .await
+    .context("failed to advertise link")?;
+    assert_advertise_link(
+        &ctl_client,
+        &rust_http_server_id,
+        COMPONENT_ID,
+        "two",
+        "wasi",
+        "http",
+        vec!["incoming-handler".to_string()],
+        vec!["path_two".to_string()],
+        vec![],
+    )
+    .await
+    .context("failed to advertise link")?;
+    assert_advertise_link(
+        &ctl_client,
+        &rust_http_server_id,
+        COMPONENT_ID,
+        "three",
+        "wasi",
+        "http",
+        vec!["incoming-handler".to_string()],
+        vec!["path_three".to_string()],
+        vec![],
+    )
+    .await
+    .context("failed to advertise link")?;
+
+    let http_client = reqwest::Client::builder()
+        .with_native_certificates()
+        .timeout(Duration::from_secs(20))
+        .connect_timeout(Duration::from_secs(20))
+        .build()
+        .context("failed to build HTTP client")?;
+
+    let base_url = format!("http://localhost:{http_port}");
+    let req_one = http_client.get(format!("{base_url}/one")).send();
+    let req_two = http_client.get(format!("{base_url}/two")).send();
+    let req_three = http_client.get(format!("{base_url}/three")).send();
+
+    let (res_one, res_two, res_three) = try_join!(req_one, req_two, req_three)?;
+
+    assert!(res_one.status().is_success());
+    assert!(res_two.status().is_success());
+    assert!(res_three.status().is_success());
+
+    let four_oh_four = http_client.get(format!("{base_url}/four")).send().await?;
+    assert_eq!(four_oh_four.status().as_u16(), 404);
+
+    nats_server.stop().await.context("failed to stop NATS")?;
+    Ok(())
+}
+
+/// Create many valid links between a few components, then ensure that links that are invalid
+/// (e.g. a new link with the same source, WIT interface, and link name but different target) are rejected
+#[instrument(skip_all, ret)]
+#[tokio::test]
+async fn valid_and_invalid() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().compact().without_time())
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")
+            }),
+        )
+        .init();
+
+    let (nats_server, nats_url, nats_client) =
+        start_nats().await.context("failed to start NATS")?;
+
+    // Build client for interacting with the lattice
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client)
+        .lattice(LATTICE.to_string())
+        .build();
+    // Build the host
+    let _host = WasmCloudTestHost::start(&nats_url, LATTICE)
+        .await
+        .context("failed to start test host")?;
+
+    // Set up a few IDs and interfaces for enumerating tests
+    let component_one = "component_one";
+    let component_two = "component_two";
+    let component_three = "component_three";
+    let interface_one = "test1";
+    let interface_two = "test2";
+    let interface_three = "test3";
+    let link_name_one = "one";
+    let link_name_two = "two";
+    let link_name_three = "three";
+
+    //
+    // VALID LINKS
+    //
+
+    // Link one -(one)-> two on all interfaces
+    define_link(
+        &ctl_client,
+        component_one,
+        component_two,
+        link_name_one,
+        vec![interface_one, interface_two, interface_three],
+    )
+    .await?;
+    // Link two -(one)-> three on all interfaces
+    define_link(
+        &ctl_client,
+        component_two,
+        component_three,
+        link_name_one,
+        vec![interface_one, interface_two, interface_three],
+    )
+    .await?;
+    // Link three -(one)-> one on all interfaces
+    define_link(
+        &ctl_client,
+        component_three,
+        component_one,
+        link_name_one,
+        vec![interface_one, interface_two, interface_three],
+    )
+    .await?;
+    // NOTE: Defining one-at-a-time actually doesn't work. We need to be able to handle this
+    // TODO: disjoint sets issue
+    // define_link(
+    //     &ctl_client,
+    //     component_three,
+    //     component_one,
+    //     link_name_one,
+    //     vec![interface_two],
+    // )
+    // .await?;
+    // define_link(
+    //     &ctl_client,
+    //     component_three,
+    //     &component_one,
+    //     link_name_one,
+    //     vec![interface_three],
+    // )
+    // .await?;
+
+    // Ensure links were validly created
+    let resp = ctl_client
+        .get_links()
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+    assert!(resp.success);
+    assert!(resp.response.is_some());
+    let links = resp.response.unwrap();
+    assert_eq!(links.len(), 3);
+    for link in links.iter() {
+        match &link.source_id {
+            id if id == component_one => {
+                assert_eq!(link.target, component_two);
+                assert_eq!(link.interfaces.len(), 3);
+            }
+            id if id == component_two => {
+                assert_eq!(link.target, component_three);
+                assert_eq!(link.interfaces.len(), 3);
+            }
+            id if id == component_three => {
+                assert_eq!(link.target, component_one);
+                assert_eq!(link.interfaces.len(), 3);
+            }
+            id => bail!("unexpected link source {id}"),
+        }
+    }
+
+    // Components can be linked to different targets on different link names
+    // Link one -(two)-> two on all interfaces
+    define_link(
+        &ctl_client,
+        component_one,
+        component_two,
+        link_name_two,
+        vec![interface_one, interface_two, interface_three],
+    )
+    .await?;
+    // Link one -(three)-> three on all interfaces
+    define_link(
+        &ctl_client,
+        component_one,
+        component_two,
+        link_name_three,
+        vec![interface_one, interface_two, interface_three],
+    )
+    .await?;
+
+    //
+    // INVALID LINKS
+    //
+
+    // Component one is already linked to component two on all interfaces
+    let invalid = define_link(
+        &ctl_client,
+        component_one,
+        component_three,
+        link_name_one,
+        vec![interface_one, interface_two, interface_three],
+    )
+    .await?;
+    assert!(!invalid.success);
+    // This assertion will fail if we change the message, but it's a good test
+    assert_eq!(invalid.message,  "link already exists with different target, consider deleting the existing link or using a different link name");
+    // Component one is already linked to component two on all interfaces
+    let invalid = define_link(
+        &ctl_client,
+        component_one,
+        component_three,
+        link_name_three,
+        vec![interface_one],
+    )
+    .await?;
+    assert!(!invalid.success);
+    assert_eq!(invalid.message,  "link already exists with different target, consider deleting the existing link or using a different link name");
+    // Component three is already linked to component one on all interfaces
+    let invalid = define_link(
+        &ctl_client,
+        component_three,
+        component_two,
+        link_name_one,
+        vec![interface_three],
+    )
+    .await?;
+    assert!(!invalid.success);
+    assert_eq!(invalid.message,  "link already exists with different target, consider deleting the existing link or using a different link name");
+
+    nats_server.stop().await.context("failed to stop NATS")?;
+    Ok(())
+}
+
+const NAMESPACE: &str = "wasi";
+const PACKAGE: &str = "tests";
+
+/// Helper function for the [`valid_and_invalid`] test when we're
+/// defining a link with the same info often
+async fn define_link(
+    client: &wasmcloud_control_interface::Client,
+    source: &str,
+    target: &str,
+    name: &str,
+    interfaces: Vec<&str>,
+) -> anyhow::Result<CtlResponse<()>> {
+    assert_advertise_link(
+        client,
+        source,
+        target,
+        name,
+        NAMESPACE,
+        PACKAGE,
+        interfaces.iter().map(|i| i.to_string()).collect(),
+        vec![],
+        vec![],
+    )
+    .await
+    .context("failed to advertise link")
+}


### PR DESCRIPTION
## Feature or Problem
This PR implements rejecting links with the same source ID, wit namespace/package, and link name but with different targets. This is a scenario that components cannot support, but some providers did support this.

After this PR, if your provider supported links on the same interface to multiple targets (e.g. the HTTP server targeting many components on `wasi:http/incoming-handler`, you **must** provide a link name in order to keep these links separate. wasmCloud will reject the link if it's not supplied. In a future PR, wadm should reject this at manifest validation since it's easy to tell if there is a conflict.

Here's a diagram that illustrates the difference:
![image](https://github.com/user-attachments/assets/da0adbf7-4990-4568-a355-e01b86cd9687)

## Related Issues
resolves issues of link deletion found in #2902 

This PR also includes fixes for capability providers not receiving the full amount of information on a link delete in order to support link names & multiple components.

We also need an issue for supporting, or not, adding interfaces to links, because that's not currently supported today (see TODO in test)

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
I've also included a new `links.rs` integration test to ensure this functionality does not drift in the future.

### Manual Verification
I validated this all worked well first, but then turned that into a test.
