### PR TITLE
fix(charts/wasmcloud-host): set observability flags correctly

### DIFF
--- a/charts/wasmcloud-host/Chart.yaml
+++ b/charts/wasmcloud-host/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.4
+version: 0.8.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.0"
+appVersion: "1.4.2"

--- a/charts/wasmcloud-host/templates/deployment.yaml
+++ b/charts/wasmcloud-host/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - name: wasmcloud-host
           command: ["wasmcloud"]
         {{- if or (eq .Values.config.observability.enable true) (eq .Values.config.observability.traces.enable true) (eq .Values.config.observability.metrics.enable true) (eq .Values.config.observability.logs.enable true) }}
-          arg:
+          args:
           {{- if .Values.config.observability.enable }}
             - --enable-observability
           {{- end }}
@@ -37,21 +37,21 @@ spec:
             - {{ .Values.config.observability.protocol }}
           {{- end }}
           {{- if .Values.config.observability.traces.enable }}
-            - --enable-traces
+            - --enable-traces=true
           {{ end }}
           {{- if .Values.config.observability.traces.endpoint }}
             - --override-traces-endpoint
             - {{ .Values.config.observability.traces.endpoint }}
           {{- end }}
           {{- if .Values.config.observability.metrics.enable }}
-            - --enable-metrics
+            - --enable-metrics=true
           {{ end }}
           {{- if .Values.config.observability.metrics.endpoint }}
             - --override-metrics-endpoint
             - {{ .Values.config.observability.metrics.endpoint }}
           {{- end }}
           {{- if .Values.config.observability.logs.enable }}
-            - --enable-logs
+            - --enable-logs=true
           {{ end }}
           {{- if .Values.config.observability.logs.endpoint }}
             - --override-logs-endpoint
@@ -165,7 +165,7 @@ spec:
             name: {{ include "wasmcloud-host.nats-config-name" . }}
       {{- if .Values.config.natsCredentialsSecret }}
         - name: {{ .Values.config.natsCredentialsSecret }}
-          secret: 
+          secret:
             secretName: {{ .Values.config.natsCredentialsSecret }}
             items:
               - key: nats.creds


### PR DESCRIPTION
## Feature or Problem
Small fix for the observability related flags in the wasmcloud-host chart, since they're actually `Option<bool>` in the host so they need explicit values.

Also fix a typo so that the relevant options are in the `args` block in the template.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
