### PR TITLE
fix: windows ambiguous as_ref

### DIFF
--- a/crates/host/src/wasmbus/handler.rs
+++ b/crates/host/src/wasmbus/handler.rs
@@ -569,7 +569,9 @@ impl MessagingHostMessage0_3 for Message {
             }) => {
                 *headers = headers
                     .iter()
-                    .filter(|(k, ..)| (k.as_ref() != key))
+                    // NOTE(brooksmtownsend): The funky construction here is to provide a concrete type
+                    // to the `as_ref()` call, which is necessary to satisfy the type inference on Windows.
+                    .filter(|(k, ..)| (<&async_nats::HeaderName as AsRef<str>>::as_ref(k) != key))
                     .flat_map(|(k, vs)| zip(repeat(k.clone()), vs.iter().cloned()))
                     .collect();
                 Ok(())


### PR DESCRIPTION
## Feature or Problem
This PR fixes a failure in the Windows build on main.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Here's a previous version of this PR that ran the windows build successfully , which normally just runs on `main` https://github.com/wasmCloud/wasmCloud/actions/runs/12562395410/job/35022758233?pr=3901
