### PR TITLE
chore(ci): cancel in flight duplicate pull_request workflows

### DIFF
--- a/.github/workflows/examples-components.yml
+++ b/.github/workflows/examples-components.yml
@@ -54,7 +54,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/examples-providers.yml
+++ b/.github/workflows/examples-providers.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/secrets-nats-kv.yml
+++ b/.github/workflows/secrets-nats-kv.yml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -16,7 +16,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: washboard-${{ github.ref }}
+  group: washboard-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -14,7 +14,7 @@ on:
       - crates/wash-lib/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -94,7 +94,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Feature or Problem

Since we're already using `concurrency:` to cancel in-flight requests keyed by SHA, I thought it might be useful in PRs to cancel them by pull request number so as to only test the latest changes.

This was inspired by https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
