### PR TITLE
fix(wasmcloud): remove short help-markdown flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -329,7 +329,6 @@ struct Args {
 
     #[clap(
         long = "help-markdown",
-        short,
         action=ArgAction::SetTrue,
         conflicts_with = "help",
         hide = true


### PR DESCRIPTION
## Feature or Problem
This PR fixes a panic when running `./wasmcloud --help` by removing the conflicting short help flag for help markdown.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
