### PR TITLE
feat(wash-cli): support reloading wasmcloud.toml on dev loop

### DIFF
--- a/crates/wash-cli/src/cmd/dev/mod.rs
+++ b/crates/wash-cli/src/cmd/dev/mod.rs
@@ -129,7 +129,7 @@ pub async fn handle_command(
     let current_dir =
         std::env::current_dir().context("failed to get current directory for wash dev")?;
     let project_path = cmd.code_dir.unwrap_or(current_dir);
-    let project_cfg = load_config(Some(project_path.clone()), Some(true)).await?;
+    let mut project_cfg = load_config(Some(project_path.clone()), Some(true)).await?;
 
     let mut wash_dev_session = WashDevSession::from_sessions_file(&project_path)
         .await
@@ -227,7 +227,7 @@ pub async fn handle_command(
         dev_session: &mut wash_dev_session,
         nats_client: &nats_client,
         ctl_client: &ctl_client,
-        project_cfg: &project_cfg,
+        project_cfg: &mut project_cfg,
         lattice,
         session_id: &session_id,
         manifest_output_dir: cmd.manifest_output_dir.as_ref(),


### PR DESCRIPTION
## Feature or Problem
This PR ensures that on each dev loop we attempt to reload the project configuration. We need this so that you can make changes to interface overrides, configuration, etc and have the dev loop update to pick up the latest changes.

## Related Issues
Enables https://github.com/wasmCloud/wasmcloud.com/pull/679 without the caveat!

## Release Information
wash 0.39

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
