### PR TITLE
fix(core): allow missing registry authentication

### DIFF
--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -112,11 +112,16 @@ impl RegistryConfigBuilder {
     }
 
     pub fn build(self) -> Result<RegistryConfig> {
+        let allow_insecure = self.allow_insecure.unwrap_or_default();
         Ok(RegistryConfig {
-            reg_type: self.reg_type.context("missing reg type")?,
-            auth: self.auth.context("missing reg auth")?,
+            reg_type: self.reg_type.context("missing registry type")?,
+            auth: if allow_insecure {
+                self.auth.unwrap_or_default()
+            } else {
+                self.auth.context("missing registry auth")?
+            },
             allow_latest: self.allow_insecure.unwrap_or_default(),
-            allow_insecure: self.allow_insecure.unwrap_or_default(),
+            allow_insecure,
             additional_ca_paths: self.additional_ca_paths.unwrap_or_default(),
         })
     }


### PR DESCRIPTION
This commit fixes a bug that ignored the `allow_insecure` setting when building registry configuration.

Resolves #3366 

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
