### PR TITLE
ci: add action for cached-install of wash

### DIFF
--- a/.github/actions/install-cached-wash-cli/action.yml
+++ b/.github/actions/install-cached-wash-cli/action.yml
@@ -1,0 +1,44 @@
+name: Install Cached Wash CLI
+
+description: |
+  This action will install the Wash CLI from a given repository and revision. If there are no changes that might affect the build, the action will build and install the Wash CLI from the current commit. Otherwise, it will build and install the Wash CLI from the base ref.
+
+runs:
+  using: composite
+  steps:
+    - name: Check for changes that might affect the build for wash
+      if: ${{ github.event_name == 'pull_request' }}
+      # It'd be a little nicer if we calculated if wash was affected by the changes, but this will do for now
+      id: changed-files
+      uses: tj-actions/changed-files@bab30c2299617f6615ec02a68b9a40d10bd21366 # v45.0.5
+      with:
+        files_ignore: |
+          adr/**
+          brand/**
+          examples/**
+          **/*.md
+
+    - name: Set wash revision to build/cache
+      id: base-ref
+      shell: bash
+      run: |
+        # Determine the revision to build from
+        if [ ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha }} == null ]; then
+          echo "No base ref, building from the current commit"
+          REVISION=${{ github.sha }}
+        elif [ ${{ steps.changed-files.outputs.all_changed_and_modified_files_count }} -eq 0 ]; then
+          echo "Something changed that might affect the build, building from the current commit"
+          REVISION=${{ github.sha }}
+        else
+          echo "Building from the base ref"
+          REVISION=${{ github.event.pull_request.base.sha }}
+        fi
+        echo "target_revision=$REVISION" >> $GITHUB_OUTPUT
+        echo "Using $REVISION as the target revision"
+
+    - name: Build wash
+      uses: taiki-e/cache-cargo-install-action@caa6f48d18d42462f9c30df89e2b4f71a42b7c2c # v2.0.1
+      with:
+        tool: wash-cli
+        git: https://github.com/${{ github.repository }}
+        rev: ${{ steps.base-ref.outputs.target_revision }}

--- a/.github/actions/wasm-lang-toolchain-setup/action.yml
+++ b/.github/actions/wasm-lang-toolchain-setup/action.yml
@@ -88,8 +88,4 @@ runs:
 
     - name: install wash (current)
       if: ${{ inputs.wash-version && inputs.wash-version == 'current' }}
-      uses: taiki-e/cache-cargo-install-action@caa6f48d18d42462f9c30df89e2b4f71a42b7c2c # v2.0.1
-      with:
-        tool: wash-cli
-        git: https://github.com/${{ github.repository }}
-        rev: ${{ github.sha }}
+      uses: ./.github/actions/install-cached-wash-cli

--- a/.github/workflows/examples-components.yml
+++ b/.github/workflows/examples-components.yml
@@ -60,37 +60,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-wash-cli:
-    name: build wash-cli (${{ matrix.wash-version }})
+  # build/cache wash-cli so following steps can use the cached version
+  prepare-wash-cache:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        wash-version:
-          # NOTE(2024/10/23): we need to use the current version of wash *only*
-          # due to all the new WIT package retrieval goodness
-          #
-          # Once a new version of wash is out we can use prebuilt versions again (>= 35.0)
-          - current
     steps:
-    - name: install wash (${{ matrix.wash-version }})
-      if: ${{ matrix.wash-version && matrix.wash-version != 'current' }}
-      uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14 # v2.47.0
-      with:
-        tool: wash@${{ matrix.wash-version }}
-
-    - name: install wash (current)
-      if: ${{ matrix.wash-version && matrix.wash-version == 'current' }}
-      uses: taiki-e/cache-cargo-install-action@caa6f48d18d42462f9c30df89e2b4f71a42b7c2c # v2.0.1
-      with:
-        tool: wash-cli
-        git: https://github.com/${{ github.repository }}
-        rev: ${{ github.sha }}
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/install-cached-wash-cli
 
   # Ensure that `wash build` and `wash app validate` works for all example projects below
   wash-build:
     name: ${{ matrix.project.folder }}:${{ matrix.project.lang_version && format('{0}@{1}', matrix.project.lang, matrix.project.lang_version) || matrix.project.lang }} (wash@${{ matrix.wash-version }})
     runs-on: ubuntu-22.04
-    needs: [build-wash-cli]
+    needs: [prepare-wash-cache]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/examples-providers.yml
+++ b/.github/workflows/examples-providers.yml
@@ -25,34 +25,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-wash-cli:
-    name: build wash-cli (${{ matrix.wash-version }})
+  # build/cache wash-cli so following steps can use the cached version
+  prepare-wash-cache:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        wash-version:
-          - 0.37.0
-          - current
     steps:
-    - name: install wash (${{ matrix.wash-version }})
-      if: ${{ matrix.wash-version && matrix.wash-version != 'current' }}
-      uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14 # v2.47.0
-      with:
-        tool: wash@${{ matrix.wash-version }}
-
-    - name: install wash (current)
-      if: ${{ matrix.wash-version && matrix.wash-version == 'current' }}
-      uses: taiki-e/cache-cargo-install-action@caa6f48d18d42462f9c30df89e2b4f71a42b7c2c # v2.0.1
-      with:
-        tool: wash-cli
-        git: https://github.com/${{ github.repository }}
-        rev: ${{ github.sha }}
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/install-cached-wash-cli
 
   # Ensure that `wash build` and `wash app validate` works for all example projects below
   wash-build:
     name: ${{ matrix.project.name }}:${{ matrix.project.lang_version && format('{0}@{1}', matrix.project.lang, matrix.project.lang_version) || matrix.project.lang }} (wash@${{ matrix.wash-version }})
     runs-on: ubuntu-22.04
-    needs: [build-wash-cli]
+    needs: [prepare-wash-cache]
     strategy:
       fail-fast: false
       matrix:
@@ -85,11 +69,7 @@ jobs:
 
       - name: install wash (current)
         if: ${{ matrix.wash-version && matrix.wash-version == 'current' }}
-        uses: taiki-e/cache-cargo-install-action@caa6f48d18d42462f9c30df89e2b4f71a42b7c2c # v2.0.1
-        with:
-          tool: wash-cli
-          git: https://github.com/${{ github.repository }}
-          rev: ${{ github.sha }}
+        uses: ./.github/actions/install-cached-wash-cli
 
       # Language specific setup
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a


### PR DESCRIPTION
This moves wash install into an action that can be reused. If no version is specified, it will do a super basic check on which files have changed to see if it is better to use the commit from main, or the commit from the PR to build `wash` from. This means if the PR is just a change to examples, the latest commit on main has most probably already been built and cached.

This could also be used in E2E tests as per the improvements in #3889