### PR TITLE
fix(ci): Pass in the OCI auth info for wkg setup

### DIFF
--- a/.github/actions/configure-wkg/action.yml
+++ b/.github/actions/configure-wkg/action.yml
@@ -4,6 +4,12 @@ inputs:
   wkg-version:
     description: version of wkg to install. Should be a valid tag from https://github.com/bytecodealliance/wasm-pkg-tools/releases
     default: "v0.7.0"
+  oci-username:
+    description: username for oci registry
+    required: true
+  oci-password:
+    description: password for oci registry
+    required: true
 
 runs:
   using: composite
@@ -17,8 +23,8 @@ runs:
     - name: Generate and set wkg config
       shell: bash
       env:
-        WKG_OCI_USERNAME: ${{ github.repository_owner }}
-        WKG_OCI_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        WKG_OCI_USERNAME: ${{ inputs.oci-username }}
+        WKG_OCI_PASSWORD: ${{ inputs.oci-password }}
       run: |
         cat << EOF > wkg-config.toml
         [namespace_registries]

--- a/.github/workflows/wash-plugins.yml
+++ b/.github/workflows/wash-plugins.yml
@@ -21,6 +21,9 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "version is ${version}"
     - uses: ./.github/actions/configure-wkg
+      with:
+        oci-username: ${{ github.repository_owner }}
+        oci-password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       working-directory: crates/wash-lib
       run: |

--- a/.github/workflows/wit-wasmcloud-lattice-bus.yml
+++ b/.github/workflows/wit-wasmcloud-lattice-bus.yml
@@ -27,6 +27,9 @@ jobs:
           echo "tarball=wit-wasmcloud-bus-${version}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "version is ${version}"
     - uses: ./.github/actions/configure-wkg
+      with:
+        oci-username: ${{ github.repository_owner }}
+        oci-password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       working-directory: wit/bus
       run: wkg wit build -o package.wasm

--- a/.github/workflows/wit-wasmcloud-postgres.yml
+++ b/.github/workflows/wit-wasmcloud-postgres.yml
@@ -28,6 +28,9 @@ jobs:
           echo "tarball=wit-wasmcloud-postgres-${version}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "version is ${version}"
     - uses: ./.github/actions/configure-wkg
+      with:
+        oci-username: ${{ github.repository_owner }}
+        oci-password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       working-directory: wit/postgres
       run: wkg wit build -o package.wasm

--- a/.github/workflows/wit-wasmcloud-secrets.yml
+++ b/.github/workflows/wit-wasmcloud-secrets.yml
@@ -27,6 +27,9 @@ jobs:
           echo "tarball=wit-wasmcloud-secrets-${version}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "version is ${version}"
     - uses: ./.github/actions/configure-wkg
+      with:
+        oci-username: ${{ github.repository_owner }}
+        oci-password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       working-directory: wit/secrets
       run: wkg wit build -o package.wasm


### PR DESCRIPTION
Secrets are not available in context of a composite action, so this adds the ability to pass them