### PR TITLE
fix: gate messaging behind feature flag

### DIFF
--- a/crates/host/src/wasmbus/experimental.rs
+++ b/crates/host/src/wasmbus/experimental.rs
@@ -10,6 +10,8 @@ pub struct Features {
     /// Enable the built-in NATS Messaging capability provider
     /// that can be started with the reference wasmcloud+builtin://messaging-nats
     pub(crate) builtin_messaging_nats: bool,
+    /// Enable the wasmcloud:messaging@v3 interface support in the host
+    pub(crate) wasmcloud_messaging_v3: bool,
 }
 
 impl Features {
@@ -29,6 +31,12 @@ impl Features {
         self.builtin_messaging_nats = true;
         self
     }
+
+    /// Enable the wasmcloud:messaging@v3 interface support in the host
+    pub fn enable_wasmcloud_messaging_v3(mut self) -> Self {
+        self.wasmcloud_messaging_v3 = true;
+        self
+    }
 }
 
 /// This enables unioning feature flags together
@@ -39,6 +47,7 @@ impl std::ops::BitOr for Features {
         Self {
             builtin_http_server: self.builtin_http_server || rhs.builtin_http_server,
             builtin_messaging_nats: self.builtin_messaging_nats || rhs.builtin_messaging_nats,
+            wasmcloud_messaging_v3: self.wasmcloud_messaging_v3 || rhs.wasmcloud_messaging_v3,
         }
     }
 }
@@ -62,10 +71,22 @@ impl From<&str> for Features {
             "builtin-messaging-nats" | "builtin_messaging_nats" => {
                 Self::new().enable_builtin_messaging_nats()
             }
+            "wasmcloud-messaging-v3" | "wasmcloud_messaging_v3" => {
+                Self::new().enable_wasmcloud_messaging_v3()
+            }
             _ => {
                 warn!(%s, "unknown feature flag");
                 Self::new()
             }
+        }
+    }
+}
+
+/// Convert the host feature flags to the runtime feature flags
+impl From<Features> for wasmcloud_runtime::experimental::Features {
+    fn from(f: Features) -> wasmcloud_runtime::experimental::Features {
+        wasmcloud_runtime::experimental::Features {
+            wasmcloud_messaging_v3: f.wasmcloud_messaging_v3,
         }
     }
 }

--- a/crates/host/src/wasmbus/experimental.rs
+++ b/crates/host/src/wasmbus/experimental.rs
@@ -6,10 +6,10 @@ use tracing::warn;
 pub struct Features {
     /// Enable the built-in HTTP server capability provider
     /// that can be started with the reference wasmcloud+builtin://http-server
-    pub(crate) builtin_http: bool,
+    pub(crate) builtin_http_server: bool,
     /// Enable the built-in NATS Messaging capability provider
     /// that can be started with the reference wasmcloud+builtin://messaging-nats
-    pub(crate) builtin_messaging: bool,
+    pub(crate) builtin_messaging_nats: bool,
 }
 
 impl Features {
@@ -19,14 +19,14 @@ impl Features {
     }
 
     /// Enable the built-in HTTP server capability provider
-    pub fn enable_builtin_http(mut self) -> Self {
-        self.builtin_http = true;
+    pub fn enable_builtin_http_server(mut self) -> Self {
+        self.builtin_http_server = true;
         self
     }
 
     /// Enable the built-in NATS messaging capability provider
-    pub fn enable_builtin_messaging(mut self) -> Self {
-        self.builtin_messaging = true;
+    pub fn enable_builtin_messaging_nats(mut self) -> Self {
+        self.builtin_messaging_nats = true;
         self
     }
 }
@@ -37,8 +37,8 @@ impl std::ops::BitOr for Features {
 
     fn bitor(self, rhs: Self) -> Self::Output {
         Self {
-            builtin_http: self.builtin_http || rhs.builtin_http,
-            builtin_messaging: self.builtin_messaging || rhs.builtin_messaging,
+            builtin_http_server: self.builtin_http_server || rhs.builtin_http_server,
+            builtin_messaging_nats: self.builtin_messaging_nats || rhs.builtin_messaging_nats,
         }
     }
 }
@@ -56,8 +56,12 @@ impl std::iter::Sum for Features {
 impl From<&str> for Features {
     fn from(s: &str) -> Self {
         match &*s.to_ascii_lowercase() {
-            "builtin-http" | "builtin_http" => Self::new().enable_builtin_http(),
-            "builtin-messaging" | "builtin_messaging" => Self::new().enable_builtin_messaging(),
+            "builtin-http-server" | "builtin_http_server" => {
+                Self::new().enable_builtin_http_server()
+            }
+            "builtin-messaging-nats" | "builtin_messaging_nats" => {
+                Self::new().enable_builtin_messaging_nats()
+            }
             _ => {
                 warn!(%s, "unknown feature flag");
                 Self::new()

--- a/crates/host/src/wasmbus/handler.rs
+++ b/crates/host/src/wasmbus/handler.rs
@@ -26,7 +26,7 @@ use wasmcloud_tracing::context::TraceContextInjector;
 use wrpc_transport::InvokeExt as _;
 
 use super::config::ConfigBundle;
-use super::injector_to_headers;
+use super::{injector_to_headers, Features};
 
 #[derive(Clone, Debug)]
 pub struct Handler {
@@ -62,6 +62,8 @@ pub struct Handler {
     pub messaging_links: Arc<RwLock<HashMap<Box<str>, async_nats::Client>>>,
 
     pub invocation_timeout: Duration,
+    /// Experimental features enabled in the host for gating handler functionality
+    pub experimental_features: Features,
 }
 
 impl Handler {
@@ -78,6 +80,7 @@ impl Handler {
             instance_links: self.instance_links.clone(),
             messaging_links: self.messaging_links.clone(),
             invocation_timeout: self.invocation_timeout,
+            experimental_features: self.experimental_features,
         }
     }
 }
@@ -585,6 +588,7 @@ impl MessagingHostMessage0_3 for Message {
 }
 
 impl Messaging0_3 for Handler {
+    #[instrument(level = "debug", skip_all)]
     async fn connect(
         &self,
         name: String,
@@ -596,6 +600,7 @@ impl Messaging0_3 for Handler {
         })))
     }
 
+    #[instrument(level = "debug", skip_all)]
     async fn send(
         &self,
         client: &(dyn MessagingClient0_3 + Send + Sync),
@@ -741,6 +746,7 @@ impl Messaging0_3 for Handler {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     async fn request(
         &self,
         client: &(dyn MessagingClient0_3 + Send + Sync),
@@ -906,6 +912,7 @@ impl Messaging0_3 for Handler {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     async fn reply(
         &self,
         reply_to: &messaging0_3_0::types::Message,

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2621,7 +2621,7 @@ impl Host {
                     .await?
                 }
                 (None, ResourceRef::Builtin(name)) => match *name {
-                    "http-server" if self.experimental_features.builtin_http => {
+                    "http-server" if self.experimental_features.builtin_http_server => {
                         self.start_http_server_provider(
                             &mut tasks,
                             link_definitions,
@@ -2632,8 +2632,10 @@ impl Host {
                         )
                         .await?
                     }
-                    "http-server" => bail!("feature `builtin-http` is not enabled, denying start"),
-                    "messaging-nats" if self.experimental_features.builtin_messaging => {
+                    "http-server" => {
+                        bail!("feature `builtin-http-server` is not enabled, denying start")
+                    }
+                    "messaging-nats" if self.experimental_features.builtin_messaging_nats => {
                         self.start_messaging_nats_provider(
                             &mut tasks,
                             link_definitions,
@@ -2645,7 +2647,7 @@ impl Host {
                         .await?
                     }
                     "messaging-nats" => {
-                        bail!("feature `messaging-nats` is not enabled, denying start")
+                        bail!("feature `builtin-messaging-nats` is not enabled, denying start")
                     }
                     _ => bail!("unknown builtin name: {name}"),
                 },

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -824,6 +824,7 @@ impl Host {
             .max_linear_memory(config.max_linear_memory)
             .max_components(config.max_components)
             .max_component_size(config.max_component_size)
+            .experimental_features(config.experimental_features.into())
             .build()
             .context("failed to build runtime")?;
         let event_builder = EventBuilderV10::new().source(host_key.public_key());
@@ -1451,6 +1452,7 @@ impl Host {
                 Arc::clone(links.entry(Arc::clone(&component_id)).or_default())
             },
             invocation_timeout: Duration::from_secs(10), // TODO: Make this configurable
+            experimental_features: self.experimental_features,
         };
         let component = wasmcloud_runtime::Component::new(&self.runtime, &wasm)?;
         let component = self

--- a/crates/runtime/src/component/messaging/mod.rs
+++ b/crates/runtime/src/component/messaging/mod.rs
@@ -1,10 +1,9 @@
 use core::ops::Deref;
 
 use anyhow::Context as _;
-use tracing::{info_span, instrument, warn, Instrument as _, Span};
+use tracing::{instrument, warn, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
-use crate::capability::messaging0_2_0::types;
 use crate::capability::wrpc;
 use crate::component::{new_store, Handler, Instance, WrpcServeEvent};
 
@@ -25,41 +24,23 @@ where
         // Set the parent of the current context to the span passed in
         Span::current().set_parent(cx.deref().context());
         let mut store = new_store(&self.engine, self.handler.clone(), self.max_execution_time);
-        let call_handle_message = info_span!("call_handle_message");
-        store.data_mut().parent_context = Some(call_handle_message.context());
 
-        let res = if let Ok(pre) = v0_3::bindings::MessagingHandlerPre::new(self.pre.clone()) {
-            let bindings = pre.instantiate_async(&mut store).await?;
-            let msg = store
-                .data_mut()
-                .table
-                .push(v0_3::Message::Wrpc(msg))
-                .context("failed to push message to table")?;
-            bindings
-                .wasmcloud_messaging0_3_0_incoming_handler()
-                .call_handle(&mut store, msg)
-                .instrument(call_handle_message)
-                .await
-                .context("failed to call `wasmcloud:messaging/incoming-handler@0.3.0#handle`")
-                .map(|err| err.map_err(|err| err.to_string()))
+        // If wasmcloud:messaging@0.3.0 is enabled and we can instantiate the 0.3.0 bindings,
+        // handle the message using 0.3.0. Otherwise, use the 0.2.0 bindings.
+        let res = if self.experimental_features.wasmcloud_messaging_v3 {
+            if let Ok(pre) = v0_3::bindings::MessagingHandlerPre::new(self.pre.clone()) {
+                v0_3::handle_message(pre, &mut store, msg).await
+            } else {
+                let pre = v0_2::bindings::MessagingHandlerOhTwoPre::new(self.pre.clone())
+                    .context("failed to pre-instantiate `wasmcloud:messaging/handler`")?;
+                v0_2::handle_message(pre, &mut store, msg).await
+            }
         } else {
             let pre = v0_2::bindings::MessagingHandlerOhTwoPre::new(self.pre.clone())
                 .context("failed to pre-instantiate `wasmcloud:messaging/handler`")?;
-            let bindings = pre.instantiate_async(&mut store).await?;
-            bindings
-                .wasmcloud_messaging0_2_0_handler()
-                .call_handle_message(
-                    &mut store,
-                    &types::BrokerMessage {
-                        subject: msg.subject,
-                        body: msg.body.into(),
-                        reply_to: msg.reply_to,
-                    },
-                )
-                .instrument(call_handle_message)
-                .await
-                .context("failed to call `wasmcloud:messaging/handler@0.2.0#handle-message`")
+            v0_2::handle_message(pre, &mut store, msg).await
         };
+
         let success = res.is_ok();
         if let Err(err) =
             self.events

--- a/crates/runtime/src/component/messaging/v0_2.rs
+++ b/crates/runtime/src/component/messaging/v0_2.rs
@@ -1,9 +1,13 @@
 use core::future::Future;
 
+use anyhow::Context as _;
 use async_trait::async_trait;
-use tracing::instrument;
+use tracing::{info_span, instrument, Instrument as _};
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+use wasmtime::Store;
 
 use crate::capability::messaging0_2_0::{consumer, types};
+use crate::capability::wrpc;
 use crate::component::{Ctx, Handler};
 
 pub mod bindings {
@@ -56,4 +60,31 @@ where
         self.attach_parent_context();
         self.handler.publish(msg).await
     }
+}
+
+#[instrument(level = "debug", skip_all)]
+pub(crate) async fn handle_message<H>(
+    pre: bindings::MessagingHandlerOhTwoPre<Ctx<H>>,
+    mut store: &mut Store<Ctx<H>>,
+    msg: wrpc::wasmcloud::messaging0_2_0::types::BrokerMessage,
+) -> anyhow::Result<Result<(), String>>
+where
+    H: Handler,
+{
+    let call_handle_message = info_span!("call_handle_message");
+    store.data_mut().parent_context = Some(call_handle_message.context());
+    let bindings = pre.instantiate_async(&mut store).await?;
+    bindings
+        .wasmcloud_messaging0_2_0_handler()
+        .call_handle_message(
+            &mut store,
+            &types::BrokerMessage {
+                subject: msg.subject,
+                body: msg.body.into(),
+                reply_to: msg.reply_to,
+            },
+        )
+        .instrument(call_handle_message)
+        .await
+        .context("failed to call `wasmcloud:messaging/handler@0.2.0#handle-message`")
 }

--- a/crates/runtime/src/experimental.rs
+++ b/crates/runtime/src/experimental.rs
@@ -1,0 +1,59 @@
+use tracing::warn;
+
+/// Feature flags to enable experimental functionality in the runtime. Flags are disabled
+/// by default and must be explicitly enabled.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Features {
+    /// Enable the wasmcloud:messaging@v3 interface support in the runtime
+    pub wasmcloud_messaging_v3: bool,
+}
+
+impl Features {
+    /// Create a new set of feature flags with all features disabled
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enable the wasmcloud:messaging@v3 interface support in the runtime
+    #[must_use]
+    pub fn enable_wasmcloud_messaging_v3(mut self) -> Self {
+        self.wasmcloud_messaging_v3 = true;
+        self
+    }
+}
+
+/// This enables unioning feature flags together
+impl std::ops::BitOr for Features {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self {
+            wasmcloud_messaging_v3: self.wasmcloud_messaging_v3 || rhs.wasmcloud_messaging_v3,
+        }
+    }
+}
+
+/// Allow for summing over a collection of feature flags
+impl std::iter::Sum for Features {
+    fn sum<I: Iterator<Item = Self>>(mut iter: I) -> Self {
+        // Grab the first set of flags, fall back on defaults (all disabled)
+        let first = iter.next().unwrap_or_default();
+        iter.fold(first, |a, b| a | b)
+    }
+}
+
+/// Parse a feature flag from a string, enabling the feature if the string matches
+impl From<&str> for Features {
+    fn from(s: &str) -> Self {
+        match &*s.to_ascii_lowercase() {
+            "wasmcloud-messaging-v3" | "wasmcloud_messaging_v3" => {
+                Self::new().enable_wasmcloud_messaging_v3()
+            }
+            _ => {
+                warn!(%s, "unknown feature flag");
+                Self::new()
+            }
+        }
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -13,6 +13,9 @@ pub mod component;
 /// Capability bindings
 pub mod capability;
 
+/// Feature flags to enable experimental functionality in the runtime
+pub mod experimental;
+
 /// Shared wasmCloud runtime engine
 pub mod runtime;
 

--- a/crates/test-util/src/host.rs
+++ b/crates/test-util/src/host.rs
@@ -103,7 +103,8 @@ impl WasmCloudTestHost {
             secrets_topic_prefix,
             experimental_features: Features::new()
                 .enable_builtin_http_server()
-                .enable_builtin_messaging_nats(),
+                .enable_builtin_messaging_nats()
+                .enable_wasmcloud_messaging_v3(),
             ..Default::default()
         };
         if let Some(psc) = policy_service_config {

--- a/crates/test-util/src/host.rs
+++ b/crates/test-util/src/host.rs
@@ -102,8 +102,8 @@ impl WasmCloudTestHost {
             allow_file_load: true,
             secrets_topic_prefix,
             experimental_features: Features::new()
-                .enable_builtin_http()
-                .enable_builtin_messaging(),
+                .enable_builtin_http_server()
+                .enable_builtin_messaging_nats(),
             ..Default::default()
         };
         if let Some(psc) = policy_service_config {


### PR DESCRIPTION
- **refactor(host): consistently name features**
- **feat(host): gate messaging@v3 behind feature flag**

## Feature or Problem
This PR:
1. More consistently names the builtin features
1. Gates the wasmcloud:messaging@v3 interface behind a feature flag to note its experimental status.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
The integration tests fail if this feature flag is not enabled, as designed:

```bash
TRACE handle:call_http_incoming_handle:wit-bindgen import: wasmcloud_runtime::capability::wasmtime_bindings::wasmcloud::messaging0_3_0::types: call name="" module="types" function="[static]client.connect"
TRACE handle:call_http_incoming_handle:wit-bindgen import: wasmcloud_runtime::capability::wasmtime_bindings::wasmcloud::messaging0_3_0::types: return result=Err(wasmcloud-messaging-v3 feature flag is disabled, rejecting invocation) module="types" function="[static]client.connect"
 WARN handle: wasmcloud_runtime::component::http: failed to call `wasi:http/incoming-handler.handle` err=error while executing at wasm backtrace:
    0: 0x685ed5 - wit-component:shim!indirect-wasmcloud:messaging/types@0.3.0-[static]client.connect
    1: 0x96165 - interfaces_reactor.wasm!_ZN19wasmcloud_component8bindings9wasmcloud14messaging0_3_05types6Client7connect17h47ee842ac7bc50aeE
    2: 0x3be73 - interfaces_reactor.wasm!_ZN18interfaces_reactor9messaging8run_test17h05d96e0311fc905cE
    3: 0x30e08 - interfaces_reactor.wasm!_ZN18interfaces_reactor8run_test17he90b7db4683b8f7eE
    4: 0x4af71 - interfaces_reactor.wasm!_ZN18interfaces_reactor4http15assert_http_run17he770875f5bd821f0E
    5: 0x2c721 - interfaces_reactor.wasm!_ZN18interfaces_reactor4http120_$LT$impl$u20$interfaces_reactor..exports..wasi..http..incoming_handler..Guest$u20$for$u20$interfaces_reactor..Actor$GT$6handle17h6a638c195a05c448E
    6: 0x418da - interfaces_reactor.wasm!_ZN18interfaces_reactor7exports4wasi4http16incoming_handler19_export_handle_cabi17ha7f9e8bf8558edd4E
    7: 0x31ab3 - interfaces_reactor.wasm!wasi:http/incoming-handler@0.2.2#handle
note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information

Caused by:
    wasmcloud-messaging-v3 feature flag is disabled, rejecting invocation
```

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
