### PR TITLE
Adding clap-markdown feature into arg parsing logic of wasmCloud host

### DIFF
--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -143,7 +143,7 @@ struct Cli {
         hide = true,
         global = true
     )]
-    markdown_help: bool,
+    help_markdown: bool,
 
     #[clap(subcommand)]
     command: CliCommand,
@@ -387,7 +387,7 @@ async fn main() {
     let output_kind = cli.output;
 
     // Implements clap_markdown for markdown generation of command line documentation. Most straightforward way to invoke is probably `wash app get --help-markdown > help.md`
-    if cli.markdown_help {
+    if cli.help_markdown {
         clap_markdown::print_help_markdown::<Cli>();
         std::process::exit(0);
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,13 +328,13 @@ struct Args {
     heartbeat_interval: Option<Duration>,
 
     #[clap(
-    long = "help-markdown",
-    short,
-    action=ArgAction::SetTrue,
-    conflicts_with = "help",
-    hide = true
+        long = "help-markdown",
+        short,
+        action=ArgAction::SetTrue,
+        conflicts_with = "help",
+        hide = true
     )]
-    markdown_help: bool,
+    help_markdown: bool,
 }
 
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
@@ -345,7 +345,7 @@ async fn main() -> anyhow::Result<()> {
     let args: Args = Args::parse();
 
     // Implements clap_markdown for markdown generation of command line documentation.`
-    if args.markdown_help {
+    if args.help_markdown {
         clap_markdown::print_help_markdown::<Args>();
         std::process::exit(0);
     }


### PR DESCRIPTION
## Feature or Problem
WasmCloud Host should utilize the same `clap-markdown` capability implemented in wash-cli  in order to auto-generate docs. Additionally docs should exist on how to update the documentation for copy into wasm docs. 

## Related Issues
https://github.com/wasmCloud/wasmcloud.com/issues/597

## Release Information
next

## Consumer Impact
- wasm host binary invocations and arg parsing
- wasm documentation output


## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
