### PR TITLE
chore(wash-cli): note wash-cli move to wash

### DIFF
--- a/crates/wash-cli/README.md
+++ b/crates/wash-cli/README.md
@@ -14,6 +14,9 @@
    \_/\_/ \__,_|___/_| |_| |_|\_____|_|\___/ \__,_|\__,_| |_____/|_| |_|\___|_|_|
 ```
 
+> [!WARNING]  
+> This crate is being deprecated in favor of [wash](https://crates.io/crates/wash), where the wash CLI will be published from now on.
+
 - [Why wash](#why-wash)
 - [Installing wash](#installing-wash)
   - [Cargo](#cargo)


### PR DESCRIPTION
## Feature or Problem
Chore to note that the `wash-cli` crate will move to `wash` on the next release. What we can do is publish the next version of `wash-cli` with the deprecation notice, then publish to `wash` on the next release, and finally update the `wash-cli` README once and for all to point towards the new `wash` crate.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
