### PR TITLE
chore: Explicitly use OTEL_EXPORTER_ environment variables for exporter configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -275,20 +275,35 @@ struct Args {
     #[clap(long = "enable-logs", env = "WASMCLOUD_LOGS_ENABLED", hide = true)]
     enable_logs: Option<bool>,
 
-    /// Overrides the OpenTelemetry endpoint used for emitting traces, metrics and logs. This can also be set with `OTEL_EXPORTER_OTLP_ENDPOINT`.
-    #[clap(long = "override-observability-endpoint")]
+    /// Overrides the OpenTelemetry endpoint used for emitting traces, metrics and logs.
+    #[clap(
+        long = "override-observability-endpoint",
+        env = "OTEL_EXPORTER_OTLP_ENDPOINT"
+    )]
     observability_endpoint: Option<String>,
 
-    /// Overrides the OpenTelemetry endpoint used for emitting traces. This can also be set with `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
-    #[clap(long = "override-traces-endpoint", hide = true)]
+    /// Overrides the OpenTelemetry endpoint used for emitting traces.
+    #[clap(
+        long = "override-traces-endpoint",
+        env = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        hide = true
+    )]
     traces_endpoint: Option<String>,
 
-    /// Overrides the OpenTelemetry endpoint used for emitting metrics. This can also be set with `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`.
-    #[clap(long = "override-metrics-endpoint", hide = true)]
+    /// Overrides the OpenTelemetry endpoint used for emitting metrics.
+    #[clap(
+        long = "override-metrics-endpoint",
+        env = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        hide = true
+    )]
     metrics_endpoint: Option<String>,
 
-    /// Overrides the OpenTelemetry endpoint used for emitting logs. This can also be set with `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`.
-    #[clap(long = "override-logs-endpoint", hide = true)]
+    /// Overrides the OpenTelemetry endpoint used for emitting logs.
+    #[clap(
+        long = "override-logs-endpoint",
+        env = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+        hide = true
+    )]
     logs_endpoint: Option<String>,
 
     /// Configures whether grpc or http will be used for exporting the enabled telemetry. This defaults to 'http'.


### PR DESCRIPTION
## Feature or Problem

In the interest of making it easier to pass these values down to providers, let's just directly use the environment variables.

## Related Issues

#3080

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
