### PR TITLE
chore: Add WASMCLOUD_TLS_CA_PATH to mirror tls-ca-path flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -323,7 +323,11 @@ struct Args {
     flame_graph: Option<String>,
 
     /// Configures the set of certificate authorities as repeatable set of file paths to load into the OCI and OpenTelemetry clients
-    #[arg(long = "tls-ca-path")]
+    #[arg(
+        long = "tls-ca-path",
+        env = "WASMCLOUD_TLS_CA_PATH",
+        value_delimiter = ','
+    )]
     pub tls_ca_paths: Option<Vec<PathBuf>>,
 
     /// If provided, overrides the default heartbeat interval of every 30 seconds. Provided value is interpreted as seconds.


### PR DESCRIPTION
## Feature or Problem

This adds `WASMCLOUD_TLS_CA_PATH` (or should it be called `WASMCLOUD_TLS_CA_PATHS`?) environment variable as alternative to `--tls-ca-path` for configuring additional CA paths to load into the OCI and OpenTelemetry clients.

This intended to make implementing https://github.com/wasmCloud/wasmCloud/issues/4109 slightly easier.

## Related Issues

https://github.com/wasmCloud/wasmCloud/issues/4109

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
