### PR TITLE
ci: wasmcloud wash separate releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    authors:
+      - dependabot

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -945,22 +945,14 @@ jobs:
             .#${{ matrix.bin }}-oci-wolfi
         if: steps.cache.outputs.cache-hit != 'true'
 
-  release:
-    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/wash-cli-v')
+  release-wasmcloud:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - build-doc
-      - build-wash-bin
-      - build-wash-lipo
       - build-wasmcloud-bin
       - build-wasmcloud-lipo
       - cargo
       - oci
-      - test-wash-linux-aarch64
-      - test-wash-linux-aarch64-oci
-      - test-wash-linux-x86_64
-      - test-wash-macos-aarch64
-      - test-wash-macos-x86_64
-      - test-wash-windows-x86_64
       - test-wasmcloud-linux-aarch64
       - test-wasmcloud-linux-aarch64-oci
       - test-wasmcloud-linux-x86_64
@@ -973,12 +965,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-        if: startsWith(github.ref, 'refs/tags/v')
         with:
           path: artifacts
           pattern: wasmcloud-*
-      - if: startsWith(github.ref, 'refs/tags/v')
-        run: |
+      - run: |
           for dir in ./artifacts/wasmcloud-*; do
             target=${dir#./artifacts/wasmcloud-}
             for bin_path in $(find ${dir}/bin -type f); do
@@ -998,13 +988,37 @@ jobs:
             done
           done
 
+      - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
+        with:
+          draft: true
+          prerelease: true
+          generate_release_notes: true
+          files: ./wasmcloud/*
+
+  release-wash-cli:
+    if: startsWith(github.ref, 'refs/tags/wash-cli-v')
+    needs:
+      - build-doc
+      - build-wash-bin
+      - build-wash-lipo
+      - cargo
+      - oci
+      - test-wash-linux-aarch64
+      - test-wash-linux-aarch64-oci
+      - test-wash-linux-x86_64
+      - test-wash-macos-aarch64
+      - test-wash-macos-x86_64
+      - test-wash-windows-x86_64
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-        if: startsWith(github.ref, 'refs/tags/wash-cli-v')
         with:
           path: artifacts
           pattern: wash-*
-      - if: startsWith(github.ref, 'refs/tags/wash-cli-v')
-        run: |
+      - run: |
           for dir in ./artifacts/wash-*; do
             target=${dir#./artifacts/wash-}
             for bin_path in $(find ${dir}/bin -type f); do
@@ -1025,17 +1039,9 @@ jobs:
           done
 
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          draft: true
-          prerelease: true
-          generate_release_notes: true
-          files: ./wasmcloud/*
-
-      - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
         if: startsWith(github.ref, 'refs/tags/wash-cli-v')
         with:
-          draft: false
+          draft: true
           prerelease: true
           generate_release_notes: true
           files: ./wash/*


### PR DESCRIPTION
## Feature or Problem
This PR separates the release jobs for wasmcloud and wash, which notably drop the requirement for wash to be built to release wasmcloud and vice versa.

I also included something nice in this PR to remove all of the dependabot commits from our generated release notes, which should be useful while we research conventional commit tools to do this 😄 

## Related Issues
When I tried to release wasmcloud v1.6.0 it didn't complete because the job required wash to be built https://github.com/wasmCloud/wasmCloud/actions/runs/13186620296

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
