### PR TITLE
chore: Remove wasm32-wasi usage

### DIFF
--- a/crates/wash-cli/tests/fixtures/old-examples/http-hello-world-go/wasmcloud.toml
+++ b/crates/wash-cli/tests/fixtures/old-examples/http-hello-world-go/wasmcloud.toml
@@ -5,5 +5,5 @@ version = "0.1.0"
 
 [component]
 wit_world = "hello"
-wasm_target = "wasm32-wasi"
+wasm_target = "wasm32-wasip1"
 destination = "build/http_hello_world_s.wasm"

--- a/crates/wash-cli/tests/fixtures/separate-wkg/.cargo/config.toml
+++ b/crates/wash-cli/tests/fixtures/separate-wkg/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/crates/wash-lib/src/build/component.rs
+++ b/crates/wash-lib/src/build/component.rs
@@ -851,9 +851,9 @@ func main() {}
 
     #[test]
     fn can_parse_custom_command() {
-        let cargo_component_build = "cargo component build --release --target wasm32-wasi";
+        let cargo_component_build = "cargo component build --release --target wasm32-wasip1";
         let tinygo_build =
-            "tinygo build -o build/test.wasm -target wasm32-wasi -scheduler none -no-debug .";
+            "tinygo build -o build/test.wasm -target wasm32-wasip1 -scheduler none -no-debug .";
         // Raw strings because backslashes are used and shouldn't trigger escape sequences
         let some_other_language = r"zig build-exe .\tiny-hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target aarch64-linux";
 
@@ -862,7 +862,13 @@ func main() {}
         assert_eq!(command, "cargo");
         assert_eq!(
             args,
-            vec!["component", "build", "--release", "--target", "wasm32-wasi"]
+            vec![
+                "component",
+                "build",
+                "--release",
+                "--target",
+                "wasm32-wasip1"
+            ]
         );
 
         let (command, args) = super::parse_custom_command(tinygo_build)
@@ -875,7 +881,7 @@ func main() {}
                 "-o",
                 "build/test.wasm",
                 "-target",
-                "wasm32-wasi",
+                "wasm32-wasip1",
                 "-scheduler",
                 "none",
                 "-no-debug",

--- a/examples/golang/providers/custom-template/component/wasmcloud.toml
+++ b/examples/golang/providers/custom-template/component/wasmcloud.toml
@@ -5,5 +5,5 @@ version = "0.1.0"
 
 [component]
 wit_world = "component"
-wasm_target = "wasm32-wasi"
+wasm_target = "wasm32-wasip1"
 destination = "build/custom_template_component_s.wasm"

--- a/examples/rust/components/messaging-image-processor-worker/wasmcloud.toml
+++ b/examples/rust/components/messaging-image-processor-worker/wasmcloud.toml
@@ -5,4 +5,4 @@ type = "component"
 [component]
 # NOTE: rustix does not yet allow use of unstable library feature wasip2,
 # we must allow wash to auto-adapt this component
-wasm_target = "wasm32-wasi"
+wasm_target = "wasm32-wasip1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,7 +3,6 @@ channel = "stable"
 components = ["clippy", "rust-src", "rustfmt"]
 targets = [
     "wasm32-unknown-unknown",
-    "wasm32-wasi",
     "wasm32-wasip1",
     "wasm32-wasip2",
 ]

--- a/tests/components/rust/ponger-config-component/.cargo/config.toml
+++ b/tests/components/rust/ponger-config-component/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"


### PR DESCRIPTION
## Feature or Problem

Rust 1.84 completes the transition from `wasm32-wasi` to `wasm32-wasip1` and `wasm32-wasip2`, which also includes removing the target entirely. [See 1.84 compatibility notes section for more details](https://releases.rs/docs/1.84.0/#compatibility-notes).

[This showed up in merge queue](https://github.com/wasmCloud/wasmCloud/actions/runs/12694029922/job/35382927907).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
