### PR TITLE
ci(wasmcloud): use ubuntu 22.04 for oci

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -425,7 +425,7 @@ jobs:
         id: deployment
 
   oci:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
actions/runner-images#10443

## Feature or Problem
This fixes an issue with the way we use `unshare` and Ubuntu 24.04.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
