### PR TITLE
feat(ci): Adds pipeline for custom k6 test runner

### DIFF
--- a/.github/workflows/k6runner.yml
+++ b/.github/workflows/k6runner.yml
@@ -1,0 +1,56 @@
+name: Build and Push k6runner
+
+on:
+  push:
+    tags:
+      - 'k6runner-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (without "v" prefix)'
+        required: true
+        type: string
+
+env:
+  IMAGE_NAME: k6runner
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Login to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=${GITHUB_REF_NAME#k6runner-v}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d
+        with:
+          context: ./ci/
+          file: ci/Dockerfile.k6runner
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest

--- a/ci/Dockerfile.k6runner
+++ b/ci/Dockerfile.k6runner
@@ -1,0 +1,6 @@
+FROM grafana/xk6:0.13.4 AS builder
+
+RUN xk6 build v0.56.0 --with github.com/grafana/xk6-kubernetes@v0.10.0
+
+FROM grafana/k6:0.56.0
+COPY --from=builder /xk6/k6 /usr/bin/k6


### PR DESCRIPTION
In order to collect the test results from k6 into a configmap (which can then be collected and published wherever we want), we need to build k6 with custom extensions. Even if we choose to publish these in other ways in the future, we'll still need a custom runner like this. This is just a simple pipeline and dockerfile for building said custom runner