### PR TITLE
chore: remove platform category from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 
 [workspace.package]
 authors = ["The wasmCloud Team"]
-categories = ["wasm", "platform"]
+categories = ["wasm"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/wasmCloud/wasmCloud"


### PR DESCRIPTION
## Feature or Problem
As per https://github.com/wasmCloud/wasmCloud/actions/runs/12813978751/job/35729348587 this is not an allowed category.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
