### PR TITLE
fix: secret object for wasmcloud-host chart

### DIFF
--- a/charts/wasmcloud-host/templates/configmap.yaml
+++ b/charts/wasmcloud-host/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
         remotes = [
             {
               {{- include "wasmcloud-host.nats.address" . | nindent 14 }}
-              {{- if .Values.config.natsCredentialsSecret -}}
+              {{- if .Values.config.natsCredentialsSecret }}
               credentials: "/nats/nats.creds"
               {{- end }}
             },

--- a/charts/wasmcloud-host/templates/deployment.yaml
+++ b/charts/wasmcloud-host/templates/deployment.yaml
@@ -165,8 +165,11 @@ spec:
             name: {{ include "wasmcloud-host.nats-config-name" . }}
       {{- if .Values.config.natsCredentialsSecret }}
         - name: {{ .Values.config.natsCredentialsSecret }}
-          secret: /nats/nats.creds
+          secret: 
             secretName: {{ .Values.config.natsCredentialsSecret }}
+            items:
+              - key: nats.creds
+                path: nats.creds
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

The secret object is incorrectly defined. It should be an object as per [definition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretvolumesource-v1-core) and [example](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#project-secret-keys-to-specific-file-paths)

Also modified the template for NATS configuration

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

Take the [value file](https://github.com/wasmCloud/wasmCloud/blob/main/charts/wasmcloud-host/values.yaml) with the `config.natsCredentialsSecret` set. Execute `helm template test ~/path/to/wasmCloud/charts/wasmcloud-host/  -f wasmcloud-host.yaml --debug`.

First commit to fix secret object:
Before: (line number may be different due to configurations)
```
Error: YAML parse error on wasmcloud-host/templates/deployment.yaml: error converting YAML to JSON: yaml: line 90: mapping values are not allowed in this context
helm.go:86: 2024-10-10 11:52:03.164973 +0800 CST m=+0.025260834 [debug] error converting YAML to JSON: yaml: line 90: mapping values are not allowed in this context
YAML parse error on wasmcloud-host/templates/deployment.yaml
```

After: Error is gone.

Second commit to fix secret object:
Before:
```yaml
data:
  nats.conf: |
    jetstream {
        domain="leaf"
        store_dir="/tmp/nats-leaf-jetstream"
    }

    listen: "127.0.0.1:4222"
    leafnodes {
        remotes = [
            {
              
              url: "nats://nats-headless.default.svc.cluster.local"credentials: "/nats/nats.creds"
            },
        ]
    }
```

After:
```yaml
data:
  nats.conf: |
    jetstream {
        domain="leaf"
        store_dir="/tmp/nats-leaf-jetstream"
    }

    listen: "127.0.0.1:4222"
    leafnodes {
        remotes = [
            {
              
              url: "nats://nats-headless.default.svc.cluster.local"
              credentials: "/nats/nats.creds"
            },
        ]
    }
```