### PR TITLE
Fix wash link delete returns success for invalid args

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2911,10 +2911,8 @@ impl Host {
         );
 
         let Some(mut component_spec) = self.get_component_spec(source_id).await? else {
-            // If the component spec doesn't exist, the link is deleted
-            return Ok(CtlResponse::<()>::success(
-                "successfully deleted link (spec doesn't exist)".into(),
-            ));
+            // If the component spec doesn't exist, then the link does not exist ;-)
+            return Ok(CtlResponse::error("link does not exist"));
         };
 
         // If we can find an existing link with the same source, namespace, package, and name, remove it

--- a/crates/wash-cli/src/common/link_cmd.rs
+++ b/crates/wash-cli/src/common/link_cmd.rs
@@ -87,7 +87,16 @@ pub async fn handle_command(
 
             let failure = delete_link(wco, &source_id, &link_name, &namespace, &package)
                 .await
-                .map_or_else(|e| Some(format!("{e}")), |_| None);
+                .map_or_else(
+                    |e| Some(format!("{e}")),
+                    |response| {
+                        if response.succeeded() {
+                            None
+                        } else {
+                            Some(response.message().to_string())
+                        }
+                    },
+                );
 
             link_del_output(&source_id, &link_name, &namespace, &package, failure)?
         }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Return an error message when trying to delete a link that does not exist. 

Fixes issue #3683.

Changes components:

- **wash-cli**
- **wasmcloud(_host)**

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->
Preamble build wasmcloud(host) and wash-cli (assuming the repo is at **~/dev/wasmcloud**):

1. cd ~/dev/wasmcloud; cargo build -j 6
2. cd ~/dev/wasmcloud/crates/wash-cli; cargo build -j 6

Start up wasmcloud, get an overview of the (current) links and delete a non-existent one:

1. export WASMCLOUD_HOST_PATH=$HOME/dev/wasmcloud/target/debug/wasmcloud
2. $HOME/dev/wasmcloud/target/debug/wash up -d 
3. $HOME/dev/wasmcloud/target/debug/wash get links
```bash
>>> ⢀⠀                                                                                                                                                                                                                                        
                                                                                                                       
  Source ID                                            Target                    Interface(s)                 Name     
  dev_ekgdmd_http_hello_world-ekgdmd_dep_http_server   eKgDmd-http-hello-world   wasi:http/incoming-handler   default  
  dev_exbk4g_http_hello_world-exbk4g_dep_http_server   EXBK4G-http-hello-world   wasi:http/incoming-handler   default  
```                                                                                                                       
4. $HOME/dev/wasmcloud/target/debug/wash links del dev_xxxxx_http_hello_world-xxxxxx_dep_http_server wasi HTTP 
```bash

Error deleting link: link does not exist
```

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->
None

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->
None

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
See **_Testing_** section.