### PR TITLE
ci(wash-up-tests): example providers and component github actions are early

### DIFF
--- a/.github/workflows/examples-components.yml
+++ b/.github/workflows/examples-components.yml
@@ -271,7 +271,7 @@ jobs:
           set -xe
           wash up &
           WASH_PID=$!
-          sleep 3;
+          sleep 4;
           wash app deploy ${{ matrix.project.test-deploy }};
           TRIES=0
           while [[ $(wash get inventory --output=json | jq '.inventories[0].components | length') -eq 0 ]] ; do

--- a/.github/workflows/examples-providers.yml
+++ b/.github/workflows/examples-providers.yml
@@ -139,7 +139,7 @@ jobs:
           set -xe
           wash up &
           WASH_PID=$!
-          sleep 3;
+          sleep 4;
           wash app deploy ${{ matrix.project.test_deploy }};
           TRIES=0
           while [[ $(wash get inventory --output=json | jq '.inventories[0].providers | length') -eq 0 ]] ; do


### PR DESCRIPTION
## Problem

After introducing this: https://github.com/wasmCloud/wasmCloud/issues/2032

some of the github ci steps are flaky doe to the external dependency (GitHub api)
example https://github.com/wasmCloud/wasmCloud/actions/runs/12060066556/job/33630065389
where the sleep is not giving enough time for the `wash up` to get the new version of the wasmcloud and/or wadm before `wash app deploy ...`.

I did some measurement before the commit and now with the following command:
```
hyperfine --runs 100 "../../target/release/wash up -d" --prepare="../../target/release/wash down --all && ../../target/release/wash drain all" --cleanup="../../target/release/wash down --all && ../../target/release/wash drain all" --time-unit=microsecond --export-json={{old|new|new_with_version}}.json
```

and the difference in start time (~0.4 seconds) might be the root cause of the flakiness.

these are just a few metrics that I measured running the command for 100 times on my computer, the actual time might(probably) differ in the GitHub action pipelines.

```json
#new.json
{
  "results": [
    {
      "command": "../../target/release/wash up -d",
      "mean": 4.5176046671900005,
      "stddev": 0.29190612444065595,
      "median": 4.4443525312,
      "user": 0.6242332600000001,
      "system": 0.44115340000000025,
      "min": 4.0033326982,
      "max": 6.0148419472,
      "times": [
        4.5625977812,
        5.3193222392,
        4.4017891982,
        ///...
}
```


```json
#old.json
{
  "results": [
    {
      "command": "../../target/release/wash up -d",
      "mean": 4.20346870174,
      "stddev": 0.2162365136481171,
      "median": 4.209481669240001,
      "user": 0.5394435700000001,
      "system": 0.41381448999999987,
      "min": 3.40764939874,
      "max": 4.76407998174,
      "times": [
        4.76407998174,
        4.00914444074,
        4.202527147740001,
        4.43679148174,
        4.14897160674,
        4.24103123174,
        4.15672989874,
        4.28594685674,
        4.31438885674,
        4.08847635674,
        3.7266441487399997,
        3.40764939874,
        3.60665160674,
        //...
}
```

```json
#new_with_version.json
{
  "results": [
    {
      "command": "../../target/release/wash up -d --wasmcloud-version=v1.4.0 --wadm-version=v0.18.0",
      "mean": 4.3353233158999975,
      "stddev": 0.2868764228516866,
      "median": 4.2906352167,
      "user": 0.5404942500000002,
      "system": 0.41290261,
      "min": 3.9304439872000003,
      "max": 6.1569731122,
      "times": [
        5.4651272792,
        3.9400791542,
        4.4010730712,
        4.0368799042,
        4.6805339462,
        4.1071778212000005,
        4.1151339042,
        4.2288779042,
        4.6846051542,
        ///
}
```


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
