### PR TITLE
feat: Provide predefined testcontainers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,6 +1519,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "conquer-once"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d008a441c0f269f36ca13712528069a86a3e60dffee1d98b976eb3b0b2160b4"
+dependencies = [
+ "conquer-util",
+]
+
+[[package]]
+name = "conquer-util"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e763eef8846b13b380f37dfecda401770b0ca4e56e95170237bd7c25c7db3582"
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5918,6 +5933,7 @@ dependencies = [
  "bollard",
  "bollard-stubs",
  "bytes",
+ "conquer-once",
  "dirs",
  "docker_credential",
  "either",
@@ -5929,6 +5945,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "signal-hook",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,7 +2099,7 @@ version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
 dependencies = [
- "dirs-sys 0.3.7",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -2113,15 +2113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,18 +2121,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2277,6 +2256,17 @@ name = "escape_string"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e867569975c88fdf73833a30bd6e0978aa6ab6bd784b648fcece07450951ba"
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "event-listener"
@@ -4021,12 +4011,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -5925,18 +5909,18 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.21.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7d80fe0008971413157e67062150cbf508b92f0eb525b9f49de1aec4267f24"
+checksum = "5b52850ed7c71aa299608b4d891473e1e2698e47287426b81c4938408f058aac"
 dependencies = [
  "async-trait",
  "bollard",
  "bollard-stubs",
  "bytes",
  "conquer-once",
- "dirs",
  "docker_credential",
  "either",
+ "etcetera",
  "futures",
  "log",
  "memchr",
@@ -5949,6 +5933,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-tar",
  "tokio-util",
  "url",
 ]
@@ -6196,6 +6181,7 @@ dependencies = [
  "redox_syscall 0.3.5",
  "tokio",
  "tokio-stream",
+ "xattr",
 ]
 
 [[package]]
@@ -7022,7 +7008,6 @@ dependencies = [
  "tempfile",
  "term-table",
  "test-case",
- "testcontainers",
  "thiserror",
  "time",
  "tokio",
@@ -7040,6 +7025,7 @@ dependencies = [
  "wasm-encoder 0.217.0",
  "wasmcloud-control-interface 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmcloud-core 0.10.0",
+ "wasmcloud-test-util",
  "wasmparser 0.217.0",
  "wasmtime",
  "wasmtime-wasi",
@@ -7519,13 +7505,13 @@ dependencies = [
  "path-clean",
  "serde",
  "serde_json",
- "testcontainers",
  "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
  "wasmcloud-provider-sdk",
+ "wasmcloud-test-util",
  "wrpc-interface-blobstore",
  "wrpc-transport 0.26.8",
  "wrpc-transport-nats 0.23.1",
@@ -7565,12 +7551,12 @@ dependencies = [
  "rustls 0.22.4",
  "serde",
  "serde_json",
- "testcontainers",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
  "wasmcloud-provider-sdk",
+ "wasmcloud-test-util",
  "wrpc-interface-blobstore",
  "wrpc-transport 0.26.8",
 ]
@@ -7615,7 +7601,6 @@ dependencies = [
  "reqwest 0.12.7",
  "serde",
  "serde_json",
- "testcontainers",
  "thiserror",
  "tokio",
  "toml 0.8.19",
@@ -7884,6 +7869,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "testcontainers",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9179,6 +9165,17 @@ dependencies = [
  "der",
  "spki",
  "tls_codec",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,7 +299,7 @@ termcolor = { version = "1", default-features = false }
 termsize = { version = "0.1", default-features = false }
 test-case = { version = "3", default-features = false }
 test-components = { version = "0", path = "./tests/components", default-features = false }
-testcontainers = { version = "0.21", default-features = false }
+testcontainers = { version = "0.23" }
 thiserror = { version = "1", default-features = false }
 time = { version = "0.3", default-features = false }
 tokio = { version = "1", default-features = false }

--- a/crates/provider-blobstore-azure/Cargo.toml
+++ b/crates/provider-blobstore-azure/Cargo.toml
@@ -40,5 +40,5 @@ wrpc-interface-blobstore = { workspace = true }
 wrpc-transport = { workspace = true }
 
 [dev-dependencies]
-testcontainers = { workspace = true }
+wasmcloud-test-util = { workspace = true, features = ["testcontainers"] }
 wrpc-transport-nats = { workspace = true }

--- a/crates/provider-blobstore-s3/Cargo.toml
+++ b/crates/provider-blobstore-s3/Cargo.toml
@@ -40,4 +40,4 @@ wrpc-transport = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
-testcontainers = { workspace = true }
+wasmcloud-test-util = { workspace = true, features = ["testcontainers"] }

--- a/crates/provider-blobstore-s3/tests/storage.rs
+++ b/crates/provider-blobstore-s3/tests/storage.rs
@@ -32,27 +32,8 @@ use std::collections::HashMap;
 use std::env;
 
 use anyhow::{Context as _, Result};
-use testcontainers::{core::WaitFor, runners::AsyncRunner as _, ContainerAsync, Image, ImageExt};
 use wasmcloud_provider_blobstore_s3::{StorageClient, StorageConfig};
-
-#[derive(Default, Debug, Clone)]
-pub struct LocalStack {
-    _priv: (),
-}
-
-impl Image for LocalStack {
-    fn name(&self) -> &str {
-        "localstack/localstack"
-    }
-
-    fn tag(&self) -> &str {
-        "3.7.0"
-    }
-
-    fn ready_conditions(&self) -> Vec<WaitFor> {
-        vec![WaitFor::message_on_stdout("Ready."), WaitFor::millis(3000)]
-    }
-}
+use wasmcloud_test_util::testcontainers::{AsyncRunner as _, ContainerAsync, ImageExt, LocalStack};
 
 struct TestEnv {
     _container: Option<ContainerAsync<LocalStack>>,

--- a/crates/provider-http-server/Cargo.toml
+++ b/crates/provider-http-server/Cargo.toml
@@ -36,5 +36,4 @@ wrpc-interface-http = { workspace = true, features = ["http-body"] }
 
 [dev-dependencies]
 reqwest = { workspace = true }
-wasmcloud-test-util = { workspace = true }
-testcontainers = { workspace = true }
+wasmcloud-test-util = { workspace = true, features = ["testcontainers"] }

--- a/crates/provider-http-server/src/lib.rs
+++ b/crates/provider-http-server/src/lib.rs
@@ -367,14 +367,10 @@ mod test {
 
     use anyhow::Result;
     use futures::StreamExt;
-    use testcontainers::{
-        core::{ContainerPort, WaitFor},
-        runners::AsyncRunner,
-        GenericImage,
-    };
     use wasmcloud_provider_sdk::{
         provider::initialize_host_data, run_provider, HostData, InterfaceLinkDefinition,
     };
+    use wasmcloud_test_util::testcontainers::{AsyncRunner, NatsServer};
 
     use crate::{address, path};
 
@@ -383,14 +379,10 @@ mod test {
     #[ignore]
     #[tokio::test]
     async fn can_listen_and_invoke_with_timeout() -> Result<()> {
-        let nats_container = GenericImage::new("nats", "2.10.18-alpine")
-            .with_exposed_port(ContainerPort::Tcp(4222))
-            .with_wait_for(WaitFor::message_on_stderr(
-                "Listening for client connections on 0.0.0.0:4222",
-            ))
+        let nats_container = NatsServer::default()
             .start()
             .await
-            .expect("failed to start squid-proxy container");
+            .expect("failed to start nats-server container");
         let nats_port = nats_container
             .get_host_port_ipv4(4222)
             .await
@@ -469,11 +461,7 @@ mod test {
     #[ignore]
     #[tokio::test]
     async fn can_support_path_based_routing() -> Result<()> {
-        let nats_container = GenericImage::new("nats", "2.10.18-alpine")
-            .with_exposed_port(ContainerPort::Tcp(4222))
-            .with_wait_for(WaitFor::message_on_stderr(
-                "Listening for client connections on 0.0.0.0:4222",
-            ))
+        let nats_container = NatsServer::default()
             .start()
             .await
             .expect("failed to start nats-server container");

--- a/crates/test-util/Cargo.toml
+++ b/crates/test-util/Cargo.toml
@@ -26,7 +26,7 @@ nkeys = { workspace = true }
 rmp-serde = { workspace = true}
 serde = { workspace = true }
 serde_json = { workspace = true }
-testcontainers = { workspace = true, features = ["watchdog"], optional = true }
+testcontainers = { workspace = true, optional = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
@@ -41,3 +41,6 @@ wasmcloud-secrets-types = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true, features = [ "rt", "macros" ]  }
 tempfile = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+testcontainers = { workspace = true, optional = true, features = ["watchdog"] }

--- a/crates/test-util/Cargo.toml
+++ b/crates/test-util/Cargo.toml
@@ -15,6 +15,9 @@ repository.workspace = true
 [badges.maintenance]
 status = "actively-developed"
 
+[features]
+testcontainers = ["dep:testcontainers"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-nats = { workspace = true }
@@ -23,6 +26,7 @@ nkeys = { workspace = true }
 rmp-serde = { workspace = true}
 serde = { workspace = true }
 serde_json = { workspace = true }
+testcontainers = { workspace = true, features = ["watchdog"], optional = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }

--- a/crates/test-util/src/lib.rs
+++ b/crates/test-util/src/lib.rs
@@ -61,6 +61,8 @@ pub mod component;
 pub mod host;
 pub mod lattice;
 pub mod provider;
+#[cfg(feature = "testcontainers")]
+pub mod testcontainers;
 
 /// Re-export of control interface fo ruse
 pub use wasmcloud_control_interface as control_interface;

--- a/crates/test-util/src/testcontainers/azurite.rs
+++ b/crates/test-util/src/testcontainers/azurite.rs
@@ -1,0 +1,42 @@
+use testcontainers::{core::WaitFor, Image};
+
+#[derive(Default, Debug, Clone)]
+pub struct Azurite {
+    _priv: (),
+}
+
+impl Image for Azurite {
+    fn name(&self) -> &str {
+        "mcr.microsoft.com/azure-storage/azurite"
+    }
+
+    fn tag(&self) -> &str {
+        "3.32.0"
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout(
+            "Azurite Blob service is successfully listening",
+        )]
+    }
+
+    // We need to override the command used for running Azurite so that loose mode can be enabled
+    fn cmd(&self) -> impl IntoIterator<Item = impl Into<std::borrow::Cow<'_, str>>> {
+        vec![
+            // Defaults from the Dockerfile:
+            // https://github.com/Azure/Azurite/blob/76f626284e4b4b58b95065bb3c92351f30af7f3d/Dockerfile#L47
+            "azurite",
+            "-l",
+            "/data",
+            "--blobHost",
+            "0.0.0.0",
+            "--queueHost",
+            "0.0.0.0",
+            "--tableHost",
+            "0.0.0.0",
+            // Loose mode is required for testing the `get-container-data` endpoint, for more info on what the flag does see:
+            // https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=docker-hub%2Cblob-storage#loose-mode
+            "--loose",
+        ]
+    }
+}

--- a/crates/test-util/src/testcontainers/localstack.rs
+++ b/crates/test-util/src/testcontainers/localstack.rs
@@ -1,0 +1,20 @@
+use testcontainers::{core::WaitFor, Image};
+
+#[derive(Default, Debug, Clone)]
+pub struct LocalStack {
+    _priv: (),
+}
+
+impl Image for LocalStack {
+    fn name(&self) -> &str {
+        "localstack/localstack"
+    }
+
+    fn tag(&self) -> &str {
+        "3.7.0"
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout("Ready."), WaitFor::millis(3000)]
+    }
+}

--- a/crates/test-util/src/testcontainers/mod.rs
+++ b/crates/test-util/src/testcontainers/mod.rs
@@ -1,0 +1,13 @@
+pub use testcontainers::{core::Mount, runners::AsyncRunner, ContainerAsync, ImageExt};
+
+pub mod azurite;
+pub use azurite::*;
+
+pub mod localstack;
+pub use localstack::*;
+
+pub mod nats_server;
+pub use nats_server::*;
+
+pub mod squid_proxy;
+pub use squid_proxy::*;

--- a/crates/test-util/src/testcontainers/nats_server.rs
+++ b/crates/test-util/src/testcontainers/nats_server.rs
@@ -1,0 +1,20 @@
+use testcontainers::{core::WaitFor, Image};
+
+#[derive(Default, Debug, Clone)]
+pub struct NatsServer {
+    _priv: (),
+}
+
+impl Image for NatsServer {
+    fn name(&self) -> &str {
+        "library/nats"
+    }
+
+    fn tag(&self) -> &str {
+        "2.10.18-linux"
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stderr("Server is ready")]
+    }
+}

--- a/crates/test-util/src/testcontainers/squid_proxy.rs
+++ b/crates/test-util/src/testcontainers/squid_proxy.rs
@@ -1,0 +1,30 @@
+use testcontainers::{
+    core::{ContainerPort, WaitFor},
+    Image,
+};
+
+#[derive(Default, Debug, Clone)]
+pub struct SquidProxy {
+    _priv: (),
+}
+
+impl Image for SquidProxy {
+    fn name(&self) -> &str {
+        "cgr.dev/chainguard/squid-proxy"
+    }
+
+    fn tag(&self) -> &str {
+        "latest"
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![
+            WaitFor::message_on_stdout("listening port: 3128"),
+            WaitFor::seconds(3),
+        ]
+    }
+
+    fn expose_ports(&self) -> &[ContainerPort] {
+        &[ContainerPort::Tcp(3128)]
+    }
+}

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -123,7 +123,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "time", "macros", "ne
 [dev-dependencies]
 claims = { workspace = true }
 tempfile = { workspace = true }
-testcontainers = { workspace = true }
+wasmcloud-test-util = { workspace = true, features = ["testcontainers"] }
 test-case = { workspace = true }
 tokio = { workspace = true }
 wasmparser = { workspace = true }

--- a/crates/wash-lib/src/start/github.rs
+++ b/crates/wash-lib/src/start/github.rs
@@ -128,11 +128,9 @@ pub(crate) fn get_download_client() -> Result<reqwest::Client> {
 mod test {
     use std::{collections::HashMap, env::temp_dir};
 
-    use testcontainers::core::{ContainerPort, Mount, WaitFor};
-    use testcontainers::runners::AsyncRunner as _;
-    use testcontainers::{GenericImage, ImageExt};
     use tokio::fs::{create_dir_all, remove_dir_all};
     use tokio::io::AsyncBufReadExt;
+    use wasmcloud_test_util::testcontainers::{AsyncRunner as _, ImageExt, Mount, SquidProxy};
 
     use crate::start::{get_download_client, github::DOWNLOAD_CLIENT_USER_AGENT};
 
@@ -193,10 +191,7 @@ shutdown_lifetime 1 seconds
             .await
             .unwrap();
 
-        let container = GenericImage::new("cgr.dev/chainguard/squid-proxy", "latest")
-            .with_exposed_port(ContainerPort::Tcp(3128))
-            .with_wait_for(WaitFor::message_on_stdout("listening port: 3128"))
-            .with_wait_for(WaitFor::seconds(3))
+        let container = SquidProxy::default()
             .with_mount(Mount::bind_mount(
                 squid_config_path.to_string_lossy().to_string(),
                 "/etc/squid.conf",
@@ -217,7 +212,7 @@ shutdown_lifetime 1 seconds
                 format!(
                     "http://localhost:{}",
                     container
-                        .get_host_port_ipv4(ContainerPort::Tcp(3128))
+                        .get_host_port_ipv4(3128)
                         .await
                         .expect("failed to get squid-proxy host port")
                 ),
@@ -277,10 +272,7 @@ shutdown_lifetime 1 seconds
             .await
             .unwrap();
 
-        let container = GenericImage::new("chainguard/squid-proxy", "latest")
-            .with_exposed_port(ContainerPort::Tcp(3128))
-            .with_wait_for(WaitFor::message_on_stdout("listening port: 3128"))
-            .with_wait_for(WaitFor::seconds(3))
+        let container = SquidProxy::default()
             .with_mount(Mount::bind_mount(
                 squid_config_path.to_string_lossy().to_string(),
                 "/etc/squid.conf",


### PR DESCRIPTION
## Feature or Problem

To make it easier to test consistently against the same versions of software (and have the flexibility to change the version to different one with ease as needed), we should provide a set of predefined testcontainers that can be used across the various crates in this repository as well as pulled in by external projects as well.

This also consolidates the existing usage of testcontainers across the repository to switching them to the ones under `wasmcloud_test_util` instead.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
