### PR TITLE
fix(examples): rust component http-task-manager fix order and config …

### DIFF
--- a/examples/rust/components/http-task-manager/README.md
+++ b/examples/rust/components/http-task-manager/README.md
@@ -62,10 +62,23 @@ docker run \
     postgres:16-alpine
 ```
 
+### Start the application
+
+Now, we're ready to start our component along with the required providers.
+
+First we start a new wasmCloud host:
+
+```console
+wash up
+```
+
+> [!NOTE]
+> This command won't return, so run open a new terminal to continue running commands
+
 To enable our application we'll start to *connect* to Postgres requires setting up some configuration with `wash`:
 
 ```console
-wash config put pg-task-db \
+wash config put default-postgres \
     POSTGRES_HOST=localhost \
     POSTGRES_PORT=5432 \
     POSTGRES_USERNAME=postgres \
@@ -81,18 +94,6 @@ wash config put pg-task-db \
 
 [wasmcloud-secrets]: https://wasmcloud.com/docs/concepts/secrets
 
-### Start the application
-
-Now, we're ready to start our component along with the required providers.
-
-First we start a new wasmCloud host:
-
-```console
-wash up
-```
-
-> [!NOTE]
-> This command won't return, so run open a new terminal to continue running commands
 
 Next, we deploy our application:
 
@@ -103,7 +104,7 @@ wash app deploy ./local.wadm.yaml
 We can confirm that the application was deployed successfully:
 
 ```console
-wash app get
+wash app list
 ```
 
 Once the application reports as **Deployed** in the application list, you can use `curl` to send a request to the running HTTP server.
@@ -155,10 +156,7 @@ curl \
 To retrieve all existing tasks:
 
 ```console
-curl \
-    -X GET \
-    -H "Content-Type: application/json; charset=utf8" \
-    localhost:8080/api/v1/tasks
+curl localhost:8080/api/v1/tasks
 ```
 
 > [!NOTE]

--- a/examples/rust/components/http-task-manager/local.wadm.yaml
+++ b/examples/rust/components/http-task-manager/local.wadm.yaml
@@ -39,7 +39,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.23.2
+        image: ghcr.io/wasmcloud/http-server:0.24.0
         ## To configure OTEL integration for this provider specifically, uncomment the lines below
         # config:
         #   - name: otel
@@ -70,7 +70,7 @@ spec:
       properties:
         image: ghcr.io/wasmcloud/sqldb-postgres:0.7.1
         config:
-          - name: 'default-postgres'
+          - name: default-postgres
           ## To configure OTEL integration for this provider specifically, uncomment the lines below
           # - name: otel
           #   properties:

--- a/examples/rust/components/http-task-manager/wadm.yaml
+++ b/examples/rust/components/http-task-manager/wadm.yaml
@@ -40,7 +40,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.23.2
+        image: ghcr.io/wasmcloud/http-server:0.24.0
         ## To configure OTEL integration for this provider specifically, uncomment the lines below
         # config:
         #   - name: otel
@@ -71,7 +71,7 @@ spec:
       properties:
         image: ghcr.io/wasmcloud/sqldb-postgres:0.7.1
         config:
-          - name: 'default-postgres'
+          - name: default-postgres
           ## To configure OTEL integration for this provider specifically, uncomment the lines below
           # - name: otel
           #   properties:


### PR DESCRIPTION
## Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

When I went through the rust/components/http-task-manager example: [link](https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/components/http-task-manager)

- I've seen that the config is called different in the `*.wadm.yaml`s compared to the README.md one and the readme suggests to add the config before starting the host. Which should be the other way around.
- Simplified one of the `curl` calls to make is less scary 😄 
- unified the config in the yaml - removed quotes
- bumped the http server version 


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
