### PR TITLE
feat(wash): add support for Rust wasm32-wasip2 target

### DIFF
--- a/crates/wash-lib/src/build/component.rs
+++ b/crates/wash-lib/src/build/component.rs
@@ -52,10 +52,10 @@ pub async fn build_component(
                 let rust_wasm_path =
                     build_rust_component(common_config, rust_config, component_config).await?;
                 match component_config.wasm_target {
-                    WasmTarget::CoreModule | WasmTarget::WasiP1 => rust_wasm_path,
-                    WasmTarget::WasiP2 => {
+                    WasmTarget::CoreModule | WasmTarget::WasiP1 => {
                         adapt_component_to_wasip2(&rust_wasm_path, component_config)?
                     }
+                    WasmTarget::WasiP2 => rust_wasm_path,
                 }
             }
             LanguageConfig::TinyGo(tinygo_config) => {

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -12,6 +12,7 @@ use cargo_toml::{Manifest, Product};
 use config::Config;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Deserializer};
+use tracing::warn;
 use wadm_types::{Component, Properties, SecretSourceProperty};
 use wasm_pkg_core::config::Config as PackageConfig;
 use wasmcloud_control_interface::RegistryCredential;
@@ -82,7 +83,8 @@ impl RustConfig {
     pub fn build_target(&self, wasm_target: &WasmTarget) -> &'static str {
         match wasm_target {
             WasmTarget::CoreModule => "wasm32-unknown-unknown",
-            WasmTarget::WasiP1 | WasmTarget::WasiP2 => "wasm32-wasip1",
+            WasmTarget::WasiP1 => "wasm32-wasip1",
+            WasmTarget::WasiP2 => "wasm32-wasip2",
         }
     }
 }
@@ -204,7 +206,11 @@ impl From<&str> for WasmTarget {
             "wasm32-wasi" => WasmTarget::WasiP1,
             "wasm32-wasi-preview2" => WasmTarget::WasiP2,
             "wasm32-wasip2" => WasmTarget::WasiP2,
-            _ => WasmTarget::CoreModule,
+            "wasm32-unknown-unknown" => WasmTarget::CoreModule,
+            _ => {
+                warn!("Unknown wasm_target `{value}`, expected wasm32-wasip2 or wasm32-wasip1. Defaulting to wasm32-unknown-unknown");
+                WasmTarget::CoreModule
+            }
         }
     }
 }

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -16,20 +16,18 @@ wash build
 
 As WebAssembly is intended to be a "compilation target" for native Rust code, upstream work is underway to integrate and improve support for the various standards of WebAssembly.
 
-| Language | Core Modules (`wasm32-unknown-unknown`) | Preview 1 (`wasm32-wasi-preview1`) | WASIP2 (`wasm32-wasip2`)                                              |
-|----------|-----------------------------------------|------------------------------------|--------------------------------------------------------------------------------------|
-| Rust     | ✅ (`--target=wasm32-unknown-unknown`)  | ✅ (`--target=wasm32-wasi`)        | ✅ (requires [adapter][wasi-p2-adapter],  [`rustc` Github Issue][rust-wasip2-issue]) |
+| Language | Core Modules (`wasm32-unknown-unknown`) | Preview 1 (`wasm32-wasi-preview1`) | WASIP2 (`wasm32-wasip2`)      |
+| -------- | --------------------------------------- | ---------------------------------- | ----------------------------- |
+| Rust     | ✅ (`--target=wasm32-unknown-unknown`)  | ✅ (`--target=wasm32-wasip1`)      | ✅ (`--target=wasm32-wasip2`) |
 
 > [!NOTE]
 > Don't know what `wasm32-unknown-unknown` means versus `wasm32-wasi-preview1`?
 >
 > `wasm32-unknown-unknown` is a compile target which deals in core [WebAssembly modules][wasm-core-modules] (i.e. you're only given access to numbers at this level)
-> [`wasm32-wasi-preview1`][wasi-p1] is a compile target that provides richer types, support for more higher level platform APIs
+> [`wasm32-wasip1`][wasi-p1] is a compile target that provides richer types, support for more higher level platform APIs
 > [`wasm32-wasip2`][wasi-p2] is the next generation compile target with much richer types, higher level APIs like async, streaming, the WIT IDL.
 >
 > In a sentence, WebAssembly functionality is layered, with `wasm32-unknown-unknown` being the most basic (only doing operations on numbers) and `wasm32-wasip2` being the current most advanced.
-
-[rust-wasip2-issue]: https://github.com/rust-lang/rust/pull/119616
 
 ## Want to learn more?
 
@@ -45,7 +43,6 @@ The Bytecode Alliance maintains a WebAssembly runtime called [`wasmtime`][wasmti
 [wasmcloud]: https://wasmcloud.com
 [wasi-p1]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md
 [wasi-p2]: https://github.com/WebAssembly/WASI/blob/main/preview2
-[wasi-p2-adapter]: https://github.com/bytecodealliance/wasmtime/tree/main/crates/wasi-preview1-component-adapter
 [wasm-core-modules]: https://webassembly.github.io/spec/core/
 [bca]: https://bytecodealliance.org/
 [wasmtime]: https://github.com/bytecodealliance/wasmtime

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,4 +5,5 @@ targets = [
     "wasm32-unknown-unknown",
     "wasm32-wasi",
     "wasm32-wasip1",
+    "wasm32-wasip2",
 ]


### PR DESCRIPTION
## Feature or Problem
Now that `wasm32-wasip2` is a [tier 2 target in rust](https://doc.rust-lang.org/nightly/releases.html#compiler), we can support it natively in `wash build`! So, now, when a Rust component has a wasm_target of wasm32-wasip2, we'll use the native target instead of adapting the core module/p1 module.

I considered making `wasm32-wasip2` the default here instead of the unknown module, but that would be a significant breaking change for the wasmcloud.tomls that don't specify a target. I'll file a followup issue instead to make this a default after the next release of wash.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wash 0.36

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->