### PR TITLE
style(wash-cli): main help is colorized

### DIFF
--- a/crates/wash-cli/src/bin/wash.rs
+++ b/crates/wash-cli/src/bin/wash.rs
@@ -56,18 +56,17 @@ struct HelpTopic {
 impl Display for HelpTopic {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         const PADDING_AFTER_LONGEST_SPACES: usize = 3;
+        const DEFAULT_PADDING_START: usize = 25;
         writeln!(f, "{}", self.name.green().bold())?;
         let longest_command_length = self
             .commands
             .iter()
             .map(|(name, _)| name.len())
             .max()
-            .unwrap_or(25)
+            .unwrap_or(DEFAULT_PADDING_START)
             + PADDING_AFTER_LONGEST_SPACES;
 
         for (name, desc) in &self.commands {
-            // Add a padding to the desc to align the descriptions
-            // NOTE: There should be a (hopefullty) a better way to align the descriptions
             let padding = " ".repeat(longest_command_length - name.len());
             writeln!(f, "  {}{}{}", name.blue(), padding, desc)?;
         }


### PR DESCRIPTION
## Feature or Problem
Using colours for the main help. 🎉 


although I have a question: compared to the "not overwritten" version of the help this command is not in the list of commands when using the custom 🤔 

I know it i behind experimental flag, but was it intentionally hidden from the cli?

 > capture      Capture and debug cluster invocations and state
 
 
and I updated the comments above the (Sub)Commands to reflect the plain text version. 
Some of them have been out of sync (beside the `NOTE`).

Did a minimal research too if there is a dynamic stuff or not, but not really 😞 manual maintenance it is.
 
## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.


--->

closes: #2873 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
```console
cd crates/wash-cli
```
```console
cargo run --
```

