### PR TITLE
feature(wash-cli) test buffered stdout of wash dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -396,3 +396,6 @@ wrpc-transport = { version = "0.28", default-features = false }
 wrpc-transport-nats = { version = "0.27.1", default-features = false, features = [
     "async-nats-0_36",
 ] }
+
+[package.metadata.cargo-machete]
+ignored = ["wasmcloud-provider-lattice-controller", "wasmcloud-provider-sdk"]

--- a/crates/wash-cli/tests/wash_app.rs
+++ b/crates/wash-cli/tests/wash_app.rs
@@ -169,7 +169,6 @@ async fn test_undeploy_all_and_delete_undeployed() -> Result<()> {
     // Wait until the app is deployed via wash app get
     tokio::time::timeout(Duration::from_secs(30), async {
         loop {
-            eprintln!("resp: {:#?}", instance.list_apps().await);
             if instance.list_apps().await.is_ok_and(|output| {
                 output.applications.iter().any(|a| {
                     a.name == "sample"

--- a/crates/wash-cli/tests/wash_dev.rs
+++ b/crates/wash-cli/tests/wash_dev.rs
@@ -1198,6 +1198,7 @@ async fn integration_dev_hello_component_piped_stdout() -> Result<()> {
     // Test setup
     // ========================================================================
     // Create the 'wash dev' process using a piped stdout
+    #[allow(clippy::zombie_processes)]
     let mut proc1 = Command::new(env!("CARGO_BIN_EXE_wash"))
         .env("RUST_BACKTRACE", "full")
         .args([
@@ -1220,6 +1221,7 @@ async fn integration_dev_hello_component_piped_stdout() -> Result<()> {
     let pid1 = proc1.id();
 
     // Create the 'wc -l' process and use the piped stdout of wash dev as stdin
+    #[allow(clippy::zombie_processes)]
     let mut proc2 = Command::new("wc")
         .arg("-l")
         .stdin(
@@ -1276,6 +1278,7 @@ async fn integration_dev_hello_component_piped_stdout() -> Result<()> {
             nix::sys::signal::Signal::SIGINT,
         )
         .expect("cannot send ctrl-c to piped proc(`wc -l`)");
+        proc2.wait()?;
     }
 
     // Give the first process some time to do its job/damage
@@ -1289,6 +1292,7 @@ async fn integration_dev_hello_component_piped_stdout() -> Result<()> {
             nix::sys::signal::Signal::SIGINT,
         )
         .expect("cannot send ctrl-c to proc(`wash dev`)");
+        proc1.wait()?;
     }
 
     // Wait for the processes to complete


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Add an integration test to verify that `wash dev` uses buffered writes to stdout as defined in feature #3706

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
This PR adds a regression test for issue #3680


## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->
Using **crates/wash-cli** as working directory it can be tested as follows:

```console
cargo build
cargo test --test wash_dev -- integration_dev_hello_component_piped_stdout
```

To test a failure; i.e. broken pipe error, replace the **write!()**- to **println!()** calls in **src/bin/wash.rs**.

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->
Following tests have been added:

- wash_dev::integration_dev_hello_component_piped_stdout

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
