### PR TITLE
chore(core): Use Default impl for Level

### DIFF
--- a/crates/core/src/otel.rs
+++ b/crates/core/src/otel.rs
@@ -44,12 +44,8 @@ pub struct OtelConfig {
     #[serde(default)]
     pub additional_ca_paths: Vec<PathBuf>,
     /// The level of tracing to enable.
-    #[serde(default = "default_trace_level")]
+    #[serde(default)]
     pub trace_level: Level,
-}
-
-fn default_trace_level() -> Level {
-    Level::Info
 }
 
 impl OtelConfig {


### PR DESCRIPTION
## Feature or Problem

Since we're `Default` impl for `OtelProtocol`, we should just do the same for [`Level` since it matches the value we're setting with the function](https://github.com/wasmCloud/wasmCloud/blob/71fc4b8f60a1f5f469912b712452f1c96a7744ef/crates/core/src/logging.rs#L32-L36).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
