### PR TITLE
build(oci): update images, manually patch hashes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
             "GOVERNANCE.md"
             "LICENSE"
             "MAINTAINERS.md"
+            "nix"
             "OWNERS"
             "performance.md"
             "README.md"

--- a/flake.nix
+++ b/flake.nix
@@ -204,6 +204,8 @@
           interpreters.riscv64gc-unknown-linux-gnu = "/lib/ld-linux-riscv64-lp64d.so.1";
           interpreters.x86_64-unknown-linux-gnu = "/lib64/ld-linux-x86-64.so.2";
 
+          images = mapAttrs (_: pkgs.dockerTools.pullImage) (import ./nix/images);
+
           mkFHS = {
             name,
             src,
@@ -256,54 +258,6 @@
             name = "wasmcloud-x86_64-unknown-linux-gnu-fhs";
             src = packages.wasmcloud-x86_64-unknown-linux-gnu;
             interpreter = interpreters.x86_64-unknown-linux-gnu;
-          };
-
-          pullDebian = {
-            imageDigest,
-            sha256,
-          }:
-            pkgs.dockerTools.pullImage {
-              inherit
-                imageDigest
-                sha256
-                ;
-
-              imageName = "debian";
-              finalImageTag = "12.2-slim";
-              finalImageName = "debian";
-            };
-
-          debian.aarch64 = pullDebian {
-            imageDigest = "sha256:9ccb91746bf0b2e3e82b2dd37069ef9b358cb7d813217ea3fa430b940fc5dac3";
-            sha256 = "sha256-cb2lPuBXaQGMrVmvp/Gq0/PtNuTtlZzUmF3S+4jHVtQ=";
-          };
-          debian.x86_64 = pullDebian {
-            imageDigest = "sha256:ea5ad531efe1ac11ff69395d032909baf423b8b88e9aade07e11b40b2e5a1338";
-            sha256 = "sha256-k+x4aUW10YAQ7X20xxJxqW57y2k20sc4e7unh/kqQZQ=";
-          };
-
-          pullWolfi = {
-            imageDigest,
-            sha256,
-          }:
-            pkgs.dockerTools.pullImage {
-              inherit
-                imageDigest
-                sha256
-                ;
-
-              imageName = "cgr.dev/chainguard/wolfi-base";
-              finalImageTag = "latest";
-              finalImageName = "cgr.dev/chainguard/wolfi-base";
-            };
-
-          wolfi.aarch64 = pullWolfi {
-            imageDigest = "sha256:4857dbc65f7dbf22dd662370a6b211621eba5550d276a9b2ad2596b666cbbdfe";
-            sha256 = "sha256-fIxLRqjZpo1An3nBWLZoaYzFJ6qCOereN93/rflEGl4=";
-          };
-          wolfi.x86_64 = pullWolfi {
-            imageDigest = "sha256:4857dbc65f7dbf22dd662370a6b211621eba5550d276a9b2ad2596b666cbbdfe";
-            sha256 = "sha256-OFpWnJj7J2qMEEubZ3dFHbqd08Pqmg4qajztkk9WRkE=";
           };
 
           buildImage = {
@@ -372,22 +326,22 @@
             };
           wash-aarch64-unknown-linux-musl-oci-debian = buildWashImage {
             pkg = packages.wasmcloud-aarch64-unknown-linux-musl;
-            fromImage = debian.aarch64;
+            fromImage = images.debian-arm64;
             architecture = "arm64";
           };
           wash-x86_64-unknown-linux-musl-oci-debian = buildWashImage {
             pkg = packages.wasmcloud-x86_64-unknown-linux-musl;
-            fromImage = debian.x86_64;
+            fromImage = images.debian-amd64;
             architecture = "amd64";
           };
           wash-aarch64-unknown-linux-musl-oci-wolfi = buildWashImage {
             pkg = packages.wasmcloud-aarch64-unknown-linux-musl;
-            fromImage = wolfi.aarch64;
+            fromImage = images.wolfi-arm64;
             architecture = "arm64";
           };
           wash-x86_64-unknown-linux-musl-oci-wolfi = buildWashImage {
             pkg = packages.wasmcloud-x86_64-unknown-linux-musl;
-            fromImage = wolfi.x86_64;
+            fromImage = images.wolfi-amd64;
             architecture = "amd64";
           };
 
@@ -407,22 +361,22 @@
             };
           wasmcloud-aarch64-unknown-linux-musl-oci-debian = buildWasmcloudImage {
             pkg = packages.wasmcloud-aarch64-unknown-linux-musl;
-            fromImage = debian.aarch64;
+            fromImage = images.debian-arm64;
             architecture = "arm64";
           };
           wasmcloud-x86_64-unknown-linux-musl-oci-debian = buildWasmcloudImage {
             pkg = packages.wasmcloud-x86_64-unknown-linux-musl;
-            fromImage = debian.x86_64;
+            fromImage = images.debian-amd64;
             architecture = "amd64";
           };
           wasmcloud-aarch64-unknown-linux-musl-oci-wolfi = buildWasmcloudImage {
             pkg = packages.wasmcloud-aarch64-unknown-linux-musl;
-            fromImage = wolfi.aarch64;
+            fromImage = images.wolfi-arm64;
             architecture = "arm64";
           };
           wasmcloud-x86_64-unknown-linux-musl-oci-wolfi = buildWasmcloudImage {
             pkg = packages.wasmcloud-x86_64-unknown-linux-musl;
-            fromImage = wolfi.x86_64;
+            fromImage = images.wolfi-amd64;
             architecture = "amd64";
           };
 
@@ -518,6 +472,7 @@
               pkgs.minio
               pkgs.nats-server
               pkgs.redis
+              pkgs.skopeo
               pkgs.tinygo
               pkgs.vault
               pkgs.wit-deps

--- a/nix/images/default.nix
+++ b/nix/images/default.nix
@@ -4,23 +4,23 @@
    debian-amd64.finalImageTag = "12-slim";
    debian-amd64.imageDigest = "sha256:36e591f228bb9b99348f584e83f16e012c33ba5cad44ef5981a1d7c0a93eca22";
    debian-amd64.imageName = "debian";
-   debian-amd64.sha256 = "sha256-MOYfHp7XaB3KZVqvT8kSCjmvDPYAaMIW9K74bmxPqCg=";
+   debian-amd64.sha256 = "sha256-ay7tfkWFe6mhW/ysqJKd9+u89g25qtZjCN5/EwaUktg=";
    debian-arm64.arch = "arm64";
    debian-arm64.finalImageName = "debian";
    debian-arm64.finalImageTag = "12-slim";
    debian-arm64.imageDigest = "sha256:36e591f228bb9b99348f584e83f16e012c33ba5cad44ef5981a1d7c0a93eca22";
    debian-arm64.imageName = "debian";
-   debian-arm64.sha256 = "sha256-Zy9awVhKdhYU2mTQMeQprDJffLZj5veOmr4Nkh3Jdc0=";
+   debian-arm64.sha256 = "sha256-dB2CTDtJAdlkBzUOUHxioXtkFNmlbT6IRreBUB5h+zk=";
    wolfi-amd64.arch = "amd64";
    wolfi-amd64.finalImageName = "cgr.dev/chainguard/wolfi-base";
    wolfi-amd64.finalImageTag = "latest";
    wolfi-amd64.imageDigest = "sha256:4857dbc65f7dbf22dd662370a6b211621eba5550d276a9b2ad2596b666cbbdfe";
    wolfi-amd64.imageName = "cgr.dev/chainguard/wolfi-base";
-   wolfi-amd64.sha256 = "sha256-yRSO+//09a00qd+cJJDBhckJPOsdw26tuwvHMEoZrnk=";
+   wolfi-amd64.sha256 = "sha256-OFpWnJj7J2qMEEubZ3dFHbqd08Pqmg4qajztkk9WRkE=";
    wolfi-arm64.arch = "arm64";
    wolfi-arm64.finalImageName = "cgr.dev/chainguard/wolfi-base";
    wolfi-arm64.finalImageTag = "latest";
    wolfi-arm64.imageDigest = "sha256:4857dbc65f7dbf22dd662370a6b211621eba5550d276a9b2ad2596b666cbbdfe";
    wolfi-arm64.imageName = "cgr.dev/chainguard/wolfi-base";
-   wolfi-arm64.sha256 = "sha256-kdsF5b7qKmVpRR2DNYXLD/PVmuAYq8TYLXLA1YyH3+0=";
+   wolfi-arm64.sha256 = "sha256-fIxLRqjZpo1An3nBWLZoaYzFJ6qCOereN93/rflEGl4=";
 }

--- a/nix/images/default.nix
+++ b/nix/images/default.nix
@@ -1,0 +1,26 @@
+{
+   debian-amd64.arch = "amd64";
+   debian-amd64.finalImageName = "debian";
+   debian-amd64.finalImageTag = "12-slim";
+   debian-amd64.imageDigest = "sha256:36e591f228bb9b99348f584e83f16e012c33ba5cad44ef5981a1d7c0a93eca22";
+   debian-amd64.imageName = "debian";
+   debian-amd64.sha256 = "sha256-MOYfHp7XaB3KZVqvT8kSCjmvDPYAaMIW9K74bmxPqCg=";
+   debian-arm64.arch = "arm64";
+   debian-arm64.finalImageName = "debian";
+   debian-arm64.finalImageTag = "12-slim";
+   debian-arm64.imageDigest = "sha256:36e591f228bb9b99348f584e83f16e012c33ba5cad44ef5981a1d7c0a93eca22";
+   debian-arm64.imageName = "debian";
+   debian-arm64.sha256 = "sha256-Zy9awVhKdhYU2mTQMeQprDJffLZj5veOmr4Nkh3Jdc0=";
+   wolfi-amd64.arch = "amd64";
+   wolfi-amd64.finalImageName = "cgr.dev/chainguard/wolfi-base";
+   wolfi-amd64.finalImageTag = "latest";
+   wolfi-amd64.imageDigest = "sha256:4857dbc65f7dbf22dd662370a6b211621eba5550d276a9b2ad2596b666cbbdfe";
+   wolfi-amd64.imageName = "cgr.dev/chainguard/wolfi-base";
+   wolfi-amd64.sha256 = "sha256-yRSO+//09a00qd+cJJDBhckJPOsdw26tuwvHMEoZrnk=";
+   wolfi-arm64.arch = "arm64";
+   wolfi-arm64.finalImageName = "cgr.dev/chainguard/wolfi-base";
+   wolfi-arm64.finalImageTag = "latest";
+   wolfi-arm64.imageDigest = "sha256:4857dbc65f7dbf22dd662370a6b211621eba5550d276a9b2ad2596b666cbbdfe";
+   wolfi-arm64.imageName = "cgr.dev/chainguard/wolfi-base";
+   wolfi-arm64.sha256 = "sha256-kdsF5b7qKmVpRR2DNYXLD/PVmuAYq8TYLXLA1YyH3+0=";
+}

--- a/nix/update-images.sh
+++ b/nix/update-images.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -xe
+
+update() {
+    local dir
+    dir="$(mktemp -d)"
+
+    local amd64
+    amd64=$(skopeo inspect --format '{{ .Digest }}' --override-os linux --override-arch amd64 "docker://${1}:${2}")
+    skopeo --override-os linux --override-arch amd64 --insecure-policy copy "docker://${1}@${amd64}" "docker-archive://${dir}/${3}-amd64.tar" >&2
+
+    local arm64
+    arm64=$(skopeo inspect --format '{{ .Digest }}' --override-os linux --override-arch arm64 "docker://${1}:${2}")
+    skopeo --override-os linux --override-arch arm64 --insecure-policy copy "docker://${1}@${arm64}" "docker-archive://${dir}/${3}-arm64.tar" >&2
+
+    echo "   ${3}-amd64.arch = \"amd64\";"
+    echo "   ${3}-amd64.finalImageName = \"${1}\";"
+    echo "   ${3}-amd64.finalImageTag = \"${2}\";"
+    echo "   ${3}-amd64.imageDigest = \"${amd64}\";"
+    echo "   ${3}-amd64.imageName = \"${1}\";"
+    echo "   ${3}-amd64.sha256 = \"$(nix hash file "${dir}/${3}-amd64.tar")\";"
+    echo "   ${3}-arm64.arch = \"arm64\";"
+    echo "   ${3}-arm64.finalImageName = \"${1}\";"
+    echo "   ${3}-arm64.finalImageTag = \"${2}\";"
+    echo "   ${3}-arm64.imageDigest = \"${arm64}\";"
+    echo "   ${3}-arm64.imageName = \"${1}\";"
+    echo "   ${3}-arm64.sha256 = \"$(nix hash file "${dir}/${3}-arm64.tar")\";"
+
+    rm -rf "${dir}"
+}
+
+cat >"$(git rev-parse --show-toplevel)/nix/images/default.nix" <<EOF
+{
+$(update "debian" "12-slim" "debian")
+$(update "cgr.dev/chainguard/wolfi-base" "latest" "wolfi")
+}
+EOF


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

- add `nix/update-images.sh` script
   - by some reason `skopeo` run from CLI and within Nix sandbox behave differently running the same commands - on CLI it omits the repository metadata in the downloaded tarball, but in the sandbox it includes it. That causes a hash mismatch, so for now the generated output is manually patched. This will be fixed tomorrow
- we never actually specified the correct arch when fetching the image, handling of this generally depends on the OCI registry/image, i.e. for multi-arch images that's a problem, but not for single arch images. It's likely that `wolfi` image was not multi-arch originally, which is why we did not run into issues

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
