### PR TITLE
chore(wasmcloud): bump to v1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8232,7 +8232,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "1.5.0"
+version = "1.5.1"
 description = "wasmCloud is a Cloud Native Computing Foundation (CNCF) project that enables teams to build polyglot applications composed of reusable Wasm components and run them—resiliently and efficiently—across any cloud, Kubernetes, datacenter, or edge."
 default-run = "wasmcloud"
 readme = "README.md"


### PR DESCRIPTION
## Feature or Problem
This PR bumps wasmCloud to 1.5.1 for the release of a few bug fixes and the following changes to experimental features:
1. Support disabling component/provider auctions
1. Replace `todo!()` with path-based routing support in the builtin HTTP server

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wasmcloud v1.5.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
