### PR TITLE
fix(host): warn if config sender is dropped

### DIFF
--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -8,7 +8,7 @@ use tokio::sync::{
     watch::{self, Receiver, Sender},
     RwLock, RwLockReadGuard,
 };
-use tracing::{error, Instrument};
+use tracing::{error, warn, Instrument};
 
 type LockedConfig = Arc<RwLock<HashMap<String, String>>>;
 /// A cache of named config mapped to an existing receiver
@@ -136,7 +136,7 @@ impl ConfigBundle {
                                         .await;
                                 }
                                 Err(e) => {
-                                    error!(error = %e, %name, "Config updater has failed!");
+                                    warn!(error = %e, %name, "config sender dropped, updates will not be delivered");
                                     return;
                                 }
                             }


### PR DESCRIPTION
## Feature or Problem
Small fix to be less aggressive with an error that usually appears during the shutdown of a host

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
