### PR TITLE
ci: fix tag glob

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - main
     tags:
-      - 'typescript/apps/*'
-      - 'typescript/packages/*'
+      - 'typescript/apps/**'
+      - 'typescript/packages/**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
tags are matching using glob pattern, so a single `*` only matches to the next `/`. The correct pattern for this one should have been `~/**`.
