### PR TITLE
fix(wash-cli)!: disable loading from stdin

### DIFF
--- a/crates/wash-cli/src/app/mod.rs
+++ b/crates/wash-cli/src/app/mod.rs
@@ -320,8 +320,15 @@ async fn deploy_model(cmd: DeployCommand) -> Result<CommandOutput> {
     let client = connection_opts.into_nats_client().await?;
 
     let app_manifest = match cmd.app_name {
+        Some(source) if source == "-" => load_app_manifest("-".parse()?).await?,
         Some(source) => load_app_manifest(source.parse()?).await?,
-        None => load_app_manifest("-".parse()?).await?,
+        None => {
+            return Err(wadm_client::error::ClientError::ManifestLoad(
+                anyhow::anyhow!(
+                    "Missing manifest name/path. To load a manifest from STDIN, please pass '-'"
+                ),
+            ))
+        }
     };
 
     // If --replace was specified, we should attempt to replace the resources by deleting them beforehand


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This option was evidently confusing, and would cause `wash app deploy` to hang for a bit while waiting for STDIN. It is likely better to force users to pass `-` directly to read from STDIN.


Resolves https://github.com/wasmCloud/wasmCloud/issues/3604

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
