### PR TITLE
chore(host): Proxy SSL_CERT_FILE and SSL_CERT_DIR to providers

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2301,6 +2301,14 @@ impl Host {
                 let _ = child_cmd.env("RUST_LOG", rust_log);
             }
 
+            // Proxy SSL_CERT_FILE and SSL_CERT_DIR to the provider to use for setting up TLS connections
+            if let Ok(ssl_cert_file) = env::var("SSL_CERT_FILE") {
+                let _ = child_cmd.env("SSL_CERT_FILE", ssl_cert_file);
+            }
+            if let Ok(ssl_cert_dir) = env::var("SSL_CERT_DIR") {
+                let _ = child_cmd.env("SSL_CERT_DIR", ssl_cert_dir);
+            }
+
             let mut child = child_cmd
                 .stdin(Stdio::piped())
                 .kill_on_drop(true)


### PR DESCRIPTION
## Feature or Problem

In an environment where custom CAs are used, `SSL_CERT_FILE` and `SSL_CERT_DIR` can be used to configure many TLS libraries to read a specific file or directory for it's certificates to use.

These values can be used to configure the host itself already, but when the host starts providers, these values were not being passed down to the provider to make use of, and so it would not be able to start.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
