### PR TITLE
feat(wash): allow overriding project, wit, build folders

### DIFF
--- a/.github/workflows/examples-components.yml
+++ b/.github/workflows/examples-components.yml
@@ -53,7 +53,7 @@ jobs:
       - run: rustup show
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
-          shared-key: "ubuntu-22.04-shared-cache"
+          shared-key: 'ubuntu-22.04-shared-cache'
       - name: install wash (previous version)
         if: ${{ matrix.wash-version != 'current' }}
         uses: taiki-e/install-action@3e1dd227d968fb9fa43ff604bd9b0ccd1b714919
@@ -86,70 +86,71 @@ jobs:
           - current
         project:
           # Golang example components
-          - lang: "golang"
-            lang_version: "1.20"
-            name: "http-echo-tinygo"
+          - lang: 'golang'
+            lang_version: '1.21'
+            name: 'http-echo-tinygo'
             test_deploy: wadm.yaml
-          - lang: "golang"
-            lang_version: "1.20"
-            name: "http-hello-world"
+          - lang: 'golang'
+            lang_version: '1.21'
+            name: 'http-hello-world'
             test_deploy: wadm.yaml
-          - name: "sqldb-postgres-query"
-            lang: "golang"
-            wasm-bin: "sqldb_postgres_query_s.wasm"
+          - name: 'sqldb-postgres-query'
+            lang: 'golang'
+            lang_version: '1.21'
+            wasm-bin: 'sqldb_postgres_query_s.wasm'
             test_deploy: local.wadm.yaml
           # Rust example components
-          - name: "blobby"
-            lang: "rust"
-            wasm-bin: "blobby_s.wasm"
-          - name: "dog-fetcher"
-            lang: "rust"
-            wasm-bin: "dog_fetcher_s.wasm"
+          - name: 'blobby'
+            lang: 'rust'
+            wasm-bin: 'blobby_s.wasm'
+          - name: 'dog-fetcher'
+            lang: 'rust'
+            wasm-bin: 'dog_fetcher_s.wasm'
             test_deploy: local.wadm.yaml
-          - name: "echo-messaging"
-            lang: "rust"
-            wasm-bin: "echo_messaging_s.wasm"
+          - name: 'echo-messaging'
+            lang: 'rust'
+            wasm-bin: 'echo_messaging_s.wasm'
             test_deploy: local.wadm.yaml
-          - name: "ferris-says"
-            lang: "rust"
-            wasm-bin: "ferris_says_s.wasm"
+          - name: 'ferris-says'
+            lang: 'rust'
+            wasm-bin: 'ferris_says_s.wasm'
             test_deploy: local.wadm.yaml
-          - name: "http-blobstore"
-            lang: "rust"
-            wasm-bin: "http_blobstore_s.wasm"
+          - name: 'http-blobstore'
+            lang: 'rust'
+            wasm-bin: 'http_blobstore_s.wasm'
             test_deploy: local.wadm.yaml
-          - name: "http-hello-world"
-            lang: "rust"
-            wasm-bin: "http_hello_world_s.wasm"
+          - name: 'http-hello-world'
+            lang: 'rust'
+            wasm-bin: 'http_hello_world_s.wasm'
             test_deploy: local.wadm.yaml
-          - name: "http-jsonify"
-            lang: "rust"
-            wasm-bin: "http_jsonify_s.wasm"
+          - name: 'http-jsonify'
+            lang: 'rust'
+            wasm-bin: 'http_jsonify_s.wasm'
             test_deploy: local.wadm.yaml
-          - name: "http-keyvalue-counter"
-            lang: "rust"
-            wasm-bin: "http_keyvalue_counter_s.wasm"
+          - name: 'http-keyvalue-counter'
+            lang: 'rust'
+            wasm-bin: 'http_keyvalue_counter_s.wasm'
             test_deploy: local.wadm.yaml
-          - name: "keyvalue-messaging"
-            lang: "rust"
-            wasm-bin: "keyvalue_messaging_s.wasm"
+          - name: 'keyvalue-messaging'
+            lang: 'rust'
+            wasm-bin: 'keyvalue_messaging_s.wasm'
             test_deploy: local.wadm.yaml
-          - name: "sqldb-postgres-query"
-            lang: "rust"
-            wasm-bin: "sqldb_postgres_query_s.wasm"
+          - name: 'sqldb-postgres-query'
+            lang: 'rust'
+            wasm-bin: 'sqldb_postgres_query_s.wasm'
             test_deploy: local.wadm.yaml
-          - name: "http-task-manager"
-            lang: "rust"
-            wasm-bin: "http_task_manager_s.wasm"
+          - name: 'http-task-manager'
+            lang: 'rust'
+            wasm-bin: 'http_task_manager_s.wasm'
             test_deploy: local.wadm.yaml
           # Python example components
-          - name: "http-hello-world"
-            lang: "python"
-            lang_version: "3.10"
+          - name: 'http-hello-world'
+            lang: 'python'
+            lang_version: '3.10'
           # Typescript example components
-          - name: "http-hello-world"
-            lang: "typescript"
-            lang_version: "20.x"
+          - name: 'http-hello-world'
+            lang: 'typescript'
+            lang_version: '20.x'
             test_deploy: wadm.yaml
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
@@ -171,8 +172,8 @@ jobs:
       - uses: acifani/setup-tinygo@b2ba42b249c7d3efdfe94166ec0f48b3191404f7
         if: ${{ matrix.project.lang == 'golang' }}
         with:
-          tinygo-version: "0.30.0"
-          install-binaryen: "false"
+          tinygo-version: '0.33.0'
+          install-binaryen: 'false'
       - uses: taiki-e/install-action@3e1dd227d968fb9fa43ff604bd9b0ccd1b714919
         if: ${{ matrix.project.lang == 'golang' }}
         with:
@@ -256,46 +257,46 @@ jobs:
           - 0.34.1
         project:
           # Go example components (to publish)
-          - lang: "golang"
-            lang_version: "1.20"
-            name: "http-echo-tinygo"
-          - lang: "golang"
-            lang_version: "1.20"
-            name: "http-hello-world"
+          - lang: 'golang'
+            lang_version: '1.20'
+            name: 'http-echo-tinygo'
+          - lang: 'golang'
+            lang_version: '1.20'
+            name: 'http-hello-world'
           # Rust example components (to publish)
-          - name: "blobby"
-            lang: "rust"
-            wasm-bin: "blobby_s.wasm"
-          - name: "dog-fetcher"
-            lang: "rust"
-            wasm-bin: "dog_fetcher_s.wasm"
-          - name: "echo-messaging"
-            lang: "rust"
-            wasm-bin: "echo_messaging_s.wasm"
-          - name: "ferris-says"
-            lang: "rust"
-            wasm-bin: "ferris_says_s.wasm"
-          - name: "http-blobstore"
-            lang: "rust"
-            wasm-bin: "http_blobstore_s.wasm"
-          - name: "http-hello-world"
-            lang: "rust"
-            wasm-bin: "http_hello_world_s.wasm"
-          - name: "http-jsonify"
-            lang: "rust"
-            wasm-bin: "http_jsonify_s.wasm"
-          - name: "http-keyvalue-counter"
-            lang: "rust"
-            wasm-bin: "http_keyvalue_counter_s.wasm"
-          - name: "keyvalue-messaging"
-            lang: "rust"
-            wasm-bin: "keyvalue_messaging_s.wasm"
-          - name: "sqldb-postgres-query"
-            lang: "rust"
-            wasm-bin: "sqldb_postgres_query_s.wasm"
-          - name: "http-task-manager"
-            lang: "rust"
-            wasm-bin: "http_task_manager_s.wasm"
+          - name: 'blobby'
+            lang: 'rust'
+            wasm-bin: 'blobby_s.wasm'
+          - name: 'dog-fetcher'
+            lang: 'rust'
+            wasm-bin: 'dog_fetcher_s.wasm'
+          - name: 'echo-messaging'
+            lang: 'rust'
+            wasm-bin: 'echo_messaging_s.wasm'
+          - name: 'ferris-says'
+            lang: 'rust'
+            wasm-bin: 'ferris_says_s.wasm'
+          - name: 'http-blobstore'
+            lang: 'rust'
+            wasm-bin: 'http_blobstore_s.wasm'
+          - name: 'http-hello-world'
+            lang: 'rust'
+            wasm-bin: 'http_hello_world_s.wasm'
+          - name: 'http-jsonify'
+            lang: 'rust'
+            wasm-bin: 'http_jsonify_s.wasm'
+          - name: 'http-keyvalue-counter'
+            lang: 'rust'
+            wasm-bin: 'http_keyvalue_counter_s.wasm'
+          - name: 'keyvalue-messaging'
+            lang: 'rust'
+            wasm-bin: 'keyvalue_messaging_s.wasm'
+          - name: 'sqldb-postgres-query'
+            lang: 'rust'
+            wasm-bin: 'sqldb_postgres_query_s.wasm'
+          - name: 'http-task-manager'
+            lang: 'rust'
+            wasm-bin: 'http_task_manager_s.wasm'
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       # Determine tag version (if this is a release tag), without the 'v'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6298,9 +6298,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.129"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",

--- a/crates/wash-cli/src/appearance/spinner.rs
+++ b/crates/wash-cli/src/appearance/spinner.rs
@@ -39,19 +39,15 @@ impl Spinner {
     /// Handles updating the spinner for text output
     /// JSON output will be corrupted with a spinner
     pub fn update_spinner_message(&self, msg: impl Into<Cow<'static, str>>) {
-        match &self.spinner {
-            Some(spinner) => {
-                spinner.set_prefix(">>>");
-                spinner.set_message(msg);
-            }
-            None => {}
+        if let Some(spinner) = &self.spinner {
+            spinner.set_prefix(">>>");
+            spinner.set_message(msg);
         }
     }
 
     pub fn finish_and_clear(&self) {
-        match &self.spinner {
-            Some(progress_bar) => progress_bar.finish_and_clear(),
-            None => {}
+        if let Some(progress_bar) = &self.spinner {
+            progress_bar.finish_and_clear()
         }
     }
 }

--- a/crates/wash-cli/src/build.rs
+++ b/crates/wash-cli/src/build.rs
@@ -83,10 +83,13 @@ pub async fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
             let component_path = if command.sign_only {
                 std::env::set_current_dir(&config.common.path)?;
                 let component_wasm_path =
-                    if let Some(path) = component_config.build_artifact.clone() {
-                        path
+                    if let Some(path) = component_config.build_artifact.as_ref() {
+                        path.clone()
                     } else {
-                        PathBuf::from(format!("build/{}.wasm", config.common.wasm_bin_name()))
+                        config
+                            .common
+                            .build_path
+                            .join(format!("{}.wasm", config.common.wasm_bin_name()))
                     };
                 let signed_path = sign_component_wasm(
                     &config.common,
@@ -95,7 +98,7 @@ pub async fn handle_command(command: BuildCommand) -> Result<CommandOutput> {
                     &sign_config.context("cannot supply --build-only and --sign-only")?,
                     component_wasm_path,
                 )?;
-                config.common.path.join(signed_path)
+                config.common.build_path.join(signed_path)
             } else {
                 build_project(
                     &config,

--- a/crates/wash-cli/src/cmd/dev/deps.rs
+++ b/crates/wash-cli/src/cmd/dev/deps.rs
@@ -12,8 +12,7 @@ use wadm_types::{
 };
 use wash_lib::generate::emoji;
 use wash_lib::parser::{
-    DevConfigSpec, DevSecretSpec, InterfaceComponentOverride, InterfaceOverrides, ProjectConfig,
-    WitInterfaceSpec,
+    DevConfigSpec, DevSecretSpec, InterfaceComponentOverride, ProjectConfig, WitInterfaceSpec,
 };
 use wasmcloud_core::{
     parse_wit_meta_from_operation, LinkName, WitInterface, WitNamespace, WitPackage,
@@ -638,11 +637,11 @@ impl ProjectDeps {
         cfg: &ProjectConfig,
     ) -> Result<Self> {
         // If no overrides were present, we can return immediately
-        let Some(InterfaceOverrides { imports, exports }) =
-            cfg.dev.as_ref().map(|dc| &dc.overrides)
-        else {
+        let imports = &cfg.dev.overrides.imports;
+        let exports = &cfg.dev.overrides.exports;
+        if imports.is_empty() && exports.is_empty() {
             return Ok(Self::default());
-        };
+        }
 
         // Build full list of overrides with generated dep specs
         let mut overrides_with_deps = Vec::with_capacity(imports.len() + exports.len());

--- a/crates/wash-cli/src/cmd/dev/devloop.rs
+++ b/crates/wash-cli/src/cmd/dev/devloop.rs
@@ -81,9 +81,11 @@ pub(crate) async fn generate_manifests(
             .map(DependencySpec::name)
             .collect::<BTreeSet<String>>()
     );
-    let pkey =
-        ProjectDependencyKey::from_project(&project_cfg.common.name, &project_cfg.common.path)
-            .context("failed to build key for project")?;
+    let pkey = ProjectDependencyKey::from_project(
+        &project_cfg.common.name,
+        &project_cfg.common.project_dir,
+    )
+    .context("failed to build key for project")?;
 
     let mut current_project_deps = match previous_deps {
         Some(deps) => deps.clone(),
@@ -96,7 +98,7 @@ pub(crate) async fn generate_manifests(
         .with_context(|| {
             format!(
                 "failed to discover project dependencies from config [{}]",
-                project_cfg.common.path.display(),
+                project_cfg.common.project_dir.display(),
             )
         })?;
     current_project_deps

--- a/crates/wash-cli/src/cmd/dev/mod.rs
+++ b/crates/wash-cli/src/cmd/dev/mod.rs
@@ -14,7 +14,7 @@ use tokio::{select, sync::mpsc};
 use wash_lib::cli::{CommandOutput, CommonPackageArgs};
 use wash_lib::generate::emoji;
 use wash_lib::id::ServerId;
-use wash_lib::parser::get_config;
+use wash_lib::parser::load_config;
 
 use crate::cmd::up::{
     nats_client_from_wasmcloud_opts, remove_wadm_pidfile, NatsOpts, WadmOpts, WasmcloudOpts,
@@ -122,7 +122,7 @@ pub async fn handle_command(
 ) -> Result<CommandOutput> {
     let current_dir = std::env::current_dir()?;
     let project_path = cmd.code_dir.unwrap_or(current_dir);
-    let project_cfg = get_config(Some(project_path.clone()), Some(true))?;
+    let project_cfg = load_config(Some(project_path.clone()), Some(true))?;
 
     let mut wash_dev_session = WashDevSession::from_sessions_file(&project_path)
         .await

--- a/crates/wash-cli/src/cmd/dev/wit.rs
+++ b/crates/wash-cli/src/cmd/dev/wit.rs
@@ -18,7 +18,7 @@ pub(crate) fn parse_component_wit(component: &[u8]) -> Result<(Resolve, WorldId)
 /// Parse Build a [`wit_parser::Resolve`] from a provided directory
 /// and select a given world
 pub(crate) fn parse_project_wit(project_cfg: &ProjectConfig) -> Result<(Resolve, WorldId)> {
-    let project_dir = &project_cfg.common.path;
+    let project_dir = &project_cfg.common.project_dir;
     let wit_dir = project_dir.join("wit");
     let world = project_cfg.project_type.wit_world();
 

--- a/crates/wash-cli/src/common/registry_cmd.rs
+++ b/crates/wash-cli/src/common/registry_cmd.rs
@@ -170,7 +170,7 @@ fn resolve_artifact_ref(
     }
 
     match project_config {
-        _ if !url.is_empty() && registry.is_empty() => {
+        _ if !url.is_empty() && !registry.is_empty() => {
             let image: Reference = format!("{}/{}", registry, url)
                 .parse()
                 .context("failed to parse artifact url from specified registry and repository")?;

--- a/crates/wash-cli/src/common/registry_cmd.rs
+++ b/crates/wash-cli/src/common/registry_cmd.rs
@@ -10,7 +10,7 @@ use tracing::warn;
 
 use wash_lib::cli::registry::{RegistryPullCommand, RegistryPushCommand};
 use wash_lib::cli::{input_vec_to_hashmap, CommandOutput, OutputKind};
-use wash_lib::parser::{get_config, ProjectConfig};
+use wash_lib::parser::{load_config, ProjectConfig};
 use wash_lib::registry::{
     identify_artifact, pull_oci_artifact, push_oci_artifact, ArtifactType, OciPullOptions,
     OciPushOptions,
@@ -91,7 +91,7 @@ pub async fn registry_push(
     cmd: RegistryPushCommand,
     output_kind: OutputKind,
 ) -> Result<CommandOutput> {
-    let project_config = get_config(cmd.project_config, Some(true)).ok();
+    let project_config = load_config(cmd.project_config, Some(true)).ok();
     let image: Reference = resolve_artifact_ref(
         &cmd.url,
         &cmd.registry.unwrap_or_default(),
@@ -198,7 +198,7 @@ fn resolve_artifact_ref(
 }
 
 async fn resolve_registry_credentials(registry: &str) -> Result<RegistryCredential> {
-    let credentials = if let Ok(credentials) = get_config(None, Some(true))
+    let credentials = if let Ok(credentials) = load_config(None, Some(true))
         .and_then(|config| config.resolve_registry_credentials(registry))
     {
         credentials

--- a/crates/wash-cli/src/wit.rs
+++ b/crates/wash-cli/src/wit.rs
@@ -123,15 +123,7 @@ impl FetchArgs {
         let client = self.common.get_client().await?;
         let wkg_config = wasm_pkg_core::config::Config::load().await?;
         let mut lock_file = LockFile::load(false).await?;
-        monkey_patch_fetch_logging(
-            wkg_config,
-            self.dir
-                .parent()
-                .ok_or_else(|| anyhow::anyhow!("Could find parent directory for wit"))?,
-            &mut lock_file,
-            client,
-        )
-        .await?;
+        monkey_patch_fetch_logging(wkg_config, self.dir, &mut lock_file, client).await?;
         // Now write out the lock file since everything else succeeded
         lock_file.write().await?;
         Ok("Dependencies fetched".into())

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -133,4 +133,5 @@ tempfile = { workspace = true }
 wasmcloud-test-util = { workspace = true, features = ["testcontainers"] }
 test-case = { workspace = true }
 tokio = { workspace = true }
+toml = { workspace = true }
 wasmparser = { workspace = true }

--- a/crates/wash-lib/src/app.rs
+++ b/crates/wash-lib/src/app.rs
@@ -158,7 +158,7 @@ impl FromStr for AppManifestSource {
 /// Undeploy a model, instructing wadm to no longer manage the given application
 ///
 /// # Arguments
-/// * `client` - The [Client] to use in order to send the request message
+/// * `client` - The [`Client`] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application is managed on, defaults to `default`
 /// * `model_name` - Model name to undeploy
 pub async fn undeploy_model(
@@ -178,7 +178,7 @@ pub async fn undeploy_model(
 /// Deploy a model, instructing wadm to manage the application
 ///
 /// # Arguments
-/// * `client` - The [Client] to use in order to send the request message
+/// * `client` - The [`Client`] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application will be managed on, defaults to `default`
 /// * `model_name` - Model name to deploy
 /// * `version` - Version to deploy, defaults to deploying the latest "put" version
@@ -202,7 +202,7 @@ pub async fn deploy_model(
 /// Put a model definition, instructing wadm to store the application manifest for later deploys
 ///
 /// # Arguments
-/// * `client` - The [Client] to use in order to send the request message
+/// * `client` - The [`Client`] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifest will be stored on, defaults to `default`
 /// * `model` - The full YAML or JSON string containing the OAM wadm manifest
 ///
@@ -226,7 +226,7 @@ pub async fn put_model(
 /// Deploy a model, instructing wadm to manage the application
 ///
 /// # Arguments
-/// * `client` - The [Client] to use in order to send the request message
+/// * `client` - The [`Client`] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application will be managed on, defaults to `default`
 /// * `model` - The full YAML or JSON string containing the OAM wadm manifest
 ///
@@ -250,7 +250,7 @@ pub async fn put_and_deploy_model(
 /// Query wadm for the history of a given model name
 ///
 /// # Arguments
-/// * `client` - The [Client] to use in order to send the request message
+/// * `client` - The [`Client`] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model to retrieve history for
 pub async fn get_model_history(
@@ -270,7 +270,7 @@ pub async fn get_model_history(
 /// Query wadm for the status of a given model by name
 ///
 /// # Arguments
-/// * `client` - The [Client] to use in order to send the request message
+/// * `client` - The [`Client`] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model to retrieve status for
 pub async fn get_model_status(
@@ -290,7 +290,7 @@ pub async fn get_model_status(
 /// Query wadm for details on a given model
 ///
 /// # Arguments
-/// * `client` - The [Client] to use in order to send the request message
+/// * `client` - The [`Client`] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model to retrieve history for
 /// * `version` - Version to retrieve, defaults to retrieving the latest "put" version
@@ -314,7 +314,7 @@ pub async fn get_model_details(
 /// Delete a model version from wadm
 ///
 /// # Arguments
-/// * `client` - The [Client] to use in order to send the request message
+/// * `client` - The [`Client`] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model
 /// * `version` - Version to retrieve, defaults to deleting the latest "put" version (or all if `delete_all` is specified)
@@ -338,7 +338,7 @@ pub async fn delete_model_version(
 /// Query wadm for all application manifests
 ///
 /// # Arguments
-/// * `client` - The [Client] to use in order to send the request message
+/// * `client` - The [`Client`] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifests are stored on, defaults to `default`
 pub async fn get_models(client: &Client, lattice: Option<String>) -> Result<Vec<ModelSummary>> {
     let wadm_client = wadm_client::Client::from_nats_client(

--- a/crates/wash-lib/src/app.rs
+++ b/crates/wash-lib/src/app.rs
@@ -158,7 +158,7 @@ impl FromStr for AppManifestSource {
 /// Undeploy a model, instructing wadm to no longer manage the given application
 ///
 /// # Arguments
-/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `client` - The [Client] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application is managed on, defaults to `default`
 /// * `model_name` - Model name to undeploy
 pub async fn undeploy_model(
@@ -178,7 +178,7 @@ pub async fn undeploy_model(
 /// Deploy a model, instructing wadm to manage the application
 ///
 /// # Arguments
-/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `client` - The [Client] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application will be managed on, defaults to `default`
 /// * `model_name` - Model name to deploy
 /// * `version` - Version to deploy, defaults to deploying the latest "put" version
@@ -202,7 +202,7 @@ pub async fn deploy_model(
 /// Put a model definition, instructing wadm to store the application manifest for later deploys
 ///
 /// # Arguments
-/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `client` - The [Client] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifest will be stored on, defaults to `default`
 /// * `model` - The full YAML or JSON string containing the OAM wadm manifest
 ///
@@ -226,7 +226,7 @@ pub async fn put_model(
 /// Deploy a model, instructing wadm to manage the application
 ///
 /// # Arguments
-/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `client` - The [Client] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application will be managed on, defaults to `default`
 /// * `model` - The full YAML or JSON string containing the OAM wadm manifest
 ///
@@ -250,7 +250,7 @@ pub async fn put_and_deploy_model(
 /// Query wadm for the history of a given model name
 ///
 /// # Arguments
-/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `client` - The [Client] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model to retrieve history for
 pub async fn get_model_history(
@@ -270,7 +270,7 @@ pub async fn get_model_history(
 /// Query wadm for the status of a given model by name
 ///
 /// # Arguments
-/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `client` - The [Client] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model to retrieve status for
 pub async fn get_model_status(
@@ -290,7 +290,7 @@ pub async fn get_model_status(
 /// Query wadm for details on a given model
 ///
 /// # Arguments
-/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `client` - The [Client] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model to retrieve history for
 /// * `version` - Version to retrieve, defaults to retrieving the latest "put" version
@@ -314,7 +314,7 @@ pub async fn get_model_details(
 /// Delete a model version from wadm
 ///
 /// # Arguments
-/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `client` - The [Client] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifest is stored on, defaults to `default`
 /// * `model_name` - Name of the model
 /// * `version` - Version to retrieve, defaults to deleting the latest "put" version (or all if `delete_all` is specified)
@@ -338,7 +338,7 @@ pub async fn delete_model_version(
 /// Query wadm for all application manifests
 ///
 /// # Arguments
-/// * `client` - The [Client](async_nats::Client) to use in order to send the request message
+/// * `client` - The [Client] to use in order to send the request message
 /// * `lattice` - Optional lattice name that the application manifests are stored on, defaults to `default`
 pub async fn get_models(client: &Client, lattice: Option<String>) -> Result<Vec<ModelSummary>> {
     let wadm_client = wadm_client::Client::from_nats_client(

--- a/crates/wash-lib/src/build/component.rs
+++ b/crates/wash-lib/src/build/component.rs
@@ -710,6 +710,7 @@ func main() {}
                     name: "test".into(),
                     version: Version::parse("0.1.0")?,
                     revision: 0,
+                    wit_path: project_dir.path().join("wit"),
                     path: project_dir.path().into(),
                     wasm_bin_name: Some("test.wasm".into()),
                     registry: RegistryConfig::default(),

--- a/crates/wash-lib/src/build/mod.rs
+++ b/crates/wash-lib/src/build/mod.rs
@@ -73,7 +73,10 @@ pub async fn build_project(
     if !skip_fetch {
         // Fetch dependencies for the component before building
         let client = package_args.get_client().await?;
-        let lock_path = &config.common.path.join(wasm_pkg_core::lock::LOCK_FILE_NAME);
+        let lock_path = &config
+            .common
+            .project_dir
+            .join(wasm_pkg_core::lock::LOCK_FILE_NAME);
         let mut lock = if tokio::fs::try_exists(&lock_path).await? {
             LockFile::load_from_path(lock_path, false).await?
         } else {
@@ -84,7 +87,7 @@ pub async fn build_project(
         };
         let conf_path = &config
             .common
-            .path
+            .project_dir
             .join(wasm_pkg_core::config::CONFIG_FILE_NAME);
         let wkg_conf = if tokio::fs::try_exists(&conf_path).await? {
             wasm_pkg_core::config::Config::load_from_path(conf_path).await?
@@ -92,7 +95,7 @@ pub async fn build_project(
             wasm_pkg_core::config::Config::default()
         };
 
-        monkey_patch_fetch_logging(wkg_conf, &config.common.wit_path, &mut lock, client)
+        monkey_patch_fetch_logging(wkg_conf, &config.common.wit_dir, &mut lock, client)
             .await
             .context("Failed to patch logging dependency")?;
 

--- a/crates/wash-lib/src/build/provider.rs
+++ b/crates/wash-lib/src/build/provider.rs
@@ -59,10 +59,7 @@ pub(crate) async fn build_provider(
         return Ok(provider_path_buf);
     };
 
-    let destination = common_config
-        .path
-        .join("build")
-        .join(format!("{bin_name}.par.gz"));
+    let destination = common_config.build_path.join(format!("{bin_name}.par.gz"));
     if let Some(parent) = destination.parent() {
         tokio::fs::create_dir_all(parent)
             .await

--- a/crates/wash-lib/src/build/provider.rs
+++ b/crates/wash-lib/src/build/provider.rs
@@ -59,7 +59,7 @@ pub(crate) async fn build_provider(
         return Ok(provider_path_buf);
     };
 
-    let destination = common_config.build_path.join(format!("{bin_name}.par.gz"));
+    let destination = common_config.build_dir.join(format!("{bin_name}.par.gz"));
     if let Some(parent) = destination.parent() {
         tokio::fs::create_dir_all(parent)
             .await
@@ -88,7 +88,7 @@ pub(crate) async fn build_provider(
     Ok(if destination.is_absolute() {
         destination
     } else {
-        common_config.path.join(destination)
+        common_config.project_dir.join(destination)
     })
 }
 
@@ -106,12 +106,11 @@ fn build_rust_provider(
     };
 
     // Change directory into the project directory
-    std::env::set_current_dir(&common_config.path)?;
-    trace!("Building provider in {:?}", common_config.path);
+    std::env::set_current_dir(&common_config.project_dir)?;
+    trace!("Building provider in {:?}", common_config.project_dir);
 
     // Build for a specified target if provided, or the default rust target
-    let mut build_args = Vec::with_capacity(4);
-    build_args.push("build");
+    let mut build_args = vec!["build"];
 
     if !rust_config.debug {
         build_args.push("--release");
@@ -183,8 +182,8 @@ fn build_go_provider(
     };
 
     // Change directory into the project directory
-    std::env::set_current_dir(&common_config.path)?;
-    trace!("Building provider in {:?}", common_config.path);
+    std::env::set_current_dir(&common_config.project_dir)?;
+    trace!("Building provider in {:?}", common_config.project_dir);
 
     // Generate interfaces, if not disabled
     if !go_config.disable_go_generate {

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -1241,12 +1241,14 @@ mod test {
                 path: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
                     .unwrap(),
-                build_path: PathBuf::from("./tests/parser/files/build/")
+                build_path: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
-                    .unwrap(),
-                wit_path: PathBuf::from("./tests/parser/files/wit/")
+                    .unwrap()
+                    .join("build"),
+                wit_path: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
-                    .unwrap(),
+                    .unwrap()
+                    .join("wit"),
                 wasm_bin_name: None,
                 registry: RegistryConfig::default(),
             }
@@ -1327,7 +1329,6 @@ mod test {
                     .contains(&"wasmcloud.com/experimental".to_string())); // from project_config
                 assert_eq!(cmd.metadata.rev.unwrap(), 777);
                 assert_eq!(cmd.metadata.ver.unwrap(), "0.2.0");
-                assert_eq!(cmd.metadata.call_alias.unwrap(), "test-component"); // from project_config
             }
 
             _ => unreachable!("claims constructed incorrect command"),
@@ -1378,16 +1379,18 @@ mod test {
                 name: "testprovider".to_string(),
                 version: Version::parse("0.1.0").unwrap(),
                 revision: 666,
+                wasm_bin_name: None,
                 path: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
                     .unwrap(),
-                build_path: PathBuf::from("./tests/parser/files/build/")
+                build_path: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
-                    .unwrap(),
-                wasm_bin_name: None,
-                wit_path: PathBuf::from("./tests/parser/files/wit/")
+                    .unwrap()
+                    .join("build"),
+                wit_path: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
-                    .unwrap(),
+                    .unwrap()
+                    .join("wit"),
                 registry: RegistryConfig::default(),
             }
         );

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -1242,6 +1242,9 @@ mod test {
                 path: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
                     .unwrap(),
+                wit_path: PathBuf::from("./tests/parser/files/wit/")
+                    .canonicalize()
+                    .unwrap(),
                 wasm_bin_name: None,
                 registry: RegistryConfig::default(),
             }
@@ -1377,6 +1380,9 @@ mod test {
                     .canonicalize()
                     .unwrap(),
                 wasm_bin_name: None,
+                wit_path: PathBuf::from("./tests/parser/files/wit/")
+                    .canonicalize()
+                    .unwrap(),
                 registry: RegistryConfig::default(),
             }
         );

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -1222,11 +1222,6 @@ mod test {
         assert_eq!(
             project_config.project_type,
             TypeConfig::Component(ComponentConfig {
-                claims: vec![
-                    "wasmcloud:httpserver".to_string(),
-                    "wasmcloud:httpclient".to_string(),
-                    "lexcorp:quantum-simulator".to_string()
-                ],
                 key_directory: PathBuf::from("./keys"),
                 destination: Some(PathBuf::from("./build/testcomponent.wasm".to_string())),
                 call_alias: Some("test-component".to_string()),

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -20,7 +20,7 @@ use crate::{
     cli::inspect,
     common::boxed_err_to_anyhow,
     config::WashConnectionOptions,
-    parser::{get_config, ComponentConfig, ProjectConfig, ProviderConfig, TypeConfig},
+    parser::{load_config, ComponentConfig, ProjectConfig, ProviderConfig, TypeConfig},
 };
 
 #[derive(Debug, Clone, Subcommand)]
@@ -350,7 +350,7 @@ pub async fn handle_command(
     command: ClaimsCliCommand,
     output_kind: OutputKind,
 ) -> Result<CommandOutput> {
-    let project_config = get_config(None, Some(true)).ok();
+    let project_config = load_config(None, Some(true)).ok();
     match command {
         ClaimsCliCommand::Inspect(inspectcmd) => {
             warn!("claims inspect will be deprecated in future versions. Use inspect instead.");
@@ -1201,7 +1201,7 @@ mod test {
 
     #[test]
     fn rust_component_metadata_with_project_config_overrides() -> anyhow::Result<()> {
-        let result = get_config(
+        let result = load_config(
             Some(PathBuf::from(
                 "./tests/parser/files/rust_component_claims_metadata.toml",
             )),
@@ -1238,14 +1238,14 @@ mod test {
                 name: "testcomponent".to_string(),
                 version: Version::parse("0.1.0").unwrap(),
                 revision: 666,
-                path: PathBuf::from("./tests/parser/files/")
+                project_dir: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
                     .unwrap(),
-                build_path: PathBuf::from("./tests/parser/files/")
+                build_dir: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
                     .unwrap()
                     .join("build"),
-                wit_path: PathBuf::from("./tests/parser/files/")
+                wit_dir: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
                     .unwrap()
                     .join("wit"),
@@ -1263,7 +1263,7 @@ mod test {
                 name: Some("testcomponent".to_string()),
                 ver: Some(Version::parse("0.1.0")?.to_string()),
                 rev: Some(666),
-                call_alias: Some("test-component".to_string()),
+                call_alias: None,
                 tags: vec!["test".to_string(), "wasmcloud.com/experimental".to_string()],
                 common: GenerateCommon {
                     directory: Some(PathBuf::from("./keys")),
@@ -1339,7 +1339,7 @@ mod test {
 
     #[test]
     fn rust_provider_metadata_with_project_config_overrides() -> anyhow::Result<()> {
-        let result = get_config(
+        let result = load_config(
             Some(PathBuf::from(
                 "./tests/parser/files/rust_provider_claims_metadata.toml",
             )),
@@ -1380,14 +1380,14 @@ mod test {
                 version: Version::parse("0.1.0").unwrap(),
                 revision: 666,
                 wasm_bin_name: None,
-                path: PathBuf::from("./tests/parser/files/")
+                project_dir: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
                     .unwrap(),
-                build_path: PathBuf::from("./tests/parser/files/")
+                build_dir: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
                     .unwrap()
                     .join("build"),
-                wit_path: PathBuf::from("./tests/parser/files/")
+                wit_dir: PathBuf::from("./tests/parser/files/")
                     .canonicalize()
                     .unwrap()
                     .join("wit"),

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -316,7 +316,7 @@ impl ComponentMetadata {
                     .collect::<Vec<String>>(),
                 None => self.tags,
             },
-            call_alias: self.call_alias.or(component_config.call_alias),
+            call_alias: self.call_alias,
             common: GenerateCommon {
                 directory: self
                     .common
@@ -1224,7 +1224,6 @@ mod test {
             TypeConfig::Component(ComponentConfig {
                 key_directory: PathBuf::from("./keys"),
                 destination: Some(PathBuf::from("./build/testcomponent.wasm".to_string())),
-                call_alias: Some("test-component".to_string()),
                 tags: Some(HashSet::from([
                     "wasmcloud.com/experimental".into(),
                     "test".into(),
@@ -1240,6 +1239,9 @@ mod test {
                 version: Version::parse("0.1.0").unwrap(),
                 revision: 666,
                 path: PathBuf::from("./tests/parser/files/")
+                    .canonicalize()
+                    .unwrap(),
+                build_path: PathBuf::from("./tests/parser/files/build/")
                     .canonicalize()
                     .unwrap(),
                 wit_path: PathBuf::from("./tests/parser/files/wit/")
@@ -1377,6 +1379,9 @@ mod test {
                 version: Version::parse("0.1.0").unwrap(),
                 revision: 666,
                 path: PathBuf::from("./tests/parser/files/")
+                    .canonicalize()
+                    .unwrap(),
+                build_path: PathBuf::from("./tests/parser/files/build/")
                     .canonicalize()
                     .unwrap(),
                 wasm_bin_name: None,

--- a/crates/wash-lib/src/cli/registry.rs
+++ b/crates/wash-lib/src/cli/registry.rs
@@ -81,9 +81,13 @@ pub struct RegistryPushCommand {
     #[clap(short = 'r', long = "registry", env = "WASH_REG_URL")]
     pub registry: Option<String>,
 
-    /// Path to config file, if omitted will default to a blank configuration
+    /// Path to OCI config file, if omitted will default to a blank configuration
     #[clap(short = 'c', long = "config")]
     pub config: Option<PathBuf>,
+
+    /// Path to wasmcloud.toml file to use to find registry configuration, defaults to searching
+    /// for a wasmcloud.toml file in the current directory
+    pub project_config: Option<PathBuf>,
 
     /// Allow latest artifact tags
     #[clap(long = "allow-latest")]

--- a/crates/wash-lib/src/config.rs
+++ b/crates/wash-lib/src/config.rs
@@ -73,7 +73,7 @@ pub struct WashConnectionOptions {
     pub ctl_seed: Option<String>,
 
     /// Credsfile for CTL authentication. Combines ctl_seed and ctl_jwt.
-    /// See https://docs.nats.io/using-nats/developer/connecting/creds for details.
+    /// See <https://docs.nats.io/using-nats/developer/connecting/creds> for details.
     pub ctl_credsfile: Option<PathBuf>,
 
     /// Path to a file containing a CA certificate to use for TLS connections

--- a/crates/wash-lib/src/lib.rs
+++ b/crates/wash-lib/src/lib.rs
@@ -10,10 +10,10 @@
 //!
 //! | Feature Name | Default Enabled | Description |
 //! | --- | --- | --- |
-//! | start | true | Contains the [start](start) module, with utilities to start wasmCloud runtimes, NATS, and wadm |
-//! | parser | true | Contains the [parser](parser) module, with utilities to parse `wasmcloud.toml` files |
+//! | start | true | Contains the [start] module, with utilities to start wasmCloud runtimes, NATS, and wadm |
+//! | parser | true | Contains the [parser] module, with utilities to parse `wasmcloud.toml` files |
 //! | cli | false | Contains the build, cli, and generate modules with additional trait derives for usage in building CLI applications |
-//! | nats| true| Contains the [app](app), [component](component), [capture](capture), [config](config), [context](context), [drain](drain), [spier](spier) and [wait](wait) modules with a dependency on `async_nats` |
+//! | nats| true| Contains the [app], [component], [capture], [config], [context], [drain], [spier] and [wait] modules with a dependency on `async_nats` |
 
 #[cfg(feature = "nats")]
 pub mod app;

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -45,12 +45,6 @@ impl TypeConfig {
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct ComponentConfig {
-    /// The list of provider claims that this component requires. eg. ["wasmcloud:httpserver", "wasmcloud:blobstore"]
-    #[serde(default)]
-    pub claims: Vec<String>,
-    /// Whether to push to the registry insecurely. Defaults to false.
-    #[serde(default)]
-    pub push_insecure: bool,
     /// The directory to store the private signing keys in.
     #[serde(default = "default_key_directory")]
     pub key_directory: PathBuf,

--- a/crates/wash-lib/src/start/wasmcloud.rs
+++ b/crates/wash-lib/src/start/wasmcloud.rs
@@ -329,8 +329,8 @@ mod test {
 
     #[tokio::test]
     #[cfg_attr(not(can_reach_github_com), ignore = "github.com is not reachable")]
-    async fn can_download_wasmcloud_burrito() {
-        let download_dir = temp_dir().join("can_download_wasmcloud_burrito");
+    async fn can_download_wasmcloud_host() {
+        let download_dir = temp_dir().join("can_download_wasmcloud_host");
         let res = ensure_wasmcloud_for_os_arch_pair(WASMCLOUD_VERSION, &download_dir)
             .await
             .expect("Should be able to download tarball");

--- a/crates/wash-lib/tests/parser/files/separate_project_paths.toml
+++ b/crates/wash-lib/tests/parser/files/separate_project_paths.toml
@@ -1,0 +1,21 @@
+# This TOML file validates that our parser can handle paths relative to the manifest,
+# and that the project, WIT, build, etc directories can be in different locations.
+language = "rust"
+type = "component"
+name = "testcomponent"
+version = "0.1.0"
+# Absolute paths
+path = "/tmp/myprojectpath"
+# Absolute paths to other directories
+build = "/tmp/myprojectpath/some/other/build"
+wit = "/tmp/myprojectpath/nested/wit"
+
+[component]
+# Relative paths (to the project path)
+build_artifact = "build/testcomponent_raw.wasm"
+destination = "./build/testcomponent.wasm"
+
+[rust]
+# Relative paths (to the project path)
+cargo_path = "../cargo"
+target_path = "./target"

--- a/crates/wash-lib/tests/parser/files/separate_project_paths.toml
+++ b/crates/wash-lib/tests/parser/files/separate_project_paths.toml
@@ -4,11 +4,10 @@ language = "rust"
 type = "component"
 name = "testcomponent"
 version = "0.1.0"
-# Absolute paths
-path = "/tmp/myprojectpath"
+path = "../"
 # Absolute paths to other directories
-build = "/tmp/myprojectpath/some/other/build"
-wit = "/tmp/myprojectpath/nested/wit"
+build = "/tmp/some/other/build"
+wit = "/tmp/nested/wit"
 
 [component]
 # Relative paths (to the project path)

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -414,7 +414,6 @@ fn minimal_rust_component_p2() {
         etcetera::home_dir().expect("Unable to determine the user's home directory");
     expected_default_key_dir.push(".wash/keys");
 
-    assert_eq!(
         config.project_type,
         TypeConfig::Component(ComponentConfig {
             claims: vec!["wasmcloud:httpserver".to_string()],

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -3,13 +3,13 @@ use std::{collections::HashSet, fs, path::PathBuf};
 use claims::{assert_err, assert_ok};
 use semver::Version;
 use wash_lib::parser::{
-    get_config, CommonConfig, ComponentConfig, LanguageConfig, RegistryConfig, RustConfig,
+    load_config, CommonConfig, ComponentConfig, LanguageConfig, RegistryConfig, RustConfig,
     TinyGoConfig, TinyGoGarbageCollector, TinyGoScheduler, TypeConfig, WasmTarget,
 };
 
 #[test]
 fn rust_component() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from("./tests/parser/files/rust_component.toml")),
         None,
     );
@@ -42,14 +42,14 @@ fn rust_component() {
             name: "testcomponent".to_string(),
             version: Version::parse("0.1.0").unwrap(),
             revision: 0,
-            path: PathBuf::from("./tests/parser/files/")
+            project_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
-            build_path: PathBuf::from("./tests/parser/files/")
+            build_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap()
                 .join("build"),
-            wit_path: PathBuf::from("./tests/parser/files/")
+            wit_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap()
                 .join("wit"),
@@ -62,7 +62,7 @@ fn rust_component() {
 #[test]
 /// When given a specific toml file's path, it should parse the file and return a `ProjectConfig`.
 fn rust_component_with_revision() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from(
             "./tests/parser/files/rust_component_with_revision.toml",
         )),
@@ -98,14 +98,14 @@ fn rust_component_with_revision() {
             name: "testcomponent".to_string(),
             version: Version::parse("0.1.0").unwrap(),
             revision: 666,
-            path: PathBuf::from("./tests/parser/files/")
+            project_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
-            build_path: PathBuf::from("./tests/parser/files/")
+            build_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap()
                 .join("build"),
-            wit_path: PathBuf::from("./tests/parser/files/")
+            wit_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap()
                 .join("wit"),
@@ -117,7 +117,7 @@ fn rust_component_with_revision() {
 
 #[test]
 fn tinygo_component_module_scheduler_gc() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from(
             "./tests/parser/files/tinygo_component_scheduler_gc.toml",
         )),
@@ -139,7 +139,7 @@ fn tinygo_component_module_scheduler_gc() {
 
 #[test]
 fn tinygo_component_module() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from(
             "./tests/parser/files/tinygo_component_module.toml",
         )),
@@ -175,14 +175,14 @@ fn tinygo_component_module() {
             name: "testcomponent".to_string(),
             version: Version::parse("0.1.0").unwrap(),
             revision: 0,
-            path: PathBuf::from("./tests/parser/files/")
+            project_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
-            build_path: PathBuf::from("./tests/parser/files/")
+            build_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap()
                 .join("build"),
-            wit_path: PathBuf::from("./tests/parser/files/")
+            wit_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap()
                 .join("wit"),
@@ -194,7 +194,7 @@ fn tinygo_component_module() {
 
 #[test]
 fn tinygo_component() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from("./tests/parser/files/tinygo_component.toml")),
         None,
     );
@@ -216,7 +216,7 @@ fn tinygo_component() {
 #[test]
 /// When given a folder, should automatically grab a wasmcloud.toml file inside it and parse it.
 fn folder_path() {
-    let result = get_config(Some(PathBuf::from("./tests/parser/files/folder")), None);
+    let result = load_config(Some(PathBuf::from("./tests/parser/files/folder")), None);
 
     let config = assert_ok!(result);
 
@@ -241,7 +241,7 @@ fn get_full_path(path: &str) -> String {
 #[test]
 /// When given a folder with no wasmcloud.toml file, should return an error.
 fn folder_path_with_no_config() {
-    let result = get_config(Some(PathBuf::from("./tests/parser/files/noconfig")), None);
+    let result = load_config(Some(PathBuf::from("./tests/parser/files/noconfig")), None);
 
     let err = assert_err!(result);
     assert_eq!(
@@ -256,7 +256,7 @@ fn folder_path_with_no_config() {
 #[test]
 /// When given a random file, should return an error.
 fn random_file() {
-    let result = get_config(Some(PathBuf::from("./tests/parser/files/random.txt")), None);
+    let result = load_config(Some(PathBuf::from("./tests/parser/files/random.txt")), None);
 
     let err = assert_err!(result);
     assert_eq!(
@@ -271,7 +271,7 @@ fn random_file() {
 #[test]
 /// When given a nonexistent file or path, should return an error.
 fn nonexistent_file() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from("./tests/parser/files/nonexistent.toml")),
         None,
     );
@@ -285,7 +285,7 @@ fn nonexistent_file() {
 
 #[test]
 fn nonexistent_folder() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from("./tests/parser/files/nonexistent/")),
         None,
     );
@@ -299,7 +299,7 @@ fn nonexistent_folder() {
 
 #[test]
 fn minimal_rust_component() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from(
             "./tests/parser/files/minimal_rust_component.toml",
         )),
@@ -337,14 +337,14 @@ fn minimal_rust_component() {
         CommonConfig {
             name: "testcomponent".to_string(),
             version: Version::parse("0.1.0").unwrap(),
-            path: PathBuf::from("./tests/parser/files/")
+            project_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
-            build_path: PathBuf::from("./tests/parser/files/")
+            build_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap()
                 .join("build"),
-            wit_path: PathBuf::from("./tests/parser/files/")
+            wit_dir: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap()
                 .join("wit"),
@@ -357,7 +357,7 @@ fn minimal_rust_component() {
 
 #[test]
 fn cargo_toml_component() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from(
             "./tests/parser/files/withcargotoml/minimal_rust_component_with_cargo.toml",
         )),
@@ -395,14 +395,14 @@ fn cargo_toml_component() {
         CommonConfig {
             name: "withcargotoml".to_string(),
             version: Version::parse("0.200.0").unwrap(),
-            path: PathBuf::from("./tests/parser/files/withcargotoml")
+            project_dir: PathBuf::from("./tests/parser/files/withcargotoml")
                 .canonicalize()
                 .unwrap(),
-            build_path: PathBuf::from("./tests/parser/files/withcargotoml")
+            build_dir: PathBuf::from("./tests/parser/files/withcargotoml")
                 .canonicalize()
                 .unwrap()
                 .join("build"),
-            wit_path: PathBuf::from("./tests/parser/files/withcargotoml")
+            wit_dir: PathBuf::from("./tests/parser/files/withcargotoml")
                 .canonicalize()
                 .unwrap()
                 .join("wit"),
@@ -417,7 +417,7 @@ fn cargo_toml_component() {
 /// see: https://github.com/wasmCloud/wash/issues/640
 #[test]
 fn minimal_rust_component_p2() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from(
             "./tests/parser/files/minimal_rust_component_wasip2.toml",
         )),
@@ -445,7 +445,7 @@ fn minimal_rust_component_p2() {
 /// see: https://github.com/wasmCloud/wash/issues/640
 #[test]
 fn minimal_rust_component_wasip1() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from(
             "./tests/parser/files/minimal_rust_component_wasip1.toml",
         )),
@@ -466,7 +466,7 @@ fn minimal_rust_component_wasip1() {
 /// see: https://github.com/wasmCloud/wash/issues/640
 #[test]
 fn minimal_rust_component_core_module() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from(
             "./tests/parser/files/minimal_rust_component_core_module.toml",
         )),
@@ -487,7 +487,7 @@ fn minimal_rust_component_core_module() {
 /// see: https://github.com/wasmCloud/wash/pull/951
 #[test]
 fn tags() {
-    let result = get_config(Some(PathBuf::from("./tests/parser/files/tags.toml")), None);
+    let result = load_config(Some(PathBuf::from("./tests/parser/files/tags.toml")), None);
 
     let config = assert_ok!(result);
     assert!(matches!(
@@ -502,7 +502,7 @@ fn tags() {
 /// Projects with overridden paths should be properly handled
 #[test]
 fn separate_project_paths() {
-    let result = get_config(
+    let result = load_config(
         Some(PathBuf::from(
             "./tests/parser/files/separate_project_paths.toml",
         )),
@@ -511,17 +511,17 @@ fn separate_project_paths() {
     let config = assert_ok!(result);
     // Different project path handled
     assert_eq!(
-        config.common.path,
+        config.common.project_dir,
         PathBuf::from("./tests/parser")
             .canonicalize()
             .expect("failed to canonicalize test path")
     );
     // Absolute paths properly handled
     assert_eq!(
-        config.common.build_path,
+        config.common.build_dir,
         PathBuf::from("/tmp/some/other/build")
     );
-    assert_eq!(config.common.wit_path, PathBuf::from("/tmp/nested/wit"));
+    assert_eq!(config.common.wit_dir, PathBuf::from("/tmp/nested/wit"));
 
     // Relative paths properly handled
     assert!(matches!(

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -28,9 +28,6 @@ fn rust_component() {
     assert_eq!(
         config.project_type,
         TypeConfig::Component(ComponentConfig {
-            claims: vec!["wasmcloud:httpserver".to_string()],
-
-            push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             destination: Some(PathBuf::from("./build/testcomponent.wasm".to_string())),
             call_alias: Some("testcomponent".to_string()),
@@ -47,6 +44,9 @@ fn rust_component() {
             version: Version::parse("0.1.0").unwrap(),
             revision: 0,
             path: PathBuf::from("./tests/parser/files/")
+                .canonicalize()
+                .unwrap(),
+            wit_path: PathBuf::from("./tests/parser/files/wit/")
                 .canonicalize()
                 .unwrap(),
             wasm_bin_name: None,
@@ -79,9 +79,6 @@ fn rust_component_with_revision() {
     assert_eq!(
         config.project_type,
         TypeConfig::Component(ComponentConfig {
-            claims: vec!["wasmcloud:httpserver".to_string()],
-
-            push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             destination: Some(PathBuf::from("./build/testcomponent.wasm".to_string())),
             call_alias: Some("testcomponent".to_string()),
@@ -99,6 +96,9 @@ fn rust_component_with_revision() {
             version: Version::parse("0.1.0").unwrap(),
             revision: 666,
             path: PathBuf::from("./tests/parser/files/")
+                .canonicalize()
+                .unwrap(),
+            wit_path: PathBuf::from("./tests/parser/files/wit/")
                 .canonicalize()
                 .unwrap(),
             wasm_bin_name: None,
@@ -153,9 +153,6 @@ fn tinygo_component_module() {
     assert_eq!(
         config.project_type,
         TypeConfig::Component(ComponentConfig {
-            claims: vec!["wasmcloud:httpserver".to_string()],
-
-            push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             destination: Some(PathBuf::from("./build/testcomponent.wasm".to_string())),
             call_alias: Some("testcomponent".to_string()),
@@ -172,6 +169,9 @@ fn tinygo_component_module() {
             version: Version::parse("0.1.0").unwrap(),
             revision: 0,
             path: PathBuf::from("./tests/parser/files/")
+                .canonicalize()
+                .unwrap(),
+            wit_path: PathBuf::from("./tests/parser/files/wit/")
                 .canonicalize()
                 .unwrap(),
             wasm_bin_name: None,
@@ -192,9 +192,6 @@ fn tinygo_component() {
     assert_eq!(
         config.project_type,
         TypeConfig::Component(ComponentConfig {
-            claims: vec!["wasmcloud:httpserver".to_string()],
-
-            push_insecure: false,
             key_directory: PathBuf::from("./keys"),
             destination: Some(PathBuf::from("./build/testcomponent.wasm".to_string())),
             call_alias: Some("testcomponent".to_string()),
@@ -316,9 +313,6 @@ fn minimal_rust_component() {
     assert_eq!(
         config.project_type,
         TypeConfig::Component(ComponentConfig {
-            claims: vec!["wasmcloud:httpserver".to_string()],
-
-            push_insecure: false,
             key_directory: expected_key_dir,
             destination: None,
             call_alias: None,
@@ -334,6 +328,9 @@ fn minimal_rust_component() {
             name: "testcomponent".to_string(),
             version: Version::parse("0.1.0").unwrap(),
             path: PathBuf::from("./tests/parser/files/")
+                .canonicalize()
+                .unwrap(),
+            wit_path: PathBuf::from("./tests/parser/files/wit/")
                 .canonicalize()
                 .unwrap(),
             revision: 0,
@@ -370,9 +367,6 @@ fn cargo_toml_component() {
     assert_eq!(
         config.project_type,
         TypeConfig::Component(ComponentConfig {
-            claims: vec!["wasmcloud:httpserver".to_string()],
-
-            push_insecure: false,
             key_directory: expected_key_dir,
             destination: None,
             call_alias: None,
@@ -388,6 +382,9 @@ fn cargo_toml_component() {
             name: "withcargotoml".to_string(),
             version: Version::parse("0.200.0").unwrap(),
             path: PathBuf::from("./tests/parser/files/withcargotoml")
+                .canonicalize()
+                .unwrap(),
+            wit_path: PathBuf::from("./tests/parser/files/wit/")
                 .canonicalize()
                 .unwrap(),
             revision: 0,
@@ -414,9 +411,9 @@ fn minimal_rust_component_p2() {
         etcetera::home_dir().expect("Unable to determine the user's home directory");
     expected_default_key_dir.push(".wash/keys");
 
+    assert_eq!(
         config.project_type,
         TypeConfig::Component(ComponentConfig {
-            claims: vec!["wasmcloud:httpserver".to_string()],
             key_directory: expected_default_key_dir,
             wasm_target: WasmTarget::WasiP2,
             wit_world: Some("test-world".to_string()),

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -45,12 +45,14 @@ fn rust_component() {
             path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
-            build_path: PathBuf::from("./tests/parser/files/build/")
+            build_path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap(),
-            wit_path: PathBuf::from("./tests/parser/files/wit/")
+                .unwrap()
+                .join("build"),
+            wit_path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap(),
+                .unwrap()
+                .join("wit"),
             wasm_bin_name: None,
             registry: RegistryConfig::default(),
         }
@@ -99,12 +101,14 @@ fn rust_component_with_revision() {
             path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
-            build_path: PathBuf::from("./tests/parser/files/build/")
+            build_path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap(),
-            wit_path: PathBuf::from("./tests/parser/files/wit/")
+                .unwrap()
+                .join("build"),
+            wit_path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap(),
+                .unwrap()
+                .join("wit"),
             wasm_bin_name: None,
             registry: RegistryConfig::default(),
         }
@@ -174,12 +178,14 @@ fn tinygo_component_module() {
             path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
-            build_path: PathBuf::from("./tests/parser/files/build/")
+            build_path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap(),
-            wit_path: PathBuf::from("./tests/parser/files/wit/")
+                .unwrap()
+                .join("build"),
+            wit_path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap(),
+                .unwrap()
+                .join("wit"),
             wasm_bin_name: None,
             registry: RegistryConfig::default(),
         }
@@ -334,12 +340,14 @@ fn minimal_rust_component() {
             path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
                 .unwrap(),
-            build_path: PathBuf::from("./tests/parser/files/build/")
+            build_path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap(),
-            wit_path: PathBuf::from("./tests/parser/files/wit/")
+                .unwrap()
+                .join("build"),
+            wit_path: PathBuf::from("./tests/parser/files/")
                 .canonicalize()
-                .unwrap(),
+                .unwrap()
+                .join("wit"),
             revision: 0,
             wasm_bin_name: None,
             registry: RegistryConfig::default(),
@@ -390,12 +398,14 @@ fn cargo_toml_component() {
             path: PathBuf::from("./tests/parser/files/withcargotoml")
                 .canonicalize()
                 .unwrap(),
-            build_path: PathBuf::from("./tests/parser/files/build/")
+            build_path: PathBuf::from("./tests/parser/files/withcargotoml")
                 .canonicalize()
-                .unwrap(),
-            wit_path: PathBuf::from("./tests/parser/files/wit/")
+                .unwrap()
+                .join("build"),
+            wit_path: PathBuf::from("./tests/parser/files/withcargotoml")
                 .canonicalize()
-                .unwrap(),
+                .unwrap()
+                .join("wit"),
             revision: 0,
             wasm_bin_name: None,
             registry: RegistryConfig::default(),
@@ -499,16 +509,19 @@ fn separate_project_paths() {
         None,
     );
     let config = assert_ok!(result);
+    // Different project path handled
+    assert_eq!(
+        config.common.path,
+        PathBuf::from("./tests/parser")
+            .canonicalize()
+            .expect("failed to canonicalize test path")
+    );
     // Absolute paths properly handled
-    assert_eq!(config.common.path, PathBuf::from("/tmp/myprojectpath"));
     assert_eq!(
         config.common.build_path,
-        PathBuf::from("/tmp/myprojectpath/some/other/build")
+        PathBuf::from("/tmp/some/other/build")
     );
-    assert_eq!(
-        config.common.wit_path,
-        PathBuf::from("/tmp/myprojectpath/nested/wit")
-    );
+    assert_eq!(config.common.wit_path, PathBuf::from("/tmp/nested/wit"));
 
     // Relative paths properly handled
     assert!(matches!(

--- a/crates/wash-lib/tests/parser/main.rs
+++ b/crates/wash-lib/tests/parser/main.rs
@@ -231,60 +231,6 @@ fn get_full_path(path: &str) -> String {
 }
 
 #[test]
-fn no_component_config() {
-    let result = get_config(
-        Some(PathBuf::from("./tests/parser/files/no_component.toml")),
-        None,
-    );
-
-    let err = assert_err!(result);
-
-    assert_eq!(
-        format!(
-            "missing component config in {}",
-            get_full_path("./tests/parser/files/no_component.toml")
-        ),
-        err.to_string().as_str()
-    );
-}
-
-#[test]
-fn no_provider_config() {
-    let result = get_config(
-        Some(PathBuf::from("./tests/parser/files/no_provider.toml")),
-        None,
-    );
-
-    let err = assert_err!(result);
-
-    assert_eq!(
-        format!(
-            "missing provider config in {}",
-            get_full_path("./tests/parser/files/no_provider.toml")
-        ),
-        err.to_string().as_str()
-    );
-}
-
-#[test]
-fn no_interface_config() {
-    let result = get_config(
-        Some(PathBuf::from("./tests/parser/files/no_interface.toml")),
-        None,
-    );
-
-    let err = assert_err!(result);
-
-    assert_eq!(
-        format!(
-            "unknown project type: interface in {}",
-            get_full_path("./tests/parser/files/no_interface.toml")
-        ),
-        err.to_string().as_str()
-    );
-}
-
-#[test]
 /// When given a folder with no wasmcloud.toml file, should return an error.
 fn folder_path_with_no_config() {
     let result = get_config(Some(PathBuf::from("./tests/parser/files/noconfig")), None);


### PR DESCRIPTION
## Feature or Problem
Decent wash-lib refactor which should simplify understanding the code and give us a nice `WasmcloudDotToml` struct to point at in documentation.

This PR:
- [x] Refactors the parsing logic to remove all the "Raw" structs
- [x] Removes the unused `claims`, `push_insecure`, and `call_alias` fields under component
- [x] Adds a top level wasmcloud.toml field `wit` to allow for overriding the WIT directory
- [x] Adds a top level wasmcloud.toml field `build` to allow for overriding the build directory
- [x] Actually uses the top level wasmcloud.toml field `path` to run commands & support putting the wasmcloud.toml in a different directory than the project itself
- [x] Actually uses the Rust config `debug` flag for component building if supplied
- [x] Adds the `push_insecure` field to the registry config, and another flag that fixes an issue where the OCI config would try to parse as wasmcloud.toml

## Related Issues
Fixes #2757 

## Release Information
next minor wash-cli
next minor wash-lib

## Consumer Impact
None of these changes for overriding the build/wit directories (which is the main point of this pr) will break existing manifests as the default behavior is the same.

Existing manifests that had the `claims`, `push_insecure`, or `call_alias` fields will parse fine as well, as we'll just ignore them.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
Added a unit test to ensure this works as expected

### Acceptance or Integration
Added an integration test to ensure this works as expected. This test will need to change with #3132 because it sed-style replaces the WIT directory in the code.

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
