### PR TITLE
ci: always upload `nix-store` artifact

### DIFF
--- a/.github/actions/build-nix/action.yml
+++ b/.github/actions/build-nix/action.yml
@@ -30,7 +30,6 @@ runs:
       name: ${{ inputs.package }}
       path: ${{ inputs.package }}
   - run: nix copy --to "file://${{ runner.temp }}/nix-store-${{ inputs.package }}" '.#${{ inputs.package }}'
-    if: steps.cache.outputs.cache-hit != 'true'
     shell: bash
   - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
     with:


### PR DESCRIPTION
Upload nix-store artifact even on cache hit