### PR TITLE
chore(ci): Pin componentize-py to known good version

### DIFF
--- a/.github/actions/wasm-lang-toolchain-setup/action.yml
+++ b/.github/actions/wasm-lang-toolchain-setup/action.yml
@@ -46,7 +46,7 @@ runs:
       if: ${{ inputs.language == 'python' }}
       shell: bash
       run: |
-        pip install componentize-py
+        pip install componentize-py==0.14.0
     - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6
       if: ${{ inputs.language == 'typescript' }}
       with:


### PR DESCRIPTION
## Feature or Problem

Based on my testing it appears that something changed from `0.14.0` to `0.15.0` such that a component that could've been built everything leading up to `0.14.0` worked, but now in `0.15.0` does not.

For this reason and others, we need to pin `componentize-py` to a known good version.

Separately I'll see if I can track down the regression and open up an issue in upstream or PR it even.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
