### PR TITLE
fix(wash-lib): canonicalize wit, build, override paths

### DIFF
--- a/crates/wash-cli/tests/wash_build.rs
+++ b/crates/wash-cli/tests/wash_build.rs
@@ -741,7 +741,7 @@ async fn integration_build_tinygo_component_separate_paths() -> Result<()> {
     language = "tinygo"
     type = "component"
     path = "../"
-    wit = "wow"
+    wit = "../wow"
     build = "artifacts"
     
     [component]
@@ -773,12 +773,12 @@ async fn integration_build_tinygo_component_separate_paths() -> Result<()> {
         .context("Failed to build project")?;
 
     assert!(status.success());
-    let unsigned_file = project_dir.join("artifacts/tinygo-moved.wasm");
+    let unsigned_file = project_dir.join("config/artifacts/tinygo-moved.wasm");
     assert!(
         tokio::fs::try_exists(unsigned_file).await.unwrap(),
         "unsigned file not found!"
     );
-    let signed_file = project_dir.join("artifacts/tinygo-moved_s.wasm");
+    let signed_file = project_dir.join("config/artifacts/tinygo-moved_s.wasm");
     assert!(
         tokio::fs::try_exists(signed_file).await.unwrap(),
         "signed file not found!"

--- a/crates/wash-lib/src/build/mod.rs
+++ b/crates/wash-lib/src/build/mod.rs
@@ -119,10 +119,16 @@ pub async fn build_project(
     let wit_deps_exists = tokio::fs::try_exists(config.common.wit_dir.join(WIT_DEPS_TOML)).await?;
 
     if wit_deps_exists {
-        eprintln!("Skipping fetching dependencies because deps.toml exists in the wit directory. Use 'wit-deps' to fetch dependencies.");
+        info!("Skipping fetching dependencies because deps.toml exists in the wit directory. Use 'wit-deps' to fetch dependencies.");
     }
 
-    if !skip_fetch && !wit_deps_exists {
+    let wit_dir_exists = tokio::fs::metadata(&config.common.wit_dir).await.is_ok();
+    if !wit_dir_exists {
+        info!("Skipping fetching dependencies because the wit directory does not exist.");
+        info!("Assuming that dependencies are included in the project.");
+    }
+
+    if !skip_fetch && !wit_deps_exists && wit_dir_exists {
         // Fetch dependencies for the component before building
         let client = package_args.get_client().await?;
         let mut lock = load_lock_file(&config.wasmcloud_toml_dir).await?;


### PR DESCRIPTION
## Feature or Problem
This PR fixes issues related to `wit`, `build` dirs and WIT deps override paths when using the `wash build -p <path/to/project>` argument by canonicalizing relative paths.

There's also some additional error context that I've added to the monkey patch function in case there were errors there to aid in tracking down the issue.

In the latest commit, I've pushed a fix to enable building components when a `wit` dir is not available, which is completely fine when a crate like `wasmcloud_component` already generated all of the bindings.

## Related Issues

## Release Information
wash-lib 0.30.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
