### PR TITLE
feat(wash-cli): Implement Humantime duration input for --watch flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6992,6 +6992,7 @@ dependencies = [
  "futures",
  "heck 0.5.0",
  "home",
+ "humantime",
  "ignore",
  "indicatif",
  "nkeys 0.4.4",

--- a/crates/wash-cli/tests/wash_app.rs
+++ b/crates/wash-cli/tests/wash_app.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context, Result};
+use std::time::Duration;
 use tokio::process::Command;
-use wash_lib::{app::validate_manifest_file, cli::output::AppValidateOutput};
+use wash_lib::{
+    app::validate_manifest_file, cli::get::parse_watch_interval, cli::output::AppValidateOutput,
+};
 
 /// Ensure a simple WADM manifest passes validation
 #[tokio::test]
@@ -93,4 +96,29 @@ spec:
     tokio::fs::remove_dir_all(&test_dir)
         .await
         .expect("Failed to clean up test directory");
+}
+
+#[test]
+fn test_parse_watch_interval_milliseconds() {
+    // Test parsing normal millisecond input
+    let result = parse_watch_interval("1500").unwrap();
+    assert_eq!(result, Duration::from_millis(1500));
+}
+
+#[test]
+fn test_parse_watch_interval_humantime_seconds() {
+    // Test parsing humantime input (5s)
+    let result = parse_watch_interval("5s").unwrap();
+    assert_eq!(result, Duration::from_secs(5));
+}
+
+#[test]
+fn test_parse_watch_interval_invalid_input() {
+    // Test invalid input
+    let result = parse_watch_interval("invalid");
+    assert!(result.is_err());
+    assert_eq!(
+            result.unwrap_err(),
+            "Invalid duration: 'invalid'. Expected a duration like '5s', '1m', '100ms', or milliseconds as an integer."
+        );
 }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -56,6 +56,7 @@ dialoguer = { workspace = true, optional = true }
 futures = { workspace = true }
 heck = { workspace = true, optional = true }
 home = { workspace = true }
+humantime = { workspace = true }
 ignore = { workspace = true, optional = true }
 indicatif = { workspace = true, optional = true }
 nkeys = { workspace = true }


### PR DESCRIPTION
- Backwards compatibility with millisecond input still maintained
- Improved terminal handling while watching application lattice
- watch interval for `app list` is now configurable with a default interval of 1000ms.
- Added Short flag of -w as an alternative to --watch

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
