### PR TITLE
feat(host): Adds support for batch support to the host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6041,7 +6041,7 @@ checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ clap-markdown = { workspace = true }
 nkeys = { workspace = true }
 file-guard = { workspace = true }
 redis = { workspace = true, optional = true }
-regex = { workspace = true}
+regex = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 tracing = { workspace = true } # TODO: revisit the 'release_max_level_info' feature https://github.com/wasmCloud/wasmCloud/issues/468
 tracing-subscriber = { workspace = true }
@@ -150,7 +150,7 @@ redis = { workspace = true, features = [
     "connection-manager",
     "tokio-comp",
 ] }
-regex = { workspace = true}
+regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 rmp-serde = { workspace = true }
 rustversion = { workspace = true }
@@ -220,7 +220,7 @@ cloudevents-sdk = { version = "0.7", default-features = false }
 command-group = { version = "5", default-features = false }
 config = { version = "0.13", default-features = false }
 console = { version = "0.15", default-features = false }
-crossterm = {version = "0.28.1",default-features = false }
+crossterm = { version = "0.28.1", default-features = false }
 data-encoding = { version = "2", default-features = false }
 deadpool-postgres = { version = "0.13", default-features = false }
 dialoguer = { version = "0.10", default-features = false }
@@ -333,7 +333,7 @@ warp = { version = "0.3", default-features = false }
 wascap = { version = "^0.15.0", path = "./crates/wascap", default-features = false }
 wash-cli = { version = "0", path = "./crates/wash-cli", default-features = false }
 wash-lib = { version = "^0.25.1", path = "./crates/wash-lib", default-features = false }
-wasi = { version = "=0.13.1", default-features = false } # WASI 0.2.1 is not currently supported
+wasi = { version = "=0.13.1", default-features = false }                                                                                # WASI 0.2.1 is not currently supported
 wasi-preview1-component-adapter-provider = { version = "24", default-features = false }
 wasm-encoder = { version = "0.216", default-features = false }
 wasm-gen = { version = "0.1", default-features = false }
@@ -371,11 +371,11 @@ which = { version = "4", default-features = false }
 wit-bindgen = { version = "0.30", default-features = false }
 wit-bindgen-core = { version = "0.30", default-features = false }
 wit-bindgen-go = { version = "0.30", default-features = false }
-wit-bindgen-wrpc = { version = "0.6.4", default-features = false }
+wit-bindgen-wrpc = { version = "0.6.5", default-features = false }
 wit-component = { version = "0.215", default-features = false }
 wit-parser = { version = "0.215", default-features = false }
 wrpc-interface-blobstore = { version = "0.18", default-features = false }
 wrpc-interface-http = { version = "0.27", default-features = false }
-wrpc-runtime-wasmtime = { version = "0.21", default-features = false }
+wrpc-runtime-wasmtime = { version = "0.21.1", default-features = false }
 wrpc-transport = { version = "0.26.8", default-features = false }
-wrpc-transport-nats = { version = "0.23.0", default-features = false }
+wrpc-transport-nats = { version = "0.23.1", default-features = false }

--- a/crates/component/src/lib.rs
+++ b/crates/component/src/lib.rs
@@ -14,6 +14,7 @@ mod bindings {
             "wasi:io/streams@0.2.0": ::wasi::io::streams,
             "wasi:keyvalue/atomics@0.2.0-draft": generate,
             "wasi:keyvalue/store@0.2.0-draft": generate,
+            "wasi:keyvalue/batch@0.2.0-draft": generate,
             "wasi:logging/logging": generate,
             "wasi:random/random@0.2.0": ::wasi::random::random,
             "wasmcloud:bus/lattice@1.0.0": generate,

--- a/crates/component/wit/interfaces.wit
+++ b/crates/component/wit/interfaces.wit
@@ -9,6 +9,7 @@ world interfaces {
     import wasi:http/outgoing-handler@0.2.0;
     import wasi:keyvalue/atomics@0.2.0-draft;
     import wasi:keyvalue/store@0.2.0-draft;
+    import wasi:keyvalue/batch@0.2.0-draft;
     import wasi:logging/logging;
     import wasi:random/random@0.2.0;
 

--- a/crates/host/src/wasmbus/handler.rs
+++ b/crates/host/src/wasmbus/handler.rs
@@ -153,6 +153,7 @@ impl wrpc_transport::Invoke for Handler {
             ) => "wasi:blobstore/blobstore",
             Some(ReplacedInstanceTarget::KeyvalueAtomics) => "wasi:keyvalue/atomics",
             Some(ReplacedInstanceTarget::KeyvalueStore) => "wasi:keyvalue/store",
+            Some(ReplacedInstanceTarget::KeyvalueBatch) => "wasi:keyvalue/batch",
             Some(ReplacedInstanceTarget::HttpIncomingHandler) => "wasi:http/incoming-handler",
             Some(ReplacedInstanceTarget::HttpOutgoingHandler) => "wasi:http/outgoing-handler",
             None => instance.split_once('@').map_or(instance, |(l, _)| l),

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -50,6 +50,8 @@ pub enum ReplacedInstanceTarget {
     KeyvalueAtomics,
     /// `wasi:keyvalue/store` instance replacement
     KeyvalueStore,
+    /// `wasi:keyvalue/batch` instance replacement
+    KeyvalueBatch,
     /// `wasi:http/incoming-handler` instance replacement
     HttpIncomingHandler,
     /// `wasi:http/outgoing-handler` instance replacement
@@ -86,6 +88,7 @@ macro_rules! skip_static_instances {
             | "wasi:io/streams@0.2.0"
             | "wasi:keyvalue/atomics@0.2.0-draft"
             | "wasi:keyvalue/store@0.2.0-draft"
+            | "wasi:keyvalue/batch@0.2.0-draft"
             | "wasi:logging/logging"
             | "wasi:random/random@0.2.0"
             | "wasi:sockets/instance-network@0.2.0"
@@ -323,6 +326,8 @@ where
             .context("failed to link `wasi:keyvalue/atomics`")?;
         capability::keyvalue::store::add_to_linker(&mut linker, |ctx| ctx)
             .context("failed to link `wasi:keyvalue/store`")?;
+        capability::keyvalue::batch::add_to_linker(&mut linker, |ctx| ctx)
+            .context("failed to link `wasi:keyvalue/batch`")?;
         capability::logging::logging::add_to_linker(&mut linker, |ctx| ctx)
             .context("failed to link `wasi:logging/logging`")?;
 

--- a/crates/runtime/wit/host.wit
+++ b/crates/runtime/wit/host.wit
@@ -5,6 +5,7 @@ world interfaces {
     import wasi:config/runtime@0.2.0-draft;
     import wasi:keyvalue/atomics@0.2.0-draft;
     import wasi:keyvalue/store@0.2.0-draft;
+    import wasi:keyvalue/batch@0.2.0-draft;
     import wasi:logging/logging;
     import wasmcloud:bus/lattice@1.0.0;
     import wasmcloud:messaging/consumer@0.2.0;
@@ -16,6 +17,7 @@ world wrpc-interfaces {
     import wasmcloud:messaging/consumer@0.2.0;
     import wrpc:keyvalue/atomics@0.2.0-draft;
     import wrpc:keyvalue/store@0.2.0-draft;
+    import wrpc:keyvalue/batch@0.2.0-draft;
 
     import wrpc:blobstore/blobstore@0.1.0;
 

--- a/src/bin/keyvalue-redis-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-redis-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Redis"
 language = "rust"
 type = "provider"
-version = "0.27.0"
+version = "0.28.0"
 
 [rust]
 target_path = "../../../target"

--- a/tests/components/build.rs
+++ b/tests/components/build.rs
@@ -12,9 +12,7 @@ use serde::Deserialize;
 use tokio::fs;
 use tokio::process::Command;
 use tokio::task::JoinSet;
-use wasi_preview1_component_adapter_provider::{
-    WASI_SNAPSHOT_PREVIEW1_ADAPTER_NAME, WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER,
-};
+use wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER;
 
 /// List of (manifest path, output artifact name) for all the packages used during test
 ///
@@ -218,7 +216,10 @@ fn encode_component(module: impl AsRef<[u8]>, adapter: &[u8]) -> Result<Vec<u8>>
         .validate(true)
         .module(module.as_ref())
         .context("failed to set core component module")?
-        .adapter(WASI_SNAPSHOT_PREVIEW1_ADAPTER_NAME, adapter)
+        .adapter(
+            wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_ADAPTER_NAME,
+            adapter,
+        )
         .context("failed to add WASI adapter")?
         .encode()
         .context("failed to encode a component")

--- a/tests/components/rust/interfaces-reactor/src/lib.rs
+++ b/tests/components/rust/interfaces-reactor/src/lib.rs
@@ -155,6 +155,9 @@ pub fn run_test(body: &[u8]) -> (Vec<u8>, String) {
     eprintln!("test default keyvalue/atomics...");
     keyvalue::run_atomics_test();
 
+    eprintln!("test default keyvalue/batch...");
+    keyvalue::run_batch_test();
+
     eprintln!("test default blobstore...");
     blobstore::run_test(1, &body, "container");
 

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -344,7 +344,11 @@ async fn interfaces() -> anyhow::Result<()> {
         "default",
         "wasi",
         "keyvalue",
-        vec!["atomics".to_string(), "store".to_string()],
+        vec![
+            "atomics".to_string(),
+            "store".to_string(),
+            "batch".to_string(),
+        ],
         vec![],
         vec![keyvalue_redis_config_name],
     )
@@ -431,7 +435,7 @@ async fn interfaces() -> anyhow::Result<()> {
         r#"{{"min":42,"max":4242,"config_key":"test-config-data","authority":"localhost:{http_port}"}}"#,
     );
     redis::Cmd::set("foo", "bar")
-        .query_async(&mut redis_conn)
+        .query_async::<_, ()>(&mut redis_conn)
         .await
         .context("failed to set `foo` key in Redis")?;
     vaultrs::kv2::set(


### PR DESCRIPTION
This enables keyvalue batch support inside of the host, along with a test to make sure it works. Not all of our providers implement batch yet, so this uses the Redis provider, which did have implementions. I did have to fix the redis provider to get the right type of data back and transform it. I also had to update our wRPC versions so we could pick up on some bug fixes for the types we are encoding in the batch interface.