### PR TITLE
ci(wasmcloud): support WIT embed for released providers

### DIFF
--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -7,6 +7,11 @@ on:
         description: Provider name
         required: true
         type: string
+      embed_wit:
+        description: Whether to include the WIT in the provider archive
+        required: false
+        default: false
+        type: boolean
     secrets:
       subject:
         description: Capability provider issuer subject key
@@ -70,6 +75,9 @@ jobs:
           fi
           if [ "${{ secrets.subject }}" != '' ]; then
             export WASH_SUBJECT_KEY="${{ secrets.subject }}"
+          fi
+          if [[ "${{ inputs.embed_wit }}" == 'true' ]]; then
+            export WIT_DIR="crates/provider-${{ inputs.name }}/wit"
           fi
           ./wash par create \
                 --binary "./artifacts/${{ inputs.name }}-provider-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider" \

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -10,7 +10,7 @@ on:
       embed_wit:
         description: Whether to include the WIT in the provider archive
         required: false
-        default: false
+        default: true
         type: boolean
     secrets:
       subject:

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -595,36 +595,47 @@ jobs:
         include:
           - name: blobstore-azure
             subject: BLOBSTORE_AZURE_SUBJECT
+            embed_wit: true
 
           - name: blobstore-fs
             subject: BLOBSTORE_FS_SUBJECT
+            embed_wit: true
 
           - name: blobstore-s3
             subject: BLOBSTORE_S3_SUBJECT
+            embed_wit: true
 
           - name: keyvalue-nats
             subject: KEYVALUE_NATS_SUBJECT
+            embed_wit: true
 
           - name: keyvalue-redis
             subject: KEYVALUE_REDIS_SUBJECT
+            embed_wit: true
 
           - name: keyvalue-vault
             subject: KEYVALUE_VAULT_SUBJECT
+            embed_wit: true
 
           - name: http-client
             subject: HTTP_CLIENT_SUBJECT
+            embed_wit: false
 
           - name: http-server
             subject: HTTP_SERVER_SUBJECT
+            embed_wit: false
 
           - name: messaging-kafka
             subject: MESSAGING_KAFKA_SUBJECT
+            embed_wit: true
 
           - name: messaging-nats
             subject: MESSAGING_NATS_SUBJECT
+            embed_wit: true
 
           - name: sqldb-postgres
             subject: SQLDB_POSTGRES_SUBJECT
+            embed_wit: true
 
     needs:
       - meta
@@ -637,6 +648,7 @@ jobs:
     uses: ./.github/workflows/provider.yml
     with:
       name: ${{ matrix.name }}
+      embed_wit: ${{ matrix.embed_wit }}
     secrets:
       issuer: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
       subject: ${{ secrets[matrix.subject] }}

--- a/crates/wash-cli/src/par.rs
+++ b/crates/wash-cli/src/par.rs
@@ -103,7 +103,7 @@ pub struct CreateCommand {
     disable_keygen: bool,
 
     /// Location of project directory containing WIT
-    #[clap(long = "wit-directory")]
+    #[clap(long = "wit-directory", env = "WIT_DIR")]
     wit_dir: Option<PathBuf>,
 }
 


### PR DESCRIPTION
## Feature or Problem
This PR adds an option to embed provider WIT information into the provider archive. The HTTP capability providers actually do not have a wit directory and they implement the wrpc interface directly via the crate, so we avoid embedding the WIT there.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
```bash
➜ WIT_DIR=./crates/provider-blobstore-azure/wit cargo run -p wash-cli -- par create --vendor me --name az --binary ./target/debug/blobstore-azure-provider --compress
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.57s
     Running `target/debug/wash par create --vendor me --name az --binary ./target/debug/blobstore-azure-provider --compress`

Successfully created archive blobstore-azure-provider.par.gz
➜ cargo run -p wash-cli -- inspect --wit ./blobstore-azure-provider.par.gz
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.79s
     Running `target/debug/wash inspect --wit ./blobstore-azure-provider.par.gz`

package wasmcloud:provider-blobstore-azure;

world interfaces {
  import wasi:io/error@0.2.0;
  import wasi:io/poll@0.2.0;
  import wasi:io/streams@0.2.0;
  import wasi:blobstore/types@0.2.0-draft;
  import wrpc:blobstore/types@0.2.0;

  export wrpc:blobstore/blobstore@0.2.0;
}
world testing-client {
  import wasi:io/error@0.2.0;
  import wasi:io/poll@0.2.0;
  import wasi:io/streams@0.2.0;
  import wasi:blobstore/types@0.2.0-draft;
  import wrpc:blobstore/types@0.2.0;
  import wrpc:blobstore/blobstore@0.2.0;
}
```
