### PR TITLE
chore: Remove serde_cbor and serde-transcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,12 +3049,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
-
-[[package]]
 name = "handlebars"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6214,15 +6208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-transcode"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
-dependencies = [
- "serde 1.0.210",
-]
-
-[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6238,16 +6223,6 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
- "serde 1.0.210",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
  "serde 1.0.210",
 ]
 
@@ -8159,8 +8134,6 @@ dependencies = [
  "rmp-serde",
  "semver",
  "serde 1.0.210",
- "serde-transcode",
- "serde_cbor",
  "serde_json",
  "serde_with",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,9 +284,7 @@ secrecy = { version = "0.8", default-features = false }
 secrets-nats-kv = { version = "0.1", path = "crates/secrets-nats-kv", default-features = false }
 semver = { version = "1", default-features = false }
 serde = { version = "1", default-features = false }
-serde-transcode = { version = "1", default-features = false }
 serde_bytes = { version = "0.11", default-features = false }
-serde_cbor = { version = "0.11", default-features = false }
 serde_json = { version = "1", default-features = false }
 serde_with = { version = "3", default-features = false }
 serde_yaml = { version = "0.9", default-features = false }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -72,8 +72,6 @@ reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
 rmp-serde = { workspace = true }
 semver = { workspace = true, features = ["serde"], optional = true }
 serde = { workspace = true, features = ["derive"] }
-serde-transcode = { workspace = true }
-serde_cbor = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["macros"] }
 serde_yaml = { workspace = true }


### PR DESCRIPTION
## Feature or Problem

https://github.com/wasmCloud/wasmCloud/pull/2769 removed the code that made use of these dependencies, so let's clean up the unused dependencies.

This also addresses [`RUSTSEC-2021-0127`](https://rustsec.org/advisories/RUSTSEC-2021-0127)

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
