### PR TITLE
Add more e2e tests

### DIFF
--- a/typescript/apps/washboard-ui/.eslintrc.cjs
+++ b/typescript/apps/washboard-ui/.eslintrc.cjs
@@ -21,6 +21,17 @@ const config = {
       },
     },
   },
+  overrides: [
+    {
+      files: ['*.spec.ts?(x)', '*.fixture.ts?(x)', '*.test.ts?(x)'],
+      rules: {
+        // the 'use' function is not a react hook
+        'react-hooks/rules-of-hooks': 'off',
+        // playwright Locators do not have the dataset property
+        'unicorn/prefer-dom-node-dataset': 'off',
+      },
+    },
+  ],
 };
 
 module.exports = config;

--- a/typescript/apps/washboard-ui/src/app/components/components-table.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/components-table.tsx
@@ -126,7 +126,7 @@ export function ComponentsTable(): ReactElement {
             <TableBody>
               {table.getRowModel().rows?.length ? (
                 table.getRowModel().rows.map((row) => (
-                  <Collapsible key={row.id} asChild>
+                  <Collapsible key={row.id} asChild data-testid="component">
                     <Fragment>
                       <TableRow>
                         {row

--- a/typescript/apps/washboard-ui/src/app/components/configs-table.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/configs-table.tsx
@@ -112,7 +112,7 @@ export function ConfigsTable(): ReactElement {
             <TableBody>
               {table.getRowModel().rows?.length ? (
                 table.getRowModel().rows.map((row) => (
-                  <Collapsible key={row.id} asChild>
+                  <Collapsible key={row.id} asChild data-testid="config">
                     <Fragment>
                       <TableRow>
                         {row

--- a/typescript/apps/washboard-ui/src/app/components/connection-status.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/connection-status.tsx
@@ -4,24 +4,28 @@ import * as React from 'react';
 
 export function ConnectionStatus(): React.ReactElement {
   const {config: latticeConfig} = useLatticeConfig();
-  const [status, setStatus] = React.useState<'PENDING' | 'ONLINE' | 'OFFLINE'>('PENDING');
+  const [status, setStatus] = React.useState<'Pending' | 'Online' | 'Offline'>('Pending');
   React.useEffect(() => {
     canConnect(latticeConfig?.latticeUrl).then((online) =>
-      setStatus(online ? 'ONLINE' : 'OFFLINE'),
+      setStatus(online ? 'Online' : 'Offline'),
     );
   }, [latticeConfig.latticeUrl]);
+
   return (
     <div
+      data-testid="connection-status"
+      data-status={status}
       className={clsx(
         {
-          PENDING: 'text-gray-500 bg-gray-100/10',
-          ONLINE: 'text-green-400 bg-green-400/10',
-          OFFLINE: 'text-rose-400 bg-rose-400/10',
+          Pending: 'text-gray-500 bg-gray-100/10',
+          Online: 'text-green-400 bg-green-400/10',
+          Offline: 'text-rose-400 bg-rose-400/10',
         }[status],
         'flex-none rounded-full p-1',
       )}
     >
       <div className="size-2 rounded-full bg-current" />
+      <span className="sr-only">Lattice Connection: {status}</span>
     </div>
   );
 }

--- a/typescript/apps/washboard-ui/src/app/components/hosts-summary.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/hosts-summary.tsx
@@ -17,7 +17,7 @@ export function HostsSummary(): ReactElement {
       <div className="grid grid-cols-1 grid-rows-1 gap-2">
         <Accordion type="single" collapsible className="w-full">
           {hostsArray.map((host) => (
-            <AccordionItem value={host.host_id} key={host.host_id}>
+            <AccordionItem value={host.host_id} key={host.host_id} data-testid="host">
               <AccordionTrigger>
                 <div className="me-2 flex w-full gap-2">
                   <Badge>{host.version}</Badge>

--- a/typescript/apps/washboard-ui/src/app/components/links-table.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/links-table.tsx
@@ -42,7 +42,11 @@ export function LinksTable(): React.ReactElement {
 
   return (
     <div>
-      <DataTable columns={columns as ColumnDef<WasmCloudLink>[]} data={data} />
+      <DataTable
+        columns={columns as ColumnDef<WasmCloudLink>[]}
+        data={data}
+        rowProps={{'data-testid': 'link'}}
+      />
     </div>
   );
 }

--- a/typescript/apps/washboard-ui/src/app/components/providers-table.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/providers-table.tsx
@@ -178,7 +178,7 @@ const ProviderTableBody = (table: ReactTable<WasmCloudProvider>) => {
     <TableBody>
       {table.getRowModel().rows?.length ? (
         table.getRowModel().rows.map((row) => (
-          <Collapsible key={row.id} asChild>
+          <Collapsible key={row.id} asChild data-testid="provider">
             <>
               <ProvidersTableMainRow {...row} />
               <CollapsibleContent asChild>

--- a/typescript/apps/washboard-ui/src/app/components/settings.tsx
+++ b/typescript/apps/washboard-ui/src/app/components/settings.tsx
@@ -1,5 +1,5 @@
 import {SettingsIcon} from 'lucide-react';
-import {PropsWithChildren, ReactElement} from 'react';
+import {PropsWithChildren, ReactElement, useState} from 'react';
 import {DarkModeToggle} from '@/app/components/dark-mode-toggle';
 import {LatticeSettings} from '@/app/components/lattice-settings';
 import {Button} from '@/components/button';
@@ -16,8 +16,10 @@ import {
 import {WadmManagedToggle} from './wadm-indicator/wadm-managed-toggle';
 
 function Settings(): ReactElement {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+
   return (
-    <Sheet>
+    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
       <SheetTrigger asChild>
         <Button variant="ghost" size="icon" className="size-6 p-0.5">
           <SettingsIcon className="size-full" />
@@ -48,7 +50,7 @@ function Settings(): ReactElement {
           <SettingsSection>
             <SettingsSectionLabel>Lattice Configuration</SettingsSectionLabel>
             <SettingsSectionContent>
-              <LatticeSettings />
+              <LatticeSettings onSubmit={() => setIsSheetOpen(false)} />
             </SettingsSectionContent>
           </SettingsSection>
         </div>

--- a/typescript/apps/washboard-ui/src/components/data-table/index.tsx
+++ b/typescript/apps/washboard-ui/src/components/data-table/index.tsx
@@ -11,13 +11,17 @@ import {
 import * as React from 'react';
 import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/table';
 
+type RowProps = React.HTMLAttributes<HTMLTableRowElement> & Record<`data-${string}`, string>;
+
 type DataTableProps<TData, TValue> = {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  rowProps?: RowProps | ((row: TData) => RowProps);
 };
 export function DataTable<TData, TValue>({
   data,
   columns,
+  rowProps = {},
 }: DataTableProps<TData, TValue>): React.ReactElement {
   const [sorting, setSorting] = React.useState<SortingState>([]);
 
@@ -31,6 +35,11 @@ export function DataTable<TData, TValue>({
     getFilteredRowModel: getFilteredRowModel(),
     state: {sorting},
   });
+
+  const generateRowProps = React.useCallback(
+    (row: TData) => (typeof rowProps === 'function' ? rowProps(row) : rowProps),
+    [rowProps],
+  );
 
   return (
     <div className="w-full">
@@ -57,7 +66,7 @@ export function DataTable<TData, TValue>({
           <TableBody>
             {table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id}>
+                <TableRow key={row.id} data-testid="" {...generateRowProps(row.original)}>
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/typescript/apps/washboard-ui/src/components/sheet/index.tsx
+++ b/typescript/apps/washboard-ui/src/components/sheet/index.tsx
@@ -29,7 +29,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+  'fixed z-50 gap-4 overflow-auto bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
   {
     variants: {
       side: {

--- a/typescript/apps/washboard-ui/tests/common/test.ts
+++ b/typescript/apps/washboard-ui/tests/common/test.ts
@@ -1,28 +1,45 @@
-/* eslint-disable react-hooks/rules-of-hooks -- Disabling rules-of-hooks since these are Playwright extensions */
-
 import {test as base} from '@playwright/test';
 
 import {logger} from './logger';
 import {WasmCloudInstance, WasmCloudInstanceOptions} from './wasmcloud-instance';
 
-export type TestMeta = {instance: WasmCloudInstance};
+export type WasmCloudInstanceFixture = {
+  wasmCloud: WasmCloudInstance;
+  wasmCloudOptions: WasmCloudInstanceOptions;
+};
 
 // Extend basic test by providing a wasmCloud instance that starts before
 // the tests run and enables programmatic manipulation of a wasmCloud instance via `wash`
-export const test = base.extend<TestMeta>({
-  instance: async ({page}, use) => {
-    const instance = new WasmCloudInstance({
-      ...WasmCloudInstanceOptions.default(),
-      washUI: {
-        // NOTE: this port is set to the deafult for the `webServer` configured via playwright config
-        port: 5173,
-      },
-    });
-    await instance.start();
-    const uiBaseURL = instance.uiBaseURL();
-    logger.debug(`UI available at @ ${uiBaseURL}]`);
-    await page.goto(uiBaseURL);
-    await use(instance);
-    await instance.stop();
-  },
+export const test = base.extend<WasmCloudInstanceFixture>({
+  wasmCloudOptions: {},
+  wasmCloud: [
+    async ({wasmCloudOptions}, use, testInfo) => {
+      const instance = new WasmCloudInstance({
+        ...WasmCloudInstanceOptions.default(),
+        ...wasmCloudOptions,
+      });
+      await test.step(`Start (${instance.uuid()})`, async () => {
+        if (wasmCloudOptions.startWashUI) {
+          await instance.start();
+          const uiBaseURL = instance.uiBaseURL();
+          logger.debug(`UI available at @ ${uiBaseURL}]`);
+          test.use({baseURL: uiBaseURL});
+        }
+      });
+
+      await use(instance);
+
+      await test.step(`Stop (${instance.uuid()})`, async () => {
+        await instance.stop();
+
+        // Attach logs if the test failed
+        if (testInfo.status !== testInfo.expectedStatus) {
+          for (const [name, logFile] of Object.entries(instance.logPaths)) {
+            testInfo.attachments.push({name, contentType: 'text/plain', path: logFile});
+          }
+        }
+      });
+    },
+    {title: 'wasmCloud', auto: true},
+  ],
 });

--- a/typescript/apps/washboard-ui/tests/common/test.ts
+++ b/typescript/apps/washboard-ui/tests/common/test.ts
@@ -19,10 +19,10 @@ export const test = base.extend<WasmCloudInstanceFixture>({
         ...wasmCloudOptions,
       });
       await test.step(`Start (${instance.uuid()})`, async () => {
+        await instance.start();
         if (wasmCloudOptions.startWashUI) {
-          await instance.start();
           const uiBaseURL = instance.uiBaseURL();
-          logger.debug(`UI available at @ ${uiBaseURL}]`);
+          logger.debug(`UI available at @ ${uiBaseURL}`);
           test.use({baseURL: uiBaseURL});
         }
       });

--- a/typescript/apps/washboard-ui/tests/common/wasmcloud-instance.ts
+++ b/typescript/apps/washboard-ui/tests/common/wasmcloud-instance.ts
@@ -130,6 +130,14 @@ export class WasmCloudInstance {
     };
   }
 
+  get pids() {
+    const pids = new Map<WashProcessType, number>();
+    for (const [type, processAndMeta] of this.#processes.entries()) {
+      if (!processAndMeta.stopped) pids.set(type, processAndMeta.process?.pid ?? -1);
+    }
+    return pids;
+  }
+
   constructor(options?: WasmCloudInstanceOptions) {
     this.opts = options ?? WasmCloudInstanceOptions.default();
     this.#_uuid = uuidv1();

--- a/typescript/apps/washboard-ui/tests/e2e/fixtures/home-page.fixture.ts
+++ b/typescript/apps/washboard-ui/tests/e2e/fixtures/home-page.fixture.ts
@@ -1,0 +1,65 @@
+import {type Page, type Locator, expect} from '@playwright/test';
+
+export class HomePage {
+  readonly #connectionStatus: Locator;
+
+  constructor(readonly page: Page) {
+    this.#connectionStatus = this.page.getByTestId('connection-status');
+  }
+
+  async goto() {
+    await this.page.goto('/');
+  }
+
+  async expectConnectionStatus(status: string, options?: {timeout?: number; ignoreCase?: boolean}) {
+    await expect(this.#connectionStatus).toHaveAttribute('data-status', status, options);
+  }
+
+  async changeSettings(fields: Array<{label: string; value: string}>) {
+    await this.openSettings();
+    for (const {label, value} of fields) {
+      await this.page.getByLabel(label).fill(value);
+    }
+    await this.saveSettings();
+    await this.openSettings();
+    for (const {label, value} of fields) {
+      await expect(this.page.getByLabel(label)).toHaveValue(value);
+    }
+    await this.saveSettings();
+  }
+
+  async refreshLattice() {
+    await this.openSettings();
+    await this.saveSettings();
+  }
+
+  async openSettings() {
+    await this.page.getByRole('button', {name: 'Settings'}).click();
+    await expect(this.page.getByRole('dialog', {name: 'Settings'})).toBeVisible();
+  }
+
+  async saveSettings() {
+    await this.page.getByRole('button', {name: 'Update'}).click();
+    await expect(this.page.getByRole('dialog', {name: 'Settings'})).toBeHidden();
+  }
+
+  async hosts() {
+    return this.page.getByTestId('host');
+  }
+
+  async components() {
+    return this.page.getByTestId('component');
+  }
+
+  async providers() {
+    return this.page.getByTestId('provider');
+  }
+
+  async links() {
+    return this.page.getByTestId('link');
+  }
+
+  async configs() {
+    return this.page.getByTestId('config');
+  }
+}

--- a/typescript/apps/washboard-ui/tests/e2e/home.spec.ts
+++ b/typescript/apps/washboard-ui/tests/e2e/home.spec.ts
@@ -2,11 +2,13 @@ import {expect} from '@playwright/test';
 
 import {test} from '../common';
 
-/// ////////
-// Tests //
-/// ////////
-
-test('home page has the the proper title', async ({page, instance}) => {
-  await page.goto(instance.uiBaseURL());
+test('home page has the the proper title', async ({page}) => {
+  await page.goto('/');
   await expect(page).toHaveTitle('wasmCloud UI | Washboard 🏄');
+});
+
+test('page shows the application frame', async ({page}) => {
+  await page.goto('/');
+  const rootElement = await page.$('#root');
+  await expect(await rootElement.innerHTML()).toBeTruthy();
 });

--- a/typescript/apps/washboard-ui/tests/e2e/home.spec.ts
+++ b/typescript/apps/washboard-ui/tests/e2e/home.spec.ts
@@ -1,14 +1,25 @@
 import {expect} from '@playwright/test';
 
-import {test} from '../common';
+import {test as base} from '../common';
+import {HomePage} from './fixtures/home-page.fixture';
 
-test('home page has the the proper title', async ({page}) => {
-  await page.goto('/');
+const test = base.extend<{homePage: HomePage}>({
+  homePage: async ({page, wasmCloud}, use) => {
+    const homePage = new HomePage(page);
+    await homePage.goto();
+    await homePage.expectConnectionStatus('Online');
+    await homePage.changeSettings([{label: 'Lattice ID', value: wasmCloud.uuid()}]);
+    await use(homePage);
+  },
+});
+
+test('has the the proper title', async ({
+  page,
+  homePage, // eslint-disable-line @typescript-eslint/no-unused-vars -- including the fixture is what enables it
+}) => {
   await expect(page).toHaveTitle('wasmCloud UI | Washboard 🏄');
 });
 
-test('page shows the application frame', async ({page}) => {
-  await page.goto('/');
-  const rootElement = await page.$('#root');
-  await expect(await rootElement.innerHTML()).toBeTruthy();
+test('shows host status', async ({homePage}) => {
+  await expect(await homePage.hosts()).toHaveCount(1);
 });


### PR DESCRIPTION
## Description
Added some new E2E tests for the washboard ui. There's a number of changes in the `typescript/apps/washboard-ui/src` folder which are related to fixing bugs and accessing ui elements through some common `data-testid` attributes. Because of this, it might be easier to review the changes in the `typescript/apps/washboard-ui/tests` folder first.

### Commits
- **test(washboard): make wasmcloud fixture automatic and configurable**
- **test(washboard): add UI e2e tests**
- **chore(washboard): update eslint config for better e2e devx**
