### PR TITLE
chore: Revise the default NATS Server address logic

### DIFF
--- a/.github/workflows/wasmcloud-host-chart.yml
+++ b/.github/workflows/wasmcloud-host-chart.yml
@@ -14,6 +14,7 @@ permissions:
 
 env:
   HELM_VERSION: v3.13.3
+  CHART_TESTING_NAMESPACE: chart-testing
 
 jobs:
   validate:
@@ -51,10 +52,15 @@ jobs:
         run: |
           helm repo add nats https://nats-io.github.io/k8s/helm/charts/
           helm repo update
-          helm install nats nats/nats -f charts/ci/nats-values.yaml
+          helm install nats nats/nats -f charts/ci/nats-values.yaml --namespace ${{ env.CHART_TESTING_NAMESPACE }} --create-namespace
 
-      - name: Run chart-testing (install)
-        run: ct install --config charts/wasmcloud-host/ct.yaml
+      - name: Run chart-testing install / same namespace
+        run: |
+          ct install --config charts/wasmcloud-host/ct.yaml --namespace ${{ env.CHART_TESTING_NAMESPACE }}
+
+      - name: Run chart-testing install / across namespaces
+        run: |
+          ct install --config charts/wasmcloud-host/ct.yaml --helm-extra-set-args "--set=config.natsAddress=nats://nats-headless.${{ env.CHART_TESTING_NAMESPACE }}.svc.cluster.local"
 
   publish:
     if: ${{ startsWith(github.ref, 'refs/tags/wasmcloud-host-chart-v') }}

--- a/charts/wasmcloud-host/Chart.yaml
+++ b/charts/wasmcloud-host/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wasmcloud-host/templates/_helpers.tpl
+++ b/charts/wasmcloud-host/templates/_helpers.tpl
@@ -72,3 +72,11 @@ Create the name of the service account to use
 {{- end }}
 {{- join "," $list }}
 {{- end }}
+
+{{- define "wasmcloud-host.nats.address" -}}
+{{- if .Values.config.natsAddress }}
+url: {{ .Values.config.natsAddress | quote }}
+{{- else }}
+url: "nats://nats-headless.{{ .Release.Namespace }}.svc.cluster.local"
+{{- end }}
+{{- end }}

--- a/charts/wasmcloud-host/templates/configmap.yaml
+++ b/charts/wasmcloud-host/templates/configmap.yaml
@@ -15,8 +15,8 @@ data:
     leafnodes {
         remotes = [
             {
-              url: {{ .Values.config.natsAddress | quote }}
-              {{- if .Values.config.natsCredentialsSecret }}
+              {{- include "wasmcloud-host.nats.address" . | nindent 14 }}
+              {{- if .Values.config.natsCredentialsSecret -}}
               credentials: "/nats/nats.creds"
               {{- end }}
             },

--- a/charts/wasmcloud-host/values.yaml
+++ b/charts/wasmcloud-host/values.yaml
@@ -36,8 +36,8 @@ config:
   configServiceEnabled: false
   # Optional: The log level to use for the host. Defaults to "INFO".
   logLevel: "INFO"
-  # Optional: The address of the NATS server to connect to. Defaults to "nats://nats.default.svc.cluster.local".
-  natsAddress: "nats://nats.default.svc.cluster.local"
+  # Optional: The address of the NATS server to connect to. Defaults to "nats://nats-headless.<namespace>.svc.cluster.local".
+  natsAddress: ""
   # Optional: Allow the host to deploy using the latest tag on OCI components or providers. Defaults to "false".
   allowLatest: false
   # Optional: Allow the host to pull artifacts from OCI registries insecurely.


### PR DESCRIPTION
## Feature or Problem

This adjusts the NATS Server defaulting behavior to better align with the deployment patterns we're seeing, which is to say that rather than using `nats://nats.default.svc.cluster.local`, we're using `nats://nats-headless.<namespace>.svc.cluster.local` to match the namespace the `wasmcloud-host` is deployed in to.

Of course the ability to override this via `config.natsAddress` remains unchanged.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
