### PR TITLE
Fix dog-fetcher panic and Redis provider deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8875,7 +8875,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/crates/provider-keyvalue-redis/Cargo.toml
+++ b/crates/provider-keyvalue-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.28.1"
+version = "0.28.2"
 
 authors.workspace = true
 categories.workspace = true

--- a/examples/rust/components/dog-fetcher/src/lib.rs
+++ b/examples/rust/components/dog-fetcher/src/lib.rs
@@ -3,20 +3,20 @@ mod bindings {
 
     wit_bindgen::generate!({
         with: {
-            "wasi:clocks/monotonic-clock@0.2.1": ::wasi::clocks::monotonic_clock,
-            "wasi:http/incoming-handler@0.2.1": generate,
-            "wasi:http/outgoing-handler@0.2.1": ::wasi::http::outgoing_handler,
-            "wasi:http/types@0.2.1": ::wasi::http::types,
-            "wasi:io/error@0.2.1": ::wasi::io::error,
-            "wasi:io/poll@0.2.1": ::wasi::io::poll,
-            "wasi:io/streams@0.2.1": ::wasi::io::streams,
+            "wasi:clocks/monotonic-clock@0.2.2": ::wasi::clocks::monotonic_clock,
+            "wasi:http/incoming-handler@0.2.2": generate,
+            "wasi:http/outgoing-handler@0.2.2": ::wasi::http::outgoing_handler,
+            "wasi:http/types@0.2.2": ::wasi::http::types,
+            "wasi:io/error@0.2.2": ::wasi::io::error,
+            "wasi:io/poll@0.2.2": ::wasi::io::poll,
+            "wasi:io/streams@0.2.2": ::wasi::io::streams,
         }
     });
 
     export!(DogFetcher);
 }
 
-use std::io::{Write as _, Read as _};
+use std::io::{Read as _, Write as _};
 
 use bindings::exports::wasi::http::incoming_handler::Guest;
 use wasi::http::types::*;
@@ -75,10 +75,10 @@ impl Guest for DogFetcher {
         // Build the HTTP response we'll send back to the user
         let response = OutgoingResponse::new(Fields::new());
         response.set_status_code(200).unwrap();
-        let response_body = response.body().unwrap();
-        let mut write_stream = response_body.write().unwrap();
 
         // Write the headers and then write the body
+        let response_body = response.body().unwrap();
+        let mut write_stream = response_body.write().unwrap();
         ResponseOutparam::set(response_out, Ok(response));
 
         // wasi:io/outgoing-stream.blocking_write_and_flush() is the simplest way to

--- a/examples/rust/components/dog-fetcher/wasmcloud.lock
+++ b/examples/rust/components/dog-fetcher/wasmcloud.lock
@@ -7,6 +7,6 @@ name = "wasi:http"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.2.1"
-version = "0.2.1"
-digest = "sha256:a2e003de97f144467a05a545d376207267e82abb18741505a6b87aa40f4b33db"
+requirement = "=0.2.2"
+version = "0.2.2"
+digest = "sha256:a1f129cdf1fde55ec2d4ae8d998c39a7e5cf7544a8bd84a831054ac0d2ac64dd"

--- a/examples/rust/components/dog-fetcher/wit/deps/wasi-cli-0.2.2/package.wit
+++ b/examples/rust/components/dog-fetcher/wit/deps/wasi-cli-0.2.2/package.wit
@@ -1,19 +1,19 @@
-package wasi:cli@0.2.1;
+package wasi:cli@0.2.2;
 
 interface stdout {
-  use wasi:io/streams@0.2.1.{output-stream};
+  use wasi:io/streams@0.2.2.{output-stream};
 
   get-stdout: func() -> output-stream;
 }
 
 interface stderr {
-  use wasi:io/streams@0.2.1.{output-stream};
+  use wasi:io/streams@0.2.2.{output-stream};
 
   get-stderr: func() -> output-stream;
 }
 
 interface stdin {
-  use wasi:io/streams@0.2.1.{input-stream};
+  use wasi:io/streams@0.2.2.{input-stream};
 
   get-stdin: func() -> input-stream;
 }

--- a/examples/rust/components/dog-fetcher/wit/deps/wasi-clocks-0.2.2/package.wit
+++ b/examples/rust/components/dog-fetcher/wit/deps/wasi-clocks-0.2.2/package.wit
@@ -1,7 +1,7 @@
-package wasi:clocks@0.2.1;
+package wasi:clocks@0.2.2;
 
 interface monotonic-clock {
-  use wasi:io/poll@0.2.1.{pollable};
+  use wasi:io/poll@0.2.2.{pollable};
 
   type instant = u64;
 

--- a/examples/rust/components/dog-fetcher/wit/deps/wasi-http-0.2.2/package.wit
+++ b/examples/rust/components/dog-fetcher/wit/deps/wasi-http-0.2.2/package.wit
@@ -1,4 +1,4 @@
-package wasi:http@0.2.1;
+package wasi:http@0.2.2;
 
 /// This interface defines all of the types and methods for implementing
 /// HTTP Requests and Responses, both incoming and outgoing, as well as
@@ -6,13 +6,13 @@ package wasi:http@0.2.1;
 @since(version = 0.2.0)
 interface types {
   @since(version = 0.2.0)
-  use wasi:clocks/monotonic-clock@0.2.1.{duration};
+  use wasi:clocks/monotonic-clock@0.2.2.{duration};
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.1.{input-stream, output-stream};
+  use wasi:io/streams@0.2.2.{input-stream, output-stream};
   @since(version = 0.2.0)
-  use wasi:io/error@0.2.1.{error as io-error};
+  use wasi:io/error@0.2.2.{error as io-error};
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.1.{pollable};
+  use wasi:io/poll@0.2.2.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
   @since(version = 0.2.0)
@@ -112,11 +112,11 @@ interface types {
   /// setting or appending to a `fields` resource.
   @since(version = 0.2.0)
   variant header-error {
-    /// This error indicates that a `field-key` or `field-value` was
+    /// This error indicates that a `field-name` or `field-value` was
     /// syntactically invalid when used with an operation that sets headers in a
     /// `fields`.
     invalid-syntax,
-    /// This error indicates that a forbidden `field-key` was used when trying
+    /// This error indicates that a forbidden `field-name` was used when trying
     /// to set a header in a `fields`.
     forbidden,
     /// This error indicates that the operation on the `fields` was not
@@ -125,8 +125,23 @@ interface types {
   }
 
   /// Field keys are always strings.
+  ///
+  /// Field keys should always be treated as case insensitive by the `fields`
+  /// resource for the purposes of equality checking.
+  ///
+  /// # Deprecation
+  ///
+  /// This type has been deprecated in favor of the `field-name` type.
   @since(version = 0.2.0)
+  @deprecated(version = 0.2.2)
   type field-key = string;
+
+  /// Field names are always strings.
+  ///
+  /// Field names should always be treated as case insensitive by the `fields`
+  /// resource for the purposes of equality checking.
+  @since(version = 0.2.1)
+  type field-name = field-key;
 
   /// Field values should always be ASCII strings. However, in
   /// reality, HTTP implementations often have to interpret malformed values,
@@ -155,62 +170,65 @@ interface types {
     ///
     /// The resulting `fields` is mutable.
     ///
-    /// The list represents each key-value pair in the Fields. Keys
+    /// The list represents each name-value pair in the Fields. Names
     /// which have multiple values are represented by multiple entries in this
-    /// list with the same key.
+    /// list with the same name.
     ///
-    /// The tuple is a pair of the field key, represented as a string, and
+    /// The tuple is a pair of the field name, represented as a string, and
     /// Value, represented as a list of bytes.
     ///
-    /// An error result will be returned if any `field-key` or `field-value` is
+    /// An error result will be returned if any `field-name` or `field-value` is
     /// syntactically invalid, or if a field is forbidden.
     @since(version = 0.2.0)
-    from-list: static func(entries: list<tuple<field-key, field-value>>) -> result<fields, header-error>;
-    /// Get all of the values corresponding to a key. If the key is not present
+    from-list: static func(entries: list<tuple<field-name, field-value>>) -> result<fields, header-error>;
+    /// Get all of the values corresponding to a name. If the name is not present
     /// in this `fields` or is syntactically invalid, an empty list is returned.
-    /// However, if the key is present but empty, this is represented by a list
+    /// However, if the name is present but empty, this is represented by a list
     /// with one or more empty field-values present.
     @since(version = 0.2.0)
-    get: func(name: field-key) -> list<field-value>;
-    /// Returns `true` when the key is present in this `fields`. If the key is
+    get: func(name: field-name) -> list<field-value>;
+    /// Returns `true` when the name is present in this `fields`. If the name is
     /// syntactically invalid, `false` is returned.
     @since(version = 0.2.0)
-    has: func(name: field-key) -> bool;
-    /// Set all of the values for a key. Clears any existing values for that
-    /// key, if they have been set.
+    has: func(name: field-name) -> bool;
+    /// Set all of the values for a name. Clears any existing values for that
+    /// name, if they have been set.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
     ///
-    /// Fails with `header-error.invalid-syntax` if the `field-key` or any of
+    /// Fails with `header-error.invalid-syntax` if the `field-name` or any of
     /// the `field-value`s are syntactically invalid.
     @since(version = 0.2.0)
-    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
-    /// Delete all values for a key. Does nothing if no values for the key
+    set: func(name: field-name, value: list<field-value>) -> result<_, header-error>;
+    /// Delete all values for a name. Does nothing if no values for the name
     /// exist.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
     ///
-    /// Fails with `header-error.invalid-syntax` if the `field-key` is
+    /// Fails with `header-error.invalid-syntax` if the `field-name` is
     /// syntactically invalid.
     @since(version = 0.2.0)
-    delete: func(name: field-key) -> result<_, header-error>;
-    /// Append a value for a key. Does not change or delete any existing
-    /// values for that key.
+    delete: func(name: field-name) -> result<_, header-error>;
+    /// Append a value for a name. Does not change or delete any existing
+    /// values for that name.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
     ///
-    /// Fails with `header-error.invalid-syntax` if the `field-key` or
+    /// Fails with `header-error.invalid-syntax` if the `field-name` or
     /// `field-value` are syntactically invalid.
     @since(version = 0.2.0)
-    append: func(name: field-key, value: field-value) -> result<_, header-error>;
-    /// Retrieve the full set of keys and values in the Fields. Like the
-    /// constructor, the list represents each key-value pair.
+    append: func(name: field-name, value: field-value) -> result<_, header-error>;
+    /// Retrieve the full set of names and values in the Fields. Like the
+    /// constructor, the list represents each name-value pair.
     ///
-    /// The outer list represents each key-value pair in the Fields. Keys
+    /// The outer list represents each name-value pair in the Fields. Names
     /// which have multiple values are represented by multiple entries in this
-    /// list with the same key.
+    /// list with the same name.
+    ///
+    /// The names and values are always returned in the original casing and in
+    /// the order in which they will be serialized for transport.
     @since(version = 0.2.0)
-    entries: func() -> list<tuple<field-key, field-value>>;
+    entries: func() -> list<tuple<field-name, field-value>>;
     /// Make a deep copy of the Fields. Equivalent in behavior to calling the
     /// `fields` constructor on the return value of `entries`. The resulting
     /// `fields` is mutable.
@@ -647,23 +665,23 @@ interface outgoing-handler {
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.1;
+  import wasi:io/poll@0.2.2;
   @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.1;
+  import wasi:clocks/monotonic-clock@0.2.2;
   @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.1;
+  import wasi:clocks/wall-clock@0.2.2;
   @since(version = 0.2.0)
-  import wasi:random/random@0.2.1;
+  import wasi:random/random@0.2.2;
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.1;
+  import wasi:io/error@0.2.2;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.1;
+  import wasi:io/streams@0.2.2;
   @since(version = 0.2.0)
-  import wasi:cli/stdout@0.2.1;
+  import wasi:cli/stdout@0.2.2;
   @since(version = 0.2.0)
-  import wasi:cli/stderr@0.2.1;
+  import wasi:cli/stderr@0.2.2;
   @since(version = 0.2.0)
-  import wasi:cli/stdin@0.2.1;
+  import wasi:cli/stdin@0.2.2;
   @since(version = 0.2.0)
   import types;
   @since(version = 0.2.0)
@@ -676,25 +694,25 @@ world imports {
 @since(version = 0.2.0)
 world proxy {
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.1;
+  import wasi:io/poll@0.2.2;
   @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.1;
+  import wasi:clocks/monotonic-clock@0.2.2;
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.1;
+  import wasi:io/error@0.2.2;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.1;
+  import wasi:io/streams@0.2.2;
   @since(version = 0.2.0)
   import types;
   @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.1;
+  import wasi:clocks/wall-clock@0.2.2;
   @since(version = 0.2.0)
-  import wasi:random/random@0.2.1;
+  import wasi:random/random@0.2.2;
   @since(version = 0.2.0)
-  import wasi:cli/stdout@0.2.1;
+  import wasi:cli/stdout@0.2.2;
   @since(version = 0.2.0)
-  import wasi:cli/stderr@0.2.1;
+  import wasi:cli/stderr@0.2.2;
   @since(version = 0.2.0)
-  import wasi:cli/stdin@0.2.1;
+  import wasi:cli/stdin@0.2.2;
   @since(version = 0.2.0)
   import outgoing-handler;
 

--- a/examples/rust/components/dog-fetcher/wit/deps/wasi-io-0.2.2/package.wit
+++ b/examples/rust/components/dog-fetcher/wit/deps/wasi-io-0.2.2/package.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 interface poll {
   resource pollable {

--- a/examples/rust/components/dog-fetcher/wit/deps/wasi-random-0.2.2/package.wit
+++ b/examples/rust/components/dog-fetcher/wit/deps/wasi-random-0.2.2/package.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.1;
+package wasi:random@0.2.2;
 
 interface random {
   get-random-bytes: func(len: u64) -> list<u8>;

--- a/examples/rust/components/dog-fetcher/wit/world.wit
+++ b/examples/rust/components/dog-fetcher/wit/world.wit
@@ -1,7 +1,7 @@
 package wasmcloud:hello;
 
 world hello {
-  import wasi:http/outgoing-handler@0.2.1;
+  import wasi:http/outgoing-handler@0.2.2;
 
-  export wasi:http/incoming-handler@0.2.1;
+  export wasi:http/incoming-handler@0.2.2;
 }

--- a/src/bin/keyvalue-redis-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-redis-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Redis"
 language = "rust"
 type = "provider"
-version = "0.28.0"
+version = "0.28.2"
 
 [rust]
 target_path = "../../../target"


### PR DESCRIPTION
## Feature or Problem
This PR fixes a panic in the dog-fetcher component and a deadlock in the kv-redis provider

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next dog-fetcher
keyvalue-redis-provider 0.28.2

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
