### PR TITLE
ci: fix permissions for ts pipeline

### DIFF
--- a/.github/workflows/ts-release.yml
+++ b/.github/workflows/ts-release.yml
@@ -1,6 +1,9 @@
 on:
   workflow_call: {}
 
+permissions:
+  contents: write
+
 jobs:
   # typescript/apps/*
   washboard-ui:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,6 +1,7 @@
 name: Typescript
 
 on:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -12,7 +12,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: washboard-${{ github.ref }}


### PR DESCRIPTION
TS Pipeline is currently failing because the release workflow needs higher permissions from its parent.

In related news, we should update the required checks for merging to include this renamed pipeline.

This should be rebased and merged after #3236