### PR TITLE
feat(ci): build release binaries for nats-kv-secrets

### DIFF
--- a/.github/workflows/secrets-nats-kv.yml
+++ b/.github/workflows/secrets-nats-kv.yml
@@ -45,3 +45,165 @@ jobs:
       - name: Run integration tests
         run: make test-integration-ci
         working-directory: ./crates/secrets-nats-kv
+
+  release-build:
+    if: ${{ startsWith(github.ref, 'refs/tags/secrets-nats-kv-v') }}
+    runs-on: ${{ matrix.build.runs-on }}
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        build:
+          - os: linux
+            arch: amd64
+            abi: gnu
+            runs-on: ubuntu-22.04
+            rust-target: x86_64-unknown-linux-gnu
+          - os: linux
+            arch: amd64
+            abi: musl
+            runs-on: ubuntu-22.04
+            rust-target: x86_64-unknown-linux-musl
+          - os: darwin
+            arch: amd64
+            runs-on: macos-13
+            rust-target: x86_64-apple-darwin
+          - os: darwin
+            arch: aarch64
+            runs-on: macos-14
+            rust-target: aarch64-apple-darwin
+          - os: windows
+            arch: amd64
+            abi: msvc
+            runs-on: windows-2022
+            rust-target: x86_64-pc-windows-msvc
+          - os: linux
+            arch: aarch64
+            abi: gnu
+            runs-on: ubuntu-22.04
+            rust-target: aarch64-unknown-linux-gnu
+            skip-test: true # No runner on GH for this yet
+          - os: linux
+            arch: aarch64
+            abi: musl
+            runs-on: ubuntu-22.04
+            rust-target: aarch64-unknown-linux-musl
+            skip-test: true # No runner on GH for this yet
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: rustup target add ${{ matrix.build.rust-target }}
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+        with:
+          shared-key: "ubuntu-22.04-shared-cache"
+
+      - name: Extract tag context
+        id: ctx
+        shell: bash
+        run: |
+          sha_short=$(git rev-parse --short HEAD)
+          echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"
+
+          version=$(cargo metadata --manifest-path "./crates/secrets-nats-kv/Cargo.toml" --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "wasmcloud-nats-kv-secrets") | .version')
+          echo "untagged version is ${version}"
+          echo "untagged version ${version} is a pre-release"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if [[ $version == *"-"* ]]; then
+            echo "tagged version ${version} is a pre-release"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install musl toolchain
+        if: ${{ matrix.build.abi == 'musl' }}
+        run: |
+          sudo apt-get install -y musl-tools clang llvm
+
+      - name: Install aarch64 toolchain
+        if: ${{ matrix.build.abi == 'gnu' && matrix.build.arch == 'aarch64' }}
+        run: |
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build
+        shell: bash
+        run: |
+          export PLATFORM="${{ matrix.build.arch }}-${{ matrix.build.os }}-${{ matrix.build.abi }}";
+          if [ "aarch64-linux-gnu" == "$PLATFORM" ]; then
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc
+          elif [ "aarch64-linux-musl" == "$PLATFORM" ]; then
+            export CC_aarch64_unknown_linux_musl=clang;
+            export AR_aarch64_unknown_linux_musl=llvm-ar;
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld";
+          fi
+          cargo build --release -p secrets-nats-kv --target ${{ matrix.build.rust-target }}
+
+      - name: Determine binary name
+        id: bin-name
+        shell: bash
+        run: |
+          if [ "" == "${{ matrix.build.abi }}" ]; then
+            export BIN_NAME=secrets-nats-kv-${{ matrix.build.arch }}-${{ matrix.build.os }};
+          else
+            export BIN_NAME=secrets-nats-kv-${{ matrix.build.arch }}-${{ matrix.build.os }}-${{ matrix.build.abi }};
+          fi
+          echo "bin-name=$BIN_NAME" >> $GITHUB_OUTPUT;
+
+      - name: Basic binary test
+        if: ${{ !matrix.build.skip-test }}
+        run: |
+          ./target/${{ matrix.build.rust-target}}/release/secrets-nats-kv --version
+
+      - name: Copy binary
+        shell: bash
+        run: |
+          mkdir artifacts;
+          cp ./target/${{ matrix.build.rust-target}}/release/secrets-nats-kv artifacts/${{ steps.bin-name.outputs.bin-name }}
+
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: ${{ steps.bin-name.outputs.bin-name }}
+          path:
+            artifacts/*
+
+  release:
+    if: ${{ startsWith(github.ref, 'refs/tags/secrets-nats-kv-v') }}
+    needs: [ release-build ]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+
+      - name: Extract tag context
+        id: ctx
+        shell: bash
+        run: |
+          sha_short=$(git rev-parse --short HEAD)
+          echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"
+
+          version=$(cargo metadata --manifest-path "./crates/secrets-nats-kv/Cargo.toml" --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "wasmcloud-nats-kv-secrets") | .version')
+          echo "untagged version is ${version}"
+          echo "untagged version ${version} is a pre-release"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if [[ $version == *"-"* ]]; then
+            echo "tagged version ${version} is a pre-release"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          pattern: secrets-nats-kv-*
+          merge-multiple: true
+          path: artifacts
+
+      - name: Add musl versions as default linux binaries
+        run: |
+          cp artifacts/secrets-nats-kv-amd64-linux-musl artifacts/secrets-nats-kv-amd64-linux
+          cp artifacts/secrets-nats-kv-aarch64-linux-musl artifacts/secrets-nats-kv-aarch64-linux
+
+      - name: Release
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
+        with:
+          draft: true
+          prerelease: ${{ steps.ctx.outputs.prerelease != '' }}
+          generate_release_notes: true
+          files: |
+            ./artifacts/*


### PR DESCRIPTION
This commit adds automation to CI to build and release binaries for `nats-kv-secrets` when tags are pushed to wasmcloud/wasmcloud.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
