### PR TITLE
chore/codeowners release notes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 .gitignore @wasmCloud/org-maintainers
 LICENSE @wasmCloud/org-maintainers
 *.md @wasmCloud/org-maintainers
+.github/workflows/check-conventional-commits.yml
 
 ## CI and nix
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,5 +2,21 @@
 
 changelog:
   exclude:
+    labels:
+      - type:ci
+      - type:docs
     authors:
       - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - impact:breaking
+    - title: New Features 🎉
+      labels:
+        - type:feature
+    - title: Bug Fixes 🐞
+      labels:
+        - type:fix
+    - title: Other Changes
+      labels:
+        - '*'


### PR DESCRIPTION
- **chore(CODEOWNERS): require org maintainer review on cc workflow**
- **ci(release): generate release note categories based on labels**

## Feature or Problem
This PR:
1. Makes the conventional commit workflow require an org maintainer given its status as a `pull_request_target` triggered workflow
1. Generates nice headings for release notes based on our new labels.

One thing I'm not really clear about is an easy way to separate these based on _wasmcloud_ releases, crate releases, and wash releases. Ideally, wasmcloud releases would only include PRs with the `scope:wasmcloud` label. See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes for more information. For now, I figure this is better than what we had and that we can see how it works.

Worst case, we can always create more specific labels for releases like `release:feat(wasmcloud)` /shrug

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
