### PR TITLE
fix(wash): delete manifest when dev stops

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -71,10 +71,10 @@ jobs:
           shared-key: 'ubuntu-22.04-shared-cache'
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       - uses: acifani/setup-tinygo@b2ba42b249c7d3efdfe94166ec0f48b3191404f7
         with:
-          tinygo-version: '0.31.0'
+          tinygo-version: '0.33.0'
           install-binaryen: 'false'
       - name: Launch integration test services
         uses: sudo-bot/action-docker-compose@ef4c4da08a9673f93d4eb8a5da1e942bf24a37ea

--- a/crates/wash-cli/src/cmd/dev/deps.rs
+++ b/crates/wash-cli/src/cmd/dev/deps.rs
@@ -1045,7 +1045,7 @@ impl ProjectDeps {
                 client,
                 Some(lattice.into()),
                 &manifest.metadata.name,
-                Some(manifest.version().into()),
+                None,
             )
             .await
             .with_context(|| {


### PR DESCRIPTION
## Feature or Problem
As of 0.36.0, there may be multiple versions of a deployed manifest. We want to ensure we delete all versions when the dev session ends.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wash-cli 0.36.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
