### PR TITLE
fix(runtime): extract suffix from version not name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8687,7 +8687,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-runtime"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "1.6.0"
+version = "1.6.1"
 description = "wasmCloud is a Cloud Native Computing Foundation (CNCF) project that enables teams to build polyglot applications composed of reusable Wasm components and run them—resiliently and efficiently—across any cloud, Kubernetes, datacenter, or edge."
 default-run = "wasmcloud"
 readme = "README.md"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-runtime"
-version = "0.8.0"
+version = "0.8.1"
 description = "wasmCloud runtime library"
 readme = "README.md"
 

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -349,7 +349,7 @@ where
             match name.split_once('/').map(|(pkg, suffix)| {
                 suffix
                     .split_once('@')
-                    .map_or((pkg, name, None), |(iface, version)| {
+                    .map_or((pkg, suffix, None), |(iface, version)| {
                         (pkg, iface, Some(version))
                     })
             }) {


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue where parsing an unversioned WIT interface would end up bringing in the fully qualified WIT name instead of just the interface.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
runtime 0.8.1
wasmcloud 1.6.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
