### PR TITLE
feat(wash)!: allow specifying oci push/pull concurrency

### DIFF
--- a/crates/wash-cli/src/common/registry_cmd.rs
+++ b/crates/wash-cli/src/common/registry_cmd.rs
@@ -45,6 +45,7 @@ pub async fn registry_pull(
             allow_latest: cmd.allow_latest,
             user: credentials.username().map(String::from),
             password: credentials.password().map(String::from),
+            concurrency: cmd.concurrency,
             insecure: cmd.opts.insecure,
             insecure_skip_tls_verify: cmd.opts.insecure_skip_tls_verify,
         },
@@ -126,6 +127,7 @@ pub async fn registry_push(
             password: credentials.password().map(String::from),
             insecure: cmd.opts.insecure,
             insecure_skip_tls_verify: cmd.opts.insecure_skip_tls_verify,
+            concurrency: cmd.concurrency,
             annotations,
         },
     )

--- a/crates/wash-cli/src/par.rs
+++ b/crates/wash-cli/src/par.rs
@@ -143,6 +143,10 @@ pub struct InspectCommand {
     #[clap(long = "insecure-skip-tls-verify")]
     pub insecure_skip_tls_verify: bool,
 
+    /// Maximum number of concurrent chunks to download from an OCI registry
+    #[clap(long = "concurrency", default_value_t = 16)]
+    pub concurrency: usize,
+
     /// skip the local OCI cache
     #[clap(long = "no-cache")]
     no_cache: bool,
@@ -206,6 +210,7 @@ impl From<InspectCommand> for inspect::InspectCliCommand {
             password: cmd.password,
             insecure: cmd.insecure,
             insecure_skip_tls_verify: cmd.insecure_skip_tls_verify,
+            concurrency: cmd.concurrency,
             no_cache: cmd.no_cache,
         }
     }
@@ -599,6 +604,7 @@ mod test {
                 insecure,
                 insecure_skip_tls_verify,
                 no_cache,
+                concurrency: _c,
             }) => {
                 assert_eq!(archive, LOCAL);
                 assert_eq!(digest.unwrap(), "sha256:blah");
@@ -636,6 +642,7 @@ mod test {
                 insecure,
                 insecure_skip_tls_verify,
                 no_cache,
+                concurrency: _c,
             }) => {
                 assert_eq!(archive, REMOTE);
                 assert_eq!(digest.unwrap(), "sha256:blah");

--- a/crates/wash-cli/src/plugin.rs
+++ b/crates/wash-cli/src/plugin.rs
@@ -173,6 +173,8 @@ pub async fn handle_install(
                     password: cmd.oci_auth.password,
                     insecure: cmd.oci_auth.insecure,
                     insecure_skip_tls_verify: cmd.oci_auth.insecure_skip_tls_verify,
+                    // TODO: allow configuration
+                    concurrency: 16,
                 },
             )
             .await

--- a/crates/wash-lib/src/cli/claims.rs
+++ b/crates/wash-lib/src/cli/claims.rs
@@ -84,6 +84,10 @@ pub struct InspectCommand {
     #[clap(long = "insecure-skip-tls-verify")]
     pub insecure_skip_tls_verify: bool,
 
+    /// Maximum number of concurrent chunks to download from an OCI registry
+    #[clap(long = "concurrency", default_value_t = 16)]
+    pub concurrency: usize,
+
     /// skip the local OCI cache
     #[clap(long = "no-cache")]
     pub(crate) no_cache: bool,
@@ -341,6 +345,7 @@ impl From<InspectCommand> for inspect::InspectCliCommand {
             password: cmd.password,
             insecure: cmd.insecure,
             insecure_skip_tls_verify: cmd.insecure_skip_tls_verify,
+            concurrency: cmd.concurrency,
             no_cache: cmd.no_cache,
         }
     }
@@ -807,6 +812,7 @@ mod test {
                 insecure_skip_tls_verify,
                 no_cache,
                 wit,
+                concurrency,
             }) => {
                 assert_eq!(module, SUBSCRIBER_OCI);
                 assert_eq!(
@@ -815,6 +821,7 @@ mod test {
                 );
                 assert_eq!(user.unwrap(), "name");
                 assert_eq!(password.unwrap(), "opensesame");
+                assert_eq!(concurrency, 16);
                 assert!(allow_latest);
                 assert!(insecure);
                 assert!(!insecure_skip_tls_verify);
@@ -853,6 +860,7 @@ mod test {
                 password,
                 insecure,
                 insecure_skip_tls_verify,
+                concurrency,
                 no_cache,
                 wit,
             }) => {
@@ -863,6 +871,7 @@ mod test {
                 );
                 assert_eq!(user.unwrap(), "name");
                 assert_eq!(password.unwrap(), "opensesame");
+                assert_eq!(concurrency, 16);
                 assert!(allow_latest);
                 assert!(insecure);
                 assert!(insecure_skip_tls_verify);

--- a/crates/wash-lib/src/cli/inspect.rs
+++ b/crates/wash-lib/src/cli/inspect.rs
@@ -66,6 +66,10 @@ pub struct InspectCliCommand {
     #[clap(long = "insecure-skip-tls-verify")]
     pub insecure_skip_tls_verify: bool,
 
+    /// Maximum number of concurrent chunks to download from an OCI registry
+    #[clap(long = "concurrency", default_value_t = 16)]
+    pub concurrency: usize,
+
     /// skip the local OCI cache and pull the artifact from the registry to inspect
     #[clap(long = "no-cache")]
     pub no_cache: bool,
@@ -98,6 +102,7 @@ pub async fn handle_command(
                 password: command.password.clone(),
                 insecure: command.insecure,
                 insecure_skip_tls_verify: command.insecure_skip_tls_verify,
+                concurrency: command.concurrency,
             },
         )
         .await?;
@@ -425,6 +430,7 @@ mod test {
             insecure_skip_tls_verify,
             no_cache,
             wit,
+            concurrency,
         } = inspect_long.command;
         assert_eq!(target, LOCAL);
         assert_eq!(digest.unwrap(), "sha256:blah");
@@ -433,6 +439,7 @@ mod test {
         assert!(!insecure_skip_tls_verify);
         assert_eq!(user.unwrap(), "name");
         assert_eq!(password.unwrap(), "secret");
+        assert_eq!(concurrency, 16);
         assert!(jwt_only);
         assert!(no_cache);
         assert!(!wit);
@@ -463,12 +470,14 @@ mod test {
             insecure_skip_tls_verify,
             no_cache,
             wit,
+            concurrency,
         } = inspect_short.command;
         assert_eq!(target, REMOTE);
         assert_eq!(digest.unwrap(), "sha256:blah");
         assert!(allow_latest);
         assert!(insecure);
         assert!(!insecure_skip_tls_verify);
+        assert_eq!(concurrency, 16);
         assert_eq!(user.unwrap(), "name");
         assert_eq!(password.unwrap(), "secret");
         assert!(jwt_only);
@@ -502,6 +511,7 @@ mod test {
             insecure_skip_tls_verify,
             no_cache,
             wit,
+            concurrency,
         } = cmd.command;
         assert_eq!(target, SUBSCRIBER_OCI);
         assert_eq!(
@@ -510,6 +520,7 @@ mod test {
         );
         assert_eq!(user.unwrap(), "name");
         assert_eq!(password.unwrap(), "opensesame");
+        assert_eq!(concurrency, 16);
         assert!(allow_latest);
         assert!(insecure);
         assert!(!insecure_skip_tls_verify);
@@ -539,6 +550,7 @@ mod test {
             jwt_only,
             digest,
             allow_latest,
+            concurrency,
             user,
             password,
             insecure,
@@ -552,6 +564,7 @@ mod test {
             "sha256:5790f650cff526fcbc1271107a05111a6647002098b74a9a5e2e26e3c0a116b8"
         );
         assert_eq!(user.unwrap(), "name");
+        assert_eq!(concurrency, 16);
         assert_eq!(password.unwrap(), "opensesame");
         assert!(allow_latest);
         assert!(insecure);

--- a/crates/wash-lib/src/cli/registry.rs
+++ b/crates/wash-lib/src/cli/registry.rs
@@ -63,6 +63,10 @@ pub struct RegistryPullCommand {
     #[clap(long = "allow-latest")]
     pub allow_latest: bool,
 
+    /// Maximum concurrent chunk downloads
+    #[clap(long = "concurrency", default_value_t = 16)]
+    pub concurrency: usize,
+
     #[clap(flatten)]
     pub opts: AuthOpts,
 }
@@ -88,6 +92,10 @@ pub struct RegistryPushCommand {
     /// Allow latest artifact tags
     #[clap(long = "allow-latest")]
     pub allow_latest: bool,
+
+    /// Maximum concurrent chunk uploads
+    #[clap(long = "concurrency", default_value_t = 16)]
+    pub concurrency: usize,
 
     /// Optional set of annotations to apply to the OCI artifact manifest
     #[clap(short = 'a', long = "annotation", name = "annotations")]

--- a/crates/wash-lib/src/registry.rs
+++ b/crates/wash-lib/src/registry.rs
@@ -38,6 +38,8 @@ pub struct OciPullOptions {
     pub password: Option<String>,
     /// Whether or not to allow pulling from non-https registries
     pub insecure: bool,
+    /// The number of concurrent chunk downloads to allow
+    pub concurrency: usize,
     /// Whether or not OCI registry's certificate will be checked for validity. This will make your HTTPS connections insecure.
     pub insecure_skip_tls_verify: bool,
 }
@@ -57,6 +59,8 @@ pub struct OciPushOptions {
     pub insecure: bool,
     /// Whether or not OCI registry's certificate will be checked for validity. This will make your HTTPS connections insecure.
     pub insecure_skip_tls_verify: bool,
+    /// The number of concurrent chunk uploads to allow
+    pub concurrency: usize,
     /// Optional annotations you'd like to add to the pushed artifact
     pub annotations: Option<HashMap<String, String>>,
 }
@@ -137,6 +141,7 @@ pub async fn pull_oci_artifact(image_ref: &Reference, options: OciPullOptions) -
         },
         extra_root_certificates: tls::NATIVE_ROOTS_OCI.to_vec(),
         accept_invalid_certificates: options.insecure_skip_tls_verify,
+        max_concurrent_download: options.concurrency,
         ..Default::default()
     });
 
@@ -228,6 +233,7 @@ pub async fn push_oci_artifact(
         },
         extra_root_certificates: tls::NATIVE_ROOTS_OCI.to_vec(),
         accept_invalid_certificates: options.insecure_skip_tls_verify,
+        max_concurrent_upload: options.concurrency,
         ..Default::default()
     });
 


### PR DESCRIPTION
## Feature or Problem
This PR adds an optional flag `--concurrency` that allows for controlling the maximum concurrency for pulling and pushing chunks when using `wash pull/push`.

Draft for testing.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
