### PR TITLE
build(nix): avoid always building provider binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,9 @@ required-features = ["providers"]
 name = "sqldb-postgres-provider"
 required-features = ["providers"]
 
+[[bin]]
+name = "wasmcloud"
+
 [profile.release]
 strip = true
 opt-level = "z"

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -11,6 +11,9 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[[bin]]
+name = "wash"
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,10 @@
           "wash-cli"
           "wasmcloud"
         ];
+        build.bins = [
+          "wash"
+          "wasmcloud"
+        ];
 
         clippy.allTargets = true;
         clippy.deny = ["warnings"];


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Avoid building all provider binaries on all builds, only build `wash` and `wasmcloud` binaries by default.

If this does not fix the OCI builds, at least it should speed them up

For now, explicitly set `bin` in `Cargo.toml` to help `crane` figure out what to do, but these should not be necessary. I'll follow-up upstream

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
