### PR TITLE
feat: add Github action workflow for benchmarking the host

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,74 @@
+name: run-benchmarks
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'SHA of the commit to benchmark'
+        required: true
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  http-benchmark:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install k6
+        run: |
+          sudo gpg -k
+          sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update
+          sudo apt-get install k6
+
+      - name: Start services
+        run: |
+          sudo docker compose -f benches/http-loadtesting/docker-compose.yml up -d
+      - name:  Install wash
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmcloud/core/script.deb.sh | sudo bash
+          sudo apt-get install wash
+
+      - name: Benchmark
+        run: |
+          wash get hosts
+          wash app deploy benches/http-loadtesting/wadm.yaml
+          wash app status rust-hello-world -o json
+          #./artifacts/1/wasmcloud-x86_64-unknown-linux-musl --log-level error &
+          sudo docker run -d --name wasmcloud --network=host ghcr.io/wasmcloud/wasmcloud:${{ github.event.inputs.sha }} wasmcloud --log-level error
+          timeout=30
+          while :; do
+            if [ $timeout -eq 0 ]; then
+              echo "Timeout waiting for app to deploy"
+              exit 1
+            fi
+            wash get hosts -o json
+            res=$(wash app status rust-hello-world -o json | jq -r '.status.status.type')
+            if [ "$res" == "deployed" ]; then
+              break
+            fi
+
+            timeout=$((timeout - 1))
+            sleep 1
+          done
+
+          k6 run benches/http-loadtesting/script.js --summary-export summary.json --summary-trend-stats="med,p(95),p(99.9)"
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: summary.json
+          path: summary.json
+
+      - name: Stop workload
+        if: always()
+        run: |
+          sudo docker compose -f benches/http-loadtesting/docker-compose.yml down
+          sudo docker kill wasmcloud && sudo docker rm wasmcloud
+

--- a/benches/http-loadtesting/docker-compose.yml
+++ b/benches/http-loadtesting/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  nats:
+    image: nats:2.10-alpine
+    network_mode: "host"
+    command: ["-js"]
+
+  wadm:
+    depends_on:
+      - "nats"
+    image: ghcr.io/wasmcloud/wadm:v0.18.0
+    network_mode: "host"

--- a/benches/http-loadtesting/script.js
+++ b/benches/http-loadtesting/script.js
@@ -1,0 +1,65 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export const options = {
+  // A number specifying the number of VUs to run concurrently.
+ // vus: 10000,
+ // // A string specifying the total duration of the test run.
+ // duration: '10s',
+  stages: [
+    { duration: '5s', target: 1000 },
+    { duration: '5s', target: 10000},
+    { duration: '60s', target: 10000},
+    { duration: '5s', target: 0}
+
+  ]
+
+  // The following section contains configuration options for execution of this
+  // test script in Grafana Cloud.
+  //
+  // See https://grafana.com/docs/grafana-cloud/k6/get-started/run-cloud-tests-from-the-cli/
+  // to learn about authoring and running k6 test scripts in Grafana k6 Cloud.
+  //
+  // cloud: {
+  //   // The ID of the project to which the test is assigned in the k6 Cloud UI.
+  //   // By default tests are executed in default project.
+  //   projectID: "",
+  //   // The name of the test in the k6 Cloud UI.
+  //   // Test runs with the same name will be grouped.
+  //   name: "script.js"
+  // },
+
+  // Uncomment this section to enable the use of Browser API in your tests.
+  //
+  // See https://grafana.com/docs/k6/latest/using-k6-browser/running-browser-tests/ to learn more
+  // about using Browser API in your test scripts.
+  //
+  // scenarios: {
+  //   // The scenario name appears in the result summary, tags, and so on.
+  //   // You can give the scenario any name, as long as each name in the script is unique.
+  //   ui: {
+  //     // Executor is a mandatory parameter for browser-based tests.
+  //     // Shared iterations in this case tells k6 to reuse VUs to execute iterations.
+  //     //
+  //     // See https://grafana.com/docs/k6/latest/using-k6/scenarios/executors/ for other executor types.
+  //     executor: 'shared-iterations',
+  //     options: {
+  //       browser: {
+  //         // This is a mandatory parameter that instructs k6 to launch and
+  //         // connect to a chromium-based browser, and use it to run UI-based
+  //         // tests.
+  //         type: 'chromium',
+  //       },
+  //     },
+  //   },
+  // }
+};
+
+// The function that defines VU logic.
+//
+// See https://grafana.com/docs/k6/latest/examples/get-started-with-k6/ to learn more
+// about authoring k6 scripts.
+//
+export default function() {
+  http.get('http://127.0.0.1:8080');
+}

--- a/benches/http-loadtesting/wadm.yaml
+++ b/benches/http-loadtesting/wadm.yaml
@@ -1,0 +1,52 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: rust-hello-world
+  annotations:
+    description: 'HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+    wasmcloud.dev/authors: wasmCloud team
+    wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/http-hello-world/wadm.yaml
+    wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/http-hello-world/README.md
+    wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/components/http-hello-world
+    wasmcloud.dev/categories: |
+      http,http-server,rust,hello-world,example
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+         image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1000
+
+    # Add a capability provider that enables HTTP access
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.23.1
+        ## To configure OTEL integration for this provider specifically, uncomment the lines below
+        # config:
+        #   - name: otel
+        #     properties:
+        #       otel_exporter_otlp_endpoint: "http://all-in-one:4318"
+        #       otel_exporter_otlp_traces_endpoint: "http://traces-backend/v1/traces"
+        #       otel_exporter_otlp_metrics_endpoint: "http://metrics-backend/v1/metrics"
+        #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
+      traits:
+        # Establish a unidirectional link from this http server provider (the "source")
+        # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
+        #
+        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8080
+        - type: link
+          properties:
+            target: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 0.0.0.0:8080


### PR DESCRIPTION
## Feature or Problem
Add a workflow that benchmarks the host using the Rust http-hello-world example. This should give us a decent benchmark of roughly how many requests per second the host can handle using the stock HTTP server provider without tuning the OS.

We may want to use a larger runner to get better baseline performance, since this is a fairly demanding test in terms of CPU usage.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
