### PR TITLE
feat(host): emit metrics for HTTP fuel consumption

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -305,6 +305,7 @@ impl wrpc_transport::Serve for WrpcServer {
                             // TODO(metrics): insert information about the source once we have concrete context data
                             vec![
                                 KeyValue::new("component.ref", image_reference),
+                                KeyValue::new("component.id", id),
                                 KeyValue::new("lattice", metrics.lattice_id.clone()),
                                 KeyValue::new("host", metrics.host_id.clone()),
                                 KeyValue::new("operation", format!("{instance}/name")),
@@ -1261,20 +1262,24 @@ impl Host {
                                     WrpcServeEvent::HttpIncomingHandlerHandleReturned {
                                         context: (start_at, ref attributes),
                                         success,
+                                        fuel_consumed,
                                     }
                                     | WrpcServeEvent::MessagingHandlerHandleMessageReturned {
                                         context: (start_at, ref attributes),
                                         success,
+                                        fuel_consumed,
                                     }
                                     | WrpcServeEvent::DynamicExportReturned {
                                         context: (start_at, ref attributes),
                                         success,
+                                        fuel_consumed,
                                     } => {
                                         metrics.record_component_invocation(
                                             u64::try_from(start_at.elapsed().as_nanos())
                                                 .unwrap_or_default(),
                                             attributes,
                                             !success,
+                                            fuel_consumed,
                                         );
                                     }
                                 }

--- a/crates/runtime/src/component/messaging.rs
+++ b/crates/runtime/src/component/messaging.rs
@@ -124,6 +124,7 @@ where
                 .try_send(WrpcServeEvent::MessagingHandlerHandleMessageReturned {
                     context: cx,
                     success,
+                    fuel_consumed: None,
                 })
         {
             warn!(

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -38,6 +38,7 @@ impl RuntimeBuilder {
         engine_config.epoch_interruption(true);
         engine_config.memory_init_cow(false);
         engine_config.wasm_component_model(true);
+        engine_config.consume_fuel(true);
 
         Self {
             engine_config,

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -5,7 +5,7 @@ use heck::ToKebabCase;
 #[cfg(feature = "otel")]
 pub use opentelemetry::{
     global,
-    metrics::{Counter, Histogram, Meter, Unit},
+    metrics::{Counter, Gauge, Histogram, Meter, Unit},
     KeyValue,
 };
 use wasmcloud_core::logging::Level;


### PR DESCRIPTION
Draft PR to spur some discussion. I would love to get thoughts on if we should turn this on if it's supposed to be expensive computationally to measure fuel. I like emitting this to metrics for now so that users could feasibly measure how much work a component is doing, and if that's useful we can also use this metric as a limiter for the store instead of using a `u64::MAX`

## Feature or Problem

This PR enables another OTEL metric for component invocations, fuel consumed, which is a monotonically increasing number per-store that counts the number of WebAssembly instructions that a component executed. https://docs.rs/wasmtime/24.0.0/wasmtime/struct.Config.html#method.consume_fuel. The goal of this PR, or a PR like this, would be to allow instrumenting components to understand how many instructions they are calling during their execution. This consumption is deterministic, and the same inputs to an invocation should result in the same usage of fuel.

This PR is a draft because
- I didn't implement fuel counting for messaging or dynamic invocations yet
- To implement this for HTTP, I had to await the task handle which likely has unintended consequences in error scenarios
- Fuel counting is, according to the documentation, computationally expensive. I didn't notice a difference in our HTTP hello world benchmark, but I don't want to enable this for no reason.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Here's a fun comparison of the HTTP hello world Rust example and the HTTP client tinygo example, using `180` and `136183` fuel units respectively. This isn't a fair comparison because the tinygo example does more (an outgoing HTTP request).

<img width="1596" alt="image" src="https://github.com/user-attachments/assets/5e7942e1-90c1-4fe9-b621-2e5ed0043dd2">

