### PR TITLE
feat: Tinygo scheduler & garbage collection overrides

### DIFF
--- a/crates/wash-lib/src/build/component.rs
+++ b/crates/wash-lib/src/build/component.rs
@@ -314,12 +314,12 @@ async fn build_tinygo_component(
 
             if let Some(scheduler) = &tinygo_config.scheduler {
                 args.push("-scheduler");
-                args.push(scheduler);
+                args.push(scheduler.as_str());
             }
 
             if let Some(gc) = &tinygo_config.garbage_collector {
                 args.push("-gc");
-                args.push(gc);
+                args.push(gc.as_str());
             }
 
             args.push(".");

--- a/crates/wash-lib/src/build/component.rs
+++ b/crates/wash-lib/src/build/component.rs
@@ -297,7 +297,8 @@ async fn build_tinygo_component(
             "-no-debug",
             ".",
         ],
-        WasmTarget::WasiP2 => vec![
+        WasmTarget::WasiP2 => {
+            let mut args = vec![
             "build",
             "-o",
             filename.as_str(),
@@ -309,8 +310,21 @@ async fn build_tinygo_component(
             component_config.wit_world.as_ref().context(
                 "missing `wit_world` in wasmcloud.toml ([component] section) to run go bindgen generate",
             )?,
-            ".",
-        ],
+        ];
+
+            if let Some(scheduler) = &tinygo_config.scheduler {
+                args.push("-scheduler");
+                args.push(scheduler);
+            }
+
+            if let Some(gc) = &tinygo_config.garbage_collector {
+                args.push("-gc");
+                args.push(gc);
+            }
+
+            args.push(".");
+            args
+        }
     };
 
     let result = command.args(build_args).status().await.map_err(|e| {

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -407,6 +407,10 @@ pub struct TinyGoConfig {
     pub tinygo_path: Option<PathBuf>,
     /// Whether to disable the `go generate` step in the build process. Defaults to false.
     pub disable_go_generate: bool,
+    /// The scheduler to use for the TinyGo build. Override the default scheduler (asyncify). Valid values are: none, tasks, asyncify.
+    pub scheduler: Option<String>,
+    /// The garbage collector to use for the TinyGo build. Override the default garbage collector (conservative). Valid values are: none, conservative, leaking.
+    pub garbage_collector: Option<String>,
 }
 
 impl TinyGoConfig {
@@ -427,6 +431,10 @@ struct RawTinyGoConfig {
     /// Whether to disable the `go generate` step in the build process. Defaults to false.
     #[serde(default)]
     pub disable_go_generate: bool,
+    /// The scheduler to use for the TinyGo build. Override the default scheduler (asyncify). Valid values are: none, tasks, asyncify.
+    pub scheduler: Option<String>,
+    /// The garbage collector to use for the TinyGo build. Override the default garbage collector (conservative). Valid values are: none, conservative, leaking.
+    pub garbage_collector: Option<String>,
 }
 
 impl TryFrom<RawTinyGoConfig> for TinyGoConfig {
@@ -436,6 +444,8 @@ impl TryFrom<RawTinyGoConfig> for TinyGoConfig {
         Ok(Self {
             tinygo_path: raw.tinygo_path,
             disable_go_generate: raw.disable_go_generate,
+            scheduler: raw.scheduler,
+            garbage_collector: raw.garbage_collector,
         })
     }
 }

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -401,16 +401,56 @@ impl TryFrom<RawGoConfig> for GoConfig {
     }
 }
 
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum TinyGoScheduler {
+    None,
+    Tasks,
+    Asyncify,
+}
+
+impl TinyGoScheduler {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Tasks => "tasks",
+            Self::Asyncify => "asyncify",
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum TinyGoGarbageCollector {
+    None,
+    Conservative,
+    Leaking,
+}
+
+impl TinyGoGarbageCollector {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Conservative => "conservative",
+            Self::Leaking => "leaking",
+        }
+    }
+}
+
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct TinyGoConfig {
     /// The path to the tinygo binary. Optional, will default to `tinygo` if not specified.
     pub tinygo_path: Option<PathBuf>,
     /// Whether to disable the `go generate` step in the build process. Defaults to false.
     pub disable_go_generate: bool,
-    /// The scheduler to use for the TinyGo build. Override the default scheduler (asyncify). Valid values are: none, tasks, asyncify.
-    pub scheduler: Option<String>,
-    /// The garbage collector to use for the TinyGo build. Override the default garbage collector (conservative). Valid values are: none, conservative, leaking.
-    pub garbage_collector: Option<String>,
+    /// The scheduler to use for the TinyGo build.
+    ///
+    /// Override the default scheduler (asyncify). Valid values are: none, tasks, asyncify.
+    pub scheduler: Option<TinyGoScheduler>,
+    /// The garbage collector to use for the TinyGo build.
+    ///
+    /// Override the default garbage collector (conservative). Valid values are: none, conservative, leaking.
+    pub garbage_collector: Option<TinyGoGarbageCollector>,
 }
 
 impl TinyGoConfig {
@@ -431,10 +471,14 @@ struct RawTinyGoConfig {
     /// Whether to disable the `go generate` step in the build process. Defaults to false.
     #[serde(default)]
     pub disable_go_generate: bool,
-    /// The scheduler to use for the TinyGo build. Override the default scheduler (asyncify). Valid values are: none, tasks, asyncify.
-    pub scheduler: Option<String>,
-    /// The garbage collector to use for the TinyGo build. Override the default garbage collector (conservative). Valid values are: none, conservative, leaking.
-    pub garbage_collector: Option<String>,
+    /// The scheduler to use for the TinyGo build.
+    ///
+    /// Override the default scheduler (asyncify). Valid values are: none, tasks, asyncify.
+    pub scheduler: Option<TinyGoScheduler>,
+    /// The garbage collector to use for the TinyGo build.
+    ///
+    /// Override the default garbage collector (conservative). Valid values are: none, conservative, leaking.
+    pub garbage_collector: Option<TinyGoGarbageCollector>,
 }
 
 impl TryFrom<RawTinyGoConfig> for TinyGoConfig {

--- a/crates/wash-lib/tests/parser/files/tinygo_component_scheduler_gc.toml
+++ b/crates/wash-lib/tests/parser/files/tinygo_component_scheduler_gc.toml
@@ -1,0 +1,17 @@
+language = "tinygo"
+type = "component"
+name = "testcomponent"
+version = "0.1.0"
+
+[component]
+claims = ["wasmcloud:httpserver"]
+registry = "localhost:8080"
+push_insecure = false
+key_directory = "./keys"
+destination = "./build/testcomponent.wasm"
+wasm_target = "wasm32-wasip2"
+call_alias = "testcomponent"
+
+[tinygo]
+scheduler = "none"
+garbage_collector = "leaking"

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -108,6 +108,28 @@ fn rust_component_with_revision() {
 }
 
 #[test]
+fn tinygo_component_module_scheduler_gc() {
+    let result = get_config(
+        Some(PathBuf::from(
+            "./tests/parser/files/tinygo_component_scheduler_gc.toml",
+        )),
+        None,
+    );
+
+    let config = assert_ok!(result);
+
+    assert_eq!(
+        config.language,
+        LanguageConfig::TinyGo(TinyGoConfig {
+            tinygo_path: None,
+            disable_go_generate: false,
+            scheduler: Some("none".into()),
+            garbage_collector: Some("leaking".into()),
+        })
+    );
+}
+
+#[test]
 fn tinygo_component_module() {
     let result = get_config(
         Some(PathBuf::from(
@@ -123,6 +145,8 @@ fn tinygo_component_module() {
         LanguageConfig::TinyGo(TinyGoConfig {
             tinygo_path: Some("path/to/tinygo".into()),
             disable_go_generate: false,
+            scheduler: None,
+            garbage_collector: None,
         })
     );
 

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -4,7 +4,7 @@ use claims::{assert_err, assert_ok};
 use semver::Version;
 use wash_lib::parser::{
     get_config, CommonConfig, ComponentConfig, LanguageConfig, RegistryConfig, RustConfig,
-    TinyGoConfig, TypeConfig, WasmTarget,
+    TinyGoConfig, TinyGoGarbageCollector, TinyGoScheduler, TypeConfig, WasmTarget,
 };
 
 #[test]
@@ -123,8 +123,8 @@ fn tinygo_component_module_scheduler_gc() {
         LanguageConfig::TinyGo(TinyGoConfig {
             tinygo_path: None,
             disable_go_generate: false,
-            scheduler: Some("none".into()),
-            garbage_collector: Some("leaking".into()),
+            scheduler: Some(TinyGoScheduler::None),
+            garbage_collector: Some(TinyGoGarbageCollector::Leaking),
         })
     );
 }


### PR DESCRIPTION
Changes to wasmcloud.toml as per #3216 

```
[tinygo]
scheduler = none | tasks | asyncify
garbage_collector = none | conservative | leaking
```