### PR TITLE
chore: bump wasmCloud 1.4.1, httpserver 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8830,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-server"
-version = "0.23.2"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "1.4.0"
+version = "1.4.1"
 description = "wasmCloud host runtime"
 default-run = "wasmcloud"
 readme = "README.md"

--- a/crates/provider-http-server/Cargo.toml
+++ b/crates/provider-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-server"
-version = "0.23.2"
+version = "0.24.0"
 description = "Http server for wasmcloud, using Axum. This package provides a library, and a capability provider"
 
 authors.workspace = true

--- a/src/bin/http-server-provider/wasmcloud.toml
+++ b/src/bin/http-server-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "HTTP Server"
 language = "rust"
-version = "0.23.2"
+version = "0.24.0"
 type = "provider"
 
 [rust]


### PR DESCRIPTION
## Feature or Problem
This PR bumps wasmCloud to 1.4.1 and the HTTP server to 0.24.0 to release performance improvements in previous PRs.

## Related Issues
#3510 #3511

## Release Information
wasmCloud 1.4.1
http-server 0.24.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
