### PR TITLE
feat(flake): Adds wash output package to the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -459,6 +459,10 @@
               ;
 
             rust = hostRustToolchain;
+            wash = pkgs.runCommandLocal "wash" {} ''
+              mkdir -p $out/bin
+              cp ${packages.wasmcloud}/bin/wash $out/bin/wash
+            '';
           };
 
         withDevShells = {


### PR DESCRIPTION
Talking to @rvolosatovs, we probably should split up individual builds eventually, but I did want to make it easier to install wash from the flake (since I'm working on adding one for wadm, and having wash in the devShell there would be good)
