### PR TITLE
ci(wasmcloud): build wash for provider releases

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -150,7 +150,7 @@ jobs:
 
   build-wash-bin:
     needs: [meta]
-    if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || startsWith(github.ref, 'refs/tags/wash-cli-v') }}
+    if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || startsWith(github.ref, 'refs/tags/wash-cli-v')  || startswith(github.ref, 'refs/tags/provider-') }}
     strategy:
       matrix:
         config:
@@ -405,7 +405,6 @@ jobs:
           name: wash-aarch64-unknown-linux-musl-oci
       - run: docker load < ./wash-aarch64-unknown-linux-musl-oci
       - run: docker run --rm wash:$(nix eval --raw .#wash-aarch64-unknown-linux-musl-oci.imageTag) wash --version
-
 
   test-wash-linux-x86_64:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Feature or Problem
This PR ensures we build the wash binary for provider releases.

## Related Issues
See https://github.com/wasmCloud/wasmCloud/actions/runs/13160153715 which did not build wash and therefore did not release the provider

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
