### PR TITLE
feat(runtime): Adds support for versioned wasi logging interface

### DIFF
--- a/crates/runtime/src/capability.rs
+++ b/crates/runtime/src/capability.rs
@@ -56,6 +56,16 @@ mod wasmtime_bindings {
     });
 }
 
+#[allow(missing_docs)]
+mod unversioned_logging_bindings {
+    wasmtime::component::bindgen!({
+        world: "unversioned-interfaces",
+        async: true,
+        tracing: true,
+        trappable_imports: true,
+    });
+}
+
 #[allow(clippy::doc_markdown)]
 #[allow(missing_docs)]
 /// wRPC interface bindings
@@ -70,7 +80,8 @@ pub mod wrpc {
     });
 }
 
-pub use wasmtime_bindings::wasi::{blobstore, config, keyvalue, logging};
+pub use unversioned_logging_bindings::wasi::logging as unversioned_logging;
+pub use wasmtime_bindings::wasi::{blobstore, config, keyvalue, logging0_1_0_draft as logging};
 pub use wasmtime_bindings::wasmcloud::{bus, messaging, secrets};
 pub use wasmtime_bindings::Interfaces;
 pub use wasmtime_wasi_http::bindings::http;

--- a/crates/runtime/src/component/logging.rs
+++ b/crates/runtime/src/component/logging.rs
@@ -5,6 +5,16 @@ use crate::capability::logging::logging;
 use async_trait::async_trait;
 use tracing::instrument;
 
+pub mod unversioned_logging_bindings {
+    wasmtime::component::bindgen!({
+        world: "unversioned-logging",
+        async: true,
+        with: {
+           "wasi:logging/logging": crate::capability::unversioned_logging,
+        },
+    });
+}
+
 pub mod logging_bindings {
     wasmtime::component::bindgen!({
         world: "logging",
@@ -36,6 +46,30 @@ impl<H: Handler> logging::Host for Ctx<H> {
         context: String,
         message: String,
     ) -> anyhow::Result<()> {
+        self.handler.log(level, context, message).await
+    }
+}
+
+#[async_trait]
+impl<H: Handler> crate::capability::unversioned_logging::logging::Host for Ctx<H> {
+    #[instrument(skip_all)]
+    async fn log(
+        &mut self,
+        level: crate::capability::unversioned_logging::logging::Level,
+        context: String,
+        message: String,
+    ) -> anyhow::Result<()> {
+        // NOTE(thomastaylor312): I couldn't figure out the proper incantation for using `with` to
+        // avoid this. If there is a better way, we can fix it
+        use crate::capability::unversioned_logging::logging::Level;
+        let level = match level {
+            Level::Trace => logging::Level::Trace,
+            Level::Debug => logging::Level::Debug,
+            Level::Info => logging::Level::Info,
+            Level::Warn => logging::Level::Warn,
+            Level::Error => logging::Level::Error,
+            Level::Critical => logging::Level::Critical,
+        };
         self.handler.log(level, context, message).await
     }
 }

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -110,6 +110,7 @@ macro_rules! skip_static_instances {
             | "wasi:keyvalue/atomics@0.2.0-draft"
             | "wasi:keyvalue/batch@0.2.0-draft"
             | "wasi:keyvalue/store@0.2.0-draft"
+            | "wasi:logging/logging@0.1.0-draft"
             | "wasi:logging/logging"
             | "wasi:random/insecure-seed@0.2.0"
             | "wasi:random/insecure-seed@0.2.1"
@@ -364,6 +365,8 @@ where
             .context("failed to link `wasi:keyvalue/batch`")?;
         capability::logging::logging::add_to_linker(&mut linker, |ctx| ctx)
             .context("failed to link `wasi:logging/logging`")?;
+        capability::unversioned_logging::logging::add_to_linker(&mut linker, |ctx| ctx)
+            .context("failed to link unversioned `wasi:logging/logging`")?;
 
         capability::bus::lattice::add_to_linker(&mut linker, |ctx| ctx)
             .context("failed to link `wasmcloud:bus/lattice`")?;

--- a/crates/runtime/wit/deps.lock
+++ b/crates/runtime/wit/deps.lock
@@ -48,9 +48,14 @@ sha256 = "384d54bed5a91e7673732138b9b35c85351c64abd4d359e196aaf11a97d663ed"
 sha512 = "feabffd5a6b10b1043342aa7378132f2f6aace06c1d0bb67492e8ec8c23db62b2cf357db51f1672f21bb6b20e3bf8952347ce6fc2e108955e66766574e8e7793"
 
 [logging]
-url = "https://github.com/WebAssembly/wasi-logging/archive/main.tar.gz"
+url = "https://github.com/WebAssembly/wasi-logging/archive/3293e84de91a1ead98a1b4362f95ac8af5a16ddd.tar.gz"
 sha256 = "9676b482485bb0fd2751a390374c1108865a096b7037f4b5dbe524f066bfb06e"
 sha512 = "30a621a6d48a0175e8047c062e618523a85f69c45a7c31918da2b888f7527fce1aca67fa132552222725d0f6cdcaed95be7f16c28488d9468c0fad00cb7450b9"
+
+[logging-0-1-0]
+url = "https://github.com/WebAssembly/wasi-logging/archive/main.tar.gz"
+sha256 = "ad81d8b7f7a8ceb729cf551f1d24586f0de9560a43eea57a9bb031d2175804e1"
+sha512 = "1687ad9a02ab3e689443e67d1a0605f58fc5dea828d2e4d2c7825c6002714fac9bd4289b1a68b61a37dcca6c3b421f4c8ed4b1e6cc29f6460e0913cf1bf11c04"
 
 [messaging]
 url = "https://github.com/wasmCloud/messaging/archive/v0.2.0-rc.1.tar.gz"

--- a/crates/runtime/wit/deps.toml
+++ b/crates/runtime/wit/deps.toml
@@ -4,7 +4,9 @@ config = "https://github.com/WebAssembly/wasi-runtime-config/archive/c667fe67ffa
 http = "https://github.com/WebAssembly/wasi-http/archive/v0.2.0.tar.gz"
 keyvalue = "https://github.com/WebAssembly/wasi-keyvalue/archive/219ea3612a53f1bf5b2d137551b22d0268fd3c58.tar.gz"
 keyvalue-wrpc = "https://github.com/wrpc/keyvalue/archive/v0.2.0-draft.tar.gz"
-logging = "https://github.com/WebAssembly/wasi-logging/archive/main.tar.gz"
+# Pre-tagged version of logging
+logging = "https://github.com/WebAssembly/wasi-logging/archive/3293e84de91a1ead98a1b4362f95ac8af5a16ddd.tar.gz"
+logging-0-1-0 = "https://github.com/WebAssembly/wasi-logging/archive/main.tar.gz"
 messaging = "https://github.com/wasmCloud/messaging/archive/v0.2.0-rc.1.tar.gz"
 secret = "../../secrets-types/wit"
 wasmcloud = "../../../wit/bus/wit"

--- a/crates/runtime/wit/deps/logging-0-1-0/logging.wit
+++ b/crates/runtime/wit/deps/logging-0-1-0/logging.wit
@@ -1,0 +1,35 @@
+/// WASI Logging is a logging API intended to let users emit log messages with
+/// simple priority levels and context values.
+interface logging {
+    /// A log level, describing a kind of message.
+    enum level {
+       /// Describes messages about the values of variables and the flow of
+       /// control within a program.
+       trace,
+
+       /// Describes messages likely to be of interest to someone debugging a
+       /// program.
+       debug,
+
+       /// Describes messages likely to be of interest to someone monitoring a
+       /// program.
+       info,
+
+       /// Describes messages indicating hazardous situations.
+       warn,
+
+       /// Describes messages indicating serious errors.
+       error,
+
+       /// Describes messages indicating fatal errors.
+       critical,
+    }
+
+    /// Emit a log message.
+    ///
+    /// A log message has a `level` describing what kind of message is being
+    /// sent, a context, which is an uninterpreted string meant to help
+    /// consumers group similar messages, and a string containing the message
+    /// text.
+    log: func(level: level, context: string, message: string);
+}

--- a/crates/runtime/wit/deps/logging-0-1-0/world.wit
+++ b/crates/runtime/wit/deps/logging-0-1-0/world.wit
@@ -1,0 +1,5 @@
+package wasi:logging@0.1.0-draft;
+
+world imports {
+    import logging;
+}

--- a/crates/runtime/wit/guest.wit
+++ b/crates/runtime/wit/guest.wit
@@ -1,6 +1,10 @@
 package wasmcloud:host@1.0.1;
 
 world logging {
+    export wasi:logging/logging@0.1.0-draft;
+}
+
+world unversioned-logging {
     export wasi:logging/logging;
 }
 

--- a/crates/runtime/wit/host.wit
+++ b/crates/runtime/wit/host.wit
@@ -6,11 +6,16 @@ world interfaces {
     import wasi:keyvalue/atomics@0.2.0-draft;
     import wasi:keyvalue/store@0.2.0-draft;
     import wasi:keyvalue/batch@0.2.0-draft;
-    import wasi:logging/logging;
+    import wasi:logging/logging@0.1.0-draft;
+    
     import wasmcloud:bus/lattice@1.0.0;
     import wasmcloud:messaging/consumer@0.2.0;
     import wasmcloud:secrets/store@0.1.0-draft;
     import wasmcloud:secrets/reveal@0.1.0-draft;
+}
+
+world unversioned-interfaces {
+    import wasi:logging/logging;
 }
 
 world wrpc-interfaces {


### PR DESCRIPTION
This brings in the new versioned wasi logging dependency and adds it to the host's default exports. This also maintains support for the unversioned logging as well.

Please note that I did not update the component crate as it should still work and its current deps can't be updated from the runtime crate. I did manually test this and will have more tests in the next commit with upgrading dependencies