### PR TITLE
chore(test-util): Enable jetstream by default

### DIFF
--- a/crates/test-util/src/testcontainers/nats_server.rs
+++ b/crates/test-util/src/testcontainers/nats_server.rs
@@ -11,10 +11,20 @@ impl Image for NatsServer {
     }
 
     fn tag(&self) -> &str {
-        "2.10.18-linux"
+        "2.10.22-linux"
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {
         vec![WaitFor::message_on_stderr("Server is ready")]
+    }
+
+    // Based on https://github.com/nats-io/nats-docker/blob/v2.10.22/2.10.x/scratch/Dockerfile#L8
+    fn entrypoint(&self) -> Option<&str> {
+        Some("/nats-server")
+    }
+
+    // Based on https://github.com/nats-io/nats-docker/blob/v2.10.22/2.10.x/scratch/Dockerfile#L9
+    fn cmd(&self) -> impl IntoIterator<Item = impl Into<std::borrow::Cow<'_, str>>> {
+        vec!["--config", "nats-server.conf", "--jetstream"]
     }
 }


### PR DESCRIPTION
## Feature or Problem

Given that JetStream is a common dependency, it makes sense to enable it by default in our NatsServer test image

## Related Issues

Resolves #3490

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
