### PR TITLE
chore/wash wasmcloud v1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7734,7 +7734,7 @@ dependencies = [
 
 [[package]]
 name = "wash-cli"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/crates/wash-cli/Cargo.toml
+++ b/crates/wash-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-cli"
-version = "0.38.0"
+version = "0.38.1"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) CLI tool"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash-cli/src/config.rs
+++ b/crates/wash-cli/src/config.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_NATS_WEBSOCKET_PORT: &str = "4223";
 pub const WADM_VERSION: &str = "v0.19.0";
 
 // wasmCloud configuration values, https://wasmcloud.com/docs/reference/host-config
-pub const WASMCLOUD_HOST_VERSION: &str = "v1.4.2";
+pub const WASMCLOUD_HOST_VERSION: &str = "v1.5.1";
 
 // NATS isolation configuration variables
 pub const WASMCLOUD_LATTICE: &str = "WASMCLOUD_LATTICE";


### PR DESCRIPTION
- **feat(wash-cli): update wasmcloud to 1.5.1**
- **chore(wash-cli): release v0.38.1**

## Feature or Problem
Bumps wasmCloud to 1.5.1 and sets wash up to release 0.38.1. This is required because `wash up` only downloads patch releases, not minor, for wasmCloud updates.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
