### PR TITLE
ci: downgrade action-gh-release 2.1.0

### DIFF
--- a/.github/workflows/secrets-nats-kv.yml
+++ b/.github/workflows/secrets-nats-kv.yml
@@ -203,7 +203,7 @@ jobs:
           cp artifacts/secrets-nats-kv-aarch64-linux-musl artifacts/secrets-nats-kv-aarch64-linux
 
       - name: Release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
         with:
           draft: true
           prerelease: ${{ steps.ctx.outputs.prerelease != '' }}

--- a/.github/workflows/wash-plugins.yml
+++ b/.github/workflows/wash-plugins.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         tar czf wash-plugins-${{ steps.ctx.outputs.version }}.tar.gz wash-lib/wit
     - name: Release
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+      uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
       with:
         files: crates/wash-plugins-${{ steps.ctx.outputs.version }}.tar.gz
         make_latest: "false"

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -604,7 +604,7 @@ jobs:
             done
           done
 
-      - uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+      - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           draft: true
@@ -612,7 +612,7 @@ jobs:
           generate_release_notes: true
           files: ./wasmcloud/*
 
-      - uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+      - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
         if: startsWith(github.ref, 'refs/tags/wash-cli-v')
         with:
           draft: false

--- a/.github/workflows/wit-wasmcloud-lattice-bus.yml
+++ b/.github/workflows/wit-wasmcloud-lattice-bus.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit bus/wit
     - name: Release
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+      uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
       with:
         files: ${{ steps.ctx.outputs.tarball }}
         make_latest: "false"

--- a/.github/workflows/wit-wasmcloud-postgres.yml
+++ b/.github/workflows/wit-wasmcloud-postgres.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit postgres/wit
     - name: Release
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+      uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
       with:
         files: ${{ steps.ctx.outputs.tarball }}
         make_latest: "false"

--- a/.github/workflows/wit-wasmcloud-secrets.yml
+++ b/.github/workflows/wit-wasmcloud-secrets.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit secrets/wit
     - name: Release
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+      uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
       with:
         files: ${{ steps.ctx.outputs.tarball }}
         make_latest: "false"


### PR DESCRIPTION
## Feature or Problem
This PR downgrades the actions-gh-release action to 2.1.0 just like https://github.com/dj95/kdl-fmt/commit/f7c3fd9d587738332a6579a3bba688072270c7da#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R99.

## Related Issues
Upstream issue https://github.com/softprops/action-gh-release/issues/555
Can be reverted after https://github.com/softprops/action-gh-release/pull/562 releases

## Release Information
This prevented wasmCloud 1.5.0 from having the release artifacts, so going to delete and re-create the tag afterwards https://github.com/wasmCloud/wasmCloud/actions/runs/12602813631/job/35130401952#step:5:18

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
