### PR TITLE
fix: nats messaging init observe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8878,7 +8878,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/crates/provider-messaging-nats/Cargo.toml
+++ b/crates/provider-messaging-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.23.1"
+version = "0.24.0"
 description = """
 A capability provider that satisfies the 'wasmcloud:messaging' contract using NATS as a backend.
 """

--- a/crates/provider-messaging-nats/src/lib.rs
+++ b/crates/provider-messaging-nats/src/lib.rs
@@ -15,10 +15,11 @@ use tracing::{debug, error, instrument, warn};
 use tracing_futures::Instrument;
 use wascap::prelude::KeyPair;
 use wasmcloud_provider_sdk::core::HostData;
+use wasmcloud_provider_sdk::provider::WrpcClient;
 use wasmcloud_provider_sdk::wasmcloud_tracing::context::TraceContextInjector;
 use wasmcloud_provider_sdk::{
-    get_connection, load_host_data, propagate_trace_for_ctx, run_provider, serve_provider_exports,
-    Context, LinkConfig, LinkDeleteInfo, Provider,
+    get_connection, initialize_observability, load_host_data, propagate_trace_for_ctx,
+    run_provider, serve_provider_exports, Context, LinkConfig, LinkDeleteInfo, Provider,
 };
 
 mod connection;

--- a/src/bin/messaging-nats-provider/wasmcloud.toml
+++ b/src/bin/messaging-nats-provider/wasmcloud.toml
@@ -1,10 +1,10 @@
 name = "Messaging NATS"
 language = "rust"
 type = "provider"
-version = "0.22.0"
+version = "0.24.0"
 
 [rust]
-target_dir = "../../"
+target_dir = "../../../"
 
 [provider]
 bin_name = "messaging-nats-provider"


### PR DESCRIPTION
## Feature or Problem
This PR ensures the nats messaging provider initializes observability and re-uses wRPC clients for invocations. This should result in a general efficiency improvement for handling messages since we don't recreate the wRPC client on each message.

Lastly, I'm pushing a commit to remove the semaphore from the NATS message subscription. It seems odd to arbitrarily limit the incoming messages at 75, which must've been an artifact of previous performance testings.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Combined with #3670 here's the debug level trace of the echo-messaging component 
<img width="1361" alt="image" src="https://github.com/user-attachments/assets/875fd70a-6927-49e7-aa20-236b5b9339c0">

