### PR TITLE
ci(nix): avoid checking signatures on import

### DIFF
--- a/.github/actions/build-nix/action.yml
+++ b/.github/actions/build-nix/action.yml
@@ -16,7 +16,7 @@ runs:
       restore-keys: |
         ${{ inputs.package }}-
 
-  - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-${{ inputs.package }}"
+  - run: nix copy --no-check-sigs --all --from "file://${{ runner.temp }}/nix-store-${{ inputs.package }}"
     continue-on-error: true
     shell: bash
   - run: rm -rf "${{ runner.temp }}/nix-store-${{ inputs.package }}"

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -50,7 +50,7 @@ jobs:
           key: ${{ inputs.bin }}-x86_64-unknown-linux-musl-${{ github.sha }}
           restore-keys: |
             ${{ inputs.bin }}-x86_64-unknown-linux-musl-
-      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-amd64"
+      - run: nix copy --no-check-sigs --all --from "file://${{ runner.temp }}/nix-store-amd64"
         continue-on-error: true
       - run: rm -rf "${{ runner.temp }}/nix-store-amd64"
 
@@ -60,7 +60,7 @@ jobs:
           key: ${{ inputs.bin }}-aarch64-unknown-linux-musl-${{ github.sha }}
           restore-keys: |
             ${{ inputs.bin }}-aarch64-unknown-linux-musl-
-      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-arm64"
+      - run: nix copy --no-check-sigs --all --from "file://${{ runner.temp }}/nix-store-arm64"
         continue-on-error: true
       - run: rm -rf "${{ runner.temp }}/nix-store-arm64"
 
@@ -71,7 +71,7 @@ jobs:
           key: ${{ inputs.bin }}-oci-${{ github.sha }}
           restore-keys: |
             ${{ inputs.bin }}-oci-
-      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store-oci"
+      - run: nix copy --no-check-sigs --all --from "file://${{ runner.temp }}/nix-store-oci"
         continue-on-error: true
       - run: rm -rf "${{ runner.temp }}/nix-store-oci"
 

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -563,7 +563,7 @@ jobs:
             wash-x86_64_unknown-linux-musl-
             wasmcloud-
             wash-
-      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store"
+      - run: nix copy --no-check-sigs --all --from "file://${{ runner.temp }}/nix-store"
         continue-on-error: true
       - run: rm -rf "${{ runner.temp }}/nix-store"
       - run: nix build --fallback -L .#checks.x86_64-linux.nextest
@@ -597,7 +597,7 @@ jobs:
             wash-x86_64_unknown-linux-musl-
             wasmcloud-
             wash-
-      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store"
+      - run: nix copy --no-check-sigs --all --from "file://${{ runner.temp }}/nix-store"
         continue-on-error: true
       - run: rm -rf "${{ runner.temp }}/nix-store"
       - run: nix build --fallback -L .#checks.x86_64-linux.${{ matrix.check }}
@@ -623,7 +623,7 @@ jobs:
             wash-x86_64_unknown-linux-musl-
             wasmcloud-
             wash-
-      - run: nix copy --all --from "file://${{ runner.temp }}/nix-store"
+      - run: nix copy --no-check-sigs --all --from "file://${{ runner.temp }}/nix-store"
         continue-on-error: true
       - run: rm -rf "${{ runner.temp }}/nix-store"
       - run: nix build --fallback -L .#checks.x86_64-linux.doc


### PR DESCRIPTION
Nix caches stored on GitHub are trusted, so no need to check signatures