### PR TITLE
ci(typescript): add typescript_successful_check

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -20,15 +20,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      modified: ${{ steps.changes.outputs.typescript }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            typescript:
+              - './.github/workflows/typescript.yml'
+              - 'typescript/**'
+              - '!typescript/**/*.md'
+
+  # TS actions will run if typescript files are modified or if a tag triggers a release
   build:
+    needs: [meta]
+    if: ${{ needs.meta.outputs.modified == 'true' || startswith(github.ref, 'refs/tags/typescript/') }}
     uses: ./.github/workflows/ts-build.yml
 
   test:
+    needs: [meta]
+    if: ${{ needs.meta.outputs.modified == 'true' || startswith(github.ref, 'refs/tags/typescript/') }}
     uses: ./.github/workflows/ts-test.yml
 
   release:
-    if: startswith(github.ref, 'refs/tags/typescript/')
-    needs: [build, test]
+    if: ${{ needs.meta.outputs.modified == 'true' || startswith(github.ref, 'refs/tags/typescript/') }}
+    needs: [meta, build, test]
     permissions:
       contents: write
     uses: ./.github/workflows/ts-release.yml
+
+  # This check always runs, and only succeeds if wash tests should run and they pass
+  typescript_successful_checks:
+    needs:
+      - meta
+      - build
+      - test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Results
+        run: |
+          echo 'needs.build.result: ${{ needs.build.result }}'
+          echo 'needs.test.result: ${{ needs.test.result }}'
+      - name: Verify jobs
+        # All jobs must succeed or be skipped.
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## Feature or Problem
This PR adds a check `typescript_successful_check` that runs every PR, reporting status of the typescript build and test only if typescript files were modified. We will be able to mark this a required action of this repository to ensure typescript doesn't have a failed build.

@lachieh any other files I should add to the glob?

## Related Issues
#3875 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
