### PR TITLE
ci(wasmcloud): allow publishing httpserver/nats provider crates

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -1023,6 +1023,12 @@ jobs:
           - crate: provider-archive
             workspace-dependencies: true
 
+          - crate: provider-http-server
+            workspace-dependencies: true
+
+          - crate: provider-messaging-nats
+            workspace-dependencies: true
+
           - crate: provider-sdk
             workspace-dependencies: true
 


### PR DESCRIPTION
## Feature or Problem
I've been doing a slightly naughty thing and publishing these crates manually. This change ensures that when we publish a tag for them the crate gets published too.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
