### PR TITLE
chore: bump washboard version

### DIFF
--- a/crates/wash-cli/src/ui/mod.rs
+++ b/crates/wash-cli/src/ui/mod.rs
@@ -14,7 +14,7 @@ use wash_lib::{
 };
 use wasmcloud_core::tls;
 
-const DEFAULT_WASHBOARD_VERSION: &str = "v0.4.0";
+const DEFAULT_WASHBOARD_VERSION: &str = "v0.5.0";
 
 #[derive(Parser, Debug, Clone)]
 pub struct UiCommand {

--- a/typescript/apps/washboard-ui/package.json
+++ b/typescript/apps/washboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wasmcloud/washboard-ui",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite --clearScreen false",


### PR DESCRIPTION
Bumps washboard version to 0.5.0

This will be merged after the release for wash 0.36.0