### PR TITLE
feat(wasmcloud-host): enable preliminary support for multiple lattices on a single host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8535,6 +8535,7 @@ dependencies = [
  "bytes",
  "clap",
  "clap-markdown",
+ "cloudevents-sdk",
  "file-guard",
  "futures",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ wasmcloud-tracing = { workspace = true, features = ["otel"] }
 async-nats = { workspace = true, features = ["ring"] }
 bytes = { workspace = true }
 base64 = { workspace = true }
+cloudevents-sdk = { workspace = true }
 futures = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }

--- a/crates/host/src/metrics.rs
+++ b/crates/host/src/metrics.rs
@@ -16,16 +16,12 @@ pub struct HostMetrics {
     // but we don't really hve a way of getting at those. We should figure out a way to get at that
     // information so we don't have to duplicate it here.
     pub host_id: String,
-    /// The host's lattice ID.
-    // Eventually a host will be able to support multiple lattices, so this will need to either be
-    // removed or metrics will need to be scoped per-lattice.
-    pub lattice_id: String,
 }
 
 impl HostMetrics {
     /// Construct a new [`HostMetrics`] instance for accessing the various wasmcloud host metrics linked to the provided meter.
     #[must_use]
-    pub fn new(meter: &Meter, host_id: String, lattice_id: String) -> Self {
+    pub fn new(meter: &Meter, host_id: String) -> Self {
         let wasmcloud_host_handle_rpc_message_duration_ns = meter
             .u64_histogram("wasmcloud_host.handle_rpc_message.duration")
             .with_description("Duration in nanoseconds each handle_rpc_message operation took")
@@ -47,7 +43,6 @@ impl HostMetrics {
             component_invocations: component_invocation_count,
             component_errors: component_error_count,
             host_id,
-            lattice_id,
         }
     }
 

--- a/crates/host/src/wasmbus/host_config.rs
+++ b/crates/host/src/wasmbus/host_config.rs
@@ -34,8 +34,7 @@ pub struct Host {
     /// Whether to require TLS for RPC connection
     pub rpc_tls: bool,
     /// The lattices the host belongs to
-    /// TODO: should this actually be Vec<Arc<str>>?
-    pub lattices: Vec<String>,
+    pub lattices: Arc<[Box<str>]>,
     /// The domain to use for host Jetstream operations
     pub js_domain: Option<String>,
     /// Labels (key-value pairs) to add to the host
@@ -101,7 +100,7 @@ impl Default for Host {
             rpc_jwt: None,
             rpc_key: None,
             rpc_tls: false,
-            lattices: vec!["default".to_string()],
+            lattices: Arc::new(["default".to_string().into_boxed_str()]),
             js_domain: None,
             labels: HashMap::default(),
             host_key: None,

--- a/crates/host/src/wasmbus/host_config.rs
+++ b/crates/host/src/wasmbus/host_config.rs
@@ -33,8 +33,9 @@ pub struct Host {
     pub rpc_key: Option<Arc<KeyPair>>,
     /// Whether to require TLS for RPC connection
     pub rpc_tls: bool,
-    /// The lattice the host belongs to
-    pub lattice: Arc<str>,
+    /// The lattices the host belongs to
+    /// TODO: should this actually be Vec<Arc<str>>?
+    pub lattices: Vec<String>,
     /// The domain to use for host Jetstream operations
     pub js_domain: Option<String>,
     /// Labels (key-value pairs) to add to the host
@@ -100,7 +101,7 @@ impl Default for Host {
             rpc_jwt: None,
             rpc_key: None,
             rpc_tls: false,
-            lattice: "default".into(),
+            lattices: vec!["default".to_string()],
             js_domain: None,
             labels: HashMap::default(),
             host_key: None,

--- a/crates/host/src/wasmbus/lattice.rs
+++ b/crates/host/src/wasmbus/lattice.rs
@@ -1,0 +1,2957 @@
+use crate::wasmbus::host_config::PolicyService;
+use crate::wasmbus::{
+    component_import_links, create_bucket, event, fetch_component, handler::Handler,
+    injector_to_headers, load_supplemental_config, merge_registry_config, serialize_ctl_response,
+    Annotations, Claims, Component, ComponentSpecification, Provider, Queue, StoredClaims,
+    SupplementalConfig, WrpcServer, MAX_INVOCATION_CHANNEL_SIZE, MIN_INVOCATION_CHANNEL_SIZE,
+};
+use crate::WasmbusHostConfig;
+
+use std::collections::hash_map::{self};
+use url::Url;
+use wasmcloud_core::logging::Level as LogLevel;
+
+use std::collections::btree_map::Entry as BTreeMapEntry;
+use std::collections::{BTreeMap, HashMap};
+use std::env;
+use std::num::NonZeroUsize;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, ensure, Context as _};
+use async_nats::jetstream::kv::{Entry as KvEntry, Operation, Store};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use bytes::Bytes;
+use futures::stream::{AbortHandle, Abortable};
+use futures::{join, stream, StreamExt, TryFutureExt, TryStreamExt};
+use nkeys::{KeyPair, XKey};
+use secrecy::Secret;
+use serde_json::json;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::{broadcast, mpsc, watch, RwLock, Semaphore};
+use tokio::task::{JoinHandle, JoinSet};
+use tokio::time::{Instant, Interval};
+use tokio::{process, select, spawn};
+use tokio_stream::wrappers::IntervalStream;
+use tracing::{debug, error, info, instrument, trace, warn, Instrument as _};
+use uuid::Uuid;
+use wascap::jwt;
+use wasmcloud_control_interface::{
+    ComponentAuctionAck, ComponentAuctionRequest, ComponentDescription, CtlResponse,
+    DeleteInterfaceLinkDefinitionRequest, HostLabel, Link, ProviderAuctionAck,
+    ProviderAuctionRequest, ProviderDescription, RegistryCredential, ScaleComponentCommand,
+    StartProviderCommand, StopProviderCommand, UpdateComponentCommand,
+};
+use wasmcloud_core::{
+    provider_config_update_subject, ComponentId, HealthCheckResponse, HostData, OtelConfig,
+};
+use wasmcloud_runtime::capability::secrets::store::SecretValue;
+use wasmcloud_runtime::component::WrpcServeEvent;
+use wasmcloud_runtime::Runtime;
+use wasmcloud_secrets_types::SECRET_PREFIX;
+use wasmcloud_tracing::context::TraceContextInjector;
+use wasmcloud_tracing::KeyValue;
+
+use crate::registry::RegistryCredentialExt;
+use crate::{
+    HostMetrics, OciConfig, PolicyHostInfo, PolicyManager, PolicyResponse, RegistryConfig,
+    SecretsManager,
+};
+
+use crate::wasmbus::config::{BundleGenerator, ConfigBundle};
+
+/// wasmCloud Host configuration
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Debug)]
+pub struct LatticeConfig {
+    /// The topic prefix to use for control interface subscriptions, defaults to `wasmbus.ctl`
+    pub ctl_topic_prefix: String,
+    /// NATS URL to connect to for component RPC
+    pub rpc_nats_url: Url,
+    /// Timeout period for all RPC calls
+    pub rpc_timeout: Duration,
+    /// Authentication JWT for RPC connection, must be specified with `rpc_seed`
+    pub rpc_jwt: Option<String>,
+    /// Authentication key pair for RPC connection, must be specified with `rpc_jwt`
+    pub rpc_key: Option<Arc<KeyPair>>,
+    /// The amount of time to wait for a provider to gracefully shut down before terminating it
+    pub provider_shutdown_delay: Option<Duration>,
+    /// Configuration for downloading artifacts from OCI registries
+    pub oci_opts: OciConfig,
+    /// Whether to allow loading component or provider components from the filesystem
+    pub allow_file_load: bool,
+    /// Whether or not structured logging is enabled
+    pub enable_structured_logging: bool,
+    /// Log level to pass to capability providers to use. Should be parsed from a [`tracing::Level`]
+    pub log_level: LogLevel,
+    /// Whether to enable loading supplemental configuration
+    pub config_service_enabled: bool,
+    /// configuration for OpenTelemetry tracing
+    pub otel_config: OtelConfig,
+    /// configuration for wasmCloud policy service
+    pub policy_service_config: PolicyService,
+    /// topic for wasmCloud secrets backend
+    pub secrets_topic_prefix: Option<String>,
+}
+
+impl From<WasmbusHostConfig> for LatticeConfig {
+    fn from(config: WasmbusHostConfig) -> Self {
+        Self {
+            ctl_topic_prefix: config.ctl_topic_prefix,
+            rpc_nats_url: config.rpc_nats_url,
+            rpc_timeout: config.rpc_timeout,
+            rpc_jwt: config.rpc_jwt,
+            rpc_key: config.rpc_key,
+            provider_shutdown_delay: config.provider_shutdown_delay,
+            oci_opts: config.oci_opts,
+            allow_file_load: config.allow_file_load,
+            enable_structured_logging: config.enable_structured_logging,
+            log_level: config.log_level,
+            config_service_enabled: config.config_service_enabled,
+            otel_config: config.otel_config,
+            secrets_topic_prefix: config.secrets_topic_prefix,
+            policy_service_config: config.policy_service_config,
+        }
+    }
+}
+
+/// All data associated with a particular lattice
+pub struct Lattice {
+    name: Arc<str>,
+    ctl_nats: async_nats::Client,
+    rpc_nats: Arc<async_nats::Client>,
+    config: LatticeConfig,
+    host_key: String,
+    host_token: jwt::Token<jwt::Host>,
+    labels: Arc<RwLock<BTreeMap<String, String>>>,
+    components: RwLock<HashMap<ComponentId, Arc<Component>>>,
+    secrets_xkey: Arc<XKey>,
+    data: Store,
+    data_watch_abort: AbortHandle,
+    config_data: Store,
+    config_generator: BundleGenerator,
+    policy_manager: Arc<PolicyManager>,
+    secrets_manager: Arc<SecretsManager>,
+    providers: RwLock<HashMap<String, Provider>>,
+    registry_config: RwLock<HashMap<String, RegistryConfig>>,
+    queue_abort: AbortHandle,
+    links: RwLock<HashMap<String, Vec<Link>>>,
+    component_claims: Arc<RwLock<HashMap<ComponentId, jwt::Claims<jwt::Component>>>>, // TODO: use a single map once Claims is an enum
+    provider_claims: Arc<RwLock<HashMap<String, jwt::Claims<jwt::CapabilityProvider>>>>,
+    metrics: Arc<HostMetrics>,
+    pub(crate) stop_tx: watch::Sender<Option<Instant>>,
+    stop_rx: watch::Receiver<Option<Instant>>,
+    max_execution_time: Duration,
+    runtime: Runtime,
+    event_rx: mpsc::Sender<(String, String, serde_json::Value)>,
+    ctl_topic_prefix: String,
+    heartbeat_abort: AbortHandle,
+}
+
+impl Lattice {
+    /// Instantiate a new Lattice which is capable of running workloads for a particular wasmCloud
+    /// lattice.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn new(
+        name: String,
+        client: async_nats::Client,
+        ctl_client: async_nats::Client,
+        jetstream_client: async_nats::jetstream::Context,
+        host_key: String,
+        labels: Arc<RwLock<BTreeMap<String, String>>>,
+        metrics: Arc<HostMetrics>,
+        max_execution_time: Duration,
+        runtime: Runtime,
+        event_rx: mpsc::Sender<(String, String, serde_json::Value)>,
+        config: LatticeConfig,
+        heartbeat_interval: Interval,
+        host_token: jwt::Token<jwt::Host>,
+    ) -> anyhow::Result<Arc<Self>> {
+        let (stop_tx, stop_rx) = watch::channel(None);
+
+        let bucket = format!("LATTICEDATA_{}", name.clone());
+        let data = create_bucket(&jetstream_client, &bucket).await?;
+
+        let config_bucket = format!("CONFIGDATA_{}", name.clone());
+        let config_data = create_bucket(&jetstream_client, &config_bucket).await?;
+
+        let supplemental_config = if config.config_service_enabled {
+            load_supplemental_config(&client, &name, &labels.read().await.clone()).await?
+        } else {
+            SupplementalConfig::default()
+        };
+
+        let registry_config = RwLock::new(supplemental_config.registry_config.unwrap_or_default());
+        merge_registry_config(&registry_config, config.oci_opts.clone()).await;
+
+        let policy_manager = PolicyManager::new(
+            client.clone(),
+            PolicyHostInfo {
+                public_key: host_key.clone(),
+                lattice: name.clone(),
+                labels: HashMap::from_iter(labels.read().await.clone()),
+            },
+            config.policy_service_config.policy_topic.clone(),
+            config.policy_service_config.policy_timeout_ms,
+            config.policy_service_config.policy_changes_topic.clone(),
+        )
+        .await?;
+
+        let secrets_manager = Arc::new(SecretsManager::new(
+            &config_data,
+            config.secrets_topic_prefix.as_ref(),
+            &client,
+        ));
+        let config_generator = BundleGenerator::new(config_data.clone());
+
+        let (data_watch_abort, data_watch_abort_reg) = AbortHandle::new_pair();
+        let (queue_abort, queue_abort_reg) = AbortHandle::new_pair();
+        let (heartbeat_abort, heartbeat_abort_reg) = AbortHandle::new_pair();
+        let lattice = Self {
+            name: Arc::from(name.clone()),
+            labels,
+            // TODO this is in theory redundant with some other config options
+            ctl_topic_prefix: config.ctl_topic_prefix.clone(),
+            config: config.clone(),
+            host_key: host_key.clone(),
+            ctl_nats: ctl_client.clone(),
+            rpc_nats: Arc::new(client),
+            components: RwLock::default(),
+            secrets_xkey: Arc::new(XKey::new()),
+            secrets_manager,
+            policy_manager,
+            registry_config,
+            providers: RwLock::default(),
+            config_generator,
+            config_data,
+            data: data.clone(),
+            links: RwLock::default(),
+            component_claims: Arc::default(),
+            provider_claims: Arc::default(),
+            queue_abort: queue_abort.clone(),
+            data_watch_abort,
+            metrics,
+            stop_tx,
+            stop_rx,
+            max_execution_time,
+            runtime,
+            event_rx,
+            host_token,
+            heartbeat_abort,
+        };
+
+        let lattice = Arc::new(lattice);
+        let name = name.clone();
+        let _data_watch: JoinHandle<anyhow::Result<_>> = spawn({
+            let data = data.clone();
+            let lattice: Arc<Lattice> = Arc::clone(&lattice);
+            let name = name.clone();
+            async move {
+                let data_watch = data
+                    .watch_all()
+                    .await
+                    .context("failed to watch lattice data bucket")?;
+                let mut data_watch = Abortable::new(data_watch, data_watch_abort_reg);
+                data_watch
+                    .by_ref()
+                    .for_each({
+                        let lattice: Arc<Lattice> = Arc::clone(&lattice);
+                        move |entry| {
+                            let lattice = Arc::clone(&lattice);
+                            async move {
+                                match entry {
+                                    Err(error) => {
+                                        error!("failed to watch lattice data bucket: {error}");
+                                    }
+                                    Ok(entry) => lattice.process_entry(entry, true).await,
+                                }
+                            }
+                        }
+                    })
+                    .await;
+                let deadline = { *lattice.stop_rx.borrow() };
+                lattice.stop_tx.send_replace(deadline);
+                if data_watch.is_aborted() {
+                    info!(lattice = name, "data watch task gracefully stopped");
+                } else {
+                    error!(lattice = name, "data watch task unexpectedly stopped");
+                }
+                Ok(())
+            }
+        });
+
+        let queue = Queue::new_lattice(
+            &ctl_client.clone(),
+            &config.ctl_topic_prefix.clone(),
+            &name,
+            &host_key,
+        )
+        .await
+        .context("failed to initialize queue")?;
+
+        let _queue = spawn({
+            let lattice = Arc::clone(&lattice);
+            async move {
+                let mut queue = Abortable::new(queue, queue_abort_reg);
+                queue
+                    .by_ref()
+                    .for_each_concurrent(None, {
+                        let lattice = Arc::clone(&lattice);
+                        move |msg| {
+                            let lattice = Arc::clone(&lattice);
+                            async move { lattice.handle_ctl_message(msg).await }
+                        }
+                    })
+                    .await;
+                let deadline = { *lattice.stop_rx.borrow() };
+                lattice.stop_tx.send_replace(deadline);
+                if queue.is_aborted() {
+                    info!("control interface queue task gracefully stopped");
+                } else {
+                    error!("control interface queue task unexpectedly stopped");
+                }
+            }
+        });
+
+        // Shutdown when requested
+        spawn({
+            let mut stop = lattice.stop_rx.clone();
+            let lattice = Arc::clone(&lattice);
+            let name = lattice.name.clone();
+            async move {
+                if let Err(e) = stop.changed().await {
+                    error!(lattice =% name.clone(), "failed to wait for stop: {e}");
+                }
+                if let Err(err) = lattice.shutdown().await {
+                    error!(lattice =% name, "failed to shutdown lattice: {err}");
+                };
+                info!(lattice =% name, "lattice stopped");
+            }
+        });
+
+        // TODO this feels like a host-level responsibility and not a lattice thing. The problem of
+        // course is that we need to fix the control interface so that a host heartbeat contains
+        // information from all lattices.
+        let heartbeat = IntervalStream::new(heartbeat_interval);
+        spawn({
+            let lattice = Arc::clone(&lattice);
+            async move {
+                let mut heartbeat = Abortable::new(heartbeat, heartbeat_abort_reg);
+                heartbeat
+                    .by_ref()
+                    .for_each({
+                        let lattice = Arc::clone(&lattice);
+                        move |_| {
+                            let lattice = lattice.clone();
+                            async move {
+                                let heartbeat =
+                                    match serde_json::to_value(lattice.inventory().await) {
+                                        Ok(heartbeat) => heartbeat,
+                                        Err(e) => {
+                                            error!("failed to generate heartbeat: {e}");
+                                            return;
+                                        }
+                                    };
+
+                                if let Err(e) =
+                                    lattice.publish_event("host_heartbeat", heartbeat).await
+                                {
+                                    error!("failed to publish heartbeat: {e}");
+                                }
+                            }
+                        }
+                    })
+                    .await;
+                let deadline = { *lattice.stop_rx.borrow() };
+                lattice.stop_tx.send_replace(deadline);
+                if heartbeat.is_aborted() {
+                    info!(lattice = name, "heartbeat task gracefully stopped");
+                } else {
+                    error!(lattice = name, "heartbeat task unexpectedly stopped");
+                }
+            }
+        });
+
+        data.keys()
+            .await
+            .context("failed to read keys of lattice data bucket")?
+            .map_err(|e| anyhow!(e).context("failed to read lattice data stream"))
+            .try_filter_map(|key| async {
+                data.entry(key)
+                    .await
+                    .context("failed to get entry in lattice data bucket")
+            })
+            .for_each(|entry| async {
+                match entry {
+                    Ok(entry) => lattice.process_entry(entry, false).await,
+                    Err(err) => error!(%err, "failed to read entry from lattice data bucket"),
+                }
+            })
+            .await;
+
+        Ok(Arc::clone(&lattice))
+    }
+
+    async fn shutdown(&self) -> anyhow::Result<()> {
+        self.data_watch_abort.abort();
+        self.queue_abort.abort();
+        self.heartbeat_abort.abort();
+        self.policy_manager.policy_changes.abort();
+        // TODO add this back in
+        //let _ = try_join!(queue, data_watch).context("failed to await tasks")?;
+
+        self.rpc_nats
+            .flush()
+            .await
+            .context("failed to flush NATS connection")?;
+        // NOTE: Epoch interrupt thread will only stop once there are no more references to the engine
+        Ok(())
+    }
+
+    /// Waits for host to be stopped via lattice commands and returns the shutdown deadline on
+    /// success
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if internal stop channel is closed prematurely
+    //#[instrument(level = "debug", skip_all)]
+    //pub async fn stopped(&self) -> anyhow::Result<Option<Instant>> {
+    //    self.stop_rx
+    //        .clone()
+    //        .changed()
+    //        .await
+    //        .context("failed to wait for stop")?;
+    //    Ok(*self.stop_rx.borrow())
+    //}
+
+    #[instrument(level = "debug", skip_all)]
+    pub(crate) async fn inventory(&self) -> (Vec<ComponentDescription>, Vec<ProviderDescription>) {
+        trace!("generating host inventory");
+        let components = self.components.read().await;
+        let components: Vec<_> = stream::iter(components.iter())
+            .filter_map(|(id, component)| async move {
+                let mut description = ComponentDescription::builder()
+                    .id(id.into())
+                    .image_ref(component.image_reference.to_string())
+                    .annotations(component.annotations.clone().into_iter().collect())
+                    .max_instances(component.max_instances.get().try_into().unwrap_or(u32::MAX))
+                    .revision(
+                        component
+                            .claims()
+                            .and_then(|claims| claims.metadata.as_ref())
+                            .and_then(|jwt::Component { rev, .. }| *rev)
+                            .unwrap_or_default(),
+                    );
+                // Add name if present
+                if let Some(name) = component
+                    .claims()
+                    .and_then(|claims| claims.metadata.as_ref())
+                    .and_then(|metadata| metadata.name.as_ref())
+                    .cloned()
+                {
+                    description = description.name(name);
+                };
+
+                Some(
+                    description
+                        .build()
+                        .expect("failed to build component description: {e}"),
+                )
+            })
+            .collect()
+            .await;
+
+        let providers: Vec<_> = self
+            .providers
+            .read()
+            .await
+            .iter()
+            .map(
+                |(
+                    provider_id,
+                    Provider {
+                        annotations,
+                        claims_token,
+                        image_ref,
+                        ..
+                    },
+                )| {
+                    let mut provider_description = ProviderDescription::builder()
+                        .id(provider_id)
+                        .image_ref(image_ref);
+                    if let Some(name) = claims_token
+                        .as_ref()
+                        .and_then(|claims| claims.claims.metadata.as_ref())
+                        .and_then(|metadata| metadata.name.as_ref())
+                    {
+                        provider_description = provider_description.name(name);
+                    }
+                    provider_description
+                        .annotations(
+                            annotations
+                                .clone()
+                                .into_iter()
+                                .collect::<BTreeMap<String, String>>(),
+                        )
+                        .revision(
+                            claims_token
+                                .as_ref()
+                                .and_then(|claims| claims.claims.metadata.as_ref())
+                                .and_then(|jwt::CapabilityProvider { rev, .. }| *rev)
+                                .unwrap_or_default(),
+                        )
+                        .build()
+                        .expect("failed to build provider description")
+                },
+            )
+            .collect();
+
+        (components, providers)
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    async fn publish_event(&self, name: &str, data: serde_json::Value) -> anyhow::Result<()> {
+        self.event_rx
+            .send(((*self.name).to_string(), name.to_string(), data))
+            .await
+            .context("failed to send event")
+    }
+
+    /// Instantiate a component
+    #[allow(clippy::too_many_arguments)] // TODO: refactor into a config struct
+    #[instrument(level = "debug", skip_all)]
+    async fn instantiate_component(
+        &self,
+        annotations: &Annotations,
+        image_reference: Arc<str>,
+        id: Arc<str>,
+        max_instances: NonZeroUsize,
+        mut component: wasmcloud_runtime::Component<Handler>,
+        handler: Handler,
+    ) -> anyhow::Result<Arc<Component>> {
+        trace!(
+            component_ref = ?image_reference,
+            max_instances,
+            "instantiating component"
+        );
+
+        let max_execution_time = self.max_execution_time;
+        component.set_max_execution_time(max_execution_time);
+
+        let (events_tx, mut events_rx) = mpsc::channel(
+            max_instances
+                .get()
+                .clamp(MIN_INVOCATION_CHANNEL_SIZE, MAX_INVOCATION_CHANNEL_SIZE),
+        );
+        let prefix = Arc::from(format!("{}.{id}", &self.name));
+        let exports = component
+            .serve_wrpc(
+                &WrpcServer {
+                    nats: wrpc_transport_nats::Client::new(
+                        Arc::clone(&self.rpc_nats),
+                        Arc::clone(&prefix),
+                        Some(prefix),
+                    ),
+                    claims: component.claims().cloned().map(Arc::new),
+                    id: Arc::clone(&id),
+                    image_reference: Arc::clone(&image_reference),
+                    annotations: Arc::new(annotations.clone()),
+                    policy_manager: Arc::clone(&self.policy_manager),
+                    trace_ctx: Arc::clone(&handler.trace_ctx),
+                    metrics: Arc::clone(&self.metrics),
+                },
+                handler.clone(),
+                events_tx,
+            )
+            .await?;
+        let permits = Arc::new(Semaphore::new(
+            usize::from(max_instances).min(Semaphore::MAX_PERMITS),
+        ));
+        let metrics: Arc<HostMetrics> = Arc::clone(&self.metrics);
+        let lattice = self.name.clone().to_string();
+        Ok(Arc::new(Component {
+            component,
+            id,
+            handler,
+            exports: spawn(
+                async move {
+                    join!(
+                        async move {
+                            let mut tasks = JoinSet::new();
+                            let mut exports = stream::select_all(exports);
+                            loop {
+                                let permits = Arc::clone(&permits);
+                                select! {
+                                    Some(fut) = exports.next() => {
+                                        match fut {
+                                            Ok(fut) => {
+                                                debug!("accepted invocation, acquiring permit");
+                                                let permit = permits.acquire_owned().await;
+                                                tasks.spawn(async move {
+                                                    let _permit = permit;
+                                                    debug!("handling invocation");
+                                                    match fut.await {
+                                                        Ok(()) => {
+                                                            debug!("successfully handled invocation");
+                                                            Ok(())
+                                                        },
+                                                        Err(err) => {
+                                                            warn!(?err, "failed to handle invocation");
+                                                            Err(err)
+                                                        },
+                                                    }
+                                                });
+                                            }
+                                            Err(err) => {
+                                                warn!(?err, "failed to accept invocation")
+                                            }
+                                        }
+                                    }
+                                    Some(res) = tasks.join_next() => {
+                                        if let Err(err) = res {
+                                            error!(?err, "export serving task failed");
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        async move {
+                            while let Some(evt) = events_rx.recv().await {
+                                match evt {
+                                    WrpcServeEvent::HttpIncomingHandlerHandleReturned {
+                                        context: (start_at, ref attributes),
+                                        success,
+                                    }
+                                    | WrpcServeEvent::MessagingHandlerHandleMessageReturned {
+                                        context: (start_at, ref attributes),
+                                        success,
+                                    }
+                                    | WrpcServeEvent::DynamicExportReturned {
+                                        context: (start_at, ref attributes),
+                                        success,
+                                    } => {
+                                        let mut attributes = attributes.clone();
+                                        attributes.push(KeyValue::new("lattice".to_string(), lattice.clone()));
+                                        metrics.record_component_invocation(
+                                        u64::try_from(start_at.elapsed().as_nanos())
+                                            .unwrap_or_default(),
+                                        &attributes,
+                                        !success,
+                                    )
+                                    },
+                                }
+                            }
+                            debug!("serving event stream is done");
+                        },
+                    );
+                    debug!("export serving task done");
+                }
+                .in_current_span(),
+            ),
+            annotations: annotations.clone(),
+            max_instances,
+            image_reference,
+        }))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(level = "debug", skip_all)]
+    async fn start_component<'a>(
+        &self,
+        entry: hash_map::VacantEntry<'a, String, Arc<Component>>,
+        wasm: Vec<u8>,
+        claims: Option<jwt::Claims<jwt::Component>>,
+        component_ref: Arc<str>,
+        component_id: Arc<str>,
+        max_instances: NonZeroUsize,
+        annotations: &Annotations,
+        config: ConfigBundle,
+        secrets: HashMap<String, Secret<SecretValue>>,
+    ) -> anyhow::Result<&'a mut Arc<Component>> {
+        debug!(?component_ref, ?max_instances, "starting new component");
+
+        if let Some(ref claims) = claims {
+            self.store_claims(Claims::Component(claims.clone()))
+                .await
+                .context("failed to store claims")?;
+        }
+
+        let component_spec = self
+            .get_component_spec(&component_id)
+            .await?
+            .unwrap_or_else(|| ComponentSpecification::new(&component_ref));
+        self.store_component_spec(&component_id, &component_spec)
+            .await?;
+
+        // Map the imports to pull out the result types of the functions for lookup when invoking them
+        let handler = Handler {
+            nats: Arc::clone(&self.rpc_nats),
+            config_data: Arc::new(RwLock::new(config)),
+            lattice: Arc::clone(&self.name),
+            component_id: Arc::clone(&component_id),
+            secrets: Arc::new(RwLock::new(secrets)),
+            targets: Arc::default(),
+            trace_ctx: Arc::default(),
+            instance_links: Arc::new(RwLock::new(component_import_links(&component_spec.links))),
+            invocation_timeout: Duration::from_secs(10), // TODO: Make this configurable
+        };
+        let component = wasmcloud_runtime::Component::new(&self.runtime, &wasm)?;
+        let component = self
+            .instantiate_component(
+                annotations,
+                Arc::clone(&component_ref),
+                Arc::clone(&component_id),
+                max_instances,
+                component,
+                handler,
+            )
+            .await
+            .context("failed to instantiate component")?;
+
+        info!(?component_ref, "component started");
+        self.publish_event(
+            "component_scaled",
+            event::component_scaled(
+                claims.as_ref(),
+                annotations,
+                self.host_key.clone(),
+                max_instances,
+                &component_ref,
+                &component_id,
+            ),
+        )
+        .await?;
+
+        Ok(entry.insert(component))
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn stop_component(&self, component: &Component, _host_id: &str) -> anyhow::Result<()> {
+        trace!(component_id = %component.id, "stopping component");
+
+        component.exports.abort();
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_auction_component(
+        &self,
+        payload: impl AsRef<[u8]>,
+    ) -> anyhow::Result<Option<CtlResponse<ComponentAuctionAck>>> {
+        let req = serde_json::from_slice::<ComponentAuctionRequest>(payload.as_ref())
+            .context("failed to deserialize component auction command")?;
+        let component_ref = req.component_ref();
+        let component_id = req.component_id();
+        let constraints = req.constraints();
+
+        info!(
+            component_ref,
+            component_id,
+            ?constraints,
+            "handling auction for component"
+        );
+
+        let host_labels = self.labels.read().await;
+        let constraints_satisfied = constraints
+            .iter()
+            .all(|(k, v)| host_labels.get(k).is_some_and(|hv| hv == v));
+        let component_id_running = self.components.read().await.contains_key(component_id);
+
+        // This host can run the component if all constraints are satisfied and the component is not already running
+        if constraints_satisfied && !component_id_running {
+            Ok(Some(CtlResponse::ok(
+                ComponentAuctionAck::from_component_host_and_constraints(
+                    component_ref,
+                    component_id,
+                    &self.host_key,
+                    constraints.clone(),
+                ),
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_auction_provider(
+        &self,
+        payload: impl AsRef<[u8]>,
+    ) -> anyhow::Result<Option<CtlResponse<ProviderAuctionAck>>> {
+        let req = serde_json::from_slice::<ProviderAuctionRequest>(payload.as_ref())
+            .context("failed to deserialize provider auction command")?;
+        let provider_ref = req.provider_ref();
+        let provider_id = req.provider_id();
+        let constraints = req.constraints();
+
+        info!(
+            provider_ref,
+            provider_id,
+            ?constraints,
+            "handling auction for provider"
+        );
+
+        let host_labels = self.labels.read().await;
+        let constraints_satisfied = constraints
+            .iter()
+            .all(|(k, v)| host_labels.get(k).is_some_and(|hv| hv == v));
+        let providers = self.providers.read().await;
+        let provider_running = providers.contains_key(provider_id);
+        if constraints_satisfied && !provider_running {
+            Ok(Some(CtlResponse::ok(
+                ProviderAuctionAck::builder()
+                    .provider_ref(provider_ref.into())
+                    .provider_id(provider_id.into())
+                    .constraints(constraints.clone())
+                    .host_id(self.host_key.clone())
+                    .build()
+                    .map_err(|e| anyhow!("failed to build provider auction ack: {e}"))?,
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    async fn fetch_component(&self, component_ref: &str) -> anyhow::Result<Vec<u8>> {
+        let registry_config = self.registry_config.read().await;
+        fetch_component(
+            component_ref,
+            self.config.allow_file_load,
+            &self.config.oci_opts.additional_ca_paths,
+            &registry_config,
+        )
+        .await
+        .context("failed to fetch component")
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    async fn store_component_claims(
+        &self,
+        claims: jwt::Claims<jwt::Component>,
+    ) -> anyhow::Result<()> {
+        let mut component_claims = self.component_claims.write().await;
+        component_claims.insert(claims.subject.clone(), claims);
+        Ok(())
+    }
+
+    //#[instrument(level = "debug", skip_all)]
+    //async fn handle_stop_host(
+    //    &self,
+    //    payload: impl AsRef<[u8]>,
+    //    transport_host_id: &str,
+    //) -> anyhow::Result<CtlResponse<()>> {
+    //    // Allow an empty payload to be used for stopping hosts
+    //    let timeout = if payload.as_ref().is_empty() {
+    //        None
+    //    } else {
+    //        let cmd = serde_json::from_slice::<StopHostCommand>(payload.as_ref())
+    //            .context("failed to deserialize stop command")?;
+    //        let timeout = cmd.timeout();
+    //        let host_id = cmd.host_id();
+
+    //        // If the Host ID was provided (i..e not the empty string, due to #[serde(default)]), then
+    //        // we should check it against the known transport-provided host_id, and this actual host's ID
+    //        if !host_id.is_empty() {
+    //            anyhow::ensure!(
+    //                host_id == transport_host_id && host_id == self.host_key,
+    //                "invalid host_id [{host_id}]"
+    //            );
+    //        }
+    //        timeout
+    //    };
+
+    //    // It *should* be impossible for the transport-derived host ID to not match at this point
+    //    anyhow::ensure!(
+    //        transport_host_id == self.host_key,
+    //        "invalid host_id [{transport_host_id}]"
+    //    );
+
+    //    info!(?timeout, "handling stop host");
+
+    //    self.heartbeat.abort();
+    //    self.data_watch.abort();
+    //    self.queue.abort();
+    //    self.policy_manager.policy_changes.abort();
+    //    let deadline =
+    //        timeout.and_then(|timeout| Instant::now().checked_add(Duration::from_millis(timeout)));
+    //    self.stop_tx.send_replace(deadline);
+    //    Ok(CtlResponse::<()>::success(
+    //        "successfully handled stop host".into(),
+    //    ))
+    //}
+
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_scale_component(
+        self: Arc<Self>,
+        payload: impl AsRef<[u8]>,
+        host_id: &str,
+    ) -> anyhow::Result<CtlResponse<()>> {
+        let cmd = serde_json::from_slice::<ScaleComponentCommand>(payload.as_ref())
+            .context("failed to deserialize component scale command")?;
+        let component_ref = cmd.component_ref();
+        let component_id = cmd.component_id();
+        let annotations = cmd.annotations();
+        let max_instances = cmd.max_instances();
+        let config = cmd.config().clone();
+        let allow_update = cmd.allow_update();
+
+        debug!(
+            component_ref,
+            max_instances, component_id, "handling scale component"
+        );
+
+        let host_id = host_id.to_string();
+        let annotations: Annotations = annotations
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+
+        // Basic validation to ensure that the component is running and that the image reference matches
+        // If it doesn't match, we can still successfully scale, but we won't be updating the image reference
+        let (original_ref, ref_changed) = {
+            self.components
+                .read()
+                .await
+                .get(component_id)
+                .map(|v| {
+                    (
+                        Some(Arc::clone(&v.image_reference)),
+                        &*v.image_reference != component_ref,
+                    )
+                })
+                .unwrap_or_else(|| (None, false))
+        };
+
+        let mut perform_post_update: bool = false;
+        let message = match (allow_update, original_ref, ref_changed) {
+            // Updates are not allowed, original ref changed
+            (false, Some(original_ref), true) => {
+                let msg = format!(
+                    "Requested to scale existing component to a different image reference: {original_ref} != {component_ref}. The component will be scaled but the image reference will not be updated. If you meant to update this component to a new image ref, use the update command."
+                );
+                warn!(msg);
+                msg
+            }
+            // Updates are allowed, ref changed and we'll do an update later
+            (true, Some(original_ref), true) => {
+                perform_post_update = true;
+                format!(
+                    "Requested to scale existing component, with a changed image reference: {original_ref} != {component_ref}. The component will be scaled, and the image reference will be updated afterwards."
+                )
+            }
+            _ => String::with_capacity(0),
+        };
+
+        let component_id = Arc::from(component_id);
+        let component_ref = Arc::from(component_ref);
+        // Spawn a task to perform the scaling and possibly an update of the component afterwards
+        spawn(async move {
+            // Fetch the component from the reference
+            let component_and_claims =
+                self.fetch_component(&component_ref)
+                    .await
+                    .map(|component_bytes| {
+                        // Pull the claims token from the component, this returns an error only if claims are embedded
+                        // and they are invalid (expired, tampered with, etc)
+                        let claims_token =
+                            wasmcloud_runtime::component::claims_token(&component_bytes);
+                        (component_bytes, claims_token)
+                    });
+            let (wasm, claims_token) = match component_and_claims {
+                Ok((wasm, Ok(claims_token))) => (wasm, claims_token),
+                Err(e) | Ok((_, Err(e))) => {
+                    if let Err(e) = self
+                        .publish_event(
+                            "component_scale_failed",
+                            event::component_scale_failed(
+                                None,
+                                &annotations,
+                                host_id,
+                                &component_ref,
+                                &component_id,
+                                max_instances,
+                                &e,
+                            ),
+                        )
+                        .await
+                    {
+                        error!(%component_ref, %component_id, err = ?e, "failed to publish component scale failed event");
+                    }
+                    return;
+                }
+            };
+            // Scale the component
+            if let Err(e) = self
+                .handle_scale_component_task(
+                    Arc::clone(&component_ref),
+                    Arc::clone(&component_id),
+                    &host_id,
+                    max_instances,
+                    &annotations,
+                    config,
+                    wasm,
+                    claims_token.as_ref(),
+                )
+                .await
+            {
+                error!(%component_ref, %component_id, err = ?e, "failed to scale component");
+                if let Err(e) = self
+                    .publish_event(
+                        "component_scale_failed",
+                        event::component_scale_failed(
+                            claims_token.map(|c| c.claims).as_ref(),
+                            &annotations,
+                            host_id,
+                            &component_ref,
+                            &component_id,
+                            max_instances,
+                            &e,
+                        ),
+                    )
+                    .await
+                {
+                    error!(%component_ref, %component_id, err = ?e, "failed to publish component scale failed event");
+                }
+                return;
+            }
+
+            if perform_post_update {
+                if let Err(e) = self
+                    .handle_update_component_task(
+                        Arc::clone(&component_id),
+                        Arc::clone(&component_ref),
+                        &host_id,
+                        None,
+                    )
+                    .await
+                {
+                    error!(%component_ref, %component_id, err = ?e, "failed to update component after scale");
+                }
+            }
+        });
+
+        Ok(CtlResponse::<()>::success(message))
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    /// Handles scaling an component to a supplied number of `max` concurrently executing instances.
+    /// Supplying `0` will result in stopping that component instance.
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_scale_component_task(
+        &self,
+        component_ref: Arc<str>,
+        component_id: Arc<str>,
+        host_id: &str,
+        max_instances: u32,
+        annotations: &Annotations,
+        config: Vec<String>,
+        wasm: Vec<u8>,
+        claims_token: Option<&jwt::Token<jwt::Component>>,
+    ) -> anyhow::Result<()> {
+        trace!(?component_ref, max_instances, "scale component task");
+
+        let claims = claims_token.map(|c| c.claims.clone());
+        match self
+            .policy_manager
+            .evaluate_start_component(
+                &component_id,
+                &component_ref,
+                max_instances,
+                annotations,
+                claims.as_ref(),
+            )
+            .await?
+        {
+            PolicyResponse {
+                permitted: false,
+                message: Some(message),
+                ..
+            } => bail!("Policy denied request to scale component `{component_id}`: `{message:?}`"),
+            PolicyResponse {
+                permitted: false, ..
+            } => bail!("Policy denied request to scale component `{component_id}`"),
+            PolicyResponse {
+                permitted: true, ..
+            } => (),
+        };
+
+        let scaled_event = match (
+            self.components
+                .write()
+                .await
+                .entry(component_id.to_string()),
+            NonZeroUsize::new(max_instances as usize),
+        ) {
+            // No component is running and we requested to scale to zero, noop.
+            // We still publish the event to indicate that the component has been scaled to zero
+            (hash_map::Entry::Vacant(_), None) => event::component_scaled(
+                claims.as_ref(),
+                annotations,
+                host_id,
+                0_usize,
+                &component_ref,
+                &component_id,
+            ),
+            // No component is running and we requested to scale to some amount, start with specified max
+            (hash_map::Entry::Vacant(entry), Some(max)) => {
+                let (config, secrets) = self
+                    .fetch_config_and_secrets(
+                        &config,
+                        claims_token.as_ref().map(|c| &c.jwt),
+                        annotations.get("wasmcloud.dev/appspec"),
+                    )
+                    .await?;
+
+                self.start_component(
+                    entry,
+                    wasm,
+                    claims.clone(),
+                    Arc::clone(&component_ref),
+                    Arc::clone(&component_id),
+                    max,
+                    annotations,
+                    config,
+                    secrets,
+                )
+                .await?;
+
+                event::component_scaled(
+                    claims.as_ref(),
+                    annotations,
+                    host_id,
+                    max,
+                    &component_ref,
+                    &component_id,
+                )
+            }
+            // Component is running and we requested to scale to zero instances, stop component
+            (hash_map::Entry::Occupied(entry), None) => {
+                let component = entry.remove();
+                self.stop_component(&component, host_id)
+                    .await
+                    .context("failed to stop component in response to scale to zero")?;
+
+                info!(?component_ref, "component stopped");
+                event::component_scaled(
+                    claims.as_ref(),
+                    &component.annotations,
+                    host_id,
+                    0_usize,
+                    &component.image_reference,
+                    &component.id,
+                )
+            }
+            // Component is running and we requested to scale to some amount or unbounded, scale component
+            (hash_map::Entry::Occupied(mut entry), Some(max)) => {
+                let component = entry.get_mut();
+                let config_changed =
+                    &config != component.handler.config_data.read().await.config_names();
+
+                // Create the event first to avoid borrowing the component
+                // This event is idempotent.
+                let event = event::component_scaled(
+                    claims.as_ref(),
+                    &component.annotations,
+                    host_id,
+                    max,
+                    &component.image_reference,
+                    &component.id,
+                );
+
+                // Modify scale only if the requested max differs from the current max or if the configuration has changed
+                if component.max_instances != max || config_changed {
+                    // We must partially clone the handler as we can't be sharing the targets between components
+                    let handler = component.handler.copy_for_new();
+                    if config_changed {
+                        let (config, secrets) = self
+                            .fetch_config_and_secrets(
+                                &config,
+                                claims_token.as_ref().map(|c| &c.jwt),
+                                annotations.get("wasmcloud.dev/appspec"),
+                            )
+                            .await?;
+                        *handler.config_data.write().await = config;
+                        *handler.secrets.write().await = secrets;
+                    }
+                    let instance = self
+                        .instantiate_component(
+                            annotations,
+                            Arc::clone(&component_ref),
+                            Arc::clone(&component.id),
+                            max,
+                            component.component.clone(),
+                            handler,
+                        )
+                        .await
+                        .context("failed to instantiate component")?;
+                    let component = entry.insert(instance);
+                    self.stop_component(&component, host_id)
+                        .await
+                        .context("failed to stop component after scaling")?;
+
+                    info!(?component_ref, ?max, "component scaled");
+                } else {
+                    debug!(?component_ref, ?max, "component already at desired scale");
+                }
+                event
+            }
+        };
+
+        self.publish_event("component_scaled", scaled_event).await?;
+
+        Ok(())
+    }
+
+    // TODO(#1548): With component IDs, new component references, configuration, etc, we're going to need to do some
+    // design thinking around how update component should work. Should it be limited to a single host or latticewide?
+    // Should it also update configuration, or is that separate? Should scaling be done via an update?
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_update_component(
+        self: Arc<Self>,
+        payload: impl AsRef<[u8]>,
+        host_id: &str,
+    ) -> anyhow::Result<CtlResponse<()>> {
+        let cmd = serde_json::from_slice::<UpdateComponentCommand>(payload.as_ref())
+            .context("failed to deserialize component update command")?;
+        let component_id = cmd.component_id();
+        let annotations = cmd.annotations().cloned();
+        let new_component_ref = cmd.new_component_ref();
+
+        debug!(
+            component_id,
+            new_component_ref,
+            ?annotations,
+            "handling update component"
+        );
+
+        // Find the component and extract the image reference
+        #[allow(clippy::map_clone)]
+        // NOTE: clippy thinks, that we can just replace the `.map` below by
+        // `.cloned` - we can't, because we need to clone the field
+        let Some(component_ref) = self
+            .components
+            .read()
+            .await
+            .get(component_id)
+            .map(|component| Arc::clone(&component.image_reference))
+        else {
+            return Ok(CtlResponse::error(&format!(
+                "component {component_id} not found"
+            )));
+        };
+
+        // If the component image reference is the same, respond with an appropriate message
+        if &*component_ref == new_component_ref {
+            return Ok(CtlResponse::<()>::success(format!(
+                "component {component_id} already updated to {new_component_ref}"
+            )));
+        }
+
+        let host_id = host_id.to_string();
+        let message = format!(
+            "component {component_id} updating from {component_ref} to {new_component_ref}"
+        );
+        let component_id = Arc::from(component_id);
+        let new_component_ref = Arc::from(new_component_ref);
+        spawn(async move {
+            if let Err(e) = self
+                .handle_update_component_task(
+                    Arc::clone(&component_id),
+                    Arc::clone(&new_component_ref),
+                    &host_id,
+                    annotations,
+                )
+                .await
+            {
+                error!(%new_component_ref, %component_id, err = ?e, "failed to update component");
+            }
+        });
+
+        Ok(CtlResponse::<()>::success(message))
+    }
+
+    async fn handle_update_component_task(
+        &self,
+        component_id: Arc<str>,
+        new_component_ref: Arc<str>,
+        host_id: &str,
+        annotations: Option<BTreeMap<String, String>>,
+    ) -> anyhow::Result<()> {
+        // NOTE: This block is specifically scoped to ensure we drop the read lock on `self.components` before
+        // we attempt to grab a write lock.
+        let component = {
+            let components = self.components.read().await;
+            let existing_component = components
+                .get(&*component_id)
+                .context("component not found")?;
+            let annotations = annotations.unwrap_or_default().into_iter().collect();
+
+            // task is a no-op if the component image reference is the same
+            if existing_component.image_reference == new_component_ref {
+                info!(%component_id, %new_component_ref, "component already updated");
+                return Ok(());
+            }
+
+            let new_component = self.fetch_component(&new_component_ref).await?;
+            let new_component = wasmcloud_runtime::Component::new(&self.runtime, &new_component)
+                .context("failed to initialize component")?;
+            let new_claims = new_component.claims().cloned();
+            if let Some(ref claims) = new_claims {
+                self.store_claims(Claims::Component(claims.clone()))
+                    .await
+                    .context("failed to store claims")?;
+            }
+
+            let max = existing_component.max_instances;
+            let Ok(component) = self
+                .instantiate_component(
+                    &annotations,
+                    Arc::clone(&new_component_ref),
+                    Arc::clone(&component_id),
+                    max,
+                    new_component,
+                    existing_component.handler.copy_for_new(),
+                )
+                .await
+            else {
+                bail!("failed to instantiate component from new reference");
+            };
+
+            info!(%new_component_ref, "component updated");
+            self.publish_event(
+                "component_scaled",
+                event::component_scaled(
+                    new_claims.as_ref(),
+                    &component.annotations,
+                    host_id,
+                    max,
+                    new_component_ref,
+                    &component_id,
+                ),
+            )
+            .await?;
+
+            // TODO(#1548): If this errors, we need to rollback
+            self.stop_component(&component, host_id)
+                .await
+                .context("failed to stop old component")?;
+            self.publish_event(
+                "component_scaled",
+                event::component_scaled(
+                    component.claims(),
+                    &component.annotations,
+                    host_id,
+                    0_usize,
+                    &component.image_reference,
+                    &component.id,
+                ),
+            )
+            .await?;
+
+            component
+        };
+
+        self.components
+            .write()
+            .await
+            .insert(component_id.to_string(), component);
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_start_provider(
+        self: Arc<Self>,
+        payload: impl AsRef<[u8]>,
+        host_id: &str,
+    ) -> anyhow::Result<CtlResponse<()>> {
+        let cmd = serde_json::from_slice::<StartProviderCommand>(payload.as_ref())
+            .context("failed to deserialize provider start command")?;
+
+        if self.providers.read().await.contains_key(cmd.provider_id()) {
+            return Ok(CtlResponse::error(
+                "provider with that ID is already running",
+            ));
+        }
+
+        info!(
+            provider_ref = cmd.provider_ref(),
+            provider_id = cmd.provider_id(),
+            "handling start provider"
+        ); // Log at info since starting providers can take a while
+
+        let host_id = host_id.to_string();
+        spawn(async move {
+            let config = cmd.config();
+            let provider_id = cmd.provider_id();
+            let provider_ref = cmd.provider_ref();
+            let annotations = cmd.annotations();
+            if let Err(err) = self
+                .handle_start_provider_task(
+                    config,
+                    provider_id,
+                    provider_ref,
+                    annotations.cloned().unwrap_or_default(),
+                    &host_id,
+                )
+                .await
+            {
+                error!(provider_ref, provider_id, ?err, "failed to start provider");
+                if let Err(err) = self
+                    .publish_event(
+                        "provider_start_failed",
+                        event::provider_start_failed(provider_ref, provider_id, &err),
+                    )
+                    .await
+                {
+                    error!(?err, "failed to publish provider_start_failed event");
+                }
+            }
+        });
+        Ok(CtlResponse::<()>::success(
+            "successfully started provider".into(),
+        ))
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_start_provider_task(
+        &self,
+        config: &[String],
+        provider_id: &str,
+        provider_ref: &str,
+        annotations: BTreeMap<String, String>,
+        host_id: &str,
+    ) -> anyhow::Result<()> {
+        trace!(provider_ref, provider_id, "start provider task");
+
+        let registry_config = self.registry_config.read().await;
+        let (path, claims_token) = crate::fetch_provider(
+            provider_ref,
+            host_id,
+            self.config.allow_file_load,
+            &registry_config,
+        )
+        .await
+        .context("failed to fetch provider")?;
+        let claims = claims_token.as_ref().map(|t| t.claims.clone());
+
+        if let Some(claims) = claims.clone() {
+            self.store_claims(Claims::Provider(claims))
+                .await
+                .context("failed to store claims")?;
+        }
+
+        let annotations: Annotations = annotations.into_iter().collect();
+
+        let PolicyResponse {
+            permitted,
+            request_id,
+            message,
+        } = self
+            .policy_manager
+            .evaluate_start_provider(provider_id, provider_ref, &annotations, claims.as_ref())
+            .await?;
+        ensure!(
+            permitted,
+            "policy denied request to start provider `{request_id}`: `{message:?}`",
+        );
+
+        let component_specification = self
+            .get_component_spec(provider_id)
+            .await?
+            .unwrap_or_else(|| ComponentSpecification::new(provider_ref));
+
+        self.store_component_spec(&provider_id, &component_specification)
+            .await?;
+
+        let (config, secrets) = self
+            .fetch_config_and_secrets(
+                config,
+                claims_token.as_ref().map(|t| &t.jwt),
+                annotations.get("wasmcloud.dev/appspec"),
+            )
+            .await?;
+
+        let mut providers = self.providers.write().await;
+        if let hash_map::Entry::Vacant(entry) = providers.entry(provider_id.into()) {
+            let lattice_rpc_user_seed = self
+                .config
+                .rpc_key
+                .as_ref()
+                .map(|key| key.seed())
+                .transpose()
+                .context("private key missing for provider RPC key")?;
+            let default_rpc_timeout_ms = Some(
+                self.config
+                    .rpc_timeout
+                    .as_millis()
+                    .try_into()
+                    .context("failed to convert rpc_timeout to u64")?,
+            );
+            let otel_config = OtelConfig {
+                enable_observability: self.config.otel_config.enable_observability,
+                enable_traces: self.config.otel_config.enable_traces,
+                enable_metrics: self.config.otel_config.enable_metrics,
+                enable_logs: self.config.otel_config.enable_logs,
+                observability_endpoint: self.config.otel_config.observability_endpoint.clone(),
+                traces_endpoint: self.config.otel_config.traces_endpoint.clone(),
+                metrics_endpoint: self.config.otel_config.metrics_endpoint.clone(),
+                logs_endpoint: self.config.otel_config.logs_endpoint.clone(),
+                protocol: self.config.otel_config.protocol,
+                additional_ca_paths: self.config.otel_config.additional_ca_paths.clone(),
+                trace_level: self.config.otel_config.trace_level.clone(),
+            };
+
+            let provider_xkey = XKey::new();
+            // The provider itself needs to know its private key
+            let provider_xkey_private_key = if let Ok(seed) = provider_xkey.seed() {
+                seed
+            } else if self.config.secrets_topic_prefix.is_none() {
+                "".to_string()
+            } else {
+                // This should never happen since this returns an error when an Xkey is
+                // created from a public key, but if we can't generate one for whatever
+                // reason, we should bail.
+                bail!("failed to generate seed for provider xkey")
+            };
+            // We only need to store the public key of the provider xkey, as the private key is only needed by the provider
+            let xkey = XKey::from_public_key(&provider_xkey.public_key())
+                .context("failed to create XKey from provider public key xkey")?;
+
+            // Prepare startup links by generating the source and target configs. Note that because the provider may be the source
+            // or target of a link, we need to iterate over all links to find the ones that involve the provider.
+            let all_links = self.links.read().await;
+            let provider_links = all_links
+                .values()
+                .flatten()
+                .filter(|link| link.source_id() == provider_id || link.target() == provider_id);
+            let link_definitions = stream::iter(provider_links)
+                .filter_map(|link| async {
+                    if link.source_id() == provider_id || link.target() == provider_id {
+                        match self
+                            .resolve_link_config(
+                                link.clone(),
+                                claims_token.as_ref().map(|t| &t.jwt),
+                                annotations.get("wasmcloud.dev/appspec"),
+                                &xkey,
+                            )
+                            .await
+                        {
+                            Ok(provider_link) => Some(provider_link),
+                            Err(e) => {
+                                error!(
+                                    error = ?e,
+                                    provider_id,
+                                    source_id = link.source_id(),
+                                    target = link.target(),
+                                    "failed to resolve link config, skipping link"
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<wasmcloud_core::InterfaceLinkDefinition>>()
+                .await;
+
+            let secrets = {
+                // NOTE(brooksmtownsend): This trait import is used here to ensure we're only exposing secret
+                // values when we need them.
+                use secrecy::ExposeSecret;
+                secrets
+                    .iter()
+                    .map(|(k, v)| match v.expose_secret() {
+                        SecretValue::String(s) => (
+                            k.clone(),
+                            wasmcloud_core::secrets::SecretValue::String(s.to_owned()),
+                        ),
+                        SecretValue::Bytes(b) => (
+                            k.clone(),
+                            wasmcloud_core::secrets::SecretValue::Bytes(b.to_owned()),
+                        ),
+                    })
+                    .collect()
+            };
+
+            let host_data = HostData {
+                host_id: self.host_key.clone(),
+                lattice_rpc_prefix: (*self.name).into(),
+                link_name: "default".to_string(),
+                lattice_rpc_user_jwt: self.config.rpc_jwt.clone().unwrap_or_default(),
+                lattice_rpc_user_seed: lattice_rpc_user_seed.unwrap_or_default(),
+                lattice_rpc_url: self.config.rpc_nats_url.to_string(),
+                env_values: vec![],
+                instance_id: Uuid::new_v4().to_string(),
+                provider_key: provider_id.to_string(),
+                link_definitions,
+                config: config.get_config().await.clone(),
+                secrets,
+                provider_xkey_private_key,
+                host_xkey_public_key: self.secrets_xkey.public_key(),
+                cluster_issuers: vec![],
+                default_rpc_timeout_ms,
+                log_level: Some(self.config.log_level.clone()),
+                structured_logging: self.config.enable_structured_logging,
+                otel_config,
+            };
+            let host_data =
+                serde_json::to_vec(&host_data).context("failed to serialize provider data")?;
+
+            trace!("spawn provider process");
+
+            let mut child_cmd = process::Command::new(&path);
+            // Prevent the provider from inheriting the host's environment, with the exception of
+            // the following variables we manually add back
+            child_cmd.env_clear();
+
+            if cfg!(windows) {
+                // Proxy SYSTEMROOT to providers. Without this, providers on Windows won't be able to start
+                child_cmd.env(
+                    "SYSTEMROOT",
+                    env::var("SYSTEMROOT")
+                        .context("SYSTEMROOT is not set. Providers cannot be started")?,
+                );
+            }
+
+            // Proxy RUST_LOG to (Rust) providers, so they can use the same module-level directives
+            if let Ok(rust_log) = env::var("RUST_LOG") {
+                let _ = child_cmd.env("RUST_LOG", rust_log);
+            }
+
+            let mut child = child_cmd
+                .stdin(Stdio::piped())
+                .kill_on_drop(true)
+                .spawn()
+                .context("failed to spawn provider process")?;
+            let mut stdin = child.stdin.take().context("failed to take stdin")?;
+            stdin
+                .write_all(STANDARD.encode(&host_data).as_bytes())
+                .await
+                .context("failed to write provider data")?;
+            stdin
+                .write_all(b"\r\n")
+                .await
+                .context("failed to write newline")?;
+            stdin.shutdown().await.context("failed to close stdin")?;
+
+            // Create a channel for watching for child process exit
+            let (exit_tx, exit_rx) = broadcast::channel::<()>(1);
+            spawn(async move {
+                match child.wait().await {
+                    Ok(status) => {
+                        debug!("provider @ [{}] exited with `{status:?}`", path.display());
+                    }
+                    Err(e) => {
+                        error!(
+                            "failed to wait for provider @ [{}] to execute: {e}",
+                            path.display()
+                        );
+                    }
+                }
+                if let Err(err) = exit_tx.send(()) {
+                    warn!(%err, "failed to send exit tx");
+                }
+            });
+            let mut exit_health_rx = exit_rx.resubscribe();
+
+            // TODO: Change method receiver to Arc<Self> and `move` into the closure
+            let rpc_nats = self.rpc_nats.clone();
+            //let ctl_nats = self.ctl_nats.clone();
+            // NOTE: health_lattice here is to allow us to move the variables into the closure
+            let health_lattice = (*self.name).to_string();
+            let health_host_id = host_id.to_string();
+            let health_provider_id = provider_id.to_string();
+            let event_rx = self.event_rx.clone();
+            let lattice_name = (*self.name).to_string();
+            let health_check_task = spawn(async move {
+                // Check the health of the provider every 30 seconds
+                let mut health_check = tokio::time::interval(Duration::from_secs(30));
+                let mut previous_healthy = false;
+                // Allow the provider 5 seconds to initialize
+                health_check.reset_after(Duration::from_secs(5));
+                let health_topic =
+                    format!("wasmbus.rpc.{health_lattice}.{health_provider_id}.health");
+                // TODO: Refactor this logic to simplify nesting
+                loop {
+                    select! {
+                        _ = health_check.tick() => {
+                            trace!(provider_id=health_provider_id, "performing provider health check");
+                            let request = async_nats::Request::new()
+                                .payload(Bytes::new())
+                                .headers(injector_to_headers(&TraceContextInjector::default_with_span()));
+                            if let Ok(async_nats::Message { payload, ..}) = rpc_nats.send_request(
+                                health_topic.clone(),
+                                request,
+                                ).await {
+                                    match (serde_json::from_slice::<HealthCheckResponse>(&payload), previous_healthy) {
+                                        (Ok(HealthCheckResponse { healthy: true, ..}), false) => {
+                                            trace!(provider_id=health_provider_id, "provider health check succeeded");
+                                            previous_healthy = true;
+                                            if let Err(e)= publish_event(
+                                            event_rx.clone(),
+                                                "health_check_passed".to_string(),
+                                                lattice_name.clone(),
+                                                event::provider_health_check(
+                                                    &health_host_id,
+                                                    &health_provider_id,
+                                                )
+                                            ).await {
+                                                warn!(
+                                                    ?e,
+                                                    provider_id = health_provider_id,
+                                                    "failed to publish provider health check succeeded event",
+                                                );
+                                            }
+                                        },
+                                        (Ok(HealthCheckResponse { healthy: false, ..}), true) => {
+                                            trace!(provider_id=health_provider_id, "provider health check failed");
+                                            previous_healthy = false;
+                                            if let Err(e) = publish_event(
+                                                event_rx.clone(),
+                                                "health_check_failed".to_string(),
+                                                lattice_name.clone(),
+                                                event::provider_health_check(
+                                                    &health_host_id,
+                                                    &health_provider_id,
+                                                )
+                                            ).await {
+                                                warn!(
+                                                    ?e,
+                                                    provider_id = health_provider_id,
+                                                    "failed to publish provider health check failed event",
+                                                );
+                                            }
+                                        }
+                                        // If the provider health status didn't change, we simply publish a health check status event
+                                        (Ok(_), _) => {
+                                            if let Err(e) = publish_event(
+                                        event_rx.clone(),
+                                                "health_check_status".to_string(),
+                                                lattice_name.clone(),
+                                                event::provider_health_check(
+                                                    &health_host_id,
+                                                    &health_provider_id,
+                                                )
+                                            ).await {
+                                                warn!(
+                                                    ?e,
+                                                    provider_id = health_provider_id,
+                                                    "failed to publish provider health check status event",
+                                                );
+                                            }
+                                        },
+                                        _ => warn!(
+                                            provider_id = health_provider_id,
+                                            "failed to deserialize provider health check response"
+                                        ),
+                                    }
+                                }
+                                else {
+                                    warn!(provider_id = health_provider_id, "failed to request provider health, retrying in 30 seconds");
+                                }
+                        }
+                        exit = exit_health_rx.recv() => {
+                            if let Err(err) = exit {
+                                warn!(%err, provider_id = health_provider_id, "failed to receive exit in health check task");
+                            }
+                            break;
+                        }
+                    }
+                }
+            });
+            info!(provider_ref, provider_id, "provider started");
+            self.publish_event(
+                "provider_started",
+                event::provider_started(
+                    claims.as_ref(),
+                    &annotations,
+                    host_id,
+                    provider_ref,
+                    provider_id,
+                ),
+            )
+            .await?;
+
+            // Spawn off a task to watch for config bundle updates and forward them to
+            // the provider that we're spawning and managing
+            let mut exit_config_tx = exit_rx;
+            let provider_id = provider_id.to_string();
+            let lattice = (*self.name).to_string();
+            let client = self.rpc_nats.clone();
+            let config = Arc::new(RwLock::new(config));
+            let update_config = config.clone();
+            let config_update_task = spawn(async move {
+                let subject = provider_config_update_subject(&lattice, &provider_id);
+                trace!(provider_id, "starting config update listener");
+                loop {
+                    let mut update_config = update_config.write().await;
+                    select! {
+                        maybe_update = update_config.changed() => {
+                            let Ok(update) = maybe_update else {
+                                break;
+                            };
+                            trace!(provider_id, "provider config bundle changed");
+                            let bytes = match serde_json::to_vec(&*update) {
+                                Ok(bytes) => bytes,
+                                Err(err) => {
+                                    error!(%err, provider_id, lattice, "failed to serialize configuration update ");
+                                    continue;
+                                }
+                            };
+                            trace!(provider_id, subject, "publishing config bundle bytes");
+                            if let Err(err) = client.publish(subject.clone(), Bytes::from(bytes)).await {
+                                error!(%err, provider_id, lattice, "failed to publish configuration update bytes to component");
+                            }
+                        }
+                        exit = exit_config_tx.recv() => {
+                            if let Err(err) = exit {
+                                warn!(%err, provider_id, "failed to receive exit in config update task");
+                            }
+                            break;
+                        }
+                    }
+                }
+            });
+
+            // Add the provider
+            entry.insert(Provider {
+                health_check_task,
+                config_update_task,
+                annotations,
+                claims_token,
+                image_ref: provider_ref.to_string(),
+                xkey,
+                config,
+            });
+        } else {
+            bail!("provider is already running with that ID")
+        }
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_stop_provider(
+        &self,
+        payload: impl AsRef<[u8]>,
+        host_id: &str,
+    ) -> anyhow::Result<CtlResponse<()>> {
+        let cmd = serde_json::from_slice::<StopProviderCommand>(payload.as_ref())
+            .context("failed to deserialize provider stop command")?;
+        let provider_id = cmd.provider_id();
+
+        debug!(provider_id, "handling stop provider");
+
+        let mut providers = self.providers.write().await;
+        let hash_map::Entry::Occupied(entry) = providers.entry(provider_id.into()) else {
+            warn!(
+                provider_id,
+                "received request to stop provider that is not running"
+            );
+            return Ok(CtlResponse::error("provider with that ID is not running"));
+        };
+        let Provider {
+            ref annotations, ..
+        } = entry.remove();
+
+        // Send a request to the provider, requesting a graceful shutdown
+        let req = serde_json::to_vec(&json!({ "host_id": host_id }))
+            .context("failed to encode provider stop request")?;
+        let req = async_nats::Request::new()
+            .payload(req.into())
+            .timeout(self.config.provider_shutdown_delay)
+            .headers(injector_to_headers(
+                &TraceContextInjector::default_with_span(),
+            ));
+        if let Err(e) = self
+            .rpc_nats
+            .send_request(
+                format!(
+                    "wasmbus.rpc.{}.{provider_id}.default.shutdown",
+                    &(*self.name),
+                ),
+                req,
+            )
+            .await
+        {
+            warn!(
+                ?e,
+                provider_id,
+                "provider did not gracefully shut down in time, shutting down forcefully"
+            );
+        }
+        info!(provider_id, "provider stopped");
+        self.publish_event(
+            "provider_stopped",
+            event::provider_stopped(annotations, host_id, provider_id, "stop"),
+        )
+        .await?;
+        Ok(CtlResponse::<()>::success(
+            "successfully stopped provider".into(),
+        ))
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    async fn handle_claims(&self) -> anyhow::Result<CtlResponse<Vec<HashMap<String, String>>>> {
+        trace!("handling claims");
+
+        let (component_claims, provider_claims) =
+            join!(self.component_claims.read(), self.provider_claims.read());
+        let component_claims = component_claims.values().cloned().map(Claims::Component);
+        let provider_claims = provider_claims.values().cloned().map(Claims::Provider);
+        let claims: Vec<StoredClaims> = component_claims
+            .chain(provider_claims)
+            .flat_map(TryFrom::try_from)
+            .collect();
+
+        Ok(CtlResponse::ok(
+            claims.into_iter().map(std::convert::Into::into).collect(),
+        ))
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    async fn handle_links(&self) -> anyhow::Result<Vec<u8>> {
+        trace!("handling links");
+
+        let links = self.links.read().await;
+        let links: Vec<&Link> = links.values().flatten().collect();
+        let res =
+            serde_json::to_vec(&CtlResponse::ok(links)).context("failed to serialize response")?;
+        Ok(res)
+    }
+
+    #[instrument(level = "trace", skip(self))]
+    async fn handle_config_get(&self, config_name: &str) -> anyhow::Result<Vec<u8>> {
+        trace!(%config_name, "handling get config");
+        if let Some(config_bytes) = self.config_data.get(config_name).await? {
+            let config_map: HashMap<String, String> = serde_json::from_slice(&config_bytes)
+                .context("config data should be a map of string -> string")?;
+            serde_json::to_vec(&CtlResponse::ok(config_map)).map_err(anyhow::Error::from)
+        } else {
+            serde_json::to_vec(&CtlResponse::<()>::success(
+                "Configuration not found".into(),
+            ))
+            .map_err(anyhow::Error::from)
+        }
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_label_put(
+        &self,
+        host_id: &str,
+        payload: impl AsRef<[u8]>,
+    ) -> anyhow::Result<CtlResponse<()>> {
+        let host_label = serde_json::from_slice::<HostLabel>(payload.as_ref())
+            .context("failed to deserialize put label request")?;
+        let key = host_label.key();
+        let value = host_label.value();
+        let mut labels = self.labels.write().await;
+        match labels.entry(key.into()) {
+            BTreeMapEntry::Occupied(mut entry) => {
+                info!(key = entry.key(), value, "updated label");
+                entry.insert(value.into());
+            }
+            BTreeMapEntry::Vacant(entry) => {
+                info!(key = entry.key(), value, "set label");
+                entry.insert(value.into());
+            }
+        }
+
+        self.publish_event(
+            "labels_changed",
+            event::labels_changed(host_id, HashMap::from_iter(labels.clone())),
+        )
+        .await
+        .context("failed to publish labels_changed event")?;
+
+        Ok(CtlResponse::<()>::success("successfully put label".into()))
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_label_del(
+        &self,
+        host_id: &str,
+        payload: impl AsRef<[u8]>,
+    ) -> anyhow::Result<CtlResponse<()>> {
+        let label = serde_json::from_slice::<HostLabel>(payload.as_ref())
+            .context("failed to deserialize delete label request")?;
+        let key = label.key();
+        let mut labels = self.labels.write().await;
+        let value = labels.remove(key);
+
+        if value.is_none() {
+            warn!(key, "could not remove unset label");
+            return Ok(CtlResponse::<()>::success(
+                "successfully deleted label (no such label)".into(),
+            ));
+        };
+
+        info!(key, "removed label");
+        self.publish_event(
+            "labels_changed",
+            event::labels_changed(host_id, HashMap::from_iter(labels.clone())),
+        )
+        .await
+        .context("failed to publish labels_changed event")?;
+
+        Ok(CtlResponse::<()>::success(
+            "successfully deleted label".into(),
+        ))
+    }
+
+    /// Handle a new link by modifying the relevant source [ComponentSpeficication]. Once
+    /// the change is written to the LATTICEDATA store, each host in the lattice (including this one)
+    /// will handle the new specification and update their own internal link maps via [process_component_spec_put].
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_link_put(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<CtlResponse<()>> {
+        let payload = payload.as_ref();
+        let link: Link = serde_json::from_slice(payload)
+            .context("failed to deserialize wrpc link definition")?;
+
+        let link_set_result: anyhow::Result<()> = async {
+                        let source_id = link.source_id();
+            let target = link.target();
+            let wit_namespace = link.wit_namespace();
+            let wit_package = link.wit_package();
+            let interfaces = link.interfaces();
+            let name = link.name();
+
+            let ns_and_package = format!("{wit_namespace}:{wit_package}");
+                        debug!(
+                source_id,
+                target,
+                ns_and_package,
+                name,
+                ?interfaces,
+                "handling put wrpc link definition"
+            );
+
+            // Validate all configurations
+              self.validate_config(
+                link
+                    .source_config()
+                    .clone()
+                    .iter()
+                    .chain(link.target_config())
+            ).await?;
+
+            let mut component_spec = self
+                .get_component_spec(source_id)
+                .await?
+                .unwrap_or_default();
+
+            // If the link is defined from this source on the same interface and link name, but to a different target,
+            // we need to reject this link and suggest deleting the existing link or using a different link name.
+            if let Some(existing_conflict_link) = component_spec.links.iter().find(|link| {
+                link.source_id() == source_id
+                    && link.wit_namespace() == wit_namespace
+                    && link.wit_package() == wit_package
+                    && link.name() == name
+                    && link.target() != target
+            }) {
+                error!(source_id, desired_target = target, existing_target = existing_conflict_link.target(), ns_and_package, name, "link already exists with different target, consider deleting the existing link or using a different link name");
+                bail!("link already exists with different target, consider deleting the existing link or using a different link name");
+            }
+
+            // If we can find an existing link with the same source, target, namespace, package, and name, update it.
+            // Otherwise, add the new link to the component specification.
+            if let Some(existing_link_index) = component_spec.links.iter().position(|link| {
+                link.source_id() == source_id
+                    && link.target() == target
+                    && link.wit_namespace() == wit_namespace
+                    && link.wit_package() == wit_package
+                    && link.name() == name
+            }) {
+                if let Some(existing_link) = component_spec.links.get_mut(existing_link_index) {
+                    *existing_link = link.clone();
+                }
+            } else {
+                component_spec.links.push(link.clone());
+            };
+
+            // Update component specification with the new link
+            self.store_component_spec(&source_id, &component_spec)
+                .await?;
+
+            self.put_backwards_compat_provider_link(&link)
+                .await?;
+
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = link_set_result {
+            self.publish_event("linkdef_set_failed", event::linkdef_set_failed(&link, &e))
+                .await?;
+            Ok(CtlResponse::error(e.to_string().as_ref()))
+        } else {
+            self.publish_event("linkdef_set", event::linkdef_set(&link))
+                .await?;
+            Ok(CtlResponse::<()>::success("successfully set link".into()))
+        }
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    /// Remove an interface link on a source component for a specific package
+    async fn handle_link_del(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<CtlResponse<()>> {
+        let payload = payload.as_ref();
+        let req = serde_json::from_slice::<DeleteInterfaceLinkDefinitionRequest>(payload)
+            .context("failed to deserialize wrpc link definition")?;
+        let source_id = req.source_id();
+        let wit_namespace = req.wit_namespace();
+        let wit_package = req.wit_package();
+        let link_name = req.link_name();
+
+        let ns_and_package = format!("{wit_namespace}:{wit_package}");
+
+        debug!(
+            source_id,
+            ns_and_package, link_name, "handling del wrpc link definition"
+        );
+
+        let Some(mut component_spec) = self.get_component_spec(source_id).await? else {
+            // If the component spec doesn't exist, the link is deleted
+            return Ok(CtlResponse::<()>::success(
+                "successfully deleted link (spec doesn't exist)".into(),
+            ));
+        };
+
+        // If we can find an existing link with the same source, namespace, package, and name, remove it
+        // and update the component specification.
+        let deleted_link = if let Some(existing_link_index) =
+            component_spec.links.iter().position(|link| {
+                link.source_id() == source_id
+                    && link.wit_namespace() == wit_namespace
+                    && link.wit_package() == wit_package
+                    && link.name() == link_name
+            }) {
+            // Sanity safety check since `swap_remove` will panic if the index is out of bounds
+            if existing_link_index < component_spec.links.len() {
+                Some(component_spec.links.swap_remove(existing_link_index))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(link) = deleted_link.as_ref() {
+            // Update component specification with the deleted link
+            self.store_component_spec(&source_id, &component_spec)
+                .await?;
+
+            // Send the link to providers for deletion
+            self.del_provider_link(link).await?;
+        }
+
+        // For idempotency, we always publish the deleted event, even if the link didn't exist
+        let deleted_link_target = deleted_link
+            .as_ref()
+            .map(|link| String::from(link.target()));
+        self.publish_event(
+            "linkdef_deleted",
+            event::linkdef_deleted(
+                source_id,
+                deleted_link_target.as_ref(),
+                link_name,
+                wit_namespace,
+                wit_package,
+                deleted_link.as_ref().map(|link| link.interfaces()),
+            ),
+        )
+        .await?;
+
+        Ok(CtlResponse::<()>::success(
+            "successfully deleted link".into(),
+        ))
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_registries_put(
+        &self,
+        payload: impl AsRef<[u8]>,
+    ) -> anyhow::Result<CtlResponse<()>> {
+        let registry_creds: HashMap<String, RegistryCredential> =
+            serde_json::from_slice(payload.as_ref())
+                .context("failed to deserialize registries put command")?;
+
+        info!(
+            registries = ?registry_creds.keys(),
+            "updating registry config",
+        );
+
+        let mut registry_config = self.registry_config.write().await;
+        for (reg, new_creds) in registry_creds {
+            let mut new_config = new_creds.into_registry_config()?;
+            match registry_config.entry(reg) {
+                hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().set_auth(new_config.auth().clone());
+                }
+                hash_map::Entry::Vacant(entry) => {
+                    new_config.set_allow_latest(self.config.oci_opts.allow_latest);
+                    entry.insert(new_config);
+                }
+            }
+        }
+
+        Ok(CtlResponse::<()>::success(
+            "successfully put registries".into(),
+        ))
+    }
+
+    #[instrument(level = "debug", skip_all, fields(%config_name))]
+    async fn handle_config_put(
+        &self,
+        config_name: &str,
+        data: Bytes,
+    ) -> anyhow::Result<CtlResponse<()>> {
+        debug!("handle config entry put");
+        // Validate that the data is of the proper type by deserialing it
+        serde_json::from_slice::<HashMap<String, String>>(&data)
+            .context("config data should be a map of string -> string")?;
+        self.config_data
+            .put(config_name, data)
+            .await
+            .context("unable to store config data")?;
+        // We don't write it into the cached data and instead let the caching thread handle it as we
+        // won't need it immediately.
+        self.publish_event("config_set", event::config_set(config_name))
+            .await?;
+
+        Ok(CtlResponse::<()>::success("successfully put config".into()))
+    }
+
+    #[instrument(level = "debug", skip_all, fields(%config_name))]
+    async fn handle_config_delete(&self, config_name: &str) -> anyhow::Result<CtlResponse<()>> {
+        debug!("handle config entry deletion");
+
+        self.config_data
+            .purge(config_name)
+            .await
+            .context("Unable to delete config data")?;
+
+        self.publish_event("config_deleted", event::config_deleted(config_name))
+            .await?;
+
+        Ok(CtlResponse::<()>::success(
+            "successfully deleted config".into(),
+        ))
+    }
+
+    #[instrument(level = "trace", skip_all, fields(subject = %message.subject))]
+    async fn handle_ctl_message(self: Arc<Self>, message: async_nats::Message) {
+        // NOTE: if log level is not `trace`, this won't have an effect, since the current span is
+        // disabled. In most cases that's fine, since we aren't aware of any control interface
+        // requests including a trace context
+        opentelemetry_nats::attach_span_context(&message);
+        // Skip the topic prefix, the version, and the lattice
+        // e.g. `wasmbus.ctl.v1.{prefix}`
+        let subject = message.subject;
+        let mut parts = subject
+            .trim()
+            .trim_start_matches(&self.ctl_topic_prefix)
+            .trim_start_matches('.')
+            .split('.')
+            .skip(2);
+        trace!(%subject, "handling control interface request");
+
+        // This response is a wrapped Result<Option<Result<Vec<u8>>>> for a good reason.
+        // The outer Result is for reporting protocol errors in handling the request, e.g. failing to
+        //    deserialize the request payload.
+        // The Option is for the case where the request is handled successfully, but the handler
+        //    doesn't want to send a response back to the client, like with an auction.
+        // The inner Result is purely for the success or failure of serializing the [CtlResponse], which
+        //    should never fail but it's a result we must handle.
+        // And finally, the Vec<u8> is the serialized [CtlResponse] that we'll send back to the client
+        let ctl_response = match (parts.next(), parts.next(), parts.next(), parts.next()) {
+            // Component commands
+            (Some("component"), Some("auction"), None, None) => self
+                .handle_auction_component(message.payload)
+                .await
+                .map(serialize_ctl_response),
+            (Some("component"), Some("scale"), Some(host_id), None) => Arc::clone(&self)
+                .handle_scale_component(message.payload, host_id)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            (Some("component"), Some("update"), Some(host_id), None) => Arc::clone(&self)
+                .handle_update_component(message.payload, host_id)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Provider commands
+            (Some("provider"), Some("auction"), None, None) => self
+                .handle_auction_provider(message.payload)
+                .await
+                .map(serialize_ctl_response),
+            (Some("provider"), Some("start"), Some(host_id), None) => Arc::clone(&self)
+                .handle_start_provider(message.payload, host_id)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            (Some("provider"), Some("stop"), Some(host_id), None) => self
+                .handle_stop_provider(message.payload, host_id)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Claims commands
+            (Some("claims"), Some("get"), None, None) => self
+                .handle_claims()
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Link commands
+            (Some("link"), Some("del"), None, None) => self
+                .handle_link_del(message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            (Some("link"), Some("get"), None, None) => {
+                // Explicitly returning a Vec<u8> for non-cloning efficiency within handle_links
+                self.handle_links().await.map(|bytes| Some(Ok(bytes)))
+            }
+            (Some("link"), Some("put"), None, None) => self
+                .handle_link_put(message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Registry commands
+            (Some("registry"), Some("put"), None, None) => self
+                .handle_registries_put(message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Config commands
+            (Some("config"), Some("get"), Some(config_name), None) => self
+                .handle_config_get(config_name)
+                .await
+                .map(|bytes| Some(Ok(bytes))),
+            (Some("config"), Some("put"), Some(config_name), None) => self
+                .handle_config_put(config_name, message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            (Some("config"), Some("del"), Some(config_name), None) => self
+                .handle_config_delete(config_name)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Topic fallback
+            _ => {
+                warn!(%subject, "received control interface request on unsupported subject");
+                Ok(serialize_ctl_response(Some(CtlResponse::error(
+                    "unsupported subject",
+                ))))
+            }
+        };
+
+        if let Err(err) = &ctl_response {
+            error!(%subject, ?err, "failed to handle control interface request");
+        } else {
+            trace!(%subject, "handled control interface request");
+        }
+
+        if let Some(reply) = message.reply {
+            let headers = injector_to_headers(&TraceContextInjector::default_with_span());
+
+            let payload = match ctl_response {
+                Ok(Some(Ok(payload))) => Some(payload.into()),
+                // No response from the host (e.g. auctioning provider)
+                Ok(None) => None,
+                Err(e) => Some(
+                    serde_json::to_vec(&CtlResponse::error(&e.to_string()))
+                        .context("failed to encode control interface response")
+                        // This should never fail to serialize, but the fallback ensures that we send
+                        // something back to the client even if we somehow fail.
+                        .unwrap_or_else(|_| format!(r#"{{"success":false,"error":"{e}"}}"#).into())
+                        .into(),
+                ),
+                // This would only occur if we failed to serialize a valid CtlResponse. This is
+                // programmer error.
+                Ok(Some(Err(e))) => Some(
+                    serde_json::to_vec(&CtlResponse::error(&e.to_string()))
+                        .context("failed to encode control interface response")
+                        .unwrap_or_else(|_| format!(r#"{{"success":false,"error":"{e}"}}"#).into())
+                        .into(),
+                ),
+            };
+
+            if let Some(payload) = payload {
+                if let Err(err) = self
+                    .ctl_nats
+                    .publish_with_headers(reply.clone(), headers, payload)
+                    .err_into::<anyhow::Error>()
+                    .and_then(|()| self.ctl_nats.flush().err_into::<anyhow::Error>())
+                    .await
+                {
+                    error!(%subject, ?err, "failed to publish reply to control interface request");
+                }
+            }
+        }
+    }
+
+    // TODO: Remove this before wasmCloud 1.2 is released. This is a backwards-compatible
+    // provider link definition put that is published to the provider's id, which is what
+    // providers built for wasmCloud 1.0 expected.
+    //
+    // Thankfully, in a lattice where there are no "older" providers running, these publishes
+    // will return immediately as there will be no subscribers on those topics.
+    async fn put_backwards_compat_provider_link(&self, link: &Link) -> anyhow::Result<()> {
+        // Only attempt to publish the backwards-compatible provider link definition if the link
+        // does not contain any secret values.
+        let source_config_contains_secret = link
+            .source_config()
+            .iter()
+            .any(|c| c.starts_with(SECRET_PREFIX));
+        let target_config_contains_secret = link
+            .target_config()
+            .iter()
+            .any(|c| c.starts_with(SECRET_PREFIX));
+        if source_config_contains_secret || target_config_contains_secret {
+            debug!("link contains secrets and is not backwards compatible, skipping");
+            return Ok(());
+        }
+        let provider_link = self
+            .resolve_link_config(link.clone(), None, None, &XKey::new())
+            .await
+            .context("failed to resolve link config")?;
+        let lattice = &self.name;
+        let payload: Bytes = serde_json::to_vec(&provider_link)
+            .context("failed to serialize provider link definition")?
+            .into();
+
+        if let Err(e) = self
+            .rpc_nats
+            .publish_with_headers(
+                format!("wasmbus.rpc.{lattice}.{}.linkdefs.put", link.source_id()),
+                injector_to_headers(&TraceContextInjector::default_with_span()),
+                payload.clone(),
+            )
+            .await
+        {
+            warn!(
+                ?e,
+                "failed to publish backwards-compatible provider link to source"
+            );
+        }
+
+        if let Err(e) = self
+            .rpc_nats
+            .publish_with_headers(
+                format!("wasmbus.rpc.{lattice}.{}.linkdefs.put", link.target()),
+                injector_to_headers(&TraceContextInjector::default_with_span()),
+                payload,
+            )
+            .await
+        {
+            warn!(
+                ?e,
+                "failed to publish backwards-compatible provider link to target"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Publishes a link to a provider running on this host to handle.
+    #[instrument(level = "debug", skip_all)]
+    async fn put_provider_link(&self, provider: &Provider, link: &Link) -> anyhow::Result<()> {
+        let provider_link = self
+            .resolve_link_config(
+                link.clone(),
+                provider.claims_token.as_ref().map(|t| &t.jwt),
+                provider.annotations.get("wasmcloud.dev/appspec"),
+                &provider.xkey,
+            )
+            .await
+            .context("failed to resolve link config and secrets")?;
+        let lattice = &self.name;
+        let payload: Bytes = serde_json::to_vec(&provider_link)
+            .context("failed to serialize provider link definition")?
+            .into();
+
+        self.rpc_nats
+            .publish_with_headers(
+                format!(
+                    "wasmbus.rpc.{lattice}.{}.linkdefs.put",
+                    provider.xkey.public_key()
+                ),
+                injector_to_headers(&TraceContextInjector::default_with_span()),
+                payload.clone(),
+            )
+            .await
+            .context("failed to publish provider link definition put")
+    }
+
+    /// Publishes a delete link to the lattice for all instances of a provider to handle
+    /// Right now this is publishing _both_ to the source and the target in order to
+    /// ensure that the provider is aware of the link delete. This would cause problems if a provider
+    /// is linked to a provider (which it should never be.)
+    #[instrument(level = "debug", skip(self))]
+    async fn del_provider_link(&self, link: &Link) -> anyhow::Result<()> {
+        let lattice = &self.name;
+        // The provider expects the [`wasmcloud_core::InterfaceLinkDefinition`]
+        let link = wasmcloud_core::InterfaceLinkDefinition {
+            source_id: link.source_id().to_string(),
+            target: link.target().to_string(),
+            wit_namespace: link.wit_namespace().to_string(),
+            wit_package: link.wit_package().to_string(),
+            name: link.name().to_string(),
+            interfaces: link.interfaces().clone(),
+            // Configuration isn't needed for deletion
+            ..Default::default()
+        };
+        let source_id = &link.source_id;
+        let target = &link.target;
+        let payload: Bytes = serde_json::to_vec(&link)
+            .context("failed to serialize provider link definition for deletion")?
+            .into();
+
+        let (source_result, target_result) = futures::future::join(
+            self.rpc_nats.publish_with_headers(
+                format!("wasmbus.rpc.{lattice}.{source_id}.linkdefs.del"),
+                injector_to_headers(&TraceContextInjector::default_with_span()),
+                payload.clone(),
+            ),
+            self.rpc_nats.publish_with_headers(
+                format!("wasmbus.rpc.{lattice}.{target}.linkdefs.del"),
+                injector_to_headers(&TraceContextInjector::default_with_span()),
+                payload,
+            ),
+        )
+        .await;
+
+        source_result
+            .and(target_result)
+            .context("failed to publish provider link definition delete")
+    }
+
+    /// Retrieve a component specification based on the provided ID. The outer Result is for errors
+    /// accessing the store, and the inner option indicates if the spec exists.
+    #[instrument(level = "debug", skip_all)]
+    async fn get_component_spec(&self, id: &str) -> anyhow::Result<Option<ComponentSpecification>> {
+        let key = format!("COMPONENT_{id}");
+        let spec = self
+            .data
+            .get(key)
+            .await
+            .context("failed to get component spec")?
+            .map(|spec_bytes| serde_json::from_slice(&spec_bytes))
+            .transpose()
+            .context(format!(
+                "failed to deserialize stored component specification for {id}"
+            ))?;
+        Ok(spec)
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn store_component_spec(
+        &self,
+        id: impl AsRef<str>,
+        spec: &ComponentSpecification,
+    ) -> anyhow::Result<()> {
+        let id = id.as_ref();
+        let key = format!("COMPONENT_{id}");
+        let bytes = serde_json::to_vec(spec)
+            .context("failed to serialize component spec")?
+            .into();
+        self.data
+            .put(key, bytes)
+            .await
+            .context("failed to put component spec")?;
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn store_claims(&self, claims: Claims) -> anyhow::Result<()> {
+        match &claims {
+            Claims::Component(claims) => {
+                self.store_component_claims(claims.clone()).await?;
+            }
+            Claims::Provider(claims) => {
+                let mut provider_claims = self.provider_claims.write().await;
+                provider_claims.insert(claims.subject.clone(), claims.clone());
+            }
+        };
+        let claims: StoredClaims = claims.try_into()?;
+        let subject = match &claims {
+            StoredClaims::Component(claims) => &claims.subject,
+            StoredClaims::Provider(claims) => &claims.subject,
+        };
+        let key = format!("CLAIMS_{subject}");
+        trace!(?claims, ?key, "storing claims");
+
+        let bytes = serde_json::to_vec(&claims)
+            .context("failed to serialize claims")?
+            .into();
+        self.data
+            .put(key, bytes)
+            .await
+            .context("failed to put claims")?;
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn process_component_spec_put(
+        &self,
+        id: impl AsRef<str>,
+        value: impl AsRef<[u8]>,
+        _publish: bool,
+    ) -> anyhow::Result<()> {
+        let id = id.as_ref();
+        debug!(id, "process component spec put");
+
+        let spec: ComponentSpecification = serde_json::from_slice(value.as_ref())
+            .context("failed to deserialize component specification")?;
+
+        // Compute all new links that do not exist in the host map, which we'll use to
+        // publish to any running providers that are the source or target of the link.
+        // Computing this ahead of time is a tradeoff to hold only one lock at the cost of
+        // allocating an extra Vec. This may be a good place to optimize allocations.
+        let new_links = {
+            let all_links = self.links.read().await;
+            spec.links
+                .iter()
+                .filter(|spec_link| {
+                    // Retain only links that do not exist in the host map
+                    !all_links
+                        .iter()
+                        .filter_map(|(source_id, links)| {
+                            // Only consider links that are either the source or target of the new link
+                            if source_id == spec_link.source_id() || source_id == spec_link.target()
+                            {
+                                Some(links)
+                            } else {
+                                None
+                            }
+                        })
+                        .flatten()
+                        .any(|host_link| *spec_link == host_link)
+                })
+                .collect::<Vec<_>>()
+        };
+
+        {
+            // Acquire lock once in this block to avoid continually trying to acquire it.
+            let providers = self.providers.read().await;
+            // For every new link, if a provider is running on this host as the source or target,
+            // send the link to the provider for handling based on the xkey public key.
+            for link in new_links {
+                if let Some(provider) = providers.get(link.source_id()) {
+                    if let Err(e) = self.put_provider_link(provider, link).await {
+                        error!(?e, "failed to put provider link");
+                    }
+                }
+                if let Some(provider) = providers.get(link.target()) {
+                    if let Err(e) = self.put_provider_link(provider, link).await {
+                        error!(?e, "failed to put provider link");
+                    }
+                }
+            }
+        }
+
+        // If the component is already running, update the links
+        if let Some(component) = self.components.write().await.get(id) {
+            *component.handler.instance_links.write().await = component_import_links(&spec.links);
+            // NOTE(brooksmtownsend): We can consider updating the component if the image URL changes
+        };
+
+        // Insert the links into host map
+        self.links.write().await.insert(id.to_string(), spec.links);
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn process_component_spec_delete(
+        &self,
+        id: impl AsRef<str>,
+        _value: impl AsRef<[u8]>,
+        _publish: bool,
+    ) -> anyhow::Result<()> {
+        let id = id.as_ref();
+        debug!(id, "process component delete");
+        // TODO: TBD: stop component if spec deleted?
+        if self.components.write().await.get(id).is_some() {
+            warn!(
+                component_id = id,
+                "component spec deleted, but component is still running"
+            );
+        }
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn process_claims_put(
+        &self,
+        pubkey: impl AsRef<str>,
+        value: impl AsRef<[u8]>,
+    ) -> anyhow::Result<()> {
+        let pubkey = pubkey.as_ref();
+
+        debug!(pubkey, "process claim entry put");
+
+        let stored_claims: StoredClaims =
+            serde_json::from_slice(value.as_ref()).context("failed to decode stored claims")?;
+        let claims = Claims::from(stored_claims);
+
+        ensure!(claims.subject() == pubkey, "subject mismatch");
+        match claims {
+            Claims::Component(claims) => self.store_component_claims(claims).await,
+            Claims::Provider(claims) => {
+                let mut provider_claims = self.provider_claims.write().await;
+                provider_claims.insert(claims.subject.clone(), claims);
+                Ok(())
+            }
+        }
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn process_claims_delete(
+        &self,
+        pubkey: impl AsRef<str>,
+        value: impl AsRef<[u8]>,
+    ) -> anyhow::Result<()> {
+        let pubkey = pubkey.as_ref();
+
+        debug!(pubkey, "process claim entry deletion");
+
+        let stored_claims: StoredClaims =
+            serde_json::from_slice(value.as_ref()).context("failed to decode stored claims")?;
+        let claims = Claims::from(stored_claims);
+
+        ensure!(claims.subject() == pubkey, "subject mismatch");
+
+        match claims {
+            Claims::Component(claims) => {
+                let mut component_claims = self.component_claims.write().await;
+                component_claims.remove(&claims.subject);
+            }
+            Claims::Provider(claims) => {
+                let mut provider_claims = self.provider_claims.write().await;
+                provider_claims.remove(&claims.subject);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    async fn process_entry(
+        &self,
+        KvEntry {
+            key,
+            value,
+            operation,
+            ..
+        }: KvEntry,
+        publish: bool,
+    ) {
+        let key_id = key.split_once('_');
+        let res = match (operation, key_id) {
+            (Operation::Put, Some(("COMPONENT", id))) => {
+                self.process_component_spec_put(id, value, publish).await
+            }
+            (Operation::Delete, Some(("COMPONENT", id))) => {
+                self.process_component_spec_delete(id, value, publish).await
+            }
+            (Operation::Put, Some(("LINKDEF", _id))) => {
+                debug!("ignoring deprecated LINKDEF put operation");
+                Ok(())
+            }
+            (Operation::Delete, Some(("LINKDEF", _id))) => {
+                debug!("ignoring deprecated LINKDEF delete operation");
+                Ok(())
+            }
+            (Operation::Put, Some(("CLAIMS", pubkey))) => {
+                self.process_claims_put(pubkey, value).await
+            }
+            (Operation::Delete, Some(("CLAIMS", pubkey))) => {
+                self.process_claims_delete(pubkey, value).await
+            }
+            (operation, Some(("REFMAP", id))) => {
+                // TODO: process REFMAP entries
+                debug!(?operation, id, "ignoring REFMAP entry");
+                Ok(())
+            }
+            _ => {
+                warn!(key, ?operation, "unsupported KV bucket entry");
+                Ok(())
+            }
+        };
+        if let Err(error) = &res {
+            error!(key, ?operation, ?error, "failed to process KV bucket entry");
+        }
+    }
+
+    async fn fetch_config_and_secrets(
+        &self,
+        config_names: &[String],
+        entity_jwt: Option<&String>,
+        application: Option<&String>,
+    ) -> anyhow::Result<(ConfigBundle, HashMap<String, Secret<SecretValue>>)> {
+        let (secret_names, config_names) = config_names
+            .iter()
+            .map(|s| s.to_string())
+            .partition(|name| name.starts_with(SECRET_PREFIX));
+
+        let config = self
+            .config_generator
+            .generate(config_names)
+            .await
+            .context("Unable to fetch requested config")?;
+
+        let secrets = self
+            .secrets_manager
+            .fetch_secrets(secret_names, entity_jwt, &self.host_token.jwt, application)
+            .await
+            .context("Unable to fetch requested secrets")?;
+
+        Ok((config, secrets))
+    }
+
+    /// Validates that the provided configuration names exist in the store and are valid.
+    ///
+    /// For any configuration that starts with `SECRET_`, the configuration is expected to be a secret reference.
+    /// For any other configuration, the configuration is expected to be a [`HashMap<String, String>`].
+    async fn validate_config<I>(&self, config_names: I) -> anyhow::Result<()>
+    where
+        I: IntoIterator<Item: AsRef<str>>,
+    {
+        let config_store = self.config_data.clone();
+        let validation_errors =
+            futures::future::join_all(config_names.into_iter().map(|config_name| {
+                let config_store = config_store.clone();
+                let config_name = config_name.as_ref().to_string();
+                async move {
+                    match config_store.get(&config_name).await {
+                        Ok(Some(_)) => None,
+                        Ok(None) if config_name.starts_with(SECRET_PREFIX) => Some(format!(
+                            "Secret reference {config_name} not found in config store"
+                        )),
+                        Ok(None) => Some(format!(
+                            "Configuration {config_name} not found in config store"
+                        )),
+                        Err(e) => Some(e.to_string()),
+                    }
+                }
+            }))
+            .await;
+
+        // NOTE(brooksmtownsend): Not using `join` here because it requires a `String` and we
+        // need to flatten out the `None` values.
+        let validation_errors = validation_errors
+            .into_iter()
+            .flatten()
+            .fold(String::new(), |acc, e| acc + &e + ". ");
+        if !validation_errors.is_empty() {
+            bail!(format!(
+                "Failed to validate configuration and secrets. {validation_errors}",
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Transform a [`wasmcloud_control_interface::Link`] into a [`wasmcloud_core::InterfaceLinkDefinition`]
+    /// by fetching the source and target configurations and secrets, and encrypting the secrets.
+    async fn resolve_link_config(
+        &self,
+        link: Link,
+        provider_jwt: Option<&String>,
+        application: Option<&String>,
+        provider_xkey: &XKey,
+    ) -> anyhow::Result<wasmcloud_core::InterfaceLinkDefinition> {
+        let (source_bundle, raw_source_secrets) = self
+            .fetch_config_and_secrets(link.source_config().as_slice(), provider_jwt, application)
+            .await?;
+        let (target_bundle, raw_target_secrets) = self
+            .fetch_config_and_secrets(link.target_config().as_slice(), provider_jwt, application)
+            .await?;
+
+        let source_config = source_bundle.get_config().await;
+        let target_config = target_bundle.get_config().await;
+        // NOTE(brooksmtownsend): This trait import is used here to ensure we're only exposing secret
+        // values when we need them.
+        use secrecy::ExposeSecret;
+        let source_secrets_map: HashMap<String, wasmcloud_core::secrets::SecretValue> =
+            raw_source_secrets
+                .iter()
+                .map(|(k, v)| match v.expose_secret() {
+                    SecretValue::String(s) => (
+                        k.clone(),
+                        wasmcloud_core::secrets::SecretValue::String(s.to_owned()),
+                    ),
+                    SecretValue::Bytes(b) => (
+                        k.clone(),
+                        wasmcloud_core::secrets::SecretValue::Bytes(b.to_owned()),
+                    ),
+                })
+                .collect();
+        let target_secrets_map: HashMap<String, wasmcloud_core::secrets::SecretValue> =
+            raw_target_secrets
+                .iter()
+                .map(|(k, v)| match v.expose_secret() {
+                    SecretValue::String(s) => (
+                        k.clone(),
+                        wasmcloud_core::secrets::SecretValue::String(s.to_owned()),
+                    ),
+                    SecretValue::Bytes(b) => (
+                        k.clone(),
+                        wasmcloud_core::secrets::SecretValue::Bytes(b.to_owned()),
+                    ),
+                })
+                .collect();
+        // Serializing & sealing an empty map results in a non-empty Vec, which is difficult to tell the
+        // difference between an empty map and an encrypted empty map. To avoid this, we explicitly handle
+        // the case where the map is empty.
+        let source_secrets = if source_secrets_map.is_empty() {
+            None
+        } else {
+            Some(
+                serde_json::to_vec(&source_secrets_map)
+                    .map(|secrets| self.secrets_xkey.seal(&secrets, provider_xkey))
+                    .context("failed to serialize and encrypt source secrets")??,
+            )
+        };
+        let target_secrets = if target_secrets_map.is_empty() {
+            None
+        } else {
+            Some(
+                serde_json::to_vec(&target_secrets_map)
+                    .map(|secrets| self.secrets_xkey.seal(&secrets, provider_xkey))
+                    .context("failed to serialize and encrypt target secrets")??,
+            )
+        };
+
+        Ok(wasmcloud_core::InterfaceLinkDefinition {
+            source_id: link.source_id().to_string(),
+            target: link.target().to_string(),
+            name: link.name().to_string(),
+            wit_namespace: link.wit_namespace().to_string(),
+            wit_package: link.wit_package().to_string(),
+            interfaces: link.interfaces().clone(),
+            source_config: source_config.clone(),
+            target_config: target_config.clone(),
+            source_secrets,
+            target_secrets,
+        })
+    }
+}
+
+async fn publish_event(
+    event_rx: mpsc::Sender<(String, String, serde_json::Value)>,
+    name: String,
+    lattice: String,
+    data: serde_json::Value,
+) -> anyhow::Result<()> {
+    event_rx
+        .send((name, lattice, data))
+        .await
+        .context("failed to send event")
+}

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1,65 +1,50 @@
 use std::collections::btree_map::Entry as BTreeMapEntry;
-use std::collections::hash_map::{self, Entry};
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
-use std::env;
 use std::env::consts::{ARCH, FAMILY, OS};
 use std::future::Future;
 use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::pin::Pin;
-use std::process::Stdio;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, ensure, Context as _};
-use async_nats::jetstream::kv::{Entry as KvEntry, Operation, Store};
-use base64::engine::general_purpose::STANDARD;
-use base64::Engine;
-use bytes::{BufMut, Bytes, BytesMut};
+use async_nats::jetstream::kv::Store;
+use bytes::{BufMut, BytesMut};
 use cloudevents::{EventBuilder, EventBuilderV10};
 use futures::future::Either;
 use futures::stream::{AbortHandle, Abortable, SelectAll};
-use futures::{join, stream, try_join, Stream, StreamExt, TryFutureExt, TryStreamExt};
+use futures::{try_join, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use nkeys::{KeyPair, KeyPairType, XKey};
-use secrecy::Secret;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tokio::sync::{broadcast, mpsc, watch, RwLock, Semaphore};
-use tokio::task::{JoinHandle, JoinSet};
+use tokio::io::AsyncWrite;
+use tokio::sync::{mpsc, watch, RwLock};
+use tokio::task::JoinHandle;
 use tokio::time::{interval_at, timeout_at, Instant};
-use tokio::{process, select, spawn};
-use tokio_stream::wrappers::IntervalStream;
+use tokio::{select, spawn};
 use tracing::{debug, error, info, instrument, trace, warn, Instrument as _};
-use uuid::Uuid;
 use wascap::{jwt, prelude::ClaimsBuilder};
 use wasmcloud_control_interface::{
-    ComponentAuctionAck, ComponentAuctionRequest, ComponentDescription, CtlResponse,
-    DeleteInterfaceLinkDefinitionRequest, HostInventory, HostLabel, Link, ProviderAuctionAck,
-    ProviderAuctionRequest, ProviderDescription, RegistryCredential, ScaleComponentCommand,
-    StartProviderCommand, StopHostCommand, StopProviderCommand, UpdateComponentCommand,
+    CtlResponse, HostInventory, HostLabel, Link, RegistryCredential, StopHostCommand,
 };
-use wasmcloud_core::{
-    provider_config_update_subject, ComponentId, HealthCheckResponse, HostData, OtelConfig,
-    CTL_API_VERSION_1,
-};
-use wasmcloud_runtime::capability::secrets::store::SecretValue;
-use wasmcloud_runtime::component::WrpcServeEvent;
+use wasmcloud_core::CTL_API_VERSION_1;
 use wasmcloud_runtime::Runtime;
-use wasmcloud_secrets_types::SECRET_PREFIX;
 use wasmcloud_tracing::context::TraceContextInjector;
 use wasmcloud_tracing::{global, KeyValue};
 
 use crate::registry::RegistryCredentialExt;
 use crate::{
-    fetch_component, HostMetrics, OciConfig, PolicyHostInfo, PolicyManager, PolicyResponse,
-    RegistryAuth, RegistryConfig, RegistryType, SecretsManager,
+    fetch_component, HostMetrics, OciConfig, PolicyManager, PolicyResponse, RegistryAuth,
+    RegistryConfig, RegistryType,
 };
 
 mod event;
 mod handler;
+mod lattice;
 
 pub mod config;
 /// wasmCloud host configuration
@@ -67,8 +52,9 @@ pub mod host_config;
 
 pub use self::host_config::Host as HostConfig;
 
-use self::config::{BundleGenerator, ConfigBundle};
+use self::config::ConfigBundle;
 use self::handler::Handler;
+use self::lattice::{Lattice, LatticeConfig};
 
 const MAX_INVOCATION_CHANNEL_SIZE: usize = 5000;
 const MIN_INVOCATION_CHANNEL_SIZE: usize = 256;
@@ -127,21 +113,48 @@ impl TryFrom<AsyncBytesMut> for Vec<u8> {
     }
 }
 
+// TODO enum?!
 impl Queue {
     #[instrument]
-    async fn new(
+    async fn new_host(
+        nats: &async_nats::Client,
+        topic_prefix: &str,
+        lattices: &Vec<String>,
+        host_id: &str,
+    ) -> anyhow::Result<Self> {
+        let mut subscriptions = Vec::new();
+        for lattice in lattices {
+            subscriptions.push(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.host.ping",
+            )));
+            subscriptions.push(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.label.*.{host_id}"
+            )));
+            subscriptions.push(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.host.*.{host_id}"
+            )));
+        }
+
+        let streams = futures::future::join_all(subscriptions)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, async_nats::SubscribeError>>()
+            .context("failed to subscribe to queues")?;
+        Ok(Self {
+            all_streams: futures::stream::select_all(streams),
+        })
+    }
+
+    #[instrument]
+    async fn new_lattice(
         nats: &async_nats::Client,
         topic_prefix: &str,
         lattice: &str,
-        host_key: &KeyPair,
+        host_id: &str,
     ) -> anyhow::Result<Self> {
-        let host_id = host_key.public_key();
         let streams = futures::future::join_all([
             Either::Left(nats.subscribe(format!(
                 "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.registry.put",
-            ))),
-            Either::Left(nats.subscribe(format!(
-                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.host.ping",
             ))),
             Either::Left(nats.subscribe(format!(
                 "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.*.auction",
@@ -159,12 +172,6 @@ impl Queue {
             ))),
             Either::Left(nats.subscribe(format!(
                 "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.provider.*.{host_id}"
-            ))),
-            Either::Left(nats.subscribe(format!(
-                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.label.*.{host_id}"
-            ))),
-            Either::Left(nats.subscribe(format!(
-                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.host.*.{host_id}"
             ))),
             Either::Right(nats.queue_subscribe(
                 format!("{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.config.>"),
@@ -309,7 +316,6 @@ impl wrpc_transport::Serve for WrpcServer {
                             // TODO(metrics): insert information about the source once we have concrete context data
                             vec![
                                 KeyValue::new("component.ref", image_reference),
-                                KeyValue::new("lattice", metrics.lattice_id.clone()),
                                 KeyValue::new("host", metrics.host_id.clone()),
                                 KeyValue::new("operation", format!("{instance}/{func}")),
                             ],
@@ -349,42 +355,29 @@ impl Drop for Provider {
 
 /// wasmCloud Host
 pub struct Host {
-    components: RwLock<HashMap<ComponentId, Arc<Component>>>,
     event_builder: EventBuilderV10,
     friendly_name: String,
-    heartbeat: AbortHandle,
+    heartbeats: Vec<AbortHandle>,
     host_config: HostConfig,
     host_key: Arc<KeyPair>,
+    #[allow(unused)]
     host_token: Arc<jwt::Token<jwt::Host>>,
-    /// The Xkey used to encrypt secrets when sending them over NATS
-    secrets_xkey: Arc<XKey>,
-    labels: RwLock<BTreeMap<String, String>>,
+    labels: Arc<RwLock<BTreeMap<String, String>>>,
     ctl_topic_prefix: String,
     /// NATS client to use for control interface subscriptions and jetstream queries
     ctl_nats: async_nats::Client,
     /// NATS client to use for RPC calls
     rpc_nats: Arc<async_nats::Client>,
-    data: Store,
-    /// Task to watch for changes in the LATTICEDATA store
-    data_watch: AbortHandle,
-    config_data: Store,
-    config_generator: BundleGenerator,
-    policy_manager: Arc<PolicyManager>,
-    secrets_manager: Arc<SecretsManager>,
-    /// The provider map is a map of provider component ID to provider
-    providers: RwLock<HashMap<String, Provider>>,
-    registry_config: RwLock<HashMap<String, RegistryConfig>>,
+    #[allow(unused)]
     runtime: Runtime,
     start_at: Instant,
     stop_tx: watch::Sender<Option<Instant>>,
     stop_rx: watch::Receiver<Option<Instant>>,
     queue: AbortHandle,
-    // Component ID -> All Links
-    links: RwLock<HashMap<String, Vec<Link>>>,
-    component_claims: Arc<RwLock<HashMap<ComponentId, jwt::Claims<jwt::Component>>>>, // TODO: use a single map once Claims is an enum
-    provider_claims: Arc<RwLock<HashMap<String, jwt::Claims<jwt::CapabilityProvider>>>>,
-    metrics: Arc<HostMetrics>,
+    #[allow(unused)]
     max_execution_time: Duration,
+    /// Map of lattice names to their respective lattice configurations
+    lattices: HashMap<String, Arc<Lattice>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -762,11 +755,11 @@ impl Host {
                 )
                 .await
                 .context("failed to establish NATS control server connection")?;
-                let queue = Queue::new(
+                let queue = Queue::new_host(
                     &ctl_nats,
                     &config.ctl_topic_prefix,
-                    &config.lattice,
-                    &host_key,
+                    &config.lattices,
+                    &host_key.public_key(),
                 )
                 .await
                 .context("failed to initialize queue")?;
@@ -798,7 +791,6 @@ impl Host {
         let heartbeat_start_at = start_at
             .checked_add(heartbeat_interval)
             .context("failed to compute heartbeat start time")?;
-        let heartbeat = IntervalStream::new(interval_at(heartbeat_start_at, heartbeat_interval));
 
         let (stop_tx, stop_rx) = watch::channel(None);
 
@@ -811,59 +803,7 @@ impl Host {
             .context("failed to build runtime")?;
         let event_builder = EventBuilderV10::new().source(host_key.public_key());
 
-        let ctl_jetstream = if let Some(domain) = config.js_domain.as_ref() {
-            async_nats::jetstream::with_domain(ctl_nats.clone(), domain)
-        } else {
-            async_nats::jetstream::new(ctl_nats.clone())
-        };
-        let bucket = format!("LATTICEDATA_{}", config.lattice);
-        let data = create_bucket(&ctl_jetstream, &bucket).await?;
-
-        let config_bucket = format!("CONFIGDATA_{}", config.lattice);
-        let config_data = create_bucket(&ctl_jetstream, &config_bucket).await?;
-
         let (queue_abort, queue_abort_reg) = AbortHandle::new_pair();
-        let (heartbeat_abort, heartbeat_abort_reg) = AbortHandle::new_pair();
-        let (data_watch_abort, data_watch_abort_reg) = AbortHandle::new_pair();
-
-        let supplemental_config = if config.config_service_enabled {
-            load_supplemental_config(&ctl_nats, &config.lattice, &labels).await?
-        } else {
-            SupplementalConfig::default()
-        };
-
-        let registry_config = RwLock::new(supplemental_config.registry_config.unwrap_or_default());
-        merge_registry_config(&registry_config, config.oci_opts.clone()).await;
-
-        let policy_manager = PolicyManager::new(
-            ctl_nats.clone(),
-            PolicyHostInfo {
-                public_key: host_key.public_key(),
-                lattice: config.lattice.to_string(),
-                labels: HashMap::from_iter(labels.clone()),
-            },
-            config.policy_service_config.policy_topic.clone(),
-            config.policy_service_config.policy_timeout_ms,
-            config.policy_service_config.policy_changes_topic.clone(),
-        )
-        .await?;
-
-        // If provided, secrets topic must be non-empty
-        // TODO(#2411): Validate secrets topic prefix as a valid NATS subject
-        ensure!(
-            config.secrets_topic_prefix.is_none()
-                || config
-                    .secrets_topic_prefix
-                    .as_ref()
-                    .is_some_and(|topic| !topic.is_empty()),
-            "secrets topic prefix must be non-empty"
-        );
-
-        let secrets_manager = Arc::new(SecretsManager::new(
-            &config_data,
-            config.secrets_topic_prefix.as_ref(),
-            &ctl_nats,
-        ));
 
         let meter = global::meter_with_version(
             "wasmcloud-host",
@@ -874,43 +814,60 @@ impl Host {
                 KeyValue::new("host.version", config.version.clone()),
             ]),
         );
-        let metrics = HostMetrics::new(&meter, host_key.public_key(), config.lattice.to_string());
+        let ctl_jetstream = if let Some(domain) = config.js_domain.as_ref() {
+            async_nats::jetstream::with_domain(ctl_nats.clone(), domain)
+        } else {
+            async_nats::jetstream::new(ctl_nats.clone())
+        };
 
-        let config_generator = BundleGenerator::new(config_data.clone());
+        let labels = Arc::new(RwLock::new(labels));
+        let metrics = Arc::new(HostMetrics::new(&meter, host_key.public_key()));
+        let mut lattices = HashMap::new();
+        let exec_time = config.max_execution_time;
+        let (event_tx, mut event_rx) = mpsc::channel(100);
+        for lattice_name in &config.lattices {
+            let heartbeat_interval = interval_at(heartbeat_start_at, heartbeat_interval);
+            let cfg = LatticeConfig::from(config.clone());
+            let lattice = Lattice::new(
+                lattice_name.clone(),
+                rpc_nats.clone(),
+                ctl_nats.clone(),
+                ctl_jetstream.clone(),
+                host_key.public_key(),
+                labels.clone(),
+                metrics.clone(),
+                exec_time,
+                runtime.clone(),
+                event_tx.clone(),
+                cfg,
+                heartbeat_interval,
+                (*host_token).clone(),
+            )
+            .await
+            .context("failed to initialize lattice")?;
+            lattices.insert(lattice_name.clone(), lattice);
+        }
 
         let max_execution_time_ms = config.max_execution_time;
 
         let host = Host {
-            components: RwLock::default(),
             event_builder,
             friendly_name,
-            heartbeat: heartbeat_abort.clone(),
+            heartbeats: Vec::new(),
             ctl_topic_prefix: config.ctl_topic_prefix.clone(),
             host_key,
             host_token,
-            secrets_xkey: Arc::new(XKey::new()),
-            labels: RwLock::new(labels),
+            labels,
             ctl_nats,
             rpc_nats: Arc::new(rpc_nats),
             host_config: config,
-            data: data.clone(),
-            data_watch: data_watch_abort.clone(),
-            config_data: config_data.clone(),
-            config_generator,
-            policy_manager,
-            secrets_manager,
-            providers: RwLock::default(),
-            registry_config,
             runtime,
             start_at,
             stop_rx,
             stop_tx,
             queue: queue_abort.clone(),
-            links: RwLock::default(),
-            component_claims: Arc::default(),
-            provider_claims: Arc::default(),
-            metrics: Arc::new(metrics),
             max_execution_time: max_execution_time_ms,
+            lattices,
         };
 
         let host = Arc::new(host);
@@ -938,121 +895,50 @@ impl Host {
             }
         });
 
-        let data_watch: JoinHandle<anyhow::Result<_>> = spawn({
-            let data = data.clone();
+        spawn({
             let host = Arc::clone(&host);
             async move {
-                let data_watch = data
-                    .watch_all()
-                    .await
-                    .context("failed to watch lattice data bucket")?;
-                let mut data_watch = Abortable::new(data_watch, data_watch_abort_reg);
-                data_watch
-                    .by_ref()
-                    .for_each({
-                        let host = Arc::clone(&host);
-                        move |entry| {
-                            let host = Arc::clone(&host);
-                            async move {
-                                match entry {
-                                    Err(error) => {
-                                        error!("failed to watch lattice data bucket: {error}");
-                                    }
-                                    Ok(entry) => host.process_entry(entry, true).await,
-                                }
-                            }
+                loop {
+                    select! {
+                        Some((lattice, name, payload)) = event_rx.recv() => {
+                            host.publish_event(&name, &lattice, payload).await.map_err(|e| error!(%e, "failed to publish event")).ok();
                         }
-                    })
-                    .await;
-                let deadline = { *host.stop_rx.borrow() };
-                host.stop_tx.send_replace(deadline);
-                if data_watch.is_aborted() {
-                    info!("data watch task gracefully stopped");
-                } else {
-                    error!("data watch task unexpectedly stopped");
-                }
-                Ok(())
-            }
-        });
-
-        let heartbeat = spawn({
-            let host = Arc::clone(&host);
-            async move {
-                let mut heartbeat = Abortable::new(heartbeat, heartbeat_abort_reg);
-                heartbeat
-                    .by_ref()
-                    .for_each({
-                        let host = Arc::clone(&host);
-                        move |_| {
-                            let host = Arc::clone(&host);
-                            async move {
-                                let heartbeat = match host.heartbeat().await {
-                                    Ok(heartbeat) => heartbeat,
-                                    Err(e) => {
-                                        error!("failed to generate heartbeat: {e}");
-                                        return;
-                                    }
-                                };
-
-                                if let Err(e) =
-                                    host.publish_event("host_heartbeat", heartbeat).await
-                                {
-                                    error!("failed to publish heartbeat: {e}");
-                                }
-                            }
+                            // TODO graceful shutdown?
+                        _ = host.stopped() => {
+                            break;
                         }
-                    })
-                    .await;
-                let deadline = { *host.stop_rx.borrow() };
-                host.stop_tx.send_replace(deadline);
-                if heartbeat.is_aborted() {
-                    info!("heartbeat task gracefully stopped");
-                } else {
-                    error!("heartbeat task unexpectedly stopped");
+                    }
                 }
             }
         });
 
-        // Process existing data without emitting events
-        data.keys()
-            .await
-            .context("failed to read keys of lattice data bucket")?
-            .map_err(|e| anyhow!(e).context("failed to read lattice data stream"))
-            .try_filter_map(|key| async {
-                data.entry(key)
-                    .await
-                    .context("failed to get entry in lattice data bucket")
-            })
-            .for_each(|entry| async {
-                match entry {
-                    Ok(entry) => host.process_entry(entry, false).await,
-                    Err(err) => error!(%err, "failed to read entry from lattice data bucket"),
-                }
-            })
-            .await;
-
-        host.publish_event("host_started", start_evt)
-            .await
-            .context("failed to publish start event")?;
+        let lattice_names = host.lattices.keys().cloned().collect::<Vec<_>>();
+        for lattice in lattice_names.clone() {
+            host.publish_event("host_started", &lattice, start_evt.clone())
+                .await
+                .context("failed to publish start event")?;
+        }
         info!(
             host_id = host.host_key.public_key(),
             "wasmCloud host started"
         );
 
         Ok((Arc::clone(&host), async move {
-            heartbeat_abort.abort();
             queue_abort.abort();
-            data_watch_abort.abort();
-            host.policy_manager.policy_changes.abort();
-            let _ = try_join!(queue, data_watch, heartbeat).context("failed to await tasks")?;
-            host.publish_event(
-                "host_stopped",
-                json!({
-                    "labels": *host.labels.read().await,
-                }),
-            )
-            .await
-            .context("failed to publish stop event")?;
+            let _ = try_join!(queue).context("failed to await tasks")?;
+            for lattice in lattice_names {
+                let deadline = host.stop_rx.borrow().unwrap_or_else(|| {
+                    let now = Instant::now();
+                    // epoch ticks operate on a second precision
+                    now.checked_add(Duration::from_secs(1)).unwrap_or(now)
+                });
+                host.lattices.values().for_each(|lattice| {
+                    lattice.stop_tx.send_replace(Some(deadline));
+                });
+                host.publish_event("host_stopped", &lattice, json!({}))
+                    .await
+                    .context("failed to publish stop event")?;
+            }
             // Before we exit, make sure to flush all messages or we may lose some that we've
             // thought were sent (like the host_stopped event)
             try_join!(host.ctl_nats.flush(), host.rpc_nats.flush(),)
@@ -1094,89 +980,13 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn inventory(&self) -> HostInventory {
-        trace!("generating host inventory");
-        let components = self.components.read().await;
-        let components: Vec<_> = stream::iter(components.iter())
-            .filter_map(|(id, component)| async move {
-                let mut description = ComponentDescription::builder()
-                    .id(id.into())
-                    .image_ref(component.image_reference.to_string())
-                    .annotations(component.annotations.clone().into_iter().collect())
-                    .max_instances(component.max_instances.get().try_into().unwrap_or(u32::MAX))
-                    .revision(
-                        component
-                            .claims()
-                            .and_then(|claims| claims.metadata.as_ref())
-                            .and_then(|jwt::Component { rev, .. }| *rev)
-                            .unwrap_or_default(),
-                    );
-                // Add name if present
-                if let Some(name) = component
-                    .claims()
-                    .and_then(|claims| claims.metadata.as_ref())
-                    .and_then(|metadata| metadata.name.as_ref())
-                    .cloned()
-                {
-                    description = description.name(name);
-                };
+    async fn inventory(&self, lattice: &str) -> anyhow::Result<HostInventory> {
+        trace!(lattice = lattice, "generating host inventory");
 
-                Some(
-                    description
-                        .build()
-                        .expect("failed to build component description: {e}"),
-                )
-            })
-            .collect()
-            .await;
-
-        let providers: Vec<_> = self
-            .providers
-            .read()
-            .await
-            .iter()
-            .map(
-                |(
-                    provider_id,
-                    Provider {
-                        annotations,
-                        claims_token,
-                        image_ref,
-                        ..
-                    },
-                )| {
-                    let mut provider_description = ProviderDescription::builder()
-                        .id(provider_id)
-                        .image_ref(image_ref);
-                    if let Some(name) = claims_token
-                        .as_ref()
-                        .and_then(|claims| claims.claims.metadata.as_ref())
-                        .and_then(|metadata| metadata.name.as_ref())
-                    {
-                        provider_description = provider_description.name(name);
-                    }
-                    provider_description
-                        .annotations(
-                            annotations
-                                .clone()
-                                .into_iter()
-                                .collect::<BTreeMap<String, String>>(),
-                        )
-                        .revision(
-                            claims_token
-                                .as_ref()
-                                .and_then(|claims| claims.claims.metadata.as_ref())
-                                .and_then(|jwt::CapabilityProvider { rev, .. }| *rev)
-                                .unwrap_or_default(),
-                        )
-                        .build()
-                        .expect("failed to build provider description")
-                },
-            )
-            .collect();
-
+        let lattice = self.lattices.get(lattice).context("lattice not found")?;
+        let (components, providers) = lattice.inventory().await;
         let uptime = self.start_at.elapsed();
-        HostInventory::builder()
+        Ok(HostInventory::builder()
             .components(components)
             .providers(providers)
             .friendly_name(self.friendly_name.clone())
@@ -1186,338 +996,23 @@ impl Host {
             .version(self.host_config.version.clone())
             .host_id(self.host_key.public_key())
             .build()
-            .expect("failed to build host inventory")
+            .expect("failed to build host inventory"))
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn heartbeat(&self) -> anyhow::Result<serde_json::Value> {
+    async fn heartbeat(&self, lattice: &str) -> anyhow::Result<serde_json::Value> {
         trace!("generating heartbeat");
-        Ok(serde_json::to_value(self.inventory().await)?)
+        Ok(serde_json::to_value(self.inventory(lattice).await?)?)
     }
 
     #[instrument(level = "debug", skip(self))]
-    async fn publish_event(&self, name: &str, data: serde_json::Value) -> anyhow::Result<()> {
-        event::publish(
-            &self.event_builder,
-            &self.ctl_nats,
-            &self.host_config.lattice,
-            name,
-            data,
-        )
-        .await
-    }
-
-    /// Instantiate a component
-    #[allow(clippy::too_many_arguments)] // TODO: refactor into a config struct
-    #[instrument(level = "debug", skip_all)]
-    async fn instantiate_component(
+    async fn publish_event(
         &self,
-        annotations: &Annotations,
-        image_reference: Arc<str>,
-        id: Arc<str>,
-        max_instances: NonZeroUsize,
-        mut component: wasmcloud_runtime::Component<Handler>,
-        handler: Handler,
-    ) -> anyhow::Result<Arc<Component>> {
-        trace!(
-            component_ref = ?image_reference,
-            max_instances,
-            "instantiating component"
-        );
-
-        let max_execution_time = self.max_execution_time;
-        component.set_max_execution_time(max_execution_time);
-
-        let (events_tx, mut events_rx) = mpsc::channel(
-            max_instances
-                .get()
-                .clamp(MIN_INVOCATION_CHANNEL_SIZE, MAX_INVOCATION_CHANNEL_SIZE),
-        );
-        let prefix = Arc::from(format!("{}.{id}", &self.host_config.lattice));
-        let exports = component
-            .serve_wrpc(
-                &WrpcServer {
-                    nats: wrpc_transport_nats::Client::new(
-                        Arc::clone(&self.rpc_nats),
-                        Arc::clone(&prefix),
-                        Some(prefix),
-                    ),
-                    claims: component.claims().cloned().map(Arc::new),
-                    id: Arc::clone(&id),
-                    image_reference: Arc::clone(&image_reference),
-                    annotations: Arc::new(annotations.clone()),
-                    policy_manager: Arc::clone(&self.policy_manager),
-                    trace_ctx: Arc::clone(&handler.trace_ctx),
-                    metrics: Arc::clone(&self.metrics),
-                },
-                handler.clone(),
-                events_tx,
-            )
-            .await?;
-        let permits = Arc::new(Semaphore::new(
-            usize::from(max_instances).min(Semaphore::MAX_PERMITS),
-        ));
-        let metrics = Arc::clone(&self.metrics);
-        Ok(Arc::new(Component {
-            component,
-            id,
-            handler,
-            exports: spawn(
-                async move {
-                    join!(
-                        async move {
-                            let mut tasks = JoinSet::new();
-                            let mut exports = stream::select_all(exports);
-                            loop {
-                                let permits = Arc::clone(&permits);
-                                select! {
-                                    Some(fut) = exports.next() => {
-                                        match fut {
-                                            Ok(fut) => {
-                                                debug!("accepted invocation, acquiring permit");
-                                                let permit = permits.acquire_owned().await;
-                                                tasks.spawn(async move {
-                                                    let _permit = permit;
-                                                    debug!("handling invocation");
-                                                    match fut.await {
-                                                        Ok(()) => {
-                                                            debug!("successfully handled invocation");
-                                                            Ok(())
-                                                        },
-                                                        Err(err) => {
-                                                            warn!(?err, "failed to handle invocation");
-                                                            Err(err)
-                                                        },
-                                                    }
-                                                });
-                                            }
-                                            Err(err) => {
-                                                warn!(?err, "failed to accept invocation")
-                                            }
-                                        }
-                                    }
-                                    Some(res) = tasks.join_next() => {
-                                        if let Err(err) = res {
-                                            error!(?err, "export serving task failed");
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        async move {
-                            while let Some(evt) = events_rx.recv().await {
-                                match evt {
-                                    WrpcServeEvent::HttpIncomingHandlerHandleReturned {
-                                        context: (start_at, ref attributes),
-                                        success,
-                                    }
-                                    | WrpcServeEvent::MessagingHandlerHandleMessageReturned {
-                                        context: (start_at, ref attributes),
-                                        success,
-                                    }
-                                    | WrpcServeEvent::DynamicExportReturned {
-                                        context: (start_at, ref attributes),
-                                        success,
-                                    } => metrics.record_component_invocation(
-                                        u64::try_from(start_at.elapsed().as_nanos())
-                                            .unwrap_or_default(),
-                                        attributes,
-                                        !success,
-                                    ),
-                                }
-                            }
-                            debug!("serving event stream is done");
-                        },
-                    );
-                    debug!("export serving task done");
-                }
-                .in_current_span(),
-            ),
-            annotations: annotations.clone(),
-            max_instances,
-            image_reference,
-        }))
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
-    async fn start_component<'a>(
-        &self,
-        entry: hash_map::VacantEntry<'a, String, Arc<Component>>,
-        wasm: Vec<u8>,
-        claims: Option<jwt::Claims<jwt::Component>>,
-        component_ref: Arc<str>,
-        component_id: Arc<str>,
-        max_instances: NonZeroUsize,
-        annotations: &Annotations,
-        config: ConfigBundle,
-        secrets: HashMap<String, Secret<SecretValue>>,
-    ) -> anyhow::Result<&'a mut Arc<Component>> {
-        debug!(?component_ref, ?max_instances, "starting new component");
-
-        if let Some(ref claims) = claims {
-            self.store_claims(Claims::Component(claims.clone()))
-                .await
-                .context("failed to store claims")?;
-        }
-
-        let component_spec = self
-            .get_component_spec(&component_id)
-            .await?
-            .unwrap_or_else(|| ComponentSpecification::new(&component_ref));
-        self.store_component_spec(&component_id, &component_spec)
-            .await?;
-
-        // Map the imports to pull out the result types of the functions for lookup when invoking them
-        let handler = Handler {
-            nats: Arc::clone(&self.rpc_nats),
-            config_data: Arc::new(RwLock::new(config)),
-            lattice: Arc::clone(&self.host_config.lattice),
-            component_id: Arc::clone(&component_id),
-            secrets: Arc::new(RwLock::new(secrets)),
-            targets: Arc::default(),
-            trace_ctx: Arc::default(),
-            instance_links: Arc::new(RwLock::new(component_import_links(&component_spec.links))),
-            invocation_timeout: Duration::from_secs(10), // TODO: Make this configurable
-        };
-        let component = wasmcloud_runtime::Component::new(&self.runtime, &wasm)?;
-        let component = self
-            .instantiate_component(
-                annotations,
-                Arc::clone(&component_ref),
-                Arc::clone(&component_id),
-                max_instances,
-                component,
-                handler,
-            )
-            .await
-            .context("failed to instantiate component")?;
-
-        info!(?component_ref, "component started");
-        self.publish_event(
-            "component_scaled",
-            event::component_scaled(
-                claims.as_ref(),
-                annotations,
-                self.host_key.public_key(),
-                max_instances,
-                &component_ref,
-                &component_id,
-            ),
-        )
-        .await?;
-
-        Ok(entry.insert(component))
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn stop_component(&self, component: &Component, _host_id: &str) -> anyhow::Result<()> {
-        trace!(component_id = %component.id, "stopping component");
-
-        component.exports.abort();
-
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_auction_component(
-        &self,
-        payload: impl AsRef<[u8]>,
-    ) -> anyhow::Result<Option<CtlResponse<ComponentAuctionAck>>> {
-        let req = serde_json::from_slice::<ComponentAuctionRequest>(payload.as_ref())
-            .context("failed to deserialize component auction command")?;
-        let component_ref = req.component_ref();
-        let component_id = req.component_id();
-        let constraints = req.constraints();
-
-        info!(
-            component_ref,
-            component_id,
-            ?constraints,
-            "handling auction for component"
-        );
-
-        let host_labels = self.labels.read().await;
-        let constraints_satisfied = constraints
-            .iter()
-            .all(|(k, v)| host_labels.get(k).is_some_and(|hv| hv == v));
-        let component_id_running = self.components.read().await.contains_key(component_id);
-
-        // This host can run the component if all constraints are satisfied and the component is not already running
-        if constraints_satisfied && !component_id_running {
-            Ok(Some(CtlResponse::ok(
-                ComponentAuctionAck::from_component_host_and_constraints(
-                    component_ref,
-                    component_id,
-                    &self.host_key.public_key(),
-                    constraints.clone(),
-                ),
-            )))
-        } else {
-            Ok(None)
-        }
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_auction_provider(
-        &self,
-        payload: impl AsRef<[u8]>,
-    ) -> anyhow::Result<Option<CtlResponse<ProviderAuctionAck>>> {
-        let req = serde_json::from_slice::<ProviderAuctionRequest>(payload.as_ref())
-            .context("failed to deserialize provider auction command")?;
-        let provider_ref = req.provider_ref();
-        let provider_id = req.provider_id();
-        let constraints = req.constraints();
-
-        info!(
-            provider_ref,
-            provider_id,
-            ?constraints,
-            "handling auction for provider"
-        );
-
-        let host_labels = self.labels.read().await;
-        let constraints_satisfied = constraints
-            .iter()
-            .all(|(k, v)| host_labels.get(k).is_some_and(|hv| hv == v));
-        let providers = self.providers.read().await;
-        let provider_running = providers.contains_key(provider_id);
-        if constraints_satisfied && !provider_running {
-            Ok(Some(CtlResponse::ok(
-                ProviderAuctionAck::builder()
-                    .provider_ref(provider_ref.into())
-                    .provider_id(provider_id.into())
-                    .constraints(constraints.clone())
-                    .host_id(self.host_key.public_key())
-                    .build()
-                    .map_err(|e| anyhow!("failed to build provider auction ack: {e}"))?,
-            )))
-        } else {
-            Ok(None)
-        }
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    async fn fetch_component(&self, component_ref: &str) -> anyhow::Result<Vec<u8>> {
-        let registry_config = self.registry_config.read().await;
-        fetch_component(
-            component_ref,
-            self.host_config.allow_file_load,
-            &self.host_config.oci_opts.additional_ca_paths,
-            &registry_config,
-        )
-        .await
-        .context("failed to fetch component")
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    async fn store_component_claims(
-        &self,
-        claims: jwt::Claims<jwt::Component>,
+        name: &str,
+        lattice: &str,
+        data: serde_json::Value,
     ) -> anyhow::Result<()> {
-        let mut component_claims = self.component_claims.write().await;
-        component_claims.insert(claims.subject.clone(), claims);
-        Ok(())
+        event::publish(&self.event_builder, &self.ctl_nats, lattice, name, data).await
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -1554,10 +1049,8 @@ impl Host {
 
         info!(?timeout, "handling stop host");
 
-        self.heartbeat.abort();
-        self.data_watch.abort();
+        self.heartbeats.iter().for_each(|abort| abort.abort());
         self.queue.abort();
-        self.policy_manager.policy_changes.abort();
         let deadline =
             timeout.and_then(|timeout| Instant::now().checked_add(Duration::from_millis(timeout)));
         self.stop_tx.send_replace(deadline);
@@ -1566,1078 +1059,17 @@ impl Host {
         ))
     }
 
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_scale_component(
-        self: Arc<Self>,
-        payload: impl AsRef<[u8]>,
-        host_id: &str,
-    ) -> anyhow::Result<CtlResponse<()>> {
-        let cmd = serde_json::from_slice::<ScaleComponentCommand>(payload.as_ref())
-            .context("failed to deserialize component scale command")?;
-        let component_ref = cmd.component_ref();
-        let component_id = cmd.component_id();
-        let annotations = cmd.annotations();
-        let max_instances = cmd.max_instances();
-        let config = cmd.config().clone();
-        let allow_update = cmd.allow_update();
-
-        debug!(
-            component_ref,
-            max_instances, component_id, "handling scale component"
-        );
-
-        let host_id = host_id.to_string();
-        let annotations: Annotations = annotations
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
-
-        // Basic validation to ensure that the component is running and that the image reference matches
-        // If it doesn't match, we can still successfully scale, but we won't be updating the image reference
-        let (original_ref, ref_changed) = {
-            self.components
-                .read()
-                .await
-                .get(component_id)
-                .map(|v| {
-                    (
-                        Some(Arc::clone(&v.image_reference)),
-                        &*v.image_reference != component_ref,
-                    )
-                })
-                .unwrap_or_else(|| (None, false))
-        };
-
-        let mut perform_post_update: bool = false;
-        let message = match (allow_update, original_ref, ref_changed) {
-            // Updates are not allowed, original ref changed
-            (false, Some(original_ref), true) => {
-                let msg = format!(
-                    "Requested to scale existing component to a different image reference: {original_ref} != {component_ref}. The component will be scaled but the image reference will not be updated. If you meant to update this component to a new image ref, use the update command."
-                );
-                warn!(msg);
-                msg
-            }
-            // Updates are allowed, ref changed and we'll do an update later
-            (true, Some(original_ref), true) => {
-                perform_post_update = true;
-                format!(
-                    "Requested to scale existing component, with a changed image reference: {original_ref} != {component_ref}. The component will be scaled, and the image reference will be updated afterwards."
-                )
-            }
-            _ => String::with_capacity(0),
-        };
-
-        let component_id = Arc::from(component_id);
-        let component_ref = Arc::from(component_ref);
-        // Spawn a task to perform the scaling and possibly an update of the component afterwards
-        spawn(async move {
-            // Fetch the component from the reference
-            let component_and_claims =
-                self.fetch_component(&component_ref)
-                    .await
-                    .map(|component_bytes| {
-                        // Pull the claims token from the component, this returns an error only if claims are embedded
-                        // and they are invalid (expired, tampered with, etc)
-                        let claims_token =
-                            wasmcloud_runtime::component::claims_token(&component_bytes);
-                        (component_bytes, claims_token)
-                    });
-            let (wasm, claims_token) = match component_and_claims {
-                Ok((wasm, Ok(claims_token))) => (wasm, claims_token),
-                Err(e) | Ok((_, Err(e))) => {
-                    if let Err(e) = self
-                        .publish_event(
-                            "component_scale_failed",
-                            event::component_scale_failed(
-                                None,
-                                &annotations,
-                                host_id,
-                                &component_ref,
-                                &component_id,
-                                max_instances,
-                                &e,
-                            ),
-                        )
-                        .await
-                    {
-                        error!(%component_ref, %component_id, err = ?e, "failed to publish component scale failed event");
-                    }
-                    return;
-                }
-            };
-            // Scale the component
-            if let Err(e) = self
-                .handle_scale_component_task(
-                    Arc::clone(&component_ref),
-                    Arc::clone(&component_id),
-                    &host_id,
-                    max_instances,
-                    &annotations,
-                    config,
-                    wasm,
-                    claims_token.as_ref(),
-                )
-                .await
-            {
-                error!(%component_ref, %component_id, err = ?e, "failed to scale component");
-                if let Err(e) = self
-                    .publish_event(
-                        "component_scale_failed",
-                        event::component_scale_failed(
-                            claims_token.map(|c| c.claims).as_ref(),
-                            &annotations,
-                            host_id,
-                            &component_ref,
-                            &component_id,
-                            max_instances,
-                            &e,
-                        ),
-                    )
-                    .await
-                {
-                    error!(%component_ref, %component_id, err = ?e, "failed to publish component scale failed event");
-                }
-                return;
-            }
-
-            if perform_post_update {
-                if let Err(e) = self
-                    .handle_update_component_task(
-                        Arc::clone(&component_id),
-                        Arc::clone(&component_ref),
-                        &host_id,
-                        None,
-                    )
-                    .await
-                {
-                    error!(%component_ref, %component_id, err = ?e, "failed to update component after scale");
-                }
-            }
-        });
-
-        Ok(CtlResponse::<()>::success(message))
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    /// Handles scaling an component to a supplied number of `max` concurrently executing instances.
-    /// Supplying `0` will result in stopping that component instance.
-    #[allow(clippy::too_many_arguments)]
-    async fn handle_scale_component_task(
-        &self,
-        component_ref: Arc<str>,
-        component_id: Arc<str>,
-        host_id: &str,
-        max_instances: u32,
-        annotations: &Annotations,
-        config: Vec<String>,
-        wasm: Vec<u8>,
-        claims_token: Option<&jwt::Token<jwt::Component>>,
-    ) -> anyhow::Result<()> {
-        trace!(?component_ref, max_instances, "scale component task");
-
-        let claims = claims_token.map(|c| c.claims.clone());
-        match self
-            .policy_manager
-            .evaluate_start_component(
-                &component_id,
-                &component_ref,
-                max_instances,
-                annotations,
-                claims.as_ref(),
-            )
-            .await?
-        {
-            PolicyResponse {
-                permitted: false,
-                message: Some(message),
-                ..
-            } => bail!("Policy denied request to scale component `{component_id}`: `{message:?}`"),
-            PolicyResponse {
-                permitted: false, ..
-            } => bail!("Policy denied request to scale component `{component_id}`"),
-            PolicyResponse {
-                permitted: true, ..
-            } => (),
-        };
-
-        let scaled_event = match (
-            self.components
-                .write()
-                .await
-                .entry(component_id.to_string()),
-            NonZeroUsize::new(max_instances as usize),
-        ) {
-            // No component is running and we requested to scale to zero, noop.
-            // We still publish the event to indicate that the component has been scaled to zero
-            (hash_map::Entry::Vacant(_), None) => event::component_scaled(
-                claims.as_ref(),
-                annotations,
-                host_id,
-                0_usize,
-                &component_ref,
-                &component_id,
-            ),
-            // No component is running and we requested to scale to some amount, start with specified max
-            (hash_map::Entry::Vacant(entry), Some(max)) => {
-                let (config, secrets) = self
-                    .fetch_config_and_secrets(
-                        &config,
-                        claims_token.as_ref().map(|c| &c.jwt),
-                        annotations.get("wasmcloud.dev/appspec"),
-                    )
-                    .await?;
-
-                self.start_component(
-                    entry,
-                    wasm,
-                    claims.clone(),
-                    Arc::clone(&component_ref),
-                    Arc::clone(&component_id),
-                    max,
-                    annotations,
-                    config,
-                    secrets,
-                )
-                .await?;
-
-                event::component_scaled(
-                    claims.as_ref(),
-                    annotations,
-                    host_id,
-                    max,
-                    &component_ref,
-                    &component_id,
-                )
-            }
-            // Component is running and we requested to scale to zero instances, stop component
-            (hash_map::Entry::Occupied(entry), None) => {
-                let component = entry.remove();
-                self.stop_component(&component, host_id)
-                    .await
-                    .context("failed to stop component in response to scale to zero")?;
-
-                info!(?component_ref, "component stopped");
-                event::component_scaled(
-                    claims.as_ref(),
-                    &component.annotations,
-                    host_id,
-                    0_usize,
-                    &component.image_reference,
-                    &component.id,
-                )
-            }
-            // Component is running and we requested to scale to some amount or unbounded, scale component
-            (hash_map::Entry::Occupied(mut entry), Some(max)) => {
-                let component = entry.get_mut();
-                let config_changed =
-                    &config != component.handler.config_data.read().await.config_names();
-
-                // Create the event first to avoid borrowing the component
-                // This event is idempotent.
-                let event = event::component_scaled(
-                    claims.as_ref(),
-                    &component.annotations,
-                    host_id,
-                    max,
-                    &component.image_reference,
-                    &component.id,
-                );
-
-                // Modify scale only if the requested max differs from the current max or if the configuration has changed
-                if component.max_instances != max || config_changed {
-                    // We must partially clone the handler as we can't be sharing the targets between components
-                    let handler = component.handler.copy_for_new();
-                    if config_changed {
-                        let (config, secrets) = self
-                            .fetch_config_and_secrets(
-                                &config,
-                                claims_token.as_ref().map(|c| &c.jwt),
-                                annotations.get("wasmcloud.dev/appspec"),
-                            )
-                            .await?;
-                        *handler.config_data.write().await = config;
-                        *handler.secrets.write().await = secrets;
-                    }
-                    let instance = self
-                        .instantiate_component(
-                            annotations,
-                            Arc::clone(&component_ref),
-                            Arc::clone(&component.id),
-                            max,
-                            component.component.clone(),
-                            handler,
-                        )
-                        .await
-                        .context("failed to instantiate component")?;
-                    let component = entry.insert(instance);
-                    self.stop_component(&component, host_id)
-                        .await
-                        .context("failed to stop component after scaling")?;
-
-                    info!(?component_ref, ?max, "component scaled");
-                } else {
-                    debug!(?component_ref, ?max, "component already at desired scale");
-                }
-                event
-            }
-        };
-
-        self.publish_event("component_scaled", scaled_event).await?;
-
-        Ok(())
-    }
-
-    // TODO(#1548): With component IDs, new component references, configuration, etc, we're going to need to do some
-    // design thinking around how update component should work. Should it be limited to a single host or latticewide?
-    // Should it also update configuration, or is that separate? Should scaling be done via an update?
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_update_component(
-        self: Arc<Self>,
-        payload: impl AsRef<[u8]>,
-        host_id: &str,
-    ) -> anyhow::Result<CtlResponse<()>> {
-        let cmd = serde_json::from_slice::<UpdateComponentCommand>(payload.as_ref())
-            .context("failed to deserialize component update command")?;
-        let component_id = cmd.component_id();
-        let annotations = cmd.annotations().cloned();
-        let new_component_ref = cmd.new_component_ref();
-
-        debug!(
-            component_id,
-            new_component_ref,
-            ?annotations,
-            "handling update component"
-        );
-
-        // Find the component and extract the image reference
-        #[allow(clippy::map_clone)]
-        // NOTE: clippy thinks, that we can just replace the `.map` below by
-        // `.cloned` - we can't, because we need to clone the field
-        let Some(component_ref) = self
-            .components
-            .read()
-            .await
-            .get(component_id)
-            .map(|component| Arc::clone(&component.image_reference))
-        else {
-            return Ok(CtlResponse::error(&format!(
-                "component {component_id} not found"
-            )));
-        };
-
-        // If the component image reference is the same, respond with an appropriate message
-        if &*component_ref == new_component_ref {
-            return Ok(CtlResponse::<()>::success(format!(
-                "component {component_id} already updated to {new_component_ref}"
-            )));
-        }
-
-        let host_id = host_id.to_string();
-        let message = format!(
-            "component {component_id} updating from {component_ref} to {new_component_ref}"
-        );
-        let component_id = Arc::from(component_id);
-        let new_component_ref = Arc::from(new_component_ref);
-        spawn(async move {
-            if let Err(e) = self
-                .handle_update_component_task(
-                    Arc::clone(&component_id),
-                    Arc::clone(&new_component_ref),
-                    &host_id,
-                    annotations,
-                )
-                .await
-            {
-                error!(%new_component_ref, %component_id, err = ?e, "failed to update component");
-            }
-        });
-
-        Ok(CtlResponse::<()>::success(message))
-    }
-
-    async fn handle_update_component_task(
-        &self,
-        component_id: Arc<str>,
-        new_component_ref: Arc<str>,
-        host_id: &str,
-        annotations: Option<BTreeMap<String, String>>,
-    ) -> anyhow::Result<()> {
-        // NOTE: This block is specifically scoped to ensure we drop the read lock on `self.components` before
-        // we attempt to grab a write lock.
-        let component = {
-            let components = self.components.read().await;
-            let existing_component = components
-                .get(&*component_id)
-                .context("component not found")?;
-            let annotations = annotations.unwrap_or_default().into_iter().collect();
-
-            // task is a no-op if the component image reference is the same
-            if existing_component.image_reference == new_component_ref {
-                info!(%component_id, %new_component_ref, "component already updated");
-                return Ok(());
-            }
-
-            let new_component = self.fetch_component(&new_component_ref).await?;
-            let new_component = wasmcloud_runtime::Component::new(&self.runtime, &new_component)
-                .context("failed to initialize component")?;
-            let new_claims = new_component.claims().cloned();
-            if let Some(ref claims) = new_claims {
-                self.store_claims(Claims::Component(claims.clone()))
-                    .await
-                    .context("failed to store claims")?;
-            }
-
-            let max = existing_component.max_instances;
-            let Ok(component) = self
-                .instantiate_component(
-                    &annotations,
-                    Arc::clone(&new_component_ref),
-                    Arc::clone(&component_id),
-                    max,
-                    new_component,
-                    existing_component.handler.copy_for_new(),
-                )
-                .await
-            else {
-                bail!("failed to instantiate component from new reference");
-            };
-
-            info!(%new_component_ref, "component updated");
-            self.publish_event(
-                "component_scaled",
-                event::component_scaled(
-                    new_claims.as_ref(),
-                    &component.annotations,
-                    host_id,
-                    max,
-                    new_component_ref,
-                    &component_id,
-                ),
-            )
-            .await?;
-
-            // TODO(#1548): If this errors, we need to rollback
-            self.stop_component(&component, host_id)
-                .await
-                .context("failed to stop old component")?;
-            self.publish_event(
-                "component_scaled",
-                event::component_scaled(
-                    component.claims(),
-                    &component.annotations,
-                    host_id,
-                    0_usize,
-                    &component.image_reference,
-                    &component.id,
-                ),
-            )
-            .await?;
-
-            component
-        };
-
-        self.components
-            .write()
-            .await
-            .insert(component_id.to_string(), component);
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_start_provider(
-        self: Arc<Self>,
-        payload: impl AsRef<[u8]>,
-        host_id: &str,
-    ) -> anyhow::Result<CtlResponse<()>> {
-        let cmd = serde_json::from_slice::<StartProviderCommand>(payload.as_ref())
-            .context("failed to deserialize provider start command")?;
-
-        if self.providers.read().await.contains_key(cmd.provider_id()) {
-            return Ok(CtlResponse::error(
-                "provider with that ID is already running",
-            ));
-        }
-
-        // NOTE: We log at info since starting providers can take a while
-        info!(
-            provider_ref = cmd.provider_ref(),
-            provider_id = cmd.provider_id(),
-            "handling start provider"
-        );
-
-        let host_id = host_id.to_string();
-        spawn(async move {
-            let config = cmd.config();
-            let provider_id = cmd.provider_id();
-            let provider_ref = cmd.provider_ref();
-            let annotations = cmd.annotations();
-
-            if let Err(err) = self
-                .handle_start_provider_task(
-                    config,
-                    provider_id,
-                    provider_ref,
-                    annotations.cloned().unwrap_or_default(),
-                    &host_id,
-                )
-                .await
-            {
-                error!(provider_ref, provider_id, ?err, "failed to start provider");
-                if let Err(err) = self
-                    .publish_event(
-                        "provider_start_failed",
-                        event::provider_start_failed(provider_ref, provider_id, &err),
-                    )
-                    .await
-                {
-                    error!(?err, "failed to publish provider_start_failed event");
-                }
-            }
-        });
-        Ok(CtlResponse::<()>::success(
-            "successfully started provider".into(),
-        ))
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_start_provider_task(
-        &self,
-        config: &[String],
-        provider_id: &str,
-        provider_ref: &str,
-        annotations: BTreeMap<String, String>,
-        host_id: &str,
-    ) -> anyhow::Result<()> {
-        trace!(provider_ref, provider_id, "start provider task");
-
-        let registry_config = self.registry_config.read().await;
-        let (path, claims_token) = crate::fetch_provider(
-            provider_ref,
-            host_id,
-            self.host_config.allow_file_load,
-            &registry_config,
-        )
-        .await
-        .context("failed to fetch provider")?;
-        let claims = claims_token.as_ref().map(|t| t.claims.clone());
-
-        if let Some(claims) = claims.clone() {
-            self.store_claims(Claims::Provider(claims))
-                .await
-                .context("failed to store claims")?;
-        }
-
-        let annotations: Annotations = annotations.into_iter().collect();
-
-        let PolicyResponse {
-            permitted,
-            request_id,
-            message,
-        } = self
-            .policy_manager
-            .evaluate_start_provider(provider_id, provider_ref, &annotations, claims.as_ref())
-            .await?;
-        ensure!(
-            permitted,
-            "policy denied request to start provider `{request_id}`: `{message:?}`",
-        );
-
-        let component_specification = self
-            .get_component_spec(provider_id)
-            .await?
-            .unwrap_or_else(|| ComponentSpecification::new(provider_ref));
-
-        self.store_component_spec(&provider_id, &component_specification)
-            .await?;
-
-        let (config, secrets) = self
-            .fetch_config_and_secrets(
-                config,
-                claims_token.as_ref().map(|t| &t.jwt),
-                annotations.get("wasmcloud.dev/appspec"),
-            )
-            .await?;
-
-        let mut providers = self.providers.write().await;
-        if let hash_map::Entry::Vacant(entry) = providers.entry(provider_id.into()) {
-            let lattice_rpc_user_seed = self
-                .host_config
-                .rpc_key
-                .as_ref()
-                .map(|key| key.seed())
-                .transpose()
-                .context("private key missing for provider RPC key")?;
-            let default_rpc_timeout_ms = Some(
-                self.host_config
-                    .rpc_timeout
-                    .as_millis()
-                    .try_into()
-                    .context("failed to convert rpc_timeout to u64")?,
-            );
-            let otel_config = OtelConfig {
-                enable_observability: self.host_config.otel_config.enable_observability,
-                enable_traces: self.host_config.otel_config.enable_traces,
-                enable_metrics: self.host_config.otel_config.enable_metrics,
-                enable_logs: self.host_config.otel_config.enable_logs,
-                observability_endpoint: self.host_config.otel_config.observability_endpoint.clone(),
-                traces_endpoint: self.host_config.otel_config.traces_endpoint.clone(),
-                metrics_endpoint: self.host_config.otel_config.metrics_endpoint.clone(),
-                logs_endpoint: self.host_config.otel_config.logs_endpoint.clone(),
-                protocol: self.host_config.otel_config.protocol,
-                additional_ca_paths: self.host_config.otel_config.additional_ca_paths.clone(),
-                trace_level: self.host_config.otel_config.trace_level.clone(),
-            };
-
-            let provider_xkey = XKey::new();
-            // The provider itself needs to know its private key
-            let provider_xkey_private_key = if let Ok(seed) = provider_xkey.seed() {
-                seed
-            } else if self.host_config.secrets_topic_prefix.is_none() {
-                "".to_string()
-            } else {
-                // This should never happen since this returns an error when an Xkey is
-                // created from a public key, but if we can't generate one for whatever
-                // reason, we should bail.
-                bail!("failed to generate seed for provider xkey")
-            };
-            // We only need to store the public key of the provider xkey, as the private key is only needed by the provider
-            let xkey = XKey::from_public_key(&provider_xkey.public_key())
-                .context("failed to create XKey from provider public key xkey")?;
-
-            // Prepare startup links by generating the source and target configs. Note that because the provider may be the source
-            // or target of a link, we need to iterate over all links to find the ones that involve the provider.
-            let all_links = self.links.read().await;
-            let provider_links = all_links
-                .values()
-                .flatten()
-                .filter(|link| link.source_id() == provider_id || link.target() == provider_id);
-            let link_definitions = stream::iter(provider_links)
-                .filter_map(|link| async {
-                    if link.source_id() == provider_id || link.target() == provider_id {
-                        match self
-                            .resolve_link_config(
-                                link.clone(),
-                                claims_token.as_ref().map(|t| &t.jwt),
-                                annotations.get("wasmcloud.dev/appspec"),
-                                &xkey,
-                            )
-                            .await
-                        {
-                            Ok(provider_link) => Some(provider_link),
-                            Err(e) => {
-                                error!(
-                                    error = ?e,
-                                    provider_id,
-                                    source_id = link.source_id(),
-                                    target = link.target(),
-                                    "failed to resolve link config, skipping link"
-                                );
-                                None
-                            }
-                        }
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<wasmcloud_core::InterfaceLinkDefinition>>()
-                .await;
-
-            let secrets = {
-                // NOTE(brooksmtownsend): This trait import is used here to ensure we're only exposing secret
-                // values when we need them.
-                use secrecy::ExposeSecret;
-                secrets
-                    .iter()
-                    .map(|(k, v)| match v.expose_secret() {
-                        SecretValue::String(s) => (
-                            k.clone(),
-                            wasmcloud_core::secrets::SecretValue::String(s.to_owned()),
-                        ),
-                        SecretValue::Bytes(b) => (
-                            k.clone(),
-                            wasmcloud_core::secrets::SecretValue::Bytes(b.to_owned()),
-                        ),
-                    })
-                    .collect()
-            };
-
-            let host_data = HostData {
-                host_id: self.host_key.public_key(),
-                lattice_rpc_prefix: self.host_config.lattice.to_string(),
-                link_name: "default".to_string(),
-                lattice_rpc_user_jwt: self.host_config.rpc_jwt.clone().unwrap_or_default(),
-                lattice_rpc_user_seed: lattice_rpc_user_seed.unwrap_or_default(),
-                lattice_rpc_url: self.host_config.rpc_nats_url.to_string(),
-                env_values: vec![],
-                instance_id: Uuid::new_v4().to_string(),
-                provider_key: provider_id.to_string(),
-                link_definitions,
-                config: config.get_config().await.clone(),
-                secrets,
-                provider_xkey_private_key,
-                host_xkey_public_key: self.secrets_xkey.public_key(),
-                cluster_issuers: vec![],
-                default_rpc_timeout_ms,
-                log_level: Some(self.host_config.log_level.clone()),
-                structured_logging: self.host_config.enable_structured_logging,
-                otel_config,
-            };
-            let host_data =
-                serde_json::to_vec(&host_data).context("failed to serialize provider data")?;
-
-            trace!("spawn provider process");
-
-            let mut child_cmd = process::Command::new(&path);
-            // Prevent the provider from inheriting the host's environment, with the exception of
-            // the following variables we manually add back
-            child_cmd.env_clear();
-
-            if cfg!(windows) {
-                // Proxy SYSTEMROOT to providers. Without this, providers on Windows won't be able to start
-                child_cmd.env(
-                    "SYSTEMROOT",
-                    env::var("SYSTEMROOT")
-                        .context("SYSTEMROOT is not set. Providers cannot be started")?,
-                );
-            }
-
-            // Proxy RUST_LOG to (Rust) providers, so they can use the same module-level directives
-            if let Ok(rust_log) = env::var("RUST_LOG") {
-                let _ = child_cmd.env("RUST_LOG", rust_log);
-            }
-
-            let mut child = child_cmd
-                .stdin(Stdio::piped())
-                .kill_on_drop(true)
-                .spawn()
-                .context("failed to spawn provider process")?;
-            let mut stdin = child.stdin.take().context("failed to take stdin")?;
-            stdin
-                .write_all(STANDARD.encode(&host_data).as_bytes())
-                .await
-                .context("failed to write provider data")?;
-            stdin
-                .write_all(b"\r\n")
-                .await
-                .context("failed to write newline")?;
-            stdin.shutdown().await.context("failed to close stdin")?;
-
-            // Create a channel for watching for child process exit
-            let (exit_tx, exit_rx) = broadcast::channel::<()>(1);
-            spawn(async move {
-                match child.wait().await {
-                    Ok(status) => {
-                        debug!("provider @ [{}] exited with `{status:?}`", path.display());
-                    }
-                    Err(e) => {
-                        error!(
-                            "failed to wait for provider @ [{}] to execute: {e}",
-                            path.display()
-                        );
-                    }
-                }
-                if let Err(err) = exit_tx.send(()) {
-                    warn!(%err, "failed to send exit tx");
-                }
-            });
-            let mut exit_health_rx = exit_rx.resubscribe();
-
-            // TODO: Change method receiver to Arc<Self> and `move` into the closure
-            let rpc_nats = self.rpc_nats.clone();
-            let ctl_nats = self.ctl_nats.clone();
-            let event_builder = self.event_builder.clone();
-            // NOTE: health_ prefix here is to allow us to move the variables into the closure
-            let health_lattice = self.host_config.lattice.clone();
-            let health_host_id = host_id.to_string();
-            let health_provider_id = provider_id.to_string();
-            let health_check_task = spawn(async move {
-                // Check the health of the provider every 30 seconds
-                let mut health_check = tokio::time::interval(Duration::from_secs(30));
-                let mut previous_healthy = false;
-                // Allow the provider 5 seconds to initialize
-                health_check.reset_after(Duration::from_secs(5));
-                let health_topic =
-                    format!("wasmbus.rpc.{health_lattice}.{health_provider_id}.health");
-                // TODO: Refactor this logic to simplify nesting
-                loop {
-                    select! {
-                        _ = health_check.tick() => {
-                            trace!(provider_id=health_provider_id, "performing provider health check");
-                            let request = async_nats::Request::new()
-                                .payload(Bytes::new())
-                                .headers(injector_to_headers(&TraceContextInjector::default_with_span()));
-                            if let Ok(async_nats::Message { payload, ..}) = rpc_nats.send_request(
-                                health_topic.clone(),
-                                request,
-                                ).await {
-                                    match (serde_json::from_slice::<HealthCheckResponse>(&payload), previous_healthy) {
-                                        (Ok(HealthCheckResponse { healthy: true, ..}), false) => {
-                                            trace!(provider_id=health_provider_id, "provider health check succeeded");
-                                            previous_healthy = true;
-                                            if let Err(e) = event::publish(
-                                                &event_builder,
-                                                &ctl_nats,
-                                                &health_lattice,
-                                                "health_check_passed",
-                                                event::provider_health_check(
-                                                    &health_host_id,
-                                                    &health_provider_id,
-                                                )
-                                            ).await {
-                                                warn!(
-                                                    ?e,
-                                                    provider_id = health_provider_id,
-                                                    "failed to publish provider health check succeeded event",
-                                                );
-                                            }
-                                        },
-                                        (Ok(HealthCheckResponse { healthy: false, ..}), true) => {
-                                            trace!(provider_id=health_provider_id, "provider health check failed");
-                                            previous_healthy = false;
-                                            if let Err(e) = event::publish(
-                                                &event_builder,
-                                                &ctl_nats,
-                                                &health_lattice,
-                                                "health_check_failed",
-                                                event::provider_health_check(
-                                                    &health_host_id,
-                                                    &health_provider_id,
-                                                )
-                                            ).await {
-                                                warn!(
-                                                    ?e,
-                                                    provider_id = health_provider_id,
-                                                    "failed to publish provider health check failed event",
-                                                );
-                                            }
-                                        }
-                                        // If the provider health status didn't change, we simply publish a health check status event
-                                        (Ok(_), _) => {
-                                            if let Err(e) = event::publish(
-                                                &event_builder,
-                                                &ctl_nats,
-                                                &health_lattice,
-                                                "health_check_status",
-                                                event::provider_health_check(
-                                                    &health_host_id,
-                                                    &health_provider_id,
-                                                )
-                                            ).await {
-                                                warn!(
-                                                    ?e,
-                                                    provider_id = health_provider_id,
-                                                    "failed to publish provider health check status event",
-                                                );
-                                            }
-                                        },
-                                        _ => warn!(
-                                            provider_id = health_provider_id,
-                                            "failed to deserialize provider health check response"
-                                        ),
-                                    }
-                                }
-                                else {
-                                    warn!(provider_id = health_provider_id, "failed to request provider health, retrying in 30 seconds");
-                                }
-                        }
-                        exit = exit_health_rx.recv() => {
-                            if let Err(err) = exit {
-                                warn!(%err, provider_id = health_provider_id, "failed to receive exit in health check task");
-                            }
-                            break;
-                        }
-                    }
-                }
-            });
-            info!(provider_ref, provider_id, "provider started");
-            self.publish_event(
-                "provider_started",
-                event::provider_started(
-                    claims.as_ref(),
-                    &annotations,
-                    host_id,
-                    provider_ref,
-                    provider_id,
-                ),
-            )
-            .await?;
-
-            // Spawn off a task to watch for config bundle updates and forward them to
-            // the provider that we're spawning and managing
-            let mut exit_config_tx = exit_rx;
-            let provider_id = provider_id.to_string();
-            let lattice = self.host_config.lattice.to_string();
-            let client = self.rpc_nats.clone();
-            let config = Arc::new(RwLock::new(config));
-            let update_config = config.clone();
-            let config_update_task = spawn(async move {
-                let subject = provider_config_update_subject(&lattice, &provider_id);
-                trace!(provider_id, "starting config update listener");
-                loop {
-                    let mut update_config = update_config.write().await;
-                    select! {
-                        maybe_update = update_config.changed() => {
-                            let Ok(update) = maybe_update else {
-                                break;
-                            };
-                            trace!(provider_id, "provider config bundle changed");
-                            let bytes = match serde_json::to_vec(&*update) {
-                                Ok(bytes) => bytes,
-                                Err(err) => {
-                                    error!(%err, provider_id, lattice, "failed to serialize configuration update ");
-                                    continue;
-                                }
-                            };
-                            trace!(provider_id, subject, "publishing config bundle bytes");
-                            if let Err(err) = client.publish(subject.clone(), Bytes::from(bytes)).await {
-                                error!(%err, provider_id, lattice, "failed to publish configuration update bytes to component");
-                            }
-                        }
-                        exit = exit_config_tx.recv() => {
-                            if let Err(err) = exit {
-                                warn!(%err, provider_id, "failed to receive exit in config update task");
-                            }
-                            break;
-                        }
-                    }
-                }
-            });
-
-            // Add the provider
-            entry.insert(Provider {
-                health_check_task,
-                config_update_task,
-                annotations,
-                claims_token,
-                image_ref: provider_ref.to_string(),
-                xkey,
-                config,
-            });
-        } else {
-            bail!("provider is already running with that ID")
-        }
-
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_stop_provider(
-        &self,
-        payload: impl AsRef<[u8]>,
-        host_id: &str,
-    ) -> anyhow::Result<CtlResponse<()>> {
-        let cmd = serde_json::from_slice::<StopProviderCommand>(payload.as_ref())
-            .context("failed to deserialize provider stop command")?;
-        let provider_id = cmd.provider_id();
-
-        debug!(provider_id, "handling stop provider");
-
-        let mut providers = self.providers.write().await;
-        let hash_map::Entry::Occupied(entry) = providers.entry(provider_id.into()) else {
-            warn!(
-                provider_id,
-                "received request to stop provider that is not running"
-            );
-            return Ok(CtlResponse::error("provider with that ID is not running"));
-        };
-        let Provider {
-            ref annotations, ..
-        } = entry.remove();
-
-        // Send a request to the provider, requesting a graceful shutdown
-        let req = serde_json::to_vec(&json!({ "host_id": host_id }))
-            .context("failed to encode provider stop request")?;
-        let req = async_nats::Request::new()
-            .payload(req.into())
-            .timeout(self.host_config.provider_shutdown_delay)
-            .headers(injector_to_headers(
-                &TraceContextInjector::default_with_span(),
-            ));
-        if let Err(e) = self
-            .rpc_nats
-            .send_request(
-                format!(
-                    "wasmbus.rpc.{}.{provider_id}.default.shutdown",
-                    self.host_config.lattice
-                ),
-                req,
-            )
-            .await
-        {
-            warn!(
-                ?e,
-                provider_id,
-                "provider did not gracefully shut down in time, shutting down forcefully"
-            );
-        }
-        info!(provider_id, "provider stopped");
-        self.publish_event(
-            "provider_stopped",
-            event::provider_stopped(annotations, host_id, provider_id, "stop"),
-        )
-        .await?;
-        Ok(CtlResponse::<()>::success(
-            "successfully stopped provider".into(),
-        ))
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_inventory(&self) -> anyhow::Result<CtlResponse<HostInventory>> {
+    async fn handle_inventory(&self, lattice: &str) -> anyhow::Result<CtlResponse<HostInventory>> {
         trace!("handling inventory");
-        let inventory = self.inventory().await;
+        let inventory = self.inventory(lattice).await?;
         Ok(CtlResponse::ok(inventory))
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    async fn handle_claims(&self) -> anyhow::Result<CtlResponse<Vec<HashMap<String, String>>>> {
-        trace!("handling claims");
-
-        let (component_claims, provider_claims) =
-            join!(self.component_claims.read(), self.provider_claims.read());
-        let component_claims = component_claims.values().cloned().map(Claims::Component);
-        let provider_claims = provider_claims.values().cloned().map(Claims::Provider);
-        let claims: Vec<StoredClaims> = component_claims
-            .chain(provider_claims)
-            .flat_map(TryFrom::try_from)
-            .collect();
-
-        Ok(CtlResponse::ok(
-            claims.into_iter().map(std::convert::Into::into).collect(),
-        ))
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    async fn handle_links(&self) -> anyhow::Result<Vec<u8>> {
-        trace!("handling links");
-
-        let links = self.links.read().await;
-        let links: Vec<&Link> = links.values().flatten().collect();
-        let res =
-            serde_json::to_vec(&CtlResponse::ok(links)).context("failed to serialize response")?;
-        Ok(res)
-    }
-
-    #[instrument(level = "trace", skip(self))]
-    async fn handle_config_get(&self, config_name: &str) -> anyhow::Result<Vec<u8>> {
-        trace!(%config_name, "handling get config");
-        if let Some(config_bytes) = self.config_data.get(config_name).await? {
-            let config_map: HashMap<String, String> = serde_json::from_slice(&config_bytes)
-                .context("config data should be a map of string -> string")?;
-            serde_json::to_vec(&CtlResponse::ok(config_map)).map_err(anyhow::Error::from)
-        } else {
-            serde_json::to_vec(&CtlResponse::<()>::success(
-                "Configuration not found".into(),
-            ))
-            .map_err(anyhow::Error::from)
-        }
     }
 
     #[instrument(level = "debug", skip_all)]
     async fn handle_label_put(
         &self,
         host_id: &str,
+        lattice: &str,
         payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<CtlResponse<()>> {
         let host_label = serde_json::from_slice::<HostLabel>(payload.as_ref())
@@ -2658,6 +1090,7 @@ impl Host {
 
         self.publish_event(
             "labels_changed",
+            lattice,
             event::labels_changed(host_id, HashMap::from_iter(labels.clone())),
         )
         .await
@@ -2670,6 +1103,7 @@ impl Host {
     async fn handle_label_del(
         &self,
         host_id: &str,
+        lattice: &str,
         payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<CtlResponse<()>> {
         let label = serde_json::from_slice::<HostLabel>(payload.as_ref())
@@ -2688,6 +1122,7 @@ impl Host {
         info!(key, "removed label");
         self.publish_event(
             "labels_changed",
+            lattice,
             event::labels_changed(host_id, HashMap::from_iter(labels.clone())),
         )
         .await
@@ -2698,255 +1133,10 @@ impl Host {
         ))
     }
 
-    /// Handle a new link by modifying the relevant source [ComponentSpeficication]. Once
-    /// the change is written to the LATTICEDATA store, each host in the lattice (including this one)
-    /// will handle the new specification and update their own internal link maps via [process_component_spec_put].
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_link_put(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<CtlResponse<()>> {
-        let payload = payload.as_ref();
-        let link: Link = serde_json::from_slice(payload)
-            .context("failed to deserialize wrpc link definition")?;
-
-        let link_set_result: anyhow::Result<()> = async {
-            let source_id = link.source_id();
-            let target = link.target();
-            let wit_namespace = link.wit_namespace();
-            let wit_package = link.wit_package();
-            let interfaces = link.interfaces();
-            let name = link.name();
-
-            let ns_and_package = format!("{wit_namespace}:{wit_package}");
-            debug!(
-                source_id,
-                target,
-                ns_and_package,
-                name,
-                ?interfaces,
-                "handling put wrpc link definition"
-            );
-
-            // Validate all configurations
-            self.validate_config(
-                link
-                    .source_config()
-                    .clone()
-                    .iter()
-                    .chain(link.target_config())
-            ).await?;
-
-            let mut component_spec = self
-                .get_component_spec(source_id)
-                .await?
-                .unwrap_or_default();
-
-            // If the link is defined from this source on the same interface and link name, but to a different target,
-            // we need to reject this link and suggest deleting the existing link or using a different link name.
-            if let Some(existing_conflict_link) = component_spec.links.iter().find(|link| {
-                link.source_id() == source_id
-                    && link.wit_namespace() == wit_namespace
-                    && link.wit_package() == wit_package
-                    && link.name() == name
-                    && link.target() != target
-            }) {
-                error!(
-                    source_id,
-                    desired_target = target,
-                    existing_target = existing_conflict_link.target(),
-                    ns_and_package,
-                    name,
-                    "link already exists with different target, consider deleting the existing link or using a different link name"
-                );
-                bail!("link already exists with different target, consider deleting the existing link or using a different link name");
-            }
-
-            // If we can find an existing link with the same source, target, namespace, package, and name, update it.
-            // Otherwise, add the new link to the component specification.
-            if let Some(existing_link_index) = component_spec.links.iter().position(|link| {
-                link.source_id() == source_id
-                    && link.target() == target
-                    && link.wit_namespace() == wit_namespace
-                    && link.wit_package() == wit_package
-                    && link.name() == name
-            }) {
-                if let Some(existing_link) = component_spec.links.get_mut(existing_link_index) {
-                    *existing_link = link.clone();
-                }
-            } else {
-                component_spec.links.push(link.clone());
-            };
-
-            // Update component specification with the new link
-            self.store_component_spec(&source_id, &component_spec)
-                .await?;
-
-            self.put_backwards_compat_provider_link(&link)
-                .await?;
-
-            Ok(())
-        }
-        .await;
-
-        if let Err(e) = link_set_result {
-            self.publish_event("linkdef_set_failed", event::linkdef_set_failed(&link, &e))
-                .await?;
-            Ok(CtlResponse::error(e.to_string().as_ref()))
-        } else {
-            self.publish_event("linkdef_set", event::linkdef_set(&link))
-                .await?;
-            Ok(CtlResponse::<()>::success("successfully set link".into()))
-        }
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    /// Remove an interface link on a source component for a specific package
-    async fn handle_link_del(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<CtlResponse<()>> {
-        let payload = payload.as_ref();
-        let req = serde_json::from_slice::<DeleteInterfaceLinkDefinitionRequest>(payload)
-            .context("failed to deserialize wrpc link definition")?;
-        let source_id = req.source_id();
-        let wit_namespace = req.wit_namespace();
-        let wit_package = req.wit_package();
-        let link_name = req.link_name();
-
-        let ns_and_package = format!("{wit_namespace}:{wit_package}");
-
-        debug!(
-            source_id,
-            ns_and_package, link_name, "handling del wrpc link definition"
-        );
-
-        let Some(mut component_spec) = self.get_component_spec(source_id).await? else {
-            // If the component spec doesn't exist, the link is deleted
-            return Ok(CtlResponse::<()>::success(
-                "successfully deleted link (spec doesn't exist)".into(),
-            ));
-        };
-
-        // If we can find an existing link with the same source, namespace, package, and name, remove it
-        // and update the component specification.
-        let deleted_link = if let Some(existing_link_index) =
-            component_spec.links.iter().position(|link| {
-                link.source_id() == source_id
-                    && link.wit_namespace() == wit_namespace
-                    && link.wit_package() == wit_package
-                    && link.name() == link_name
-            }) {
-            // Sanity safety check since `swap_remove` will panic if the index is out of bounds
-            if existing_link_index < component_spec.links.len() {
-                Some(component_spec.links.swap_remove(existing_link_index))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        if let Some(link) = deleted_link.as_ref() {
-            // Update component specification with the deleted link
-            self.store_component_spec(&source_id, &component_spec)
-                .await?;
-
-            // Send the link to providers for deletion
-            self.del_provider_link(link).await?;
-        }
-
-        // For idempotency, we always publish the deleted event, even if the link didn't exist
-        let deleted_link_target = deleted_link
-            .as_ref()
-            .map(|link| String::from(link.target()));
-        self.publish_event(
-            "linkdef_deleted",
-            event::linkdef_deleted(
-                source_id,
-                deleted_link_target.as_ref(),
-                link_name,
-                wit_namespace,
-                wit_package,
-                deleted_link.as_ref().map(|link| link.interfaces()),
-            ),
-        )
-        .await?;
-
-        Ok(CtlResponse::<()>::success(
-            "successfully deleted link".into(),
-        ))
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn handle_registries_put(
-        &self,
-        payload: impl AsRef<[u8]>,
-    ) -> anyhow::Result<CtlResponse<()>> {
-        let registry_creds: HashMap<String, RegistryCredential> =
-            serde_json::from_slice(payload.as_ref())
-                .context("failed to deserialize registries put command")?;
-
-        info!(
-            registries = ?registry_creds.keys(),
-            "updating registry config",
-        );
-
-        let mut registry_config = self.registry_config.write().await;
-        for (reg, new_creds) in registry_creds {
-            let mut new_config = new_creds.into_registry_config()?;
-            match registry_config.entry(reg) {
-                hash_map::Entry::Occupied(mut entry) => {
-                    entry.get_mut().set_auth(new_config.auth().clone());
-                }
-                hash_map::Entry::Vacant(entry) => {
-                    new_config.set_allow_latest(self.host_config.oci_opts.allow_latest);
-                    entry.insert(new_config);
-                }
-            }
-        }
-
-        Ok(CtlResponse::<()>::success(
-            "successfully put registries".into(),
-        ))
-    }
-
-    #[instrument(level = "debug", skip_all, fields(%config_name))]
-    async fn handle_config_put(
-        &self,
-        config_name: &str,
-        data: Bytes,
-    ) -> anyhow::Result<CtlResponse<()>> {
-        debug!("handle config entry put");
-        // Validate that the data is of the proper type by deserialing it
-        serde_json::from_slice::<HashMap<String, String>>(&data)
-            .context("config data should be a map of string -> string")?;
-        self.config_data
-            .put(config_name, data)
-            .await
-            .context("unable to store config data")?;
-        // We don't write it into the cached data and instead let the caching thread handle it as we
-        // won't need it immediately.
-        self.publish_event("config_set", event::config_set(config_name))
-            .await?;
-
-        Ok(CtlResponse::<()>::success("successfully put config".into()))
-    }
-
-    #[instrument(level = "debug", skip_all, fields(%config_name))]
-    async fn handle_config_delete(&self, config_name: &str) -> anyhow::Result<CtlResponse<()>> {
-        debug!("handle config entry deletion");
-
-        self.config_data
-            .purge(config_name)
-            .await
-            .context("Unable to delete config data")?;
-
-        self.publish_event("config_deleted", event::config_deleted(config_name))
-            .await?;
-
-        Ok(CtlResponse::<()>::success(
-            "successfully deleted config".into(),
-        ))
-    }
-
     #[instrument(level = "debug", skip_all)]
     async fn handle_ping_hosts(
         &self,
+        lattice: &str,
         _payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<CtlResponse<wasmcloud_control_interface::Host>> {
         trace!("replying to ping");
@@ -2961,7 +1151,7 @@ impl Host {
             .version(self.host_config.version.clone())
             .ctl_host(self.host_config.ctl_nats_url.to_string())
             .rpc_host(self.host_config.rpc_nats_url.to_string())
-            .lattice(self.host_config.lattice.to_string());
+            .lattice(lattice.to_string());
 
         if let Some(ref js_domain) = self.host_config.js_domain {
             host = host.js_domain(js_domain.clone());
@@ -2988,7 +1178,7 @@ impl Host {
             .trim_start_matches(&self.ctl_topic_prefix)
             .trim_start_matches('.')
             .split('.')
-            .skip(2);
+            .skip(1);
         trace!(%subject, "handling control interface request");
 
         // This response is a wrapped Result<Option<Result<Vec<u8>>>> for a good reason.
@@ -2999,103 +1189,37 @@ impl Host {
         // The inner Result is purely for the success or failure of serializing the [CtlResponse], which
         //    should never fail but it's a result we must handle.
         // And finally, the Vec<u8> is the serialized [CtlResponse] that we'll send back to the client
-        let ctl_response = match (parts.next(), parts.next(), parts.next(), parts.next()) {
-            // Component commands
-            (Some("component"), Some("auction"), None, None) => self
-                .handle_auction_component(message.payload)
-                .await
-                .map(serialize_ctl_response),
-            (Some("component"), Some("scale"), Some(host_id), None) => Arc::clone(&self)
-                .handle_scale_component(message.payload, host_id)
-                .await
-                .map(Some)
-                .map(serialize_ctl_response),
-            (Some("component"), Some("update"), Some(host_id), None) => Arc::clone(&self)
-                .handle_update_component(message.payload, host_id)
-                .await
-                .map(Some)
-                .map(serialize_ctl_response),
-            // Provider commands
-            (Some("provider"), Some("auction"), None, None) => self
-                .handle_auction_provider(message.payload)
-                .await
-                .map(serialize_ctl_response),
-            (Some("provider"), Some("start"), Some(host_id), None) => Arc::clone(&self)
-                .handle_start_provider(message.payload, host_id)
-                .await
-                .map(Some)
-                .map(serialize_ctl_response),
-            (Some("provider"), Some("stop"), Some(host_id), None) => self
-                .handle_stop_provider(message.payload, host_id)
-                .await
-                .map(Some)
-                .map(serialize_ctl_response),
+        let ctl_response = match (
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+        ) {
             // Host commands
-            (Some("host"), Some("get"), Some(_host_id), None) => self
-                .handle_inventory()
+            (Some(lattice), Some("host"), Some("get"), Some(_host_id), None) => self
+                .handle_inventory(lattice)
                 .await
                 .map(Some)
                 .map(serialize_ctl_response),
-            (Some("host"), Some("ping"), None, None) => self
-                .handle_ping_hosts(message.payload)
+            (Some(lattice), Some("host"), Some("ping"), None, None) => self
+                .handle_ping_hosts(lattice, message.payload)
                 .await
                 .map(Some)
                 .map(serialize_ctl_response),
-            (Some("host"), Some("stop"), Some(host_id), None) => self
+            (Some(_lattice), Some("host"), Some("stop"), Some(host_id), None) => self
                 .handle_stop_host(message.payload, host_id)
                 .await
                 .map(Some)
                 .map(serialize_ctl_response),
-            // Claims commands
-            (Some("claims"), Some("get"), None, None) => self
-                .handle_claims()
-                .await
-                .map(Some)
-                .map(serialize_ctl_response),
-            // Link commands
-            (Some("link"), Some("del"), None, None) => self
-                .handle_link_del(message.payload)
-                .await
-                .map(Some)
-                .map(serialize_ctl_response),
-            (Some("link"), Some("get"), None, None) => {
-                // Explicitly returning a Vec<u8> for non-cloning efficiency within handle_links
-                self.handle_links().await.map(|bytes| Some(Ok(bytes)))
-            }
-            (Some("link"), Some("put"), None, None) => self
-                .handle_link_put(message.payload)
-                .await
-                .map(Some)
-                .map(serialize_ctl_response),
             // Label commands
-            (Some("label"), Some("del"), Some(host_id), None) => self
-                .handle_label_del(host_id, message.payload)
+            (Some(lattice), Some("label"), Some("del"), Some(host_id), None) => self
+                .handle_label_del(host_id, lattice, message.payload)
                 .await
                 .map(Some)
                 .map(serialize_ctl_response),
-            (Some("label"), Some("put"), Some(host_id), None) => self
-                .handle_label_put(host_id, message.payload)
-                .await
-                .map(Some)
-                .map(serialize_ctl_response),
-            // Registry commands
-            (Some("registry"), Some("put"), None, None) => self
-                .handle_registries_put(message.payload)
-                .await
-                .map(Some)
-                .map(serialize_ctl_response),
-            // Config commands
-            (Some("config"), Some("get"), Some(config_name), None) => self
-                .handle_config_get(config_name)
-                .await
-                .map(|bytes| Some(Ok(bytes))),
-            (Some("config"), Some("put"), Some(config_name), None) => self
-                .handle_config_put(config_name, message.payload)
-                .await
-                .map(Some)
-                .map(serialize_ctl_response),
-            (Some("config"), Some("del"), Some(config_name), None) => self
-                .handle_config_delete(config_name)
+            (Some(lattice), Some("label"), Some("put"), Some(host_id), None) => self
+                .handle_label_put(host_id, lattice, message.payload)
                 .await
                 .map(Some)
                 .map(serialize_ctl_response),
@@ -3151,554 +1275,6 @@ impl Host {
                 }
             }
         }
-    }
-
-    // TODO: Remove this before wasmCloud 1.2 is released. This is a backwards-compatible
-    // provider link definition put that is published to the provider's id, which is what
-    // providers built for wasmCloud 1.0 expected.
-    //
-    // Thankfully, in a lattice where there are no "older" providers running, these publishes
-    // will return immediately as there will be no subscribers on those topics.
-    async fn put_backwards_compat_provider_link(&self, link: &Link) -> anyhow::Result<()> {
-        // Only attempt to publish the backwards-compatible provider link definition if the link
-        // does not contain any secret values.
-        let source_config_contains_secret = link
-            .source_config()
-            .iter()
-            .any(|c| c.starts_with(SECRET_PREFIX));
-        let target_config_contains_secret = link
-            .target_config()
-            .iter()
-            .any(|c| c.starts_with(SECRET_PREFIX));
-        if source_config_contains_secret || target_config_contains_secret {
-            debug!("link contains secrets and is not backwards compatible, skipping");
-            return Ok(());
-        }
-        let provider_link = self
-            .resolve_link_config(link.clone(), None, None, &XKey::new())
-            .await
-            .context("failed to resolve link config")?;
-        let lattice = &self.host_config.lattice;
-        let payload: Bytes = serde_json::to_vec(&provider_link)
-            .context("failed to serialize provider link definition")?
-            .into();
-
-        if let Err(e) = self
-            .rpc_nats
-            .publish_with_headers(
-                format!("wasmbus.rpc.{lattice}.{}.linkdefs.put", link.source_id()),
-                injector_to_headers(&TraceContextInjector::default_with_span()),
-                payload.clone(),
-            )
-            .await
-        {
-            warn!(
-                ?e,
-                "failed to publish backwards-compatible provider link to source"
-            );
-        }
-
-        if let Err(e) = self
-            .rpc_nats
-            .publish_with_headers(
-                format!("wasmbus.rpc.{lattice}.{}.linkdefs.put", link.target()),
-                injector_to_headers(&TraceContextInjector::default_with_span()),
-                payload,
-            )
-            .await
-        {
-            warn!(
-                ?e,
-                "failed to publish backwards-compatible provider link to target"
-            );
-        }
-
-        Ok(())
-    }
-
-    /// Publishes a link to a provider running on this host to handle.
-    #[instrument(level = "debug", skip_all)]
-    async fn put_provider_link(&self, provider: &Provider, link: &Link) -> anyhow::Result<()> {
-        let provider_link = self
-            .resolve_link_config(
-                link.clone(),
-                provider.claims_token.as_ref().map(|t| &t.jwt),
-                provider.annotations.get("wasmcloud.dev/appspec"),
-                &provider.xkey,
-            )
-            .await
-            .context("failed to resolve link config and secrets")?;
-        let lattice = &self.host_config.lattice;
-        let payload: Bytes = serde_json::to_vec(&provider_link)
-            .context("failed to serialize provider link definition")?
-            .into();
-
-        self.rpc_nats
-            .publish_with_headers(
-                format!(
-                    "wasmbus.rpc.{lattice}.{}.linkdefs.put",
-                    provider.xkey.public_key()
-                ),
-                injector_to_headers(&TraceContextInjector::default_with_span()),
-                payload.clone(),
-            )
-            .await
-            .context("failed to publish provider link definition put")
-    }
-
-    /// Publishes a delete link to the lattice for all instances of a provider to handle
-    /// Right now this is publishing _both_ to the source and the target in order to
-    /// ensure that the provider is aware of the link delete. This would cause problems if a provider
-    /// is linked to a provider (which it should never be.)
-    #[instrument(level = "debug", skip(self))]
-    async fn del_provider_link(&self, link: &Link) -> anyhow::Result<()> {
-        let lattice = &self.host_config.lattice;
-        // The provider expects the [`wasmcloud_core::InterfaceLinkDefinition`]
-        let link = wasmcloud_core::InterfaceLinkDefinition {
-            source_id: link.source_id().to_string(),
-            target: link.target().to_string(),
-            wit_namespace: link.wit_namespace().to_string(),
-            wit_package: link.wit_package().to_string(),
-            name: link.name().to_string(),
-            interfaces: link.interfaces().clone(),
-            // Configuration isn't needed for deletion
-            ..Default::default()
-        };
-        let source_id = &link.source_id;
-        let target = &link.target;
-        let payload: Bytes = serde_json::to_vec(&link)
-            .context("failed to serialize provider link definition for deletion")?
-            .into();
-
-        let (source_result, target_result) = futures::future::join(
-            self.rpc_nats.publish_with_headers(
-                format!("wasmbus.rpc.{lattice}.{source_id}.linkdefs.del"),
-                injector_to_headers(&TraceContextInjector::default_with_span()),
-                payload.clone(),
-            ),
-            self.rpc_nats.publish_with_headers(
-                format!("wasmbus.rpc.{lattice}.{target}.linkdefs.del"),
-                injector_to_headers(&TraceContextInjector::default_with_span()),
-                payload,
-            ),
-        )
-        .await;
-
-        source_result
-            .and(target_result)
-            .context("failed to publish provider link definition delete")
-    }
-
-    /// Retrieve a component specification based on the provided ID. The outer Result is for errors
-    /// accessing the store, and the inner option indicates if the spec exists.
-    #[instrument(level = "debug", skip_all)]
-    async fn get_component_spec(&self, id: &str) -> anyhow::Result<Option<ComponentSpecification>> {
-        let key = format!("COMPONENT_{id}");
-        let spec = self
-            .data
-            .get(key)
-            .await
-            .context("failed to get component spec")?
-            .map(|spec_bytes| serde_json::from_slice(&spec_bytes))
-            .transpose()
-            .context(format!(
-                "failed to deserialize stored component specification for {id}"
-            ))?;
-        Ok(spec)
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn store_component_spec(
-        &self,
-        id: impl AsRef<str>,
-        spec: &ComponentSpecification,
-    ) -> anyhow::Result<()> {
-        let id = id.as_ref();
-        let key = format!("COMPONENT_{id}");
-        let bytes = serde_json::to_vec(spec)
-            .context("failed to serialize component spec")?
-            .into();
-        self.data
-            .put(key, bytes)
-            .await
-            .context("failed to put component spec")?;
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn store_claims(&self, claims: Claims) -> anyhow::Result<()> {
-        match &claims {
-            Claims::Component(claims) => {
-                self.store_component_claims(claims.clone()).await?;
-            }
-            Claims::Provider(claims) => {
-                let mut provider_claims = self.provider_claims.write().await;
-                provider_claims.insert(claims.subject.clone(), claims.clone());
-            }
-        };
-        let claims: StoredClaims = claims.try_into()?;
-        let subject = match &claims {
-            StoredClaims::Component(claims) => &claims.subject,
-            StoredClaims::Provider(claims) => &claims.subject,
-        };
-        let key = format!("CLAIMS_{subject}");
-        trace!(?claims, ?key, "storing claims");
-
-        let bytes = serde_json::to_vec(&claims)
-            .context("failed to serialize claims")?
-            .into();
-        self.data
-            .put(key, bytes)
-            .await
-            .context("failed to put claims")?;
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn process_component_spec_put(
-        &self,
-        id: impl AsRef<str>,
-        value: impl AsRef<[u8]>,
-        _publish: bool,
-    ) -> anyhow::Result<()> {
-        let id = id.as_ref();
-        debug!(id, "process component spec put");
-
-        let spec: ComponentSpecification = serde_json::from_slice(value.as_ref())
-            .context("failed to deserialize component specification")?;
-
-        // Compute all new links that do not exist in the host map, which we'll use to
-        // publish to any running providers that are the source or target of the link.
-        // Computing this ahead of time is a tradeoff to hold only one lock at the cost of
-        // allocating an extra Vec. This may be a good place to optimize allocations.
-        let new_links = {
-            let all_links = self.links.read().await;
-            spec.links
-                .iter()
-                .filter(|spec_link| {
-                    // Retain only links that do not exist in the host map
-                    !all_links
-                        .iter()
-                        .filter_map(|(source_id, links)| {
-                            // Only consider links that are either the source or target of the new link
-                            if source_id == spec_link.source_id() || source_id == spec_link.target()
-                            {
-                                Some(links)
-                            } else {
-                                None
-                            }
-                        })
-                        .flatten()
-                        .any(|host_link| *spec_link == host_link)
-                })
-                .collect::<Vec<_>>()
-        };
-
-        {
-            // Acquire lock once in this block to avoid continually trying to acquire it.
-            let providers = self.providers.read().await;
-            // For every new link, if a provider is running on this host as the source or target,
-            // send the link to the provider for handling based on the xkey public key.
-            for link in new_links {
-                if let Some(provider) = providers.get(link.source_id()) {
-                    if let Err(e) = self.put_provider_link(provider, link).await {
-                        error!(?e, "failed to put provider link");
-                    }
-                }
-                if let Some(provider) = providers.get(link.target()) {
-                    if let Err(e) = self.put_provider_link(provider, link).await {
-                        error!(?e, "failed to put provider link");
-                    }
-                }
-            }
-        }
-
-        // If the component is already running, update the links
-        if let Some(component) = self.components.write().await.get(id) {
-            *component.handler.instance_links.write().await = component_import_links(&spec.links);
-            // NOTE(brooksmtownsend): We can consider updating the component if the image URL changes
-        };
-
-        // Insert the links into host map
-        self.links.write().await.insert(id.to_string(), spec.links);
-
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn process_component_spec_delete(
-        &self,
-        id: impl AsRef<str>,
-        _value: impl AsRef<[u8]>,
-        _publish: bool,
-    ) -> anyhow::Result<()> {
-        let id = id.as_ref();
-        debug!(id, "process component delete");
-        // TODO: TBD: stop component if spec deleted?
-        if self.components.write().await.get(id).is_some() {
-            warn!(
-                component_id = id,
-                "component spec deleted, but component is still running"
-            );
-        }
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn process_claims_put(
-        &self,
-        pubkey: impl AsRef<str>,
-        value: impl AsRef<[u8]>,
-    ) -> anyhow::Result<()> {
-        let pubkey = pubkey.as_ref();
-
-        debug!(pubkey, "process claim entry put");
-
-        let stored_claims: StoredClaims =
-            serde_json::from_slice(value.as_ref()).context("failed to decode stored claims")?;
-        let claims = Claims::from(stored_claims);
-
-        ensure!(claims.subject() == pubkey, "subject mismatch");
-        match claims {
-            Claims::Component(claims) => self.store_component_claims(claims).await,
-            Claims::Provider(claims) => {
-                let mut provider_claims = self.provider_claims.write().await;
-                provider_claims.insert(claims.subject.clone(), claims);
-                Ok(())
-            }
-        }
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn process_claims_delete(
-        &self,
-        pubkey: impl AsRef<str>,
-        value: impl AsRef<[u8]>,
-    ) -> anyhow::Result<()> {
-        let pubkey = pubkey.as_ref();
-
-        debug!(pubkey, "process claim entry deletion");
-
-        let stored_claims: StoredClaims =
-            serde_json::from_slice(value.as_ref()).context("failed to decode stored claims")?;
-        let claims = Claims::from(stored_claims);
-
-        ensure!(claims.subject() == pubkey, "subject mismatch");
-
-        match claims {
-            Claims::Component(claims) => {
-                let mut component_claims = self.component_claims.write().await;
-                component_claims.remove(&claims.subject);
-            }
-            Claims::Provider(claims) => {
-                let mut provider_claims = self.provider_claims.write().await;
-                provider_claims.remove(&claims.subject);
-            }
-        }
-
-        Ok(())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    async fn process_entry(
-        &self,
-        KvEntry {
-            key,
-            value,
-            operation,
-            ..
-        }: KvEntry,
-        publish: bool,
-    ) {
-        let key_id = key.split_once('_');
-        let res = match (operation, key_id) {
-            (Operation::Put, Some(("COMPONENT", id))) => {
-                self.process_component_spec_put(id, value, publish).await
-            }
-            (Operation::Delete, Some(("COMPONENT", id))) => {
-                self.process_component_spec_delete(id, value, publish).await
-            }
-            (Operation::Put, Some(("LINKDEF", _id))) => {
-                debug!("ignoring deprecated LINKDEF put operation");
-                Ok(())
-            }
-            (Operation::Delete, Some(("LINKDEF", _id))) => {
-                debug!("ignoring deprecated LINKDEF delete operation");
-                Ok(())
-            }
-            (Operation::Put, Some(("CLAIMS", pubkey))) => {
-                self.process_claims_put(pubkey, value).await
-            }
-            (Operation::Delete, Some(("CLAIMS", pubkey))) => {
-                self.process_claims_delete(pubkey, value).await
-            }
-            (operation, Some(("REFMAP", id))) => {
-                // TODO: process REFMAP entries
-                debug!(?operation, id, "ignoring REFMAP entry");
-                Ok(())
-            }
-            _ => {
-                warn!(key, ?operation, "unsupported KV bucket entry");
-                Ok(())
-            }
-        };
-        if let Err(error) = &res {
-            error!(key, ?operation, ?error, "failed to process KV bucket entry");
-        }
-    }
-
-    async fn fetch_config_and_secrets(
-        &self,
-        config_names: &[String],
-        entity_jwt: Option<&String>,
-        application: Option<&String>,
-    ) -> anyhow::Result<(ConfigBundle, HashMap<String, Secret<SecretValue>>)> {
-        let (secret_names, config_names) = config_names
-            .iter()
-            .map(|s| s.to_string())
-            .partition(|name| name.starts_with(SECRET_PREFIX));
-
-        let config = self
-            .config_generator
-            .generate(config_names)
-            .await
-            .context("Unable to fetch requested config")?;
-
-        let secrets = self
-            .secrets_manager
-            .fetch_secrets(secret_names, entity_jwt, &self.host_token.jwt, application)
-            .await
-            .context("Unable to fetch requested secrets")?;
-
-        Ok((config, secrets))
-    }
-
-    /// Validates that the provided configuration names exist in the store and are valid.
-    ///
-    /// For any configuration that starts with `SECRET_`, the configuration is expected to be a secret reference.
-    /// For any other configuration, the configuration is expected to be a [`HashMap<String, String>`].
-    async fn validate_config<I>(&self, config_names: I) -> anyhow::Result<()>
-    where
-        I: IntoIterator<Item: AsRef<str>>,
-    {
-        let config_store = self.config_data.clone();
-        let validation_errors =
-            futures::future::join_all(config_names.into_iter().map(|config_name| {
-                let config_store = config_store.clone();
-                let config_name = config_name.as_ref().to_string();
-                async move {
-                    match config_store.get(&config_name).await {
-                        Ok(Some(_)) => None,
-                        Ok(None) if config_name.starts_with(SECRET_PREFIX) => Some(format!(
-                            "Secret reference {config_name} not found in config store"
-                        )),
-                        Ok(None) => Some(format!(
-                            "Configuration {config_name} not found in config store"
-                        )),
-                        Err(e) => Some(e.to_string()),
-                    }
-                }
-            }))
-            .await;
-
-        // NOTE(brooksmtownsend): Not using `join` here because it requires a `String` and we
-        // need to flatten out the `None` values.
-        let validation_errors = validation_errors
-            .into_iter()
-            .flatten()
-            .fold(String::new(), |acc, e| acc + &e + ". ");
-        if !validation_errors.is_empty() {
-            bail!(format!(
-                "Failed to validate configuration and secrets. {validation_errors}",
-            ));
-        }
-
-        Ok(())
-    }
-
-    /// Transform a [`wasmcloud_control_interface::Link`] into a [`wasmcloud_core::InterfaceLinkDefinition`]
-    /// by fetching the source and target configurations and secrets, and encrypting the secrets.
-    async fn resolve_link_config(
-        &self,
-        link: Link,
-        provider_jwt: Option<&String>,
-        application: Option<&String>,
-        provider_xkey: &XKey,
-    ) -> anyhow::Result<wasmcloud_core::InterfaceLinkDefinition> {
-        let (source_bundle, raw_source_secrets) = self
-            .fetch_config_and_secrets(link.source_config().as_slice(), provider_jwt, application)
-            .await?;
-        let (target_bundle, raw_target_secrets) = self
-            .fetch_config_and_secrets(link.target_config().as_slice(), provider_jwt, application)
-            .await?;
-
-        let source_config = source_bundle.get_config().await;
-        let target_config = target_bundle.get_config().await;
-        // NOTE(brooksmtownsend): This trait import is used here to ensure we're only exposing secret
-        // values when we need them.
-        use secrecy::ExposeSecret;
-        let source_secrets_map: HashMap<String, wasmcloud_core::secrets::SecretValue> =
-            raw_source_secrets
-                .iter()
-                .map(|(k, v)| match v.expose_secret() {
-                    SecretValue::String(s) => (
-                        k.clone(),
-                        wasmcloud_core::secrets::SecretValue::String(s.to_owned()),
-                    ),
-                    SecretValue::Bytes(b) => (
-                        k.clone(),
-                        wasmcloud_core::secrets::SecretValue::Bytes(b.to_owned()),
-                    ),
-                })
-                .collect();
-        let target_secrets_map: HashMap<String, wasmcloud_core::secrets::SecretValue> =
-            raw_target_secrets
-                .iter()
-                .map(|(k, v)| match v.expose_secret() {
-                    SecretValue::String(s) => (
-                        k.clone(),
-                        wasmcloud_core::secrets::SecretValue::String(s.to_owned()),
-                    ),
-                    SecretValue::Bytes(b) => (
-                        k.clone(),
-                        wasmcloud_core::secrets::SecretValue::Bytes(b.to_owned()),
-                    ),
-                })
-                .collect();
-        // Serializing & sealing an empty map results in a non-empty Vec, which is difficult to tell the
-        // difference between an empty map and an encrypted empty map. To avoid this, we explicitly handle
-        // the case where the map is empty.
-        let source_secrets = if source_secrets_map.is_empty() {
-            None
-        } else {
-            Some(
-                serde_json::to_vec(&source_secrets_map)
-                    .map(|secrets| self.secrets_xkey.seal(&secrets, provider_xkey))
-                    .context("failed to serialize and encrypt source secrets")??,
-            )
-        };
-        let target_secrets = if target_secrets_map.is_empty() {
-            None
-        } else {
-            Some(
-                serde_json::to_vec(&target_secrets_map)
-                    .map(|secrets| self.secrets_xkey.seal(&secrets, provider_xkey))
-                    .context("failed to serialize and encrypt target secrets")??,
-            )
-        };
-
-        Ok(wasmcloud_core::InterfaceLinkDefinition {
-            source_id: link.source_id().to_string(),
-            target: link.target().to_string(),
-            name: link.name().to_string(),
-            wit_namespace: link.wit_namespace().to_string(),
-            wit_package: link.wit_package().to_string(),
-            interfaces: link.interfaces().clone(),
-            source_config: source_config.clone(),
-            target_config: target_config.clone(),
-            source_secrets,
-            target_secrets,
-        })
     }
 }
 

--- a/crates/test-util/tests/quickstart.rs
+++ b/crates/test-util/tests/quickstart.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as _, Result};
+use std::sync::Arc;
 
 use wasmcloud_test_util::control_interface::ClientBuilder;
 use wasmcloud_test_util::{assert_config_put, assert_scale_component, WasmCloudTestHost};
@@ -15,7 +16,7 @@ async fn test_quickstart() -> Result<()> {
     let (nats_server, nats_url, nats_client) = start_nats().await?;
 
     let lattice = "default";
-    let host = WasmCloudTestHost::start(nats_url, vec![lattice.to_string()])
+    let host = WasmCloudTestHost::start(nats_url, Arc::from(vec![Box::from(lattice)]))
         .await
         .context("failed to start host")?;
 

--- a/crates/test-util/tests/quickstart.rs
+++ b/crates/test-util/tests/quickstart.rs
@@ -15,12 +15,12 @@ async fn test_quickstart() -> Result<()> {
     let (nats_server, nats_url, nats_client) = start_nats().await?;
 
     let lattice = "default";
-    let host = WasmCloudTestHost::start(nats_url, lattice)
+    let host = WasmCloudTestHost::start(nats_url, vec![lattice.to_string()])
         .await
         .context("failed to start host")?;
 
     let ctl_client = ClientBuilder::new(nats_client)
-        .lattice(host.lattice_name().to_string())
+        .lattice(lattice.to_string())
         .build();
 
     assert_config_put(

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,10 +67,11 @@ struct Args {
     #[clap(
         short = 'x',
         long = "lattice",
-        default_value = "default",
+        default_values_t = ["default".to_string()],
+        value_delimiter = ',',
         env = "WASMCLOUD_LATTICE"
     )]
-    lattice: String,
+    lattice: Vec<String>,
     /// The seed key (a printable 256-bit Ed25519 private key) used by this host to generate its public key
     #[clap(long = "host-seed", env = "WASMCLOUD_HOST_SEED")]
     host_seed: Option<String>,
@@ -452,9 +453,17 @@ async fn main() -> anyhow::Result<()> {
             "Invalid secrets topic"
         );
     }
+
+    let lattices = args
+        .lattice
+        .into_iter()
+        .collect::<HashSet<String>>()
+        .into_iter()
+        .collect::<Vec<String>>();
+
     let (host, shutdown) = Box::pin(wasmcloud_host::wasmbus::Host::new(WasmbusHostConfig {
         ctl_nats_url,
-        lattice: Arc::from(args.lattice),
+        lattices,
         host_key,
         config_service_enabled: args.config_service_enabled,
         js_domain: args.js_domain,

--- a/src/main.rs
+++ b/src/main.rs
@@ -460,10 +460,15 @@ async fn main() -> anyhow::Result<()> {
         .collect::<HashSet<String>>()
         .into_iter()
         .collect::<Vec<String>>();
+    let lattices = lattices
+        .iter()
+        .map(|l| l.clone().into_boxed_str())
+        .collect::<Vec<Box<str>>>();
+    let l = &lattices[..];
 
     let (host, shutdown) = Box::pin(wasmcloud_host::wasmbus::Host::new(WasmbusHostConfig {
         ctl_nats_url,
-        lattices,
+        lattices: Arc::from(l),
         host_key,
         config_service_enabled: args.config_service_enabled,
         js_domain: args.js_domain,

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -155,7 +155,7 @@ async fn config_e2e() -> anyhow::Result<()> {
     // Build the host
     let host = WasmCloudTestHost::start_custom(
         &nats_url,
-        vec![LATTICE.to_string()],
+        Arc::from(vec![Box::from(LATTICE)]),
         None,
         None,
         None,

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -155,7 +155,7 @@ async fn config_e2e() -> anyhow::Result<()> {
     // Build the host
     let host = WasmCloudTestHost::start_custom(
         &nats_url,
-        LATTICE,
+        vec![LATTICE.to_string()],
         None,
         None,
         None,

--- a/tests/example-rust-hello-world.rs
+++ b/tests/example-rust-hello-world.rs
@@ -4,6 +4,7 @@ use core::str;
 use core::time::Duration;
 
 use std::net::Ipv4Addr;
+use std::sync::Arc;
 
 use anyhow::Context as _;
 use tokio::task::JoinSet;
@@ -48,7 +49,7 @@ async fn example_rust_http_hello_world() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
+    let host = WasmCloudTestHost::start(&nats_url, Arc::from(vec![Box::from(LATTICE)]))
         .await
         .context("failed to start test host")?;
 

--- a/tests/example-rust-hello-world.rs
+++ b/tests/example-rust-hello-world.rs
@@ -48,7 +48,7 @@ async fn example_rust_http_hello_world() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let host = WasmCloudTestHost::start(&nats_url, LATTICE)
+    let host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
         .await
         .context("failed to start test host")?;
 

--- a/tests/example-rust-http-keyvalue-counter.rs
+++ b/tests/example-rust-http-keyvalue-counter.rs
@@ -64,7 +64,7 @@ async fn example_rust_http_keyvalue_counter() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let host = WasmCloudTestHost::start(&nats_url, LATTICE)
+    let host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
         .await
         .context("failed to start test host")?;
 

--- a/tests/example-rust-http-keyvalue-counter.rs
+++ b/tests/example-rust-http-keyvalue-counter.rs
@@ -4,6 +4,7 @@ use core::str;
 use core::time::Duration;
 
 use std::net::Ipv4Addr;
+use std::sync::Arc;
 
 use anyhow::Context as _;
 use tokio::time::sleep;
@@ -64,7 +65,7 @@ async fn example_rust_http_keyvalue_counter() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
+    let host = WasmCloudTestHost::start(&nats_url, Arc::from(vec![Box::from(LATTICE)]))
         .await
         .context("failed to start test host")?;
 

--- a/tests/host.rs
+++ b/tests/host.rs
@@ -1,0 +1,150 @@
+#![cfg(feature = "providers")]
+
+use core::str;
+use core::time::Duration;
+
+use std::net::Ipv4Addr;
+
+use anyhow::{anyhow, Context};
+use tokio::time::sleep;
+use tokio::try_join;
+use tracing_subscriber::prelude::*;
+use wasmcloud_test_util::lattice::config::assert_config_put;
+use wasmcloud_test_util::provider::{assert_start_provider, StartProviderArgs};
+use wasmcloud_test_util::{
+    component::assert_scale_component, host::WasmCloudTestHost,
+    lattice::link::assert_advertise_link,
+};
+
+use test_components::RUST_HTTP_HELLO_WORLD;
+
+pub mod common;
+use common::free_port;
+use common::nats::start_nats;
+use common::providers;
+
+const LATTICES: &[&str] = &["default", "test-lattice"];
+const COMPONENT_ID: &str = "http_hello_world";
+
+#[tokio::test]
+async fn host_multiple_lattices() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().compact().without_time())
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")
+            }),
+        )
+        .init();
+
+    let (nats_server, nats_url, nats_client) =
+        start_nats().await.context("failed to start NATS")?;
+
+    // Build client for interacting with the lattice
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
+        .lattice(LATTICES[0].to_string())
+        .build();
+    // Build the host
+    let host =
+        WasmCloudTestHost::start(&nats_url, LATTICES.iter().map(|v| v.to_string()).collect())
+            .await
+            .context("failed to start test host")?;
+
+    let http_port = free_port().await?;
+
+    let http_server_config_name = "http-server".to_string();
+
+    let rust_http_server = providers::rust_http_server().await;
+    let rust_http_server_id = rust_http_server.subject.public_key();
+
+    try_join!(
+        async {
+            assert_config_put(
+                &ctl_client,
+                &http_server_config_name,
+                [(
+                    "ADDRESS".to_string(),
+                    format!("{}:{http_port}", Ipv4Addr::LOCALHOST),
+                )],
+            )
+            .await
+            .context("failed to put configuration")
+        },
+        async {
+            let host_key = host.host_key();
+            let rust_http_server_url = rust_http_server.url();
+            assert_start_provider(StartProviderArgs {
+                client: &ctl_client,
+                lattice: LATTICES[0],
+                host_key: &host_key,
+                provider_key: &rust_http_server.subject,
+                provider_id: &rust_http_server_id,
+                url: &rust_http_server_url,
+                config: vec![],
+            })
+            .await
+            .context("failed to start providers")
+        },
+        async {
+            assert_scale_component(
+                &ctl_client,
+                &host.host_key(),
+                format!("file://{RUST_HTTP_HELLO_WORLD}"),
+                COMPONENT_ID,
+                None,
+                5,
+                Vec::new(),
+            )
+            .await
+            .context("failed to scale `rust-http-hello-world` component")
+        }
+    )?;
+
+    assert_advertise_link(
+        &ctl_client,
+        &rust_http_server_id,
+        COMPONENT_ID,
+        "default",
+        "wasi",
+        "http",
+        vec!["incoming-handler".to_string()],
+        vec![http_server_config_name],
+        vec![],
+    )
+    .await
+    .context("failed to advertise link")?;
+
+    // Wait for data to be propagated across lattice
+    sleep(Duration::from_secs(1)).await;
+
+    let test_lattice_client = host.get_ctl_client(Some(nats_client), LATTICES[1]).await?;
+    let inventory = test_lattice_client
+        .get_host_inventory(&host.host_key().public_key())
+        .await
+        .map_err(|e| anyhow!(e).context("failed to get host inventory"))?;
+    let d = inventory.data().unwrap();
+    assert_eq!(d.components().len(), 0);
+
+    assert_scale_component(
+        &test_lattice_client,
+        &host.host_key(),
+        format!("file://{RUST_HTTP_HELLO_WORLD}"),
+        COMPONENT_ID,
+        None,
+        5,
+        Vec::new(),
+    )
+    .await
+    .context("failed to scale `rust-http-hello-world` component on test-lattice")?;
+    let inventory_resp = test_lattice_client
+        .get_host_inventory(&host.host_key().public_key())
+        .await
+        .map_err(|e| anyhow!(e).context("failed to get host inventory"))?;
+    let inventory = inventory_resp.data().unwrap();
+    // Check that the component started and there isn't a provider
+    assert_eq!(inventory.components().len(), 1);
+    assert_eq!(inventory.providers().len(), 0);
+
+    nats_server.stop().await.context("failed to stop NATS")?;
+    Ok(())
+}

--- a/tests/host.rs
+++ b/tests/host.rs
@@ -3,10 +3,13 @@
 use core::str;
 use core::time::Duration;
 
+use std::collections::HashMap;
 use std::net::Ipv4Addr;
+use std::sync::Arc;
 
-use anyhow::{anyhow, Context};
-use tokio::time::sleep;
+use anyhow::{anyhow, bail, Context};
+use tokio::task::JoinSet;
+use tokio::time::{sleep, timeout};
 use tokio::try_join;
 use tracing_subscriber::prelude::*;
 use wasmcloud_test_util::lattice::config::assert_config_put;
@@ -41,26 +44,24 @@ async fn host_multiple_lattices() -> anyhow::Result<()> {
         start_nats().await.context("failed to start NATS")?;
 
     // Build client for interacting with the lattice
-    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
+    let default_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
         .lattice(LATTICES[0].to_string())
         .build();
     // Build the host
-    let host =
-        WasmCloudTestHost::start(&nats_url, LATTICES.iter().map(|v| v.to_string()).collect())
-            .await
-            .context("failed to start test host")?;
+    let lattices: Vec<Box<str>> = LATTICES.iter().map(|l| Box::from(*l)).collect();
+    let host = WasmCloudTestHost::start(&nats_url, Arc::from(lattices))
+        .await
+        .context("failed to start test host")?;
 
     let http_port = free_port().await?;
-
     let http_server_config_name = "http-server".to_string();
-
     let rust_http_server = providers::rust_http_server().await;
     let rust_http_server_id = rust_http_server.subject.public_key();
 
     try_join!(
         async {
             assert_config_put(
-                &ctl_client,
+                &default_client,
                 &http_server_config_name,
                 [(
                     "ADDRESS".to_string(),
@@ -74,7 +75,7 @@ async fn host_multiple_lattices() -> anyhow::Result<()> {
             let host_key = host.host_key();
             let rust_http_server_url = rust_http_server.url();
             assert_start_provider(StartProviderArgs {
-                client: &ctl_client,
+                client: &default_client,
                 lattice: LATTICES[0],
                 host_key: &host_key,
                 provider_key: &rust_http_server.subject,
@@ -87,7 +88,7 @@ async fn host_multiple_lattices() -> anyhow::Result<()> {
         },
         async {
             assert_scale_component(
-                &ctl_client,
+                &default_client,
                 &host.host_key(),
                 format!("file://{RUST_HTTP_HELLO_WORLD}"),
                 COMPONENT_ID,
@@ -101,7 +102,7 @@ async fn host_multiple_lattices() -> anyhow::Result<()> {
     )?;
 
     assert_advertise_link(
-        &ctl_client,
+        &default_client,
         &rust_http_server_id,
         COMPONENT_ID,
         "default",
@@ -141,10 +142,323 @@ async fn host_multiple_lattices() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow!(e).context("failed to get host inventory"))?;
     let inventory = inventory_resp.data().unwrap();
+
     // Check that the component started and there isn't a provider
     assert_eq!(inventory.components().len(), 1);
     assert_eq!(inventory.providers().len(), 0);
 
-    nats_server.stop().await.context("failed to stop NATS")?;
+    // Verify that the second lattice has no links
+    let links = test_lattice_client
+        .get_links()
+        .await
+        .map_err(|e| anyhow!(e).context("failed to get links"))?;
+
+    let links = links.data().unwrap();
+    assert_eq!(links.len(), 0);
+
+    let test_claims = test_lattice_client
+        .get_claims()
+        .await
+        .map_err(|e| anyhow!(e).context("failed to get claims"))?;
+    let claims = test_claims.data().unwrap();
+
+    let default_claims = default_client.get_claims().await.map_err(|e| anyhow!(e))?;
+    let default_claims = default_claims.data().unwrap();
+    assert_ne!(claims, default_claims);
+
+    _ = nats_server.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn multiple_lattices_host_api() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().compact().without_time())
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")
+            }),
+        )
+        .init();
+
+    let (nats_server, nats_url, nats_client) =
+        start_nats().await.context("failed to start NATS")?;
+
+    // Build client for interacting with the lattice
+    let default_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
+        .lattice(LATTICES[0].to_string())
+        .build();
+    // Build the host
+    let lattices: Vec<Box<str>> = LATTICES.iter().map(|l| Box::from(*l)).collect();
+    let host = WasmCloudTestHost::start(&nats_url, Arc::from(lattices))
+        .await
+        .context("failed to start test host")?;
+
+    let http_port = free_port().await?;
+    let http_server_config_name = "http-server".to_string();
+    let rust_http_server = providers::rust_http_server().await;
+    let rust_http_server_id = rust_http_server.subject.public_key();
+
+    try_join!(
+        async {
+            assert_config_put(
+                &default_client,
+                &http_server_config_name,
+                [(
+                    "ADDRESS".to_string(),
+                    format!("{}:{http_port}", Ipv4Addr::LOCALHOST),
+                )],
+            )
+            .await
+            .context("failed to put configuration")
+        },
+        async {
+            let host_key = host.host_key();
+            let rust_http_server_url = rust_http_server.url();
+            assert_start_provider(StartProviderArgs {
+                client: &default_client,
+                lattice: LATTICES[0],
+                host_key: &host_key,
+                provider_key: &rust_http_server.subject,
+                provider_id: &rust_http_server_id,
+                url: &rust_http_server_url,
+                config: vec![],
+            })
+            .await
+            .context("failed to start providers")
+        },
+        async {
+            assert_scale_component(
+                &default_client,
+                &host.host_key(),
+                format!("file://{RUST_HTTP_HELLO_WORLD}"),
+                COMPONENT_ID,
+                None,
+                5,
+                Vec::new(),
+            )
+            .await
+            .context("failed to scale `rust-http-hello-world` component")
+        }
+    )?;
+
+    // Verify that host labels still change regardless of the lattice client
+    let test_lattice_client = host.get_ctl_client(Some(nats_client), LATTICES[1]).await?;
+    test_lattice_client
+        .put_label(&host.host_key().public_key(), "i-am-a-test-label", "true")
+        .await
+        .map_err(|e| anyhow!(e).context("failed to put label"))?;
+
+    let inventory = default_client
+        .get_host_inventory(&host.host_key().public_key())
+        .await
+        .map_err(|e| anyhow!(e).context("failed to get host inventory"))?;
+    let inventory = inventory.data().unwrap();
+    let labels = inventory.labels();
+    let value = labels.get("i-am-a-test-label");
+    assert!(value.is_some());
+    assert_eq!(value.unwrap(), "true");
+
+    default_client
+        .delete_label(&host.host_key().public_key(), "i-am-a-test-label")
+        .await
+        .map_err(|e| anyhow!(e).context("failed to delete label"))?;
+
+    let inventory = test_lattice_client
+        .get_host_inventory(&host.host_key().public_key())
+        .await
+        .map_err(|e| anyhow!(e).context("failed to get host inventory"))?;
+    let inventory = inventory.data().unwrap();
+    let labels = inventory.labels();
+    let value = labels.get("i-am-a-test-label");
+    assert!(value.is_none());
+
+    default_client
+        .put_config(
+            "test-config",
+            HashMap::from([("test-key".to_string(), "test-value".to_string())]),
+        )
+        .await
+        .map_err(|e| anyhow!(e).context("failed to put config"))?;
+
+    let result = test_lattice_client
+        .get_config("test-config")
+        .await
+        .map_err(|e| anyhow!(e).context("failed to make config call"))?;
+    assert!(result.data().is_none());
+
+    _ = nats_server.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn host_events_multiple_lattices() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().compact().without_time())
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")
+            }),
+        )
+        .init();
+
+    let (_nats_server, nats_url, nats_client) =
+        start_nats().await.context("failed to start NATS")?;
+
+    let default_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
+        .lattice(LATTICES[0].to_string())
+        .build();
+    let test_lattice_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
+        .lattice(LATTICES[1].to_string())
+        .build();
+
+    let mut default_evt = default_client
+        .events_receiver(vec!["component_scaled".to_string()])
+        .await
+        .map_err(|e| anyhow!(e).context("failed to get events receiver"))?;
+    let mut test_evt = test_lattice_client
+        .events_receiver(vec!["component_scaled".to_string()])
+        .await
+        .map_err(|e| anyhow!(e).context("failed to get events receiver"))?;
+
+    let (scaled_event_tx, scaled_event_rx) =
+        tokio::sync::oneshot::channel::<anyhow::Result<serde_json::Value>>();
+    tokio::spawn(async move {
+        let evt = default_evt.recv().await.unwrap();
+        let data = evt.data().unwrap();
+        match data {
+            cloudevents::event::Data::Json(v) => {
+                scaled_event_tx.send(Ok(v.clone())).unwrap();
+            }
+            _ => scaled_event_tx
+                .send(Err(anyhow!("unexpected data type")))
+                .unwrap(),
+        }
+    });
+
+    let (test_lattice_tx, test_lattice_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let _ = test_evt.recv().await.unwrap();
+        test_lattice_tx.send(()).unwrap();
+    });
+
+    // Build the host
+    let lattices: Vec<Box<str>> = LATTICES.iter().map(|l| Box::from(*l)).collect();
+    let host = WasmCloudTestHost::start(&nats_url, Arc::from(lattices))
+        .await
+        .context("failed to start test host")?;
+
+    let http_port = free_port().await?;
+    let http_server_config_name = "http-server".to_string();
+    let rust_http_server = providers::rust_http_server().await;
+    let rust_http_server_id = rust_http_server.subject.public_key();
+
+    try_join!(
+        async {
+            assert_config_put(
+                &default_client,
+                &http_server_config_name,
+                [(
+                    "ADDRESS".to_string(),
+                    format!("{}:{http_port}", Ipv4Addr::LOCALHOST),
+                )],
+            )
+            .await
+            .context("failed to put configuration")
+        },
+        async {
+            let host_key = host.host_key();
+            let rust_http_server_url = rust_http_server.url();
+            assert_start_provider(StartProviderArgs {
+                client: &default_client,
+                lattice: LATTICES[0],
+                host_key: &host_key,
+                provider_key: &rust_http_server.subject,
+                provider_id: &rust_http_server_id,
+                url: &rust_http_server_url,
+                config: vec![],
+            })
+            .await
+            .context("failed to start providers")
+        },
+        async {
+            assert_scale_component(
+                &default_client,
+                &host.host_key(),
+                format!("file://{RUST_HTTP_HELLO_WORLD}"),
+                COMPONENT_ID,
+                None,
+                5,
+                Vec::new(),
+            )
+            .await
+            .context("failed to scale `rust-http-hello-world` component")
+        }
+    )?;
+
+    let evt = scaled_event_rx
+        .await
+        .context("failed to receive cloudevent")?;
+    let evt = evt.context("failed to receive event: wrong type (string or binary)")?;
+    let component_id = evt["component_id"].as_str().unwrap();
+    assert_eq!(component_id, COMPONENT_ID);
+
+    // If we recieve a component_scaled event on the test lattice, that's an error
+    if timeout(Duration::from_millis(500), test_lattice_rx)
+        .await
+        .is_ok()
+    {
+        anyhow::bail!("received unexpected component_scaled event on test lattice");
+    };
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn thousands_of_lattices() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().compact().without_time())
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")
+            }),
+        )
+        .init();
+
+    let (_nats_server, nats_url, nats_client) =
+        start_nats().await.context("failed to start NATS")?;
+
+    // Arbitrary number of lattices
+    let lattices: Vec<Box<str>> = (0..2000).map(|i| format!("lattice-{}", i).into()).collect();
+    let _host = WasmCloudTestHost::start(&nats_url, Arc::from(lattices.clone()))
+        .await
+        .context("failed to start test host")?;
+
+    let mut set: JoinSet<anyhow::Result<()>> = JoinSet::new();
+    for lattice in &lattices {
+        let lattice = lattice.clone();
+        let nats_client = nats_client.clone();
+        set.spawn(async move {
+            let client = wasmcloud_control_interface::ClientBuilder::new(nats_client)
+                .lattice(lattice.to_string())
+                .build();
+            client
+                .put_config(
+                    &format!("test-config-{lattice}"),
+                    HashMap::from([("test-key".to_string(), "test-value".to_string())]),
+                )
+                .await
+                .map_err(|e| anyhow!(e).context("failed to put config"))?;
+
+            Ok(())
+        });
+    }
+    while let Some(result) = set.join_next().await {
+        let result = result?;
+        if result.is_err() {
+            bail!("failed to put config in a lattice");
+        }
+    }
+
     Ok(())
 }

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -5,6 +5,7 @@ use core::time::Duration;
 
 use std::collections::{BTreeSet, HashMap};
 use std::net::Ipv4Addr;
+use std::sync::Arc;
 
 use anyhow::{ensure, Context as _};
 use base64::Engine as _;
@@ -78,7 +79,7 @@ async fn interfaces() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
+    let host = WasmCloudTestHost::start(&nats_url, Arc::from(vec![Box::from(LATTICE)]))
         .await
         .context("failed to start test host")?;
 

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -78,7 +78,7 @@ async fn interfaces() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let host = WasmCloudTestHost::start(&nats_url, LATTICE)
+    let host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
         .await
         .context("failed to start test host")?;
 

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -57,7 +57,7 @@ async fn link_deletes() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let _host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
+    let _host = WasmCloudTestHost::start(&nats_url, Arc::from(vec![Box::from(LATTICE)]))
         .await
         .context("failed to start test host")?;
 
@@ -200,7 +200,7 @@ async fn link_name_support() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
+    let host = WasmCloudTestHost::start(&nats_url, Arc::from(vec![Box::from(LATTICE)]))
         .await
         .context("failed to start test host")?;
 
@@ -389,7 +389,7 @@ async fn valid_and_invalid() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let _host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
+    let _host = WasmCloudTestHost::start(&nats_url, Arc::from(vec![Box::from(LATTICE)]))
         .await
         .context("failed to start test host")?;
 

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -57,7 +57,7 @@ async fn link_deletes() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let _host = WasmCloudTestHost::start(&nats_url, LATTICE)
+    let _host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
         .await
         .context("failed to start test host")?;
 
@@ -200,7 +200,7 @@ async fn link_name_support() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let host = WasmCloudTestHost::start(&nats_url, LATTICE)
+    let host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
         .await
         .context("failed to start test host")?;
 
@@ -389,7 +389,7 @@ async fn valid_and_invalid() -> anyhow::Result<()> {
         .lattice(LATTICE.to_string())
         .build();
     // Build the host
-    let _host = WasmCloudTestHost::start(&nats_url, LATTICE)
+    let _host = WasmCloudTestHost::start(&nats_url, vec![LATTICE.to_string()])
         .await
         .context("failed to start test host")?;
 

--- a/tests/policy.rs
+++ b/tests/policy.rs
@@ -37,7 +37,7 @@ async fn policy_always_deny() -> anyhow::Result<()> {
     // Build the host
     let host = WasmCloudTestHost::start_custom(
         &nats_url,
-        LATTICE,
+        vec![LATTICE.to_string()],
         None,
         None,
         // Since if a policy service is specified, the requests are deny-by-default

--- a/tests/policy.rs
+++ b/tests/policy.rs
@@ -1,6 +1,7 @@
 use core::time::Duration;
 
 use anyhow::Context as _;
+use std::sync::Arc;
 
 use wasmcloud_host::wasmbus::host_config::PolicyService;
 use wasmcloud_test_util::provider::{assert_start_provider, StartProviderArgs};
@@ -37,7 +38,7 @@ async fn policy_always_deny() -> anyhow::Result<()> {
     // Build the host
     let host = WasmCloudTestHost::start_custom(
         &nats_url,
-        vec![LATTICE.to_string()],
+        Arc::from(vec![Box::from(LATTICE)]),
         None,
         None,
         // Since if a policy service is specified, the requests are deny-by-default


### PR DESCRIPTION
## Feature or Problem
This implements initial support for multiple lattices running on a single host by allowing the `--lattice` flag to be specified multiple times. The host code itself is also shuffled around to support this functionality, since each lattice now needs to handle its own subscriptions, cleanup signals, etc. As a result, the host code is now much more compact than it was before.

This work is the first step towards implementing full multitenancy support in the host as outlined in #3120. The next step is to add an experimental flag to enable lattices to be defined in the control plane and have the host dynamically listen to requests to listen on lattices as they are provisioned.


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
v1.4

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
