### PR TITLE
feat(wash-cli): support interface wildcard overrides

### DIFF
--- a/crates/wash-cli/tests/wash_dev.rs
+++ b/crates/wash-cli/tests/wash_dev.rs
@@ -375,7 +375,7 @@ link_name = "default"
             .as_bytes(),
         )
         .await
-        .context("failed tow write dev configuration content to file")?;
+        .context("failed to write dev configuration content to file")?;
     wasmcloud_toml.flush().await?;
 
     // Run wash dev
@@ -467,7 +467,6 @@ link_name = "default"
             let entry = dir_entries
                 .next_entry()
                 .await
-                // .map_err(|e| anyhow!(e).context("failed to get dir entry"))?
                 .context("failed to get dir entry")?
                 .context("no more dir entries")?;
             if entry.path().extension().is_some_and(|v| v == "yaml") {

--- a/crates/wash-lib/src/parser/mod.rs
+++ b/crates/wash-lib/src/parser/mod.rs
@@ -397,7 +397,7 @@ pub struct InterfaceComponentOverride {
     /// Configuration that should be provided to the overriden component
     pub config: Option<OneOrMore<DevConfigSpec>>,
 
-    /// Configuration that should be provided to the overriden component
+    /// Secrets that should be provided to the overriden component
     pub secrets: Option<OneOrMore<DevSecretSpec>>,
 
     /// Reference to the component
@@ -672,11 +672,11 @@ pub struct DevConfig {
     #[serde(default)]
     pub manifests: Vec<DevManifestComponentTarget>,
 
-    /// Configuration values to be passed ot the
+    /// Configuration values to be passed to the component
     #[serde(default, alias = "configs")]
     pub config: Vec<DevConfigSpec>,
 
-    /// Configuration values to be passed ot the
+    /// Configuration values to be passed to the component
     #[serde(default)]
     pub secrets: Vec<DevSecretSpec>,
 


### PR DESCRIPTION
## Feature or Problem
This PR supports specifying wildcard interfaces in the wasmcloud.toml to prevent multiple overrides for the same interface.

For example, to override KV nats with Redis:
```toml
[[dev.overrides.imports]]
interface_spec = "wasi:keyvalue@0.2.0-draft"
image_ref = "ghcr.io/wasmcloud/keyvalue-redis:0.28.2"
config = { values = { url="redis://127.0.0.1:6379" } }
```

This PR also started using config & secrets where they weren't being used before, so an integration test started failing. I added support for a secrets policy in the event that one is specified in the last commit.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
This PR initially broke an integration test related to overrides because it brought in secrets that were configured on the ovveride

### Manual Verification
I manually tested with the above