### PR TITLE
fix: kubeVersion block helm to install into major clouds

### DIFF
--- a/charts/wasmcloud-platform/Chart.yaml
+++ b/charts/wasmcloud-platform/Chart.yaml
@@ -5,12 +5,12 @@ description: wasmCloud Platform Helm Chart provides a turnkey solution, for runn
 # Note: Ensure you bump this `version` field in a separate PR than what you plan
 # to tag as the updated wasmCloud version. To be safe, bump and release wasmCloud
 # in one PR, then open a new PR updating this `version` and `appVersion`.
-version: 0.1.0
+version: 0.1.1
 
 type: application
 appVersion: "1.2.1"
 
-kubeVersion: ">=1.24.0"
+kubeVersion: ">=1.24.0-0"
 
 dependencies:
   - name: nats


### PR DESCRIPTION
## Feature or Problem

Fix a problem installing/trying out Helm to major cloud providers for wasmcloud-platform chart:

```
Error: chart requires kubeVersion: >=1.24.0 which is incompatible with Kubernetes v1.29.9-gke.1177000
Error: chart requires kubeVersion: >=1.24.0 which is incompatible with Kubernetes v1.29.9-eks-ce1d5eb
```

The root cause is just Helm semVer function doesn't play nice with the actual version being used by public cloud providers. As highlighted in here: <https://github.com/helm/helm/issues/10375>

## Related Issues

N/A

## Release Information

`next`

## Consumer Impact

No changes or impact to general users

## Testing

```
$ helm pull oci://ghcr.io/wasmcloud/charts/wasmcloud-platform
$ vi charts/wasmcloud-platform/Chart.yml # and apply the changes
$ helm upgrade --install \
    wasmcloud-platform \
    --values https://raw.githubusercontent.com/wasmCloud/wasmcloud/main/charts/wasmcloud-platform/values.yaml \
    wasmcloud-platform \
    --set "operator.enabled=false" \
    --dependency-update
# it work (trust me bro)
```

### Unit Test(s)

Don't think UT going to be helpful in this case, but might want to run few integration tests with major cloud providers but this is such a small issue for such an expensive test so I don't think it is necessary.

### Acceptance or Integration

N/A

### Manual Verification

Same as the testing above.