### PR TITLE
test(wash-cli): re-enable build provider test

### DIFF
--- a/crates/wash-cli/tests/wash_build.rs
+++ b/crates/wash-cli/tests/wash_build.rs
@@ -792,8 +792,7 @@ async fn integration_build_tinygo_component_separate_paths() -> Result<()> {
 }
 
 #[tokio::test]
-// #[cfg_attr(not(can_reach_ghcr_io), ignore = "ghcr.io is not reachable")]
-#[ignore = "provider build requires wascap 0.15.3"]
+#[cfg_attr(not(can_reach_ghcr_io), ignore = "ghcr.io is not reachable")]
 async fn integration_build_provider_debug_mode() -> Result<()> {
     let test_setup = init_provider(
         /* provider_name= */ "hello-world",


### PR DESCRIPTION
## Feature or Problem
This PR re-enables the test that I disabled temporarily while we upgraded `wascap`

## Related Issues
https://github.com/wasmCloud/wasmCloud/pull/4020

## Release Information
N/A

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
