### PR TITLE
feat: Allow wash to re-use registry credentials from Docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6896,6 +6896,7 @@ dependencies = [
  "cloudevents-sdk",
  "console",
  "crossterm",
+ "docker_credential",
  "file-guard",
  "futures",
  "home",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,7 @@ crossterm = { version = "0.28.1", default-features = false }
 data-encoding = { version = "2", default-features = false }
 deadpool-postgres = { version = "0.13", default-features = false }
 dialoguer = { version = "0.10", default-features = false }
+docker_credential = { version = "1.3.1", default-features = false }
 file-guard = { version = "0.2.0", default-features = false }
 futures = { version = "0.3", default-features = false }
 geo-types = { version = "0.7", default-features = false }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -27,7 +27,8 @@ clap_complete = { workspace = true }
 clap-markdown = { workspace = true }
 cloudevents-sdk = { workspace = true }
 console = { workspace = true }
-crossterm ={ workspace = true, features = ["events","windows"] }
+crossterm = { workspace = true, features = ["events", "windows"] }
+docker_credential = { workspace = true }
 file-guard = { workspace = true }
 futures = { workspace = true }
 home = { workspace = true }


### PR DESCRIPTION
## Feature or Problem

I figured that since folks might already be using Docker CLI for managing their containers or other OCI artifacts, being able to re-use the existing keyring for wasmcloud artifacts would be handy.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
