### PR TITLE
chore: Replace backoff crate with exponential-backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,20 +1094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.15",
- "instant",
- "pin-project-lite",
- "rand 0.8.5",
- "tokio",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,6 +2622,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "exponential-backoff"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffb309d235a642598183aeda8925e871e85dd5a433c2c877e69ff0a960f4c02"
+dependencies = [
+ "fastrand 2.1.1",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,7 +3316,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -6131,9 +6126,9 @@ dependencies = [
  "anyhow",
  "async-nats",
  "async-trait",
- "backoff",
  "bytes",
  "clap",
+ "exponential-backoff",
  "futures",
  "nkeys",
  "rand 0.8.5",
@@ -7535,7 +7530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -9668,7 +9663,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,6 @@ axum-server = { version = "0.6", default-features = false }
 azure_core = { version = "0.20", default-features = false }
 azure_storage = { version = "0.20", default-features = false }
 azure_storage_blobs = { version = "0.20", default-features = false }
-backoff = { version = "0.4", default-features = false }
 base64 = { version = "0.22", default-features = false }
 bigdecimal = { version = "0.4", default-features = false }
 bit-vec = { version = "0.6", default-features = false }
@@ -226,6 +225,7 @@ deadpool-postgres = { version = "0.13", default-features = false }
 dialoguer = { version = "0.11", default-features = false }
 docker_credential = { version = "1.3.1", default-features = false }
 etcetera = { version = "0.8", default-features = false }
+exponential-backoff = { version = "2.0", default-features = false }
 file-guard = { version = "0.2.0", default-features = false }
 futures = { version = "0.3", default-features = false }
 geo-types = { version = "0.7", default-features = false }

--- a/crates/secrets-nats-kv/Cargo.toml
+++ b/crates/secrets-nats-kv/Cargo.toml
@@ -20,20 +20,28 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-nats = { workspace = true, features = ["server_2_10", "ring"] }
 async-trait = { workspace = true }
-backoff = { workspace = true, features = ["tokio"] }
-bytes = { workspace = true}
-clap = { workspace = true, features = ["derive", "std", "help", "suggestions", "color", "usage", "env"] }
+bytes = { workspace = true }
+clap = { workspace = true, features = [
+    "derive",
+    "std",
+    "help",
+    "suggestions",
+    "color",
+    "usage",
+    "env",
+] }
+exponential-backoff = { workspace = true }
 futures = { workspace = true }
 nkeys = { workspace = true, features = ["xkeys"] }
 serde = { workspace = true, features = ["derive"] }
-serde_json = {workspace = true }
-thiserror = {workspace = true }
-tokio = { workspace = true,  features = ["full"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 wascap = { workspace = true }
 wasmcloud-secrets-types = { workspace = true }
 
 [dev-dependencies]
-rand = {workspace = true}
+rand = { workspace = true }
 wasmcloud-secrets-client = { workspace = true }


### PR DESCRIPTION
## Feature or Problem

Since [`backoff`](https://crates.io/crates/backoff) is no longer maintained, and it has a dependency on [`instant`](https://github.com/ihrwein/backoff/blob/587e2da8fb2dcfc65ca544cb9249022c51f1406e/Cargo.toml#L22), which is subject to [`RUSTSEC-2024-0384`](https://rustsec.org/advisories/RUSTSEC-2024-0384.html).

For addressing this, the most straight forward answer seemed to be replacing `backoff` with [`exponential-backoff`](https://crates.io/crates/exponential-backoff), which gets us closer to being able to remove `instant`.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
