### PR TITLE
chore(wasmcloud-platform): Fetch chart dependencies as part of packaging

### DIFF
--- a/.github/workflows/wasmcloud-platform-chart.yaml
+++ b/.github/workflows/wasmcloud-platform-chart.yaml
@@ -67,8 +67,14 @@ jobs:
           version: ${{ env.HELM_VERSION }}
 
       - name: Package
+        env:
+          CHART_DIR: charts/wasmcloud-platform
         run: |
-          helm package charts/wasmcloud-platform -d .helm-charts
+          helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+          cd $CHART_DIR
+          helm dependency build
+          cd -
+          helm package $CHART_DIR -d .helm-charts
 
       - name: Login to GHCR
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567


### PR DESCRIPTION
## Feature or Problem

Without this, [the chart packaging step will fail](https://github.com/wasmCloud/wasmCloud/actions/runs/11308851349/job/31452128211) since we don't want to include the dependent charts as part of the repository.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
