### PR TITLE
fix(wasmcloud): use tls certs for provider pull

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8410,7 +8410,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-host"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud"
-version = "1.6.1"
+version = "1.6.2"
 description = "wasmCloud is a Cloud Native Computing Foundation (CNCF) project that enables teams to build polyglot applications composed of reusable Wasm components and run them—resiliently and efficiently—across any cloud, Kubernetes, datacenter, or edge."
 default-run = "wasmcloud"
 readme = "README.md"

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-host"
-version = "0.24.0"
+version = "0.24.1"
 description = "wasmCloud host library"
 readme = "README.md"
 

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -159,6 +159,7 @@ pub async fn fetch_provider(
     provider_ref: &ResourceRef<'_>,
     host_id: impl AsRef<str>,
     allow_file_load: bool,
+    additional_ca_paths: &Vec<PathBuf>,
     registry_config: &HashMap<String, RegistryConfig>,
 ) -> anyhow::Result<(PathBuf, Option<jwt::Token<jwt::CapabilityProvider>>)> {
     match provider_ref {
@@ -181,6 +182,7 @@ pub async fn fetch_provider(
             .and_then(|authority| registry_config.get(authority))
             .map(OciFetcher::from)
             .unwrap_or_default()
+            .with_additional_ca_paths(additional_ca_paths)
             .fetch_provider(provider_ref, host_id)
             .await
             .with_context(|| {

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1814,6 +1814,7 @@ impl Host {
                     &provider_ref,
                     host_id,
                     self.host_config.allow_file_load,
+                    &self.host_config.oci_opts.additional_ca_paths,
                     &registry_config,
                 )
                 .await


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue where we used additional CA certificates during component pulls but not provider pulls.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
