### PR TITLE
fix(core)!: Fixes issue with provider cache invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8105,7 +8105,7 @@ dependencies = [
  "wasm-pkg-client",
  "wasm-pkg-core",
  "wasmcloud-control-interface 2.2.0",
- "wasmcloud-core 0.13.0",
+ "wasmcloud-core 0.14.0",
  "wasmcloud-provider-sdk",
  "wasmcloud-secrets-types 0.4.0",
  "wat",
@@ -8183,7 +8183,7 @@ dependencies = [
  "wasm-pkg-client",
  "wasm-pkg-core",
  "wasmcloud-control-interface 2.2.0",
- "wasmcloud-core 0.13.0",
+ "wasmcloud-core 0.14.0",
  "wasmcloud-test-util",
  "wasmparser 0.219.1",
  "wasmtime",
@@ -8533,7 +8533,7 @@ dependencies = [
  "vaultrs",
  "wascap 0.15.1",
  "wasmcloud-control-interface 2.2.0",
- "wasmcloud-core 0.13.0",
+ "wasmcloud-core 0.14.0",
  "wasmcloud-host",
  "wasmcloud-provider-blobstore-azure",
  "wasmcloud-provider-blobstore-fs",
@@ -8588,7 +8588,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
- "wasmcloud-core 0.13.0",
+ "wasmcloud-core 0.14.0",
 ]
 
 [[package]]
@@ -8645,7 +8645,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8713,7 +8713,7 @@ dependencies = [
  "uuid 1.11.0",
  "wascap 0.15.1",
  "wasmcloud-control-interface 2.2.0",
- "wasmcloud-core 0.13.0",
+ "wasmcloud-core 0.14.0",
  "wasmcloud-runtime",
  "wasmcloud-secrets-client",
  "wasmcloud-secrets-types 0.4.0",
@@ -8984,7 +8984,7 @@ dependencies = [
  "tracing-subscriber",
  "ulid",
  "uuid 1.11.0",
- "wasmcloud-core 0.13.0",
+ "wasmcloud-core 0.14.0",
  "wasmcloud-tracing",
  "wrpc-interface-http",
  "wrpc-transport",
@@ -9046,7 +9046,7 @@ dependencies = [
  "wascap 0.15.1",
  "wasi-preview1-component-adapter-provider",
  "wasmcloud-component",
- "wasmcloud-core 0.13.0",
+ "wasmcloud-core 0.14.0",
  "wasmparser 0.219.1",
  "wasmtime",
  "wasmtime-wasi",
@@ -9120,7 +9120,7 @@ dependencies = [
  "url",
  "wascap 0.15.1",
  "wasmcloud-control-interface 2.2.0",
- "wasmcloud-core 0.13.0",
+ "wasmcloud-core 0.14.0",
  "wasmcloud-host",
  "wasmcloud-secrets-types 0.4.0",
 ]
@@ -9144,7 +9144,7 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "wasmcloud-core 0.13.0",
+ "wasmcloud-core 0.14.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,7 +342,7 @@ wasm-encoder = { version = "0.219", default-features = false }
 wasm-gen = { version = "0.1", default-features = false }
 wasmcloud-component = { version = "0", path = "crates/component", default-features = false }
 wasmcloud-control-interface = { version = "2.2.0", path = "./crates/control-interface", default-features = false }
-wasmcloud-core = { version = "^0.13.0", path = "./crates/core", default-features = false }
+wasmcloud-core = { version = "^0.14.0", path = "./crates/core", default-features = false }
 wasmcloud-host = { version = "^0.22.0", path = "./crates/host", default-features = false }
 wasmcloud-provider-blobstore-azure = { version = "*", path = "./crates/provider-blobstore-azure", default-features = false }
 wasmcloud-provider-blobstore-fs = { version = "*", path = "./crates/provider-blobstore-fs", default-features = false }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-core"
-version = "0.13.0"
+version = "0.14.0"
 description = "wasmCloud core functionality shared throughout the ecosystem"
 
 authors.workspace = true


### PR DESCRIPTION
So it turns out that our digest check and invalidation was working perfectly, but changes to a provider weren't working properly. This was due to the _separate_ caching step for the actual extracted binary. To fix this, I made the oci loader return an enum indicating whether it was a cache hit or miss and then converted that over to do the right thing when loading the par

Also, I bumped the version to 0.14 of wasmcloud-core because that is the version that is released on crates.io. I don't know why it ended up that way, but I wanted to make sure things reflected reality