### PR TITLE
fix: check local deployment paths

### DIFF
--- a/crates/wash-lib/src/app.rs
+++ b/crates/wash-lib/src/app.rs
@@ -72,11 +72,18 @@ fn resolve_relative_file_paths_in_yaml(
         serde_yaml::Value::String(s)
             if s.starts_with("file://") && s.chars().nth(7).is_some_and(|v| v != '/') =>
         {
-            // Convert the base dir + relative path into a file based URL
-            let full_path = base_dir.as_ref().join(
-                s.strip_prefix("file://")
-                    .context("failed to strip prefix")?,
-            );
+            // Only check existence for relative paths we're resolving
+            let relative_path = s.strip_prefix("file://")
+                .context("failed to strip prefix")?; 
+            
+            let full_path = base_dir.as_ref().join(relative_path);
+            // Only check existence if it was a relative path (starts with ./ or ../)
+            if relative_path.starts_with('.') {
+                (!full_path.exists()).then(|| ()).context(format!(
+                    "referenced relative file does not exist: {}", 
+                    full_path.display()
+                ))?;
+            }
             // Build a file based URL and replace the existing one
             if let Ok(url) = Url::from_file_path(&full_path) {
                 *s = url.into();


### PR DESCRIPTION
## Feature or Problem
`wash app deploy` fails to detect whether the build for a local component is available. Fix introduces checks for relative paths and their existance.

## Related Issues
Fix for issue #3034

## Release Information
Next

## Consumer Impact
Deploying a local build now checks whether the path is absolute (if yes, proceed regularly), and if not, raises an error indicating which build of the component in question is missing.

### Acceptance or Integration
No changes or additions to the acceptance or integration test suite

### Manual Verification
In `examples/rust/components/http-jsonify`, modify the `wadm.yaml` so that the build is locally sourced.
![image](https://github.com/user-attachments/assets/7ddbfa21-e9bd-407a-a927-ccf7a2187d4d)
In the same folder, run:
```shell
wash up -d
wash app deploy ./wadm.yaml
```
You should get:
![image](https://github.com/user-attachments/assets/29f6170c-32c1-4ab3-8425-3487addde418)

Which indicates that the local build is not available.

I will label this as a work in progress since I am not sure whether this particular handling makes sense, and I am open to suggestion.
