### PR TITLE
build(nix): fix OCI update script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,7 @@
 .github/workflows/nix.yml @wasmCloud/ci-maintainers
 flake.* @wasmCloud/ci-maintainers
 garnix.yaml @wasmCloud/ci-maintainers
+nix @wasmCloud/ci-maintainers
 
 ## host-related code
 

--- a/nix/update-images.sh
+++ b/nix/update-images.sh
@@ -8,11 +8,27 @@ update() {
 
     local amd64
     amd64=$(skopeo inspect --format '{{ .Digest }}' --override-os linux --override-arch amd64 "docker://${1}:${2}")
-    skopeo --override-os linux --override-arch amd64 --insecure-policy copy "docker://${1}@${amd64}" "docker-archive://${dir}/${3}-amd64.tar:${1}:${2}" >&2
+    skopeo \
+        --override-os linux \
+        --override-arch amd64 \
+        --insecure-policy \
+        copy \
+        --src-tls-verify \
+        "docker://${1}@${amd64}" \
+        "docker-archive://${dir}/${3}-amd64.tar:${1}:${2}" \
+        >&2
 
     local arm64
     arm64=$(skopeo inspect --format '{{ .Digest }}' --override-os linux --override-arch arm64 "docker://${1}:${2}")
-    skopeo --override-os linux --override-arch arm64 --insecure-policy copy "docker://${1}@${arm64}" "docker-archive://${dir}/${3}-arm64.tar:${1}:${2}" >&2
+    skopeo \
+        --override-os linux \
+        --override-arch arm64 \
+        --insecure-policy \
+        copy \
+        --src-tls-verify \
+        "docker://${1}@${arm64}" \
+        "docker-archive://${dir}/${3}-arm64.tar:${1}:${2}" \
+        >&2
 
     echo "   ${3}-amd64.arch = \"amd64\";"
     echo "   ${3}-amd64.finalImageName = \"${1}\";"

--- a/nix/update-images.sh
+++ b/nix/update-images.sh
@@ -8,11 +8,11 @@ update() {
 
     local amd64
     amd64=$(skopeo inspect --format '{{ .Digest }}' --override-os linux --override-arch amd64 "docker://${1}:${2}")
-    skopeo --override-os linux --override-arch amd64 --insecure-policy copy "docker://${1}@${amd64}" "docker-archive://${dir}/${3}-amd64.tar" >&2
+    skopeo --override-os linux --override-arch amd64 --insecure-policy copy "docker://${1}@${amd64}" "docker-archive://${dir}/${3}-amd64.tar:${1}:${2}" >&2
 
     local arm64
     arm64=$(skopeo inspect --format '{{ .Digest }}' --override-os linux --override-arch arm64 "docker://${1}:${2}")
-    skopeo --override-os linux --override-arch arm64 --insecure-policy copy "docker://${1}@${arm64}" "docker-archive://${dir}/${3}-arm64.tar" >&2
+    skopeo --override-os linux --override-arch arm64 --insecure-policy copy "docker://${1}@${arm64}" "docker-archive://${dir}/${3}-arm64.tar:${1}:${2}" >&2
 
     echo "   ${3}-amd64.arch = \"amd64\";"
     echo "   ${3}-amd64.finalImageName = \"${1}\";"


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

- `skopeo` invocation would not copy the source image name and tag over to the pulled artifact, which caused the hash mismatch, that's now fixed
- enforce TLS verification for OCI fetches

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

https://github.com/containers/skopeo/issues/1609

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
