### PR TITLE
chore(wash): adjust URL formatting in help

### DIFF
--- a/crates/wash/src/cli/cmd/up.rs
+++ b/crates/wash/src/cli/cmd/up.rs
@@ -156,7 +156,7 @@ pub struct WasmcloudOpts {
     ///
     /// defaults to the [`WASMCLOUD_HOST_VERSION`] if not provided
     /// or the latest patch version after that when `wash up` issued,
-    /// see https://github.com/wasmCloud/wasmCloud/releases for releases
+    /// see [wasmCloud releases](https://github.com/wasmCloud/wasmCloud/releases).
     #[clap(long = "wasmcloud-version", env = "WASMCLOUD_VERSION")]
     pub wasmcloud_version: Option<String>,
 
@@ -368,7 +368,7 @@ pub struct WadmOpts {
     ///
     /// defaults to the [`WADM_VERSION`] if not provided
     /// or the latest patch version after that when `wash up` issued,
-    /// see https://github.com/wasmCloud/wadm/releases for releases
+    /// see [wadm releases](https://github.com/wasmCloud/wadm/releases).
     #[clap(long = "wadm-version", env = "WADM_VERSION")]
     pub wadm_version: Option<String>,
 

--- a/crates/wash/src/cli/cmd/up.rs
+++ b/crates/wash/src/cli/cmd/up.rs
@@ -156,7 +156,7 @@ pub struct WasmcloudOpts {
     ///
     /// defaults to the [`WASMCLOUD_HOST_VERSION`] if not provided
     /// or the latest patch version after that when `wash up` issued,
-    /// see <https://github.com/wasmCloud/wasmCloud/releases> for releases
+    /// see https://github.com/wasmCloud/wasmCloud/releases for releases
     #[clap(long = "wasmcloud-version", env = "WASMCLOUD_VERSION")]
     pub wasmcloud_version: Option<String>,
 
@@ -368,7 +368,7 @@ pub struct WadmOpts {
     ///
     /// defaults to the [`WADM_VERSION`] if not provided
     /// or the latest patch version after that when `wash up` issued,
-    /// see <https://github.com/wasmCloud/wadm/releases> for releases
+    /// see https://github.com/wasmCloud/wadm/releases for releases
     #[clap(long = "wadm-version", env = "WADM_VERSION")]
     pub wadm_version: Option<String>,
 

--- a/crates/wash/src/lib/config.rs
+++ b/crates/wash/src/lib/config.rs
@@ -73,7 +73,7 @@ pub struct WashConnectionOptions {
     pub ctl_seed: Option<String>,
 
     /// Credsfile for CTL authentication. Combines `ctl_seed` and `ctl_jwt`.
-    /// See <https://docs.nats.io/using-nats/developer/connecting/creds> for details.
+    /// See https://docs.nats.io/using-nats/developer/connecting/creds for details.
     pub ctl_credsfile: Option<PathBuf>,
 
     /// Path to a file containing a CA certificate to use for TLS connections

--- a/crates/wash/src/lib/config.rs
+++ b/crates/wash/src/lib/config.rs
@@ -73,7 +73,7 @@ pub struct WashConnectionOptions {
     pub ctl_seed: Option<String>,
 
     /// Credsfile for CTL authentication. Combines `ctl_seed` and `ctl_jwt`.
-    /// See https://docs.nats.io/using-nats/developer/connecting/creds for details.
+    /// See [the NATS documentation](https://docs.nats.io/using-nats/developer/connecting/creds) for details.
     pub ctl_credsfile: Option<PathBuf>,
 
     /// Path to a file containing a CA certificate to use for TLS connections


### PR DESCRIPTION
Angle brackets in the help documentation causes the generated Markdown to error (if not offset with a backtick) when deployed to the docs site. A few angle brackets have crept in around URLs, and this PR removes them.