### PR TITLE
chore: Update OpenSSF Scorecard badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CNCF Incubating project](https://img.shields.io/website?label=CNCF%20Incubating%20Project&url=https://landscape.cncf.io/?selected=wasm-cloud&item=orchestration-management--scheduling-orchestration--wasmcloud)](https://landscape.cncf.io/?selected=wasm-cloud&item=orchestration-management--scheduling-orchestration--wasmcloud)
 ![Powered by WebAssembly](https://img.shields.io/badge/powered%20by-WebAssembly-orange.svg)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6363/badge)](https://www.bestpractices.dev/projects/6363)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wasmcloud/wasmcloud/badge)](https://securityscorecards.dev/viewer/?uri=github.com/wasmcloud/wasmcloud)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wasmCloud/wasmCloud/badge)](https://securityscorecards.dev/viewer/?uri=github.com/wasmCloud/wasmCloud)
 [![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/wasm-cloud/badge)](https://clomonitor.io/projects/cncf/wasm-cloud)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B40030%2Fgit%40github.com%3AwasmCloud%2FwasmCloud.git.svg?type=small)](https://app.fossa.com/projects/custom%2B40030%2Fgit%40github.com%3AwasmCloud%2FwasmCloud.git?ref=badge_small)
 [![twitter](https://img.shields.io/twitter/follow/wasmcloud?style=social)](https://twitter.com/wasmcloud)


### PR DESCRIPTION
## Feature or Problem

While reviewing how the OpenSSF Scorecard works, I noticed that the repository URIs are in fact case-sensitive, for comparison:
* [`github.com/wasmcloud/wasmcloud`](https://securityscorecards.dev/viewer/?uri=github.com/wasmcloud/wasmcloud) has scorecard of `5.2`, which is incorrect
* [`github.com/wasmCloud/wasmCloud`](https://securityscorecards.dev/viewer/?uri=github.com/wasmCloud/wasmCloud) has scorecard of `5.9`, which is correct.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
