### PR TITLE
fix(wash-cli): use work dir without extra package args

### DIFF
--- a/crates/wash-cli/src/cmd/dev/mod.rs
+++ b/crates/wash-cli/src/cmd/dev/mod.rs
@@ -126,10 +126,9 @@ pub async fn handle_command(
     cmd: DevCommand,
     output_kind: wash_lib::cli::OutputKind,
 ) -> Result<CommandOutput> {
-    let project_cfg = load_config(cmd.package_args.config_path().cloned(), Some(true)).await?;
-    let project_path = cmd
-        .code_dir
-        .unwrap_or_else(|| project_cfg.wasmcloud_toml_dir.clone());
+    let current_dir =
+        std::env::current_dir().context("failed to get current directory for wash dev")?;
+    let project_path = cmd.code_dir.unwrap_or(current_dir);
     let project_cfg = load_config(Some(project_path.clone()), Some(true)).await?;
 
     let mut wash_dev_session = WashDevSession::from_sessions_file(&project_path)


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue in `wash-cli` where if an extra wkg configuration file wasn't supplied we couldn't use the `--work-dir` flag with `wash dev`

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wash 0.38.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
