### PR TITLE
chore(ci): Use `create-github-app-token` action for Renovate workflow

### DIFF
--- a/.github/workflows/update-example-providers.yml
+++ b/.github/workflows/update-example-providers.yml
@@ -13,10 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'wasmCloud/wasmCloud' }}
     steps:
+      - id: app-token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@e3a862510f27d57a380efb11f0b52ad7e8dbf213 # v41.0.6
         with:
           configurationFile: .github/renovate.json
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Feature or Problem

This uses the same [GitHub App](https://github.com/apps/wasmcloud-automation-app) we've set up for the [Nix flake update](https://github.com/wasmCloud/wasmCloud/pull/3827) and [Nix OCI image update](https://github.com/wasmCloud/wasmCloud/pull/3828) actions so that it doesn't show up under my personal account.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
