### PR TITLE
fix(http-server): remove socket for last delete

### DIFF
--- a/crates/provider-http-server/src/address.rs
+++ b/crates/provider-http-server/src/address.rs
@@ -154,7 +154,7 @@ impl Provider for HttpServerProvider {
         let link_name = info.get_link_name();
 
         // Retrieve the thing by link name
-        let sockets_by_link_name = self.sockets_by_link_name.read().await;
+        let mut sockets_by_link_name = self.sockets_by_link_name.write().await;
         if let Some(addr) = sockets_by_link_name.get(link_name) {
             let mut handlers_by_socket = self.handlers_by_socket.write().await;
             if let Some((server, component_metas)) = handlers_by_socket.get_mut(addr) {
@@ -174,6 +174,7 @@ impl Provider for HttpServerProvider {
                     );
                     server.handle.shutdown();
                     handlers_by_socket.remove(addr);
+                    sockets_by_link_name.remove(link_name);
                 }
             }
         }


### PR DESCRIPTION
## Feature or Problem
This PR ensures that when the last link is deleted for an address the HTTP server is using that the socket is removed. This was causing an issue where deleting the last link for an address wouldn't allow for a new link to reserve a socket.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
