### PR TITLE
ci: run Nix with `--fallback`

### DIFF
--- a/.github/actions/build-nix/action.yml
+++ b/.github/actions/build-nix/action.yml
@@ -8,9 +8,9 @@ inputs:
 runs:
   using: composite
   steps:
-  - run: nix build -L '.#${{ inputs.package }}'
+  - run: nix build --fallback -L '.#${{ inputs.package }}'
     shell: bash
-  - run: nix run -L --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=cp -RLv ./result '${{ inputs.package }}'
+  - run: nix run --fallback -L --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=cp -RLv ./result '${{ inputs.package }}'
     shell: bash
   - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
     with:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: ./.github/actions/install-nix
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix run -L . -- --version
+      - run: nix run --fallback -L . -- --version
 
   develop:
     runs-on: ubuntu-22.04
@@ -38,4 +38,4 @@ jobs:
       - uses: ./.github/actions/install-nix
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix develop -L --ignore-environment -c cargo tree
+      - run: nix develop --fallback -L --ignore-environment -c cargo tree

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -156,7 +156,7 @@ jobs:
         config:
           - target: aarch64-unknown-linux-musl
             test-bin: |
-              nix profile install --inputs-from . 'nixpkgs#qemu'
+              nix profile install --fallback --inputs-from . 'nixpkgs#qemu'
               qemu-aarch64 ./result/bin/wash --version
             test-oci: docker load < ./result
 
@@ -172,8 +172,8 @@ jobs:
 
           - target: riscv64gc-unknown-linux-gnu-fhs
             test-bin: |
-              nix build -L '.#wash-riscv64gc-unknown-linux-gnu'
-              nix shell --inputs-from . 'nixpkgs#qemu' -c qemu-riscv64 ./result/bin/wash --version
+              nix build --fallback -L '.#wash-riscv64gc-unknown-linux-gnu'
+              nix shell --fallback --inputs-from . 'nixpkgs#qemu' -c qemu-riscv64 ./result/bin/wash --version
 
           - target: x86_64-apple-darwin
             test-bin: |
@@ -183,7 +183,7 @@ jobs:
           # TODO: Build for GNU once https://github.com/rust-lang/rust/issues/92212 is resolved
           #- target: x86_64-pc-windows-gnu
           #  test-bin: |
-          #    nix profile install --inputs-from . 'nixpkgs#wine64'
+          #    nix profile install --fallback --inputs-from . 'nixpkgs#wine64'
           #    wine64 ./result/bin/wash.exe --version
           #  test-oci: docker load < ./result
 
@@ -222,7 +222,7 @@ jobs:
         config:
           - target: aarch64-unknown-linux-musl
             test-bin: |
-              nix profile install --inputs-from . 'nixpkgs#qemu'
+              nix profile install --fallback --inputs-from . 'nixpkgs#qemu'
               qemu-aarch64 ./result/bin/wasmcloud --version
             test-oci: docker load < ./result
 
@@ -238,8 +238,8 @@ jobs:
 
           - target: riscv64gc-unknown-linux-gnu-fhs
             test-bin: |
-              nix build -L '.#wasmcloud-riscv64gc-unknown-linux-gnu'
-              nix shell --inputs-from . 'nixpkgs#qemu' -c qemu-riscv64 ./result/bin/wasmcloud --version
+              nix build --fallback -L '.#wasmcloud-riscv64gc-unknown-linux-gnu'
+              nix shell --fallback --inputs-from . 'nixpkgs#qemu' -c qemu-riscv64 ./result/bin/wasmcloud --version
 
           - target: x86_64-apple-darwin
             test-bin: |
@@ -248,7 +248,7 @@ jobs:
 
           - target: x86_64-pc-windows-gnu
             test-bin: |
-              nix profile install --inputs-from . 'nixpkgs#wine64'
+              nix profile install --fallback --inputs-from . 'nixpkgs#wine64'
               wine64 ./result/bin/wasmcloud.exe --version
             test-oci: docker load < ./result
 
@@ -559,7 +559,7 @@ jobs:
       - uses: ./.github/actions/install-nix
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix build -L .#checks.x86_64-linux.${{ matrix.check }}
+      - run: nix build --fallback -L .#checks.x86_64-linux.${{ matrix.check }}
 
   build-doc:
     needs: [meta]
@@ -570,7 +570,7 @@ jobs:
       - uses: ./.github/actions/install-nix
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix build -L .#checks.x86_64-linux.doc
+      - run: nix build --fallback -L .#checks.x86_64-linux.doc
       - run: cp --no-preserve=mode -R ./result/share/doc ./doc
       - run: rm -f doc/.lock
       - name: Create `.nojekyll`
@@ -725,12 +725,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
 
       - name: Install `skopeo`
-        run: nix profile install --inputs-from . 'nixpkgs#skopeo'
+        run: nix profile install --fallback --inputs-from . 'nixpkgs#skopeo'
 
       - name: Build `${{ matrix.bin }}` image
         run: |
-          nix build -L .#${{ matrix.bin }}-oci-debian -o ./oci-debian
-          nix build -L .#${{ matrix.bin }}-oci-wolfi -o ./oci-wolfi
+          nix build --fallback -L .#${{ matrix.bin }}-oci-debian -o ./oci-debian
+          nix build --fallback -L .#${{ matrix.bin }}-oci-wolfi -o ./oci-wolfi
 
       - name: Test `${{ matrix.bin }}` image
         run: |


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Sometimes, connection to Nix network substituters (like Cachix) can fail (like in https://github.com/wasmCloud/wasmCloud/actions/runs/13174200900/job/36770534710)

In such cases, fall back to building from source rather than failing CI run.

See https://nix.dev/manual/nix/2.25/command-ref/nix-build.html#opt-fallback for more info

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
