### PR TITLE
feat(wash-cli): bump wadm 0.16.1, wasmcloud 1.3, NATS 2.10.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -330,7 +330,7 @@ unicase = { version = "2.7.0", default-features = false }
 url = { version = "2" }
 uuid = { version = "1", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
-wadm = { version = "0.14.0", default-features = false }
+wadm = { version = "0.16.0", default-features = false }
 wadm-client = { version = "0.5.0", default-features = false }
 wadm-types = { version = "0.5.0", default-features = false }
 walkdir = { version = "2", default-features = false }

--- a/crates/wash-cli/src/config.rs
+++ b/crates/wash-cli/src/config.rs
@@ -6,16 +6,16 @@ use crate::cmd::up::WasmcloudOpts;
 use crate::creds::parse_credsfile;
 
 // NATS configuration values
-pub const NATS_SERVER_VERSION: &str = "v2.10.18";
+pub const NATS_SERVER_VERSION: &str = "v2.10.20";
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";
 pub const DEFAULT_NATS_PORT: &str = "4222";
 pub const DEFAULT_NATS_WEBSOCKET_PORT: &str = "4223";
 
 // wadm configuration values
-pub const WADM_VERSION: &str = "v0.14.0";
+pub const WADM_VERSION: &str = "v0.16.1";
 
 // wasmCloud configuration values, https://wasmcloud.com/docs/reference/host-config
-pub const WASMCLOUD_HOST_VERSION: &str = "v1.2.1";
+pub const WASMCLOUD_HOST_VERSION: &str = "v1.3.0";
 
 // NATS isolation configuration variables
 pub const WASMCLOUD_LATTICE: &str = "WASMCLOUD_LATTICE";


### PR DESCRIPTION
## Feature or Problem
This PR prepares wash-cli for an 0.35 release with all the latest and greatest.

~Draft PR while v1.3.0 isn't fully released, and waiting on #3217 before we cut the full release~

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
