### PR TITLE
chore(renovate): add scheduled renovate to bump providers for examples

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -35,9 +35,6 @@
         }
     ],
     "prHourlyLimit": 10,
-    "schedule": [
-        "every weekend"
-    ],
     "prConcurrentLimit": 1,
     "branchConcurrentLimit": 1,
     "packageRules": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,9 @@
     "enabledManagers": [
         "custom.regex"
     ],
+    "repositories": [
+        "wasmCloud/wasmCloud"
+    ],
     "ignorePaths": [
         "**/node_modules/**",
         "**/bower_components/**",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:base"
+    ],
+    "enabledManagers": [
+        "custom.regex"
+    ],
+    "ignorePaths": [
+        "**/node_modules/**",
+        "**/bower_components/**",
+        "**/vendor/**",
+        "**/__tests__/**",
+        "**/test/**",
+        "**/tests/**"
+    ],
+    "includePaths": [
+        "**/examples/**/*wadm.yaml",
+        "**/README.md"
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "description": "Update images in every example wadm.yaml and READMEs",
+            "fileMatch": [
+                ".*wadm.yaml$",
+                "README.md"
+            ],
+            "matchStrings": [
+                "image:\\s*([a-zA-Z0-9]+://)?(?<depName>[a-zA-Z0-9./:_-]+):(?<currentValue>[a-zA-Z0-9._-]+)"
+            ],
+            "datasourceTemplate": "docker",
+            "depNameTemplate": "{{depName}}",
+            "versioningTemplate": "docker"
+        }
+    ],
+    "prHourlyLimit": 10,
+    "schedule": [
+        "every weekend"
+    ],
+    "prConcurrentLimit": 1,
+    "branchConcurrentLimit": 1,
+    "packageRules": [
+        {
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
+                "major"
+            ],
+            "groupName": "example (local.)wadm.yaml and README files"
+        }
+    ]
+}

--- a/.github/workflows/update-example-providers.yml
+++ b/.github/workflows/update-example-providers.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v41.0.5
+        uses: renovatebot/github-action@936628dfbff213ab2eb95033c5e123cfcaf09ebb # v41.0.5
         with:
           configurationFile: .github/renovate-config.json
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/update-example-providers.yml
+++ b/.github/workflows/update-example-providers.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@936628dfbff213ab2eb95033c5e123cfcaf09ebb # v41.0.5
         with:
-          configurationFile: .github/renovate-config.json
+          configurationFile: .github/renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/update-example-providers.yml
+++ b/.github/workflows/update-example-providers.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'wasmCloud/wasmCloud' }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/update-example-providers.yml
+++ b/.github/workflows/update-example-providers.yml
@@ -1,0 +1,21 @@
+name: update-example-providers
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v41.0.5
+        with:
+          configurationFile: .github/renovate-config.json
+          token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Unfortunately dependabot is not flexible enough other than the existing [ecosystems](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem). Although renovate-bot can do that with regular expressions.

Heads-up, you might need to [onboard renovate app](https://docs.renovatebot.com/getting-started/installing-onboarding/) for the repository.

The PRs which will be open should look like this https://github.com/markkovari/wasmCloud/pull/36

- update -> even should create only one PR from now on.

Feel free to edit the name/description/schedule, not sure what is the most convenient.  

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

closes: #2339

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
