### PR TITLE
build(nix): avoid running cargo checks in `release`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,7 @@
                 cargoLockParsed
                 ;
               cargoExtraArgs = ""; # disable `--locked` passed by default by crane
+              CARGO_PROFILE = ""; # avoid running cargo in `release` profile
             }
             // optionalAttrs (args ? cargoArtifacts) {
               nativeCheckInputs =


### PR DESCRIPTION
avoid running cargo checks in `release`, we should instead have sufficient integration testing in place to test our `release` profile builds