### PR TITLE
fix(host): Fixes orphaned traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8680,7 +8680,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-host"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "1.4.1"
+version = "1.4.2"
 description = "wasmCloud host runtime"
 default-run = "wasmcloud"
 readme = "README.md"

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.23.0"
+version = "0.23.1"
 description = "wasmCloud host library"
 readme = "README.md"
 


### PR DESCRIPTION
We had the correct code for extracting tracing headers from wRPC calls, but our use of `in_current_span` was creating unintentionally orphaned spans. This adds an explicit span for each incoming invocation. See the comment added in the code for additional information