### PR TITLE
ci: cache Nix builds

### DIFF
--- a/.github/actions/build-nix/action.yml
+++ b/.github/actions/build-nix/action.yml
@@ -8,6 +8,19 @@ inputs:
 runs:
   using: composite
   steps:
+  - uses: actions/cache@36f1e144e1c8edb0a652766b484448563d8baf46
+    id: cache
+    with:
+      path: ${{ runner.temp }}/nix-store-${{ inputs.package }}
+      key: ${{ inputs.package }}-${{ github.sha }}
+      restore-keys: |
+        ${{ inputs.package }}-
+
+  - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-${{ inputs.package }}"
+    continue-on-error: true
+    shell: bash
+  - run: rm -rf "${{ runner.temp }}/nix-store-${{ inputs.package }}"
+    shell: bash
   - run: nix build --fallback -L '.#${{ inputs.package }}'
     shell: bash
   - run: nix run --fallback -L --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=cp -RLv ./result '${{ inputs.package }}'
@@ -16,3 +29,6 @@ runs:
     with:
       name: ${{ inputs.package }}
       path: ${{ inputs.package }}
+  - run: nix copy --to "file://${{ runner.temp }}/nix-store-${{ inputs.package }}" '.#${{ inputs.package }}'
+    if: steps.cache.outputs.cache-hit != 'true'
+    shell: bash

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           path: artifacts
+          pattern: ${{ inputs.name }}-provider-*
 
       - run: chmod +x "./artifacts/${{ inputs.name }}-provider-aarch64-apple-darwin/bin/${{ inputs.name }}-provider"
       - run: chmod +x "./artifacts/${{ inputs.name }}-provider-aarch64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
@@ -66,7 +67,11 @@ jobs:
       - run: chmod +x "./artifacts/${{ inputs.name }}-provider-x86_64-pc-windows-gnu/bin/${{ inputs.name }}-provider.exe"
       - run: chmod +x "./artifacts/${{ inputs.name }}-provider-x86_64-unknown-linux-musl/bin/${{ inputs.name }}-provider"
 
-      - run: mv "./artifacts/wash-x86_64-unknown-linux-musl/bin/wash" wash
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: wash-x86_64-unknown-linux-musl
+
+      - run: mv ./bin/wash wash
       - run: chmod +x wash
 
       - run: |

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -973,9 +973,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           path: artifacts
-
+          pattern: wasmcloud-*
       - if: startsWith(github.ref, 'refs/tags/v')
         run: |
           for dir in ./artifacts/wasmcloud-*; do
@@ -997,6 +998,11 @@ jobs:
             done
           done
 
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        if: startsWith(github.ref, 'refs/tags/wash-cli-v')
+        with:
+          path: artifacts
+          pattern: wash-*
       - if: startsWith(github.ref, 'refs/tags/wash-cli-v')
         run: |
           for dir in ./artifacts/wash-*; do

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -333,7 +333,7 @@ jobs:
       - run: mkdir "artifact/bin"
       - run: move "target/release/wash.exe" "artifact/bin/wash.exe"
 
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: wash-x86_64-pc-windows-msvc
           path: artifact
@@ -355,7 +355,7 @@ jobs:
       - run: mkdir -p ./artifact/bin
       - run: lipo -create ./aarch64/bin/wash ./x86_64/bin/wash -output ./artifact/bin/wash
 
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: wash-universal-darwin
           path: artifact
@@ -377,7 +377,7 @@ jobs:
       - run: mkdir -p ./artifact/bin
       - run: lipo -create ./aarch64/bin/wasmcloud ./x86_64/bin/wasmcloud -output ./artifact/bin/wasmcloud
 
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: wasmcloud-universal-darwin
           path: artifact

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -203,6 +203,17 @@ jobs:
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: actions/cache@36f1e144e1c8edb0a652766b484448563d8baf46
+        id: cache
+        with:
+          path: ${{ runner.temp }}/nix-store-deps
+          key: wash-${{ matrix.config.target }}-deps-${{ github.sha }}
+          restore-keys: |
+            wash-${{ matrix.config.target }}-deps-
+            wasmcloud-${{ matrix.config.target }}-deps-
+      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-deps"
+        continue-on-error: true
+      - run: rm -rf "${{ runner.temp }}/nix-store-deps"
       - uses: ./.github/actions/build-nix
         with:
           package: wash-${{ matrix.config.target }}
@@ -213,6 +224,10 @@ jobs:
           package: wash-${{ matrix.config.target }}-oci
       - run: ${{ matrix.config.test-oci }}
         if: ${{ !endsWith(matrix.config.target, 'fhs') }}
+      - run: |
+          target="${{ matrix.config.target }}"
+          nix copy --to "file://${{ runner.temp }}/nix-store-deps" ".#wash-${target%'-fhs'}-deps"
+        if: steps.cache.outputs.cache-hit != 'true'
 
   build-wasmcloud-bin:
     needs: [meta]
@@ -268,6 +283,17 @@ jobs:
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: actions/cache@36f1e144e1c8edb0a652766b484448563d8baf46
+        id: cache
+        with:
+          path: ${{ runner.temp }}/nix-store-deps
+          key: wasmcloud-${{ matrix.config.target }}-deps-${{ github.sha }}
+          restore-keys: |
+            wasmcloud-${{ matrix.config.target }}-deps-
+            wash-${{ matrix.config.target }}-deps-
+      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-deps"
+        continue-on-error: true
+      - run: rm -rf "${{ runner.temp }}/nix-store-deps"
       - uses: ./.github/actions/build-nix
         with:
           package: wasmcloud-${{ matrix.config.target }}
@@ -278,6 +304,10 @@ jobs:
           package: wasmcloud-${{ matrix.config.target }}-oci
       - run: ${{ matrix.config.test-oci }}
         if: ${{ !endsWith(matrix.config.target, 'fhs') }}
+      - run: |
+          target="${{ matrix.config.target }}"
+          nix copy --to "file://${{ runner.temp }}/nix-store-deps" ".#wasmcloud-${target%'-fhs'}-deps"
+        if: steps.cache.outputs.cache-hit != 'true'
 
   build-provider-bin:
     needs: [meta]
@@ -313,9 +343,21 @@ jobs:
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: actions/cache@36f1e144e1c8edb0a652766b484448563d8baf46
+        id: cache
+        with:
+          path: ${{ runner.temp }}/nix-store-deps
+          key: ${{ matrix.name }}-provider-${{ matrix.target }}-deps-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.name }}-provider-${{ matrix.target }}-deps-
+      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-deps"
+        continue-on-error: true
+      - run: rm -rf "${{ runner.temp }}/nix-store-deps"
       - uses: ./.github/actions/build-nix
         with:
           package: ${{ matrix.name }}-provider-${{ matrix.target }}
+      - run: nix copy --to "file://${{ runner.temp }}/nix-store-deps" '.#${{ matrix.name }}-provider-${{ matrix.target }}-deps'
+        if: steps.cache.outputs.cache-hit != 'true'
 
   build-wash-windows:
     if: ${{ startswith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'}}
@@ -559,6 +601,20 @@ jobs:
       - uses: ./.github/actions/install-nix
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: actions/cache/restore@36f1e144e1c8edb0a652766b484448563d8baf46
+        with:
+          path: ${{ runner.temp }}/nix-store
+          key: wasmcloud-cargo-doc-${{ github.sha }}
+          restore-keys: |
+            wasmcloud-cargo-doc-
+            wasmcloud-x86_64_unknown-linux-musl-${{ github.sha }}
+            wasmcloud-x86_64_unknown-linux-musl-
+            wash-x86_64_unknown-linux-musl-
+            wasmcloud-
+            wash-
+      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store"
+        continue-on-error: true
+      - run: rm -rf "${{ runner.temp }}/nix-store"
       - run: nix build --fallback -L .#checks.x86_64-linux.${{ matrix.check }}
 
   build-doc:
@@ -570,6 +626,22 @@ jobs:
       - uses: ./.github/actions/install-nix
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: actions/cache@36f1e144e1c8edb0a652766b484448563d8baf46
+        id: cache
+        with:
+          path: ${{ runner.temp }}/nix-store
+          key: wasmcloud-cargo-doc-${{ github.sha }}
+          restore-keys: |
+            wasmcloud-cargo-doc-
+            wasmcloud-cargo-nextest-
+            wasmcloud-cargo-clippy-
+            wasmcloud-cargo-doctest-
+            wasmcloud-cargo-audit-
+            wasmcloud-cargo-fmt-
+            wasmcloud-
+      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store"
+        continue-on-error: true
+      - run: rm -rf "${{ runner.temp }}/nix-store"
       - run: nix build --fallback -L .#checks.x86_64-linux.doc
       - run: cp --no-preserve=mode -R ./result/share/doc ./doc
       - run: rm -f doc/.lock
@@ -587,6 +659,8 @@ jobs:
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           path: doc
+      - run: nix copy --to "file://${{ runner.temp }}/nix-store" .#checks.x86_64-linux.doc
+        if: steps.cache.outputs.cache-hit != 'true'
 
   providers:
     if: ${{ needs.meta.outputs.providers_modified == 'true' || startswith(github.ref, 'refs/tags/provider-') }}
@@ -696,6 +770,31 @@ jobs:
       - uses: ./.github/actions/install-nix
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - uses: actions/cache/restore@36f1e144e1c8edb0a652766b484448563d8baf46
+        with:
+          path: ${{ runner.temp }}/nix-store-amd64
+          key: ${{ matrix.bin }}-x86_64-unknown-linux-musl
+      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-amd64"
+        continue-on-error: true
+      - run: rm -rf "${{ runner.temp }}/nix-store-amd64"
+
+      - uses: actions/cache/restore@36f1e144e1c8edb0a652766b484448563d8baf46
+        with:
+          path: ${{ runner.temp }}/nix-store-arm64
+          key: ${{ matrix.bin }}-aarch64-unknown-linux-musl
+      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-arm64"
+        continue-on-error: true
+      - run: rm -rf "${{ runner.temp }}/nix-store-arm64"
+
+      - uses: actions/cache@36f1e144e1c8edb0a652766b484448563d8baf46
+        id: cache
+        with:
+          path: ${{ runner.temp }}/nix-store-oci
+          key: ${{ matrix.bin }}-oci
+      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-oci"
+        continue-on-error: true
+      - run: rm -rf "${{ runner.temp }}/nix-store-oci"
 
       - name: Extract tag context
         id: ctx
@@ -839,6 +938,12 @@ jobs:
           docker run --rm ${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-wolfi ${{ matrix.bin }} --version
           docker run --rm ghcr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-wolfi ${{ matrix.bin }} --version
           docker run --rm wasmcloud.azurecr.io/${{ steps.ctx.outputs.owner }}/${{ matrix.bin }}:latest-wolfi ${{ matrix.bin }} --version
+
+      - run: |
+          nix copy --to "file://${{ runner.temp }}/nix-store-oci" \
+            .#${{ matrix.bin }}-oci-debian \
+            .#${{ matrix.bin }}-oci-wolfi
+        if: steps.cache.outputs.cache-hit != 'true'
 
   release:
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/wash-cli-v')


### PR DESCRIPTION
Cache most Nix outputs using https://github.com/actions/cache

This allows PRs from forks to benefit from caching, e.g. `oci` job should not need to build `wasmcloud` and `wash` binaries again anymore, since those builds should be pulled in from the cache.

Unfortunately, using caching for checks like `nextest` and `clippy` does not make sense, caching these takes enormous amount of time - that's due to the fact that we build all workspaces as part of running these checks. (https://github.com/wasmCloud/wasmCloud/issues/4050 is going to be the first step in fixing that)