### PR TITLE
fix: Enable default features for url crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -322,7 +322,7 @@ tracing-opentelemetry = { version = "0.24", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 ulid = { version = "1", default-features = false }
 unicase = { version = "2.7.0", default-features = false }
-url = { version = "2", default-features = false }
+url = { version = "2" }
 uuid = { version = "1", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
 wadm = { version = "0.14.0", default-features = false }


### PR DESCRIPTION
In order to make the rust-url compatible with no_std, the crate needs to introduce a `std` feature and make it default.
See https://github.com/servo/rust-url/pull/831.

In order to reduce impact, downstream libraries should leave url's default features enabled (no other features are currently `default`).