### PR TITLE
feat(secrets-nats-kv): add get command to CLI

### DIFF
--- a/crates/secrets-nats-kv/src/api.rs
+++ b/crates/secrets-nats-kv/src/api.rs
@@ -683,7 +683,7 @@ impl SecretsServer for Api {
     }
 }
 
-async fn find_key_rev(h: &mut History, revision: u64) -> Option<Entry> {
+pub(crate) async fn find_key_rev(h: &mut History, revision: u64) -> Option<Entry> {
     while let Some(entry) = h.next().await {
         if let Ok(entry) = entry {
             if entry.revision == revision {

--- a/crates/wash-cli/src/keys.rs
+++ b/crates/wash-cli/src/keys.rs
@@ -66,7 +66,7 @@ pub fn keytype_parser(keytype: &str) -> Result<KeyPairType> {
         "cluster" => Ok(KeyPairType::Cluster),
         "x25519" | "curve" => Ok(KeyPairType::Curve),
         _ => Err(anyhow::anyhow!(
-            "Invalid key type. Must be one of Account, User, Module (or Component), Service (or Provider), Server (or Host), Operator, Cluster"
+            "Invalid key type. Must be one of Account, User, Module (or Component), Service (or Provider), Server (or Host), Operator, Cluster, Curve (xkey)"
         )),
     }
 }


### PR DESCRIPTION
## Feature or Problem
This PR adds a `get` subcommand to the `secrets-nats-kv` CLI that allows for decrypting a secret that's stored in a NATS KV bucket, provided you have access to the encryption xkey seed. This requires direct JetStream access and does not actually send a request to a running secrets backend.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I manually verified this worked well for fetching a secret that I put using a valid XKey, and that it was denied if I provided the wrong kind, key, or bucket name.
