### PR TITLE
fix: Go http hello world template

### DIFF
--- a/examples/golang/components/http-hello-world/go.mod
+++ b/examples/golang/components/http-hello-world/go.mod
@@ -1,4 +1,4 @@
-module github.com/wasmcloud/wasmcloud/examples/golang/components/http-hello-world
+module {{project-name}}
 
 go 1.23.0
 

--- a/examples/golang/components/http-hello-world/wadm.yaml
+++ b/examples/golang/components/http-hello-world/wadm.yaml
@@ -1,9 +1,9 @@
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: tinygo-hello-world
+  name: "{{ project-name }}"
   annotations:
-    description: 'HTTP hello world demo in Golang (TinyGo), using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+    description: "HTTP hello world demo in Golang (TinyGo), using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)"
     wasmcloud.dev/authors: wasmCloud team
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-hello-world/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-hello-world/README.md
@@ -15,7 +15,7 @@ spec:
     - name: http-component
       type: component
       properties:
-        image: file://./build/http_hello_world_s.wasm
+        image: "file://./build/{{project-name}}_s.wasm"
       traits:
         # Govern the spread/scheduling of the component
         - type: spreadscaler

--- a/examples/golang/components/http-hello-world/wasmcloud.toml
+++ b/examples/golang/components/http-hello-world/wasmcloud.toml
@@ -1,4 +1,4 @@
-name = "http-hello-world"
+name = "{{project-name}}"
 language = "tinygo"
 type = "component"
 version = "0.1.0"
@@ -6,4 +6,3 @@ version = "0.1.0"
 [component]
 wit_world = "hello"
 wasm_target = "wasm32-wasip2"
-destination = "build/http_hello_world_s.wasm"


### PR DESCRIPTION
closes #3829

Update "http-hello-world" references to the user-defined "project-name".

Sample Run

<img width="1524" alt="Screenshot 2024-12-13 at 1 28 11 PM" src="https://github.com/user-attachments/assets/43f68100-4803-4c95-a517-e5da6e7db9e4" />
