### PR TITLE
fix(wash-lib): Try to write the newly created LockFile before using it

### DIFF
--- a/crates/wash-lib/src/build/mod.rs
+++ b/crates/wash-lib/src/build/mod.rs
@@ -54,9 +54,14 @@ pub async fn load_lock_file(dir: impl AsRef<Path>) -> Result<LockFile> {
             .await
             .context("failed to load lock file")
     } else {
-        LockFile::new_with_path([], lock_file_path)
+        let mut lock_file = LockFile::new_with_path([], lock_file_path)
             .await
-            .context("failed to create lock file")
+            .context("failed to create lock file")?;
+        lock_file
+            .write()
+            .await
+            .context("failed to write newly created lock file")?;
+        Ok(lock_file)
     }
 }
 


### PR DESCRIPTION
## Feature or Problem

Without this, we're greeted with the following error when `wash build` or `wash with build` fails initially:

```shell
$ wash wit build

failed to load lock file

Caused by:
    0: unable to parse lock file from path
    1: TOML parse error at line 1, column 1
         |
       1 | 
         | ^
       missing field `version`
```

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
