### PR TITLE
chore: Bump wash-lib to 0.31.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8106,7 +8106,6 @@ dependencies = [
  "wasm-pkg-core",
  "wasmcloud-control-interface 2.2.0",
  "wasmcloud-core 0.15.0",
- "wasmcloud-provider-sdk",
  "wasmcloud-secrets-types 0.5.0",
  "wat",
  "weld-codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8121,7 +8121,7 @@ dependencies = [
 
 [[package]]
 name = "wash-lib"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -333,7 +333,7 @@ walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
 wascap = { version = "^0.15.2", path = "./crates/wascap", default-features = false }
 wash-cli = { version = "0", path = "./crates/wash-cli", default-features = false }
-wash-lib = { version = "^0.31.0", path = "./crates/wash-lib", default-features = false }
+wash-lib = { version = "^0.31.1", path = "./crates/wash-lib", default-features = false }
 wasi = { version = "0.13.3", default-features = false }
 wasm-pkg-client = { version = "0.8.3", default-features = false }
 wasm-pkg-core = { version = "0.8.3", default-features = false }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -94,7 +94,6 @@ wasm-pkg-client = { workspace = true }
 wasm-pkg-core = { workspace = true }
 wasmcloud-control-interface = { workspace = true }
 wasmcloud-core = { workspace = true }
-wasmcloud-provider-sdk = { workspace = true }
 wasmcloud-secrets-types = { workspace = true }
 weld-codegen = { workspace = true, features = ["wasmbus"] }
 which = { workspace = true }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-lib"
-version = "0.31.0"
+version = "0.31.1"
 categories = ["wasm"]
 description = "wasmCloud Shell (wash) libraries"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]


### PR DESCRIPTION
## Feature or Problem

Brings in `wadm-types` and `wadm-client` up to `0.7.1` in order to update `wascap` to `0.15.2`

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
