### PR TITLE
fix(wash-cli) wash dev with JSON output will panic when piped into jq

### DIFF
--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use std::io::{stdout, BufWriter, Write};
+use std::path::{Path, PathBuf};
 
 use anyhow::bail;
 use clap::{self, Arg, Command, FromArgMatches, Parser, Subcommand};
@@ -477,7 +477,11 @@ async fn main() {
                     if append_json_success {
                         map.insert("success".to_string(), json!(true));
                     }
-                    let _ = writeln!(stdout_buf,"\n{}", serde_json::to_string_pretty(&map).unwrap());
+                    let _ = writeln!(
+                        stdout_buf,
+                        "\n{}",
+                        serde_json::to_string_pretty(&map).unwrap()
+                    );
                     0
                 }
                 OutputKind::Text => {


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
The _wash dev_ command will panic with a _broken pipe_ when piped to another program and CTRL^C is pressed by the user:

```console
wash dev -o json | jq
```

Please refer to issue #3639 as it contains the analysis for this issue.

**REMARK** Please note that it is (nearly) impossible to capture the JSON output from **wash dev** and pipe it to **jq** when pressing CTRL^C since the latter will terminate sooner than the former. See the '_Manual Verification_' section on how this can be achieved.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
Partially fixes issue #3639.

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

#### Verification Example1

To verify the solution do something like (and press CTRL^C):

```console
mmooij@gandalf:~/dev/hello-wc1$ wash dev --work-dir . -o json | jq
ℹ️  Resolved wash session ID [AsJHq7]
ℹ️  No running hosts found, will start one...
🚧 Starting a new host...
👀 Found nats-server version on the disk: nats-server: v2.10.20
✅ Using nats-server version [v2.10.20]
👀 Found wadm version on the disk: wadm-cli 0.18.0
✅ Successfully started host, logs writing to /home/mmooij/.wash/dev/AsJHq7/wasmcloud.log
🚧 Building project...
    Finished `release` profile [optimized] target(s) in 0.06s
✅ Successfully built project at [/home/mmooij/dev/hello-wc1/build/http_hello_world_s.wasm]
ℹ️  Detected component dependencies: {"http-server"}
🔁 Reloading component [AsJHq7-http-hello-world]...
🔁 Deployed updated manifest for application [dev-asjhq7-http-hello-world]
✨ HTTP Server: Access your application at http://127.0.0.1:8000
👀 Watching for file changes (press Ctrl+c to stop)...
^C
🛑 Received Ctrl + c, stopping devloop...
🧹 Cleaning up deployed wasmCloud application(s)...
⏳ Stopping wasmCloud instance...
⏳ Stopping wadm...
```

Please note that although **wash dev** does not panic the JSON output has not been parsed by **jq**.

#### Verification Example2

To parse the JSON output of **wash dev** by **jq**  use a sequential execution (and press CTRL^C):

```console
mmooij@gandalf:~/dev/hello-wc1$ (wash dev --work-dir . -o json 1>tmp.out; cat tmp.out | jq; rm tmp.out)
ℹ️  Resolved wash session ID [v8EHTK]
ℹ️  No running hosts found, will start one...
🚧 Starting a new host...
👀 Found nats-server version on the disk: nats-server: v2.10.20
✅ Using nats-server version [v2.10.20]
👀 Found wadm version on the disk: wadm-cli 0.18.0
✅ Successfully started host, logs writing to /home/mmooij/.wash/dev/v8EHTK/wasmcloud.log
🚧 Building project...
    Finished `release` profile [optimized] target(s) in 0.05s
✅ Successfully built project at [/home/mmooij/dev/hello-wc1/build/http_hello_world_s.wasm]
ℹ️  Detected component dependencies: {"http-server"}
🔁 Reloading component [v8EHTK-http-hello-world]...
🔁 Deployed updated manifest for application [dev-v8ehtk-http-hello-world]
✨ HTTP Server: Access your application at http://127.0.0.1:8000
👀 Watching for file changes (press Ctrl+c to stop)...
^C
🛑 Received Ctrl + c, stopping devloop...
🧹 Cleaning up deployed wasmCloud application(s)...
⏳ Stopping wasmCloud instance...
⏳ Stopping wadm...
{
  "result": "✅ Dev session [v8EHTK] exited successfully.",
  "success": true
}
```

Given the complexity of the example above it's probably best to create some for bash wrapper or a command for this :smirk:

