### PR TITLE
chore: Revert OtelProtocol rename, add future compatibility aliasing

### DIFF
--- a/crates/core/src/otel.rs
+++ b/crates/core/src/otel.rs
@@ -133,9 +133,14 @@ impl OtelConfig {
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
+// TODO(joonas): In a future release we should enable this renaming once we
+// are comfortable with the fact there are no providers being used that have
+// the case sensitive handling still in place.
+// #[serde(rename_all = "lowercase")]
 pub enum OtelProtocol {
+    #[serde(alias = "grpc", alias = "Grpc")]
     Grpc,
+    #[serde(alias = "http", alias = "Http")]
     Http,
 }
 


### PR DESCRIPTION
## Feature or Problem

Unfortunately https://github.com/wasmCloud/wasmCloud/pull/3131 breaks old Rust providers, so we need to revert this change and add the aliases for future compatibility.

We can revisit the rename in the future.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
