### PR TITLE
chore: pin cross-spawn to 7.0.5 for `GHSA-3xgq-45jj-v275`

### DIFF
--- a/typescript/apps/washboard-ui/package.json
+++ b/typescript/apps/washboard-ui/package.json
@@ -95,5 +95,8 @@
     "vite": "^5.4.11",
     "vite-plugin-svgr": "^4.3.0",
     "vite-tsconfig-paths": "^5.1.2"
+  },
+  "resolutions": {
+    "cross-spawn": "^7.0.5"
   }
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -34,5 +34,8 @@
     "prettier": "^3.3.3",
     "turbo": "^2.2.3",
     "typescript": "^5.6.3"
+  },
+  "resolutions": {
+    "cross-spawn": "^7.0.5"
   }
 }

--- a/typescript/packages/eslint-config/package.json
+++ b/typescript/packages/eslint-config/package.json
@@ -32,5 +32,8 @@
     "eslint-plugin-react-refresh": "^0.4.14",
     "eslint-plugin-tailwindcss": "3.17.5",
     "eslint-plugin-unicorn": "^56.0.0"
+  },
+  "resolutions": {
+    "cross-spawn": "^7.0.5"
   }
 }

--- a/typescript/packages/lattice-client-core/package.json
+++ b/typescript/packages/lattice-client-core/package.json
@@ -54,5 +54,8 @@
   },
   "dependencies": {
     "nats.ws": "^1.29.2"
+  },
+  "resolutions": {
+    "cross-spawn": "^7.0.5"
   }
 }

--- a/typescript/packages/lattice-client-react/package.json
+++ b/typescript/packages/lattice-client-react/package.json
@@ -56,5 +56,8 @@
   },
   "peerDependencies": {
     "react": "^18.0.0"
+  },
+  "resolutions": {
+    "cross-spawn": "^7.0.5"
   }
 }

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -3869,14 +3869,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
+"cross-spawn@npm:^7.0.5":
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
   dependencies:
     path-key: "npm:^3.1.0"
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
-  checksum: 10/e1a13869d2f57d974de0d9ef7acbf69dc6937db20b918525a01dacb5032129bd552d290d886d981e99f1b624cb03657084cc87bd40f115c07ecf376821c729ce
+  checksum: 10/0d52657d7ae36eb130999dffff1168ec348687b48dd38e2ff59992ed916c88d328cf1d07ff4a4a10bc78de5e1c23f04b306d569e42f7a2293915c081e4dfee86
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Feature or Problem

Addresses vulnerability in `cross-spawn` versions prior to 7.0.5 while waiting for our dependencies to update to it.

## Related Issues

https://github.com/advisories/GHSA-3xgq-45jj-v275/

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
