### PR TITLE
ci(wash): add wash_successful_check requirement

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -6,12 +6,6 @@ on:
   merge_group:
   pull_request:
     branches: [main]
-    paths:
-      - .github/workflows/wash.yml
-      - Cargo.lock
-      - Cargo.toml
-      - crates/wash-cli/**
-      - crates/wash-lib/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -26,7 +20,29 @@ permissions:
   contents: read
 
 jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      modified: ${{ steps.changes.outputs.wash }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            wash:
+              - './.github/workflows/wash.yml'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'crates/control-interface/**'
+              - 'crates/core/**'
+              - 'crates/secrets-types/**'
+              - 'crates/wash-cli/**'
+              - 'crates/wash-lib/**'
+
   unit_tests:
+    needs: [meta]
+    if: ${{ needs.meta.outputs.modified == 'true' }}
     name: Unit Tests
     strategy:
       fail-fast: false # Ensure we can run the full suite even if one OS fails
@@ -66,6 +82,8 @@ jobs:
         working-directory: ./crates/wash-cli
 
   integration_tests:
+    needs: [meta]
+    if: ${{ needs.meta.outputs.modified == 'true' }}
     name: Integration Tests
     runs-on: ubuntu-22.04
     steps:
@@ -96,6 +114,8 @@ jobs:
   # Regression E2E tests to ensure that `wash new component` works consistently,
   # including older (released) versions of `wash`
   e2e_tests_wash_new_actor:
+    needs: [meta]
+    if: ${{ needs.meta.outputs.modified == 'true' }}
     name: E2E Tests (`wash new`)
     runs-on: ubuntu-22.04
     strategy:
@@ -133,3 +153,23 @@ jobs:
 
       - name: Ensure `wash new` works
         run: wash new component ${{ matrix.template.name }} --template-name ${{ matrix.template.name }}
+
+  # This check always runs, and only succeeds if wash tests should run and they pass
+  wash_successful_checks:
+    needs:
+      - meta
+      - unit_tests
+      - integration_tests
+      - e2e_tests_wash_new_actor
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Results
+        run: |
+          echo 'needs.unit_tests.result: ${{ needs.unit_tests.result }}'
+          echo 'needs.integration_tests.result: ${{ needs.integration_tests.result }}'
+          echo 'needs.e2e_tests_wash_new_actor.result: ${{ needs.e2e_tests_wash_new_actor.result }}'
+      - name: Verify jobs
+        # All jobs must succeed or be skipped.
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -23,24 +23,29 @@ jobs:
   meta:
     runs-on: ubuntu-latest
     outputs:
-      modified: ${{ steps.changes.outputs.wash }}
+      modified: ${{ steps.changes.outputs.any_changed }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: dorny/paths-filter@v3
+      - uses: tj-actions/changed-files@7ac5902a02bbf88c426878d792c0728b55bb97ae
         id: changes
         with:
-          filters: |
-            wash:
-              - './.github/workflows/wash.yml'
-              - 'Cargo.lock'
-              - 'Cargo.toml'
-              - 'crates/control-interface/**'
-              - 'crates/core/**'
-              - 'crates/secrets-types/**'
-              - 'crates/wash-cli/**'
-              - 'crates/wash-lib/**'
-              - '!crates/wash-*/**/*.md'
-              - '!crates/wash-cli/.devcontainer'
+          files: |
+            ./.github/workflows/wash.yml
+            Cargo.lock
+            Cargo.toml
+            crates/control-interface/**
+            crates/core/**
+            crates/secrets-types/**
+            crates/tracing/**
+            crates/wash-cli/**
+            crates/wash-lib/**
+          files_ignore: |
+            !crates/**/*.md
+            !crates/wash-cli/.devcontainer
+      - name: Changed files
+        run: |
+          echo "Changed file(s) (${{ steps.changes.outputs.all_changed_files_count}})"
+          echo "${{ steps.changes.outputs.all_changed_files }}"
 
   unit_tests:
     needs: [meta]

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -39,6 +39,8 @@ jobs:
               - 'crates/secrets-types/**'
               - 'crates/wash-cli/**'
               - 'crates/wash-lib/**'
+              - '!crates/wash-*/**/*.md'
+              - '!crates/wash-cli/.devcontainer'
 
   unit_tests:
     needs: [meta]


### PR DESCRIPTION
~Draft for a moment while I make sure all my PRs get the right results.~

## Feature or Problem
It's currently impossible for us to require `wash` CI to pass (unit tests and integration tests) before merging because we filter wash actions to only run when `wash` is modified. This leaves us with three options (probably more but pause for dramatic effect):
1. Don't require `wash` actions, possibly allow merging failing wash checks to `main` (current)
2. Require `wash` actions, always run `wash` actions on every PR (slow)
3. Something magical (this PR)

This PR changes the path based filtering to use ~https://github.com/dorny/paths-filter~ https://github.com/tj-actions/changed-files instead of GitHub workflow's path filtering, and then adds a final job to the `wash.yml` action called `wash_successful_checks`. This action _always_ runs, and exits successfully as long as one of the following conditions are true:
1. No `wash` related files were modified
2. `wash` related files were modified, and unit, integration, and e2e tests pass

Otherwise (e.g. wash related files were modified AND unit/integration/e2e tests fail) the test fails, and will prevent merging. We can now use GitHub rulesets to require that the `wash_successful_checks` job succeeds since it will always run on PRs.

If people are happy with the solution proposed here, we can propagate it across our other expensive / long-running / specialized workflows to really cut down on the amount of CI that needs to run. Feel free to bikeshed on naming of checks and the structure if we're going to use this in many places.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
After this PR merges, we should be able to require the `wash_successful_check` action which will prevent failing wash checks from ever merging to `main`. 

## Consumer Impact
Any contributor to this repository that doesn't modify `wash` related files won't need to wait for `wash` CI to run 😄 

## Testing
Here is an example of a PR that changes a file that's not related to wash: https://github.com/brooksmtownsend/wasmCloud/actions/runs/12472751104 (wash_successful_check ✅)

Here's an example of a PR that changes a file that's related to wash that succeeds https://github.com/brooksmtownsend/wasmCloud/actions/runs/12472606336 (wash_successful_check ✅ )

Here's an example of a PR that changes a file that's related to wash that fails to build https://github.com/brooksmtownsend/wasmCloud/actions/runs/12472607833 (wash_successful_check ❌ )

### Additional Context
Other considerations to fill this GitHub feature gap were:
- https://github.com/marketplace/actions/alls-green 
  - This only works for a single workflow, and I think handling this in our own workflows will prove to be less frustrating
  - Largely unmaintained, which is fine if it all works https://github.com/re-actors/alls-green
- https://github.com/marketplace/mergify
  - This is closed source
- Refactoring our workflows to be triggered by `workflow_call` and making one top-level action that calls other actions depending on paths modified
  - This seemed like a lot of work that didn't get a much different solution than what we have here. Additionally, this raises the level of effort to just run and test a GH workflow because now all of the critical workflows must be reusable