### PR TITLE
feat(charts): Adds result aggregation to the benchmark chart

### DIFF
--- a/charts/benchmark/Chart.yaml
+++ b/charts/benchmark/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/benchmark/k6/test.js.tpl
+++ b/charts/benchmark/k6/test.js.tpl
@@ -1,4 +1,6 @@
 import http from "k6/http";
+import { Kubernetes } from 'k6/x/kubernetes';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.1.0/index.js';
 
 export const options = {
   discardResponseBodies: true,
@@ -34,14 +36,31 @@ export function teardown() {
   annotate("Test end", "wasmCloud Benchmark Chart");
 }
 
-// NOTE: In the future we could use this function to do something like store a configmap with the
-// output of the test. In conjunction with a custom pod we could watch the configmap objects
-// filtered by the labeled configmap and then run a script to generate an aggregated report.
-// export function handleSummary(data) {
-//   return {
-//     'summary.json': JSON.stringify(data), //the default data object
-//   };
-// }
+var configMap = {
+  apiVersion: "v1",
+  kind: "ConfigMap",
+  metadata: {
+    name: `${__ENV.MY_POD_NAME}`,
+    labels: {
+      "k6-result": "true",
+      "k6-test-name": "{{ include "benchmark.fullname" . }}-test",
+      "chart-revision": `{{ .Release.Revision }}`
+    }
+  },
+  data: {}
+};
+
+// Writes out the results to a configmap for later aggregation/consumption
+export function handleSummary(data) {
+  configMap.data.results = JSON.stringify(data);
+  const kubernetes = new Kubernetes();
+  // Don't know why, but we have to stringify the configmap first even though the k6 examples don't
+  // show this
+  kubernetes.apply(JSON.stringify(configMap));
+  return {
+    stdout: textSummary(data, { enableColors: true }) + "\n\n",
+  };
+}
 
 const url = {{ required "A test URL must be set" .Values.test.url | quote }};
 export default function () {

--- a/charts/benchmark/templates/NOTES.txt
+++ b/charts/benchmark/templates/NOTES.txt
@@ -1,11 +1,25 @@
 {{- if .Values.test.enabled }}
 The k6 benchmark should now be running! To get the logs and output of the test, you can run:
 
-kubectl logs -n {{ .Release.Namespace }} -l k6_cr={{ include "benchmark.fullname" . }}-test,runner=true --tail=-1
+    kubectl logs -n {{ .Release.Namespace }} -l k6_cr={{ include "benchmark.fullname" . }}-test,runner=true --tail=-1
+
+To wait for the tests to complete, you can run:
+
+    kubectl wait -n {{ .Release.Namespace }} --timeout 90s --for=jsonpath='{.status.stage}'=finished testruns/{{ include "benchmark.fullname" . }}-test
+
+Note that you may need to change the timeout value to a value that is longer than the test duration if you speciify a longer duration in the test.
+
+The test results will be output to ConfigMaps in the {{ .Release.Namespace }} namespace. To fetch all results and combine them into a single JSON array, you can run:
+
+    kubectl get cm -n {{ .Release.Namespace }} -o json -l chart-revision={{ .Release.Revision }},k6-result=true,k6-test-name={{ include "benchmark.fullname" . }}-test | jq  '[.items[].data.results | fromjson ]'
+
+To clear all test results for this chart, you can run:
+
+    kubectl delete cm -n {{ .Release.Namespace }} -l k6-result=true,k6-test-name={{ include "benchmark.fullname" . }}-test
 {{- end }}
 
 If you'd like to view dashboards during or after your tests, port-forward to the Grafana instance:
 
-kubectl port-forward -n {{ .Release.Namespace }} svc/{{ .Release.Name }}-grafana 3000:80
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ .Release.Name }}-grafana 3000:80
 
 Then open http://localhost:3000 in your browser and navigate to the "Test Environment" dashboard in the dashboards section.

--- a/charts/benchmark/templates/_helpers.tpl
+++ b/charts/benchmark/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Loki labels
 */}}
 {{- define "benchmark.lokiLabels" -}}
-helm.sh/chart: {{ include "benchmark.chart" . }}
+helm.sh/chart: {{ include "benchmark.fullname" . }}
 {{ include "benchmark.lokiSelectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/charts/benchmark/templates/k6-test.yaml
+++ b/charts/benchmark/templates/k6-test.yaml
@@ -14,6 +14,8 @@ spec:
       name: {{ include "benchmark.fullname" . }}-test-config
       file: test.js
   runner:
+    image: {{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}
+    serviceAccountName: {{ include "benchmark.fullname" . }}-test
     {{- with .Values.nodeSelector }}
     nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -43,4 +45,10 @@ spec:
         valueFrom:
           resourceFieldRef:
             resource: limits.cpu
+      - name: MY_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: TEST_UUID
+        value: {{ uuidv4 | quote }}
 {{- end }}

--- a/charts/benchmark/templates/sa.yaml
+++ b/charts/benchmark/templates/sa.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "benchmark.fullname" . }}-test
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-configmap-manager
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-configmap-manager
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "benchmark.fullname" . }}-test
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-configmap-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/benchmark/values.yaml
+++ b/charts/benchmark/values.yaml
@@ -9,6 +9,10 @@ test:
   parallelism: 3
   # Whether each test runner should be run on a separate node
   separate: false
+  # The image to use for the k6 test runner
+  image:
+    repository: ghcr.io/wasmcloud/k6runner
+    tag: "0.1.0"
   # These scenarios will be converted to JSON and added to the k6 test. These are the exact same
   # structure as the JSON scenarios in the k6 docs:
   # https://grafana.com/docs/k6/latest/using-k6/scenarios/

--- a/ci/aggregate_data.py
+++ b/ci/aggregate_data.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+import sys
+import json
+
+def create_metric_aggregator(m_type, m_contains):
+    """
+    Create a structure to hold partial sums/counters and eventually produce final merged values for
+    one metric. We need to do this because some of the metrics need to be averaged at the end of
+    aggregating all the data. Doing this with p90 values and what not isn't technically accurate,
+    but we should only average once at the end. Later down the line we might just want to integrate
+    aggregating the raw data
+    """
+    return {
+        "type": m_type,
+        "contains": m_contains,
+        # We'll accumulate data in these fields:
+        "count_sum": 0,    # for count/passes/fails
+        "has_count": False,
+        "passes_sum": 0,
+        "has_passes": False,
+        "fails_sum": 0,
+        "has_fails": False,
+        "min_val": None,   # track global min
+        "has_min": False,
+        "max_val": None,   # track global max
+        "has_max": False,
+
+        # We'll track sums of naive "avg", "med", "p(90)", "p(95)", "value"
+        # plus how many docs contributed to each
+        "avg_sum": 0.0,
+        "avg_count": 0,
+        "med_sum": 0.0,
+        "med_count": 0,
+        "p90_sum": 0.0,
+        "p90_count": 0,
+        "p95_sum": 0.0,
+        "p95_count": 0,
+        "value_sum": 0.0,
+        "value_count": 0,
+
+        # Tracking gauges which need to be summed and then min/maxed
+        "gauge_sum_min": 0,
+        "gauge_sum_max": 0,
+        "gauge_sum_value": 0,
+
+        # We'll compute 'rate' later after we know total_time
+        # but we store a flag if it’s a "counter" that might have a rate
+        "has_rate": (m_type == "counter"),
+    }
+
+def update_metric_aggregator(agg, values_dict):
+    """
+    Merge one document's .metric[<name>].values into the aggregator.
+    We do not finalize anything here; just accumulate partial sums or global min/max.
+    """
+
+    # Handle "gauge" type metrics first and then fall through to the rest
+    if agg["type"] == "gauge":
+        agg["gauge_sum_min"] += values_dict.get("min", 0)
+        agg["gauge_sum_max"] += values_dict.get("max", 0)
+        agg["gauge_sum_value"] += values_dict.get("value", 0)
+        return
+        
+    for k, v in values_dict.items():
+        if k == "count":
+            agg["count_sum"] += v
+            agg["has_count"] = True
+        elif k == "passes":
+            agg["passes_sum"] += v
+            agg["has_passes"] = True
+        elif k == "fails":
+            agg["fails_sum"] += v
+            agg["has_fails"] = True
+        elif k == "min":
+            if agg["min_val"] is None or v < agg["min_val"]:
+                agg["min_val"] = v
+            agg["has_min"] = True
+        elif k == "max":
+            if agg["max_val"] is None or v > agg["max_val"]:
+                agg["max_val"] = v
+            agg["has_max"] = True
+        elif k == "avg":
+            agg["avg_sum"] += v
+            agg["avg_count"] += 1
+        elif k == "med":
+            agg["med_sum"] += v
+            agg["med_count"] += 1
+        elif k == "p(90)":
+            agg["p90_sum"] += v
+            agg["p90_count"] += 1
+        elif k == "p(95)":
+            agg["p95_sum"] += v
+            agg["p95_count"] += 1
+        elif k == "value":
+            agg["value_sum"] += v
+            agg["value_count"] += 1
+        elif k == "rate":
+            # We'll compute rate at finalize time. We do not add or track partial rates here.
+            pass
+        # Default is to just drop values that don't exist in the aggregator.
+
+def finalize_metric_aggregator(agg, total_time_s):
+    """
+    Produce the final .metrics[<name>] entry from the aggregator. We do the naive average for avg,
+    med, p(90), p(95), value (sum / count). We do sum for count/passes/fails, global min/max, etc.
+    We compute rate = count_sum / total_time_s if it's a counter.
+    """
+    final_values = {}
+
+    # Handle gauges here. With gauges, everything else is set to default so nothing after this will be True
+    if agg["type"] == "gauge":
+        final_values["min"] = agg["gauge_sum_min"]
+        final_values["max"] = agg["gauge_sum_max"]
+        final_values["value"] = agg["gauge_sum_value"]
+
+    # Summations
+    if agg["has_count"]:
+        final_values["count"] = agg["count_sum"]
+    if agg["has_passes"]:
+        final_values["passes"] = agg["passes_sum"]
+    if agg["has_fails"]:
+        final_values["fails"] = agg["fails_sum"]
+
+    # Min/max
+    if agg["has_min"]:
+        final_values["min"] = agg["min_val"]
+    if agg["has_max"]:
+        final_values["max"] = agg["max_val"]
+
+    # Naive average fields
+    if agg["avg_count"] > 0:
+        final_values["avg"] = agg["avg_sum"] / agg["avg_count"]
+    if agg["med_count"] > 0:
+        final_values["med"] = agg["med_sum"] / agg["med_count"]
+    if agg["p90_count"] > 0:
+        final_values["p(90)"] = agg["p90_sum"] / agg["p90_count"]
+    if agg["p95_count"] > 0:
+        final_values["p(95)"] = agg["p95_sum"] / agg["p95_count"]
+    if agg["value_count"] > 0:
+        final_values["value"] = agg["value_sum"] / agg["value_count"]
+
+    # If this is a counter that might have a rate, compute it from count / total_time_s
+    # (assuming distributed tests in parallel)
+    if agg["has_rate"] and agg["has_count"] and total_time_s > 0:
+        final_values["rate"] = final_values["count"] / total_time_s
+
+    return {
+        "type": agg["type"],
+        "contains": agg["contains"],
+        "values": final_values
+    }
+
+def combine_all_docs(docs):
+    """
+    1) Find maximum .state.testRunDurationMs (assuming parallel test).
+    2) Aggregate metrics from all docs in a single pass.
+    3) Finalize the aggregates into one set of .metrics.
+    4) Return the final merged doc.
+    """
+    if not docs:
+        return {}
+
+    # 1) Determine the global "test duration" (max of testRunDurationMs).
+    max_duration_ms = 0
+    for doc in docs:
+        state = doc.get("state", {})
+        dur = state.get("testRunDurationMs", 0)
+        if dur > max_duration_ms:
+            max_duration_ms = dur
+    total_time_s = max_duration_ms / 1000.0
+
+    # 2) Build aggregators for each metric from all docs
+    metric_aggregators = {}  # metric_name -> aggregator
+    for doc in docs:
+        metrics = doc.get("metrics", {})
+        for m_name, m_data in metrics.items():
+            m_type = m_data.get("type", "")
+            m_contains = m_data.get("contains", "")
+
+            if m_name not in metric_aggregators:
+                metric_aggregators[m_name] = create_metric_aggregator(m_type, m_contains)
+
+            # Update aggregator with this doc's values
+            values_dict = m_data.get("values", {})
+            update_metric_aggregator(metric_aggregators[m_name], values_dict)
+
+    # 3) Finalize each aggregator -> produce final metrics
+    merged_metrics = {}
+    for m_name, agg in metric_aggregators.items():
+        merged_metrics[m_name] = finalize_metric_aggregator(agg, total_time_s)
+
+    # 4) Construct the final merged doc
+    # We keep root_group/options from the first doc; override testRunDurationMs with max
+    first = docs[0]
+    merged = {
+        "root_group": first.get("root_group", {}),
+        "options": first.get("options", {}),
+        "state": {
+            **first.get("state", {}),
+            "testRunDurationMs": max_duration_ms
+        },
+        "metrics": merged_metrics
+    }
+    return merged
+
+def main():
+    # Read a single JSON array from stdin
+    raw = sys.stdin.read().strip()
+    if not raw:
+        print("No input data")
+        sys.exit(1)
+
+    docs = json.loads(raw)
+    if not isinstance(docs, list):
+        print("Input JSON is not an array")
+        sys.exit(1)
+
+    merged = combine_all_docs(docs)
+    print(json.dumps(merged, indent=2))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR focuses on updating the test to publish all results to configmaps so they can be pulled out and aggregated as desired post test. This is a first step for setting up regular benchmarking tests for wasmCloud. It also includes the script we can run as part of our CI tests when we add them