### PR TITLE
fix(host): remove provider caching for local file references

### DIFF
--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -151,9 +151,14 @@ pub async fn fetch_provider(
                 allow_file_load,
                 "unable to start provider from file, file loading is disabled"
             );
-            par::read(provider_path, host_id, provider_ref)
-                .await
-                .context("failed to read provider")
+            par::read(
+                provider_path,
+                host_id,
+                provider_ref,
+                par::UseParFileCache::Ignore,
+            )
+            .await
+            .context("failed to read provider")
         }
         ref oci_ref @ ResourceRef::Oci(provider_ref) => oci_ref
             .authority()

--- a/crates/host/src/oci.rs
+++ b/crates/host/src/oci.rs
@@ -276,7 +276,7 @@ impl Fetcher {
             )
             .await
             .context("failed to fetch OCI path")?;
-        par::read(&path, host_id, oci_ref)
+        par::read(&path, host_id, oci_ref, par::UseParFileCache::Use)
             .await
             .with_context(|| format!("failed to read `{}`", path.display()))
     }


### PR DESCRIPTION
This commit removes provider caching for local file references -- when a file is loaded via a container registry, caching is enabled but if it is loaded via a local file on disk, caching is never employed.

Resolves https://github.com/wasmCloud/wasmCloud/issues/2399

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
