### PR TITLE
fix(ci): add missing wasm-tools binary for running golang tests

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -40,11 +40,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@437c908c7e5ee18b63a261286cbe5147219f8a39
         with:
-          tool: nextest
-      - name: Install wit-bindgen
-        uses: taiki-e/install-action@437c908c7e5ee18b63a261286cbe5147219f8a39
-        with:
-          tool: wit-bindgen-cli
+          tool: nextest,wit-bindgen-cli
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
           go-version: '1.22'
@@ -87,11 +83,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@437c908c7e5ee18b63a261286cbe5147219f8a39
         with:
-          tool: nextest
-      - name: Install wit-bindgen
-        uses: taiki-e/install-action@437c908c7e5ee18b63a261286cbe5147219f8a39
-        with:
-          tool: wit-bindgen-cli
+          tool: nextest,wit-bindgen-cli,wasm-tools
       - name: Run integration tests
         run: make test-integration-ci
         working-directory: ./crates/wash-cli


### PR DESCRIPTION
This commit ensures that the `wasm-tools` binary is installed, as it is required for running some integration tests, particularly the golang tests.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
