### PR TITLE
ci: run on ubuntu 24.04

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   oci:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -541,6 +541,33 @@ jobs:
           name: wasmcloud-x86_64-pc-windows-gnu
       - run: .\bin\wasmcloud.exe --version
 
+  cargo-nextest:
+    needs: [meta]
+    if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || needs.meta.outputs.providers_modified == 'true' || startsWith(github.ref, 'refs/tags/') }}
+
+    name: cargo nextest
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/install-nix
+        with:
+          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: actions/cache/restore@36f1e144e1c8edb0a652766b484448563d8baf46
+        with:
+          path: ${{ runner.temp }}/nix-store
+          key: wasmcloud-cargo-doc-${{ github.sha }}
+          restore-keys: |
+            wasmcloud-cargo-doc-
+            wasmcloud-x86_64_unknown-linux-musl-${{ github.sha }}
+            wasmcloud-x86_64_unknown-linux-musl-
+            wash-x86_64_unknown-linux-musl-
+            wasmcloud-
+            wash-
+      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store"
+        continue-on-error: true
+      - run: rm -rf "${{ runner.temp }}/nix-store"
+      - run: nix build --fallback -L .#checks.x86_64-linux.nextest
+
   cargo:
     needs: [meta]
     if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || needs.meta.outputs.providers_modified == 'true' || startsWith(github.ref, 'refs/tags/') }}
@@ -550,7 +577,6 @@ jobs:
           - audit
           - fmt
           - clippy
-          - nextest
           - doctest
 
     name: cargo ${{ matrix.check }}
@@ -750,6 +776,7 @@ jobs:
       - build-wasmcloud-bin
       - build-wasmcloud-lipo
       - cargo
+      - cargo-nextest
       - oci-wasmcloud
       - test-wasmcloud-linux-aarch64
       - test-wasmcloud-linux-aarch64-oci
@@ -800,6 +827,7 @@ jobs:
       - build-wash-bin
       - build-wash-lipo
       - cargo
+      - cargo-nextest
       - oci-wash
       - test-wash-linux-aarch64
       - test-wash-linux-aarch64-oci
@@ -875,6 +903,7 @@ jobs:
       PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_API_TOKEN }}
     needs:
       - cargo
+      - cargo-nextest
       - build-wash-bin
       - test-wash-linux-x86_64
     runs-on: ubuntu-24.04
@@ -1080,6 +1109,7 @@ jobs:
       - test-wasmcloud-macos-x86_64
       - test-wasmcloud-windows-x86_64
       - cargo
+      - cargo-nextest
       - build-doc
       - providers
       - deploy-doc
@@ -1107,6 +1137,7 @@ jobs:
           echo 'needs.test-wasmcloud-macos-x86_64.result: ${{ needs.test-wasmcloud-macos-x86_64.result }}'
           echo 'needs.test-wasmcloud-windows-x86_64.result: ${{ needs.test-wasmcloud-windows-x86_64.result }}'
           echo 'needs.cargo.result: ${{ needs.cargo.result }}'
+          echo 'needs.cargo-nextest.result: ${{ needs.cargo-nextest.result }}'
           echo 'needs.build-doc.result: ${{ needs.build-doc.result }}'
           echo 'needs.providers.result: ${{ needs.providers.result }}'
           echo 'needs.deploy-doc.result: ${{ needs.deploy-doc.result }}'

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -196,7 +196,7 @@ jobs:
               docker run --rm wash:$(nix eval --raw .#wash-x86_64-unknown-linux-musl-oci.imageTag) wash --version
 
     name: wash-${{ matrix.config.target }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
@@ -261,7 +261,7 @@ jobs:
               docker run --rm wasmcloud:$(nix eval --raw .#wasmcloud-x86_64-unknown-linux-musl-oci.imageTag) wasmcloud --version
 
     name: wasmcloud-${{ matrix.config.target }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
@@ -306,7 +306,7 @@ jobs:
           - x86_64-unknown-linux-musl
 
     name: ${{ matrix.name }}-provider-${{ matrix.target }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
@@ -384,7 +384,7 @@ jobs:
           path: artifact
 
   test-wash-linux-aarch64:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     needs: build-wash-bin
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -394,7 +394,7 @@ jobs:
       - run: ./bin/wash --version
 
   test-wash-linux-aarch64-oci:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     needs: build-wash-bin
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -408,7 +408,7 @@ jobs:
       - run: docker run --rm wash:$(nix eval --raw .#wash-aarch64-unknown-linux-musl-oci.imageTag) wash --version
 
   test-wash-linux-x86_64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-wash-bin
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -463,7 +463,7 @@ jobs:
       - run: .\bin\wash.exe --version
 
   test-wasmcloud-linux-aarch64:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     needs: build-wasmcloud-bin
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -473,7 +473,7 @@ jobs:
       - run: ./bin/wasmcloud --version
 
   test-wasmcloud-linux-aarch64-oci:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     needs: build-wasmcloud-bin
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -487,7 +487,7 @@ jobs:
       - run: docker run --rm wasmcloud:$(nix eval --raw .#wasmcloud-aarch64-unknown-linux-musl-oci.imageTag) wasmcloud --version
 
   test-wasmcloud-linux-x86_64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-wasmcloud-bin
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -554,7 +554,7 @@ jobs:
           - doctest
 
     name: cargo ${{ matrix.check }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
@@ -579,7 +579,7 @@ jobs:
   build-doc:
     needs: [meta]
     if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/install-nix
@@ -688,7 +688,7 @@ jobs:
       azurecr_password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
 
   deploy-doc:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-doc
     permissions:
       contents: read
@@ -757,7 +757,7 @@ jobs:
       - test-wasmcloud-macos-aarch64
       - test-wasmcloud-macos-x86_64
       - test-wasmcloud-windows-x86_64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -807,7 +807,7 @@ jobs:
       - test-wash-macos-aarch64
       - test-wash-macos-x86_64
       - test-wash-windows-x86_64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -877,7 +877,7 @@ jobs:
       - cargo
       - build-wash-bin
       - test-wash-linux-x86_64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
@@ -984,7 +984,7 @@ jobs:
 
     name: publish ${{ matrix.crate }} to crates.io
     needs: cargo
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
@@ -1012,7 +1012,7 @@ jobs:
 
   smart-release:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
- update ubuntu-22.04 to ubuntu-24.04
- switch OCI job to run on GitHub hosted runners (this should ensure we can reuse caches from previous runs, hopefully....)
- run `nextest` on a beefier machine