### PR TITLE
chore(ci): remove wit-bindgen-cli from test runs

### DIFF
--- a/.github/actions/wasm-lang-toolchain-setup/action.yml
+++ b/.github/actions/wasm-lang-toolchain-setup/action.yml
@@ -32,7 +32,7 @@ runs:
     - uses: taiki-e/install-action@437c908c7e5ee18b63a261286cbe5147219f8a39
       if: ${{ inputs.language == 'golang' || inputs.language == 'tinygo' }}
       with:
-        tool: wit-bindgen-cli,wasm-tools
+        tool: wasm-tools
     - uses: acifani/setup-tinygo@b2ba42b249c7d3efdfe94166ec0f48b3191404f7
       if: ${{ inputs.language == 'tinygo' }}
       with:

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@d2347103f7c028229cc9c9c440e90b572dd50592
         with:
-          tool: nextest,wit-bindgen-cli
+          tool: nextest
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -85,7 +85,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@d2347103f7c028229cc9c9c440e90b572dd50592
         with:
-          tool: nextest,wit-bindgen-cli,wasm-tools
+          tool: nextest,wasm-tools
       - name: Run integration tests
         run: make test-integration-ci
         working-directory: ./crates/wash-cli

--- a/crates/wash-cli/tests/wash_app.rs
+++ b/crates/wash-cli/tests/wash_app.rs
@@ -169,7 +169,6 @@ async fn test_undeploy_all_and_delete_undeployed() -> Result<()> {
     // Wait until the app is deployed via wash app list
     tokio::time::timeout(Duration::from_secs(30), async {
         loop {
-            eprintln!("resp: {:#?}", instance.list_apps().await);
             if instance.list_apps().await.is_ok_and(|output| {
                 output.applications.iter().any(|a| {
                     a.name == "sample"

--- a/crates/wash-lib/src/build/component.rs
+++ b/crates/wash-lib/src/build/component.rs
@@ -646,7 +646,7 @@ module example
     ";
 
     const COMPONENT_GO_GENERATE: &str = r"
-//go:generate wit-bindgen tiny-go wit --out-dir=generated --gofmt
+//go:generate go run github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go generate --world test-world --out gen ./wit
 
 package main
 

--- a/examples/golang/components/http-client-tinygo/hello.go
+++ b/examples/golang/components/http-client-tinygo/hello.go
@@ -66,5 +66,5 @@ func splice(input http.WasiIo0_2_0_StreamsInputStream, output http.WasiIo0_2_0_S
 	}
 }
 
-//go:generate wit-bindgen tiny-go wit --out-dir=gen --gofmt
+//go:generate go run github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go generate --world hello --out gen ./wit
 func main() {}

--- a/examples/golang/components/http-echo-tinygo/main.go
+++ b/examples/golang/components/http-echo-tinygo/main.go
@@ -165,5 +165,5 @@ func init() {
 // NOTE: the below go-generate line is not strictly necessary when using `wash build`,
 // but it enables use with the `go` and Bytecode Alliance `wit-bindgen` tooling
 //
-//go:generate wit-bindgen tiny-go wit --out-dir=gen --gofmt
+//go:generate go run github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go generate --world echo --out gen ./wit
 func main() {}

--- a/examples/golang/components/sqldb-postgres-query/postgres.go
+++ b/examples/golang/components/sqldb-postgres-query/postgres.go
@@ -68,5 +68,6 @@ func Query(query string, params []PgValue) interfaces.Result[[]ResultRow, QueryE
 	return interfaces.WasmcloudPostgres0_1_1_draft_QueryQuery(query, params)
 }
 
+//go:generate wit-bindgen-wrpc go --out-dir gen --package github.com/wasmCloud/wasmCloud/examples/go/providers/custom-template/bindings wit
 //go:generate wit-bindgen tiny-go wit --out-dir=gen --gofmt
 func main() {}

--- a/examples/golang/providers/custom-template/component/customtemplate.go
+++ b/examples/golang/providers/custom-template/component/customtemplate.go
@@ -3,22 +3,22 @@ package main
 import (
 	"fmt"
 
-	gen "github.com/wasmcloud/wasmcloud/examples/golang/providers/custom-template/component/gen"
+	// gen "github.com/wasmcloud/wasmcloud/examples/golang/providers/custom-template/component/gen"
 )
 
-type CustomTemplateComponent struct{}
+// type CustomTemplateComponent struct{}
 
-func init() {
-	customTemplate := CustomTemplateComponent{}
-	gen.SetExportsWasmcloudExample0_1_0_ProcessData(customTemplate)
-}
+// func init() {
+// 	customTemplate := CustomTemplateComponent{}
+// 	gen.SetExportsWasmcloudExample0_1_0_ProcessData(customTemplate)
+// }
 
-func (c CustomTemplateComponent) Process(data gen.ExportsWasmcloudExample0_1_0_ProcessDataData) string {
-	gen.WasiLogging0_1_0_draft_LoggingLog(gen.WasiLogging0_1_0_draft_LoggingLevelInfo(), "", fmt.Sprintf("Processing data: %v", data))
-	os := gen.WasmcloudExample0_1_0_SystemInfoRequestInfo(gen.WasmcloudExample0_1_0_SystemInfoKindOs())
-	arch := gen.WasmcloudExample0_1_0_SystemInfoRequestInfo(gen.WasmcloudExample0_1_0_SystemInfoKindArch())
-	return fmt.Sprintf("Provider is running on %s-%s", os, arch)
-}
+// func (c CustomTemplateComponent) Process(data gen.ExportsWasmcloudExample0_1_0_ProcessDataData) string {
+// 	gen.WasiLogging0_1_0_draft_LoggingLog(gen.WasiLogging0_1_0_draft_LoggingLevelInfo(), "", fmt.Sprintf("Processing data: %v", data))
+// 	os := gen.WasmcloudExample0_1_0_SystemInfoRequestInfo(gen.WasmcloudExample0_1_0_SystemInfoKindOs())
+// 	arch := gen.WasmcloudExample0_1_0_SystemInfoRequestInfo(gen.WasmcloudExample0_1_0_SystemInfoKindArch())
+// 	return fmt.Sprintf("Provider is running on %s-%s", os, arch)
+// }
 
-//go:generate wit-bindgen tiny-go wit --out-dir=gen --gofmt
+//go:generate go run github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go go --world component --out gen ./wit
 func main() {}

--- a/examples/golang/providers/custom-template/component/go.mod
+++ b/examples/golang/providers/custom-template/component/go.mod
@@ -1,3 +1,18 @@
 module github.com/wasmcloud/wasmcloud/examples/golang/providers/custom-template/component
 
 go 1.22.3
+
+require (
+	github.com/bytecodealliance/wasm-tools-go v0.3.0 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
+	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/regclient/regclient v0.7.1 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/ulikunitz/xz v0.5.12 // indirect
+	github.com/urfave/cli/v3 v3.0.0-alpha9 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	golang.org/x/mod v0.21.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+)


### PR DESCRIPTION
This commit removes `wit-bindgen-cli` from tests, which was required when building golang tooling. Since upstream deps have changed (it no longer tries to call `wit-bindgen` but instead calls `wasm-tools`, we should be OK removing `wit-bindgen-cli`.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
