### PR TITLE
feat: optimize communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7534,7 +7534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -9174,6 +9174,19 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.218.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09e46c7fceceaa72b2dd1a8a137ea7fd8f93dfaa69806010a709918e496c5dc"
+dependencies = [
+ "ahash",
+ "bitflags 2.6.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.6.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
@@ -9902,6 +9915,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-core"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b885a00e1c428fd12b7b7c4bccc4bad8b2a3ca0abe8eaf1e0f90adabb4c7ac7"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.218.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9931,7 +9955,7 @@ dependencies = [
  "prettyplease",
  "syn 2.0.79",
  "wasm-metadata 0.217.0",
- "wit-bindgen-core",
+ "wit-bindgen-core 0.32.0",
  "wit-component 0.217.0",
 ]
 
@@ -9946,15 +9970,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
- "wit-bindgen-core",
+ "wit-bindgen-core 0.32.0",
  "wit-bindgen-rust",
 ]
 
 [[package]]
 name = "wit-bindgen-wrpc"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01df0831fcc4429892f735d3917378ea3a333e3b5c62322dc41e28d6c4ad5f24"
+checksum = "3f5d6959d64d9b9304fe78a3d4dd5005b5517c5cdd1bf90122ff28ccce72a4ab"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -9970,30 +9994,30 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-wrpc-rust"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ee224c77026caa4b6e70a2644b82a17e891c392bd019e62186dfe3c9bb1493"
+checksum = "6e2717b4c5d6502332f4f689daff02232da72f705f4a7f61ee363811c56dae2f"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "prettyplease",
  "syn 2.0.79",
- "wit-bindgen-core",
+ "wit-bindgen-core 0.33.0",
  "wrpc-introspect",
 ]
 
 [[package]]
 name = "wit-bindgen-wrpc-rust-macro"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4425124d546904d6cf43419b6f396b40cf727af5d2964abc93548de5b0a72ded"
+checksum = "86c5ec53cc9f85dd1815cdea54c23a8adc9ce4fb623ed8872b876a551afc8476"
 dependencies = [
  "anyhow",
  "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
- "wit-bindgen-core",
+ "wit-bindgen-core 0.33.0",
  "wit-bindgen-wrpc-rust",
 ]
 
@@ -10055,6 +10079,24 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
+version = "0.218.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3d1066ab761b115f97fef2b191090faabcb0f37b555b758d3caf42d4ed9e55"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.6.0",
+ "log",
+ "semver",
+ "serde 1.0.210",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.218.0",
+]
+
+[[package]]
+name = "wit-parser"
 version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a86f669283257e8e424b9a4fc3518e3ade0b95deb9fbc0f93a1876be3eda598"
@@ -10073,18 +10115,18 @@ dependencies = [
 
 [[package]]
 name = "wrpc-interface-blobstore"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f375f08e8b470dc468cd9733ce3f281f4c3d038c58e0345100ac127473785802"
+checksum = "60b2fc7ba60f6f4fc2e03d84aab242ddb943cd68b31614df7f972e6b52354d91"
 dependencies = [
  "wit-bindgen-wrpc",
 ]
 
 [[package]]
 name = "wrpc-interface-http"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e158fbab24a26180e070ade38b8d6529ab48c8c67f16a83347a6a62da400263"
+checksum = "fb5afb6be297d32438594380b325b34a3d7ba4ad067266b6629a5307dd4d40f4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -10103,18 +10145,18 @@ dependencies = [
 
 [[package]]
 name = "wrpc-introspect"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb51f18ee0bc3844f296b40b4b251ecc9f824ecf9b25f7a01ff9f7363c778f71"
+checksum = "376a7a4463c1dcfa234702282080a61e99cf8f6e9f0c5be34aedd4d6f2f56a01"
 dependencies = [
- "wit-parser 0.217.0",
+ "wit-parser 0.218.0",
 ]
 
 [[package]]
 name = "wrpc-runtime-wasmtime"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb313d8e62d1c370ea50b8a7cb90c48e83079c7a3ae61df290d600668c4d0ff"
+checksum = "d5558f2b190334fc73e3ed6e96a36cbe0ecaacfc355f1fb49581687f0bc5f071"
 dependencies = [
  "anyhow",
  "bytes",
@@ -10126,16 +10168,16 @@ dependencies = [
  "wasm-tokio",
  "wasmtime",
  "wasmtime-wasi",
- "wit-parser 0.217.0",
+ "wit-parser 0.218.0",
  "wrpc-introspect",
  "wrpc-transport",
 ]
 
 [[package]]
 name = "wrpc-transport"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8620eae71362ab5bb34f6c8f19b4bce1780a758a69db61c44d3f08f45fa0c85"
+checksum = "ebc808d080712f55ee0ed86d8c7a98c6c5cb50903ac57a69fae18941f1171d98"
 dependencies = [
  "anyhow",
  "bytes",
@@ -10146,14 +10188,15 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "wasi 0.13.3+wasi-0.2.2",
  "wasm-tokio",
 ]
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded01ed90a194eec70be31b6b4437fb78dff325a7cb5b0a8df8de956b620f918"
+checksum = "93ceaa64afa9f6a13252909214bd2b7750db3303873dab094abb9ec8c82367ea"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,11 +374,13 @@ which = { version = "4", default-features = false }
 wit-bindgen = { version = "0.32", default-features = false }
 wit-bindgen-core = { version = "0.32", default-features = false }
 wit-bindgen-go = { version = "0.32", default-features = false }
-wit-bindgen-wrpc = { version = "0.7", default-features = false }
+wit-bindgen-wrpc = { version = "0.8", default-features = false }
 wit-component = { version = "0.219", default-features = false }
 wit-parser = { version = "0.219", default-features = false }
-wrpc-interface-blobstore = { version = "0.19", default-features = false }
-wrpc-interface-http = { version = "0.29", default-features = false }
-wrpc-runtime-wasmtime = { version = "0.23", default-features = false }
-wrpc-transport = { version = "0.27", default-features = false }
-wrpc-transport-nats = { version = "0.24.1", default-features = false }
+wrpc-interface-blobstore = { version = "0.20", default-features = false }
+wrpc-interface-http = { version = "0.30", default-features = false }
+wrpc-runtime-wasmtime = { version = "0.24", default-features = false }
+wrpc-transport = { version = "0.28", default-features = false }
+wrpc-transport-nats = { version = "0.26", default-features = false, features = [
+    "async-nats-0_36",
+] }

--- a/crates/provider-http-client/src/lib.rs
+++ b/crates/provider-http-client/src/lib.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use anyhow::Context as _;
 use bytes::Bytes;
-use futures::{StreamExt as _};
+use futures::StreamExt as _;
 use http_body::Frame;
 use http_body_util::{BodyExt as _, StreamBody};
 use hyper_util::rt::TokioExecutor;

--- a/crates/provider-http-server/src/address.rs
+++ b/crates/provider-http-server/src/address.rs
@@ -266,8 +266,10 @@ impl HttpServerCore {
                 .await
                 .context("failed to construct TLS config")?;
 
+            let mut srv = axum_server::from_tcp_rustls(listener, tls);
+            srv.http_builder().http1().keep_alive(false);
             tokio::spawn(async move {
-                if let Err(e) = axum_server::from_tcp_rustls(listener, tls)
+                if let Err(e) = srv
                     .handle(task_handle)
                     .serve(
                         service
@@ -287,8 +289,10 @@ impl HttpServerCore {
         } else {
             debug!(?addr, "bind HTTP listener");
 
+            let mut srv = axum_server::from_tcp(listener);
+            srv.http_builder().http1().keep_alive(false);
             tokio::spawn(async move {
-                if let Err(e) = axum_server::from_tcp(listener)
+                if let Err(e) = srv
                     .handle(task_handle)
                     .serve(
                         service

--- a/crates/provider-http-server/src/address.rs
+++ b/crates/provider-http-server/src/address.rs
@@ -266,8 +266,7 @@ impl HttpServerCore {
                 .await
                 .context("failed to construct TLS config")?;
 
-            let mut srv = axum_server::from_tcp_rustls(listener, tls);
-            srv.http_builder().http1().keep_alive(false);
+            let srv = axum_server::from_tcp_rustls(listener, tls);
             tokio::spawn(async move {
                 if let Err(e) = srv
                     .handle(task_handle)

--- a/crates/provider-http-server/src/lib.rs
+++ b/crates/provider-http-server/src/lib.rs
@@ -290,6 +290,12 @@ pub(crate) fn get_tcp_listener(settings: Arc<ServiceSettings>) -> anyhow::Result
         .set_reuseaddr(!cfg!(windows))
         .context("Error when setting socket to reuseaddr")?;
     socket
+        .set_nodelay(true)
+        .context("failed to set `TCP_NODELAY`")?;
+    socket
+        .set_keepalive(false)
+        .context("failed to disable TCP keepalive")?;
+    socket
         .bind(settings.address)
         .context("Unable to bind to address")?;
     let listener = socket.listen(1024).context("unable to listen on socket")?;


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

- Optimize HTTP server provider
   - disable TCP keepalive - we are quite chatty on the wire and generally these connections are short-lived, so no need for the extra overhead.
   - disable HTTP keepalive - http-server provider is a proxy, which establishes its own TCP connections to NATS server, so keepalive here actually slows down the performance by effectively blocking requests, instead strive for higher degree of concurrency by disabling keepalive and so achieving greater throughput
   - set TCP nodelay
- Update wRPC (with improved NATS transport)
- Optimize export serving by handling each invocation in a separate tokio task. In my testing, this performed much better

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

Tested on a Linux box with `Intel(R) Xeon(R) Platinum 8481C CPU @ 2.70GHz`

`nats-server 2.10.14`

#### IPv4 localhost

Old host, old HTTP server:
```
$ hey -n 1000 http://127.0.0.1:3002

Summary:
  Total:	0.9060 secs
  Slowest:	0.0593 secs
  Fastest:	0.0059 secs
  Average:	0.0448 secs
  Requests/sec:	1103.7220

$ hey -n 1000 --disable-keepalive http://127.0.0.1:3002

Summary:
  Total:	0.2737 secs
  Slowest:	0.0196 secs
  Fastest:	0.0027 secs
  Average:	0.0133 secs
  Requests/sec:	3653.6536
```

Old host, new HTTP server:
```
$ hey -n 1000 http://127.0.0.1:3002

Summary:
  Total:	0.2569 secs
  Slowest:	0.0156 secs
  Fastest:	0.0023 secs
  Average:	0.0125 secs
  Requests/sec:	3892.6621

$ hey -n 1000 --disable-keepalive http://127.0.0.1:3002

Summary:
  Total:	0.2535 secs
  Slowest:	0.0155 secs
  Fastest:	0.0024 secs
  Average:	0.0124 secs
  Requests/sec:	3945.3772
```

New host, old HTTP server:

```
$ hey -n 1000 http://127.0.0.1:3002
Summary:
  Total:	0.9076 secs
  Slowest:	0.0574 secs
  Fastest:	0.0068 secs
  Average:	0.0446 secs
  Requests/sec:	1101.7848

$ hey -n 1000 --disable-keepalive http://127.0.0.1:3002

Summary:
  Total:	0.2370 secs
  Slowest:	0.0196 secs
  Fastest:	0.0074 secs
  Average:	0.0116 secs
  Requests/sec:	4220.2748
```

New host, new HTTP server:
```
$ hey -n 1000 http://127.0.0.1:3002

Summary:
  Total:	0.2221 secs
  Slowest:	0.0126 secs
  Fastest:	0.0019 secs
  Average:	0.0108 secs
  Requests/sec:	4503.2132

$ hey -n 1000 --disable-keepalive http://127.0.0.1:3002

Summary:
  Total:	0.2196 secs
  Slowest:	0.0130 secs
  Fastest:	0.0030 secs
  Average:	0.0107 secs
  Requests/sec:	4553.4710
```


For comparison, Wasmtime serving the same component:

```
$ hey -n 1000 http://127.0.0.1:8080

Summary:
  Total:	0.0296 secs
  Slowest:	0.0059 secs
  Fastest:	0.0001 secs
  Average:	0.0013 secs
  Requests/sec:	33761.6140

$ hey -n 1000 --disable-keepalive http://127.0.0.1:8080

Summary:
  Total:	0.0477 secs
  Slowest:	0.0062 secs
  Fastest:	0.0002 secs
  Average:	0.0021 secs
  Requests/sec:	20975.7772
```

#### Remote via tailscale from Swiss mountains to US

Wasmtime:
```
$ hey -n 1000 http://100.86.31.80:8080/

Summary:
  Total:	2.1825 secs
  Slowest:	0.2214 secs
  Fastest:	0.1005 secs
  Average:	0.1088 secs
  Requests/sec:	458.1824
```

New host, new HTTP server:
```
$ hey -n 1000 http://100.86.31.80:3002 

Summary:
  Total:	4.1124 secs
  Slowest:	0.2286 secs
  Fastest:	0.2011 secs
  Average:	0.2047 secs
  Requests/sec:	243.1650
```

New host, old HTTP server:
```
$ hey -n 1000 http://100.86.31.80:3002

Summary:
  Total:	4.1900 secs
  Slowest:	0.3297 secs
  Fastest:	0.2012 secs
  Average:	0.2092 secs
  Requests/sec:	238.6620
```