### PR TITLE
fix: Added ca-certificates to runtime image to solve issues with inva…

### DIFF
--- a/crates/secrets-nats-kv/Dockerfile
+++ b/crates/secrets-nats-kv/Dockerfile
@@ -19,6 +19,10 @@ FROM debian:bullseye-slim@sha256:60a596681410bd31a48e5975806a24cd78328f3fd6b9ee5
 
 WORKDIR /app
 
+# Install CA certificates
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
 # Copy the binary from the first stage
 COPY --from=builder /app/target/release/secrets-nats-kv .
 


### PR DESCRIPTION
Added ca-certificates runtime image to solve issues with "invalid peer certificates, unknown issuers".

## Feature or Problem

When using a docker deploy of secrets-nats-kv and connecting to a nats infrastructure that requires tls, the connections would fail to validate the server certifcate because no ca-certificates is present in the docker image.

## Related Issues


## Release Information

next

## Consumer Impact

No consumer impact, no code changes, just runtime environment changes for secrets-nats-kv.

## Testing

Built and pushed docker image locally and deployed to wasmcloud environment in google cloud.

### Unit Test(s)


### Acceptance or Integration

### Manual Verification

- Built docker image
- Pushed to our GAR in GCP
- Deployed in GCP as a Cloud Run Service
- Confirmed certificate issues are gone.
- Observed connections to nats environment.