### PR TITLE
chore: Use `wrpc-interface-blobstore` for `provider-blobstore-*`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7480,7 +7480,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-azure"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-nats 0.36.0",
@@ -7501,14 +7501,14 @@ dependencies = [
  "tokio-util",
  "tracing",
  "wasmcloud-provider-sdk",
- "wit-bindgen-wrpc 0.6.5",
+ "wrpc-interface-blobstore",
  "wrpc-transport 0.26.8",
  "wrpc-transport-nats 0.23.1",
 ]
 
 [[package]]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7520,13 +7520,13 @@ dependencies = [
  "tokio-util",
  "tracing",
  "wasmcloud-provider-sdk",
- "wit-bindgen-wrpc 0.6.5",
+ "wrpc-interface-blobstore",
  "wrpc-transport 0.26.8",
 ]
 
 [[package]]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7546,7 +7546,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "wasmcloud-provider-sdk",
- "wit-bindgen-wrpc 0.6.5",
+ "wrpc-interface-blobstore",
  "wrpc-transport 0.26.8",
 ]
 

--- a/crates/provider-blobstore-azure/Cargo.toml
+++ b/crates/provider-blobstore-azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-azure"
-version = "0.4.0"
+version = "0.5.0"
 
 authors.workspace = true
 categories.workspace = true
@@ -36,7 +36,7 @@ tokio-stream = { workspace = true, features = ["fs"] }
 tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true, features = ["otel"] }
-wit-bindgen-wrpc = { workspace = true }
+wrpc-interface-blobstore = { workspace = true }
 wrpc-transport = { workspace = true }
 
 [dev-dependencies]

--- a/crates/provider-blobstore-fs/Cargo.toml
+++ b/crates/provider-blobstore-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.9.0"
+version = "0.10.0"
 description = """
 Blobstore for wasmCloud, leveraging the filesystem. This package provides a capability provider that satisfies the 'wasmcloud:blobstore' contract.
 """
@@ -25,5 +25,5 @@ tokio-stream = { workspace = true, features = ["fs"] }
 tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true, features = ["otel"] }
-wit-bindgen-wrpc = { workspace = true }
+wrpc-interface-blobstore = { workspace = true }
 wrpc-transport = { workspace = true }

--- a/crates/provider-blobstore-s3/Cargo.toml
+++ b/crates/provider-blobstore-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.10.0"
+version = "0.11.0"
 description = """
 S3-compatible object store capability provider for wasmcloud, satisfying the 'wasmcloud:blobstore' capability contract.
 """
@@ -35,7 +35,7 @@ tokio-stream = { workspace = true }
 tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true, features = ["otel"] }
-wit-bindgen-wrpc = { workspace = true }
+wrpc-interface-blobstore = { workspace = true }
 wrpc-transport = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Feature or Problem

Per @rvolosatovs's suggestion in https://github.com/wasmCloud/wasmCloud/pull/2993#discussion_r1759693691, I'm switching all of the blobstore providers we ship to use the bindings from [`wrpc-interface-blobstore`](https://crates.io/crates/wrpc-interface-blobstore) instead of generating it themselves.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
