### PR TITLE
chore: Bump config crate to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,16 +1714,14 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.13.4"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
+checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
 dependencies = [
- "async-trait",
- "lazy_static 1.5.0",
  "nom 7.1.3",
  "pathdiff",
  "serde 1.0.210",
- "toml 0.5.11",
+ "toml 0.8.19",
 ]
 
 [[package]]
@@ -3321,7 +3319,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -7535,7 +7533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -8139,7 +8137,7 @@ dependencies = [
  "clap",
  "cloudevents-sdk",
  "command-group",
- "config 0.13.4",
+ "config 0.14.1",
  "console",
  "dialoguer",
  "etcetera",
@@ -9668,7 +9666,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,7 +218,7 @@ clap_complete = { version = "4", default-features = false }
 clap-markdown = { version = "0.1.4", default-features = false }
 cloudevents-sdk = { version = "0.7", default-features = false }
 command-group = { version = "5", default-features = false }
-config = { version = "0.13", default-features = false }
+config = { version = "0.14", default-features = false }
 console = { version = "0.15", default-features = false }
 crossterm = { version = "0.28.1", default-features = false }
 data-encoding = { version = "2", default-features = false }


### PR DESCRIPTION
## Feature or Problem

In order to work towards resolving [`RUSTSEC-2024-0320`](https://rustsec.org/advisories/RUSTSEC-2024-0320.html), we need to bump [`config` to `0.14.1`, which changed the `yaml-rust` dependency to `yaml-rust2`](https://github.com/rust-cli/config-rs/blob/main/CHANGELOG.md#0141---2024-10-23).

While this change alone won't be sufficient since [`ptree` (via `warg-client`) also depends on it](https://github.com/wasmCloud/wasmCloud/blob/9d1d0a43a3027bdd55e683d9345177e5277bc2e9/Cargo.lock#L5301-L5308). 

The `ptree` dependency on old version of `config` will be resolved once `warg-client` updates its dependency on the latest version of `ptree`, which I'll propose once [another RUSTSEC issue](https://rustsec.org/advisories/RUSTSEC-2021-0139.html) is [resolved in `ptree`](https://gitlab.com/Noughmad/ptree/-/merge_requests/11).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
