### PR TITLE
fix: clippy ci requirement

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -308,7 +308,7 @@ jobs:
 
   cargo:
     needs: [meta]
-    if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/wash-cli-v')}}
+    if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || needs.meta.outputs.providers_modified == 'true' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/wash-cli-v')}}
     strategy:
       matrix:
         check:

--- a/crates/provider-http-client/src/lib.rs
+++ b/crates/provider-http-client/src/lib.rs
@@ -157,7 +157,7 @@ impl ServeOutgoingHandlerHttp<Option<Context>> for HttpClientProvider {
         >,
     > {
         propagate_trace_for_ctx!(cx);
-        wasmcloud_provider_sdk::wasmcloud_tracing::http::HeaderInjector(&mut request.headers_mut())
+        wasmcloud_provider_sdk::wasmcloud_tracing::http::HeaderInjector(request.headers_mut())
             .inject_context();
 
         // TODO: Use opts


### PR DESCRIPTION
- **ci(wasmcloud): require cargo when providers change**
- **chore(http-client): address clippy warning**

## Feature or Problem
Slight oversight in the wasmcloud_successful_check is that clippy checks the status of the entire workspace, so we need to run the cargo action if a provider changes too.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
