### PR TITLE
docs: resolve docs warnings

### DIFF
--- a/crates/control-interface/src/client.rs
+++ b/crates/control-interface/src/client.rs
@@ -582,10 +582,10 @@ impl Client {
     ///
     /// The host will acknowledge this request as soon as it verifies that the target component is running.
     ///
-    /// Note that acknowledgement occurs **before** the new bytes are downloaded. Live-updating an component can take a long time
+    /// Note that acknowledgement occurs **before** the new bytes are downloaded. Live-updating a component can take a long time
     /// and control clients cannot block waiting for a reply that could come several seconds later.
     ///
-    /// To properly verify that a component has been updated, create  listener for the appropriate [`PublishedEvent`] on the
+    /// To properly verify that a component has been updated, create a listener for the appropriate [`PublishedEvent`] on the
     /// control events channel
     ///
     /// # Arguments

--- a/crates/provider-archive/src/archive.rs
+++ b/crates/provider-archive/src/archive.rs
@@ -140,7 +140,7 @@ impl ProviderArchive {
     /// those claims will be compared and verified against hashes computed at load time. This
     /// prevents the contents of the archive from being modified without the embedded claims being
     /// re-signed. This will load all binaries into memory in the returned `ProviderArchive`. Use
-    /// [`load`] or [`try_load_target_from_file`]  methods if you only want to load a single binary
+    /// [`ProviderArchive::load`] or [`ProviderArchive::try_load_target_from_file`] methods if you only want to load a single binary
     /// into memory.
     pub async fn try_load_file(path: impl AsRef<Path>) -> Result<ProviderArchive> {
         let mut file = File::open(&path).await.map_err(|e| {
@@ -162,7 +162,7 @@ impl ProviderArchive {
     /// prevents the contents of the archive from being modified without the embedded claims being
     /// re-signed. This will only read a single binary into memory.
     ///
-    /// It is recommended to use this method or the [`load`] method when consuming a provider
+    /// It is recommended to use this method or the [ProviderArchive::load] method when consuming a provider
     /// archive. Otherwise all binaries will be loaded into memory
     pub async fn try_load_target_from_file(
         path: impl AsRef<Path>,

--- a/crates/provider-sdk/src/lib.rs
+++ b/crates/provider-sdk/src/lib.rs
@@ -33,7 +33,7 @@ pub use wasmcloud_tracing;
 ///
 /// # Errors
 ///
-/// Returns `Err` if the operation is not of the form "<package>:<ns>/<interface>.<function>"
+/// Returns `Err` if the operation is not of the form `<package>:<ns>/<interface>.<function>`
 ///
 /// # Example
 ///

--- a/crates/provider-sdk/src/otel.rs
+++ b/crates/provider-sdk/src/otel.rs
@@ -1,10 +1,11 @@
-/// Instrument a given [`provider_sdk::Context`], injecting current `tracing`-generated metadata
+/// Instrument a given [`tracing_core::Dispatch`](https://docs.rs/tracing-core/latest/tracing_core/struct.Dispatch.html),
+/// injecting current `tracing`-generated metadata
 /// if one isn't present.
 ///
 /// This functionality is exposed as a macro since the context for trace injection
 /// should be at the *call site* of this macro (ex. inside some method annotated with `#[instrument]`)
 ///
-/// This macro requires `provider_sdk` and `wasmcloud_tracing` to be imported
+/// This macro requires [`wasmcloud_provider_sdk`](crate) and [`wasmcloud_tracing`] to be imported
 #[macro_export]
 macro_rules! propagate_trace_for_ctx {
     ($ctx:ident) => {{
@@ -30,8 +31,9 @@ macro_rules! propagate_trace_for_ctx {
 /// This functionality exists as a macro due to the requirement that `tracing` be initialized
 /// from *binary* code, rather than library code.
 ///
-/// This macro loads host data and uses the provider-sdk to build a [`tracing_core::Dispatch`] and
-/// relevant guards/internal structures to configure it with information relevant to the host
+/// This macro loads host data and uses the [`wasmcloud_provider_sdk`](crate) to build a
+/// [`tracing_core::Dispatch`](https://docs.rs/tracing-core/latest/tracing_core/struct.Dispatch.html)
+/// and relevant guards/internal structures to configure it with information relevant to the host
 ///
 /// This macro introduces the following variables into scope:
 /// - `__observability__guard`

--- a/crates/wash-cli/src/call.rs
+++ b/crates/wash-cli/src/call.rs
@@ -222,12 +222,12 @@ pub struct ConnectionOpts {
     rpc_seed: Option<String>,
 
     /// Credsfile for RPC authentication. Combines rpc_seed and rpc_jwt.
-    /// See https://docs.nats.io/using-nats/developer/connecting/creds for details.
+    /// See <https://docs.nats.io/using-nats/developer/connecting/creds> for details.
     #[clap(long = "rpc-credsfile", env = "WASH_RPC_CREDS", hide_env_values = true)]
     rpc_credsfile: Option<PathBuf>,
 
     /// CA file for RPC authentication.
-    /// See https://docs.nats.io/using-nats/developer/security/securing_nats for details.
+    /// See <https://docs.nats.io/using-nats/developer/security/securing_nats> for details.
     #[clap(
         long = "rpc-ca-file",
         env = "WASH_RPC_TLS_CA_FILE",

--- a/crates/wash-cli/src/cmd/up.rs
+++ b/crates/wash-cli/src/cmd/up.rs
@@ -102,7 +102,7 @@ pub struct NatsOpts {
     )]
     pub connect_only: bool,
 
-    /// NATS server version to download, e.g. `v2.10.7`. See https://github.com/nats-io/nats-server/releases/ for releases
+    /// NATS server version to download, e.g. `v2.10.7`. See <https://github.com/nats-io/nats-server/releases/> for releases
     #[clap(long = "nats-version", default_value = NATS_SERVER_VERSION, env = "NATS_VERSION")]
     pub nats_version: String,
 
@@ -152,7 +152,7 @@ impl From<NatsOpts> for NatsConfig {
 
 #[derive(Parser, Debug, Clone)]
 pub struct WasmcloudOpts {
-    /// wasmCloud host version to download, e.g. `v0.55.0`. See https://github.com/wasmCloud/wasmcloud/releases for releases
+    /// wasmCloud host version to download, e.g. `v0.55.0`. See <https://github.com/wasmCloud/wasmcloud/releases> for releases
     #[clap(long = "wasmcloud-version", default_value = WASMCLOUD_HOST_VERSION, env = "WASMCLOUD_VERSION")]
     pub wasmcloud_version: String,
 
@@ -361,7 +361,7 @@ impl WasmcloudOpts {
 
 #[derive(Parser, Debug, Clone)]
 pub struct WadmOpts {
-    /// wadm version to download, e.g. `v0.4.0`. See https://github.com/wasmCloud/wadm/releases for releases
+    /// wadm version to download, e.g. `v0.4.0`. See <https://github.com/wasmCloud/wadm/releases> for releases
     #[clap(long = "wadm-version", default_value = WADM_VERSION, env = "WADM_VERSION")]
     pub wadm_version: String,
 

--- a/crates/wash-cli/src/style.rs
+++ b/crates/wash-cli/src/style.rs
@@ -1,7 +1,7 @@
 //! Styling for wash CLI
 //!
 //! These are originally the same styles used by clap_cargo as of v0.14.1
-//! see: https://docs.rs/clap-cargo/0.14.1/src/clap_cargo/style.rs.html
+//! see: <https://docs.rs/clap-cargo/0.14.1/src/clap_cargo/style.rs.html>
 
 use anstyle::{AnsiColor, Effects, Style};
 

--- a/crates/wash-lib/src/build/mod.rs
+++ b/crates/wash-lib/src/build/mod.rs
@@ -84,8 +84,8 @@ pub struct SignConfig {
 }
 
 /// Using a [`ProjectConfig`], usually parsed from a `wasmcloud.toml` file, build the project
-/// with the installed language toolchain. This will delegate to [`build_component`] when the project is an component,
-/// or [`build_provider`] when the project is a provider.
+/// with the installed language toolchain. This will delegate to [`build_component`] when the project is a component,
+/// builds a provider otherwise.
 ///
 /// This function returns the path to the compiled artifact, a signed Wasm component or signed provider archive.
 ///

--- a/crates/wash-lib/src/cli/mod.rs
+++ b/crates/wash-lib/src/cli/mod.rs
@@ -152,11 +152,11 @@ pub struct CliConnectionOpts {
     pub ctl_seed: Option<String>,
 
     /// Credsfile for CTL authentication. Combines ctl_seed and ctl_jwt.
-    /// See https://docs.nats.io/using-nats/developer/connecting/creds for details.
+    /// See <https://docs.nats.io/using-nats/developer/connecting/creds> for details.
     #[clap(long = "ctl-credsfile", env = "WASH_CTL_CREDS", hide_env_values = true)]
     pub ctl_credsfile: Option<PathBuf>,
 
-    /// TLS CA file for CTL authentication. See https://docs.nats.io/using-nats/developer/connecting/tls for details.
+    /// TLS CA file for CTL authentication. See <https://docs.nats.io/using-nats/developer/connecting/tls> for details.
     #[clap(
         long = "ctl-tls-ca-file",
         env = "WASH_CTL_TLS_CA_FILE",


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

A few days ago I generated locally the documentation for a crate and have seen a few `cargo doc` warnings. 🥶 This should resolve most of them ... except the following one:

```


/// To properly verify that a component has been updated, create a listener for the appropriate [`PublishedEvent`] on the

```

on [main](https://github.com/wasmCloud/wasmCloud/blob/98cd06c1dd448073d8eadef790ee7709a2ccae36/crates/control-interface/src/client.rs#L588) which I am not sure about what kind of reference should it be?
 
These are not really semantic changes, just eliminating the warnings.

 
## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
