### PR TITLE
chore: add cargo-binstall support for wash-cli

### DIFF
--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -117,3 +117,7 @@ wasm-pkg-client = { workspace = true }
 
 [build-dependencies]
 tokio = { workspace = true, features = ["macros", "net"] }
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{name}-v{version}/wash-{ target }{ binary-ext }"
+pkg-fmt = "bin"

--- a/crates/wash-cli/README.md
+++ b/crates/wash-cli/README.md
@@ -26,6 +26,7 @@
   - [MacOS (brew)](#macos-brew)
   - [Windows (choco)](#windows-choco)
   - [Nix](#nix)
+- [Proxy authentication](#proxy-authentication)
 - [Using wash](#using-wash)
 - [Shell auto-complete](#shell-auto-complete)
 - [Contributing to wash](#contributing-to-wash)
@@ -40,6 +41,12 @@
 
 ```bash
 cargo install wash-cli
+```
+
+or if you have [cargo-binstall](https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#installation):
+
+```bash
+cargo binstall wash-cli
 ```
 
 ### Linux (deb/rpm + apt)


### PR DESCRIPTION
## Feature or Problem
Adds support for `cargo binstall` for the `wash-cli` crate.

## Related Issues
None

## Release Information
next

## Consumer Impact
No impact on existing users. Anyone using `binstall` will be able to install `wash-cli` using `cargo binstall wash-cli`. This includes the `taiki-e/install-action` GitHub Action but is only really beneficial for targets other than `x86_64-unknown-linux-gnu`.

## Testing
### Manual Verification

Before:
```console
$ cargo binstall wash-cli
 INFO resolve: Resolving package: 'wash-cli'
 WARN The package wash-cli v0.35.0 will be installed from source (with cargo)
Do you wish to continue? yes/[no]
? y
    Updating crates.io index
  Installing wash-cli v0.35.0
    [ ...excluding build log... ]
    Finished `release` profile [optimized] target(s) in 3m 09s
  Installing /Users/lheywood/.cargo/bin/wash
   Installed package `wash-cli v0.35.0` (executable `wash`)
 INFO Cargo finished successfully
 INFO Done in 194.03054025s
```

After:
```console
$ cargo binstall wash-cli --manifest-path ./Cargo.toml
 INFO resolve: Resolving package: 'wash-cli'
 WARN The package wash-cli v0.35.0 (aarch64-apple-darwin) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - wash (bin-wash-cli-aarch64-apple-darwin-GhCrateMeta -> /Users/lheywood/.cargo/bin/wash)
Do you wish to continue? yes/[no]
? y
 INFO Installing binaries...
 INFO Done in 6.533972917s
```
