### PR TITLE
chore(examples): git exclude target directories for examples

### DIFF
--- a/examples/rust/components/blobby/.gitignore
+++ b/examples/rust/components/blobby/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
 build

--- a/examples/rust/components/dog-fetcher/.gitignore
+++ b/examples/rust/components/dog-fetcher/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
 build/

--- a/examples/rust/components/echo-messaging/.gitignore
+++ b/examples/rust/components/echo-messaging/.gitignore
@@ -1,1 +1,5 @@
+# Rust build artifacts
+target/
+
+# Wash build artifacts
 build/

--- a/examples/rust/components/ferris-says/.gitignore
+++ b/examples/rust/components/ferris-says/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
 build/

--- a/examples/rust/components/http-blobstore/.gitignore
+++ b/examples/rust/components/http-blobstore/.gitignore
@@ -1,1 +1,5 @@
+# Rust build artifacts
+target/
+
+# Wash build artifacts
 build/

--- a/examples/rust/components/http-hello-world/.gitignore
+++ b/examples/rust/components/http-hello-world/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
 build/

--- a/examples/rust/components/http-jsonify/.gitignore
+++ b/examples/rust/components/http-jsonify/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
-build
+build/

--- a/examples/rust/components/http-keyvalue-counter/.gitignore
+++ b/examples/rust/components/http-keyvalue-counter/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
 build/

--- a/examples/rust/components/http-task-manager/.gitignore
+++ b/examples/rust/components/http-task-manager/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
 build/

--- a/examples/rust/components/keyvalue-messaging/.gitignore
+++ b/examples/rust/components/keyvalue-messaging/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
 build/

--- a/examples/rust/components/sqldb-postgres-query/.gitignore
+++ b/examples/rust/components/sqldb-postgres-query/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
 build

--- a/examples/rust/components/wash-plugin-rust/.gitignore
+++ b/examples/rust/components/wash-plugin-rust/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
 build/

--- a/examples/rust/providers/custom-template/.gitignore
+++ b/examples/rust/providers/custom-template/.gitignore
@@ -1,1 +1,6 @@
-Cargo.lock
+# Rust build artifacts
+target/
+
+# Wash build artifacts
+build/
+

--- a/examples/rust/providers/custom-template/component/.gitignore
+++ b/examples/rust/providers/custom-template/component/.gitignore
@@ -1,5 +1,5 @@
 # Rust build artifacts
-Cargo.lock
+target/
 
 # Wash build artifacts
 build/

--- a/examples/rust/providers/messaging-nats/.gitignore
+++ b/examples/rust/providers/messaging-nats/.gitignore
@@ -1,1 +1,6 @@
-Cargo.lock
+# Rust build artifacts
+target/
+
+# Wash build artifacts
+build/
+


### PR DESCRIPTION
After `wash new`-ing a rust example, the initial `git commit` of worktree files includes the `target` directory, which normally should not be checked in.

This PR also re-enables the `Cargo.lock` file (which normally *is* checked in) -- ensuring those files aren't checked in to `wasmcloud/wasmcloud` should be done at a higher level `.gitignore`.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
