### PR TITLE
ci(mac): verify binary signatures

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -433,6 +433,7 @@ jobs:
           name: ${{ matrix.artifact }}
       - run: chmod +x ./bin/wash
       - run: ./bin/wash --version
+      - run: codesign --verify ./bin/wash
 
   test-wash-macos-x86_64:
     runs-on: macos-13
@@ -450,6 +451,7 @@ jobs:
           name: ${{ matrix.artifact }}
       - run: chmod +x ./bin/wash
       - run: ./bin/wash --version
+      - run: codesign --verify ./bin/wash
 
   test-wash-windows-x86_64:
     runs-on: windows-latest
@@ -510,6 +512,7 @@ jobs:
           name: ${{ matrix.artifact }}
       - run: chmod +x ./bin/wasmcloud
       - run: ./bin/wasmcloud --version
+      - run: codesign --verify ./bin/wasmcloud
 
   test-wasmcloud-macos-x86_64:
     runs-on: macos-13
@@ -527,6 +530,7 @@ jobs:
           name: ${{ matrix.artifact }}
       - run: chmod +x ./bin/wasmcloud
       - run: ./bin/wasmcloud --version
+      - run: codesign --verify ./bin/wasmcloud
 
   test-wasmcloud-windows-x86_64:
     runs-on: windows-latest


### PR DESCRIPTION
Refs https://github.com/rvolosatovs/nixify/pull/342, which was pulled in via #4030.

All Mac binaries, including universal ones, for all architectures, are now signed. Some Nix derivation closure size optimizations are also made for these, before signing.

Signing is done via https://github.com/indygreg/apple-platform-rs/tree/main/apple-codesign

In this PR we simply add verification steps to CI to ensure that our Mac binaries are indeed signed.