### PR TITLE
feat(otel): Adds the ability to configure sampling and buffer size

### DIFF
--- a/crates/core/src/otel.rs
+++ b/crates/core/src/otel.rs
@@ -46,6 +46,28 @@ pub struct OtelConfig {
     /// The level of tracing to enable.
     #[serde(default)]
     pub trace_level: Level,
+    /// Configures type of sampler to use for tracing. This will override any sampler set via
+    /// the standard environment variables
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traces_sampler: Option<String>,
+    /// An additional argument to pass to the sampler. Used for cases such as the
+    /// trace_id_ratio_based sampler.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traces_sampler_arg: Option<String>,
+    /// The maximum number of tracing events that can be buffered in memory before being exported.
+    /// If the queue is full, events will be dropped. If not set, the default for the underlying
+    /// exporter will be used. This will override any value set via the standard environment
+    /// variables.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_batch_queue_size: Option<usize>,
+    /// The maximum number of concurrent export threads that can be used to export tracing data to
+    /// collectors. By default, this number is set to 1, which means that export batches will be
+    /// exported synchronously. This setting has a direct impact on memory usage and performance.
+    /// Setting to > 1 can improve the performance of the exporter, but it can also increase memory
+    /// usage (and possibly CPU). This will override any value set via the standard environment
+    /// variables.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrent_exports: Option<usize>,
 }
 
 impl OtelConfig {

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2181,6 +2181,7 @@ impl Host {
                 protocol: self.host_config.otel_config.protocol,
                 additional_ca_paths: self.host_config.otel_config.additional_ca_paths.clone(),
                 trace_level: self.host_config.otel_config.trace_level.clone(),
+                ..Default::default()
             };
 
             let provider_xkey = XKey::new();

--- a/crates/provider-sdk/src/otel.rs
+++ b/crates/provider-sdk/src/otel.rs
@@ -69,6 +69,36 @@ macro_rules! initialize_observability {
                     "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT" => {
                         otel_config.logs_endpoint = Some(v.clone())
                     }
+                    "OTEL_TRACES_SAMPLER" => {
+                        otel_config.traces_sampler = Some(v.clone())
+                    }
+                    "OTEL_TRACES_SAMPLER_ARG" => {
+                        otel_config.traces_sampler_arg = Some(v.clone())
+                    }
+                    "OTEL_BSP_MAX_CONCURRENT_EXPORTS" => {
+                        let parsed = match v.parse::<usize>() {
+                            Ok(v) => v,
+                            Err(_) => {
+                                eprintln!(
+                                    "Failed to parse OTEL_BSP_MAX_CONCURRENT_EXPORTS as usize, using previously set value or default"
+                                );
+                                continue
+                            }
+                        };
+                        otel_config.concurrent_exports = Some(parsed)
+                    }
+                    "OTEL_BSP_MAX_QUEUE_SIZE" => {
+                        let parsed = match v.parse::<usize>() {
+                            Ok(v) => v,
+                            Err(_) => {
+                                eprintln!(
+                                    "Failed to parse OTEL_BSP_MAX_QUEUE_SIZE as usize, using previously set value or default"
+                                );
+                                continue
+                            }
+                        };
+                        otel_config.max_batch_queue_size = Some(parsed)
+                    }
                     _ => {}
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,6 +351,7 @@ async fn main() -> anyhow::Result<()> {
         protocol: args.observability_protocol.unwrap_or_default(),
         additional_ca_paths: args.tls_ca_paths.clone().unwrap_or_default(),
         trace_level,
+        ..Default::default()
     };
     let log_level = WasmcloudLogLevel::from(args.log_level);
 


### PR DESCRIPTION
This adds the ability for provider to configure some of the tunables for tracing via config. The underlying SDK defaults (and hence, the host) use the standard environment variables

Please note that some of our traces are using a span that lives for the lifetime of the application, so the sampling percentage may not work until we fix that as well
