### PR TITLE
ci(cc): add automatic PR commit labeler

### DIFF
--- a/.github/workflows/check-conventional-commits.yml
+++ b/.github/workflows/check-conventional-commits.yml
@@ -116,3 +116,60 @@ jobs:
           header: tip-conventional-commits
           hide: true
           hide_classify: 'RESOLVED'
+
+  label-pr:
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get pull request commits
+        id: get_commits
+        run: |
+          PR_COMMITS=$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.commits[].messageHeadline')
+          echo "COMMITS<<EOF" >> $GITHUB_ENV
+          echo "$PR_COMMITS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse commit messages and determine labels
+        id: parse_labels
+        run: |
+          LABELS=()
+          while IFS= read -r line; do
+            if [[ "$line" =~ ^([a-z]+)(\(([^\)]+)\))?!?: ]]; then
+              TYPE="${BASH_REMATCH[1]}"
+              SCOPE="${BASH_REMATCH[3]}"
+              if [[ "$line" =~ !: ]]; then
+                LABELS+=("impact: breaking")
+              fi
+              case "$TYPE" in
+                fix) LABELS+=("type: fix") ;;
+                feat) LABELS+=("type: feature") ;;
+                ci) LABELS+=("type: ci") ;;
+                docs) LABELS+=("type: docs") ;;
+              esac
+              case "$SCOPE" in
+                wash|wash-cli|wash-lib) LABELS+=("scope: wash") ;;
+                wasmcloud|host|runtime|core) LABELS+=("scope: wasmcloud") ;;
+                control-interface|ctl) LABELS+=("scope: control-interface") ;;
+                "") ;; # Ignore empty scope
+                *) ;; # Ignore unknown scopes. To enable adding any scope as a label, use this: # *) LABELS+=("$SCOPE") ;;
+              esac
+            fi
+          done <<< "$COMMITS"
+          UNIQUE_LABELS=($(echo "${LABELS[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+          echo "LABELS=${UNIQUE_LABELS[*]}" >> $GITHUB_ENV
+
+      - name: Apply labels to PR
+        if: ${{ env.LABELS != '' }}
+        run: |
+          for label in ${LABELS[@]}; do
+            gh pr edit ${{ github.event.pull_request.number }} --add-label "$label"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Feature or Problem
This PR introduces a ONE HUNDRED PERCENT HOME-GROWN HAND-WRITTEN job step after validating that commits are conventional that attaches relevant labels to PRs based on the commit message. It includes the following labels that it can add based on commits:

TYPE:
1. fix: -> bug
2. feat: -> enhancement
3. ci: -> ci

SCOPE
1. wash-cli|wash-lib|wash -> wash-cli
2. wasmcloud|host|runtime|core -> wasmcloud
3. control-interface|ctl -> wasmcloud-control-interface

BREAKING -> breaking

## Related Issues
Gives us the basis for https://github.com/orgs/wasmCloud/projects/7/views/13?pane=issue&itemId=93877347 along with #4076's release.yml to generate changelogs based on conventional commits using PR labels 🚀

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
You can see an example fix to wash in https://github.com/brooksmtownsend/wasmCloud/pull/15

You can see an example breaking feature in wasmcloud in https://github.com/brooksmtownsend/wasmCloud/pull/16
