### PR TITLE
ci: downgrade 16/8 core runners

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,28 +18,28 @@ concurrency:
 
 jobs:
   fmt:
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
-    - uses: ./.github/actions/install-nix
-      with:
-        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix fmt
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      - uses: ./.github/actions/install-nix
+        with:
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix fmt
 
   run:
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
-    - uses: ./.github/actions/install-nix
-      with:
-        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix run -L . -- --version
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      - uses: ./.github/actions/install-nix
+        with:
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix run -L . -- --version
 
   develop:
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
-    - uses: ./.github/actions/install-nix
-      with:
-        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix develop -L --ignore-environment -c cargo tree
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      - uses: ./.github/actions/install-nix
+        with:
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix develop -L --ignore-environment -c cargo tree

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   package:
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -46,11 +46,14 @@ jobs:
         with:
           tool: wit-bindgen-cli
 
+      # Run builds and tests only on Linux and macOS for PRs, Windows on `main`
       - name: Build wash
+        if: ${{ matrix.os != 'windows-latest' || github.ref == 'refs/heads/main' }}
         run: make build
         working-directory: ./crates/wash-cli
 
       - name: Run all wash & wash-lib unit tests
+        if: ${{ matrix.os != 'windows-latest' || github.ref == 'refs/heads/main' }}
         run: make test-wash-ci
         working-directory: ./crates/wash-cli
 

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -26,17 +26,17 @@ jobs:
     strategy:
       fail-fast: false # Ensure we can run the full suite even if one OS fails
       matrix:
-        os: [ubuntu-22.04, windows-latest-8-cores, macos-12]
+        os: [ubuntu-22.04, windows-latest, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6
         with:
-          node-version: "18.x"
+          node-version: '18.x'
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - run: rustup show
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
         with:
-          shared-key: "${{ matrix.os }}-shared-cache"
+          shared-key: '${{ matrix.os }}-shared-cache'
       - name: Install nextest
         uses: taiki-e/install-action@42c270942d62c8642a0086bc5854743d9a9c510d
         with:
@@ -62,18 +62,18 @@ jobs:
       - run: rustup show
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
         with:
-          shared-key: "ubuntu-22.04-shared-cache"
+          shared-key: 'ubuntu-22.04-shared-cache'
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: "1.22"
+          go-version: '1.22'
       - uses: acifani/setup-tinygo@b2ba42b249c7d3efdfe94166ec0f48b3191404f7
         with:
-          tinygo-version: "0.31.0"
-          install-binaryen: "false"
+          tinygo-version: '0.31.0'
+          install-binaryen: 'false'
       - name: Launch integration test services
         uses: sudo-bot/action-docker-compose@ef4c4da08a9673f93d4eb8a5da1e942bf24a37ea
         with:
-          cli-args: "-f ./crates/wash-cli/tools/docker-compose.yml up --detach"
+          cli-args: '-f ./crates/wash-cli/tools/docker-compose.yml up --detach'
       - name: Install nextest
         uses: taiki-e/install-action@42c270942d62c8642a0086bc5854743d9a9c510d
         with:
@@ -103,7 +103,7 @@ jobs:
       - run: rustup show
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
         with:
-          shared-key: "ubuntu-22.04-shared-cache"
+          shared-key: 'ubuntu-22.04-shared-cache'
       - name: install wash (previous version)
         if: ${{ matrix.wash-version != 'current' }}
         uses: taiki-e/install-action@42c270942d62c8642a0086bc5854743d9a9c510d

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false # Ensure we can run the full suite even if one OS fails
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-12]
+        os: [ubuntu-22.04, windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -152,7 +152,7 @@ jobs:
               docker run --rm wasmcloud:$(nix eval --raw .#wasmcloud-x86_64-unknown-linux-musl-oci.imageTag) wasmcloud --version
 
     name: wasmcloud-${{ matrix.config.target }}
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: ./.github/actions/install-nix
@@ -173,7 +173,7 @@ jobs:
 
   build-windows:
     name: wasmcloud-x86_64-pc-windows-msvc
-    runs-on: windows-latest-8-cores
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 
@@ -240,7 +240,7 @@ jobs:
           path: artifact
 
   test-linux:
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     needs: build-bin
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -252,7 +252,7 @@ jobs:
       - run: ./bin/wasmcloud --version
 
   test-windows:
-    runs-on: windows-latest-8-cores
+    runs-on: windows-latest
     needs: build-windows
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -271,7 +271,7 @@ jobs:
           - nextest
 
     name: cargo ${{ matrix.check }}
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: ./.github/actions/install-nix
@@ -280,7 +280,7 @@ jobs:
       - run: nix build -L .#checks.x86_64-linux.${{ matrix.check }}
 
   build-doc:
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: ./.github/actions/install-nix
@@ -359,7 +359,7 @@ jobs:
       azurecr_password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
 
   deploy-doc:
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     needs: build-doc
     permissions:
       contents: read
@@ -374,7 +374,7 @@ jobs:
         id: deployment
 
   docker:
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     env:
       DOCKER_BUILD_RECORD_UPLOAD: false
     needs:
@@ -407,7 +407,7 @@ jobs:
           - bin: wash
             prefix: wash-cli-
 
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -551,7 +551,7 @@ jobs:
       - oci
       - test-linux
       - test-windows
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
@@ -622,7 +622,7 @@ jobs:
   snapcraft:
     if: startsWith(github.ref, 'refs/tags/wash-cli-v')
     needs: cargo
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 
@@ -647,7 +647,7 @@ jobs:
       - cargo
       - build-bin
       - test-linux
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 
@@ -748,7 +748,7 @@ jobs:
 
     name: publish ${{ matrix.crate }} to crates.io
     needs: cargo
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -211,7 +211,7 @@ jobs:
   build-lipo:
     name: wasmcloud-universal-darwin
     needs: build-bin
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -173,6 +173,7 @@ jobs:
 
   build-windows:
     name: wasmcloud-x86_64-pc-windows-msvc
+    if: startswith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938


### PR DESCRIPTION
## Feature or Problem
This PR downgrades our use of 16 and 8 core runners to assist with the ask of CNCF project maintainers to use the default runners where possible. I plan on watching the CI on this PR to understand what takes a long time, and I think we should optimize from there.

Other things that I'd like to do
- [x] Combine CI runs when merging to main by merging multiple PRs in the merge group at the same time
- [x] Remove unneeded action runs on PR where possible

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
