### PR TITLE
ci: run `oci` job on larger runner, use `skopeo`

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -484,30 +484,30 @@ jobs:
           username: ${{ secrets.DOCKERHUB_PUSH_USER }}
           password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
 
-      - name: Install `buildah`
-        run: nix profile install --inputs-from . 'nixpkgs#buildah'
+      - name: Install `skopeo`
+        run: nix profile install --inputs-from . 'nixpkgs#skopeo'
 
       - name: Build `${{ matrix.bin }}` image
         run: |
-          nix run -L .#build-${{ matrix.bin }}-oci-debian ${{ matrix.bin }}:debian
-          nix run -L .#build-${{ matrix.bin }}-oci-wolfi ${{ matrix.bin }}:wolfi
+          nix build -L .#${{ matrix.bin }}-oci-debian -o ./oci-debian
+          nix build -L .#${{ matrix.bin }}-oci-wolfi -o ./oci-wolfi
 
       - name: Test `${{ matrix.bin }}` image
         run: |
-          buildah push ${{ matrix.bin }}:debian docker-daemon:${{ matrix.bin }}:debian-test
-          buildah push ${{ matrix.bin }}:wolfi docker-daemon:${{ matrix.bin }}:wolfi-test
+          skopeo copy oci-archive:./oci-debian docker-daemon:${{ matrix.bin }}:debian-test
+          skopeo copy oci-archive:./oci-wolfi docker-daemon:${{ matrix.bin }}:wolfi-test
           docker run --rm ${{ matrix.bin }}:debian-test ${{ matrix.bin }} --version
           docker run --rm ${{ matrix.bin }}:wolfi-test ${{ matrix.bin }} --version
 
       - name: Push `${{ matrix.bin }}` commit rev tag
         if: startswith(github.ref, format('refs/tags/{0}v', matrix.prefix)) || github.ref == 'refs/heads/main'
         run: |
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ github.sha }}
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.sha_short }}
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ github.sha }}-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.sha_short }}-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ github.sha }}-wolfi
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.sha_short }}-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ github.sha }}
+          skopeo copy --all oci-archive:./oci-wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.sha_short }}
+          skopeo copy --all oci-archive:./oci-debian docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ github.sha }}-debian
+          skopeo copy --all oci-archive:./oci-debian docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.sha_short }}-debian
+          skopeo copy --all oci-archive:./oci-wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ github.sha }}-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.sha_short }}-wolfi
 
           docker run --rm ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ github.sha }} ${{ matrix.bin }} --version
           docker run --rm ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.sha_short }} ${{ matrix.bin }} --version
@@ -520,15 +520,15 @@ jobs:
         if: github.ref == 'refs/heads/main'
         continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
         run: |
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-wolfi
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-wolfi
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary
+          skopeo copy --all oci-archive:./oci-wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary
+          skopeo copy --all oci-archive:./oci-wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary
+          skopeo copy --all oci-archive:./oci-debian docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-debian
+          skopeo copy --all oci-archive:./oci-debian docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-debian
+          skopeo copy --all oci-archive:./oci-debian docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-debian
+          skopeo copy --all oci-archive:./oci-wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary-wolfi
 
           docker run --rm ${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary ${{ matrix.bin }} --version
           docker run --rm ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:canary ${{ matrix.bin }} --version
@@ -544,15 +544,15 @@ jobs:
         if: startswith(github.ref, format('refs/tags/{0}v', matrix.prefix))
         continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
         run: |
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-wolfi
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-wolfi
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}
+          skopeo copy --all oci-archive:./oci-wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}
+          skopeo copy --all oci-archive:./oci-wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}
+          skopeo copy --all oci-archive:./oci-debian docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-debian
+          skopeo copy --all oci-archive:./oci-debian docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-debian
+          skopeo copy --all oci-archive:./oci-debian docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-debian
+          skopeo copy --all oci-archive:./oci-wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }}-wolfi
 
           docker run --rm ${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }} ${{ matrix.bin }} --version
           docker run --rm ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:${{ steps.ctx.outputs.version }} ${{ matrix.bin }} --version
@@ -568,15 +568,15 @@ jobs:
         if: startswith(github.ref, format('refs/tags/{0}v', matrix.prefix)) && !steps.ctx.outputs.prerelease
         continue-on-error: ${{ github.repository_owner != 'wasmCloud' }}
         run: |
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:debian docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-debian
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-wolfi
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-wolfi
-          buildah manifest push --all --format 'v2s2' ${{ matrix.bin }}:wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest
+          skopeo copy --all oci-archive:./oci-wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest
+          skopeo copy --all oci-archive:./oci-wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest
+          skopeo copy --all oci-archive:./oci-debian docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-debian
+          skopeo copy --all oci-archive:./oci-debian docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-debian
+          skopeo copy --all oci-archive:./oci-debian docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-debian
+          skopeo copy --all oci-archive:./oci-wolfi docker://${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-wolfi
+          skopeo copy --all oci-archive:./oci-wolfi docker://wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-wolfi
 
           docker run --rm ${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest ${{ matrix.bin }} --version
           docker run --rm ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest ${{ matrix.bin }} --version

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -425,7 +425,7 @@ jobs:
         id: deployment
 
   oci:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-8-cores
     strategy:
       matrix:
         include:

--- a/crates/provider-archive/src/archive.rs
+++ b/crates/provider-archive/src/archive.rs
@@ -334,7 +334,7 @@ impl ProviderArchive {
 
         let mut header = tokio_tar::Header::new_gnu();
         header.set_path(CLAIMS_JWT_FILE)?;
-        header.set_size(claims_jwt.as_bytes().len() as u64);
+        header.set_size(claims_jwt.len() as u64);
         header.set_cksum();
         par.append_data(&mut header, CLAIMS_JWT_FILE, Cursor::new(claims_jwt))
             .await?;

--- a/crates/provider-http-client/src/lib.rs
+++ b/crates/provider-http-client/src/lib.rs
@@ -98,7 +98,7 @@ impl HttpClientProvider {
         // Load native certificates
         if config
             .get(LOAD_NATIVE_CERTS)
-            .map(|v| v.to_ascii_lowercase() == "true")
+            .map(|v| v.eq_ignore_ascii_case("true"))
             .unwrap_or(true)
         {
             let (added, ignored) = ca.add_parsable_certificates(tls::NATIVE_ROOTS.iter().cloned());
@@ -108,7 +108,7 @@ impl HttpClientProvider {
         // Load Mozilla trusted root certificates
         if config
             .get(LOAD_WEBPKI_CERTS)
-            .map(|v| v.to_ascii_lowercase() == "true")
+            .map(|v| v.eq_ignore_ascii_case("true"))
             .unwrap_or(true)
         {
             ca.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -244,7 +244,7 @@ impl Runtime {
 
     /// [Runtime] version
     #[must_use]
-    pub fn version(&self) -> &str {
+    pub fn version(&self) -> &'static str {
         env!("CARGO_PKG_VERSION")
     }
 

--- a/crates/wash-lib/src/start/github/mod.rs
+++ b/crates/wash-lib/src/start/github/mod.rs
@@ -95,7 +95,7 @@ where
 {
     metadata(dir.as_ref().join(bin_name))
         .await
-        .map_or(false, |m| m.is_file())
+        .is_ok_and(|m| m.is_file())
 }
 
 /// Helper function to set up a reqwest client for performing the download

--- a/flake.lock
+++ b/flake.lock
@@ -546,16 +546,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1727963723,
-        "narHash": "sha256-urAGMGMH5ousEeVTZ5AaLPfowXaYQoISNXiutV00iQo=",
+        "lastModified": 1737050201,
+        "narHash": "sha256-tbHAvdDN2qkJRRfy9L3apBULRVttb7Jh00bDlb1OKJ4=",
         "owner": "bytecodealliance",
         "repo": "wit-deps",
-        "rev": "eb7c84564acfe13a4197bb15052fd2e2b3d29775",
+        "rev": "9b389783986ec8861ad9b3d6354da2c451a1ca83",
         "type": "github"
       },
       "original": {
         "owner": "bytecodealliance",
-        "ref": "v0.4.0",
+        "ref": "v0.5.0",
         "repo": "wit-deps",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1735928634,
-        "narHash": "sha256-Qg1vJOuEohAbdRmTTOLrbbGsyK9KRB54r3+aBuOMctM=",
+        "lastModified": 1737565911,
+        "narHash": "sha256-WxIWw1mSPJVU1JfIcTdIubU5UoIwwR8h7UcXop/6htg=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "63a2f39924f66ca89cf5761f299a8a244fe02543",
+        "rev": "ffa26704690a3dc403edcd94baef103ee48f66eb",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1736101677,
-        "narHash": "sha256-iKOPq86AOWCohuzxwFy/MtC8PcSVGnrxBOvxpjpzrAY=",
+        "lastModified": 1737563566,
+        "narHash": "sha256-GLJvkOG29XCynQm8XWPyykMRqIhxKcBARVu7Ydrz02M=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "61ba163d85e5adeddc7b3a69bb174034965965b2",
+        "rev": "849376434956794ebc7a6b487d31aace395392ba",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1736318091,
-        "narHash": "sha256-RkRHXZaMgOMGgkW2YmEqxxDDYRiGFbfr1JuaI0VrCKo=",
+        "lastModified": 1737613896,
+        "narHash": "sha256-ldqXIglq74C7yKMFUzrS9xMT/EVs26vZpOD68Sh7OcU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "9e13860d50cbfd42e79101a516e1939c7723f093",
+        "rev": "303a062fdd8e89f233db05868468975d17855d80",
         "type": "github"
       },
       "original": {
@@ -299,11 +299,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1737132768,
-        "narHash": "sha256-kyuyhWxj65e6Y1gObBeYMGEZJ7XyrgkuRvZn+13TrcA=",
+        "lastModified": 1737729573,
+        "narHash": "sha256-I6TzCcDkfefB0NR9QwHakheNoR8iUu1pGFdV22O0WXM=",
         "owner": "rvolosatovs",
         "repo": "nixify",
-        "rev": "91be3af27e8b4d0635625bc728beb85af7bf883c",
+        "rev": "6eddaf84bd58464968c19242a1b396a7a0ccb6b2",
         "type": "github"
       },
       "original": {
@@ -399,11 +399,11 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1735954111,
-        "narHash": "sha256-yPzRuUXx99iu9QMF9GKxxqqC7kpKdFlQi7PA9N85wxQ=",
+        "lastModified": 1737604399,
+        "narHash": "sha256-6mhxTomwwim6OrUXnXzsbIEdNdUXPF4F2+sXf1MrXPw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a4c40a8a970c147cea7e98e86b2ff2ffb184aedd",
+        "rev": "be24912af5998c5298b827d5304462e16d27215d",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
     },
     "nixpkgs-nixos": {
       "locked": {
-        "lastModified": 1736200483,
-        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
+        "lastModified": 1737569578,
+        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
+        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
         "type": "github"
       },
       "original": {
@@ -439,11 +439,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1736266405,
-        "narHash": "sha256-V2FDSb8YjuquZduBRNp5niWYlWurja2yGN6Xzh5GPYk=",
+        "lastModified": 1737581772,
+        "narHash": "sha256-t1P2Pe3FAX9TlJsCZbmJ3wn+C4qr6aSMypAOu8WNsN0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "91fc0a239af4e56b84b1d3974ac0f34dcc99b895",
+        "rev": "582af7ee9c8d84f5d534272fc7de9f292bd849be",
         "type": "github"
       },
       "original": {
@@ -507,11 +507,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736303309,
-        "narHash": "sha256-IKrk7RL+Q/2NC6+Ql6dwwCNZI6T6JH2grTdJaVWHF0A=",
+        "lastModified": 1737599167,
+        "narHash": "sha256-S2rHCrQWCDVp63XxL/AQbGr1g5M8Zx14C7Jooa4oM8o=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a0b81d4fa349d9af1765b0f0b4a899c13776f706",
+        "rev": "38374302ae9edf819eac666d1f276d62c712dd06",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
   inputs.nixlib.url = "github:nix-community/nixpkgs.lib";
   inputs.wit-deps.inputs.nixify.follows = "nixify";
   inputs.wit-deps.inputs.nixlib.follows = "nixlib";
-  inputs.wit-deps.url = "github:bytecodealliance/wit-deps/v0.4.0";
+  inputs.wit-deps.url = "github:bytecodealliance/wit-deps/v0.5.0";
 
   outputs = {
     nixify,

--- a/flake.nix
+++ b/flake.nix
@@ -427,6 +427,7 @@
                 mkdir -p $out
                 cp ${dirs.amd64}/* $out/
                 mv $out/manifest.json $out/${hashFile "sha256" manifests.amd64}.manifest.json
+                rm -f $out/version
                 cp ${dirs.arm64}/* $out/
                 mv $out/manifest.json $out/${hashFile "sha256" manifests.arm64}.manifest.json
                 rm -f $out/version


### PR DESCRIPTION
- Run `oci` job on the larger runner again
- Remove `buildah` usage - use `skopeo` instead and manually generate a multi-arch manifest
- Update `wit-deps`
- Update `nixify` and fix clippy errors, which we now encounter due to more recent Rust version

For manifest spec see https://github.com/opencontainers/image-spec/blob/main/image-index.md

Refs https://github.com/rvolosatovs/nixify/pull/337
Refs https://github.com/bytecodealliance/wrpc/pull/625
Refs https://github.com/actions/runner-images/issues/10443
Refs #4005 