### PR TITLE
ci: split binary builds into separate flake outputs

### DIFF
--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -55,13 +55,13 @@ jobs:
         with:
           path: artifacts
 
-      - run: chmod +x "./artifacts/wasmcloud-aarch64-apple-darwin/bin/${{ inputs.name }}-provider"
-      - run: chmod +x "./artifacts/wasmcloud-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
-      - run: chmod +x "./artifacts/wasmcloud-x86_64-apple-darwin/bin/${{ inputs.name }}-provider"
-      - run: chmod +x "./artifacts/wasmcloud-x86_64-pc-windows-msvc/bin/${{ inputs.name }}-provider.exe"
-      - run: chmod +x "./artifacts/wasmcloud-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
+      - run: chmod +x "./artifacts/${{ inputs.name }}-provider-aarch64-apple-darwin/bin/${{ inputs.name }}-provider"
+      - run: chmod +x "./artifacts/${{ inputs.name }}-provider-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
+      - run: chmod +x "./artifacts/${{ inputs.name }}-provider-x86_64-apple-darwin/bin/${{ inputs.name }}-provider"
+      - run: chmod +x "./artifacts/${{ inputs.name }}-provider-x86_64-pc-windows-msvc/bin/${{ inputs.name }}-provider.exe"
+      - run: chmod +x "./artifacts/${{ inputs.name }}-provider-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
 
-      - run: mv "./artifacts/wasmcloud-x86_64-unknown-linux-musl/bin/wash" wash
+      - run: mv "./artifacts/wash-x86_64-unknown-linux-musl/bin/wash" wash
       - run: chmod +x wash
 
       - run: |
@@ -72,16 +72,16 @@ jobs:
             export WASH_SUBJECT_KEY="${{ secrets.subject }}"
           fi
           ./wash par create \
-                --binary "./artifacts/wasmcloud-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider" \
+                --binary "./artifacts/${{ inputs.name }}-provider-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider" \
                 --compress \
                 --destination "${{ inputs.name }}.par.gz" \
                 --name "${{ inputs.name }}-provider" \
                 --vendor wasmcloud \
                 --version ${{ steps.ctx.outputs.version }}
-          ./wash par insert --arch aarch64-linux  --binary "./artifacts/wasmcloud-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
-          ./wash par insert --arch aarch64-macos  --binary "./artifacts/wasmcloud-aarch64-apple-darwin/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
-          ./wash par insert --arch x86_64-macos   --binary "./artifacts/wasmcloud-x86_64-apple-darwin/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
-          ./wash par insert --arch x86_64-windows --binary "./artifacts/wasmcloud-x86_64-pc-windows-msvc/bin/${{ inputs.name }}-provider.exe" "${{ inputs.name }}.par.gz"
+          ./wash par insert --arch aarch64-linux  --binary "./artifacts/${{ inputs.name }}-provider-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
+          ./wash par insert --arch aarch64-macos  --binary "./artifacts/${{ inputs.name }}-provider-aarch64-apple-darwin/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
+          ./wash par insert --arch x86_64-macos   --binary "./artifacts/${{ inputs.name }}-provider-x86_64-apple-darwin/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
+          ./wash par insert --arch x86_64-windows --binary "./artifacts/${{ inputs.name }}-provider-x86_64-pc-windows-msvc/bin/${{ inputs.name }}-provider.exe" "${{ inputs.name }}.par.gz"
           ./wash par inspect "${{ inputs.name }}.par.gz"
 
       - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
@@ -178,10 +178,10 @@ jobs:
       # Set up wash
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
-          path: artifacts
-      - run: mv "./artifacts/wasmcloud-x86_64-unknown-linux-musl/bin/wash" wash
-      - run: chmod +x wash
+          name: wash-x86_64-unknown-linux-musl
+          path: artifact
+      - run: chmod +x ./artifact/bin/wash
 
       - name: build provider
         run: |
-          ./wash build -p ${{ matrix.provider.bin-path }}
+          ./artifact/bin/wash build -p ${{ matrix.provider.bin-path }}

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -58,7 +58,7 @@ jobs:
       - run: chmod +x "./artifacts/${{ inputs.name }}-provider-aarch64-apple-darwin/bin/${{ inputs.name }}-provider"
       - run: chmod +x "./artifacts/${{ inputs.name }}-provider-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
       - run: chmod +x "./artifacts/${{ inputs.name }}-provider-x86_64-apple-darwin/bin/${{ inputs.name }}-provider"
-      - run: chmod +x "./artifacts/${{ inputs.name }}-provider-x86_64-pc-windows-msvc/bin/${{ inputs.name }}-provider.exe"
+      - run: chmod +x "./artifacts/${{ inputs.name }}-provider-x86_64-pc-windows-gnu/bin/${{ inputs.name }}-provider.exe"
       - run: chmod +x "./artifacts/${{ inputs.name }}-provider-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
 
       - run: mv "./artifacts/wash-x86_64-unknown-linux-musl/bin/wash" wash
@@ -81,7 +81,7 @@ jobs:
           ./wash par insert --arch aarch64-linux  --binary "./artifacts/${{ inputs.name }}-provider-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
           ./wash par insert --arch aarch64-macos  --binary "./artifacts/${{ inputs.name }}-provider-aarch64-apple-darwin/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
           ./wash par insert --arch x86_64-macos   --binary "./artifacts/${{ inputs.name }}-provider-x86_64-apple-darwin/bin/${{ inputs.name }}-provider" "${{ inputs.name }}.par.gz"
-          ./wash par insert --arch x86_64-windows --binary "./artifacts/${{ inputs.name }}-provider-x86_64-pc-windows-msvc/bin/${{ inputs.name }}-provider.exe" "${{ inputs.name }}.par.gz"
+          ./wash par insert --arch x86_64-windows --binary "./artifacts/${{ inputs.name }}-provider-x86_64-pc-windows-gnu/bin/${{ inputs.name }}-provider.exe" "${{ inputs.name }}.par.gz"
           ./wash par inspect "${{ inputs.name }}.par.gz"
 
       - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -288,129 +288,27 @@ jobs:
     if: ${{ needs.meta.outputs.providers_modified == 'true' || startswith(github.ref, 'refs/tags/provider-') }}
     strategy:
       matrix:
-        config:
-          - name: blobstore-azure
-            target: aarch64-apple-darwin
-          - name: blobstore-azure
-            target: aarch64-unknown-linux-musl
-          - name: blobstore-azure
-            target: x86_64-apple-darwin
-          - name: blobstore-azure
-            target: x86_64-pc-windows-gnu
-          - name: blobstore-azure
-            target: x86_64-unknown-linux-musl
+        name:
+          - blobstore-azure
+          - blobstore-fs
+          - blobstore-s3
+          - keyvalue-nats
+          - keyvalue-redis
+          - keyvalue-vault
+          - http-client
+          - http-server
+          - messaging-kafka
+          - messaging-nats
+          - sqldb-postgres
 
-          - name: blobstore-fs
-            target: aarch64-apple-darwin
-          - name: blobstore-fs
-            target: aarch64-unknown-linux-musl
-          - name: blobstore-fs
-            target: x86_64-apple-darwin
-          - name: blobstore-fs
-            target: x86_64-pc-windows-gnu
-          - name: blobstore-fs
-            target: x86_64-unknown-linux-musl
+        target:
+          - aarch64-apple-darwin
+          - aarch64-unknown-linux-musl
+          - x86_64-apple-darwin
+          - x86_64-pc-windows-gnu
+          - x86_64-unknown-linux-musl
 
-          - name: blobstore-s3
-            target: aarch64-apple-darwin
-          - name: blobstore-s3
-            target: aarch64-unknown-linux-musl
-          - name: blobstore-s3
-            target: x86_64-apple-darwin
-          - name: blobstore-s3
-            target: x86_64-pc-windows-gnu
-          - name: blobstore-s3
-            target: x86_64-unknown-linux-musl
-
-          - name: keyvalue-nats
-            target: aarch64-apple-darwin
-          - name: keyvalue-nats
-            target: aarch64-unknown-linux-musl
-          - name: keyvalue-nats
-            target: x86_64-apple-darwin
-          - name: keyvalue-nats
-            target: x86_64-pc-windows-gnu
-          - name: keyvalue-nats
-            target: x86_64-unknown-linux-musl
-
-          - name: keyvalue-redis
-            target: aarch64-apple-darwin
-          - name: keyvalue-redis
-            target: aarch64-unknown-linux-musl
-          - name: keyvalue-redis
-            target: x86_64-apple-darwin
-          - name: keyvalue-redis
-            target: x86_64-pc-windows-gnu
-          - name: keyvalue-redis
-            target: x86_64-unknown-linux-musl
-
-          - name: keyvalue-vault
-            target: aarch64-apple-darwin
-          - name: keyvalue-vault
-            target: aarch64-unknown-linux-musl
-          - name: keyvalue-vault
-            target: x86_64-apple-darwin
-          - name: keyvalue-vault
-            target: x86_64-pc-windows-gnu
-          - name: keyvalue-vault
-            target: x86_64-unknown-linux-musl
-
-          - name: http-client
-            target: aarch64-apple-darwin
-          - name: http-client
-            target: aarch64-unknown-linux-musl
-          - name: http-client
-            target: x86_64-apple-darwin
-          - name: http-client
-            target: x86_64-pc-windows-gnu
-          - name: http-client
-            target: x86_64-unknown-linux-musl
-
-          - name: http-server
-            target: aarch64-apple-darwin
-          - name: http-server
-            target: aarch64-unknown-linux-musl
-          - name: http-server
-            target: x86_64-apple-darwin
-          - name: http-server
-            target: x86_64-pc-windows-gnu
-          - name: http-server
-            target: x86_64-unknown-linux-musl
-
-          - name: messaging-kafka
-            target: aarch64-apple-darwin
-          - name: messaging-kafka
-            target: aarch64-unknown-linux-musl
-          - name: messaging-kafka
-            target: x86_64-apple-darwin
-          - name: messaging-kafka
-            target: x86_64-pc-windows-gnu
-          - name: messaging-kafka
-            target: x86_64-unknown-linux-musl
-
-          - name: messaging-nats
-            target: aarch64-apple-darwin
-          - name: messaging-nats
-            target: aarch64-unknown-linux-musl
-          - name: messaging-nats
-            target: x86_64-apple-darwin
-          - name: messaging-nats
-            target: x86_64-pc-windows-gnu
-          - name: messaging-nats
-            target: x86_64-unknown-linux-musl
-
-          - name: sqldb-postgres
-            target: aarch64-apple-darwin
-          - name: sqldb-postgres
-            target: aarch64-unknown-linux-musl
-          - name: sqldb-postgres
-            target: x86_64-apple-darwin
-          - name: sqldb-postgres
-            target: x86_64-pc-windows-gnu
-          - name: sqldb-postgres
-            target: x86_64-unknown-linux-musl
-
-    name: ${{ matrix.config.name }}-provider-${{ matrix.config.target }}
+    name: ${{ matrix.name }}-provider-${{ matrix.target }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -421,7 +319,7 @@ jobs:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - uses: ./.github/actions/build-nix
         with:
-          package: ${{ matrix.config.name }}-provider-${{ matrix.config.target }}
+          package: ${{ matrix.name }}-provider-${{ matrix.target }}
 
   build-wash-windows:
     if: ${{ startswith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'}}

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -345,7 +345,7 @@ jobs:
   build-wash-lipo:
     name: wash-universal-darwin
     needs: build-wash-bin
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
@@ -356,14 +356,8 @@ jobs:
           name: wash-x86_64-apple-darwin
           path: x86_64
 
-      - run: chmod +x ./x86_64/bin/*
-      - run: ./x86_64/bin/wash --version
-
       - run: mkdir -p ./artifact/bin
       - run: lipo -create ./aarch64/bin/wash ./x86_64/bin/wash -output ./artifact/bin/wash
-
-      - run: chmod +x ./artifact/bin/wash
-      - run: ./artifact/bin/wash --version
 
       - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
         with:
@@ -373,7 +367,7 @@ jobs:
   build-wasmcloud-lipo:
     name: wasmcloud-universal-darwin
     needs: build-wasmcloud-bin
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
@@ -384,21 +378,25 @@ jobs:
           name: wasmcloud-x86_64-apple-darwin
           path: x86_64
 
-      - run: chmod +x ./x86_64/bin/*
-      - run: ./x86_64/bin/wasmcloud --version
-
       - run: mkdir -p ./artifact/bin
       - run: lipo -create ./aarch64/bin/wasmcloud ./x86_64/bin/wasmcloud -output ./artifact/bin/wasmcloud
-
-      - run: chmod +x ./artifact/bin/wasmcloud
-      - run: ./artifact/bin/wasmcloud --version
 
       - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
         with:
           name: wasmcloud-universal-darwin
           path: artifact
 
-  test-wash-linux:
+  test-wash-linux-aarch64:
+    runs-on: ubuntu-22.04-arm
+    needs: build-wash-bin
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: wash-aarch64-unknown-linux-musl
+      - run: chmod +x ./bin/wash
+      - run: ./bin/wash --version
+
+  test-wash-linux-x86_64:
     runs-on: ubuntu-22.04
     needs: build-wash-bin
     steps:
@@ -408,7 +406,60 @@ jobs:
       - run: chmod +x ./bin/wash
       - run: ./bin/wash --version
 
-  test-wasmcloud-linux:
+  test-wash-macos-aarch64:
+    runs-on: macos-15
+    needs:
+      - build-wash-bin
+      - build-wash-lipo
+    strategy:
+      matrix:
+        artifact:
+          - wash-aarch64-apple-darwin
+          - wash-universal-darwin
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: ${{ matrix.artifact }}
+      - run: chmod +x ./bin/wash
+      - run: ./bin/wash --version
+
+  test-wash-macos-x86_64:
+    runs-on: macos-13
+    needs:
+      - build-wash-bin
+      - build-wash-lipo
+    strategy:
+      matrix:
+        artifact:
+          - wash-x86_64-apple-darwin
+          - wash-universal-darwin
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: ${{ matrix.artifact }}
+      - run: chmod +x ./bin/wash
+      - run: ./bin/wash --version
+
+  test-wash-windows-x86_64:
+    runs-on: windows-latest
+    needs: build-wash-windows
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: wash-x86_64-pc-windows-msvc
+      - run: .\bin\wash.exe --version
+
+  test-wasmcloud-linux-aarch64:
+    runs-on: ubuntu-22.04-arm
+    needs: build-wasmcloud-bin
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: wasmcloud-aarch64-unknown-linux-musl
+      - run: chmod +x ./bin/wasmcloud
+      - run: ./bin/wasmcloud --version
+
+  test-wasmcloud-linux-x86_64:
     runs-on: ubuntu-22.04
     needs: build-wasmcloud-bin
     steps:
@@ -418,7 +469,41 @@ jobs:
       - run: chmod +x ./bin/wasmcloud
       - run: ./bin/wasmcloud --version
 
-  test-wasmcloud-windows:
+  test-wasmcloud-macos-aarch64:
+    runs-on: macos-15
+    needs:
+      - build-wasmcloud-bin
+      - build-wasmcloud-lipo
+    strategy:
+      matrix:
+        artifact:
+          - wasmcloud-aarch64-apple-darwin
+          - wasmcloud-universal-darwin
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: ${{ matrix.artifact }}
+      - run: chmod +x ./bin/wasmcloud
+      - run: ./bin/wasmcloud --version
+
+  test-wasmcloud-macos-x86_64:
+    runs-on: macos-13
+    needs:
+      - build-wasmcloud-bin
+      - build-wasmcloud-lipo
+    strategy:
+      matrix:
+        artifact:
+          - wasmcloud-x86_64-apple-darwin
+          - wasmcloud-universal-darwin
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: ${{ matrix.artifact }}
+      - run: chmod +x ./bin/wasmcloud
+      - run: ./bin/wasmcloud --version
+
+  test-wasmcloud-windows-x86_64:
     runs-on: windows-latest
     needs: build-wasmcloud-bin
     steps:
@@ -426,15 +511,6 @@ jobs:
         with:
           name: wasmcloud-x86_64-pc-windows-gnu
       - run: .\bin\wasmcloud.exe --version
-
-  test-wash-windows:
-    runs-on: windows-latest
-    needs: build-wash-windows
-    steps:
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-        with:
-          name: wash-x86_64-pc-windows-msvc
-      - run: .\bin\wash.exe --version
 
   cargo:
     needs: [meta]
@@ -526,7 +602,7 @@ jobs:
       - meta
       - build-wash-bin
       - build-provider-bin
-      - test-wash-linux
+      - test-wash-linux-x86_64
     permissions:
       contents: read
       packages: write
@@ -569,8 +645,10 @@ jobs:
     needs:
       - build-wash-bin
       - build-wasmcloud-bin
-      - test-wash-linux
-      - test-wasmcloud-linux
+      - test-wash-linux-aarch64
+      - test-wash-linux-x86_64
+      - test-wasmcloud-linux-aarch64
+      - test-wasmcloud-linux-x86_64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
@@ -730,10 +808,16 @@ jobs:
       - build-wasmcloud-lipo
       - cargo
       - oci
-      - test-wash-linux
-      - test-wasmcloud-linux
-      - test-wash-windows
-      - test-wasmcloud-windows
+      - test-wash-linux-aarch64
+      - test-wash-linux-x86_64
+      - test-wash-macos-aarch64
+      - test-wash-macos-x86_64
+      - test-wash-windows-x86_64
+      - test-wasmcloud-linux-aarch64
+      - test-wasmcloud-linux-x86_64
+      - test-wasmcloud-macos-aarch64
+      - test-wasmcloud-macos-x86_64
+      - test-wasmcloud-windows-x86_64
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -833,7 +917,7 @@ jobs:
     needs:
       - cargo
       - build-wash-bin
-      - test-wash-linux
+      - test-wash-linux-x86_64
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1017,10 +1101,19 @@ jobs:
       - build-provider-bin
       - build-wash-bin
       - build-wash-lipo
+      - build-wash-windows
       - build-wasmcloud-bin
       - build-wasmcloud-lipo
-      - test-wasmcloud-linux
-      - test-wash-linux
+      - test-wash-linux-aarch64
+      - test-wash-linux-x86_64
+      - test-wash-macos-aarch64
+      - test-wash-macos-x86_64
+      - test-wash-windows-x86_64
+      - test-wasmcloud-linux-aarch64
+      - test-wasmcloud-linux-x86_64
+      - test-wasmcloud-macos-aarch64
+      - test-wasmcloud-macos-x86_64
+      - test-wasmcloud-windows-x86_64
       - cargo
       - build-doc
       - providers
@@ -1031,14 +1124,23 @@ jobs:
     steps:
       - name: Results
         run: |
-          echo 'needs.integration_tests.result: ${{ needs.integration_tests.result }}'
           echo 'needs.build-provider-bin.result: ${{ needs.build-provider-bin.result }}'
           echo 'needs.build-wash-bin.result: ${{ needs.build-wash-bin.result }}'
+          echo 'needs.build-wash-windows.result: ${{ needs.build-wash-windows.result }}'
           echo 'needs.build-wash-lipo.result: ${{ needs.build-wash-lipo.result }}'
           echo 'needs.build-wasmcloud-bin.result: ${{ needs.build-wasmcloud-bin.result }}'
           echo 'needs.build-wasmcloud-lipo.result: ${{ needs.build-wasmcloud-lipo.result }}'
-          echo 'needs.test-wash-linux.result: ${{ needs.test-wash-linux.result }}'
-          echo 'needs.test-wasmcloud-linux.result: ${{ needs.test-wasmcloud-linux.result }}'
+          echo 'needs.integration_tests.result: ${{ needs.integration_tests.result }}'
+          echo 'needs.test-wash-linux-aarch64.result: ${{ needs.test-wash-linux-aarch64.result }}'
+          echo 'needs.test-wash-linux-x86_64.result: ${{ needs.test-wash-linux-x86_64.result }}'
+          echo 'needs.test-wash-macos-aarch64.result: ${{ needs.test-wash-macos-aarch64.result }}'
+          echo 'needs.test-wash-macos-x86_64.result: ${{ needs.test-wash-macos-x86_64.result }}'
+          echo 'needs.test-wash-windows-x86_64.result: ${{ needs.test-wash-windows-x86_64.result }}'
+          echo 'needs.test-wasmcloud-linux-aarch64.result: ${{ needs.test-wasmcloud-linux-aarch64.result }}'
+          echo 'needs.test-wasmcloud-linux-x86_64.result: ${{ needs.test-wasmcloud-linux-x86_64.result }}'
+          echo 'needs.test-wasmcloud-macos-aarch64.result: ${{ needs.test-wasmcloud-macos-aarch64.result }}'
+          echo 'needs.test-wasmcloud-macos-x86_64.result: ${{ needs.test-wasmcloud-macos-x86_64.result }}'
+          echo 'needs.test-wasmcloud-windows-x86_64.result: ${{ needs.test-wasmcloud-windows-x86_64.result }}'
           echo 'needs.cargo.result: ${{ needs.cargo.result }}'
           echo 'needs.build-doc.result: ${{ needs.build-doc.result }}'
           echo 'needs.providers.result: ${{ needs.providers.result }}'

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -135,6 +135,10 @@ jobs:
         with:
           # Consider providers changed if any file in the providers change
           files: |
+            ./.github/actions/build-nix/action.yml
+            ./.github/actions/install-nix/action.yml
+            ./.github/workflows/provider.yml
+            ./.github/workflows/wasmcloud.yml
             Cargo.lock
             Cargo.toml
             crates/provider-*/*.{rs,toml,wit}

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -159,7 +159,6 @@ jobs:
               nix profile install --inputs-from . 'nixpkgs#qemu'
               qemu-aarch64 ./result/bin/wash --version
             test-oci: docker load < ./result
-            # TODO: Run aarch64 binary within OCI
 
           - target: aarch64-apple-darwin
             test-bin: |
@@ -187,7 +186,6 @@ jobs:
           #    nix profile install --inputs-from . 'nixpkgs#wine64'
           #    wine64 ./result/bin/wash.exe --version
           #  test-oci: docker load < ./result
-          #  # TODO: Run win64 binary within OCI
 
           - target: x86_64-unknown-linux-musl
             test-bin: |
@@ -227,7 +225,6 @@ jobs:
               nix profile install --inputs-from . 'nixpkgs#qemu'
               qemu-aarch64 ./result/bin/wasmcloud --version
             test-oci: docker load < ./result
-            # TODO: Run aarch64 binary within OCI
 
           - target: aarch64-apple-darwin
             test-bin: |
@@ -254,7 +251,6 @@ jobs:
               nix profile install --inputs-from . 'nixpkgs#wine64'
               wine64 ./result/bin/wasmcloud.exe --version
             test-oci: docker load < ./result
-            # TODO: Run win64 binary within OCI
 
           - target: x86_64-unknown-linux-musl
             test-bin: |
@@ -396,6 +392,21 @@ jobs:
       - run: chmod +x ./bin/wash
       - run: ./bin/wash --version
 
+  test-wash-linux-aarch64-oci:
+    runs-on: ubuntu-22.04-arm
+    needs: build-wash-bin
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/install-nix
+        with:
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: wash-aarch64-unknown-linux-musl-oci
+      - run: docker load < ./wash-aarch64-unknown-linux-musl-oci
+      - run: docker run --rm wash:$(nix eval --raw .#wash-aarch64-unknown-linux-musl-oci.imageTag) wash --version
+
+
   test-wash-linux-x86_64:
     runs-on: ubuntu-22.04
     needs: build-wash-bin
@@ -458,6 +469,20 @@ jobs:
           name: wasmcloud-aarch64-unknown-linux-musl
       - run: chmod +x ./bin/wasmcloud
       - run: ./bin/wasmcloud --version
+
+  test-wasmcloud-linux-aarch64-oci:
+    runs-on: ubuntu-22.04-arm
+    needs: build-wasmcloud-bin
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/install-nix
+        with:
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: wasmcloud-aarch64-unknown-linux-musl-oci
+      - run: docker load < ./wasmcloud-aarch64-unknown-linux-musl-oci
+      - run: docker run --rm wasmcloud:$(nix eval --raw .#wasmcloud-aarch64-unknown-linux-musl-oci.imageTag) wasmcloud --version
 
   test-wasmcloud-linux-x86_64:
     runs-on: ubuntu-22.04
@@ -646,8 +671,10 @@ jobs:
       - build-wash-bin
       - build-wasmcloud-bin
       - test-wash-linux-aarch64
+      - test-wash-linux-aarch64-oci
       - test-wash-linux-x86_64
       - test-wasmcloud-linux-aarch64
+      - test-wasmcloud-linux-aarch64-oci
       - test-wasmcloud-linux-x86_64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -809,11 +836,13 @@ jobs:
       - cargo
       - oci
       - test-wash-linux-aarch64
+      - test-wash-linux-aarch64-oci
       - test-wash-linux-x86_64
       - test-wash-macos-aarch64
       - test-wash-macos-x86_64
       - test-wash-windows-x86_64
       - test-wasmcloud-linux-aarch64
+      - test-wasmcloud-linux-aarch64-oci
       - test-wasmcloud-linux-x86_64
       - test-wasmcloud-macos-aarch64
       - test-wasmcloud-macos-x86_64

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -249,14 +249,12 @@ jobs:
               file ./result/bin/wasmcloud
             test-oci: docker load < ./result
 
-          # TODO: Build for GNU once https://github.com/rust-lang/rust/issues/92212 is resolved
-          #- target: x86_64-pc-windows-gnu
-          #  test-bin: |
-          #    nix profile install --inputs-from . 'nixpkgs#wine64'
-          #    wine64 ./result/bin/wash.exe --version
-          #    wine64 ./result/bin/wasmcloud.exe --version
-          #  test-oci: docker load < ./result
-          #  # TODO: Run win64 binary within OCI
+          - target: x86_64-pc-windows-gnu
+            test-bin: |
+              nix profile install --inputs-from . 'nixpkgs#wine64'
+              wine64 ./result/bin/wasmcloud.exe --version
+            test-oci: docker load < ./result
+            # TODO: Run win64 binary within OCI
 
           - target: x86_64-unknown-linux-musl
             test-bin: |
@@ -298,6 +296,8 @@ jobs:
           - name: blobstore-azure
             target: x86_64-apple-darwin
           - name: blobstore-azure
+            target: x86_64-pc-windows-gnu
+          - name: blobstore-azure
             target: x86_64-unknown-linux-musl
 
           - name: blobstore-fs
@@ -307,6 +307,8 @@ jobs:
           - name: blobstore-fs
             target: x86_64-apple-darwin
           - name: blobstore-fs
+            target: x86_64-pc-windows-gnu
+          - name: blobstore-fs
             target: x86_64-unknown-linux-musl
 
           - name: blobstore-s3
@@ -316,6 +318,8 @@ jobs:
           - name: blobstore-s3
             target: x86_64-apple-darwin
           - name: blobstore-s3
+            target: x86_64-pc-windows-gnu
+          - name: blobstore-s3
             target: x86_64-unknown-linux-musl
 
           - name: keyvalue-nats
@@ -324,6 +328,8 @@ jobs:
             target: aarch64-unknown-linux-musl
           - name: keyvalue-nats
             target: x86_64-apple-darwin
+          - name: keyvalue-nats
+            target: x86_64-pc-windows-gnu
           - name: keyvalue-nats
             target: x86_64-unknown-linux-musl
 
@@ -333,6 +339,8 @@ jobs:
             target: aarch64-unknown-linux-musl
           - name: keyvalue-redis
             target: x86_64-apple-darwin
+          - name: keyvalue-redis
+            target: x86_64-pc-windows-gnu
           - name: keyvalue-redis
             target: x86_64-unknown-linux-musl
 
@@ -342,6 +350,8 @@ jobs:
             target: aarch64-unknown-linux-musl
           - name: keyvalue-vault
             target: x86_64-apple-darwin
+          - name: keyvalue-vault
+            target: x86_64-pc-windows-gnu
           - name: keyvalue-vault
             target: x86_64-unknown-linux-musl
 
@@ -351,6 +361,8 @@ jobs:
             target: aarch64-unknown-linux-musl
           - name: http-client
             target: x86_64-apple-darwin
+          - name: http-client
+            target: x86_64-pc-windows-gnu
           - name: http-client
             target: x86_64-unknown-linux-musl
 
@@ -360,6 +372,8 @@ jobs:
             target: aarch64-unknown-linux-musl
           - name: http-server
             target: x86_64-apple-darwin
+          - name: http-server
+            target: x86_64-pc-windows-gnu
           - name: http-server
             target: x86_64-unknown-linux-musl
 
@@ -369,6 +383,8 @@ jobs:
             target: aarch64-unknown-linux-musl
           - name: messaging-kafka
             target: x86_64-apple-darwin
+          - name: messaging-kafka
+            target: x86_64-pc-windows-gnu
           - name: messaging-kafka
             target: x86_64-unknown-linux-musl
 
@@ -378,6 +394,8 @@ jobs:
             target: aarch64-unknown-linux-musl
           - name: messaging-nats
             target: x86_64-apple-darwin
+          - name: messaging-nats
+            target: x86_64-pc-windows-gnu
           - name: messaging-nats
             target: x86_64-unknown-linux-musl
 
@@ -387,6 +405,8 @@ jobs:
             target: aarch64-unknown-linux-musl
           - name: sqldb-postgres
             target: x86_64-apple-darwin
+          - name: sqldb-postgres
+            target: x86_64-pc-windows-gnu
           - name: sqldb-postgres
             target: x86_64-unknown-linux-musl
 
@@ -403,9 +423,9 @@ jobs:
         with:
           package: ${{ matrix.config.name }}-provider-${{ matrix.config.target }}
 
-  build-windows:
+  build-wash-windows:
     if: ${{ startswith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'}}
-    name: wasmcloud-x86_64-pc-windows-msvc
+    name: wash-x86_64-pc-windows-msvc
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -415,103 +435,14 @@ jobs:
         with:
           shared-key: windows-latest-8-cores-shared-cache
         if: ${{ !startswith(github.ref, 'refs/tags/') }}
-
-      - run: cargo build --release -p wash-cli -p wasmcloud
-
+      - run: cargo build --release -p wash-cli --bin wash
       - run: mkdir "wash/bin"
-      - run: mkdir "wasmcloud/bin"
-
-      - run: mkdir "blobstore-azure-provider/bin"
-      - run: mkdir "blobstore-fs-provider/bin"
-      - run: mkdir "blobstore-s3-provider/bin"
-      - run: mkdir "http-client-provider/bin"
-      - run: mkdir "http-server-provider/bin"
-      - run: mkdir "keyvalue-nats-provider/bin"
-      - run: mkdir "keyvalue-redis-provider/bin"
-      - run: mkdir "keyvalue-vault-provider/bin"
-      - run: mkdir "messaging-kafka-provider/bin"
-      - run: mkdir "messaging-nats-provider/bin"
-      - run: mkdir "sqldb-postgres-provider/bin"
-
-      - run: move "target/release/wash.exe" "wash/bin/wash.exe"
-      - run: move "target/release/wasmcloud.exe" "wasmcloud/bin/wasmcloud.exe"
-
-      - run: move "target/release/blobstore-azure-provider.exe" "blobstore-azure-provider/bin/blobstore-azure-provider.exe"
-      - run: move "target/release/blobstore-fs-provider.exe" "blobstore-fs-provider/bin/blobstore-fs-provider.exe"
-      - run: move "target/release/blobstore-s3-provider.exe" "blobstore-s3-provider/bin/blobstore-s3-provider.exe"
-      - run: move "target/release/http-client-provider.exe" "http-client-provider/bin/http-client-provider.exe"
-      - run: move "target/release/http-server-provider.exe" "http-server-provider/bin/http-server-provider.exe"
-      - run: move "target/release/keyvalue-nats-provider.exe" "keyvalue-nats-provider/bin/keyvalue-nats-provider.exe"
-      - run: move "target/release/keyvalue-redis-provider.exe" "keyvalue-redis-provider/bin/keyvalue-redis-provider.exe"
-      - run: move "target/release/keyvalue-vault-provider.exe" "keyvalue-vault-provider/bin/keyvalue-vault-provider.exe"
-      - run: move "target/release/messaging-kafka-provider.exe" "messaging-kafka-provider/bin/messaging-kafka-provider.exe"
-      - run: move "target/release/messaging-nats-provider.exe" "messaging-nats-provider/bin/messaging-nats-provider.exe"
-      - run: move "target/release/sqldb-postgres-provider.exe" "sqldb-postgres-provider/bin/sqldb-postgres-provider.exe"
+      - run: move "target/release/wash.exe" "artifact/bin/wash.exe"
 
       - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
         with:
           name: wash-x86_64-pc-windows-msvc
-          path: wash
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: wasmcloud-x86_64-pc-windows-msvc
-          path: wasmcloud
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: blobstore-azure-provider-x86_64-pc-windows-msvc
-          path: blobstore-azure-provider
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: blobstore-fs-provider-x86_64-pc-windows-msvc
-          path: blobstore-fs-provider
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: blobstore-s3-provider-x86_64-pc-windows-msvc
-          path: blobstore-s3-provider
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: http-client-provider-x86_64-pc-windows-msvc
-          path: http-client-provider
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: http-server-provider-x86_64-pc-windows-msvc
-          path: http-server-provider
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: keyvalue-nats-provider-x86_64-pc-windows-msvc
-          path: keyvalue-nats-provider
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: keyvalue-redis-provider-x86_64-pc-windows-msvc
-          path: keyvalue-redis-provider
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: keyvalue-vault-provider-x86_64-pc-windows-msvc
-          path: keyvalue-vault-provider
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: messaging-kafka-provider-x86_64-pc-windows-msvc
-          path: messaging-kafka-provider
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: messaging-nats-provider-x86_64-pc-windows-msvc
-          path: messaging-nats-provider
-
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
-        with:
-          name: sqldb-postgres-provider-x86_64-pc-windows-msvc
-          path: sqldb-postgres-provider
+          path: artifact
 
   build-wash-lipo:
     name: wash-universal-darwin
@@ -589,15 +520,23 @@ jobs:
       - run: chmod +x ./bin/wasmcloud
       - run: ./bin/wasmcloud --version
 
-  test-windows:
+  test-wasmcloud-windows:
     runs-on: windows-latest
-    needs: build-windows
+    needs: build-wasmcloud-bin
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
-          name: wasmcloud-x86_64-pc-windows-msvc
-      - run: .\bin\wash.exe --version
+          name: wasmcloud-x86_64-pc-windows-gnu
       - run: .\bin\wasmcloud.exe --version
+
+  test-wash-windows:
+    runs-on: windows-latest
+    needs: build-wash-windows
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: wash-x86_64-pc-windows-msvc
+      - run: .\bin\wash.exe --version
 
   cargo:
     needs: [meta]
@@ -689,7 +628,6 @@ jobs:
       - meta
       - build-wash-bin
       - build-provider-bin
-      - build-windows
       - test-wash-linux
     permissions:
       contents: read
@@ -896,7 +834,8 @@ jobs:
       - oci
       - test-wash-linux
       - test-wasmcloud-linux
-      - test-windows
+      - test-wash-windows
+      - test-wasmcloud-windows
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -141,9 +141,9 @@ jobs:
           files_ignore: |
             !crates/**/*.md
 
-  build-bin:
+  build-wash-bin:
     needs: [meta]
-    if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/wash-cli-v')}}
+    if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || startsWith(github.ref, 'refs/tags/wash-cli-v') }}
     strategy:
       matrix:
         config:
@@ -151,19 +151,84 @@ jobs:
             test-bin: |
               nix profile install --inputs-from . 'nixpkgs#qemu'
               qemu-aarch64 ./result/bin/wash --version
-              qemu-aarch64 ./result/bin/wasmcloud --version
             test-oci: docker load < ./result
             # TODO: Run aarch64 binary within OCI
 
           - target: aarch64-apple-darwin
             test-bin: |
               file ./result/bin/wash
-              file ./result/bin/wasmcloud
             test-oci: docker load < ./result
 
           - target: aarch64-linux-android
             test-bin: |
               file ./result/bin/wash
+            test-oci: docker load < ./result
+
+          - target: riscv64gc-unknown-linux-gnu-fhs
+            test-bin: |
+              nix build -L '.#wash-riscv64gc-unknown-linux-gnu'
+              nix shell --inputs-from . 'nixpkgs#qemu' -c qemu-riscv64 ./result/bin/wash --version
+
+          - target: x86_64-apple-darwin
+            test-bin: |
+              file ./result/bin/wash
+            test-oci: docker load < ./result
+
+          # TODO: Build for GNU once https://github.com/rust-lang/rust/issues/92212 is resolved
+          #- target: x86_64-pc-windows-gnu
+          #  test-bin: |
+          #    nix profile install --inputs-from . 'nixpkgs#wine64'
+          #    wine64 ./result/bin/wash.exe --version
+          #  test-oci: docker load < ./result
+          #  # TODO: Run win64 binary within OCI
+
+          - target: x86_64-unknown-linux-musl
+            test-bin: |
+              ./result/bin/wash --version
+            test-oci: |
+              docker load < ./result
+              docker run --rm wash:$(nix eval --raw .#wash-x86_64-unknown-linux-musl-oci.imageTag) wash --version
+
+    name: wash-${{ matrix.config.target }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/install-nix
+        # need to run condition inside job steps so that job will pass if all steps are skipped
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore
+        with:
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: ./.github/actions/build-nix
+        with:
+          package: wash-${{ matrix.config.target }}
+      - run: ${{ matrix.config.test-bin }}
+      - uses: ./.github/actions/build-nix
+        if: ${{ !endsWith(matrix.config.target, 'fhs') }}
+        with:
+          package: wash-${{ matrix.config.target }}-oci
+      - run: ${{ matrix.config.test-oci }}
+        if: ${{ !endsWith(matrix.config.target, 'fhs') }}
+
+  build-wasmcloud-bin:
+    needs: [meta]
+    if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || startsWith(github.ref, 'refs/tags/v') }}
+    strategy:
+      matrix:
+        config:
+          - target: aarch64-unknown-linux-musl
+            test-bin: |
+              nix profile install --inputs-from . 'nixpkgs#qemu'
+              qemu-aarch64 ./result/bin/wasmcloud --version
+            test-oci: docker load < ./result
+            # TODO: Run aarch64 binary within OCI
+
+          - target: aarch64-apple-darwin
+            test-bin: |
+              file ./result/bin/wasmcloud
+            test-oci: docker load < ./result
+
+          - target: aarch64-linux-android
+            test-bin: |
               file ./result/bin/wasmcloud
             test-oci: docker load < ./result
 
@@ -174,7 +239,6 @@ jobs:
 
           - target: x86_64-apple-darwin
             test-bin: |
-              file ./result/bin/wash
               file ./result/bin/wasmcloud
             test-oci: docker load < ./result
 
@@ -189,11 +253,9 @@ jobs:
 
           - target: x86_64-unknown-linux-musl
             test-bin: |
-              ./result/bin/wash --version
               ./result/bin/wasmcloud --version
             test-oci: |
               docker load < ./result
-              docker run --rm wasmcloud:$(nix eval --raw .#wasmcloud-x86_64-unknown-linux-musl-oci.imageTag) wash --version
               docker run --rm wasmcloud:$(nix eval --raw .#wasmcloud-x86_64-unknown-linux-musl-oci.imageTag) wasmcloud --version
 
     name: wasmcloud-${{ matrix.config.target }}
@@ -216,6 +278,124 @@ jobs:
       - run: ${{ matrix.config.test-oci }}
         if: ${{ !endsWith(matrix.config.target, 'fhs') }}
 
+  build-provider-bin:
+    needs: [meta]
+    if: ${{ needs.meta.outputs.providers_modified == 'true' || startswith(github.ref, 'refs/tags/provider-') }}
+    strategy:
+      matrix:
+        config:
+          - name: blobstore-azure
+            target: aarch64-apple-darwin
+          - name: blobstore-azure
+            target: aarch64-unknown-linux-musl
+          - name: blobstore-azure
+            target: x86_64-apple-darwin
+          - name: blobstore-azure
+            target: x86_64-unknown-linux-musl
+
+          - name: blobstore-fs
+            target: aarch64-apple-darwin
+          - name: blobstore-fs
+            target: aarch64-unknown-linux-musl
+          - name: blobstore-fs
+            target: x86_64-apple-darwin
+          - name: blobstore-fs
+            target: x86_64-unknown-linux-musl
+
+          - name: blobstore-s3
+            target: aarch64-apple-darwin
+          - name: blobstore-s3
+            target: aarch64-unknown-linux-musl
+          - name: blobstore-s3
+            target: x86_64-apple-darwin
+          - name: blobstore-s3
+            target: x86_64-unknown-linux-musl
+
+          - name: keyvalue-nats
+            target: aarch64-apple-darwin
+          - name: keyvalue-nats
+            target: aarch64-unknown-linux-musl
+          - name: keyvalue-nats
+            target: x86_64-apple-darwin
+          - name: keyvalue-nats
+            target: x86_64-unknown-linux-musl
+
+          - name: keyvalue-redis
+            target: aarch64-apple-darwin
+          - name: keyvalue-redis
+            target: aarch64-unknown-linux-musl
+          - name: keyvalue-redis
+            target: x86_64-apple-darwin
+          - name: keyvalue-redis
+            target: x86_64-unknown-linux-musl
+
+          - name: keyvalue-vault
+            target: aarch64-apple-darwin
+          - name: keyvalue-vault
+            target: aarch64-unknown-linux-musl
+          - name: keyvalue-vault
+            target: x86_64-apple-darwin
+          - name: keyvalue-vault
+            target: x86_64-unknown-linux-musl
+
+          - name: http-client
+            target: aarch64-apple-darwin
+          - name: http-client
+            target: aarch64-unknown-linux-musl
+          - name: http-client
+            target: x86_64-apple-darwin
+          - name: http-client
+            target: x86_64-unknown-linux-musl
+
+          - name: http-server
+            target: aarch64-apple-darwin
+          - name: http-server
+            target: aarch64-unknown-linux-musl
+          - name: http-server
+            target: x86_64-apple-darwin
+          - name: http-server
+            target: x86_64-unknown-linux-musl
+
+          - name: messaging-kafka
+            target: aarch64-apple-darwin
+          - name: messaging-kafka
+            target: aarch64-unknown-linux-musl
+          - name: messaging-kafka
+            target: x86_64-apple-darwin
+          - name: messaging-kafka
+            target: x86_64-unknown-linux-musl
+
+          - name: messaging-nats
+            target: aarch64-apple-darwin
+          - name: messaging-nats
+            target: aarch64-unknown-linux-musl
+          - name: messaging-nats
+            target: x86_64-apple-darwin
+          - name: messaging-nats
+            target: x86_64-unknown-linux-musl
+
+          - name: sqldb-postgres
+            target: aarch64-apple-darwin
+          - name: sqldb-postgres
+            target: aarch64-unknown-linux-musl
+          - name: sqldb-postgres
+            target: x86_64-apple-darwin
+          - name: sqldb-postgres
+            target: x86_64-unknown-linux-musl
+
+    name: ${{ matrix.config.name }}-provider-${{ matrix.config.target }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/install-nix
+        # need to run condition inside job steps so that job will pass if all steps are skipped
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore
+        with:
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: ./.github/actions/build-nix
+        with:
+          package: ${{ matrix.config.name }}-provider-${{ matrix.config.target }}
+
   build-windows:
     if: ${{ startswith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'}}
     name: wasmcloud-x86_64-pc-windows-msvc
@@ -230,31 +410,133 @@ jobs:
         if: ${{ !startswith(github.ref, 'refs/tags/') }}
 
       - run: cargo build --release -p wash-cli -p wasmcloud
-      - run: mkdir "artifact/bin"
 
-      - run: move "target/release/blobstore-azure-provider.exe" "artifact/bin/blobstore-azure-provider.exe"
-      - run: move "target/release/blobstore-fs-provider.exe" "artifact/bin/blobstore-fs-provider.exe"
-      - run: move "target/release/blobstore-s3-provider.exe" "artifact/bin/blobstore-s3-provider.exe"
-      - run: move "target/release/http-client-provider.exe" "artifact/bin/http-client-provider.exe"
-      - run: move "target/release/http-server-provider.exe" "artifact/bin/http-server-provider.exe"
-      - run: move "target/release/keyvalue-nats-provider.exe" "artifact/bin/keyvalue-nats-provider.exe"
-      - run: move "target/release/keyvalue-redis-provider.exe" "artifact/bin/keyvalue-redis-provider.exe"
-      - run: move "target/release/keyvalue-vault-provider.exe" "artifact/bin/keyvalue-vault-provider.exe"
-      - run: move "target/release/messaging-kafka-provider.exe" "artifact/bin/messaging-kafka-provider.exe"
-      - run: move "target/release/messaging-nats-provider.exe" "artifact/bin/messaging-nats-provider.exe"
-      - run: move "target/release/sqldb-postgres-provider.exe" "artifact/bin/sqldb-postgres-provider.exe"
+      - run: mkdir "wash/bin"
+      - run: mkdir "wasmcloud/bin"
 
-      - run: move "target/release/wash.exe" "artifact/bin/wash.exe"
-      - run: move "target/release/wasmcloud.exe" "artifact/bin/wasmcloud.exe"
+      - run: mkdir "blobstore-azure-provider/bin"
+      - run: mkdir "blobstore-fs-provider/bin"
+      - run: mkdir "blobstore-s3-provider/bin"
+      - run: mkdir "http-client-provider/bin"
+      - run: mkdir "http-server-provider/bin"
+      - run: mkdir "keyvalue-nats-provider/bin"
+      - run: mkdir "keyvalue-redis-provider/bin"
+      - run: mkdir "keyvalue-vault-provider/bin"
+      - run: mkdir "messaging-kafka-provider/bin"
+      - run: mkdir "messaging-nats-provider/bin"
+      - run: mkdir "sqldb-postgres-provider/bin"
+
+      - run: move "target/release/wash.exe" "wash/bin/wash.exe"
+      - run: move "target/release/wasmcloud.exe" "wasmcloud/bin/wasmcloud.exe"
+
+      - run: move "target/release/blobstore-azure-provider.exe" "blobstore-azure-provider/bin/blobstore-azure-provider.exe"
+      - run: move "target/release/blobstore-fs-provider.exe" "blobstore-fs-provider/bin/blobstore-fs-provider.exe"
+      - run: move "target/release/blobstore-s3-provider.exe" "blobstore-s3-provider/bin/blobstore-s3-provider.exe"
+      - run: move "target/release/http-client-provider.exe" "http-client-provider/bin/http-client-provider.exe"
+      - run: move "target/release/http-server-provider.exe" "http-server-provider/bin/http-server-provider.exe"
+      - run: move "target/release/keyvalue-nats-provider.exe" "keyvalue-nats-provider/bin/keyvalue-nats-provider.exe"
+      - run: move "target/release/keyvalue-redis-provider.exe" "keyvalue-redis-provider/bin/keyvalue-redis-provider.exe"
+      - run: move "target/release/keyvalue-vault-provider.exe" "keyvalue-vault-provider/bin/keyvalue-vault-provider.exe"
+      - run: move "target/release/messaging-kafka-provider.exe" "messaging-kafka-provider/bin/messaging-kafka-provider.exe"
+      - run: move "target/release/messaging-nats-provider.exe" "messaging-nats-provider/bin/messaging-nats-provider.exe"
+      - run: move "target/release/sqldb-postgres-provider.exe" "sqldb-postgres-provider/bin/sqldb-postgres-provider.exe"
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: wash-x86_64-pc-windows-msvc
+          path: wash
 
       - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
         with:
           name: wasmcloud-x86_64-pc-windows-msvc
+          path: wasmcloud
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: blobstore-azure-provider-x86_64-pc-windows-msvc
+          path: blobstore-azure-provider
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: blobstore-fs-provider-x86_64-pc-windows-msvc
+          path: blobstore-fs-provider
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: blobstore-s3-provider-x86_64-pc-windows-msvc
+          path: blobstore-s3-provider
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: http-client-provider-x86_64-pc-windows-msvc
+          path: http-client-provider
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: http-server-provider-x86_64-pc-windows-msvc
+          path: http-server-provider
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: keyvalue-nats-provider-x86_64-pc-windows-msvc
+          path: keyvalue-nats-provider
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: keyvalue-redis-provider-x86_64-pc-windows-msvc
+          path: keyvalue-redis-provider
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: keyvalue-vault-provider-x86_64-pc-windows-msvc
+          path: keyvalue-vault-provider
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: messaging-kafka-provider-x86_64-pc-windows-msvc
+          path: messaging-kafka-provider
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: messaging-nats-provider-x86_64-pc-windows-msvc
+          path: messaging-nats-provider
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: sqldb-postgres-provider-x86_64-pc-windows-msvc
+          path: sqldb-postgres-provider
+
+  build-wash-lipo:
+    name: wash-universal-darwin
+    needs: build-wash-bin
+    runs-on: macos-13
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: wash-aarch64-apple-darwin
+          path: aarch64
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: wash-x86_64-apple-darwin
+          path: x86_64
+
+      - run: chmod +x ./x86_64/bin/*
+      - run: ./x86_64/bin/wash --version
+
+      - run: mkdir -p ./artifact/bin
+      - run: lipo -create ./aarch64/bin/wash ./x86_64/bin/wash -output ./artifact/bin/wash
+
+      - run: chmod +x ./artifact/bin/wash
+      - run: ./artifact/bin/wash --version
+
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        with:
+          name: wash-universal-darwin
           path: artifact
 
-  build-lipo:
+  build-wasmcloud-lipo:
     name: wasmcloud-universal-darwin
-    needs: build-bin
+    needs: build-wasmcloud-bin
     runs-on: macos-13
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -267,15 +549,11 @@ jobs:
           path: x86_64
 
       - run: chmod +x ./x86_64/bin/*
-      - run: ./x86_64/bin/wash --version
       - run: ./x86_64/bin/wasmcloud --version
 
       - run: mkdir -p ./artifact/bin
-      - run: lipo -create ./aarch64/bin/wash ./x86_64/bin/wash -output ./artifact/bin/wash
       - run: lipo -create ./aarch64/bin/wasmcloud ./x86_64/bin/wasmcloud -output ./artifact/bin/wasmcloud
 
-      - run: chmod +x ./artifact/bin/wash
-      - run: ./artifact/bin/wash --version
       - run: chmod +x ./artifact/bin/wasmcloud
       - run: ./artifact/bin/wasmcloud --version
 
@@ -284,16 +562,24 @@ jobs:
           name: wasmcloud-universal-darwin
           path: artifact
 
-  test-linux:
+  test-wash-linux:
     runs-on: ubuntu-22.04
-    needs: build-bin
+    needs: build-wash-bin
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: wash-x86_64-unknown-linux-musl
+      - run: chmod +x ./bin/wash
+      - run: ./bin/wash --version
+
+  test-wasmcloud-linux:
+    runs-on: ubuntu-22.04
+    needs: build-wasmcloud-bin
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: wasmcloud-x86_64-unknown-linux-musl
-      - run: chmod +x ./bin/wash
       - run: chmod +x ./bin/wasmcloud
-      - run: ./bin/wash --version
       - run: ./bin/wasmcloud --version
 
   test-windows:
@@ -394,9 +680,10 @@ jobs:
 
     needs:
       - meta
-      - build-bin
+      - build-wash-bin
+      - build-provider-bin
       - build-windows
-      - test-linux
+      - test-wash-linux
     permissions:
       contents: read
       packages: write
@@ -437,8 +724,10 @@ jobs:
       contents: read
       packages: write
     needs:
-      - build-bin
-      - test-linux
+      - build-wash-bin
+      - build-wasmcloud-bin
+      - test-wash-linux
+      - test-wasmcloud-linux
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
@@ -591,12 +880,15 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/wash-cli-v')
     needs:
-      - build-bin
       - build-doc
-      - build-lipo
+      - build-wash-bin
+      - build-wash-lipo
+      - build-wasmcloud-bin
+      - build-wasmcloud-lipo
       - cargo
       - oci
-      - test-linux
+      - test-wash-linux
+      - test-wasmcloud-linux
       - test-windows
     runs-on: ubuntu-22.04
     permissions:
@@ -606,9 +898,32 @@ jobs:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           path: artifacts
-      - run: |
+
+      - if: startsWith(github.ref, 'refs/tags/v')
+        run: |
           for dir in ./artifacts/wasmcloud-*; do
             target=${dir#./artifacts/wasmcloud-}
+            for bin_path in $(find ${dir}/bin -type f); do
+              chmod +x ${bin_path}
+              bin=$(basename ${bin_path})
+              case "$bin" in
+                *.exe)
+                  bin="${bin%.exe}"
+                  mkdir -p ./${bin}
+                  mv ${bin_path} ./${bin}/${bin}-${target}.exe
+                ;;
+                *)
+                  mkdir -p ./${bin}
+                  mv ${bin_path} ./${bin}/${bin}-${target%-fhs}
+                ;;
+              esac
+            done
+          done
+
+      - if: startsWith(github.ref, 'refs/tags/wash-cli-v')
+        run: |
+          for dir in ./artifacts/wash-*; do
+            target=${dir#./artifacts/wash-}
             for bin_path in $(find ${dir}/bin -type f); do
               chmod +x ${bin_path}
               bin=$(basename ${bin_path})
@@ -673,8 +988,8 @@ jobs:
       PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_API_TOKEN }}
     needs:
       - cargo
-      - build-bin
-      - test-linux
+      - build-wash-bin
+      - test-wash-linux
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -687,11 +1002,11 @@ jobs:
 
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
-          name: wasmcloud-aarch64-unknown-linux-musl
+          name: wash-aarch64-unknown-linux-musl
           path: ./crates/wash-cli/aarch64
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
-          name: wasmcloud-x86_64-unknown-linux-musl
+          name: wash-x86_64-unknown-linux-musl
           path: ./crates/wash-cli/x86_64
       - name: Make wash executable
         working-directory: ./crates/wash-cli
@@ -855,9 +1170,13 @@ jobs:
   wasmcloud_successful_checks:
     needs:
       - meta
-      - build-bin
-      - build-lipo
-      - test-linux
+      - build-provider-bin
+      - build-wash-bin
+      - build-wash-lipo
+      - build-wasmcloud-bin
+      - build-wasmcloud-lipo
+      - test-wasmcloud-linux
+      - test-wash-linux
       - cargo
       - build-doc
       - providers
@@ -869,9 +1188,13 @@ jobs:
       - name: Results
         run: |
           echo 'needs.integration_tests.result: ${{ needs.integration_tests.result }}'
-          echo 'needs.build-bin.result: ${{ needs.build-bin.result }}'
-          echo 'needs.build-lipo.result: ${{ needs.build-lipo.result }}'
-          echo 'needs.test-linux.result: ${{ needs.test-linux.result }}'
+          echo 'needs.build-provider-bin.result: ${{ needs.build-provider-bin.result }}'
+          echo 'needs.build-wash-bin.result: ${{ needs.build-wash-bin.result }}'
+          echo 'needs.build-wash-lipo.result: ${{ needs.build-wash-lipo.result }}'
+          echo 'needs.build-wasmcloud-bin.result: ${{ needs.build-wasmcloud-bin.result }}'
+          echo 'needs.build-wasmcloud-lipo.result: ${{ needs.build-wasmcloud-lipo.result }}'
+          echo 'needs.test-wash-linux.result: ${{ needs.test-wash-linux.result }}'
+          echo 'needs.test-wasmcloud-linux.result: ${{ needs.test-wasmcloud-linux.result }}'
           echo 'needs.cargo.result: ${{ needs.cargo.result }}'
           echo 'needs.build-doc.result: ${{ needs.build-doc.result }}'
           echo 'needs.providers.result: ${{ needs.providers.result }}'

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -138,6 +138,9 @@ jobs:
             Cargo.lock
             Cargo.toml
             crates/provider-*/*.{rs,toml,wit}
+            flake.lock
+            flake.nix
+            rust-toolchain.toml
           files_ignore: |
             !crates/**/*.md
 

--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { workspace = true }
 tokio-postgres = { workspace = true, features = [ "runtime", "with-serde_json-1", "with-chrono-0_4", "with-uuid-0_8", "with-geo-types-0_7", "array-impls", "with-bit-vec-0_6", "with-uuid-1" ]  }
 tokio-postgres-rustls = { workspace = true }
 tracing = { workspace = true }
-ulid = { workspace = true }
+ulid = { workspace = true, features = ["std"] }
 uuid = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true, features = ["otel"] }
 wit-bindgen-wrpc = { workspace = true }

--- a/flake.nix
+++ b/flake.nix
@@ -450,7 +450,7 @@
           );
           wasmcloud-x86_64-unknown-linux-musl-oci-wolfi = buildImage (
             {
-              pkg = packages.wasmcloud-x86_64-unknown-linux-musl;
+              pkg = attrs.wasmcloud.packages.wasmcloud-x86_64-unknown-linux-musl;
             }
             // imageArgs.bin.wasmcloud
             // imageArgs.config.wolfi

--- a/flake.nix
+++ b/flake.nix
@@ -591,8 +591,10 @@
         }:
           extendDerivations {
             buildInputs = [
-              pkgs.buildah
               pkgs.cargo-audit
+              pkgs.go
+              pkgs.kubectl
+              pkgs.kubernetes-helm
               pkgs.minio
               pkgs.nats-server
               pkgs.redis
@@ -600,9 +602,6 @@
               pkgs.tinygo
               pkgs.vault
               pkgs.wit-deps
-              pkgs.go
-              pkgs.kubernetes-helm
-              pkgs.kubectl
             ];
           }
           devShells;


### PR DESCRIPTION
Build each binary in the project individually, as opposed to always building all binaries in the workspace.

- `clippy` still runs on the whole workspace
- wasmCloud `nextest` still builds all provider binaries (this is the lowest-hanging fruit for future optimization and requires no changes to Nix flake/github actions)
- each provider-target pair gets its own CI job
- each wash-target pair gets its own CI job