### PR TITLE
build: patch `rust-spiffe`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,9 +41,20 @@
       targets.wasm32-unknown-unknown = false;
       targets.wasm32-wasip1 = false;
       targets.wasm32-wasip2 = false;
+
+      overrideVendorCargoPackage = {name, ...}: drv:
+        if name == "spiffe"
+        then
+          drv.overrideAttrs (_: {
+            patches = [
+              ./nix/patches/rust-spiffe.patch
+            ];
+          })
+        else drv;
     in
       rust.mkFlake {
         inherit
+          overrideVendorCargoPackage
           targets
           ;
         src = ./.;
@@ -125,6 +136,10 @@
           with pkgs.lib;
             {
               cargoVendorDir = craneLib.vendorMultipleCargoDeps {
+                inherit
+                  overrideVendorCargoPackage
+                  ;
+
                 cargoLockList = [
                   ./Cargo.lock
                   ./examples/rust/components/http-hello-world/Cargo.lock
@@ -157,6 +172,7 @@
                 "${name}" =
                   rust.mkAttrs {
                     inherit
+                      overrideVendorCargoPackage
                       src
                       targets
                       ;
@@ -182,6 +198,7 @@
               wash =
                 rust.mkAttrs {
                   inherit
+                    overrideVendorCargoPackage
                     src
                     targets
                     ;
@@ -198,6 +215,7 @@
               wasmcloud =
                 rust.mkAttrs {
                   inherit
+                    overrideVendorCargoPackage
                     src
                     targets
                     ;

--- a/nix/patches/rust-spiffe.patch
+++ b/nix/patches/rust-spiffe.patch
@@ -1,0 +1,69 @@
+--- a/build.rs
++++ b/build.rs
+@@ -1,19 +1,60 @@
++use std::path::Path;
+ use std::{env, fs};
+ 
+-fn main() -> Result<(), anyhow::Error> {
++use anyhow::{bail, Context as _};
++
++fn main() -> anyhow::Result<()> {
++    println!("cargo::rerun-if-changed=src/proto");
++    println!("cargo::rerun-if-env-changed=DOCS_RS");
++
+     // Check if this is a docs.rs build
+     let is_docs_rs = env::var_os("DOCS_RS").is_some();
+ 
+     if !is_docs_rs {
+         let mut proto_config = prost_build::Config::new();
+         proto_config.bytes(["."]);
+-        let file_descriptors = protox::compile(["src/proto/workload.proto"], ["src/proto"])?;
++        let out_dir = env::var_os("OUT_DIR").context("failed to lookup `OUT_DIR`")?;
++        let out_dir = Path::new(&out_dir);
++        let proto_dir = Path::new("src/proto");
++        let file_descriptors = protox::compile([proto_dir.join("workload.proto")], [proto_dir])
++            .context("failed to compile protocol buffer file set")?;
+         tonic_build::configure()
+             .build_client(true)
+-            .out_dir("src/proto")
+-            .compile_fds_with_config(proto_config, file_descriptors)?;
+-
+-        fs::rename("src/proto/_.rs", "src/proto/workload.rs")?;
++            .out_dir(out_dir)
++            .compile_fds_with_config(proto_config, file_descriptors)
++            .context("failed to compile protocol buffers")?;
++        for entry in fs::read_dir(out_dir).context("failed to read OUT_DIR")? {
++            let entry = entry.context("failed to get entry")?;
++            let ty = entry.file_type().context("failed to get file type")?;
++            let path = entry.path();
++            if ty.is_file() {
++                let buf = fs::read(&path).with_context(|| {
++                    format!("failed to read generated file at `{}`", path.display())
++                })?;
++                let name = entry.file_name();
++                let target = match name.to_str() {
++                    Some("_.rs") => proto_dir.join("workload.rs"),
++                    _ => proto_dir.join(name),
++                };
++                if let Ok(got) = fs::read(&target) {
++                    if got == buf {
++                        continue;
++                    }
++                }
++                fs::rename(&path, &target).with_context(|| {
++                    format!(
++                        "failed to move `{}` to `{}`",
++                        path.display(),
++                        target.display()
++                    )
++                })?;
++            } else {
++                bail!(
++                    "unexpected file type generated at `{}`: {ty:?}",
++                    path.display()
++                )
++            }
++        }
+     } else {
+         println!("cargo:warning=Skipping protobuf code generation on docs.rs.");
+     }


### PR DESCRIPTION
See https://github.com/wasmCloud/wasmCloud/pull/4118#issuecomment-2666030967

This pulls in https://github.com/maxlambrecht/rust-spiffe/pull/138 as a patch applied within Nix sandbox to enable building wasmCloud binary depending on this crate while still depending on the published releases, thus not preventing `wasmcloud` from being published to crates.io

Refs https://github.com/rvolosatovs/nixify/pull/355

Tested via (on a Mac):
```
$ curl -sL https://github.com/wasmCloud/wasmCloud/pull/4118.patch | git am -3
$ nix build -L
```