### PR TITLE
fix: Make remaining doctests not fail

### DIFF
--- a/crates/wash-cli/src/cmd/dev/deps.rs
+++ b/crates/wash-cli/src/cmd/dev/deps.rs
@@ -50,7 +50,7 @@ fn is_ignored_iface_dep(ns: &str, pkg: &str, iface: &str) -> bool {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// let project_key = ProjectDependencyKey::Project {
 ///   name: "http-hello-world".into(),
 ///   imports: vec![ ("wasi".into(), "http".into(), "incoming-handler".into(), None) ],
@@ -258,7 +258,7 @@ impl DependencySpec {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let v = from_wit_import_face("wasi:keyvalue/atomics");
     /// # assert!(v.is_some())
     /// ```
@@ -361,7 +361,7 @@ impl DependencySpec {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let v = from_wit_export_face("wasi:http/incoming-handler");
     /// # assert!(v.is_some())
     /// ```

--- a/crates/wash-lib/src/start/mod.rs
+++ b/crates/wash-lib/src/start/mod.rs
@@ -4,6 +4,7 @@
 //! # Downloading and Starting NATS and wasmCloud
 //! ```no_run
 //! use anyhow::{anyhow, Result};
+//! use wash_lib::common::CommandGroupUsage;
 //! use wash_lib::start::{
 //!     start_wasmcloud_host,
 //!     start_nats_server,
@@ -28,6 +29,7 @@
 //!         nats_binary,
 //!         nats_log_file,
 //!         config,
+//!         CommandGroupUsage::UseParent,
 //!     ).await?;
 //!
 //!     // Download wasmCloud if not already installed


### PR DESCRIPTION
## Feature or Problem

This fixes the doctest that depends on #3379 and updates the remaining doctests that were failing.

In the case of the doctests where I had to add `ignore`, that's because those are marked as `pub(crate)` and can't be accessed by doctests, so there's no way to actually build them (hence `ignore` instead of `no_run`).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
