### PR TITLE
feat(wash): stop host without requiring ID

### DIFF
--- a/crates/wash-cli/src/common/stop_cmd.rs
+++ b/crates/wash-cli/src/common/stop_cmd.rs
@@ -22,8 +22,11 @@ pub async fn handle_command(
             handle_stop_provider(cmd).await?
         }
         StopCommand::Host(cmd) => {
-            let host_id = &cmd.host_id.to_string();
-            sp.update_spinner_message(format!(" Stopping host {host_id} ... "));
+            if let Some(host_id) = cmd.host_id.as_ref() {
+                sp.update_spinner_message(format!(" Stopping host {host_id} ... "));
+            } else {
+                sp.update_spinner_message(format!(" Finding and stopping host ... "));
+            }
             stop_host(cmd).await?
         }
     };
@@ -209,8 +212,7 @@ mod test {
                 assert_eq!(&opts.lattice.unwrap(), DEFAULT_LATTICE);
                 assert_eq!(opts.timeout_ms, TIMEOUT_MS);
                 assert_eq!(host_shutdown_timeout, HOST_TIMEOUT_MS);
-                assert_eq!(host_id.to_string(), HOST_ID);
-                assert_eq!(host_id.to_string(), HOST_ID,);
+                assert_eq!(host_id.expect("host to be specified"), HOST_ID);
             }
             cmd => panic!("stop host constructed incorrect command {cmd:?}"),
         }


### PR DESCRIPTION
## Feature or Problem
This PR allows you to run `wash stop host` when there's only one running locally and wash will find the host and stop it for you. I found this super annoying so this will hopefully make it easier in the local dev case.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
