### PR TITLE
chore: Go HTTP Component Template update

### DIFF
--- a/crates/wash-lib/src/generate/favorites.toml
+++ b/crates/wash-lib/src/generate/favorites.toml
@@ -21,8 +21,8 @@ subfolder = "examples/rust/components/http-hello-world"
 [[component]]
 name = "hello-world-tinygo"
 description = "a hello-world component (in TinyGo) that responds over an HTTP connection"
-git = "wasmCloud/wasmCloud"
-subfolder = "examples/golang/components/http-hello-world"
+git = "wasmCloud/go"
+subfolder = "templates/component/http-hello-world"
 
 [[component]]
 name = "hello-world-typescript"


### PR DESCRIPTION
closes #3829 

We moved Go http-hello-world example to `go` repository and turned it into an actual wash template.
This means users no longer need to change the package name inside `go.mod` before `wash build`.

This is a sample run using this new favorites toml.

```
/tmp ❯ wash new component --favorites ./favorites.toml bla
✔ Select a project template: · hello-world-tinygo: a hello-world component (in TinyGo) that responds over an HTTP connection
🔧 Cloning template from repo wasmCloud/go subfolder templates/component/http-hello-world...
🔧 Using template subfolder templates/component/http-hello-world...
🔧 Generating template...
[ 1/39]   Done: .gitignore
[ 2/39]   Done: README.md
[ 3/39]   Done: bindings.wadge.go
[ 4/39]   Done: go.mod
✨ Done! New project created /private/tmp/bla

Project generated and is located at: /private/tmp/bla
/tmp ❯ cd bla
bla ❯ ls
README.md         go.mod            main.go           tools.go          wasmcloud.lock    wit
bindings.wadge.go go.sum            main_test.go      wadm.yaml         wasmcloud.toml
bla ❯ wash build

Component built and signed and can be found at "/private/tmp/bla/build/bla_s.wasm"
```