### PR TITLE
docs(provider): update README.md to use instances

### DIFF
--- a/crates/provider-keyvalue-redis/README.md
+++ b/crates/provider-keyvalue-redis/README.md
@@ -44,7 +44,7 @@ spec:
         # Govern the spread/scheduling of the component
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
         # Link the component to Redis on the default Redis port
         #
         # Establish a unidirectional link to the `kvredis` (the keyvalue capability provider),

--- a/crates/provider-messaging-kafka/README.md
+++ b/crates/provider-messaging-kafka/README.md
@@ -135,7 +135,7 @@ spec:
         # Govern the spread/scheduling of the component
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
         - type: link
           properties:
             target: nats

--- a/crates/provider-sqldb-postgres/README.md
+++ b/crates/provider-sqldb-postgres/README.md
@@ -56,7 +56,7 @@ spec:
         # Govern the spread/scheduling of the component
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
 
         # Link the httpserver to the component, and configure the HTTP server
         # to listen on port 8080 for incoming requests
@@ -114,7 +114,7 @@ For example, the following WADM manifest fragment:
   traits:
     - type: spreadscaler
       properties:
-        replicas: 1
+        instances: 1
     - type: link
       properties:
         target: sqldb-postgres
@@ -154,7 +154,7 @@ For example, the following WADM manifest fragment:
   traits:
     - type: spreadscaler
       properties:
-        replicas: 1
+        instances: 1
     - type: link
       properties:
         target: sqldb-postgres


### PR DESCRIPTION
Replicas have been deprecated in favor of instances.

See wasmCloud/wadm#314 as an example.
