### PR TITLE
chore: Adding wash package for 'Fedora 41'

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -33,62 +33,62 @@ on:
     branches:
       - main
     tags:
-      - "component-v[0-9].[0-9]+.[0-9]+"
-      - "component-v[0-9].[0-9]+.[0-9]+-*"
-      - "control-interface-v[0-9].[0-9]+.[0-9]+"
-      - "control-interface-v[0-9].[0-9]+.[0-9]+-*"
-      - "core-v[0-9].[0-9]+.[0-9]+"
-      - "core-v[0-9].[0-9]+.[0-9]+-*"
-      - "host-sys-v[0-9].[0-9]+.[0-9]+"
-      - "host-sys-v[0-9].[0-9]+.[0-9]+-*"
-      - "host-v[0-9].[0-9]+.[0-9]+"
-      - "host-v[0-9].[0-9]+.[0-9]+-*"
-      - "opentelemetry-nats-v[0-9].[0-9]+.[0-9]+"
-      - "opentelemetry-nats-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-archive-v[0-9].[0-9]+.[0-9]+"
-      - "provider-archive-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-blobstore-azure-v[0-9].[0-9]+.[0-9]+"
-      - "provider-blobstore-azure-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-blobstore-fs-v[0-9].[0-9]+.[0-9]+"
-      - "provider-blobstore-fs-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-blobstore-s3-v[0-9].[0-9]+.[0-9]+"
-      - "provider-blobstore-s3-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-http-client-v[0-9].[0-9]+.[0-9]+"
-      - "provider-http-client-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-http-server-v[0-9].[0-9]+.[0-9]+"
-      - "provider-http-server-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-keyvalue-nats-v[0-9].[0-9]+.[0-9]+"
-      - "provider-keyvalue-nats-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-keyvalue-redis-v[0-9].[0-9]+.[0-9]+"
-      - "provider-keyvalue-redis-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-keyvalue-vault-v[0-9].[0-9]+.[0-9]+"
-      - "provider-keyvalue-vault-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-messaging-kafka-v[0-9].[0-9]+.[0-9]+"
-      - "provider-messaging-kafka-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-messaging-nats-v[0-9].[0-9]+.[0-9]+"
-      - "provider-messaging-nats-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-sdk-v[0-9].[0-9]+.[0-9]+"
-      - "provider-sdk-v[0-9].[0-9]+.[0-9]+-*"
-      - "provider-sqldb-postgres-v[0-9].[0-9]+.[0-9]+"
-      - "provider-sqldb-postgres-v[0-9].[0-9]+.[0-9]+-*"
-      - "runtime-v[0-9].[0-9]+.[0-9]+"
-      - "runtime-v[0-9].[0-9]+.[0-9]+-*"
-      - "secrets-client-v[0-9].[0-9]+.[0-9]+"
-      - "secrets-client-v[0-9].[0-9]+.[0-9]+-*"
-      - "secrets-types-v[0-9].[0-9]+.[0-9]+"
-      - "secrets-types-v[0-9].[0-9]+.[0-9]+-*"
-      - "test-util-v[0-9].[0-9]+.[0-9]+"
-      - "test-util-v[0-9].[0-9]+.[0-9]+-*"
-      - "tracing-v[0-9].[0-9]+.[0-9]+"
-      - "tracing-v[0-9].[0-9]+.[0-9]+-*"
-      - "v[0-9].[0-9]+.[0-9]+"
-      - "v[0-9].[0-9]+.[0-9]+-*"
-      - "wascap-v[0-9].[0-9]+.[0-9]+"
-      - "wascap-v[0-9].[0-9]+.[0-9]+-*"
-      - "wash-cli-v[0-9].[0-9]+.[0-9]+"
-      - "wash-cli-v[0-9].[0-9]+.[0-9]+-*"
-      - "wash-lib-v[0-9].[0-9]+.[0-9]+"
-      - "wash-lib-v[0-9].[0-9]+.[0-9]+-*"
+      - 'component-v[0-9].[0-9]+.[0-9]+'
+      - 'component-v[0-9].[0-9]+.[0-9]+-*'
+      - 'control-interface-v[0-9].[0-9]+.[0-9]+'
+      - 'control-interface-v[0-9].[0-9]+.[0-9]+-*'
+      - 'core-v[0-9].[0-9]+.[0-9]+'
+      - 'core-v[0-9].[0-9]+.[0-9]+-*'
+      - 'host-sys-v[0-9].[0-9]+.[0-9]+'
+      - 'host-sys-v[0-9].[0-9]+.[0-9]+-*'
+      - 'host-v[0-9].[0-9]+.[0-9]+'
+      - 'host-v[0-9].[0-9]+.[0-9]+-*'
+      - 'opentelemetry-nats-v[0-9].[0-9]+.[0-9]+'
+      - 'opentelemetry-nats-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-archive-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-archive-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-blobstore-azure-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-blobstore-azure-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-blobstore-fs-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-blobstore-fs-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-blobstore-s3-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-blobstore-s3-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-http-client-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-http-client-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-http-server-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-http-server-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-keyvalue-nats-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-keyvalue-nats-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-keyvalue-redis-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-keyvalue-redis-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-keyvalue-vault-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-keyvalue-vault-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-messaging-kafka-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-messaging-kafka-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-messaging-nats-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-messaging-nats-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-sdk-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-sdk-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-sqldb-postgres-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-sqldb-postgres-v[0-9].[0-9]+.[0-9]+-*'
+      - 'runtime-v[0-9].[0-9]+.[0-9]+'
+      - 'runtime-v[0-9].[0-9]+.[0-9]+-*'
+      - 'secrets-client-v[0-9].[0-9]+.[0-9]+'
+      - 'secrets-client-v[0-9].[0-9]+.[0-9]+-*'
+      - 'secrets-types-v[0-9].[0-9]+.[0-9]+'
+      - 'secrets-types-v[0-9].[0-9]+.[0-9]+-*'
+      - 'test-util-v[0-9].[0-9]+.[0-9]+'
+      - 'test-util-v[0-9].[0-9]+.[0-9]+-*'
+      - 'tracing-v[0-9].[0-9]+.[0-9]+'
+      - 'tracing-v[0-9].[0-9]+.[0-9]+-*'
+      - 'v[0-9].[0-9]+.[0-9]+'
+      - 'v[0-9].[0-9]+.[0-9]+-*'
+      - 'wascap-v[0-9].[0-9]+.[0-9]+'
+      - 'wascap-v[0-9].[0-9]+.[0-9]+-*'
+      - 'wash-cli-v[0-9].[0-9]+.[0-9]+'
+      - 'wash-cli-v[0-9].[0-9]+.[0-9]+-*'
+      - 'wash-lib-v[0-9].[0-9]+.[0-9]+'
+      - 'wash-lib-v[0-9].[0-9]+.[0-9]+-*'
 
 permissions:
   contents: read
@@ -159,7 +159,7 @@ jobs:
         # need to run condition inside job steps so that job will pass if all steps are skipped
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore
         with:
-          cachixAuthToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - uses: ./.github/actions/build-nix
         with:
           package: wasmcloud-${{ matrix.config.target }}
@@ -278,7 +278,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
         with:
-          cachixAuthToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build -L .#checks.x86_64-linux.${{ matrix.check }}
 
   build-doc:
@@ -287,7 +287,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
         with:
-          cachixAuthToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build -L .#checks.x86_64-linux.doc
       - run: cp --no-preserve=mode -R ./result/share/doc ./doc
       - run: rm -f doc/.lock
@@ -394,7 +394,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
         with:
-          cachixAuthToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Extract tag context
         id: ctx
@@ -610,7 +610,7 @@ jobs:
 
       - uses: ./.github/actions/install-nix
         with:
-          cachixAuthToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Install NFPM
         run: nix profile install -L --inputs-from . 'nixpkgs#nfpm'
 
@@ -748,7 +748,7 @@ jobs:
       - run: rustup show
       - name: install smart-release
         env:
-          RUSTFLAGS: ""
+          RUSTFLAGS: ''
         # NOTE(brooksmtownsend): Installing from my fork as updating workspace dependencies is not yet supported in the mainline
         # PR to follow: https://github.com/Byron/cargo-smart-release/pull/17
         run: cargo install cargo-smart-release --git https://github.com/brooksmtownsend/cargo-smart-release --branch feat/update-workspace-dependencies
@@ -768,7 +768,7 @@ jobs:
           signoff: true
           committer: wasmCloud Automation <automation@wasmcloud.com>
           title: Release ${{ inputs.crate }}
-          commit-message: "release(${{ inputs.crate }}): release and update CHANGELOG"
+          commit-message: 'release(${{ inputs.crate }}): release and update CHANGELOG'
 
       - name: release
         if: ${{ inputs.do-release }}

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -33,62 +33,62 @@ on:
     branches:
       - main
     tags:
-      - 'component-v[0-9].[0-9]+.[0-9]+'
-      - 'component-v[0-9].[0-9]+.[0-9]+-*'
-      - 'control-interface-v[0-9].[0-9]+.[0-9]+'
-      - 'control-interface-v[0-9].[0-9]+.[0-9]+-*'
-      - 'core-v[0-9].[0-9]+.[0-9]+'
-      - 'core-v[0-9].[0-9]+.[0-9]+-*'
-      - 'host-sys-v[0-9].[0-9]+.[0-9]+'
-      - 'host-sys-v[0-9].[0-9]+.[0-9]+-*'
-      - 'host-v[0-9].[0-9]+.[0-9]+'
-      - 'host-v[0-9].[0-9]+.[0-9]+-*'
-      - 'opentelemetry-nats-v[0-9].[0-9]+.[0-9]+'
-      - 'opentelemetry-nats-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-archive-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-archive-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-blobstore-azure-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-blobstore-azure-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-blobstore-fs-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-blobstore-fs-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-blobstore-s3-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-blobstore-s3-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-http-client-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-http-client-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-http-server-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-http-server-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-keyvalue-nats-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-keyvalue-nats-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-keyvalue-redis-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-keyvalue-redis-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-keyvalue-vault-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-keyvalue-vault-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-messaging-kafka-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-messaging-kafka-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-messaging-nats-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-messaging-nats-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-sdk-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-sdk-v[0-9].[0-9]+.[0-9]+-*'
-      - 'provider-sqldb-postgres-v[0-9].[0-9]+.[0-9]+'
-      - 'provider-sqldb-postgres-v[0-9].[0-9]+.[0-9]+-*'
-      - 'runtime-v[0-9].[0-9]+.[0-9]+'
-      - 'runtime-v[0-9].[0-9]+.[0-9]+-*'
-      - 'secrets-client-v[0-9].[0-9]+.[0-9]+'
-      - 'secrets-client-v[0-9].[0-9]+.[0-9]+-*'
-      - 'secrets-types-v[0-9].[0-9]+.[0-9]+'
-      - 'secrets-types-v[0-9].[0-9]+.[0-9]+-*'
-      - 'test-util-v[0-9].[0-9]+.[0-9]+'
-      - 'test-util-v[0-9].[0-9]+.[0-9]+-*'
-      - 'tracing-v[0-9].[0-9]+.[0-9]+'
-      - 'tracing-v[0-9].[0-9]+.[0-9]+-*'
-      - 'v[0-9].[0-9]+.[0-9]+'
-      - 'v[0-9].[0-9]+.[0-9]+-*'
-      - 'wascap-v[0-9].[0-9]+.[0-9]+'
-      - 'wascap-v[0-9].[0-9]+.[0-9]+-*'
-      - 'wash-cli-v[0-9].[0-9]+.[0-9]+'
-      - 'wash-cli-v[0-9].[0-9]+.[0-9]+-*'
-      - 'wash-lib-v[0-9].[0-9]+.[0-9]+'
-      - 'wash-lib-v[0-9].[0-9]+.[0-9]+-*'
+      - "component-v[0-9].[0-9]+.[0-9]+"
+      - "component-v[0-9].[0-9]+.[0-9]+-*"
+      - "control-interface-v[0-9].[0-9]+.[0-9]+"
+      - "control-interface-v[0-9].[0-9]+.[0-9]+-*"
+      - "core-v[0-9].[0-9]+.[0-9]+"
+      - "core-v[0-9].[0-9]+.[0-9]+-*"
+      - "host-sys-v[0-9].[0-9]+.[0-9]+"
+      - "host-sys-v[0-9].[0-9]+.[0-9]+-*"
+      - "host-v[0-9].[0-9]+.[0-9]+"
+      - "host-v[0-9].[0-9]+.[0-9]+-*"
+      - "opentelemetry-nats-v[0-9].[0-9]+.[0-9]+"
+      - "opentelemetry-nats-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-archive-v[0-9].[0-9]+.[0-9]+"
+      - "provider-archive-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-blobstore-azure-v[0-9].[0-9]+.[0-9]+"
+      - "provider-blobstore-azure-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-blobstore-fs-v[0-9].[0-9]+.[0-9]+"
+      - "provider-blobstore-fs-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-blobstore-s3-v[0-9].[0-9]+.[0-9]+"
+      - "provider-blobstore-s3-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-http-client-v[0-9].[0-9]+.[0-9]+"
+      - "provider-http-client-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-http-server-v[0-9].[0-9]+.[0-9]+"
+      - "provider-http-server-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-keyvalue-nats-v[0-9].[0-9]+.[0-9]+"
+      - "provider-keyvalue-nats-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-keyvalue-redis-v[0-9].[0-9]+.[0-9]+"
+      - "provider-keyvalue-redis-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-keyvalue-vault-v[0-9].[0-9]+.[0-9]+"
+      - "provider-keyvalue-vault-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-messaging-kafka-v[0-9].[0-9]+.[0-9]+"
+      - "provider-messaging-kafka-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-messaging-nats-v[0-9].[0-9]+.[0-9]+"
+      - "provider-messaging-nats-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-sdk-v[0-9].[0-9]+.[0-9]+"
+      - "provider-sdk-v[0-9].[0-9]+.[0-9]+-*"
+      - "provider-sqldb-postgres-v[0-9].[0-9]+.[0-9]+"
+      - "provider-sqldb-postgres-v[0-9].[0-9]+.[0-9]+-*"
+      - "runtime-v[0-9].[0-9]+.[0-9]+"
+      - "runtime-v[0-9].[0-9]+.[0-9]+-*"
+      - "secrets-client-v[0-9].[0-9]+.[0-9]+"
+      - "secrets-client-v[0-9].[0-9]+.[0-9]+-*"
+      - "secrets-types-v[0-9].[0-9]+.[0-9]+"
+      - "secrets-types-v[0-9].[0-9]+.[0-9]+-*"
+      - "test-util-v[0-9].[0-9]+.[0-9]+"
+      - "test-util-v[0-9].[0-9]+.[0-9]+-*"
+      - "tracing-v[0-9].[0-9]+.[0-9]+"
+      - "tracing-v[0-9].[0-9]+.[0-9]+-*"
+      - "v[0-9].[0-9]+.[0-9]+"
+      - "v[0-9].[0-9]+.[0-9]+-*"
+      - "wascap-v[0-9].[0-9]+.[0-9]+"
+      - "wascap-v[0-9].[0-9]+.[0-9]+-*"
+      - "wash-cli-v[0-9].[0-9]+.[0-9]+"
+      - "wash-cli-v[0-9].[0-9]+.[0-9]+-*"
+      - "wash-lib-v[0-9].[0-9]+.[0-9]+"
+      - "wash-lib-v[0-9].[0-9]+.[0-9]+-*"
 
 permissions:
   contents: read
@@ -159,7 +159,7 @@ jobs:
         # need to run condition inside job steps so that job will pass if all steps are skipped
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore
         with:
-          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          cachixAuthToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - uses: ./.github/actions/build-nix
         with:
           package: wasmcloud-${{ matrix.config.target }}
@@ -278,7 +278,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
         with:
-          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          cachixAuthToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix build -L .#checks.x86_64-linux.${{ matrix.check }}
 
   build-doc:
@@ -287,7 +287,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
         with:
-          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          cachixAuthToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix build -L .#checks.x86_64-linux.doc
       - run: cp --no-preserve=mode -R ./result/share/doc ./doc
       - run: rm -f doc/.lock
@@ -394,7 +394,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
         with:
-          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          cachixAuthToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Extract tag context
         id: ctx
@@ -610,7 +610,7 @@ jobs:
 
       - uses: ./.github/actions/install-nix
         with:
-          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          cachixAuthToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Install NFPM
         run: nix profile install -L --inputs-from . 'nixpkgs#nfpm'
 
@@ -647,7 +647,7 @@ jobs:
       - name: Push `rpm`
         working-directory: ./crates/wash-cli
         run: |
-          rpms=(194 204 209 216 226 231 236 239 240 244 260 273 279 283)
+          rpms=(194 204 209 216 226 231 236 239 240 244 260 273 279 283 302)
           for distro_version in "${rpms[@]}"; do
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.aarch64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
             curl -F "package[distro_version_id]=${distro_version}" -F "package[package_file]=@$(ls wash-*.x86_64.rpm)" https://$PACKAGECLOUD_TOKEN:@packagecloud.io/api/v1/repos/wasmcloud/core/packages.json;
@@ -748,7 +748,7 @@ jobs:
       - run: rustup show
       - name: install smart-release
         env:
-          RUSTFLAGS: ''
+          RUSTFLAGS: ""
         # NOTE(brooksmtownsend): Installing from my fork as updating workspace dependencies is not yet supported in the mainline
         # PR to follow: https://github.com/Byron/cargo-smart-release/pull/17
         run: cargo install cargo-smart-release --git https://github.com/brooksmtownsend/cargo-smart-release --branch feat/update-workspace-dependencies
@@ -768,7 +768,7 @@ jobs:
           signoff: true
           committer: wasmCloud Automation <automation@wasmcloud.com>
           title: Release ${{ inputs.crate }}
-          commit-message: 'release(${{ inputs.crate }}): release and update CHANGELOG'
+          commit-message: "release(${{ inputs.crate }}): release and update CHANGELOG"
 
       - name: release
         if: ${{ inputs.do-release }}


### PR DESCRIPTION
https://packagecloud.io/wasmCloud/core is currently missing `fedora/41` packages.

From https://packagecloud.io/api/v1/distributions.json, the fedora 41 id is `302`

![Screenshot 2024-11-11 at 12 44 03 PM](https://github.com/user-attachments/assets/5bf7e4fb-e50c-4bf9-9f03-1b64806ace58)
