### PR TITLE
fix: boolean flag set incorrectly

### DIFF
--- a/crates/wash-cli/src/up/config.rs
+++ b/crates/wash-cli/src/up/config.rs
@@ -137,7 +137,7 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
         }
     }
     if wasmcloud_opts.rpc_tls {
-        host_config.insert(WASMCLOUD_RPC_TLS.to_string(), "1".to_string());
+        host_config.insert(WASMCLOUD_RPC_TLS.to_string(), "true".to_string());
     }
 
     // NATS CTL connection configuration
@@ -161,7 +161,7 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
         }
     }
     if wasmcloud_opts.ctl_tls {
-        host_config.insert(WASMCLOUD_CTL_TLS.to_string(), "1".to_string());
+        host_config.insert(WASMCLOUD_CTL_TLS.to_string(), "true".to_string());
     }
 
     host_config.insert(
@@ -171,7 +171,7 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
 
     // Extras configuration
     if wasmcloud_opts.config_service_enabled {
-        host_config.insert(WASMCLOUD_CONFIG_SERVICE.to_string(), "1".to_string());
+        host_config.insert(WASMCLOUD_CONFIG_SERVICE.to_string(), "true".to_string());
     }
     if wasmcloud_opts.allow_file_load.unwrap_or_default() {
         host_config.insert(WASMCLOUD_ALLOW_FILE_LOAD.to_string(), "true".to_string());
@@ -205,7 +205,7 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
         wasmcloud_opts.structured_log_level,
     );
     if wasmcloud_opts.enable_ipv6 {
-        host_config.insert(WASMCLOUD_ENABLE_IPV6.to_string(), "1".to_string());
+        host_config.insert(WASMCLOUD_ENABLE_IPV6.to_string(), "true".to_string());
     }
     Ok(host_config)
 }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Execute `wash up --ctl-tls` will give:

```
error: invalid value '1' for '--ctl-tls'
  [possible values: true, false]
```

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

```bash
cargo install --path ./crates/wash-cli
~/.cargo/bin/wash up --ctl-tls
```

Giving me

```
>>> ⠅⠀  Starting wadm ...                                                                                                                                                                                                                                                                                        👀 Found wadm version on the disk: wadm-cli 0.14.0
✅ Using wadm version [v0.14.0]
🏃 Running in interactive mode.
🎛️ To start the dashboard, run `wash ui`
🚪 Press `CTRL+c` at any time to exit
Error: failed to initialize host

Caused by:
    0: failed to establish NATS control server connection
    1: failed to connect to NATS
    2: IO error: received corrupt message of type InvalidContentType
    3: received corrupt message of type InvalidContentType
```

which is expected: the warning is gone, and the connection failed due to the missing tls configuration for nats