### PR TITLE
feat(nats): Add names to nats connections

### DIFF
--- a/crates/provider-lattice-controller/src/client_cache.rs
+++ b/crates/provider-lattice-controller/src/client_cache.rs
@@ -166,6 +166,7 @@ async fn connect(cfg: &ConnectionConfig) -> Result<async_nats::Client> {
                 other => debug!("NATS client other event occurred: {other}"),
             }
         })
+        .name("provider-lattice-controller")
         .connect(url)
         .await
         .with_context(|| format!("Nats connection to {url}"))?;

--- a/crates/secrets-nats-kv/src/main.rs
+++ b/crates/secrets-nats-kv/src/main.rs
@@ -198,6 +198,7 @@ async fn run(args: RunCommand) -> anyhow::Result<()> {
 
     let nats_client = match args.global.nats_creds_file {
         Some(creds_file) => async_nats::ConnectOptions::new()
+            .name("secrets-nats-kv")
             .credentials_file(creds_file.clone())
             .await
             .context(format!(
@@ -245,6 +246,7 @@ async fn put(args: PutCommand) -> anyhow::Result<()> {
                 "failed to read NATS credentials file '{}'",
                 &creds_file
             ))?
+            .name("secrets-nats-kv")
             .connect(&args.nats_address)
             .await
             .with_context(|| {
@@ -254,6 +256,7 @@ async fn put(args: PutCommand) -> anyhow::Result<()> {
                 )
             })?,
         None => async_nats::connect(&args.nats_address)
+            .name("secrets-nats-kv")
             .await
             .with_context(|| format!("failed to connect to NATS at {}", args.nats_address))?,
     };
@@ -293,6 +296,7 @@ async fn get(args: GetCommand) -> anyhow::Result<()> {
                 "failed to read NATS credentials file '{}'",
                 &creds_file
             ))?
+            .name("secrets-nats-kv")
             .connect(&args.nats_address)
             .await
             .with_context(|| {
@@ -302,6 +306,7 @@ async fn get(args: GetCommand) -> anyhow::Result<()> {
                 )
             })?,
         None => async_nats::connect(&args.nats_address)
+            .name("secrets-nats-kv")
             .await
             .with_context(|| format!("failed to connect to NATS at {}", args.nats_address))?,
     };
@@ -349,6 +354,7 @@ async fn add_mapping(args: AddSecretMappingCommand) -> anyhow::Result<()> {
                 "failed to read NATS credentials file '{}'",
                 &creds_file
             ))?
+            .name("secrets-nats-kv")
             .connect(&args.nats_address)
             .await
             .with_context(|| {
@@ -358,6 +364,7 @@ async fn add_mapping(args: AddSecretMappingCommand) -> anyhow::Result<()> {
                 )
             })?,
         None => async_nats::connect(&args.nats_address)
+            .name("secrets-nats-kv")
             .await
             .with_context(|| format!("failed to connect to NATS at {}", args.nats_address))?,
     };
@@ -390,6 +397,7 @@ async fn remove_mapping(args: RemoveSecretMappingCommand) -> anyhow::Result<()> 
                 "failed to read NATS credentials file '{}'",
                 &creds_file
             ))?
+            .name("secrets-nats-kv")
             .connect(&args.nats_address)
             .await
             .with_context(|| {
@@ -399,6 +407,7 @@ async fn remove_mapping(args: RemoveSecretMappingCommand) -> anyhow::Result<()> 
                 )
             })?,
         None => async_nats::connect(&args.nats_address)
+            .name("secrets-nats-kv")
             .await
             .with_context(|| format!("failed to connect to NATS at {}", args.nats_address))?,
     };

--- a/crates/secrets-nats-kv/src/main.rs
+++ b/crates/secrets-nats-kv/src/main.rs
@@ -255,8 +255,9 @@ async fn put(args: PutCommand) -> anyhow::Result<()> {
                     args.nats_address, creds_file
                 )
             })?,
-        None => async_nats::connect(&args.nats_address)
+        None => async_nats::ConnectOptions::new()
             .name("secrets-nats-kv")
+            .connect(&args.nats_address)
             .await
             .with_context(|| format!("failed to connect to NATS at {}", args.nats_address))?,
     };
@@ -305,8 +306,9 @@ async fn get(args: GetCommand) -> anyhow::Result<()> {
                     args.nats_address
                 )
             })?,
-        None => async_nats::connect(&args.nats_address)
+        None => async_nats::ConnectOptions::new()
             .name("secrets-nats-kv")
+            .connect(&args.nats_address)
             .await
             .with_context(|| format!("failed to connect to NATS at {}", args.nats_address))?,
     };
@@ -363,8 +365,9 @@ async fn add_mapping(args: AddSecretMappingCommand) -> anyhow::Result<()> {
                     args.nats_address, creds_file
                 )
             })?,
-        None => async_nats::connect(&args.nats_address)
+        None => async_nats::ConnectOptions::new()
             .name("secrets-nats-kv")
+            .connect(&args.nats_address)
             .await
             .with_context(|| format!("failed to connect to NATS at {}", args.nats_address))?,
     };
@@ -406,8 +409,9 @@ async fn remove_mapping(args: RemoveSecretMappingCommand) -> anyhow::Result<()> 
                     args.nats_address, creds_file
                 )
             })?,
-        None => async_nats::connect(&args.nats_address)
+        None => async_nats::ConnectOptions::new()
             .name("secrets-nats-kv")
+            .connect(&args.nats_address)
             .await
             .with_context(|| format!("failed to connect to NATS at {}", args.nats_address))?,
     };

--- a/crates/wash/src/cli/call.rs
+++ b/crates/wash/src/cli/call.rs
@@ -564,12 +564,15 @@ async fn create_client_from_opts_wrpc(opts: &ConnectionOpts) -> Result<async_nat
                 .require_tls(true);
         }
 
-        opts.connect(&nats_url).await.with_context(|| {
-            format!(
-                "Failed to connect to NATS server {}:{} while creating client",
-                &host, &port
-            )
-        })?
+        opts.name("wash-cli")
+            .connect(&nats_url)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to connect to NATS server {}:{} while creating client",
+                    &host, &port
+                )
+            })?
     } else if let Some(credsfile_path) = credsfile {
         let mut opts = ConnectOptions::with_credentials_file(credsfile_path.clone())
             .await
@@ -586,12 +589,15 @@ async fn create_client_from_opts_wrpc(opts: &ConnectionOpts) -> Result<async_nat
                 .require_tls(true);
         }
 
-        opts.connect(&nats_url).await.with_context(|| {
-            format!(
-                "Failed to connect to NATS {} with credentials file {:?}",
-                &nats_url, &credsfile_path
-            )
-        })?
+        opts.name("wash-cli")
+            .connect(&nats_url)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to connect to NATS {} with credentials file {:?}",
+                    &nats_url, &credsfile_path
+                )
+            })?
     } else {
         let mut opts = ConnectOptions::new();
 
@@ -601,7 +607,8 @@ async fn create_client_from_opts_wrpc(opts: &ConnectionOpts) -> Result<async_nat
                 .require_tls(true);
         }
 
-        opts.connect(&nats_url)
+        opts.name("wash-cli")
+            .connect(&nats_url)
             .await
             .with_context(|| format!("Failed to connect to NATS {}", &nats_url))?
     };

--- a/crates/wash/src/lib/config.rs
+++ b/crates/wash/src/lib/config.rs
@@ -239,12 +239,15 @@ pub async fn create_nats_client_from_opts(
             opts = opts.tls_first();
         }
 
-        opts.connect(&nats_url).await.with_context(|| {
-            format!(
-                "Failed to connect to NATS server {}:{} while creating client",
-                &host, &port
-            )
-        })?
+        opts.name("wash-lib")
+            .connect(&nats_url)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to connect to NATS server {}:{} while creating client",
+                    &host, &port
+                )
+            })?
     } else if let Some(credsfile_path) = credsfile {
         let mut opts = ConnectOptions::with_credentials_file(credsfile_path.clone())
             .await
@@ -263,12 +266,15 @@ pub async fn create_nats_client_from_opts(
             opts = opts.tls_first();
         }
 
-        opts.connect(&nats_url).await.with_context(|| {
-            format!(
-                "Failed to connect to NATS {} with credentials file {:?}",
-                &nats_url, &credsfile_path
-            )
-        })?
+        opts.name("wash-lib")
+            .connect(&nats_url)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to connect to NATS {} with credentials file {:?}",
+                    &nats_url, &credsfile_path
+                )
+            })?
     } else {
         let mut opts = ConnectOptions::new();
 
@@ -280,6 +286,7 @@ pub async fn create_nats_client_from_opts(
             opts = opts.tls_first();
         }
 
+        opts = opts.name("wash-lib").retry_on_initial_connect();
         opts.connect(&nats_url)
             .await
             .with_context(|| format!("Failed to connect to NATS {}", &nats_url))?

--- a/crates/wash/src/lib/config.rs
+++ b/crates/wash/src/lib/config.rs
@@ -286,8 +286,8 @@ pub async fn create_nats_client_from_opts(
             opts = opts.tls_first();
         }
 
-        opts = opts.name("wash-lib").retry_on_initial_connect();
-        opts.connect(&nats_url)
+        opts.name("wash-lib")
+            .connect(&nats_url)
             .await
             .with_context(|| format!("Failed to connect to NATS {}", &nats_url))?
     };


### PR DESCRIPTION
## Feature or Problem

Work in progress. 
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues

Related to issue #3519
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

In order to check this PR, I build the wash-cli on my local machine with `cargo build --release`. Then I used the locally built wash cli from the rust-hello-world example project with `wash dev`. Finally, I checked the nats connections with the nats cli: `nats server report connections` to verify that nats connections have names.
