### PR TITLE
chore: Switch oci-distribution to oci feature

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,13 +12,14 @@ repository.workspace = true
 [features]
 default = [
     "hyper-rustls",
-    "oci-distribution",
+    "oci",
     "reqwest",
     "rustls-native-certs",
     "webpki-roots",
 ]
 hyper-rustls = ["dep:hyper-rustls", "dep:hyper-util"]
 otel = []
+oci = ["dep:oci-distribution", "dep:oci-wasm"]
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
@@ -34,7 +35,7 @@ hyper-rustls = { workspace = true, features = [
 hyper-util = { workspace = true, optional = true }
 nkeys = { workspace = true }
 oci-distribution = { workspace = true, features = ["rustls-tls"], optional = true }
-oci-wasm = { workspace = true, features = ["rustls-tls"] }
+oci-wasm = { workspace = true, features = ["rustls-tls"], optional = true }
 once_cell = { workspace = true }
 provider-archive = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"], optional = true }

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -33,14 +33,14 @@ wasmcloud-core = "0.7.0"
 
 `wasmcloud-core` comes with the following features:
 
-| Feature             | Default? | Description                                                            |
-|---------------------|----------|------------------------------------------------------------------------|
-| hyper-rustls        | yes      | Enable [`hyper-rustls`][hyper-rustls] usage (see `tls` module)         |
-| oci-distribution    | yes      | Enable [`oci-distribution`][oci-distribution] usage (see `tls` module) |
-| reqwest             | yes      | Enable [`reqwest`][request] extensions (see `tls` module)              |
-| rustls-native-certs | yes      | Enable [`rustls-native-certs`][rustls-native-certs] (see `tls` module) |
-| webpki-roots        | yes      | Enable [`webpki-roots`][webpki-roots] (see `tls` module)               |
-| otel                | no       | Enable [OpenTelemetry][otel] module support                            |
+| Feature             | Default? | Description                                                                             |
+|---------------------|----------|-----------------------------------------------------------------------------------------|
+| hyper-rustls        | yes      | Enable [`hyper-rustls`][hyper-rustls] usage (see `tls` module)                          |
+| oci                 | yes      | Enable [`oci-distribution`][oci-distribution] and [`oci-wasm`] usage (see `tls` module) |
+| reqwest             | yes      | Enable [`reqwest`][request] extensions (see `tls` module)                               |
+| rustls-native-certs | yes      | Enable [`rustls-native-certs`][rustls-native-certs] (see `tls` module)                  |
+| webpki-roots        | yes      | Enable [`webpki-roots`][webpki-roots] (see `tls` module)                                |
+| otel                | no       | Enable [OpenTelemetry][otel] module support                                             |
 
 [hyper-rustls]: https://crates.io/crates/hyper-rustls
 [oci-distribution]: https://crates.io/crates/oci-distribution

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,7 +13,9 @@ pub use link::*;
 pub mod otel;
 pub use otel::*;
 
+#[cfg(feature = "oci")]
 pub mod oci;
+#[cfg(feature = "oci")]
 pub use oci::*;
 
 pub mod par;

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -33,6 +33,7 @@ impl From<(Option<String>, Option<String>)> for RegistryAuth {
     }
 }
 
+#[cfg(feature = "oci")]
 impl From<&RegistryAuth> for oci_distribution::secrets::RegistryAuth {
     fn from(auth: &crate::RegistryAuth) -> Self {
         match auth {
@@ -44,6 +45,7 @@ impl From<&RegistryAuth> for oci_distribution::secrets::RegistryAuth {
     }
 }
 
+#[cfg(feature = "oci")]
 impl From<RegistryAuth> for oci_distribution::secrets::RegistryAuth {
     fn from(auth: crate::RegistryAuth) -> Self {
         match auth {

--- a/crates/core/src/tls.rs
+++ b/crates/core/src/tls.rs
@@ -35,7 +35,7 @@ pub static NATIVE_ROOTS: Lazy<Arc<[rustls::pki_types::CertificateDer<'static>]>>
         }
     });
 
-#[cfg(all(feature = "rustls-native-certs", feature = "oci-distribution"))]
+#[cfg(all(feature = "rustls-native-certs", feature = "oci"))]
 pub static NATIVE_ROOTS_OCI: Lazy<Arc<[oci_distribution::client::Certificate]>> = Lazy::new(|| {
     NATIVE_ROOTS
         .iter()

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -53,7 +53,7 @@ uuid = { workspace = true, features = ["serde"] }
 wascap = { workspace = true }
 wasmcloud-control-interface = { workspace = true }
 wasmcloud-core = { workspace = true, features = [
-    "oci-distribution",
+    "oci",
     "otel",
     "rustls-native-certs",
 ] }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -96,7 +96,7 @@ wasi-preview1-component-adapter-provider = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmcloud-control-interface = { version = "1" } # TODO: Revert once wadm is published with async-nats 0.36
 wasmcloud-core = { workspace = true, features = [
-    "oci-distribution",
+    "oci",
     "reqwest",
     "rustls-native-certs",
 ] }


### PR DESCRIPTION
## Feature or Problem

With the recent #3030 reorganization PR, it seems that building unrelated things would result in bunch of warnings related to `oci-distribution` not being available, so this changes the `oci-distribution` feature to `oci` feature and puts the functionality depending on the `oci-*` crates behind the feature flag.

It also switches the crates depending on this functionality to use the new feature.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
