### PR TITLE
fix: allow deletion of labels without providing value

### DIFF
--- a/crates/control-interface/src/client.rs
+++ b/crates/control-interface/src/client.rs
@@ -23,7 +23,9 @@ use crate::types::rpc::{
     ComponentAuctionAck, ComponentAuctionRequest, DeleteInterfaceLinkDefinitionRequest,
     ProviderAuctionAck, ProviderAuctionRequest,
 };
-use crate::{broker, json_deserialize, json_serialize, otel, IdentifierKind, Result};
+use crate::{
+    broker, json_deserialize, json_serialize, otel, HostLabelIdentifier, IdentifierKind, Result,
+};
 
 /// A client builder that can be used to fluently provide configuration settings used to construct
 /// the control interface client
@@ -568,9 +570,8 @@ impl Client {
     pub async fn delete_label(&self, host_id: &str, key: &str) -> Result<CtlResponse<()>> {
         let subject = broker::v1::delete_label(&self.topic_prefix, &self.lattice, host_id);
         debug!(%subject, "removing label");
-        let bytes = json_serialize(HostLabel {
+        let bytes = json_serialize(HostLabelIdentifier {
             key: key.to_string(),
-            value: String::new(), // value isn't parsed by the host
         })?;
         match self.request_timeout(subject, bytes, self.timeout).await {
             Ok(msg) => Ok(json_deserialize(&msg.payload)?),

--- a/crates/control-interface/src/types/host.rs
+++ b/crates/control-interface/src/types/host.rs
@@ -409,6 +409,26 @@ impl HostLabel {
     }
 }
 
+/// An identifier that represents a label on a given host (ex. "arch" in "arch=amd64")
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct HostLabelIdentifier {
+    /// Key of the label (`arch` in `arch=amd64`)
+    pub(crate) key: String,
+}
+
+impl HostLabelIdentifier {
+    /// Create a [`HostLabelIdentifier`] from a key
+    pub fn from_key(key: &str) -> Self {
+        Self { key: key.into() }
+    }
+
+    /// Get the host label key
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -46,9 +46,10 @@ use uuid::Uuid;
 use wascap::{jwt, prelude::ClaimsBuilder};
 use wasmcloud_control_interface::{
     ComponentAuctionAck, ComponentAuctionRequest, ComponentDescription, CtlResponse,
-    DeleteInterfaceLinkDefinitionRequest, HostInventory, HostLabel, Link, ProviderAuctionAck,
-    ProviderAuctionRequest, ProviderDescription, RegistryCredential, ScaleComponentCommand,
-    StartProviderCommand, StopHostCommand, StopProviderCommand, UpdateComponentCommand,
+    DeleteInterfaceLinkDefinitionRequest, HostInventory, HostLabel, HostLabelIdentifier, Link,
+    ProviderAuctionAck, ProviderAuctionRequest, ProviderDescription, RegistryCredential,
+    ScaleComponentCommand, StartProviderCommand, StopHostCommand, StopProviderCommand,
+    UpdateComponentCommand,
 };
 use wasmcloud_core::{
     provider_config_update_subject, ComponentId, HealthCheckResponse, HostData,
@@ -2837,7 +2838,7 @@ impl Host {
         host_id: &str,
         payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<CtlResponse<()>> {
-        let label = serde_json::from_slice::<HostLabel>(payload.as_ref())
+        let label = serde_json::from_slice::<HostLabelIdentifier>(payload.as_ref())
             .context("failed to deserialize delete label request")?;
         let key = label.key();
         let mut labels = self.labels.write().await;


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Allow deletion of labels without providing `value`

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
Closes #3913

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->
`next`

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->
Nothing.

## Testing
<!---
Declare the testing information for this pull request
--->
Running a deletion without providing the value should now work.

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
1. Launch locally built wasmCloud using `wash up --host-path target/debug/wasmcloud`
2. Get the host ID, use for next two commands
3. Run `nats req "wasmbus.ctl.v1.default.label.put.NCZBHUNUKL6J47Z6U7YODISBKW6FHLMIXKHBF6BCCPT4DYGVBMQZENHX" '{"key":"foo","value":"bar"}'`
4. Run `nats req "wasmbus.ctl.v1.default.label.del.NCZBHUNUKL6J47Z6U7YODISBKW6FHLMIXKHBF6BCCPT4DYGVBMQZENHX" '{"key":"foo"}'`
5. See it working
