### PR TITLE
chore: upgrade opentelemetry libraries to 0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,40 +761,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "bytes",
  "futures-util",
  "http 1.2.0",
@@ -816,23 +788,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -3255,7 +3210,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
- "webpki-roots 0.26.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3274,19 +3229,20 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.7",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 0.14.31",
+ "hyper 1.5.2",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
 ]
 
 [[package]]
@@ -4470,13 +4426,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-appender-tracing"
-version = "0.4.0"
+name = "opentelemetry"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be314095f27dde46fca7038b023457d2b3459e1c39033dacc2ec1b31df11a61c"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
 dependencies = [
- "once_cell",
- "opentelemetry",
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5feffc321035ad94088a7e5333abb4d84a8726e54a802e736ce9dd7237e85b"
+dependencies = [
+ "opentelemetry 0.27.1",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -4484,15 +4453,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.12.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ba633e55c5ea6f431875ba55e71664f2fa5d3a90bd34ec9302eecc41c865dd"
+checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
 dependencies = [
  "async-trait",
  "bytes",
- "http 0.2.12",
- "opentelemetry",
- "reqwest 0.11.27",
+ "http 1.2.0",
+ "opentelemetry 0.27.1",
+ "reqwest 0.12.9",
 ]
 
 [[package]]
@@ -4500,27 +4469,27 @@ name = "opentelemetry-nats"
 version = "0.2.0"
 dependencies = [
  "async-nats",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.27.1",
+ "opentelemetry_sdk 0.27.1",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.28.0",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.16.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 0.2.12",
- "opentelemetry",
+ "http 1.2.0",
+ "opentelemetry 0.27.1",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk",
- "prost",
- "reqwest 0.11.27",
+ "opentelemetry_sdk 0.27.1",
+ "prost 0.13.4",
+ "reqwest 0.12.9",
  "thiserror 1.0.69",
  "tokio",
  "tonic",
@@ -4528,13 +4497,13 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.6.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
+ "opentelemetry 0.27.1",
+ "opentelemetry_sdk 0.27.1",
+ "prost 0.13.4",
  "tonic",
 ]
 
@@ -4548,11 +4517,30 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "lazy_static 1.5.0",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.23.0",
  "ordered-float 4.5.0",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry 0.27.1",
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
@@ -4737,7 +4725,7 @@ checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
 dependencies = [
  "heck 0.4.1",
  "itertools 0.11.0",
- "prost",
+ "prost 0.12.6",
  "prost-types",
 ]
 
@@ -4751,7 +4739,7 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost",
+ "prost 0.12.6",
  "prost-build",
  "serde",
 ]
@@ -5093,7 +5081,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.4",
 ]
 
 [[package]]
@@ -5110,7 +5108,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.12.6",
  "prost-types",
  "regex",
  "syn 2.0.89",
@@ -5131,6 +5129,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "prost-reflect"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5139,7 +5150,7 @@ dependencies = [
  "logos",
  "miette",
  "once_cell",
- "prost",
+ "prost 0.12.6",
  "prost-types",
 ]
 
@@ -5149,7 +5160,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -5160,7 +5171,7 @@ checksum = "ac532509cee918d40f38c3e12f8ef9230f215f017d54de7dd975015538a42ce7"
 dependencies = [
  "bytes",
  "miette",
- "prost",
+ "prost 0.12.6",
  "prost-reflect",
  "prost-types",
  "protox-parse",
@@ -5441,7 +5452,7 @@ dependencies = [
  "tokio-rustls 0.25.0",
  "tokio-util",
  "url",
- "webpki-roots 0.26.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5557,7 +5568,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.31",
- "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -5565,21 +5575,17 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
- "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -5592,6 +5598,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.7",
@@ -5627,7 +5634,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.7",
+ "webpki-roots",
  "windows-registry",
 ]
 
@@ -7036,16 +7043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7263,23 +7260,26 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
+ "axum",
+ "base64 0.22.1",
  "bytes",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.2",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.4",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -7425,8 +7425,24 @@ checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.23.0",
+ "opentelemetry_sdk 0.23.0",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry 0.27.1",
+ "opentelemetry_sdk 0.27.1",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -7901,7 +7917,7 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "pbjson-types",
- "prost",
+ "prost 0.12.6",
  "prost-build",
  "prost-types",
  "protox",
@@ -7921,7 +7937,7 @@ dependencies = [
  "hex",
  "indexmap 2.6.0",
  "pbjson-types",
- "prost",
+ "prost 0.12.6",
  "prost-types",
  "semver",
  "serde",
@@ -7941,7 +7957,7 @@ checksum = "8b8d8110b6800c43422676201a6a62167769b015ca29a8fcab67d789ac8b9c63"
 dependencies = [
  "anyhow",
  "indexmap 2.6.0",
- "prost",
+ "prost 0.12.6",
  "thiserror 1.0.69",
  "warg-crypto",
  "warg-protobuf",
@@ -8551,13 +8567,13 @@ dependencies = [
  "cloudevents-sdk",
  "futures",
  "oci-client",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.27.1",
+ "opentelemetry_sdk 0.27.1",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.28.0",
 ]
 
 [[package]]
@@ -8573,13 +8589,13 @@ dependencies = [
  "cloudevents-sdk",
  "futures",
  "oci-distribution",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.23.0",
+ "opentelemetry_sdk 0.23.0",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.24.0",
  "wasmcloud-core 0.11.0",
 ]
 
@@ -8635,12 +8651,12 @@ dependencies = [
  "tracing",
  "url",
  "wascap 0.15.2",
- "webpki-roots 0.26.7",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "wasmcloud-host"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8664,7 +8680,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.28.0",
  "ulid",
  "url",
  "uuid 1.11.0",
@@ -8774,7 +8790,7 @@ dependencies = [
  "tokio",
  "tracing",
  "wasmcloud-provider-sdk",
- "webpki-roots 0.26.7",
+ "webpki-roots",
  "wrpc-interface-http",
 ]
 
@@ -8784,7 +8800,7 @@ version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-nats",
- "axum 0.7.9",
+ "axum",
  "axum-server",
  "base64 0.22.1",
  "bytes",
@@ -8916,7 +8932,7 @@ dependencies = [
  "futures",
  "nkeys",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.27.1",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -8924,7 +8940,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.28.0",
  "tracing-subscriber",
  "wasmcloud-core 0.15.0",
  "wasmcloud-tracing",
@@ -8956,7 +8972,7 @@ dependencies = [
  "ulid",
  "uuid 1.11.0",
  "wasmcloud-provider-sdk",
- "webpki-roots 0.26.7",
+ "webpki-roots",
  "wit-bindgen-wrpc",
 ]
 
@@ -8970,14 +8986,14 @@ dependencies = [
  "futures",
  "http 1.2.0",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.27.1",
  "secrecy",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.28.0",
  "tracing-subscriber",
  "wascap 0.15.2",
  "wasi-preview1-component-adapter-provider",
@@ -9061,22 +9077,22 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-tracing"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bytes",
  "heck 0.5.0",
  "http 1.2.0",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.27.1",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
- "opentelemetry_sdk",
- "reqwest 0.11.27",
+ "opentelemetry_sdk 0.27.1",
+ "reqwest 0.12.9",
  "tracing",
  "tracing-appender",
  "tracing-flame",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.28.0",
  "tracing-subscriber",
  "wasmcloud-core 0.15.0",
 ]
@@ -9410,7 +9426,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "webpki-roots 0.26.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -9483,12 +9499,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,11 +267,11 @@ num = { version = "0.4", default-features = false }
 oci-client = { version = "0.14", default-features = false }
 oci-wasm = { version = "0.2.0", default-features = false }
 once_cell = { version = "1", default-features = false }
-opentelemetry = { version = "0.23", default-features = false }
-opentelemetry-appender-tracing = { version = "0.4", default-features = false }
+opentelemetry = { version = "0.27", default-features = false }
+opentelemetry-appender-tracing = { version = "0.27", default-features = false }
 opentelemetry-nats = { version = "0.2.0", path = "./crates/opentelemetry-nats", default-features = false }
-opentelemetry-otlp = { version = "0.16", default-features = false }
-opentelemetry_sdk = { version = "0.23", default-features = false }
+opentelemetry-otlp = { version = "0.27", default-features = false }
+opentelemetry_sdk = { version = "0.27", default-features = false }
 path-absolutize = { version = "3", default-features = false }
 path-clean = { version = "1", default-features = false }
 pg_bigdecimal = { version = "0.1", default-features = false }
@@ -283,11 +283,6 @@ rand = { version = "0.8", default-features = false }
 redis = { version = "0.25", default-features = false }
 regex = { version = "1", default-features = false }
 reqwest = { version = "0.12", default-features = false }
-# reqwest 0.11 is required by `wasmcloud-tracing` to allow customization of
-# the HttpClient trait implementation for reqwest defined in `opentelemetry-http`,
-# which is then used in `opentelemetry-otlp` to customize the http client used for
-# interacting with OTEL collectors.
-reqwest-0_11 = { package = "reqwest", version = "0.11", default-features = false }
 ring = { version = "0.17", default-features = false }
 rmp-serde = { version = "1", default-features = false }
 rmpv = { version = "1", default-features = false }
@@ -328,7 +323,7 @@ tracing = { version = "0.1", default-features = false }
 tracing-appender = { version = "0.2", default-features = false }
 tracing-flame = { version = "0.2", default-features = false }
 tracing-futures = { version = "0.2", default-features = false }
-tracing-opentelemetry = { version = "0.24", default-features = false }
+tracing-opentelemetry = { version = "0.28", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 ulid = { version = "1", default-features = false }
 unicase = { version = "2.8.1", default-features = false }
@@ -357,7 +352,7 @@ wasm-gen = { version = "0.1", default-features = false }
 wasmcloud-component = { version = "0", path = "crates/component", default-features = false }
 wasmcloud-control-interface = { version = "2.2.0", path = "./crates/control-interface", default-features = false }
 wasmcloud-core = { version = "^0.15.0", path = "./crates/core", default-features = false }
-wasmcloud-host = { version = "^0.23.0", path = "./crates/host", default-features = false }
+wasmcloud-host = { version = "^0.23.2", path = "./crates/host", default-features = false }
 wasmcloud-provider-blobstore-azure = { version = "*", path = "./crates/provider-blobstore-azure", default-features = false }
 wasmcloud-provider-blobstore-fs = { version = "*", path = "./crates/provider-blobstore-fs", default-features = false }
 wasmcloud-provider-blobstore-s3 = { version = "*", path = "./crates/provider-blobstore-s3", default-features = false }
@@ -374,7 +369,7 @@ wasmcloud-runtime = { version = "^0.7.0", path = "./crates/runtime", default-fea
 wasmcloud-secrets-client = { version = "^0.6.0", path = "./crates/secrets-client", default-features = false }
 wasmcloud-secrets-types = { version = "^0.5.0", path = "./crates/secrets-types", default-features = false }
 wasmcloud-test-util = { version = "^0.15.0", path = "./crates/test-util", default-features = false }
-wasmcloud-tracing = { version = "^0.11.0", path = "./crates/tracing", default-features = false }
+wasmcloud-tracing = { version = "^0.12.0", path = "./crates/tracing", default-features = false }
 wasmparser = { version = "0.221", default-features = false }
 wasmtime = { version = "26", default-features = false }
 wasmtime-wasi = { version = "26", default-features = false }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.23.1"
+version = "0.23.2"
 description = "wasmCloud host library"
 readme = "README.md"
 

--- a/crates/host/src/metrics.rs
+++ b/crates/host/src/metrics.rs
@@ -1,4 +1,4 @@
-use wasmcloud_tracing::{Counter, Histogram, KeyValue, Meter, Unit};
+use wasmcloud_tracing::{Counter, Histogram, KeyValue, Meter};
 
 /// `HostMetrics` encapsulates the set of metrics emitted by the wasmcloud host
 #[derive(Clone, Debug)]
@@ -29,18 +29,18 @@ impl HostMetrics {
         let wasmcloud_host_handle_rpc_message_duration_ns = meter
             .u64_histogram("wasmcloud_host.handle_rpc_message.duration")
             .with_description("Duration in nanoseconds each handle_rpc_message operation took")
-            .with_unit(Unit::new("nanoseconds"))
-            .init();
+            .with_unit("nanoseconds")
+            .build();
 
         let component_invocation_count = meter
             .u64_counter("wasmcloud_host.component.invocations")
             .with_description("Number of component invocations")
-            .init();
+            .build();
 
         let component_error_count = meter
             .u64_counter("wasmcloud_host.component.invocation.errors")
             .with_description("Number of component errors")
-            .init();
+            .build();
 
         Self {
             handle_rpc_message_duration_ns: wasmcloud_host_handle_rpc_message_duration_ns,

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-tracing"
-version = "0.11.0"
+version = "0.12.0"
 description = "wasmCloud tracing functionality"
 
 authors.workspace = true
@@ -42,7 +42,7 @@ opentelemetry-otlp = { workspace = true, features = [
     "metrics",
     "reqwest-client",
 ], optional = true }
-reqwest-0_11 = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 tracing = { workspace = true, features = ["log"] }
 tracing-appender = { workspace = true }
 tracing-flame = { workspace = true }

--- a/crates/tracing/src/metrics.rs
+++ b/crates/tracing/src/metrics.rs
@@ -8,88 +8,42 @@ pub fn configure_metrics(
     service_name: &str,
     otel_config: &wasmcloud_core::OtelConfig,
 ) -> anyhow::Result<()> {
-    use opentelemetry_otlp::{MetricsExporterBuilder, WithExportConfig};
+    use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+    use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
     use wasmcloud_core::OtelProtocol;
 
-    let builder: MetricsExporterBuilder = match otel_config.protocol {
+    let exporter = match otel_config.protocol {
         OtelProtocol::Http => {
             let client = crate::get_http_client(otel_config)
                 .context("failed to get an http client for otel metrics exporter")?;
-            opentelemetry_otlp::new_exporter()
-                .http()
-                .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
+            opentelemetry_otlp::MetricExporter::builder()
+                .with_http()
                 .with_http_client(client)
+                .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
                 .with_endpoint(otel_config.metrics_endpoint())
-                .into()
+                .build()
+                .context("failed to create OTEL http exporter")?
         }
         OtelProtocol::Grpc => {
             // TODO(joonas): Configure tonic::transport::ClientTlsConfig via .with_tls_config(...), passing in additional certificates.
-            opentelemetry_otlp::new_exporter()
-                .tonic()
+            opentelemetry_otlp::MetricExporter::builder()
+                .with_tonic()
                 .with_endpoint(otel_config.metrics_endpoint())
-                .into()
+                .build()
+                .context("failed to create OTEL tonic exporter")?
         }
     };
 
-    opentelemetry_otlp::new_pipeline()
-        .metrics(opentelemetry_sdk::runtime::Tokio)
-        .with_exporter(builder)
+    let reader = PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::Tokio).build();
+
+    let meter_provider = SdkMeterProvider::builder()
         .with_resource(opentelemetry_sdk::Resource::new(vec![
             opentelemetry::KeyValue::new("service.name", service_name.to_string()),
         ]))
-        .with_aggregation_selector(ExponentialHistogramAggregationSelector::new())
-        .with_temporality_selector(
-            opentelemetry_sdk::metrics::reader::DefaultTemporalitySelector::new(),
-        )
-        .build()
-        .context("failed to create OTEL metrics provider")?;
+        .with_reader(reader)
+        .build();
+
+    opentelemetry::global::set_meter_provider(meter_provider);
 
     Ok(())
-}
-
-/// Replaces the default `ExplicitBucketHistogram` aggregation for Histograms
-/// with `Base2ExponentialHistogram`. This makes it easier to capture latency
-/// at nanosecond accuracy.
-#[cfg(feature = "otel")]
-#[derive(Clone, Default, Debug)]
-struct ExponentialHistogramAggregationSelector {
-    pub(crate) _private: (),
-}
-
-#[cfg(feature = "otel")]
-impl ExponentialHistogramAggregationSelector {
-    /// Create a new  aggregation selector.
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-#[cfg(feature = "otel")]
-impl opentelemetry_sdk::metrics::reader::AggregationSelector
-    for ExponentialHistogramAggregationSelector
-{
-    fn aggregation(
-        &self,
-        kind: opentelemetry_sdk::metrics::InstrumentKind,
-    ) -> opentelemetry_sdk::metrics::Aggregation {
-        match kind {
-            opentelemetry_sdk::metrics::InstrumentKind::Counter
-            | opentelemetry_sdk::metrics::InstrumentKind::UpDownCounter
-            | opentelemetry_sdk::metrics::InstrumentKind::ObservableCounter
-            | opentelemetry_sdk::metrics::InstrumentKind::ObservableUpDownCounter => {
-                opentelemetry_sdk::metrics::Aggregation::Sum
-            }
-            opentelemetry_sdk::metrics::InstrumentKind::Gauge
-            | opentelemetry_sdk::metrics::InstrumentKind::ObservableGauge => {
-                opentelemetry_sdk::metrics::Aggregation::LastValue
-            }
-            opentelemetry_sdk::metrics::InstrumentKind::Histogram => {
-                opentelemetry_sdk::metrics::Aggregation::Base2ExponentialHistogram {
-                    max_size: 160,
-                    max_scale: 20,
-                    record_min_max: true,
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
## Feature or Problem

Quite a bit has changed since `0.23`, most notably the breaking changes introduced in [`0.27`](https://github.com/open-telemetry/opentelemetry-rust/blob/a1dda220deed9f69bd8502e8ffc0a45d72ac836e/opentelemetry-otlp/CHANGELOG.md#0270).

I tried to keep the changes here as minimal and focused on the upgrade without changing much else

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
