### PR TITLE
fix(washboard-ui): disable eslint rules-of-hooks for playwright tes…

### DIFF
--- a/typescript/apps/washboard-ui/tests/common/test.ts
+++ b/typescript/apps/washboard-ui/tests/common/test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable react-hooks/rules-of-hooks -- Disabling rules-of-hooks since these are Playwright extensions */
+
 import {test as base} from '@playwright/test';
 
 import {logger} from './logger';


### PR DESCRIPTION
…tcontext

Dependabot was kind enough to update the dependency with a major bump, although went a bit overboard what to show as a linter error.
In the file below there is nothing react (functional) component or hooks related.


Sorry for the ping, just raising visibility: @lachieh 