### PR TITLE
chore: Add Colin as org maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,6 +30,10 @@ Name: Brooks Townsend
 GitHub: @brooksmtownsend
 Organization: Cosmonic
 
+Name: Colin Murphy
+GitHub: @cdmurph32
+Organization: Adobe
+
 ## @wasmCloud/host-maintainers
 
 Name: Kevin Hoffman  
@@ -95,6 +99,10 @@ Organization: Google
 Name: Victor Adossi  
 GitHub: @vados-cosmonic
 Organization: Cosmonic
+
+Name: Colin Murphy
+GitHub: @cdmurph32
+Organization: Adobe
 
 ## @wasmCloud/washboard-maintainers
 


### PR DESCRIPTION
After a nomination and vote from current org maintainers, Colin has been added as a wasmCloud Org Maintainer and a maintainer of wash (which he has been contributing to for a while).