### PR TITLE
feat(wasmcloud-config): Add wit config files

### DIFF
--- a/wit/config/README.md
+++ b/wit/config/README.md
@@ -1,0 +1,12 @@
+# `wasmcloud:config`
+
+Vendored API that is versioned for stability, based on [`wasi:config`](https://github.com/WebAssembly/wasi-config).
+
+## Versioning
+
+This vendored API is versioned with every revision. Patch updates for non-breaking changes, e.g. `0.1.1`, and minor releases for breaking changes (as this API is currently at major version 0).
+
+Our intention is for this interface to be eventually deprecated in favor of `wasi:config` once it is stable with an interim deprecation period. We will support all versions of this API until deprecation of `wasmcloud:config`.
+
+Note that the version of wasmcloud API's do not correlate to WASIP2 API's e.g. `wasi:config@0.2.0`
+may not be the same as `wasmcloud:config@0.2.0`.

--- a/wit/config/wit/store.wit
+++ b/wit/config/wit/store.wit
@@ -1,0 +1,31 @@
+@since(version = 0.1.0)
+interface store {
+    /// An error type that encapsulates the different errors that can occur fetching configuration values.
+    variant error {
+        /// This indicates an error from an "upstream" config source.
+        /// As this could be almost _anything_ (such as Vault, Kubernetes ConfigMaps, KeyValue buckets, etc),
+        /// the error message is a string.
+        upstream(string),
+        /// This indicates an error from an I/O operation.
+        /// As this could be almost _anything_ (such as a file read, network connection, etc),
+        /// the error message is a string.
+        /// Depending on how this ends up being consumed,
+        /// we may consider moving this to use the `wasi:io/error` type instead.
+        /// For simplicity right now in supporting multiple implementations, it is being left as a string.
+        io(string),
+    }
+
+    /// Gets a configuration value of type `string` associated with the `key`.
+    ///
+    /// The value is returned as an `option<string>`. If the key is not found,
+    /// `Ok(none)` is returned. If an error occurs, an `Err(error)` is returned.
+    get: func(
+        /// A string key to fetch
+        key: string
+    ) -> result<option<string>, error>;
+
+    /// Gets a list of configuration key-value pairs of type `string`.
+    ///
+    /// If an error occurs, an `Err(error)` is returned.
+    get-all: func() -> result<list<tuple<string, string>>, error>;
+}

--- a/wit/config/wit/world.wit
+++ b/wit/config/wit/world.wit
@@ -1,0 +1,8 @@
+package wasmcloud:config@0.1.0;
+
+@since(version = 0.1.0)
+world imports {
+    /// The interface for wasi:config/store
+    @since(version = 0.1.0)
+    import store;
+}


### PR DESCRIPTION
In an effort to ensure stability for users of wasmcloud,
this introduces a new WIT package that is a stable
version of wasi:config.
