### PR TITLE
fix(host): output host_id on provider_start_failed

### DIFF
--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -190,11 +190,13 @@ pub fn provider_started(
 pub fn provider_start_failed(
     provider_ref: impl AsRef<str>,
     provider_id: impl AsRef<str>,
+    host_id: impl AsRef<str>,
     error: &anyhow::Error,
 ) -> serde_json::Value {
     json!({
         "provider_ref": provider_ref.as_ref(),
         "provider_id": provider_id.as_ref(),
+        "host_id": host_id.as_ref(),
         "error": format!("{error:#}"),
         // TODO(#1548): remove this field when we don't depend on it
         "link_name": "default",

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2195,7 +2195,7 @@ impl Host {
                 if let Err(err) = self
                     .publish_event(
                         "provider_start_failed",
-                        event::provider_start_failed(provider_ref, provider_id, &err),
+                        event::provider_start_failed(provider_ref, provider_id, host_id, &err),
                     )
                     .await
                 {


### PR DESCRIPTION
## Feature or Problem
This PR adds the missing `host_id` field on the provider_start_failed event.

Generally we don't actually need this, because the `source` of the event is the host ID. Since we put this field on many other event payloads though, let's just get to parity and then make a longer term decision to keep or remove it from events.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
