### PR TITLE
feat(wash-cli): enable undeploying and deleting multiple apps

### DIFF
--- a/crates/wash-cli/tests/common/mod.rs
+++ b/crates/wash-cli/tests/common/mod.rs
@@ -20,6 +20,7 @@ use tokio::{
 };
 
 use wash_lib::cli::output::{
+    AppDeleteCommandOutput, AppDeployCommandOutput, AppListCommandOutput, AppUndeployCommandOutput,
     CallCommandOutput, GetHostsCommandOutput, PullCommandOutput, StartCommandOutput,
     StopCommandOutput, UpCommandOutput,
 };
@@ -572,6 +573,84 @@ impl TestWashInstance {
             .await
             .context("failed to stop host")?;
         serde_json::from_slice(&output.stdout).context("failed to parse output of `wash stop host`")
+    }
+
+    /// Trigger the equivalent of `wash app deploy` on a [`TestWashInstance`]
+    pub(crate) async fn deploy_app(&self, name_or_path: &str) -> Result<AppDeployCommandOutput> {
+        let output = Command::new(env!("CARGO_BIN_EXE_wash"))
+            .args([
+                "app",
+                "deploy",
+                name_or_path,
+                "--output",
+                "json",
+                "--ctl-port",
+                self.nats_port.to_string().as_ref(),
+            ])
+            .kill_on_drop(true)
+            .output()
+            .await
+            .context("failed to deploy app")?;
+        serde_json::from_slice(&output.stdout)
+            .context("failed to parse output of `wash app deploy`")
+    }
+
+    /// Trigger the equivalent of `wash app list` on a [`TestWashInstance`]
+    pub(crate) async fn list_apps(&self) -> Result<AppListCommandOutput> {
+        let output = Command::new(env!("CARGO_BIN_EXE_wash"))
+            .args([
+                "app",
+                "list",
+                "--output",
+                "json",
+                "--ctl-port",
+                self.nats_port.to_string().as_ref(),
+            ])
+            .kill_on_drop(true)
+            .output()
+            .await
+            .context("failed to list apps")?;
+        serde_json::from_slice(&output.stdout).context("failed to parse output of `wash app list`")
+    }
+
+    /// Trigger the equivalent of `wash app undeploy --all` on a [`TestWashInstance`]
+    pub(crate) async fn undeploy_all_apps(&self) -> Result<AppUndeployCommandOutput> {
+        let output = Command::new(env!("CARGO_BIN_EXE_wash"))
+            .args([
+                "app",
+                "undeploy",
+                "--all",
+                "--output",
+                "json",
+                "--ctl-port",
+                self.nats_port.to_string().as_ref(),
+            ])
+            .kill_on_drop(true)
+            .output()
+            .await
+            .context("failed to undeploy all apps")?;
+        serde_json::from_slice(&output.stdout)
+            .context("failed to parse output of `wash app undeploy --all`")
+    }
+
+    /// Trigger the equivalent of `wash app delete --all-undeployed` on a [`TestWashInstance`]
+    pub(crate) async fn delete_all_undeployed_apps(&self) -> Result<AppDeleteCommandOutput> {
+        let output = Command::new(env!("CARGO_BIN_EXE_wash"))
+            .args([
+                "app",
+                "delete",
+                "--all-undeployed",
+                "--output",
+                "json",
+                "--ctl-port",
+                self.nats_port.to_string().as_ref(),
+            ])
+            .kill_on_drop(true)
+            .output()
+            .await
+            .context("failed to undeploy all apps")?;
+        serde_json::from_slice(&output.stdout)
+            .context("failed to parse output of `wash app undeploy --all`")
     }
 }
 

--- a/crates/wash-cli/tests/fixtures/wadm/manifests/simple.wadm.yaml
+++ b/crates/wash-cli/tests/fixtures/wadm/manifests/simple.wadm.yaml
@@ -11,7 +11,7 @@ spec:
     - name: http-component
       type: component
       properties:
-        image: ghcr.io/wasmcloud/component-http-hello-world:0.1.0
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
       traits:
         - type: spreadscaler
           properties:

--- a/crates/wash-cli/tests/wash_app.rs
+++ b/crates/wash-cli/tests/wash_app.rs
@@ -1,9 +1,56 @@
-use anyhow::{Context, Result};
 use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serial_test::serial;
 use tokio::process::Command;
-use wash_lib::{
-    app::validate_manifest_file, cli::get::parse_watch_interval, cli::output::AppValidateOutput,
-};
+use wadm_types::api::StatusType;
+use wash_lib::app::validate_manifest_file;
+use wash_lib::cli::get::parse_watch_interval;
+use wash_lib::cli::output::{AppDeployCommandOutput, AppValidateOutput};
+
+mod common;
+use common::TestWashInstance;
+
+// Using tinygo hello world example manifest
+const TINYGO_HELLO_WORLD_MANIFEST_CONTENT: &str = r#"
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: tinygo-hello-world
+  annotations:
+    description: 'HTTP hello world demo in Golang (TinyGo), using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+    wasmcloud.dev/authors: wasmCloud team
+    wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-hello-world/wadm.yaml
+    wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-hello-world/README.md
+    wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/golang/components/http-hello-world
+    wasmcloud.dev/categories: |
+      http,outgoing-http,http-server,tinygo,golang,example
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: file://./build/http_hello_world_s.wasm
+      traits:
+        - type: spreadscaler
+          properties:
+            instances: 1
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.22.0
+      traits:
+        - type: link
+          properties:
+            target: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 127.0.0.1:8080
+    "#;
 
 /// Ensure a simple WADM manifest passes validation
 #[tokio::test]
@@ -43,53 +90,12 @@ async fn test_validate_complete_wadm_manifest() {
         .await
         .expect("Failed to create test directory");
 
-    // Using tinygo hello world example manifest
-    let manifest_content = r#"
-apiVersion: core.oam.dev/v1beta1
-kind: Application
-metadata:
-  name: tinygo-hello-world
-  annotations:
-    description: 'HTTP hello world demo in Golang (TinyGo), using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
-    wasmcloud.dev/authors: wasmCloud team
-    wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-hello-world/wadm.yaml
-    wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-hello-world/README.md
-    wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/golang/components/http-hello-world
-    wasmcloud.dev/categories: |
-      http,outgoing-http,http-server,tinygo,golang,example
-spec:
-  components:
-    - name: http-component
-      type: component
-      properties:
-        image: file://./build/http_hello_world_s.wasm
-      traits:
-        - type: spreadscaler
-          properties:
-            instances: 1
-    - name: httpserver
-      type: capability
-      properties:
-        image: ghcr.io/wasmcloud/http-server:0.23.1
-      traits:
-        - type: link
-          properties:
-            target: http-component
-            namespace: wasi
-            package: http
-            interfaces: [incoming-handler]
-            source_config:
-              - name: default-http
-                properties:
-                  address: 127.0.0.1:8080
-    "#;
-    tokio::fs::write(&manifest_file_path, manifest_content)
+    // Write out the manifest
+    tokio::fs::write(&manifest_file_path, TINYGO_HELLO_WORLD_MANIFEST_CONTENT)
         .await
         .expect("Failed to write test manifest file");
 
-    let oci_check = true;
-    let result = validate_manifest_file(&manifest_file_path, oci_check).await;
-
+    let result = validate_manifest_file(&manifest_file_path, true).await;
     assert!(result.is_ok(), "Validation failed: {:?}", result.err());
 
     // Clean up test directory
@@ -121,4 +127,81 @@ fn test_parse_watch_interval_invalid_input() {
             result.unwrap_err(),
             "Invalid duration: 'invalid'. Expected a duration like '5s', '1m', '100ms', or milliseconds as an integer."
         );
+}
+
+/// Ensure that `wash app undeploy --all` and `wash app --delete-undeployed` work
+#[tokio::test]
+#[serial]
+async fn test_undeploy_all_and_delete_undeployed() -> Result<()> {
+    let instance = TestWashInstance::create().await?;
+    // Deploy the application
+    let AppDeployCommandOutput {
+        success,
+        deployed,
+        model_name,
+        model_version,
+    } = instance
+        .deploy_app("./tests/fixtures/wadm/manifests/simple.wadm.yaml")
+        .await?;
+    assert!(success && deployed);
+    assert_eq!(model_name, "sample");
+    assert_eq!(model_version, "v0.0.1");
+
+    // Wait until the app is deployed via wash app list
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            if instance.list_apps().await.is_ok_and(|output| {
+                output.applications.iter().any(|a| {
+                    a.name == "sample" && a.detailed_status.info.status_type == StatusType::Deployed
+                })
+            }) {
+                break;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+        }
+    })
+    .await
+    .context("timed out waiting for app to be deployed")?;
+
+    // Perform an undeploy all
+    instance.undeploy_all_apps().await?;
+
+    // Wait until the app is deployed via wash app list
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            eprintln!("resp: {:#?}", instance.list_apps().await);
+            if instance.list_apps().await.is_ok_and(|output| {
+                output.applications.iter().any(|a| {
+                    a.name == "sample"
+                        && a.detailed_status.info.status_type == StatusType::Undeployed
+                })
+            }) {
+                break;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+        }
+    })
+    .await
+    .context("timed out waiting for app to be undeployed")?;
+
+    // Perform delete all
+    instance.delete_all_undeployed_apps().await?;
+
+    // Wait until the app is deployed via wash app list
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            if instance
+                .list_apps()
+                .await
+                .is_ok_and(|output| output.applications.is_empty())
+            {
+                break;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+        }
+    })
+    .await
+    .context("timed out waiting for app to be deleted")?;
+
+    Ok(())
 }

--- a/crates/wash-lib/src/cli/output.rs
+++ b/crates/wash-lib/src/cli/output.rs
@@ -137,3 +137,9 @@ pub struct AppListCommandOutput {
 pub struct AppUndeployCommandOutput {
     pub success: bool,
 }
+
+/// JSON Output representation of the `wash app delete` command
+#[derive(Debug, Deserialize)]
+pub struct AppDeleteCommandOutput {
+    pub success: bool,
+}

--- a/crates/wash-lib/src/cli/output.rs
+++ b/crates/wash-lib/src/cli/output.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use wasmcloud_control_interface::{Host, HostInventory};
 use wasmcloud_core::{InterfaceLinkDefinition, LinkName};
 
+use wadm_types::api::ModelSummary;
 use wadm_types::validation::ValidationFailure;
 
 /// JSON Output of the `wash start` command
@@ -113,4 +114,26 @@ pub struct AppValidateOutput {
     pub valid: bool,
     pub warnings: Vec<ValidationFailure>,
     pub errors: Vec<ValidationFailure>,
+}
+
+/// JSON Output representation of the `wash app deploy` command
+#[derive(Debug, Deserialize)]
+pub struct AppDeployCommandOutput {
+    pub success: bool,
+    pub deployed: bool,
+    pub model_name: String,
+    pub model_version: String,
+}
+
+/// JSON Output representation of the `wash app list` command
+#[derive(Debug, Deserialize)]
+pub struct AppListCommandOutput {
+    pub success: bool,
+    pub applications: Vec<ModelSummary>,
+}
+
+/// JSON Output representation of the `wash app undeploy` command
+#[derive(Debug, Deserialize)]
+pub struct AppUndeployCommandOutput {
+    pub success: bool,
 }


### PR DESCRIPTION
This commit enables wash to:

- Undeploy all applications at the same time
- Delete all undeployed applications

The combination of `wash app undeploy --all` and `wash app delete --all-undeployed` are meant to be used to gether in order to clear all apps in a given lattice.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
