### PR TITLE
ci(wasmcloud): ignore wash files for wasmcloud 

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -131,6 +131,12 @@ jobs:
             !crates/provider-*-*/**/*.{rs,toml,wit}
             !crates/wash-*/**/*.{rs,toml,wit}
       - uses: tj-actions/changed-files@7ac5902a02bbf88c426878d792c0728b55bb97ae
+        id: wash_changes
+        with:
+          # Used to run cargo workspace checks if any file in the wash-cli or wash-lib changes
+          files: |
+            crates/wash-*/**/*.{rs,toml,wit}
+      - uses: tj-actions/changed-files@7ac5902a02bbf88c426878d792c0728b55bb97ae
         id: provider_changes
         with:
           # Consider providers changed if any file in the providers change

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -128,8 +128,8 @@ jobs:
           # Somewhat naive assumption that providers will be under `crates/provider-<interface>-<vendor>`
           # as that is our naming convention for providers.
           files_ignore: |
-            !crates/provider-*-*
-            !crates/wash-*
+            !crates/provider-*-*/**/*.{rs,toml,wit}
+            !crates/wash-*/**/*.{rs,toml,wit}
       - uses: tj-actions/changed-files@7ac5902a02bbf88c426878d792c0728b55bb97ae
         id: provider_changes
         with:


### PR DESCRIPTION
## Feature or Problem
This PR properly ignores wash-cli and wash-lib files when considering if wasmCloud had a change and CI should run.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Here's a previous iteration of this PR that changed a file in the wash codebase that did not trigger a run of the wasmCloud workflows. https://github.com/wasmCloud/wasmCloud/actions/runs/12561146525
