### PR TITLE
Host-sys, control-interface and core dep cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8566,7 +8566,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
- "wasmcloud-core 0.15.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmcloud"
 version = "1.5.0"
-description = "wasmCloud host runtime"
+description = "wasmCloud is a Cloud Native Computing Foundation (CNCF) project that enables teams to build polyglot applications composed of reusable Wasm components and run them—resiliently and efficiently—across any cloud, Kubernetes, datacenter, or edge."
 default-run = "wasmcloud"
 readme = "README.md"
 
@@ -13,7 +13,7 @@ repository.workspace = true
 
 [workspace.package]
 authors = ["The wasmCloud Team"]
-categories = ["wasm"]
+categories = ["wasm", "platform"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/wasmCloud/wasmCloud"

--- a/crates/control-interface/Cargo.toml
+++ b/crates/control-interface/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-nats = { workspace = true }
+async-nats = { workspace = true, features = ["ring"] }
 cloudevents-sdk = { workspace = true }
 futures = { workspace = true }
 oci-client = { workspace = true, features = ["rustls-tls"] }
@@ -30,7 +30,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
-wasmcloud-core = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["cloudevents-sdk"]

--- a/crates/control-interface/src/broker.rs
+++ b/crates/control-interface/src/broker.rs
@@ -1,5 +1,6 @@
 const DEFAULT_TOPIC_PREFIX: &str = "wasmbus.ctl";
 // Copied from https://docs.rs/wasmcloud-core/0.15.0/wasmcloud_core/constant.CTL_API_VERSION_1.html
+// to avoid a dependency on a crate for one constant
 const CTL_API_VERSION_1: &str = "v1";
 
 fn prefix(topic_prefix: &Option<String>, lattice: &str, version: &str) -> String {

--- a/crates/control-interface/src/broker.rs
+++ b/crates/control-interface/src/broker.rs
@@ -1,4 +1,6 @@
 const DEFAULT_TOPIC_PREFIX: &str = "wasmbus.ctl";
+// Copied from https://docs.rs/wasmcloud-core/0.15.0/wasmcloud_core/constant.CTL_API_VERSION_1.html
+const CTL_API_VERSION_1: &str = "v1";
 
 fn prefix(topic_prefix: &Option<String>, lattice: &str, version: &str) -> String {
     format!(
@@ -10,7 +12,7 @@ fn prefix(topic_prefix: &Option<String>, lattice: &str, version: &str) -> String
 }
 
 pub mod v1 {
-    use wasmcloud_core::CTL_API_VERSION_1;
+    use crate::broker::CTL_API_VERSION_1;
 
     use super::prefix;
 
@@ -82,7 +84,7 @@ pub mod v1 {
     }
 
     pub mod commands {
-        use wasmcloud_core::CTL_API_VERSION_1;
+        use crate::broker::CTL_API_VERSION_1;
 
         use super::prefix;
 
@@ -139,7 +141,7 @@ pub mod v1 {
     }
 
     pub mod queries {
-        use wasmcloud_core::CTL_API_VERSION_1;
+        use crate::broker::CTL_API_VERSION_1;
 
         use super::prefix;
 

--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -34,6 +34,27 @@ pub use types::provider::*;
 pub use types::registry::*;
 pub use types::rpc::*;
 
+// NOTE(brooksmtownsend): These are included to avoid a major breaking change
+// in this crate by removing the public type aliases. They should be removed
+// when we release 3.0.0 of this crate.
+#[deprecated(
+    since = "2.3.0",
+    note = "String type aliases are deprecated, use Strings instead"
+)]
+#[allow(dead_code)]
+mod aliases {
+    type ComponentId = String;
+    type KnownConfigName = String;
+    type LatticeTarget = String;
+    type LinkName = String;
+    type WitInterface = String;
+    type WitNamespace = String;
+    type WitPackage = String;
+}
+#[allow(unused_imports)]
+#[allow(deprecated)]
+pub use aliases::*;
+
 /// Generic result
 type Result<T> = ::core::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 

--- a/crates/control-interface/src/lib.rs
+++ b/crates/control-interface/src/lib.rs
@@ -34,10 +34,6 @@ pub use types::provider::*;
 pub use types::registry::*;
 pub use types::rpc::*;
 
-pub use wasmcloud_core::{
-    ComponentId, KnownConfigName, LatticeTarget, LinkName, WitInterface, WitNamespace, WitPackage,
-};
-
 /// Generic result
 type Result<T> = ::core::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 

--- a/crates/control-interface/src/types/component.rs
+++ b/crates/control-interface/src/types/component.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ComponentId, Result};
+use crate::Result;
 
 /// A summary description of an component within a host inventory
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -12,7 +12,7 @@ use crate::{ComponentId, Result};
 pub struct ComponentDescription {
     /// The unique component identifier for this component
     #[serde(default)]
-    pub(crate) id: ComponentId,
+    pub(crate) id: String,
 
     /// Image reference for this component
     #[serde(default)]
@@ -39,7 +39,7 @@ pub struct ComponentDescription {
 #[derive(Default, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ComponentDescriptionBuilder {
-    id: Option<ComponentId>,
+    id: Option<String>,
     image_ref: Option<String>,
     name: Option<String>,
     annotations: Option<BTreeMap<String, String>>,

--- a/crates/control-interface/src/types/ctl.rs
+++ b/crates/control-interface/src/types/ctl.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ComponentId, Result};
+use crate::Result;
 
 /// A control interface response that wraps a response payload, a success flag, and a message
 /// with additional context if necessary.
@@ -89,7 +89,7 @@ pub struct ScaleComponentCommand {
     #[serde(default)]
     pub(crate) component_ref: String,
     /// Unique identifier of the component to scale.
-    pub(crate) component_id: ComponentId,
+    pub(crate) component_id: String,
     /// Optional set of annotations used to describe the nature of this component scale command. For
     /// example, autonomous agents may wish to "tag" scale requests as part of a given deployment
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -165,7 +165,7 @@ impl ScaleComponentCommand {
 #[non_exhaustive]
 pub struct ScaleComponentCommandBuilder {
     component_ref: Option<String>,
-    component_id: Option<ComponentId>,
+    component_id: Option<String>,
     annotations: Option<BTreeMap<String, String>>,
     max_instances: Option<u32>,
     host_id: Option<String>,
@@ -246,7 +246,7 @@ impl ScaleComponentCommandBuilder {
 #[non_exhaustive]
 pub struct StartProviderCommand {
     /// Unique identifier of the provider to start.
-    provider_id: ComponentId,
+    provider_id: String,
     /// The image reference of the provider to be started
     #[serde(default)]
     provider_ref: String,
@@ -303,7 +303,7 @@ impl StartProviderCommand {
 #[non_exhaustive]
 pub struct StartProviderCommandBuilder {
     host_id: Option<String>,
-    provider_id: Option<ComponentId>,
+    provider_id: Option<String>,
     provider_ref: Option<String>,
     annotations: Option<BTreeMap<String, String>>,
     config: Option<Vec<String>>,
@@ -435,7 +435,7 @@ pub struct StopProviderCommand {
     pub(crate) host_id: String,
     /// Unique identifier for the provider to stop.
     #[serde(default, alias = "provider_ref")]
-    pub(crate) provider_id: ComponentId,
+    pub(crate) provider_id: String,
 }
 
 impl StopProviderCommand {
@@ -460,7 +460,7 @@ impl StopProviderCommand {
 #[non_exhaustive]
 pub struct StopProviderCommandBuilder {
     host_id: Option<String>,
-    provider_id: Option<ComponentId>,
+    provider_id: Option<String>,
 }
 
 impl StopProviderCommandBuilder {
@@ -501,7 +501,7 @@ impl StopProviderCommandBuilder {
 pub struct UpdateComponentCommand {
     /// The component's 56-character unique ID
     #[serde(default)]
-    pub(crate) component_id: ComponentId,
+    pub(crate) component_id: String,
     /// Optional set of annotations used to describe the nature of this
     /// update request. Only component instances that have matching annotations
     /// will be upgraded, allowing for instance isolation by
@@ -547,7 +547,7 @@ impl UpdateComponentCommand {
 #[non_exhaustive]
 pub struct UpdateComponentCommandBuilder {
     host_id: Option<String>,
-    component_id: Option<ComponentId>,
+    component_id: Option<String>,
     new_component_ref: Option<String>,
     annotations: Option<BTreeMap<String, String>>,
 }

--- a/crates/control-interface/src/types/link.rs
+++ b/crates/control-interface/src/types/link.rs
@@ -2,11 +2,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    ComponentId, KnownConfigName, LatticeTarget, LinkName, Result, WitInterface, WitNamespace,
-    WitPackage,
-};
-
 /// A link definition between a source and target component (component or provider) on a given
 /// interface.
 ///
@@ -20,24 +15,24 @@ use crate::{
 #[non_exhaustive]
 pub struct Link {
     /// Source identifier for the link
-    pub(crate) source_id: ComponentId,
+    pub(crate) source_id: String,
     /// Target for the link, which can be a unique identifier or (future) a routing group
-    pub(crate) target: LatticeTarget,
+    pub(crate) target: String,
     /// Name of the link. Not providing this is equivalent to specifying "default"
     #[serde(default = "default_link_name")]
-    pub(crate) name: LinkName,
+    pub(crate) name: String,
     /// WIT namespace of the link operation, e.g. `wasi` in `wasi:keyvalue/readwrite.get`
-    pub(crate) wit_namespace: WitNamespace,
+    pub(crate) wit_namespace: String,
     /// WIT package of the link operation, e.g. `keyvalue` in `wasi:keyvalue/readwrite.get`
-    pub(crate) wit_package: WitPackage,
+    pub(crate) wit_package: String,
     /// WIT Interfaces to be used for the link, e.g. `readwrite`, `atomic`, etc.
-    pub(crate) interfaces: Vec<WitInterface>,
+    pub(crate) interfaces: Vec<String>,
     /// List of named configurations to provide to the source upon request
     #[serde(default)]
-    pub(crate) source_config: Vec<KnownConfigName>,
+    pub(crate) source_config: Vec<String>,
     /// List of named configurations to provide to the target upon request
     #[serde(default)]
-    pub(crate) target_config: Vec<KnownConfigName>,
+    pub(crate) target_config: Vec<String>,
 }
 
 impl Link {
@@ -91,14 +86,14 @@ impl Link {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct LinkBuilder {
-    source_id: Option<ComponentId>,
-    target: Option<LatticeTarget>,
-    name: Option<LinkName>,
-    wit_namespace: Option<WitNamespace>,
-    wit_package: Option<WitPackage>,
-    interfaces: Option<Vec<WitInterface>>,
-    source_config: Option<Vec<KnownConfigName>>,
-    target_config: Option<Vec<KnownConfigName>>,
+    source_id: Option<String>,
+    target: Option<String>,
+    name: Option<String>,
+    wit_namespace: Option<String>,
+    wit_package: Option<String>,
+    interfaces: Option<Vec<String>>,
+    source_config: Option<Vec<String>>,
+    target_config: Option<Vec<String>>,
 }
 
 impl LinkBuilder {
@@ -150,7 +145,7 @@ impl LinkBuilder {
         self
     }
 
-    pub fn build(self) -> Result<Link> {
+    pub fn build(self) -> crate::Result<Link> {
         Ok(Link {
             source_id: self
                 .source_id
@@ -175,7 +170,7 @@ impl LinkBuilder {
 }
 
 /// Helper function to provide a default link name
-pub(crate) fn default_link_name() -> LinkName {
+pub(crate) fn default_link_name() -> String {
     "default".to_string()
 }
 

--- a/crates/control-interface/src/types/provider.rs
+++ b/crates/control-interface/src/types/provider.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ComponentId, Result};
+use crate::Result;
 
 /// A summary description of a capability provider within a host inventory
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -12,7 +12,7 @@ use crate::{ComponentId, Result};
 pub struct ProviderDescription {
     /// Provider's unique identifier
     #[serde(default)]
-    pub(crate) id: ComponentId,
+    pub(crate) id: String,
     /// Image reference for this provider, if applicable
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) image_ref: Option<String>,
@@ -64,7 +64,7 @@ impl ProviderDescription {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct ProviderDescriptionBuilder {
-    id: Option<ComponentId>,
+    id: Option<String>,
     image_ref: Option<String>,
     name: Option<String>,
     revision: Option<i32>,

--- a/crates/control-interface/src/types/rpc.rs
+++ b/crates/control-interface/src/types/rpc.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ComponentId, LinkName, Result, WitNamespace, WitPackage};
+use crate::Result;
 
 /// A host response to a request to start a component.
 ///
@@ -130,7 +130,7 @@ pub struct ComponentAuctionRequest {
     /// The unique identifier to be used for this component.
     ///
     /// The host will ensure that no other component with the same ID is running on the host
-    pub(crate) component_id: ComponentId,
+    pub(crate) component_id: String,
     /// The set of constraints that must match the labels of a suitable target host
     pub(crate) constraints: BTreeMap<String, String>,
 }
@@ -162,7 +162,7 @@ impl ComponentAuctionRequest {
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct ComponentAuctionRequestBuilder {
     component_ref: Option<String>,
-    component_id: Option<ComponentId>,
+    component_id: Option<String>,
     constraints: Option<BTreeMap<String, String>>,
 }
 
@@ -312,7 +312,7 @@ pub struct ProviderAuctionRequest {
 
     /// The unique identifier to be used for this provider. The host will ensure
     /// that no other provider with the same ID is running on the host
-    pub(crate) provider_id: ComponentId,
+    pub(crate) provider_id: String,
 
     /// The set of constraints that must match the labels of a suitable target host
     pub(crate) constraints: BTreeMap<String, String>,
@@ -347,7 +347,7 @@ impl ProviderAuctionRequest {
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct ProviderAuctionRequestBuilder {
     provider_ref: Option<String>,
-    provider_id: Option<ComponentId>,
+    provider_id: Option<String>,
     constraints: Option<BTreeMap<String, String>>,
 }
 
@@ -389,17 +389,17 @@ impl ProviderAuctionRequestBuilder {
 #[non_exhaustive]
 pub struct DeleteInterfaceLinkDefinitionRequest {
     /// The source component's identifier.
-    pub(crate) source_id: ComponentId,
+    pub(crate) source_id: String,
 
     /// Name of the link. Not providing this is equivalent to specifying Some("default")
     #[serde(default = "default_link_name")]
-    pub(crate) name: LinkName,
+    pub(crate) name: String,
 
     /// WIT namespace of the link, e.g. `wasi` in `wasi:keyvalue/readwrite.get`
-    pub(crate) wit_namespace: WitNamespace,
+    pub(crate) wit_namespace: String,
 
     /// WIT package of the link, e.g. `keyvalue` in `wasi:keyvalue/readwrite.get`
-    pub(crate) wit_package: WitPackage,
+    pub(crate) wit_package: String,
 }
 
 impl DeleteInterfaceLinkDefinitionRequest {
@@ -448,10 +448,10 @@ impl DeleteInterfaceLinkDefinitionRequest {
 
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct DeleteInterfaceLinkDefinitionRequestBuilder {
-    source_id: Option<ComponentId>,
-    name: Option<LinkName>,
-    wit_namespace: Option<WitNamespace>,
-    wit_package: Option<WitPackage>,
+    source_id: Option<String>,
+    name: Option<String>,
+    wit_namespace: Option<String>,
+    wit_package: Option<String>,
 }
 
 impl DeleteInterfaceLinkDefinitionRequestBuilder {
@@ -492,7 +492,7 @@ impl DeleteInterfaceLinkDefinitionRequestBuilder {
 }
 
 /// Helper function to provide a default link name
-fn default_link_name() -> LinkName {
+fn default_link_name() -> String {
     "default".to_string()
 }
 

--- a/crates/wash-lib/src/spier.rs
+++ b/crates/wash-lib/src/spier.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use chrono::{DateTime, Local};
 use futures::{Stream, StreamExt};
 use tracing::debug;
-use wasmcloud_control_interface::ComponentId;
 
 /// A struct that represents an invocation that was observed by the spier.
 #[derive(Debug)]
@@ -54,7 +53,7 @@ impl ObservedMessage {
 /// A struct that can spy on the RPC messages sent to and from an component, consumable as a stream
 pub struct Spier {
     stream: futures::stream::SelectAll<async_nats::Subscriber>,
-    component_id: ComponentId,
+    component_id: String,
     friendly_name: Option<String>,
 }
 
@@ -152,7 +151,7 @@ impl Stream for Spier {
 
 #[derive(Debug)]
 struct ProviderDetails {
-    id: ComponentId,
+    id: String,
 }
 
 /// Fetches all components linked to the given component


### PR DESCRIPTION
## Feature or Problem
Inspired by some of the pain @joonas went through to release the last version of wash-cli

This PR:
- ~Removes the host-sys crate, which was an initial experiment but hasn't been touched since its creation (@rvolosatovs please feel free to push back if this is serving a function somewhere~
- Removes unused dependencies from the `control-interface` and `core` crates.
- Removes the reliance on the `core` crate in `wasmcloud-control-interface` by using Strings instead of type aliases.

## Related Issues
This is related to a broader issue in this monorepo where crates are too hard to release and there's too much inter-reliance for a tiny subset of functionality. In this case, the reliance on the `core` crate for string type aliases created a dependency where any core crate release would also require a control interface release. There are many other changes we can make like this in the repository that don't require a lot of changes that can help us get to a point where our crates only depend on each other when there's really functionality that should be broken out and shared.

Other, not fully featured ideas to continue this trend are:
- [ ] Reduce public interactions with `core` types so that crates can co-depend on it without needing to be on the same version
- [ ] Merge `wash-lib` and `wash-cli` into `wash` to prevent two releases for libs and CLI crates
- [ ] Combine `wascap` / `provider-archive` into wasmcloud-core as modules of the crate, or try and untangle them.

## Release Information
Nothing needed urgently. This removes public re-exports from the wasmCloud control interface so, perhaps it's a breaking change we could prevent by just creating those type aliases instead of removing them.

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
