### PR TITLE
chore(charts): Change the nats-leaf configmap name to not conflict with upstream NATS chart naming

### DIFF
--- a/charts/wasmcloud-host/Chart.yaml
+++ b/charts/wasmcloud-host/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wasmcloud-host/templates/_helpers.tpl
+++ b/charts/wasmcloud-host/templates/_helpers.tpl
@@ -24,7 +24,7 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{- define "wasmcloud-host.nats-config-name" -}}
-{{- .Release.Name | trunc 51 | trimSuffix "-" }}-nats-config
+{{- .Release.Name | trunc 51 | trimSuffix "-" }}-nats-leaf-config
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## Feature or Problem

When included as part of another chart where you might have nats-server already being installed standalone, the configmap naming will conflict, so this disambiguates the two by changing the template to include `-leaf` in the configmap name.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
