### PR TITLE
fix(wash-cli): add new url to check for washboard releases

### DIFF
--- a/crates/wash-cli/src/ui/mod.rs
+++ b/crates/wash-cli/src/ui/mod.rs
@@ -43,7 +43,10 @@ pub async fn handle_ui(cmd: UiCommand, _output_kind: OutputKind) -> Result<()> {
         .allow_methods(vec!["GET", "POST"])
         .allow_headers(vec!["Content-Type"]);
 
-    eprintln!("Washboard running on http://localhost:{}", cmd.port);
+    eprintln!(
+        "washboard-ui@{} running on http://localhost:{}",
+        cmd.version, cmd.port
+    );
     eprintln!("Hit CTRL-C to stop");
 
     warp::serve(static_files.with(cors))

--- a/crates/wash-cli/src/ui/mod.rs
+++ b/crates/wash-cli/src/ui/mod.rs
@@ -11,8 +11,8 @@ use warp::Filter;
 use wash_lib::{
     cli::{CommandOutput, OutputKind},
     config::downloads_dir,
+    start::get_download_client,
 };
-use wasmcloud_core::tls;
 
 const DEFAULT_WASHBOARD_VERSION: &str = "v0.6.0";
 
@@ -104,7 +104,7 @@ async fn try_download_from_urls(urls: &[String]) -> Result<bytes::Bytes> {
 }
 
 async fn try_download(url: &String) -> Result<bytes::Bytes> {
-    let resp = tls::DEFAULT_REQWEST_CLIENT
+    let resp = get_download_client()?
         .get(url)
         .send()
         .await

--- a/crates/wash-lib/src/start/github/mod.rs
+++ b/crates/wash-lib/src/start/github/mod.rs
@@ -96,7 +96,7 @@ where
 }
 
 /// Helper function to set up a reqwest client for performing the download
-pub(crate) fn get_download_client() -> Result<reqwest::Client> {
+pub fn get_download_client() -> Result<reqwest::Client> {
     get_download_client_with_user_agent(DOWNLOAD_CLIENT_USER_AGENT)
 }
 


### PR DESCRIPTION
Change in the tags for washboard means that washboard is no longer at the same URL. This adds the new URL pattern, and falls back to the old one if it cannot be found.

It might be worth noting that this will need an additional URL when the washboard code moves to its own repo.

Didn't add tests because I wouldn't have a clue where to even start with writing tests in rust but I'm happy to learn if someone wants to give me some direction.

Closes #3428