### PR TITLE
wip: chore(charts): deprecate old helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 ![Powered by WebAssembly](https://img.shields.io/badge/powered%20by-WebAssembly-orange.svg)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6363/badge)](https://bestpractices.coreinfrastructure.org/projects/6363)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wasmcloud/wasmcloud/badge)](https://securityscorecards.dev/viewer/?uri=github.com/wasmcloud/wasmcloud)
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/wasmcloud-chart)](https://artifacthub.io/packages/search?repo=wasmcloud-chart)
 [![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/wasm-cloud/badge)](https://clomonitor.io/projects/cncf/wasm-cloud)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B40030%2Fgit%40github.com%3AwasmCloud%2FwasmCloud.git.svg?type=small)](https://app.fossa.com/projects/custom%2B40030%2Fgit%40github.com%3AwasmCloud%2FwasmCloud.git?ref=badge_small)
 [![twitter](https://img.shields.io/twitter/follow/wasmcloud?style=social)](https://twitter.com/wasmcloud)

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -18,6 +18,8 @@ type: application
 # Note: Ensure you bump this `version` field in a separate PR than what you plan
 # to tag as the updated wasmCloud version. To be safe, bump and release wasmCloud
 # in one PR, then open a new PR updating this `version` and `appVersion`.
-version: 0.7.2
+version: 0.7.3
+
+deprecated: true
 
 appVersion: "0.81.0"


### PR DESCRIPTION
## Feature or Problem
Deprecation of old helm chart and removal of badge from the main README

## Related Issues
#2868 

## Release Information
next

## Consumer Impact
Deprecates the old helm chart

## Testing

### Unit Test(s)

### Acceptance or Integration

### Manual Verification

helm linted the charts