### PR TITLE
    fix(wash-cli): spinner rendering error

### DIFF
--- a/crates/wash-cli/src/common/get_cmd.rs
+++ b/crates/wash-cli/src/common/get_cmd.rs
@@ -19,22 +19,24 @@ use crate::ctl::{
 };
 
 pub async fn handle_command(command: GetCommand, output_kind: OutputKind) -> Result<CommandOutput> {
-    let sp: Spinner = Spinner::new(&output_kind)?;
     let out: CommandOutput = match command {
         GetCommand::Links(GetLinksCommand { opts }) => {
             handle_link_command(LinkCommand::Query(LinkQueryCommand { opts }), output_kind).await?
         }
         GetCommand::Claims(cmd) => {
+            let sp: Spinner = Spinner::new(&output_kind)?;
             sp.update_spinner_message("Retrieving claims ... ".to_string());
             let claims = get_claims(cmd).await?;
             get_claims_output(claims)
         }
         GetCommand::Hosts(cmd) => {
+            let sp: Spinner = Spinner::new(&output_kind)?;
             sp.update_spinner_message(" Retrieving Hosts ...".to_string());
             let hosts = get_hosts(cmd).await?;
             get_hosts_output(hosts)
         }
         GetCommand::HostInventories(cmd) => {
+            let sp: Spinner = Spinner::new(&output_kind)?;
             if let Some(id) = cmd.host_id.as_ref() {
                 sp.update_spinner_message(format!(" Retrieving inventory for host {} ...", id));
             } else {


### PR DESCRIPTION
    Fixed the spinner rendering inconsistencies by separating out the logic to the match statement

    Reviewed-by: Zahir S
    Refs: #3584
Signed-off-by: Zahir Sabotic <zahirsabotic@bennington.edu>

## Feature or Problem
Spinner rendering error in wash-cli crate.


## Related Issues
This refers to issue #3584.


## Release Information
Target release: next.


## Consumer Impact
No impact on consumers, just removes the visual artifact that was leftover from improper handling of the spinner.


### Acceptance or Integration
No changes or additions to the acceptance or integration test suite 


### Manual Verification
![Screenshot 2024-11-16 at 18 28 24](https://github.com/user-attachments/assets/21368a3f-4115-4d7d-8767-cf8c38849369)
As seen above, visual artifact does not show up anymore.



