### PR TITLE
fix(washboard-ui): provider status is in incorrect state

### DIFF
--- a/typescript/apps/washboard-ui/src/components/status-indicator/index.tsx
+++ b/typescript/apps/washboard-ui/src/components/status-indicator/index.tsx
@@ -1,9 +1,10 @@
+import type {WasmCloudProviderState} from '@wasmcloud/lattice-client-core';
 import {cva} from 'class-variance-authority';
 import * as React from 'react';
 import {cn} from '@/helpers';
 
 type StatusIndicatorProps = React.HTMLAttributes<HTMLDivElement> & {
-  status?: 'Running' | 'Pending' | 'Failed';
+  status?: WasmCloudProviderState;
 };
 
 const styles = cva('inline-block size-2 rounded-full bg-current', {

--- a/typescript/packages/lattice-client-core/src/controllers/providers.ts
+++ b/typescript/packages/lattice-client-core/src/controllers/providers.ts
@@ -1,5 +1,5 @@
+import type {WasmCloudProvider,  ControlResponse} from '@/types';
 import {BaseController} from '@/controllers/base-controller';
-import {type ControlResponse} from '@/types';
 
 type StartProviderBody = {
   /** The ID of the host to start the provider on */
@@ -53,6 +53,21 @@ class ProvidersController extends BaseController {
       `${this.config.ctlTopic}.provider.stop.${body.host_id}`,
       JSON.stringify(body),
     );
+  }
+
+  /**
+   * Retrieves a list of all providers currently running in the lattice
+   * @returns a list of providers
+   */
+  async list(): Promise<ControlResponse<Record<string, WasmCloudProvider>>> {
+    try {
+      const response = await this.connection.getBucketEntry<
+        Record<string, WasmCloudProvider>
+      >("wadm_state", "provider_default");
+      return {success: true, message: "Provider data successfully fetched", response};
+    } catch {
+      return {success: false, message: "There was an error fetching the providers", response: {}};
+    }
   }
 }
 

--- a/typescript/packages/lattice-client-core/src/index.ts
+++ b/typescript/packages/lattice-client-core/src/index.ts
@@ -1,5 +1,5 @@
 export {LatticeClient, type LatticeClientOptions} from './lattice-client';
-export {canConnect, getManifestFrom, getCombinedInventoryFromHosts} from './helpers';
+export {canConnect, getManifestFrom, getCombinedInventoryFromHostsAndProviders} from './helpers';
 export type {
   ApplicationSummary,
   ApplicationDetail,
@@ -13,6 +13,7 @@ export type {
   WasmCloudHostRef,
   WasmCloudLink,
   WasmCloudProvider,
+  WasmCloudProviderState
 } from '@/types';
 export type {LatticeConnection, LatticeConnectionStatus} from '@/connection/lattice-connection';
 export {NatsWsLatticeConnection} from '@/connection/nats-ws-lattice-connection';

--- a/typescript/packages/lattice-client-core/src/types.ts
+++ b/typescript/packages/lattice-client-core/src/types.ts
@@ -21,6 +21,7 @@ export type ControlResponse<ResponseType = never> = [ResponseType] extends [neve
       response: ResponseType;
     };
 
+export type WasmCloudProviderState = "Pending" | "Failed" | "Running";
 export type WasmCloudComponent = {
   id: string;
   name?: string;
@@ -29,14 +30,15 @@ export type WasmCloudComponent = {
   annotations: Record<string, string>;
   max_instances: number;
   revision: number;
+  state?: WasmCloudProviderState
 };
 
 export type WasmCloudProvider = {
   id: string;
   name?: string;
-  image_ref?: string;
+  reference?: string;
   annotations: Record<string, string>;
-  hosts: string[];
+  hosts: Record<string, WasmCloudProviderState>;
 };
 
 export type WasmCloudLink = {

--- a/typescript/packages/lattice-client-react/src/use-lattice-data.ts
+++ b/typescript/packages/lattice-client-react/src/use-lattice-data.ts
@@ -1,4 +1,4 @@
-import {type LatticeClient, getCombinedInventoryFromHosts} from '@wasmcloud/lattice-client-core';
+import {type LatticeClient, getCombinedInventoryFromHostsAndProviders} from '@wasmcloud/lattice-client-core';
 import * as React from 'react';
 import {useLatticeClient} from '@/context/use-lattice-client';
 
@@ -25,9 +25,10 @@ function useLatticeData() {
 
 async function fetchInventories(client: LatticeClient) {
   const result = await client.hosts.list({expand: true});
+  const {response: rawProviders} = await client.providers.list();
   const hostsList = result.response;
   const hosts = Object.fromEntries(hostsList.map((host) => [host.host_id, host]));
-  const {components, providers} = getCombinedInventoryFromHosts(hosts);
+  const {components, providers} = getCombinedInventoryFromHostsAndProviders(hosts, rawProviders);
   return {hosts, components, providers};
 }
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
As the related issue states, the healthiness of the providers never turn to `Running` although the bucket says otherwise. 


Tested it manually with multiple providers and hosts.
Everything looks good for now, but we might consider test it on multiple levels based on the estimated effort.


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

Should fix #2627 .

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

Should fix the falsy health indicator for providers.

## Testing
<!---
Declare the testing information for this pull request
--->


### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

1. Start hosts 
 - you can do it with ```wash up --multi-local --label zone=us-east-1 -d``` ways
2. Open wash UI
 - ```wash ui``` 
3. Deploy some applications
 - ```wash new component hello --template-name hello-world-rust```
 - ```cd hello```
 - ```wash build && wash deploy wadm.yaml```
4. Monitor the provider entries health indicator
 - wait it to to be Running and green
5. Validate with 
 ```nats kv get wadm_state provider_default --raw | jq```
6. Be amazed.