### PR TITLE
fix(wash-cli): multiple generated dependencies collision in project

### DIFF
--- a/crates/wash-cli/src/dev.rs
+++ b/crates/wash-cli/src/dev.rs
@@ -536,7 +536,7 @@ struct ProjectDeps {
     pub(crate) session_id: Option<String>,
 
     /// Lookup of dependencies by project key, with lookups into the pool
-    dependencies: HashMap<ProjectDependencyKey, DependencySpec>,
+    dependencies: HashMap<ProjectDependencyKey, Vec<DependencySpec>>,
 
     /// The component to which dependencies belong
     ///
@@ -581,7 +581,7 @@ impl ProjectDeps {
         deps: impl IntoIterator<Item = (ProjectDependencyKey, DependencySpec)>,
     ) -> Result<()> {
         for (pkey, dep) in deps.into_iter() {
-            self.dependencies.insert(pkey, dep);
+            self.dependencies.entry(pkey).or_default().push(dep);
         }
         Ok(())
     }
@@ -632,7 +632,7 @@ impl ProjectDeps {
         let mut components = Vec::new();
 
         // For each dependency, go through and generate the component along with necessary links
-        for dep in self.dependencies.values() {
+        for dep in self.dependencies.values().flatten() {
             let dep = dep.clone();
             let mut dep_component = dep
                 .generate_component(session_id)


### PR DESCRIPTION
This commit fixes a bug in the workspace-aware project dependency gathering that caused dependencies to override each other under  the same project.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
