### PR TITLE
fix(postgres-provider): include webpki-roots in the postgres provider by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7759,7 +7759,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bigdecimal 0.4.5",
@@ -7782,6 +7782,7 @@ dependencies = [
  "ulid",
  "uuid 1.10.0",
  "wasmcloud-provider-sdk",
+ "webpki-roots 0.26.5",
  "wit-bindgen-wrpc 0.6.5",
 ]
 

--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.6.0"
+version = "0.7.0"
 description = """
 wasmCloud SQL database provider for Postgres
 """
@@ -25,6 +25,7 @@ num = { workspace = true }
 pg_bigdecimal = { workspace = true }
 postgres-types = { workspace = true, features = [ "with-cidr-0_2" ] }
 rustls = { workspace = true }
+webpki-roots = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = { workspace = true, features = [ "runtime", "with-serde_json-1", "with-chrono-0_4", "with-uuid-0_8", "with-geo-types-0_7", "array-impls", "with-bit-vec-0_6", "with-uuid-1" ]  }

--- a/crates/provider-sqldb-postgres/src/lib.rs
+++ b/crates/provider-sqldb-postgres/src/lib.rs
@@ -346,11 +346,13 @@ fn create_tls_pool(
     cfg: deadpool_postgres::Config,
     runtime: Option<deadpool_postgres::Runtime>,
 ) -> Result<Pool> {
+    let mut store = rustls::RootCertStore::empty();
+    store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     cfg.create_pool(
         runtime,
         tokio_postgres_rustls::MakeRustlsConnect::new(
             rustls::ClientConfig::builder()
-                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_root_certificates(store)
                 .with_no_client_auth(),
         ),
     )


### PR DESCRIPTION
This adds the `webpki-roots` crate as a dependency to the postgres provider and uses it by default to provide CA certs when TLS is enabled.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
