### PR TITLE
chore: Replace `weld-codegen` with `handlebars`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static 1.5.0",
- "regex",
-]
-
-[[package]]
 name = "RustyXML"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,12 +162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "any_ascii"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
-
-[[package]]
 name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,12 +202,6 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "ascii_tree"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
 
 [[package]]
 name = "assert-json-diff"
@@ -482,66 +460,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "atelier_assembler"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7feecf8364a7d1c80f2323ea0d1abee09d7256a91dc5d29a1d171a52c17be36a"
-dependencies = [
- "atelier_core",
- "atelier_json",
- "atelier_smithy",
- "atelier_test",
- "log",
-]
-
-[[package]]
-name = "atelier_core"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c05c6353a26a3e1b7017058a0a99c8f61131cf9a0ecb604dd9b62069b1be75"
-dependencies = [
- "error-chain",
- "heck 0.3.3",
- "lazy_static 1.5.0",
- "log",
- "paste",
- "regex",
-]
-
-[[package]]
-name = "atelier_json"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86bad50f33038fa4dec1f5c4e83bc0a1174c17767defeff76b2eca0028ec4bf"
-dependencies = [
- "atelier_core",
- "serde_json",
-]
-
-[[package]]
-name = "atelier_smithy"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56140a8133b56c021ee62e64d35015d1f51b71e0b5cdf401edf78a2a77f2f7e3"
-dependencies = [
- "atelier_core",
- "log",
- "pest",
- "pest_ascii_tree",
- "pest_derive",
-]
-
-[[package]]
-name = "atelier_test"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81fd306eb92079fce9b7089abaf178c306877b72ec6e679ad331253ea9bfb00"
-dependencies = [
- "atelier_core",
- "pretty_assertions",
 ]
 
 [[package]]
@@ -1822,7 +1740,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "regalloc2",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "smallvec",
  "target-lexicon",
 ]
@@ -2049,16 +1967,6 @@ dependencies = [
  "salsa20",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2329,12 +2237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,19 +2325,6 @@ dependencies = [
  "base64 0.21.7",
  "serde 1.0.210",
  "serde_json",
-]
-
-[[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "futures",
- "rand 0.8.5",
- "reqwest 0.12.9",
- "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -2569,22 +2458,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
-]
-
-[[package]]
-name = "escape_string"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e867569975c88fdf73833a30bd6e0978aa6ab6bd784b648fcece07450951ba"
 
 [[package]]
 name = "etcetera"
@@ -3056,11 +2929,12 @@ checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "handlebars"
-version = "4.5.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
+checksum = "fd4ccde012831f9a071a637b0d4e31df31c0f6c525784b35ae76a9ac6bc1e315"
 dependencies = [
  "log",
+ "num-order",
  "pest",
  "pest_derive",
  "serde 1.0.210",
@@ -3113,15 +2987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http 0.2.12",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -3321,7 +3186,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -3842,15 +3707,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical-sort"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c09e4591611e231daf4d4c685a66cb0410cc1e502027a20ae55f2bb9e997207a"
-dependencies = [
- "any_ascii",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4323,6 +4179,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4634,15 +4505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4817,18 +4679,6 @@ dependencies = [
  "memchr",
  "thiserror",
  "ucd-trie",
-]
-
-[[package]]
-name = "pest_ascii_tree"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152b393638a9816cd3dedb5aea2fb60ab0b641315aa133cea219c8797e768fc"
-dependencies = [
- "ascii_tree",
- "escape_string",
- "pest",
- "pest_derive",
 ]
 
 [[package]]
@@ -5093,18 +4943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
-dependencies = [
- "ansi_term",
- "ctor",
- "diff",
- "output_vt100",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5333,7 +5171,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "rustls 0.23.13",
  "socket2 0.5.7",
  "thiserror",
@@ -5350,7 +5188,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "rustls 0.23.13",
  "slab",
  "thiserror",
@@ -5551,7 +5389,7 @@ checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
 dependencies = [
  "hashbrown 0.14.5",
  "log",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "slice-group-by",
  "smallvec",
 ]
@@ -5763,12 +5601,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -7535,7 +7367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -7606,12 +7438,6 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -8114,7 +7940,6 @@ dependencies = [
  "wasmcloud-core 0.15.0",
  "wasmcloud-secrets-types 0.5.0",
  "wat",
- "weld-codegen",
  "which",
  "wit-bindgen-wrpc",
  "wit-component 0.219.1",
@@ -8144,6 +7969,7 @@ dependencies = [
  "dialoguer",
  "etcetera",
  "futures",
+ "handlebars",
  "heck 0.5.0",
  "humantime",
  "ignore",
@@ -8195,7 +8021,6 @@ dependencies = [
  "wasmtime-wasi",
  "wasmtime-wasi-http",
  "wat",
- "weld-codegen",
  "wit-component 0.219.1",
  "wit-parser 0.219.1",
 ]
@@ -9594,36 +9419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "weld-codegen"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66385fd8affabb09b678d2f826c78d995789cdb2fbb2dd02e6010dffe298797e"
-dependencies = [
- "Inflector",
- "anyhow",
- "atelier_assembler",
- "atelier_core",
- "atelier_json",
- "atelier_smithy",
- "bytes",
- "cfg-if",
- "clap",
- "directories",
- "downloader",
- "handlebars",
- "lazy_static 1.5.0",
- "lexical-sort",
- "reqwest 0.11.27",
- "rustc-hash 1.1.0",
- "semver",
- "serde 1.0.210",
- "serde_json",
- "tempfile",
- "thiserror",
- "toml 0.7.8",
-]
-
-[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9668,7 +9463,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,6 +229,7 @@ etcetera = { version = "0.8", default-features = false }
 file-guard = { version = "0.2.0", default-features = false }
 futures = { version = "0.3", default-features = false }
 geo-types = { version = "0.7", default-features = false }
+handlebars = { version = "6.2", default-features = false }
 heck = { version = "0.5", default-features = false }
 hex = { version = "0.4", default-features = false }
 http = { version = "1", default-features = false, features = ["std"] }
@@ -369,7 +370,6 @@ wasmtime-wasi-http = { version = "25", default-features = false }
 wasmtime-wit-bindgen = { version = "25", default-features = false }
 wat = { version = "1", default-features = false }
 webpki-roots = { version = "0.26", default-features = false }
-weld-codegen = { version = "0.7", default-features = false }
 which = { version = "4", default-features = false }
 wit-bindgen = { version = "0.32", default-features = false }
 wit-bindgen-core = { version = "0.33", default-features = false }

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -95,7 +95,6 @@ wasm-pkg-core = { workspace = true }
 wasmcloud-control-interface = { workspace = true }
 wasmcloud-core = { workspace = true }
 wasmcloud-secrets-types = { workspace = true }
-weld-codegen = { workspace = true, features = ["wasmbus"] }
 which = { workspace = true }
 wit-bindgen-wrpc = { workspace = true }
 wit-parser = { workspace = true }

--- a/crates/wash-lib/Cargo.toml
+++ b/crates/wash-lib/Cargo.toml
@@ -55,6 +55,7 @@ console = { workspace = true, optional = true }
 dialoguer = { workspace = true, optional = true }
 etcetera = { workspace = true }
 futures = { workspace = true }
+handlebars = { workspace = true }
 heck = { workspace = true, optional = true }
 humantime = { workspace = true }
 ignore = { workspace = true, optional = true }
@@ -113,7 +114,6 @@ wasmtime = { workspace = true, optional = true, features = [
 wasmtime-wasi = { workspace = true, optional = true }
 wasmtime-wasi-http = { workspace = true, optional = true }
 wat = { workspace = true }
-weld-codegen = { workspace = true, features = ["wasmbus"] }
 wit-component = { workspace = true }
 wit-parser = { workspace = true }
 

--- a/crates/wash-lib/src/generate/mod.rs
+++ b/crates/wash-lib/src/generate/mod.rs
@@ -10,11 +10,11 @@ use std::{
 use anyhow::{anyhow, bail, Context, Result};
 use console::style;
 use genconfig::{Config, CONFIG_FILE_NAME};
+use handlebars::Handlebars;
 use indicatif::MultiProgress;
 use serde::Serialize;
 use tempfile::TempDir;
 use tokio::process::Command;
-use weld_codegen::render::Renderer;
 
 pub mod emoji;
 mod favorites;
@@ -254,7 +254,7 @@ async fn make_project(project: Project) -> std::result::Result<PathBuf, anyhow::
 
     // resolve all project values, prompting if necessary,
     // and expanding templates in default values
-    let renderer = Renderer::default();
+    let renderer = Handlebars::default();
     let undefined =
         fill_project_variables(&config, &mut values, &renderer, project.silent, |slot| {
             crate::generate::interactive::variable(slot)

--- a/crates/wash-lib/src/generate/project_variables.rs
+++ b/crates/wash-lib/src/generate/project_variables.rs
@@ -6,10 +6,10 @@
 //
 use crate::generate::{genconfig::Config, ParamMap, TomlMap, PROJECT_NAME_REGEX};
 use anyhow::{bail, Result};
+use handlebars::Handlebars;
 use regex::Regex;
 use serde_json::Value;
 use thiserror::Error;
-use weld_codegen::render::Renderer;
 
 #[derive(Debug)]
 pub(crate) struct TemplateSlots {
@@ -110,7 +110,7 @@ const RESERVED_NAMES: [&str; 5] = [
 pub(crate) fn fill_project_variables<F>(
     config: &Config,
     values: &mut ParamMap,
-    renderer: &weld_codegen::render::Renderer,
+    renderer: &Handlebars,
     silent: bool,
     value_provider: F,
 ) -> Result<Vec<String>>
@@ -166,7 +166,7 @@ where
 fn expand_default_value(
     entry: StringEntry,
     values: &ParamMap,
-    renderer: &Renderer,
+    renderer: &Handlebars,
 ) -> Result<StringEntry> {
     if let Some(default) = &entry.default {
         let new_def = renderer.render_template(default, values)?;
@@ -182,7 +182,7 @@ fn expand_default_value(
 fn try_placeholder_into_slot(
     table: &TomlMap,
     values: &ParamMap,
-    renderer: &Renderer,
+    renderer: &Handlebars,
 ) -> Result<TemplateSlots, ConversionError> {
     let key = match table.get("name") {
         Some(toml::Value::String(key)) => key,
@@ -308,7 +308,7 @@ fn extract_default(
     table_entry: Option<&toml::Value>,
     choices: Option<&Vec<String>>,
     values: &ParamMap,
-    renderer: &Renderer,
+    renderer: &Handlebars,
 ) -> Result<Option<SupportedVarValue>, ConversionError> {
     match (table_entry, choices, var_type) {
         // no default set
@@ -600,7 +600,7 @@ mod tests {
             None,
             None,
             &ParamMap::default(),
-            &Renderer::default(),
+            &Handlebars::default(),
         );
 
         assert_eq!(result, Ok(None));
@@ -615,7 +615,7 @@ mod tests {
             Some(&toml::Value::Boolean(true)),
             None,
             &ParamMap::default(),
-            &Renderer::default(),
+            &Handlebars::default(),
         );
 
         assert_eq!(result, Ok(Some(SupportedVarValue::Bool(true))));
@@ -630,7 +630,7 @@ mod tests {
             Some(&toml::Value::String("bar".to_string())),
             None,
             &ParamMap::default(),
-            &Renderer::default(),
+            &Handlebars::default(),
         );
 
         assert_eq!(
@@ -650,7 +650,7 @@ mod tests {
             Some(&toml::Value::String("bar".to_string())),
             None,
             &ParamMap::default(),
-            &Renderer::default(),
+            &Handlebars::default(),
         );
 
         assert_eq!(
@@ -670,7 +670,7 @@ mod tests {
             Some(&toml::Value::String("0bar".to_string())),
             None,
             &ParamMap::default(),
-            &Renderer::default(),
+            &Handlebars::default(),
         );
 
         assert_eq!(
@@ -691,7 +691,7 @@ mod tests {
             Some(&toml::Value::String("bar".to_string())),
             Some(&vec!["zoo".to_string(), "far".to_string()]),
             &ParamMap::default(),
-            &Renderer::default(),
+            &Handlebars::default(),
         );
 
         assert_eq!(
@@ -713,7 +713,7 @@ mod tests {
             Some(&toml::Value::String("bar".to_string())),
             Some(&vec!["zoo".to_string(), "bar".to_string()]),
             &ParamMap::default(),
-            &Renderer::default(),
+            &Handlebars::default(),
         );
 
         assert_eq!(result, Ok(Some(SupportedVarValue::String("bar".into()))));
@@ -730,7 +730,7 @@ mod tests {
             Some(&toml::Value::String("bar".to_string())),
             Some(&vec!["zoo".to_string(), "bar".to_string()]),
             &ParamMap::default(),
-            &Renderer::default(),
+            &Handlebars::default(),
         );
 
         assert_eq!(result, Ok(Some(SupportedVarValue::String("bar".into()))));
@@ -745,7 +745,7 @@ mod tests {
             Some(&toml::Value::Integer(0)),
             None,
             &ParamMap::default(),
-            &Renderer::default(),
+            &Handlebars::default(),
         );
 
         assert_eq!(
@@ -767,7 +767,7 @@ mod tests {
             Some(&toml::Value::Integer(0)),
             None,
             &ParamMap::default(),
-            &Renderer::default(),
+            &Handlebars::default(),
         );
 
         assert_eq!(

--- a/crates/wash-lib/src/generate/template.rs
+++ b/crates/wash-lib/src/generate/template.rs
@@ -8,6 +8,7 @@ use crate::generate::{
 };
 use anyhow::{bail, Context, Result};
 use console::style;
+use handlebars::Handlebars;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use path_absolutize::Absolutize;
@@ -17,7 +18,6 @@ use std::{
     path::{Path, PathBuf},
 };
 use walkdir::WalkDir;
-use weld_codegen::render::Renderer;
 
 /// Matcher determines disposition of file: whether it should be copied, whether translated with template engine, and whether it is renamed
 /// The exclude and raw lists use `GitIgnore` pattern matching
@@ -100,7 +100,7 @@ pub(crate) fn process_template_dir(
     source_dir: &Path,
     project_dir: &Path,
     template_config: &TemplateConfig,
-    renderer: &Renderer,
+    renderer: &Handlebars,
     values: &ParamMap,
     mp: &mut MultiProgress,
 ) -> Result<()> {


### PR DESCRIPTION
## Feature or Problem

This replaces the `weld-codegen` [Renderer](https://github.com/joonas/weld/blob/main/codegen/src/render.rs) functionality with direct dependency on Handlebars which is what's doing the heavy lifting anyway.

Since it doesn't look like we're actually making use of the additional helpers methods introduced in `weld-codegen`, this should be just a drop-in replacement.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
