### PR TITLE
chore(examples): add project-generate.toml to Rust postgres example

### DIFF
--- a/examples/rust/components/sqldb-postgres-query/project-generate.toml
+++ b/examples/rust/components/sqldb-postgres-query/project-generate.toml
@@ -1,0 +1,10 @@
+[template]
+
+raw = [
+  "*.wasm"
+]
+exclude = [
+  "target/",
+  "keys/",
+  "build/"
+]


### PR DESCRIPTION
Adds a `project-generate.toml` file to the Rust sqldb-postgres-query example so that it can be used as a template in a tutorial.