### PR TITLE
ci: correct regex pattern when ref prefix doesn't exist

### DIFF
--- a/.github/workflows/ts-release-app-washboard.yml
+++ b/.github/workflows/ts-release-app-washboard.yml
@@ -27,7 +27,7 @@ jobs:
           # - path pattern: `path/to/project/v1.2.3`
           # - package pattern: `refs/tags/package-name-v1.2.3`
           # - tag only pattern: `refs/tags/v1.2.3`
-          pattern: '^refs\/tags\/(?:.*\/|[a-z-]*)?v?(.*)$'
+          pattern: '^(?:.*\/|[a-z-]*)?v?(.*)$'
 
       - name: Download Asset
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16

--- a/.github/workflows/ts-release-package-lattice-client-core.yml
+++ b/.github/workflows/ts-release-package-lattice-client-core.yml
@@ -28,7 +28,7 @@ jobs:
           # - path pattern: `path/to/project/v1.2.3`
           # - package pattern: `refs/tags/package-name-v1.2.3`
           # - tag only pattern: `refs/tags/v1.2.3`
-          pattern: '^refs\/tags\/(?:.*\/|[a-z-]*)?v?(.*)$'
+          pattern: '^(?:.*\/|[a-z-]*)?v?(.*)$'
 
       - name: Setup
         uses: ./.github/actions/ts-setup

--- a/.github/workflows/ts-release-package-lattice-client-react.yml
+++ b/.github/workflows/ts-release-package-lattice-client-react.yml
@@ -28,7 +28,7 @@ jobs:
           # - path pattern: `path/to/project/v1.2.3`
           # - package pattern: `refs/tags/package-name-v1.2.3`
           # - tag only pattern: `refs/tags/v1.2.3`
-          pattern: '^refs\/tags\/(?:.*\/|[a-z-]*)?v?(.*)$'
+          pattern: '^(?:.*\/|[a-z-]*)?v?(.*)$'
 
       - name: Setup
         uses: ./.github/actions/ts-setup


### PR DESCRIPTION
The `release-kit/semver` uses GITHUB_REF_NAME with is the short name of the ref (i.e. `typescript/apps/washboard-ui/v0.6.0` instead of `refs/tags/typescript/apps/washboard-ui/v0.6.0`). This new pattern matches both with and without anyway.