### PR TITLE
feat(examples): add rust developer-starter-kit

### DIFF
--- a/examples/rust/components/developer-starter-kit/.gitignore
+++ b/examples/rust/components/developer-starter-kit/.gitignore
@@ -1,0 +1,5 @@
+# Rust build artifacts
+Cargo.lock
+
+# Wash build artifacts
+build/

--- a/examples/rust/components/developer-starter-kit/Cargo.toml
+++ b/examples/rust/components/developer-starter-kit/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "starter-kit"
+edition = "2021"
+version = "0.1.0"
+
+[workspace]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasi = "=0.13.1"
+wasmcloud-component = "0.1.0"
+wit-bindgen = "0.32.0"

--- a/examples/rust/components/developer-starter-kit/README.md
+++ b/examples/rust/components/developer-starter-kit/README.md
@@ -1,0 +1,198 @@
+# Rust Developer Starter Kit
+
+This is a Rust component example that can serve as a starter kit for all of your wasmCloud applications. It uses the [wasmcloud_component](https://crates.io/crates/wasmcloud-component) and [wasi](https://crates.io/crates/wasi) crates to demonstrate the standard capabilities that wasmCloud supports. This is an instructional example, and is meant to be modified to remove unneeded capabilities to create your application.
+
+## Prerequisites
+
+- `cargo` 1.81
+- [`wash`](https://wasmcloud.com/docs/installation) 0.33.0
+
+## Build & Run
+
+Developing this application and customizing it for your own needs is best done with `wash dev`, which will automatically build this component, run wasmCloud and deploy capability providers based on the capabilities used in the code.
+
+```bash
+wash dev
+```
+
+Make sure to take note of the logs directory, HTTP server endpoint, and messaging subscription for viewing logs and invoking the component.
+
+```plaintext
+🔧 Successfully started wasmCloud instance
+✅ Successfully started host, logs writing to /Users/brooks/.wash/dev/PHrCNP/wasmcloud.log
+🚧 Building project...
+ℹ️ Detected component dependencies: {"messaging-nats", "http-server", "blobstore-fs", "http-client", "keyvalue-nats"}
+🔁 Deployed development manifest for application [dev-phrcnp-starter-kit]
+✨ Messaging NATS: Listening on the following subscriptions [wasmcloud.dev]
+✨ HTTP Server: Access your application at http://127.0.0.1:8000
+```
+
+## Functionality
+
+This component implements a variety of HTTP API endpoints, and a custom messaging handler, to showcase how to use different capability interfaces in wasmCloud.
+
+### HTTP API
+
+#### Hello World
+
+```plaintext
+GET /
+GET /hello
+```
+
+Handle a basic HTTP request with a hello world message. Both the `/` and `/hello` endpoints are handled by the same function, so they respond the same.
+
+**Request**:
+
+```shell
+curl http://localhost:8000/
+```
+
+```shell
+curl http://localhost:8000/hello
+```
+
+**Response**:
+
+```plaintext
+Hello from Starter Kit!
+```
+
+#### Streaming Response
+
+```plaintext
+POST /echo
+```
+
+Stream the request body back to the client using WASI streams.
+
+**Request**:
+
+```bash
+curl -X POST localhost:8000/echo -d "Hello there"
+```
+
+**Response**:
+
+```plaintext
+Hello there%
+```
+
+**Request**:
+This example streams this Wasm component and outputs the response bytes to a file, comparing the output to the original file afterwards.
+
+```bash
+curl -X POST localhost:8000/echo -T ./build/starter_kit.wasm > ./streamed.wasm
+diff ./build/starter_kit.wasm ./streamed.wasm
+```
+
+**Response**:
+
+No output from `diff` means the files were identical.
+
+```plaintext
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  293k  100  146k  100  146k  72.0M  72.0M --:--:-- --:--:-- --:--:--  286M
+```
+
+#### Streaming to a File
+
+```plaintext
+POST /file
+```
+
+Stream the request body directly to a file using WASI streams.
+
+This example streams this Wasm component over HTTP and compares the output file to the original. If running this example with `wash dev`, the default location for files will be the `/tmp` directory.
+
+**Request:**
+
+```bash
+curl -X POST localhost:8000/file -T ./build/starter_kit.wasm
+diff /tmp/starter_kit/streaming_data ./build/starter_kit.wasm
+```
+
+**Response**:
+
+No output from `diff` means the files were identical.
+
+```plaintext
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  293k  100  146k  100  146k  72.0M  72.0M --:--:-- --:--:-- --:--:--  286M
+```
+
+#### Make an Outgoing HTTP Request
+
+```plaintext
+GET /example_dot_com
+```
+
+Make an outgoing HTTP request to [https://example.com](https://example.com), streaming the response back to the client using WASI streams.
+
+**Request**:
+
+```bash
+curl localhost:8000/example_dot_com
+```
+
+**Response**:
+
+```plaintext
+<!doctype html>
+<html>
+<head>
+    <title>Example Domain</title>
+...
+```
+
+#### Increment a Counter
+
+```plaintext
+GET /counter
+```
+
+Increment the request counter, then return the current count.
+
+**Request**:
+
+```bash
+curl localhost:8000/counter
+```
+
+**Response**:
+
+```plaintext
+Counter: n
+```
+
+### Messaging API
+
+This component also implements a messaging API, which can handle messages and send a message in response if a `reply_to` subject is provided.
+
+If running this component with `wash dev`, you can send a request to the `wasmcloud.dev` subject using the [NATS CLI](https://github.com/nats-io/natscli)
+
+**Request:**
+
+```bash
+nats req "wasmcloud.dev" "hello there"
+```
+
+**Response:**
+
+```plaintext
+14:10:47 Sending request on "wasmcloud.dev"
+14:10:47 Received with rtt 868.917µs
+hello there
+```
+
+### Logging
+
+For each request received by this component, it logs an `Info` level log detailing the request. This uses the [`wasmcloud_component::info!`](https://docs.rs/wasmcloud-component/latest/wasmcloud_component/macro.info.html) macro.
+
+## Adding Custom Capabilities
+
+<!-- TODO: new quickstart -->
+
+To learn how to extend this example with additional capabilities, see the [Adding Capabilities](https://wasmcloud.com/docs/tour/adding-capabilities) section of the wasmCloud documentation.

--- a/examples/rust/components/developer-starter-kit/src/helpers.rs
+++ b/examples/rust/components/developer-starter-kit/src/helpers.rs
@@ -1,0 +1,44 @@
+use std::io::Write;
+
+use wasmcloud_component::wasi::http::types::*;
+
+/// Helper function to send an HTTP response
+///
+/// Sending an HTTP response with `wasi:http` involves creating an `OutgoingResponse` object,
+/// setting the status code, and writing the response body. This function abstracts that process
+/// into a single function call for convenience.
+pub(crate) fn send_http_response(
+    response_out: ResponseOutparam,
+    status_code: u16,
+    body: impl AsRef<[u8]>,
+) {
+    let response = OutgoingResponse::new(Fields::new());
+    response
+        .set_status_code(status_code)
+        .expect("failed to set status code on response");
+    let response_body = response.body().expect("failed to get response body");
+
+    ResponseOutparam::set(response_out, Ok(response));
+    response_body
+        .write()
+        .expect("failed to write to response body")
+        .write_all(body.as_ref())
+        .expect("failed to write to response body");
+
+    OutgoingBody::finish(response_body, None).expect("failed to finish response body");
+}
+
+/// Splices the input stream into the output stream, copying all data from the input to the output.
+pub(crate) fn splice(
+    input: &wasi::io::streams::InputStream,
+    output: wasi::io::streams::OutputStream,
+) -> Result<(), wasi::io::error::Error> {
+    loop {
+        match output.blocking_splice(&input, u64::MAX) {
+            Ok(0) | Err(wasi::io::streams::StreamError::Closed) => break,
+            Err(wasi::io::streams::StreamError::LastOperationFailed(e)) => return Err(e),
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/examples/rust/components/developer-starter-kit/src/lib.rs
+++ b/examples/rust/components/developer-starter-kit/src/lib.rs
@@ -1,0 +1,193 @@
+use std::io::Write;
+
+mod bindings {
+    wit_bindgen::generate!({
+        with: {
+            "wasmcloud:messaging/types@0.2.0": wasmcloud_component::wasmcloud::messaging::types
+        },
+        generate_all
+    });
+    use super::StarterKit;
+    export!(StarterKit);
+}
+
+use wasmcloud_component::info;
+use wasmcloud_component::wasi::blobstore;
+use wasmcloud_component::wasi::exports::http::incoming_handler;
+use wasmcloud_component::wasi::http::types::*;
+use wasmcloud_component::wasi::keyvalue;
+use wasmcloud_component::wasmcloud::messaging;
+use wasmcloud_component::wasmcloud::messaging::types::BrokerMessage;
+
+mod helpers;
+
+struct StarterKit;
+
+impl incoming_handler::Guest for StarterKit {
+    fn handle(request: IncomingRequest, response_out: ResponseOutparam) {
+        info!(
+            "Received request {:?} {:?}",
+            request.method(),
+            request.path_with_query()
+        );
+        // Using the incoming `wasi:http` request, use a `match` for basic routing
+        match (request.method(), request.path_with_query().as_deref()) {
+            // If the path_with_query is absent, return a 400 Bad Request
+            (_, None) => {
+                let response = OutgoingResponse::new(Fields::new());
+                response
+                    .set_status_code(400)
+                    .expect("failed to set outgoing HTTP request");
+                ResponseOutparam::set(response_out, Ok(response));
+            }
+            // GET / or GET /hello will return a 200 OK with a simple message
+            (Method::Get, Some("/") | Some("/hello")) => {
+                helpers::send_http_response(response_out, 200, b"Hello from Starter Kit!\n");
+            }
+            // GET /counter will increment a counter in a keyvalue store and return the current value
+            (Method::Get, Some("/counter")) => {
+                let bucket = keyvalue::store::open("default").expect("failed to open empty bucket");
+                let count = keyvalue::atomics::increment(&bucket, "counter", 2)
+                    .expect("failed to increment count");
+                helpers::send_http_response(response_out, 200, format!("Counter: {count}\n"));
+            }
+            // GET /example_dot_com will make an outgoing HTTP request to example.com
+            (Method::Get, Some("/example_dot_com")) => {
+                let request = OutgoingRequest::new(Fields::new());
+                request
+                    .set_authority(Some("example.com"))
+                    .expect("failed to set authority");
+                request
+                    .set_path_with_query(Some("/"))
+                    .expect("failed to set path");
+                request
+                    .set_scheme(Some(&Scheme::Https))
+                    .expect("failed to set scheme");
+                request
+                    .set_method(&Method::Get)
+                    .expect("failed to set method");
+                let outgoing_request = wasi::http::outgoing_handler::handle(request, None);
+                let response = outgoing_request.expect("failed to make outgoing HTTP request");
+                response.subscribe().block();
+                let response_body = response
+                    .get()
+                    .expect("failed to get response body")
+                    .expect("failed to get response body")
+                    .expect("failed to get response body");
+                let consumed = response_body
+                    .consume()
+                    .expect("failed to consume response body");
+                let response = OutgoingResponse::new(Fields::new());
+                response
+                    .set_status_code(200)
+                    .expect("failed to set outgoing HTTP request");
+                let response_body = response.body().expect("failed to get outgoing body");
+                ResponseOutparam::set(response_out, Ok(response));
+                helpers::splice(
+                    &consumed
+                        .stream()
+                        .expect("failed to get response body stream"),
+                    response_body
+                        .write()
+                        .expect("failed to write to response body"),
+                )
+                .expect("failed to splice request body to response body");
+                OutgoingBody::finish(response_body, None).expect("failed to finish response body");
+            }
+            // POST /echo will return a 200 OK with the request body streamed back
+            (Method::Post, Some("/echo")) => {
+                let response = OutgoingResponse::new(request.headers());
+                response
+                    .set_status_code(200)
+                    .expect("failed to set outgoing HTTP request");
+                let request_body = request.consume().expect("failed to get incoming body");
+                let incoming_body_stream = request_body
+                    .stream()
+                    .expect("failed to get incoming body stream");
+                let response_body = response.body().expect("failed to get outgoing body");
+                ResponseOutparam::set(response_out, Ok(response));
+                let outgoing_body_stream = response_body
+                    .write()
+                    .expect("failed to write to outgoing body");
+                helpers::splice(&incoming_body_stream, outgoing_body_stream)
+                    .expect("failed to splice request body to response body");
+                OutgoingBody::finish(response_body, None).expect("failed to finish response body");
+            }
+            // POST /file will stream the request body to a file and return a 200 OK
+            (Method::Post, Some("/file")) => {
+                let response = OutgoingResponse::new(request.headers());
+                let request_body = request.consume().expect("failed to get incoming body");
+                let incoming_body_stream = request_body
+                    .stream()
+                    .expect("failed to get incoming body stream");
+                let response_body = response.body().expect("failed to get outgoing body");
+
+                let container_name = "starter_kit".to_string();
+                let object_name = "streaming_data".to_string();
+                let container =
+                    if blobstore::blobstore::container_exists(&container_name).is_ok_and(|b| b) {
+                        blobstore::blobstore::get_container(&container_name)
+                    } else {
+                        blobstore::blobstore::create_container(&container_name)
+                    };
+
+                if let Ok(container) = container {
+                    let data = blobstore::types::OutgoingValue::new_outgoing_value();
+                    let outgoing_stream = data
+                        .outgoing_value_write_body()
+                        .expect("failed to get outgoing value body");
+                    container
+                        .write_data(&object_name, &data)
+                        .expect("failed to write data");
+                    response
+                        .set_status_code(200)
+                        .expect("failed to set outgoing HTTP request");
+                    ResponseOutparam::set(response_out, Ok(response));
+                    response_body
+                        .write()
+                        .expect("failed to write to outgoing body")
+                        .write_fmt(format_args!(
+                            "Successfully created container {container_name} with object {object_name}\n"
+                        ))
+                        .expect("failed to write to outgoing body");
+                    helpers::splice(&incoming_body_stream, outgoing_stream)
+                        .expect("failed to splice request body to response body");
+                } else {
+                    response
+                        .set_status_code(500)
+                        .expect("failed to set outgoing HTTP request");
+                    ResponseOutparam::set(response_out, Ok(response));
+                    response_body
+                        .write()
+                        .expect("failed to write to response body")
+                        .write_fmt(format_args!(
+                            "Failed to create container {container_name}\n"
+                        ))
+                        .expect("failed to write to response body");
+                }
+                OutgoingBody::finish(response_body, None).expect("failed to finish response body");
+            }
+            _ => {
+                helpers::send_http_response(response_out, 404, b"not found");
+            }
+        }
+    }
+}
+
+// You can also implement exports as declared in your WIT world, 'wit/world.wit'
+impl bindings::exports::wasmcloud::messaging::handler::Guest for StarterKit {
+    fn handle_message(msg: BrokerMessage) -> Result<(), String> {
+        info!("Received message {:?}", msg);
+        if let Some(reply_to) = msg.reply_to {
+            let reply_message = BrokerMessage {
+                subject: reply_to,
+                body: msg.body,
+                reply_to: None,
+            };
+            messaging::consumer::publish(&reply_message).expect("Failed to publish reply message");
+        }
+        Ok(())
+    }
+}
+
+wasmcloud_component::wasi::http::proxy::export!(StarterKit);

--- a/examples/rust/components/developer-starter-kit/wasmcloud.toml
+++ b/examples/rust/components/developer-starter-kit/wasmcloud.toml
@@ -1,0 +1,8 @@
+name = "starter-kit"
+version = "0.1.0"
+language = "rust"
+type = "component"
+
+[component]
+wit_world = "starter-kit"
+wasm_target = "wasm32-wasi-preview2"

--- a/examples/rust/components/developer-starter-kit/wit/deps.lock
+++ b/examples/rust/components/developer-starter-kit/wit/deps.lock
@@ -1,0 +1,4 @@
+[messaging]
+url = "https://github.com/wasmCloud/messaging/archive/v0.2.0-rc.1.tar.gz"
+sha256 = "41ada083aceb2b4ba92d9bd16d19b6462cc02b10378c9a49135c3447f9138a44"
+sha512 = "aa9c819dfd9e85b19661f6087ffd824c44fc38c8a4bc1005c4e7fd34fe844633c52cae7a0412e9ea90f71826e0660e8a3b5672a0f0303c524e4139643ae675ac"

--- a/examples/rust/components/developer-starter-kit/wit/deps.toml
+++ b/examples/rust/components/developer-starter-kit/wit/deps.toml
@@ -1,0 +1,1 @@
+messaging = "https://github.com/wasmCloud/messaging/archive/v0.2.0-rc.1.tar.gz"

--- a/examples/rust/components/developer-starter-kit/wit/deps/messaging/messaging.wit
+++ b/examples/rust/components/developer-starter-kit/wit/deps/messaging/messaging.wit
@@ -1,0 +1,27 @@
+package wasmcloud:messaging@0.2.0;
+
+// Types common to message broker interactions
+interface types {
+    // A message sent to or received from a broker
+    record broker-message {
+        subject: string,
+        body: list<u8>,
+        reply-to: option<string>,
+    }
+}
+
+interface handler {
+    use types.{broker-message};
+
+    // Callback handled to invoke a function when a message is received from a subscription
+    handle-message: func(msg: broker-message) -> result<_, string>;
+}
+
+interface consumer {
+    use types.{broker-message};
+
+    // Perform a request operation on a subject
+    request: func(subject: string, body: list<u8>, timeout-ms: u32) -> result<broker-message, string>;
+    // Publish a message to a subject without awaiting a response
+    publish: func(msg: broker-message) -> result<_, string>;
+}

--- a/examples/rust/components/developer-starter-kit/wit/world.wit
+++ b/examples/rust/components/developer-starter-kit/wit/world.wit
@@ -1,0 +1,6 @@
+package wasmcloud:examples;
+
+world starter-kit {
+    // You can import or export any additional WIT interfaces here
+    export wasmcloud:messaging/handler@0.2.0;
+}


### PR DESCRIPTION
Draft to facilitate discussion.

## Feature or Problem
This PR adds what I've been calling a "developer starter kit" for Rust component development. It uses each standard capability that we include in the wasmcloud_component crate and support with `wash dev`, doing the right things with streams, WASI interfaces, etc. This should be a great starting point for developers to come in, run `wash dev`, and use the standard capabilities immediately.

As you can see in this PR some of this code is a little cumbersome and could be cleaned up. My goal is for anything that's surfaced here as a pain point to be considered for a helper function in `wasmcloud_component` or re-use of an upstream crate.

Once we hone in on exactly how we want this example to look, we can replicate it for the other languages.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
