### PR TITLE
chore(ci): Makes it so we don't run wasmcloud host builds against docs

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -2,6 +2,8 @@ name: wasmcloud
 
 on:
   pull_request:
+    paths-ignore:
+      - '*.md'
   merge_group:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
We were always running builds on PRs even if we were just changing the top level markdowns.
