### PR TITLE
chore: convert `wasi:logging` levels into more conventional format

### DIFF
--- a/crates/host/src/wasmbus/handler.rs
+++ b/crates/host/src/wasmbus/handler.rs
@@ -275,7 +275,7 @@ impl Logging for Handler {
                 tracing::event!(
                     tracing::Level::TRACE,
                     component_id = ?self.component_id,
-                    ?level,
+                    level = level.to_string(),
                     context,
                     "{message}"
                 );
@@ -284,7 +284,7 @@ impl Logging for Handler {
                 tracing::event!(
                     tracing::Level::DEBUG,
                     component_id = ?self.component_id,
-                    ?level,
+                    level = level.to_string(),
                     context,
                     "{message}"
                 );
@@ -293,7 +293,7 @@ impl Logging for Handler {
                 tracing::event!(
                     tracing::Level::INFO,
                     component_id = ?self.component_id,
-                    ?level,
+                    level = level.to_string(),
                     context,
                     "{message}"
                 );
@@ -302,7 +302,7 @@ impl Logging for Handler {
                 tracing::event!(
                     tracing::Level::WARN,
                     component_id = ?self.component_id,
-                    ?level,
+                    level = level.to_string(),
                     context,
                     "{message}"
                 );
@@ -311,7 +311,7 @@ impl Logging for Handler {
                 tracing::event!(
                     tracing::Level::ERROR,
                     component_id = ?self.component_id,
-                    ?level,
+                    level = level.to_string(),
                     context,
                     "{message}"
                 );
@@ -320,7 +320,7 @@ impl Logging for Handler {
                 tracing::event!(
                     tracing::Level::ERROR,
                     component_id = ?self.component_id,
-                    ?level,
+                    level = level.to_string(),
                     context,
                     "{message}"
                 );

--- a/crates/runtime/src/capability.rs
+++ b/crates/runtime/src/capability.rs
@@ -97,6 +97,23 @@ pub mod config {
     pub use super::wasmtime_bindings::wasi::config::store;
 }
 
+impl std::fmt::Display for wasmtime_bindings::wasi::logging0_1_0_draft::logging::Level {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Trace => "trace",
+                Self::Debug => "debug",
+                Self::Info => "info",
+                Self::Warn => "warn",
+                Self::Error => "error",
+                Self::Critical => "critical",
+            }
+        )
+    }
+}
+
 pub use unversioned_logging_bindings::wasi::logging as unversioned_logging;
 pub use wasmtime_bindings::wasi::{blobstore, keyvalue, logging0_1_0_draft as logging};
 pub use wasmtime_bindings::wasmcloud::{bus1_0_0, bus2_0_0 as bus, messaging, secrets};


### PR DESCRIPTION
## Feature or Problem

While I was diagnosing an issue, I noticed that the log levels that get logged from `wasi:logging` calls didn't look quite right:
```console
INFO log: wasmcloud_host::wasmbus::handler: ... level=Level::Info ...
```

what I was expecting instead was something like this:
```console
INFO log: wasmcloud_host::wasmbus::handler: ... level="info" ...
```

This implements `Display` and calls it via `to_string` in the logging handler.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
