### PR TITLE
chore(examples): use port 8000 instead of 8080 to align with

### DIFF
--- a/examples/c/components/http-hello-world/README.md
+++ b/examples/c/components/http-hello-world/README.md
@@ -33,5 +33,5 @@ Ensuring you've built your component with `wash build`, you can launch wasmCloud
 wash up -d
 wash app deploy ./wadm.yaml
 wash app get
-curl http://127.0.0.1:8080
+curl http://127.0.0.1:8000
 ```

--- a/examples/c/components/http-hello-world/local.wadm.yaml
+++ b/examples/c/components/http-hello-world/local.wadm.yaml
@@ -26,7 +26,7 @@ spec:
         # Establish a unidirectional link from this http server provider (the "source")
         # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
         #
-        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8080
+        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8000
         - type: link
           properties:
             target: http-component
@@ -36,4 +36,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/c/components/http-hello-world/wadm.yaml
+++ b/examples/c/components/http-hello-world/wadm.yaml
@@ -31,7 +31,7 @@ spec:
         # Establish a unidirectional link from this http server provider (the "source")
         # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
         #
-        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8080
+        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8000
         - type: link
           properties:
             target: http-component
@@ -41,4 +41,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/golang/components/http-client-tinygo/README.md
+++ b/examples/golang/components/http-client-tinygo/README.md
@@ -21,7 +21,7 @@ Make sure to follow the build steps above, and replace the file path in [the wad
 ```
 wash up -d
 wash app deploy ./wadm.yaml
-curl http://localhost:8080
+curl http://localhost:8000
 ```
 
 ## Adding Capabilities

--- a/examples/golang/components/http-client-tinygo/local.wadm.yaml
+++ b/examples/golang/components/http-client-tinygo/local.wadm.yaml
@@ -47,7 +47,7 @@ spec:
         #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -62,7 +62,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     - name: httpclient
       type: capability

--- a/examples/golang/components/http-client-tinygo/wadm.yaml
+++ b/examples/golang/components/http-client-tinygo/wadm.yaml
@@ -47,7 +47,7 @@ spec:
         #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -62,7 +62,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     - name: httpclient
       type: capability

--- a/examples/golang/components/http-echo-tinygo/wadm.yaml
+++ b/examples/golang/components/http-echo-tinygo/wadm.yaml
@@ -40,7 +40,7 @@ spec:
       properties:
         image: ghcr.io/wasmcloud/http-server:0.23.2
       traits:
-        # Link to Echo, and inform it to listen on port 8080
+        # Link to Echo, and inform it to listen on port 8000
         # on the local machine
         - type: link
           properties:
@@ -51,4 +51,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: '0.0.0.0:8080'
+                  address: '0.0.0.0:8000'

--- a/examples/golang/components/http-hello-world/README.md
+++ b/examples/golang/components/http-hello-world/README.md
@@ -30,7 +30,7 @@ Make sure to follow the build steps above, and replace the file path in [the wad
 ```shell
 wash up -d
 wash app deploy ./wadm.yaml
-curl http://localhost:8080
+curl http://localhost:8000
 ```
 
 ## Adding Capabilities

--- a/examples/golang/components/http-hello-world/wadm.yaml
+++ b/examples/golang/components/http-hello-world/wadm.yaml
@@ -29,7 +29,7 @@ spec:
         image: ghcr.io/wasmcloud/http-server:0.23.2
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -44,4 +44,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/golang/components/http-password-checker/wadm.yaml
+++ b/examples/golang/components/http-password-checker/wadm.yaml
@@ -29,7 +29,7 @@ spec:
         image: ghcr.io/wasmcloud/http-server:0.23.2
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -44,4 +44,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/python/components/http-hello-world/README.md
+++ b/examples/python/components/http-hello-world/README.md
@@ -39,7 +39,7 @@ Make sure to follow the build steps above, and replace the file path in [the wad
 ```
 wash up -d
 wash app deploy ./wadm.yaml
-curl http://localhost:8080
+curl http://localhost:8000
 ```
 
 ## Adding Capabilities

--- a/examples/python/components/http-hello-world/wadm.yaml
+++ b/examples/python/components/http-hello-world/wadm.yaml
@@ -29,7 +29,7 @@ spec:
         image: ghcr.io/wasmcloud/http-server:0.23.2
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -44,4 +44,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/components/blobby/README.md
+++ b/examples/rust/components/blobby/README.md
@@ -26,7 +26,7 @@ Ensuring you've built your component with `wash build`, you can launch wasmCloud
 wash up -d
 wash app deploy ./wadm.yaml
 wash app get
-curl http://localhost:8080
+curl http://localhost:8000
 ```
 
 ## Required Capabilities
@@ -43,11 +43,11 @@ annotated commands below:
 $ echo 'Hello there!' > myfile.txt
 
 # Upload the file to the fileserver
-$ curl -H 'Content-Type: text/plain' -v 'http://127.0.0.1:8080/myfile.txt' --data-binary @myfile.txt
-*   Trying 127.0.0.1:8080...
-* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+$ curl -H 'Content-Type: text/plain' -v 'http://127.0.0.1:8000/myfile.txt' --data-binary @myfile.txt
+*   Trying 127.0.0.1:8000...
+* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
 > POST /myfile.txt HTTP/1.1
-> Host: 127.0.0.1:8080
+> Host: 127.0.0.1:8000
 > User-Agent: curl/7.85.0
 > Accept: */*
 > Content-Type: text/plain
@@ -61,11 +61,11 @@ $ curl -H 'Content-Type: text/plain' -v 'http://127.0.0.1:8080/myfile.txt' --dat
 * Connection #0 to host 127.0.0.1 left intact
 
 # Get the file back from the server
-$ curl -v 'http://127.0.0.1:8080/myfile.txt'
-*   Trying 127.0.0.1:8080...
-* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+$ curl -v 'http://127.0.0.1:8000/myfile.txt'
+*   Trying 127.0.0.1:8000...
+* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
 > GET /myfile.txt HTTP/1.1
-> Host: 127.0.0.1:8080
+> Host: 127.0.0.1:8000
 > User-Agent: curl/7.85.0
 > Accept: */*
 >
@@ -79,11 +79,11 @@ Hello there!
 
 # Update the file
 $ echo 'General Kenobi!' >> myfile.txt
-$ curl -H 'Content-Type: text/plain' -v 'http://127.0.0.1:8080/myfile.txt' --data-binary @myfile.txt
-*   Trying 127.0.0.1:8080...
-* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+$ curl -H 'Content-Type: text/plain' -v 'http://127.0.0.1:8000/myfile.txt' --data-binary @myfile.txt
+*   Trying 127.0.0.1:8000...
+* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
 > POST /myfile.txt HTTP/1.1
-> Host: 127.0.0.1:8080
+> Host: 127.0.0.1:8000
 > User-Agent: curl/7.85.0
 > Accept: */*
 > Content-Type: text/plain
@@ -97,11 +97,11 @@ $ curl -H 'Content-Type: text/plain' -v 'http://127.0.0.1:8080/myfile.txt' --dat
 * Connection #0 to host 127.0.0.1 left intact
 
 # Get the file again to see your updates
-$ curl -v 'http://127.0.0.1:8080/myfile.txt'
-*   Trying 127.0.0.1:8080...
-* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+$ curl -v 'http://127.0.0.1:8000/myfile.txt'
+*   Trying 127.0.0.1:8000...
+* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
 > GET /myfile.txt HTTP/1.1
-> Host: 127.0.0.1:8080
+> Host: 127.0.0.1:8000
 > User-Agent: curl/7.85.0
 > Accept: */*
 >
@@ -115,11 +115,11 @@ General Kenobi!
 * Connection #0 to host 127.0.0.1 left intact
 
 # Delete the file
-$ curl -X DELETE -v 'http://127.0.0.1:8080/myfile.txt'
-*   Trying 127.0.0.1:8080...
-* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+$ curl -X DELETE -v 'http://127.0.0.1:8000/myfile.txt'
+*   Trying 127.0.0.1:8000...
+* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
 > DELETE /myfile.txt HTTP/1.1
-> Host: 127.0.0.1:8080
+> Host: 127.0.0.1:8000
 > User-Agent: curl/7.85.0
 > Accept: */*
 >
@@ -131,11 +131,11 @@ $ curl -X DELETE -v 'http://127.0.0.1:8080/myfile.txt'
 * Connection #0 to host 127.0.0.1 left intact
 
 # (Optional) See that the file doesn't exist anymore
-$ curl -v 'http://127.0.0.1:8080/myfile.txt'
-*   Trying 127.0.0.1:8080...
-* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+$ curl -v 'http://127.0.0.1:8000/myfile.txt'
+*   Trying 127.0.0.1:8000...
+* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
 > GET /myfile.txt HTTP/1.1
-> Host: 127.0.0.1:8080
+> Host: 127.0.0.1:8000
 > User-Agent: curl/7.85.0
 > Accept: */*
 >

--- a/examples/rust/components/blobby/src/lib.rs
+++ b/examples/rust/components/blobby/src/lib.rs
@@ -107,9 +107,9 @@ impl Guest for Blobby {
 
         // Derive the appropriate file and container name from the path & query string
         //
-        // ex. 'localhost:8080' -> bucket name 'default', file_name ''
-        // ex. 'localhost:8080?container=test' -> bucket name 'test', file name ''
-        // ex. 'localhost:8080/your-file.txt?container=test' -> bucket name 'test', file name 'your-file.txt'
+        // ex. 'localhost:8000' -> bucket name 'default', file_name ''
+        // ex. 'localhost:8000?container=test' -> bucket name 'test', file name ''
+        // ex. 'localhost:8000/your-file.txt?container=test' -> bucket name 'test', file name 'your-file.txt'
         let (file_name, container_id) = match path_and_query.split_once('?') {
             Some((path, query)) => {
                 // We have a query string, so let's split it into a container name and a file name
@@ -133,7 +133,7 @@ impl Guest for Blobby {
                 response_out,
                 Error {
                     status_code: StatusCode::BAD_REQUEST,
-                    message: "Please pass a valid file (object) by specifying a URL path (ex. 'localhost:8080/some-path')".into(),
+                    message: "Please pass a valid file (object) by specifying a URL path (ex. 'localhost:8000/some-path')".into(),
                 },
             );
             return;

--- a/examples/rust/components/blobby/wadm.yaml
+++ b/examples/rust/components/blobby/wadm.yaml
@@ -50,7 +50,7 @@ spec:
         image: ghcr.io/wasmcloud/http-server:0.23.2
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `blobby` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -65,7 +65,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 0.0.0.0:8080
+                  address: 0.0.0.0:8000
     - name: blobstore
       type: capability
       properties:

--- a/examples/rust/components/dog-fetcher/README.md
+++ b/examples/rust/components/dog-fetcher/README.md
@@ -33,7 +33,7 @@ the application list, you can use `curl` to send a request to the running HTTP s
 wash up -d
 wash app deploy ./wadm.yaml
 wash app get
-curl http://127.0.0.1:8080
+curl http://127.0.0.1:8000
 ```
 
 ## Adding Capabilities

--- a/examples/rust/components/dog-fetcher/local.wadm.yaml
+++ b/examples/rust/components/dog-fetcher/local.wadm.yaml
@@ -42,7 +42,7 @@ spec:
         #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -57,7 +57,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     - name: httpclient
       type: capability

--- a/examples/rust/components/dog-fetcher/wadm.yaml
+++ b/examples/rust/components/dog-fetcher/wadm.yaml
@@ -50,7 +50,7 @@ spec:
         #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -65,7 +65,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     - name: httpclient
       type: capability

--- a/examples/rust/components/http-blobstore/README.md
+++ b/examples/rust/components/http-blobstore/README.md
@@ -35,7 +35,7 @@ Ensuring you've built your component with `wash build`, you can launch wasmCloud
 wash up -d
 wash app deploy ./wadm.yaml
 wash app get
-curl http://localhost:8080
+curl http://localhost:8000
 ```
 
 ## Where are the Files coming from?

--- a/examples/rust/components/http-blobstore/local.wadm.yaml
+++ b/examples/rust/components/http-blobstore/local.wadm.yaml
@@ -65,7 +65,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     # Capability provider that exposes a blobstore with the filesystem
     - name: blobstore-fs

--- a/examples/rust/components/http-blobstore/wadm.yaml
+++ b/examples/rust/components/http-blobstore/wadm.yaml
@@ -73,7 +73,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     # Capability provider that exposes a blobstore with the filesystem
     - name: blobstore-fs

--- a/examples/rust/components/http-hello-world/local.wadm.yaml
+++ b/examples/rust/components/http-hello-world/local.wadm.yaml
@@ -34,7 +34,7 @@ spec:
         # Establish a unidirectional link from this http server provider (the "source")
         # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
         #
-        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8080
+        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8000
         - type: link
           properties:
             target: http-component
@@ -44,4 +44,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/components/http-hello-world/wadm.yaml
+++ b/examples/rust/components/http-hello-world/wadm.yaml
@@ -41,7 +41,7 @@ spec:
         # Establish a unidirectional link from this http server provider (the "source")
         # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
         #
-        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8080
+        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8000
         - type: link
           properties:
             target: http-component
@@ -51,4 +51,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/components/http-jsonify/README.md
+++ b/examples/rust/components/http-jsonify/README.md
@@ -32,7 +32,7 @@ Once the application reports as **Deployed** in the application list, you can us
 wash up -d
 wash app deploy ./wadm.yaml
 wash app get
-curl http://127.0.0.1:8080
+curl http://127.0.0.1:8000
 ```
 
 ## Adding Capabilities

--- a/examples/rust/components/http-jsonify/local.wadm.yaml
+++ b/examples/rust/components/http-jsonify/local.wadm.yaml
@@ -34,7 +34,7 @@ spec:
         #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -49,4 +49,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/components/http-jsonify/wadm.yaml
+++ b/examples/rust/components/http-jsonify/wadm.yaml
@@ -42,7 +42,7 @@ spec:
         #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -57,4 +57,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/components/http-keyvalue-counter/local.wadm.yaml
+++ b/examples/rust/components/http-keyvalue-counter/local.wadm.yaml
@@ -61,7 +61,7 @@ spec:
         #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `counter` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -76,4 +76,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/components/http-keyvalue-counter/wadm.yaml
+++ b/examples/rust/components/http-keyvalue-counter/wadm.yaml
@@ -69,7 +69,7 @@ spec:
         #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `counter` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -84,4 +84,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/components/http-password-checker/local.wadm.yaml
+++ b/examples/rust/components/http-password-checker/local.wadm.yaml
@@ -35,7 +35,7 @@ spec:
         # Establish a unidirectional link from this http server provider (the "source")
         # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
         #
-        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8080
+        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8000
         - type: link
           properties:
             target: http-component
@@ -45,4 +45,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/components/http-password-checker/wadm.yaml
+++ b/examples/rust/components/http-password-checker/wadm.yaml
@@ -42,7 +42,7 @@ spec:
         # Establish a unidirectional link from this http server provider (the "source")
         # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
         #
-        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8080
+        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8000
         - type: link
           properties:
             target: http-component
@@ -52,4 +52,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/components/http-task-manager/README.md
+++ b/examples/rust/components/http-task-manager/README.md
@@ -112,7 +112,7 @@ Once the application reports as **Deployed** in the application list, you can us
 We'll hit the `/ready` endpoint:
 
 ```console
-curl localhost:8080/ready
+curl localhost:8000/ready
 ```
 
 You should receive output like the following:
@@ -130,7 +130,7 @@ While normally a separate component (or manual DB administrator action) would tr
 ```console
 curl -X \
     POST -H "Content-Type: application/json; charset=utf8" \
-    localhost:8080/admin/v1/db/migrate
+    localhost:8000/admin/v1/db/migrate
 ```
 
 Regardless of how many times you run the migration, you should receive the output below:
@@ -147,7 +147,7 @@ To try out adding a new task we can use `curl`:
 curl \
     -X POST \
     -H "Content-Type: application/json; charset=utf8" \
-    localhost:8080/api/v1/tasks \
+    localhost:8000/api/v1/tasks \
     --data '{"group_id": "test", "task_data": {"one":1}}'
 ```
 
@@ -156,7 +156,7 @@ curl \
 To retrieve all existing tasks:
 
 ```console
-curl localhost:8080/api/v1/tasks
+curl localhost:8000/api/v1/tasks
 ```
 
 > [!NOTE]

--- a/examples/rust/components/http-task-manager/local.wadm.yaml
+++ b/examples/rust/components/http-task-manager/local.wadm.yaml
@@ -52,7 +52,7 @@ spec:
         # Establish a unidirectional link from this http server provider (the "source")
         # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
         #
-        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8080
+        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8000
         - type: link
           properties:
             target: http-task-mgr
@@ -62,7 +62,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     # Add a capability provider that interacts with the filesystem
     - name: sqldb-postgres

--- a/examples/rust/components/http-task-manager/tests/common.rs
+++ b/examples/rust/components/http-task-manager/tests/common.rs
@@ -19,7 +19,7 @@ const DEFAULT_POSTGRES_PASSWORD: &str = "postgres";
 const DEFAULT_POSTGRES_DATABASE: &str = "postgres";
 
 const DEFAULT_WASH_BIN: &str = "wash";
-const DEFAULT_APPLICATION_BASE_URL: &str = "http://localhost:8080";
+const DEFAULT_APPLICATION_BASE_URL: &str = "http://localhost:8000";
 
 // TODO: replace this with wasmcloud-test-util once we have the newer code released
 

--- a/examples/rust/components/http-task-manager/tests/fixtures/test.wadm.yaml
+++ b/examples/rust/components/http-task-manager/tests/fixtures/test.wadm.yaml
@@ -39,7 +39,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     - name: sqldb-postgres
       type: capability

--- a/examples/rust/components/http-task-manager/wadm.yaml
+++ b/examples/rust/components/http-task-manager/wadm.yaml
@@ -53,7 +53,7 @@ spec:
         # Establish a unidirectional link from this http server provider (the "source")
         # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
         #
-        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8080
+        # The source (this provider) is configured such that the HTTP server listens on 127.0.0.1:8000
         - type: link
           properties:
             target: http-task-mgr
@@ -63,7 +63,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     # Add a capability provider that interacts with the filesystem
     - name: sqldb-postgres

--- a/examples/rust/components/messaging-image-processor-worker/README.md
+++ b/examples/rust/components/messaging-image-processor-worker/README.md
@@ -96,7 +96,7 @@ See [the docs for the HTTP task manager][component-http-task-manager] for more i
 First, make sure the HTTP task manager is migrated:
 
 ```console
-curl -X POST localhost:8080/admin/v1/db/migrate
+curl -X POST localhost:8000/admin/v1/db/migrate
 ```
 
 Then, create a new job:
@@ -104,7 +104,7 @@ Then, create a new job:
 ```console
 curl \
     -X POST \
-    "localhost:8080/api/v1/tasks/submit \
+    "localhost:8000/api/v1/tasks/submit \
     --data-binary @- <<EOF
 {
   "source": {

--- a/examples/rust/components/messaging-image-processor-worker/local.wadm.yaml
+++ b/examples/rust/components/messaging-image-processor-worker/local.wadm.yaml
@@ -78,7 +78,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     - name: httpclient
       type: capability

--- a/examples/rust/components/messaging-image-processor-worker/tests/common.rs
+++ b/examples/rust/components/messaging-image-processor-worker/tests/common.rs
@@ -21,7 +21,7 @@ const DEFAULT_POSTGRES_USER: &str = "postgres";
 const DEFAULT_POSTGRES_PASSWORD: &str = "postgres";
 const DEFAULT_POSTGRES_DATABASE: &str = "postgres";
 
-const DEFAULT_APPLICATION_BASE_URL: &str = "http://localhost:8080";
+const DEFAULT_APPLICATION_BASE_URL: &str = "http://localhost:8000";
 
 /// Name of the subscription that will be linked to the component  (see fixtures/test.wadm.yaml)
 pub const TEST_SUBSCRIPTION_NAME: &str = "wasmcloud.test";

--- a/examples/rust/components/messaging-image-processor-worker/tests/fixtures/test.wadm.yaml
+++ b/examples/rust/components/messaging-image-processor-worker/tests/fixtures/test.wadm.yaml
@@ -70,7 +70,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     - name: httpclient
       type: capability

--- a/examples/rust/components/messaging-image-processor-worker/wadm.yaml
+++ b/examples/rust/components/messaging-image-processor-worker/wadm.yaml
@@ -91,7 +91,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 
     - name: httpclient
       type: capability

--- a/examples/rust/composition/README.md
+++ b/examples/rust/composition/README.md
@@ -121,7 +121,7 @@ Now we'll start a local wasmCloud host in detached mode, deploy the component, a
 ```shell
 wash up -d
 wash app deploy wadm.yaml
-curl localhost:8080
+curl localhost:8000
 ```
 Once we see that everything is running as expected in wasmCloud, we can undeploy the app.
 
@@ -204,7 +204,7 @@ wash app deploy wadm.yaml
 When we invoke `http-hello-world` via `curl`, it invokes `pong`:
 
 ```shell
-curl localhost:8080
+curl localhost:8000
 Hello World! I got pong demo
 ```
 
@@ -271,7 +271,7 @@ Let's try running it with Wasmtime:
 wasmtime serve -S cli=y output.wasm
 ```
 ```shell
-curl localhost:8080
+curl localhost:8000
 Hello World! I got pong demo
 ```
 We can run the composed component in wasmCloud as well:

--- a/examples/rust/composition/http-hello/README.md
+++ b/examples/rust/composition/http-hello/README.md
@@ -30,7 +30,7 @@ Ensuring you've built your component with `wash build`, you can launch wasmCloud
 wash up -d
 wash app deploy ./wadm.yaml
 wash app get
-curl http://localhost:8080
+curl http://localhost:8000
 ```
 
 ## Adding Capabilities

--- a/examples/rust/composition/http-hello/src/lib.rs
+++ b/examples/rust/composition/http-hello/src/lib.rs
@@ -16,9 +16,9 @@ impl Guest for HttpServer {
             .split('=')
             .collect::<Vec<&str>>()[..]
         {
-            // query string is "/?name=<name>" e.g. localhost:8080?name=Bob
+            // query string is "/?name=<name>" e.g. localhost:8000?name=Bob
             ["/?name", name] => name.to_string(),
-            // query string is anything else or empty e.g. localhost:8080
+            // query string is anything else or empty e.g. localhost:8000
             _ => "World".to_string(),
         };
 

--- a/examples/rust/composition/http-hello/wadm.yaml
+++ b/examples/rust/composition/http-hello/wadm.yaml
@@ -24,7 +24,7 @@ spec:
         image: ghcr.io/wasmcloud/http-server:0.23.2
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         - type: link
           properties:
             target: http-component
@@ -34,4 +34,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/composition/http-hello2/README.md
+++ b/examples/rust/composition/http-hello2/README.md
@@ -30,7 +30,7 @@ Ensuring you've built your component with `wash build`, you can launch wasmCloud
 wash up -d
 wash app deploy ./wadm.yaml
 wash app get
-curl http://localhost:8080
+curl http://localhost:8000
 ```
 
 ## Adding Capabilities

--- a/examples/rust/composition/http-hello2/src/lib.rs
+++ b/examples/rust/composition/http-hello2/src/lib.rs
@@ -16,9 +16,9 @@ impl Guest for HttpServer {
             .split('=')
             .collect::<Vec<&str>>()[..]
         {
-            // query string is "/?name=<name>" e.g. localhost:8080?name=Bob
+            // query string is "/?name=<name>" e.g. localhost:8000?name=Bob
             ["/?name", name] => name.to_string(),
-            // query string is anything else or empty e.g. localhost:8080
+            // query string is anything else or empty e.g. localhost:8000
             _ => "World".to_string(),
         };
 

--- a/examples/rust/composition/http-hello2/wadm.yaml
+++ b/examples/rust/composition/http-hello2/wadm.yaml
@@ -40,7 +40,7 @@ spec:
         image: ghcr.io/wasmcloud/http-server:0.23.2
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         - type: link
           properties:
             target: http-component
@@ -50,4 +50,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/rust/composition/wadm.yaml
+++ b/examples/rust/composition/wadm.yaml
@@ -24,7 +24,7 @@ spec:
         image: ghcr.io/wasmcloud/http-server:0.23.2
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         - type: link
           properties:
             target: http-component
@@ -34,4 +34,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/security/secrets/README.md
+++ b/examples/security/secrets/README.md
@@ -74,21 +74,21 @@ You can first verify that unauthenticated requests to Redis and the component ar
 ➜ redis-cli -u redis://127.0.0.1:6379 keys '*'
 (error) NOAUTH Authentication required.
 
-➜ curl 127.0.0.1:8080/counter
+➜ curl 127.0.0.1:8000/counter
 Unauthorized
 ```
 
 Then, authenticating passes the check in the component:
 
 ```bash
-➜ curl -H "password: opensesame" 127.0.0.1:8080/counter
+➜ curl -H "password: opensesame" 127.0.0.1:8000/counter
 Counter /counter: 1
 ```
 
 Passing in an invalid password will still fail the authentication check:
 
 ```bash
-➜ curl -H "password: letmein" 127.0.0.1:8080/counter
+➜ curl -H "password: letmein" 127.0.0.1:8000/counter
 Unauthorized
 ```
 

--- a/examples/security/secrets/wadm.yaml
+++ b/examples/security/secrets/wadm.yaml
@@ -79,7 +79,7 @@ spec:
         id: auth-http-server
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `counter` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -96,4 +96,4 @@ spec:
               config:
                 - name: default-http
                   properties:
-                    address: 0.0.0.0:8080
+                    address: 0.0.0.0:8000

--- a/examples/typescript/components/http-hello-world/README.md
+++ b/examples/typescript/components/http-hello-world/README.md
@@ -59,7 +59,7 @@ wash dev
 Once `wash dev` is serving your component, to send a request to the running component (via the HTTP server provider):
 
 ```console
-curl localhost:8080
+curl localhost:8000
 ```
 
 ## Adding Capabilities

--- a/examples/typescript/components/http-hello-world/local.wadm.yaml
+++ b/examples/typescript/components/http-hello-world/local.wadm.yaml
@@ -31,7 +31,7 @@ spec:
         image: ghcr.io/wasmcloud/http-server:0.23.2
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since this HTTP server provider calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -46,4 +46,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000

--- a/examples/typescript/components/http-password-checker/local.wadm.yaml
+++ b/examples/typescript/components/http-password-checker/local.wadm.yaml
@@ -32,7 +32,7 @@ spec:
         image: ghcr.io/wasmcloud/http-server:0.23.2
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since this HTTP server provider calls the `http-component` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -47,4 +47,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000


### PR DESCRIPTION
## Feature or Problem
When using `wash dev` the default port is 8000.
When running through the quickstart, it'd be less confusing using the same port instead of 8080.

## Related Issues
https://github.com/wasmCloud/wasmcloud.com/pull/714.
