### PR TITLE
fix(ci): Ensure credentials are passed to cleanup step

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,3 +69,7 @@ jobs:
     - name: Teardown cluster
       if: ${{ always() }}
       run: ./ci/delete-cluster.sh
+      env:
+        OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CREDENTIALS_KEY }}
+        OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CREDENTIALS_FINGERPRINT }}
+        OCI_CLI_USER: ${{ secrets.OCI_USER_ID }}


### PR DESCRIPTION
I realized that we weren't passing credentials needed for cleanup of volumes after a test run