### PR TITLE
fix(runtime): Ensures we have the proper limits set for max components

### DIFF
--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -135,6 +135,9 @@ impl RuntimeBuilder {
         #[allow(clippy::cast_possible_truncation)]
         pooling_config
             .total_component_instances(self.max_components)
+            .total_core_instances(self.max_components)
+            .total_gc_heaps(self.max_components)
+            .total_stacks(self.max_components)
             .max_component_instance_size(self.max_component_size as usize)
             .max_core_instances_per_component(max_core_instances_per_component)
             .max_tables_per_component(20)


### PR DESCRIPTION
It turns out that there are a bunch of other settings that we could have hit the limit on that we needed to set. These new settings are all set to the same as max components because you could have that number of individual components that would each have their own core module and stack.

I tested this under load to make sure it actually works