### PR TITLE
refactor: HTTP admin endpoints

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -917,7 +917,7 @@ impl Host {
         if let Some(addr) = config.http_admin {
             let socket = TcpListener::bind(addr)
                 .await
-                .context("failed to start health endpoint")?;
+                .context("failed to bind on HTTP administation endpoint")?;
             let ready = Arc::clone(&ready);
             let svc = hyper::service::service_fn(move |req| {
                 const OK: &str = r#"{"status":"ok"}"#;
@@ -953,13 +953,13 @@ impl Host {
                     let stream = match socket.accept().await {
                         Ok((stream, _)) => stream,
                         Err(err) => {
-                            error!(?err, "failed to accept health endpoint connection");
+                            error!(?err, "failed to accept HTTP administration connection");
                             continue;
                         }
                     };
                     let svc = svc.clone();
                     if let Err(err) = srv.serve_connection(TokioIo::new(stream), svc).await {
-                        error!(?err, "failed to serve connection");
+                        error!(?err, "failed to serve HTTP administration connection");
                     }
                 }
             });

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -913,7 +913,7 @@ impl Host {
         debug!("Feature flags: {:?}", config.experimental_features);
 
         let mut tasks = JoinSet::new();
-        let ready = Arc::<AtomicBool>::default();
+        let ready = Arc::new(AtomicBool::new(true));
         if let Some(addr) = config.http_admin {
             let socket = TcpListener::bind(addr)
                 .await
@@ -1120,7 +1120,6 @@ impl Host {
             })
             .await;
 
-        ready.store(true, Ordering::Relaxed);
         host.publish_event("host_started", start_evt)
             .await
             .context("failed to publish start event")?;


### PR DESCRIPTION
```
$ curl http://localhost:9090/     
unknown endpoint `/`

$ curl http://localhost:9090/hello
unknown endpoint `/hello`

$ curl http://localhost:9090/readyz
{"status":"ok"}

$ curl http://localhost:9090/livez 
{"status":"ok"}

$ curl --head http://localhost:9090/livez
HTTP/1.1 200 OK
date: Tue, 14 Jan 2025 10:03:31 GMT

$ curl --head http://localhost:9090/readyz
HTTP/1.1 200 OK
date: Tue, 14 Jan 2025 10:03:34 GMT
```

See commit messages for details

Refs https://github.com/wasmCloud/wasmCloud/pull/3874