### PR TITLE
chore(control-interface): remove count rename

### DIFF
--- a/crates/control-interface/src/types/ctl.rs
+++ b/crates/control-interface/src/types/ctl.rs
@@ -96,8 +96,7 @@ pub struct ScaleComponentCommand {
     pub(crate) annotations: Option<BTreeMap<String, String>>,
     /// The maximum number of concurrent executing instances of this component. Setting this to `0` will
     /// stop the component.
-    // NOTE: renaming to `count` lets us remain backwards compatible for a few minor versions
-    #[serde(default, alias = "count", rename = "count")]
+    #[serde(default, alias = "count")]
     pub(crate) max_instances: u32,
     /// Host ID on which to scale this component
     #[serde(default)]


### PR DESCRIPTION
## Feature or Problem
This PR removes a `count` rename in the ScaleComponentCommand that we forgot about. Since this field is also aliased to `count`, any consumer of the control interface should already be compatible with this since before we released the 1.0.0 version of this crate.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
`next` minor version

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
