### PR TITLE
fix(lattice-client-react): refresh washboard content when URL change

### DIFF
--- a/typescript/apps/washboard-ui/src/app/components/app-lattice-client-provider.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/app-lattice-client-provider.tsx
@@ -14,10 +14,7 @@ const getClient = (parameters?: Config) => {
       latticeUrl: import.meta.env.VITE_NATS_WEBSOCKET_URL ?? 'ws://localhost:4223',
       ...parameters,
     },
-    getNewConnection: ({latticeUrl}) =>
-      new NatsWsLatticeConnection({
-        latticeUrl: latticeUrl,
-      }),
+    getNewConnection: ({latticeUrl}) => new NatsWsLatticeConnection({latticeUrl}),
   };
   return new LatticeClient(config);
 };

--- a/typescript/apps/washboard-ui/src/app/components/app-lattice-client-provider.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/app-lattice-client-provider.tsx
@@ -14,9 +14,9 @@ const getClient = (parameters?: Config) => {
       latticeUrl: import.meta.env.VITE_NATS_WEBSOCKET_URL ?? 'ws://localhost:4223',
       ...parameters,
     },
-    getNewConnection: (c) =>
+    getNewConnection: ({latticeUrl}) =>
       new NatsWsLatticeConnection({
-        latticeUrl: c.latticeUrl,
+        latticeUrl: latticeUrl,
       }),
   };
   return new LatticeClient(config);

--- a/typescript/apps/washboard-ui/src/app/components/connection-status.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/connection-status.tsx
@@ -3,10 +3,12 @@ import {clsx} from 'clsx';
 import * as React from 'react';
 
 export function ConnectionStatus(): React.ReactElement {
-  const [latticeConfig] = useLatticeConfig();
+  const {config: latticeConfig} = useLatticeConfig();
   const [status, setStatus] = React.useState<'PENDING' | 'ONLINE' | 'OFFLINE'>('PENDING');
   React.useEffect(() => {
-    canConnect(latticeConfig.latticeUrl).then((online) => setStatus(online ? 'ONLINE' : 'OFFLINE'));
+    canConnect(latticeConfig?.latticeUrl).then((online) =>
+      setStatus(online ? 'ONLINE' : 'OFFLINE'),
+    );
   }, [latticeConfig.latticeUrl]);
   return (
     <div

--- a/typescript/apps/washboard-ui/src/app/components/lattice-settings.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/lattice-settings.tsx
@@ -30,7 +30,14 @@ type LatticeFormInput = z.input<typeof formSchema>;
 type LatticeFormOutput = z.output<typeof formSchema>;
 
 export function LatticeSettings(): ReactElement {
-  const [{latticeUrl, latticeId, ctlTopicPrefix, retryCount}, setConfig] = useLatticeConfig();
+  const {config, setConfig} = useLatticeConfig();
+
+  const {latticeUrl, latticeId, ctlTopicPrefix, retryCount} = config ?? {
+    latticeUrl: '',
+    latticeId: 'default',
+    ctlTopicPrefix: 'wasmcloud.control',
+    retryCount: 5,
+  };
   const form = useForm<LatticeFormInput, object, LatticeFormOutput>({
     resolver: zodResolver(formSchema),
     defaultValues: {

--- a/typescript/apps/washboard-ui/src/app/components/lattice-settings.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/lattice-settings.tsx
@@ -32,12 +32,7 @@ type LatticeFormOutput = z.output<typeof formSchema>;
 export function LatticeSettings(): ReactElement {
   const {config, setConfig} = useLatticeConfig();
 
-  const {latticeUrl, latticeId, ctlTopicPrefix, retryCount} = config ?? {
-    latticeUrl: '',
-    latticeId: 'default',
-    ctlTopicPrefix: 'wasmcloud.control',
-    retryCount: 5,
-  };
+  const {latticeUrl, latticeId, ctlTopicPrefix, retryCount} = config;
   const form = useForm<LatticeFormInput, object, LatticeFormOutput>({
     resolver: zodResolver(formSchema),
     defaultValues: {

--- a/typescript/packages/lattice-client-react/src/context/lattice-config-context.tsx
+++ b/typescript/packages/lattice-client-react/src/context/lattice-config-context.tsx
@@ -1,0 +1,18 @@
+import {type LatticeClient, type LatticeClientOptions} from '@wasmcloud/lattice-client-core';
+import * as React from 'react';
+
+export type LatticeClientConfigOutput = typeof LatticeClient.prototype.instance.config;
+export type LatticeClientConfigInput = Partial<LatticeClientOptions['config']>;
+
+export type SetConfigFunction = (value: LatticeClientConfigInput) => void;
+
+export type LatticeConfigContextType = {
+  config: LatticeClientConfigOutput;
+  setConfig: SetConfigFunction;
+};
+
+export const LatticeConfigContext = React.createContext<LatticeConfigContextType>({
+  config: {} as LatticeClientConfigOutput,
+  setConfig: () => {},
+});
+ 

--- a/typescript/packages/lattice-client-react/src/context/lattice-config-provider.tsx
+++ b/typescript/packages/lattice-client-react/src/context/lattice-config-provider.tsx
@@ -1,0 +1,52 @@
+import {type LatticeClient, type LatticeClientOptions} from '@wasmcloud/lattice-client-core';
+import * as React from 'react';
+import {useLatticeClient} from '@/context/use-lattice-client';
+
+type LatticeClientConfigOutput = typeof LatticeClient.prototype.instance.config;
+type LatticeClientConfigInput = Partial<LatticeClientOptions['config']>;
+
+type SetConfigFunction = (value: LatticeClientConfigInput) => void;
+
+export type LatticeConfigContextType = {
+  config: LatticeClientConfigOutput;
+  setConfig: SetConfigFunction;
+};
+
+export const LatticeConfigContext = React.createContext<LatticeConfigContextType>({
+  config: {} as LatticeClientConfigOutput,
+  setConfig: () => {},
+});
+
+export function LatticeConfigProvider({
+  children,
+  setClient,
+}: React.PropsWithChildren & {
+  setClient: (config: LatticeClientConfigInput) => void;
+}): React.ReactElement {
+  const client = useLatticeClient();
+  const [config, setConfigState] = React.useState<LatticeClientConfigOutput>(
+    client.instance.config,
+  );
+
+  const setConfig = React.useCallback<SetConfigFunction>(
+    (newConfig) => {
+      client.instance.disconnect();
+      setClient(newConfig);
+    },
+    [client, setClient],
+  );
+
+  React.useEffect(() => {
+    setConfigState(() => client.instance.config);
+  }, [client]);
+  return (
+    <LatticeConfigContext.Provider
+      value={{
+        config,
+        setConfig,
+      }}
+    >
+      {children}
+    </LatticeConfigContext.Provider>
+  );
+}

--- a/typescript/packages/lattice-client-react/src/context/lattice-config-provider.tsx
+++ b/typescript/packages/lattice-client-react/src/context/lattice-config-provider.tsx
@@ -1,21 +1,11 @@
-import {type LatticeClient, type LatticeClientOptions} from '@wasmcloud/lattice-client-core';
+import type {
+  LatticeClientConfigOutput,
+  LatticeClientConfigInput,
+  SetConfigFunction,
+} from './lattice-config-context';
 import * as React from 'react';
 import {useLatticeClient} from '@/context/use-lattice-client';
-
-type LatticeClientConfigOutput = typeof LatticeClient.prototype.instance.config;
-type LatticeClientConfigInput = Partial<LatticeClientOptions['config']>;
-
-type SetConfigFunction = (value: LatticeClientConfigInput) => void;
-
-export type LatticeConfigContextType = {
-  config: LatticeClientConfigOutput;
-  setConfig: SetConfigFunction;
-};
-
-export const LatticeConfigContext = React.createContext<LatticeConfigContextType>({
-  config: {} as LatticeClientConfigOutput,
-  setConfig: () => {},
-});
+import {LatticeConfigContext} from './lattice-config-context';
 
 export function LatticeConfigProvider({
   children,

--- a/typescript/packages/lattice-client-react/src/index.ts
+++ b/typescript/packages/lattice-client-react/src/index.ts
@@ -2,6 +2,7 @@
 export * from '@wasmcloud/lattice-client-core';
 
 // package exports
+export {LatticeConfigProvider,LatticeConfigContext} from '@/context/lattice-config-provider';
 export {useLatticeConfig} from '@/use-lattice-config';
 export {useLatticeData} from '@/use-lattice-data';
 export {LatticeClientProvider} from '@/context/lattice-client-provider';

--- a/typescript/packages/lattice-client-react/src/index.ts
+++ b/typescript/packages/lattice-client-react/src/index.ts
@@ -2,7 +2,7 @@
 export * from '@wasmcloud/lattice-client-core';
 
 // package exports
-export {LatticeConfigProvider,LatticeConfigContext} from '@/context/lattice-config-provider';
+export {LatticeConfigProvider} from '@/context/lattice-config-provider';
 export {useLatticeConfig} from '@/use-lattice-config';
 export {useLatticeData} from '@/use-lattice-data';
 export {LatticeClientProvider} from '@/context/lattice-client-provider';

--- a/typescript/packages/lattice-client-react/src/use-lattice-config.ts
+++ b/typescript/packages/lattice-client-react/src/use-lattice-config.ts
@@ -1,31 +1,14 @@
-import {type LatticeClient, type LatticeClientOptions} from '@wasmcloud/lattice-client-core';
 import * as React from 'react';
-import {useLatticeClient} from '@/context/use-lattice-client';
-
-type LatticeClientConfigOutput = typeof LatticeClient.prototype.instance.config;
-type LatticeClientConfigInput = Partial<LatticeClientOptions['config']>;
-
-type SetConfigFunction = (value: LatticeClientConfigInput) => void;
-
-type UseLatticeConfigResult = [LatticeClientConfigOutput, SetConfigFunction];
+import {
+  LatticeConfigContext,
+  LatticeConfigContextType,
+} from './context/lattice-config-provider';
 
 /**
  * get the current lattice config and a function to update it
  */
-function useLatticeConfig(): UseLatticeConfigResult {
-  const client = useLatticeClient();
-  const [config, setConfigState] = React.useState<LatticeClientConfigOutput>(
-    client.instance.config,
-  );
-  const setConfig = React.useCallback<SetConfigFunction>(
-    (newConfig) => {
-      client.instance.setPartialConfig(newConfig);
-      setConfigState(() => client.instance.config);
-    },
-    [client],
-  );
-
-  return [config, setConfig];
+function useLatticeConfig(): LatticeConfigContextType {
+  return React.useContext(LatticeConfigContext);
 }
 
 export {useLatticeConfig};

--- a/typescript/packages/lattice-client-react/src/use-lattice-config.ts
+++ b/typescript/packages/lattice-client-react/src/use-lattice-config.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {
   LatticeConfigContext,
   LatticeConfigContextType,
-} from './context/lattice-config-provider';
+} from './context/lattice-config-context';
 
 /**
  * get the current lattice config and a function to update it


### PR DESCRIPTION
## Feature or Problem
Fix washboard wnot change when webssocket url change

- Add LatticeConfigProvider component to manage lattice configuration
- Update AppLatticeClientProvider to use LatticeConfigProvider
- Modify ConnectionStatus and LatticeSettings to use new config context
- Update useLatticeConfig hook to use LatticeConfigContext

## Related Issues
closes #3551

https://github.com/user-attachments/assets/ba75ad38-bc06-4e05-9139-c8cab5438520

