### PR TITLE
add more logs to the flaky single conn HTTP client provider test

### DIFF
--- a/crates/provider-http-client/Cargo.toml
+++ b/crates/provider-http-client/Cargo.toml
@@ -33,4 +33,4 @@ webpki-roots = { workspace = true }
 wrpc-interface-http = { workspace = true, features = ["http-body"] }
 
 [dev-dependencies]
-test-log = { workspace = true, features = ["color", "log", "trace"] }
+test-log = { workspace = true, features = ["color", "log", "trace", "unstable"] }

--- a/crates/provider-http-client/src/lib.rs
+++ b/crates/provider-http-client/src/lib.rs
@@ -241,7 +241,7 @@ impl<T> ConnPool<T> {
             }
         }
         let stream = connect(authority).await?;
-        let (sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
+        let (sender, conn) = http1::handshake(TokioIo::new(stream))
             .await
             .map_err(hyper_request_error)?;
         let tasks = Arc::clone(&self.tasks);
@@ -304,7 +304,7 @@ impl<T> ConnPool<T> {
             types::ErrorCode::TlsProtocolError
         })?;
 
-        let (sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
+        let (sender, conn) = http1::handshake(TokioIo::new(stream))
             .await
             .map_err(hyper_request_error)?;
         let tasks = Arc::clone(&self.tasks);

--- a/crates/provider-http-client/src/lib.rs
+++ b/crates/provider-http-client/src/lib.rs
@@ -910,8 +910,8 @@ mod tests {
                         .await
                         .with_context(|| format!("failed to receive body for request {i}"))?;
                     assert_eq!(body.to_bytes(), Bytes::default());
-                    // Pooled connection should be evicted after 2*IDLE_TIMEOUT
-                    sleep(IDLE_TIMEOUT.saturating_mul(2)).await;
+                    // Pooled connection should be evicted after 5*IDLE_TIMEOUT
+                    sleep(IDLE_TIMEOUT.saturating_mul(5)).await;
                 }
                 Ok(())
             }

--- a/crates/provider-http-client/src/lib.rs
+++ b/crates/provider-http-client/src/lib.rs
@@ -727,6 +727,7 @@ mod tests {
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    #[test_log(default_log_filter = "trace")]
     async fn test_single_conn() -> anyhow::Result<()> {
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
         let addr = listener.local_addr()?;
@@ -746,7 +747,9 @@ mod tests {
                         }),
                     )
                     .await
-                    .context("failed to serve connection")
+                    .context("failed to serve connection")?;
+                info!("done serving connection");
+                anyhow::Ok(())
             },
             async {
                 let link =


### PR DESCRIPTION
Since the test is flaky and it's not clear why, log at a higher verbosity level, so once it happens, we have a trace to debug