### PR TITLE
build(nix): use current time for OCI timestamps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -275,6 +275,7 @@
                 fromImage
                 name
                 ;
+              created = "now";
               tag = architecture;
 
               config.Cmd = [name];


### PR DESCRIPTION
Set a timestamp for Docker images built in Nix

Note that this, of course, makes these builds non-reproducible