### PR TITLE
feat(runtime)!: enable opt-in error handling for custom interfaces

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -696,6 +696,7 @@ impl Host {
         let (stop_tx, stop_rx) = watch::channel(None);
 
         let (runtime, _epoch) = Runtime::builder()
+            .rpc_timeout(config.rpc_timeout)
             .max_execution_time(config.max_execution_time)
             .max_linear_memory(config.max_linear_memory)
             .max_components(config.max_components)

--- a/crates/runtime/src/component/http.rs
+++ b/crates/runtime/src/component/http.rs
@@ -140,7 +140,12 @@ where
         let scheme = wrpc_interface_http::bindings::wrpc::http::types::Scheme::from(scheme).into();
 
         let (tx, rx) = oneshot::channel();
-        let mut store = new_store(&self.engine, self.handler.clone(), self.max_execution_time);
+        let mut store = new_store(
+            &self.engine,
+            self.handler.clone(),
+            self.rpc_timeout,
+            self.max_execution_time,
+        );
         let pre = incoming_http_bindings::IncomingHttpPre::new(self.pre.clone())
             .context("failed to pre-instantiate `wasi:http/incoming-handler`")?;
         trace!("instantiating `wasi:http/incoming-handler`");

--- a/crates/runtime/src/component/messaging/mod.rs
+++ b/crates/runtime/src/component/messaging/mod.rs
@@ -23,7 +23,12 @@ where
     ) -> anyhow::Result<Result<(), String>> {
         // Set the parent of the current context to the span passed in
         Span::current().set_parent(cx.deref().context());
-        let mut store = new_store(&self.engine, self.handler.clone(), self.max_execution_time);
+        let mut store = new_store(
+            &self.engine,
+            self.handler.clone(),
+            self.rpc_timeout,
+            self.max_execution_time,
+        );
 
         // If wasmcloud:messaging@0.3.0 is enabled and we can instantiate the 0.3.0 bindings,
         // handle the message using 0.3.0. Otherwise, use the 0.2.0 bindings.

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -19,7 +19,7 @@ use wasmtime::component::{types, Linker, ResourceTable, ResourceTableError};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiView};
 use wasmtime_wasi_http::WasiHttpCtx;
 use wrpc_runtime_wasmtime::{
-    collect_component_resources, link_item, ServeExt as _, SharedResourceTable, WrpcView,
+    collect_component_resources, ServeExt as _, SharedResourceTable, WrpcView,
 };
 
 use crate::capability::{self, wrpc};
@@ -391,7 +391,7 @@ where
                     Some(version),
                 )) if is_0_2(version, 0) => {}
                 _ if rt.skip_feature_gated_instance(name) => {}
-                _ => link_item(&engine, &mut linker.root(), [], ty, "", name, None)
+                _ => crate::runtime::link_item(&engine, &mut linker.root(), [], ty, "", name, None)
                     .context("failed to link item")?,
             };
         }
@@ -527,11 +527,11 @@ where
                             move || {
                                 let span = info_span!("call_instance_function");
                                 let mut store = new_store(
-&engine,
-handler.clone(),
+                                    &engine,
+                                    handler.clone(),
                                     rpc_timeout,
-max_execution_time,
-);
+                                    max_execution_time,
+                                );
                                 store.data_mut().parent_context = Some(span.context());
                                 store
                             },

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -4,10 +4,24 @@ use core::fmt;
 use core::fmt::Debug;
 use core::time::Duration;
 
-use std::thread;
+use std::{iter::zip, pin::pin, sync::Arc, thread, time::Instant};
 
-use anyhow::Context;
-use wasmtime::{InstanceAllocationStrategy, PoolingAllocationConfig};
+use anyhow::{bail, Context};
+use bytes::BytesMut;
+use futures::future::try_join_all;
+use tokio::{io::AsyncWriteExt as _, try_join};
+use tracing::{debug, error, instrument, trace, warn, Instrument as _, Span};
+use wasmtime::{
+    component::{
+        types::{self, Field},
+        LinkerInstance, ResourceType, Type, Val,
+    },
+    AsContextMut as _, Engine, InstanceAllocationStrategy, PoolingAllocationConfig,
+};
+use wasmtime_wasi::WasiView;
+use wit_bindgen_wrpc::tokio_util::codec::Encoder;
+use wrpc_runtime_wasmtime::{read_value, RemoteResource, ValEncoder, WrpcView};
+use wrpc_transport::{Index as _, Invoke, InvokeExt as _};
 
 /// Default max linear memory for a component (256 MiB)
 pub const MAX_LINEAR_MEMORY: u64 = 256 * 1024 * 1024;
@@ -271,5 +285,362 @@ impl Runtime {
                 | "wasmcloud:messaging/request-reply@0.3.0"
                 | "wasmcloud:messaging/types@0.3.0"
                 if self.experimental_features.wasmcloud_messaging_v3)
+    }
+}
+
+/// Checks to see if a `ComponentFunc` is a function that should be linked with error handling
+pub(crate) fn returns_rpc_error_result(item: &wasmtime::component::types::ComponentFunc) -> bool {
+    let mut fn_results = item.results();
+    // Returns true if the return type of the function is result<T, wasmcloud:bus/lattice.rpc-error>
+    match fn_results.next() {
+        Some(Type::Result(result_ty)) if fn_results.len() == 0 => match result_ty.err() {
+            Some(Type::Record(record)) if record.fields().len() == 1 => {
+                if let Some(Field {
+                    ty: Type::Variant(_),
+                    name: "wasmcloud-error",
+                }) = record.fields().next()
+                {
+                    return true;
+                }
+            }
+            _ => {}
+        },
+        _ => {}
+    }
+    false
+}
+
+// Copied directly from <https://docs.rs/wrpc-runtime-wasmtime/0.25.0/wrpc_runtime_wasmtime/fn.link_item.html>
+// and modified to check ComponentFunc for error handling
+/// Polyfill [`types::ComponentItem`] in a [`LinkerInstance`] using [`wrpc_transport::Invoke`]
+#[instrument(level = "trace", skip_all)]
+pub(crate) fn link_item<V>(
+    engine: &Engine,
+    linker: &mut LinkerInstance<V>,
+    resources: impl Into<Arc<[ResourceType]>>,
+    ty: types::ComponentItem,
+    instance: impl Into<Arc<str>>,
+    name: impl Into<Arc<str>>,
+    cx: <V::Invoke as Invoke>::Context,
+) -> wasmtime::Result<()>
+where
+    V: WasiView + WrpcView,
+    <V::Invoke as Invoke>::Context: Clone + 'static,
+{
+    let instance = instance.into();
+    let resources = resources.into();
+    match ty {
+        types::ComponentItem::ComponentFunc(ty) => {
+            let name = name.into();
+            if returns_rpc_error_result(&ty) {
+                debug!(
+                    ?instance,
+                    ?name,
+                    "linking function with wasmcloud error handling"
+                );
+                crate::runtime::link_function_with_error_handling(
+                    linker, resources, ty, instance, name, cx,
+                )?;
+            } else {
+                debug!(?instance, ?name, "linking function");
+                wrpc_runtime_wasmtime::link_function(linker, resources, ty, instance, name, cx)?;
+            }
+        }
+        types::ComponentItem::CoreFunc(_) => {
+            bail!("polyfilling core functions not supported yet")
+        }
+        types::ComponentItem::Module(_) => bail!("polyfilling modules not supported yet"),
+        types::ComponentItem::Component(ty) => {
+            for (name, ty) in ty.imports(engine) {
+                debug!(?instance, name, "linking component item");
+                crate::runtime::link_item(
+                    engine,
+                    linker,
+                    Arc::clone(&resources),
+                    ty,
+                    "",
+                    name,
+                    cx.clone(),
+                )?;
+            }
+        }
+        types::ComponentItem::ComponentInstance(ty) => {
+            let name = name.into();
+            let mut linker = linker
+                .instance(&name)
+                .with_context(|| format!("failed to instantiate `{name}` in the linker"))?;
+            debug!(?instance, ?name, "linking instance");
+            crate::runtime::link_instance(engine, &mut linker, resources, ty, name, cx)?;
+        }
+        types::ComponentItem::Type(_) => {}
+        types::ComponentItem::Resource(_) => {
+            let name = name.into();
+            debug!(?instance, ?name, "linking resource");
+            linker.resource(&name, ResourceType::host::<RemoteResource>(), |_, _| Ok(()))?;
+        }
+    }
+    Ok(())
+}
+
+// Copied directly from <https://docs.rs/wrpc-runtime-wasmtime/0.25.0/wrpc_runtime_wasmtime/fn.link_instance.html>
+// and modified to recurse here to check functions for errors instead of in the caller
+/// Polyfill [`types::ComponentInstance`] in a [`LinkerInstance`] using [`wrpc_transport::Invoke`]
+#[instrument(level = "trace", skip_all)]
+pub(crate) fn link_instance<V>(
+    engine: &Engine,
+    linker: &mut LinkerInstance<V>,
+    resources: impl Into<Arc<[ResourceType]>>,
+    ty: types::ComponentInstance,
+    name: impl Into<Arc<str>>,
+    cx: <V::Invoke as Invoke>::Context,
+) -> wasmtime::Result<()>
+where
+    V: WrpcView + WasiView,
+    <V::Invoke as Invoke>::Context: Clone + 'static,
+{
+    let instance = name.into();
+    let resources = resources.into();
+    for (name, ty) in ty.exports(engine) {
+        debug!(name, "linking instance item");
+        crate::runtime::link_item(
+            engine,
+            linker,
+            Arc::clone(&resources),
+            ty,
+            Arc::clone(&instance),
+            name,
+            cx.clone(),
+        )?;
+    }
+    Ok(())
+}
+
+// Copied directly from <https://docs.rs/wrpc-runtime-wasmtime/0.25.0/wrpc_runtime_wasmtime/fn.link_function.html>
+// and modified to handle errors
+/// Polyfill [`types::ComponentFunc`] in a [`LinkerInstance`] using [`wrpc_transport::Invoke`]
+#[instrument(level = "trace", skip_all)]
+fn link_function_with_error_handling<V>(
+    linker: &mut LinkerInstance<V>,
+    resources: impl Into<Arc<[ResourceType]>>,
+    ty: wasmtime::component::types::ComponentFunc,
+    instance: impl Into<Arc<str>>,
+    name: impl Into<Arc<str>>,
+    cx: <V::Invoke as Invoke>::Context,
+) -> wasmtime::Result<()>
+where
+    V: WrpcView + WasiView,
+    <V::Invoke as Invoke>::Context: Clone + 'static,
+{
+    let span = Span::current();
+    let instance = instance.into();
+    let name = name.into();
+    let resources = resources.into();
+    linker.func_new_async(&Arc::clone(&name), move |mut store, params, results| {
+        let cx = cx.clone();
+        let ty = ty.clone();
+        let instance = Arc::clone(&instance);
+        let name = Arc::clone(&name);
+        let resources = Arc::clone(&resources);
+        Box::new(
+            async move {
+                let mut buf = BytesMut::default();
+                let mut deferred = vec![];
+
+                for (v, ref ty) in zip(params, ty.params()) {
+                    let mut enc = ValEncoder::new(store.as_context_mut(), ty, &resources);
+                    enc.encode(v, &mut buf)
+                        .context("failed to encode parameter")?;
+                    deferred.push(enc.deferred);
+                }
+                let clt = store.data().client();
+                let timeout = store.data().timeout();
+                let buf = buf.freeze();
+                // TODO: set paths
+                let paths = &[[]; 0];
+                let rpc_name = rpc_func_name(&name);
+                let start = Instant::now();
+                // MODIFICATION FOR ERROR HANDLING BEGINS
+                let invoke_res = if let Some(timeout) = timeout {
+                    clt.timeout(timeout)
+                        .invoke(cx, &instance, rpc_name, buf, paths)
+                        .await
+                } else {
+                    clt.invoke(cx, &instance, rpc_name, buf, paths).await
+                };
+
+                let (outgoing, incoming) = match invoke_res {
+                    Ok((outgoing, incoming)) => (outgoing, incoming),
+                    Err(e) => {
+                        error!(%e, %instance, %name, "failed to invoke polyfill via wRPC");
+                        if let Some(v) = results.first_mut() {
+                            *v = Val::Result(Err(Some(Box::new(Val::Record(vec![(
+                                "wasmcloud-error".to_string(),
+                                Val::Variant(
+                                    "wasmcloud".to_string(),
+                                    Some(Box::new(Val::String(e.to_string()))),
+                                ),
+                            )])))));
+                        } else {
+                            warn!(%instance, %name, "no results to write error to");
+                        }
+                        return Ok(());
+                    }
+                };
+                let tx = async {
+                    if let Err(e) = try_join_all(
+                        zip(0.., deferred)
+                            .filter_map(|(i, f)| f.map(|f| (outgoing.index(&[i]), f)))
+                            .map(|(w, f)| async move {
+                                let w = w?;
+                                f(w).await
+                            }),
+                    )
+                    .await
+                    .context("failed to write asynchronous parameters")
+                    {
+                        error!(%e, %instance, %name, "failed to write asynchronous parameters");
+                        return Ok(vec![Val::Result(Err(Some(Box::new(Val::Record(vec![(
+                            "wasmcloud-error".to_string(),
+                            Val::Variant(
+                                "wrpc".to_string(),
+                                Some(Box::new(Val::String(e.to_string()))),
+                            ),
+                        )])))))]);
+                    };
+                    let mut outgoing = pin!(outgoing);
+                    if let Err(e) = outgoing.flush().await{
+                    error!(%e, %instance, %name, "failed to flush outgoing stream");
+                        Ok(vec![Val::Result(Err(Some(Box::new(Val::Record(vec![(
+                            "wasmcloud-error".to_string(),
+                            Val::Variant(
+                                "wrpc".to_string(),
+                                Some(Box::new(Val::String(e.to_string()))),
+                            ),
+                        )])))))])
+                    } else {
+                        if let Err(err) = outgoing.shutdown().await {
+                            trace!(?err, "failed to shutdown outgoing stream");
+                        }
+                        anyhow::Ok(vec![])
+                    }
+                };
+                let rx = async {
+                    let mut incoming = pin!(incoming);
+
+                    let ty_results = ty.results();
+                    let mut rx_results: Vec<Val> = vec![Val::Bool(false); ty_results.len()];
+                    for (i, (v, ref ty)) in zip(rx_results.as_mut_slice(), ty_results).enumerate()
+                    {
+                        read_value(&mut store, &mut incoming, &resources, v, ty, &[i])
+                            .await
+                            .with_context(|| format!("failed to decode return value {i}"))?;
+                    }
+                    Ok(rx_results)
+                };
+                // TODO(brooks): would be great to find a way to not duplicate the matches for timeouts
+                if let Some(timeout) = timeout {
+                    let timeout =
+                        timeout.saturating_sub(Instant::now().saturating_duration_since(start));
+                    match try_join!(
+                        async {
+                            tokio::time::timeout(timeout, tx)
+                                .await
+                                .context("data transmission timed out")
+                        },
+                        async {
+                            tokio::time::timeout(timeout, rx)
+                                .await
+                                .context("data receipt timed out")
+                        },
+                    ) {
+                        // Any errors in transmission are reported here
+                        Ok((Ok(tx), Ok(_))) if !tx.is_empty() => {
+                            for (actual, result) in zip(tx, results) {
+                                *result = actual;
+                            }
+                        }
+                        // Write any received values to the results
+                        Ok((Ok(_), Ok(rx)))  => {
+                            for (actual, result) in zip(rx, results) {
+                                *result = actual;
+                            }
+                        }
+                        Ok((Err(e), _) | (_, Err(e))) => {
+                            error!(%e, %instance, %name, "failed to transmit or receive data");
+                            if let Some(v) = results.first_mut() {
+                                *v = Val::Result(Err(Some(Box::new(Val::Record(vec![(
+                                    "wasmcloud-error".to_string(),
+                                    Val::Variant(
+                                        "wrpc".to_string(),
+                                        Some(Box::new(Val::String(e.to_string()))),
+                                    ),
+                                )])))));
+                            }
+                        }
+                        Err(e) => {
+                            error!(%e, %instance, %name, "failed to transmit or receive data due to timeout");
+                            if let Some(v) = results.first_mut() {
+                                *v = Val::Result(Err(Some(Box::new(Val::Record(vec![(
+                                    "wasmcloud-error".to_string(),
+                                    Val::Variant(
+                                        "wrpc".to_string(),
+                                        Some(Box::new(Val::String(e.to_string()))),
+                                    ),
+                                )])))));
+                            } else {
+                                warn!(%instance, %name, "no results to write timeout error to");
+                            }
+                        }
+                    }
+                } else {
+                    match try_join!(tx, rx) {
+                        // Any errors in transmission are reported here
+                        Ok((tx, _)) if !tx.is_empty() => {
+                            for (actual, result) in zip(tx, results) {
+                                *result = actual;
+                            }
+                        }
+                        // Write any received values to the results
+                        Ok((_, rx)) => {
+                            for (actual, result) in zip(rx, results) {
+                                *result = actual;
+                            }
+                        }
+                        Err(e) => {
+                            error!(%e, %instance, %name, "failed to transmit or receive data");
+                            if let Some(v) = results.first_mut() {
+                                *v = Val::Result(Err(Some(Box::new(Val::Record(vec![(
+                                    "wasmcloud-error".to_string(),
+                                    Val::Variant(
+                                        "wrpc".to_string(),
+                                        Some(Box::new(Val::String(e.to_string()))),
+                                    ),
+                                )])))));
+                            } else {
+                                warn!(%instance, %name, "no results to write error to");
+                            }
+                        }
+                    }
+                }
+                // MODIFICATION FOR ERROR HANDLING ENDS
+                Ok(())
+            }
+            .instrument(span.clone()),
+        )
+    })
+}
+
+// this returns the RPC name for a wasmtime function name.
+// Unfortunately, the [`types::ComponentFunc`] does not include the kind information and we want to
+// avoid (re-)parsing the WIT here.
+fn rpc_func_name(name: &str) -> &str {
+    if let Some(name) = name.strip_prefix("[constructor]") {
+        name
+    } else if let Some(name) = name.strip_prefix("[static]") {
+        name
+    } else if let Some(name) = name.strip_prefix("[method]") {
+        name
+    } else {
+        name
     }
 }

--- a/tests/components/rust/pinger-config-component/src/lib.rs
+++ b/tests/components/rust/pinger-config-component/src/lib.rs
@@ -32,12 +32,18 @@ impl http::Server for Actor {
 
         // No args, return string
         let pong = pingpong::ping();
+        // Used in the error handling test
+        if let Err(e) = pong {
+            let res = json!({"error": e.to_string()});
+            let body = serde_json::to_vec(&res).expect("failed to encode response to JSON");
+            return Ok(http::Response::new(body));
+        }
         let pong_secret = pingpong::ping_secret();
 
         let res = json!({
             "single_val": config::store::get(&config_key).expect("failed to get config value"),
             "multi_val": config::store::get_all().expect("failed to get config value").into_iter().collect::<HashMap<String, String>>(),
-            "pong": pong,
+            "pong": pong.expect("failed to get pong"),
             "pong_secret": pong_secret,
         });
         let body = serde_json::to_vec(&res).expect("failed to encode response to JSON");

--- a/tests/components/rust/pinger-config-component/wit/deps/test-components-testing-0.1.0/package.wit
+++ b/tests/components/rust/pinger-config-component/wit/deps/test-components-testing-0.1.0/package.wit
@@ -8,8 +8,10 @@ interface invoke {
 
 /// Invoke a component with a `ping` function and, ideally, receive "pong"
 interface pingpong {
+  use wasmcloud:bus/lattice@2.0.0.{rpc-error};
+
   /// Call ping, get a pong back
-  ping: func() -> string;
+  ping: func() -> result<string, rpc-error>;
 
   /// Call ping, but quietly, and get a secret pong back
   ping-secret: func() -> string;

--- a/tests/components/rust/pinger-config-component/wit/deps/wasmcloud-bus-2.0.0/package.wit
+++ b/tests/components/rust/pinger-config-component/wit/deps/wasmcloud-bus-2.0.0/package.wit
@@ -1,0 +1,27 @@
+package wasmcloud:bus@2.0.0;
+
+interface lattice {
+  /// Interface target. This represents an interface, which can be selected by `set-link-name`.
+  resource call-target-interface {
+    constructor(namespace: string, %package: string, %interface: string);
+  }
+
+  variant error {
+    transport(string),
+    wasmcloud(string),
+    wrpc(string),
+  }
+
+  record rpc-error {
+    wasmcloud-error: error,
+  }
+
+  /// Set a link name to use for all interfaces specified. This is advanced functionality only
+  /// available within wasmcloud and, as such, is exposed here as part of the wasmcloud:bus package.
+  /// This is used when you are linking multiple of the same interfaces
+  /// (i.e. a keyvalue implementation for caching and another one for secrets) to a component.
+  ///
+  /// Will return an error if a link does not exist at call time with the specified name and interfaces.
+  set-link-name: func(name: string, interfaces: list<call-target-interface>) -> result<_, string>;
+}
+

--- a/tests/components/rust/pinger-config-component/wkg.toml
+++ b/tests/components/rust/pinger-config-component/wkg.toml
@@ -1,2 +1,3 @@
 [overrides]
 "test-components:testing" = { path = "../../wit/testing" }
+"wasmcloud:bus" = { path = "../../../../wit/bus/wit" }

--- a/tests/components/rust/ponger-config-component/src/lib.rs
+++ b/tests/components/rust/ponger-config-component/src/lib.rs
@@ -2,15 +2,17 @@ wit_bindgen::generate!({ generate_all });
 
 use wasmcloud_component::wasi;
 
+// TODO(brooksmtownsend): Source this from wasmcloud_component
+use crate::wasmcloud::bus::lattice::RpcError;
 use exports::test_components::testing::*;
 
 struct Actor;
 
 impl pingpong::Guest for Actor {
-    fn ping() -> String {
-        wasi::config::store::get("pong")
+    fn ping() -> Result<String, RpcError> {
+        Ok(wasi::config::store::get("pong")
             .expect("Unable to fetch value")
-            .unwrap_or_else(|| "config value not set".to_string())
+            .unwrap_or_else(|| "config value not set".to_string()))
     }
 
     fn ping_secret() -> String {

--- a/tests/components/rust/ponger-config-component/wit/deps/test-components-testing-0.1.0/package.wit
+++ b/tests/components/rust/ponger-config-component/wit/deps/test-components-testing-0.1.0/package.wit
@@ -8,8 +8,10 @@ interface invoke {
 
 /// Invoke a component with a `ping` function and, ideally, receive "pong"
 interface pingpong {
-  /// Call ping, get a pong back
-  ping: func() -> string;
+  use wasmcloud:bus/lattice@2.0.0.{rpc-error};
+
+  /// Call ping, get a pong back (with error handling)
+  ping: func() -> result<string, rpc-error>;
 
   /// Call ping, but quietly, and get a secret pong back
   ping-secret: func() -> string;

--- a/tests/components/rust/ponger-config-component/wit/deps/wasmcloud-bus-2.0.0/package.wit
+++ b/tests/components/rust/ponger-config-component/wit/deps/wasmcloud-bus-2.0.0/package.wit
@@ -1,0 +1,27 @@
+package wasmcloud:bus@2.0.0;
+
+interface lattice {
+  /// Interface target. This represents an interface, which can be selected by `set-link-name`.
+  resource call-target-interface {
+    constructor(namespace: string, %package: string, %interface: string);
+  }
+
+  variant error {
+    transport(string),
+    wasmcloud(string),
+    wrpc(string),
+  }
+
+  record rpc-error {
+    wasmcloud-error: error,
+  }
+
+  /// Set a link name to use for all interfaces specified. This is advanced functionality only
+  /// available within wasmcloud and, as such, is exposed here as part of the wasmcloud:bus package.
+  /// This is used when you are linking multiple of the same interfaces
+  /// (i.e. a keyvalue implementation for caching and another one for secrets) to a component.
+  ///
+  /// Will return an error if a link does not exist at call time with the specified name and interfaces.
+  set-link-name: func(name: string, interfaces: list<call-target-interface>) -> result<_, string>;
+}
+

--- a/tests/components/rust/ponger-config-component/wkg.toml
+++ b/tests/components/rust/ponger-config-component/wkg.toml
@@ -1,2 +1,3 @@
 [overrides]
 "test-components:testing" = { path = "../../wit/testing" }
+"wasmcloud:bus" = { path = "../../../../wit/bus/wit" }

--- a/tests/components/wit/testing/testing.wit
+++ b/tests/components/wit/testing/testing.wit
@@ -8,8 +8,9 @@ interface invoke {
 
 /// Invoke a component with a `ping` function and, ideally, receive "pong"
 interface pingpong {
-    /// Call ping, get a pong back
-    ping: func() -> string;
+    use wasmcloud:bus/lattice@2.0.0.{rpc-error};
+    /// Call ping, get a pong back (with error handling)
+    ping: func() -> result<string, rpc-error>;
 
     /// Call ping, but quietly, and get a secret pong back
     ping-secret: func() -> string;

--- a/tests/error-handle.rs
+++ b/tests/error-handle.rs
@@ -1,0 +1,187 @@
+use core::str;
+use core::time::Duration;
+
+use std::net::Ipv4Addr;
+
+use anyhow::Context as _;
+use tokio::time::sleep;
+use tokio::try_join;
+use tracing_subscriber::prelude::*;
+use wasmcloud_core::tls::NativeRootsExt as _;
+use wasmcloud_test_util::lattice::config::assert_config_put;
+use wasmcloud_test_util::provider::{assert_start_provider, StartProviderArgs};
+use wasmcloud_test_util::{
+    component::assert_scale_component, host::WasmCloudTestHost,
+    lattice::link::assert_advertise_link,
+};
+
+use test_components::RUST_PINGER_CONFIG_COMPONENT;
+
+pub mod common;
+use common::free_port;
+use common::nats::start_nats;
+use common::providers;
+
+const LATTICE: &str = "default";
+const COMPONENT_ID: &str = "http_hello_world";
+
+#[tokio::test]
+async fn pinger_transport_error_handling() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().compact().without_time())
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,cranelift_codegen=warn,wasmcloud=trace")
+            }),
+        )
+        .init();
+
+    let (nats_server, nats_url, nats_client) =
+        start_nats().await.context("failed to start NATS")?;
+
+    // Build client for interacting with the lattice
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client)
+        .lattice(LATTICE.to_string())
+        .build();
+    // Build the host
+    let host = WasmCloudTestHost::start(&nats_url, LATTICE)
+        .await
+        .context("failed to start test host")?;
+
+    let http_port = free_port().await?;
+
+    let http_server_config_name = "http-server".to_string();
+    let http_server_id = "http-server";
+
+    let host_key = host.host_key();
+    let host_id = host_key.public_key();
+
+    try_join!(
+        async {
+            assert_config_put(
+                &ctl_client,
+                &http_server_config_name,
+                [(
+                    "ADDRESS".to_string(),
+                    format!("{}:{http_port}", Ipv4Addr::LOCALHOST),
+                )],
+            )
+            .await
+            .context("failed to put configuration")
+        },
+        async {
+            assert_start_provider(StartProviderArgs {
+                client: &ctl_client,
+                host_id: &host_id,
+                provider_id: http_server_id,
+                provider_ref: providers::builtin_http_server().as_str(),
+                config: vec![],
+            })
+            .await
+            .context("failed to start providers")
+        },
+        async {
+            assert_scale_component(
+                &ctl_client,
+                &host_id,
+                format!("file://{RUST_PINGER_CONFIG_COMPONENT}"),
+                COMPONENT_ID,
+                None,
+                5,
+                Vec::new(),
+                Duration::from_secs(10),
+            )
+            .await
+            .context("failed to scale `rust-http-hello-world` component")
+        }
+    )?;
+
+    assert_advertise_link(
+        &ctl_client,
+        http_server_id,
+        COMPONENT_ID,
+        "default",
+        "wasi",
+        "http",
+        vec!["incoming-handler".to_string()],
+        vec![http_server_config_name],
+        vec![],
+    )
+    .await
+    .context("failed to advertise link")?;
+
+    let http_client = reqwest::Client::builder()
+        .with_native_certificates()
+        .timeout(Duration::from_secs(20))
+        .connect_timeout(Duration::from_secs(20))
+        .build()
+        .context("failed to build HTTP client")?;
+
+    let body = r#"{"config_key":"foo"}"#;
+
+    // Wait for data to be propagated across lattice
+    sleep(Duration::from_secs(1)).await;
+
+    // Test that missing link is handled gracefully for custom interface
+    let url = format!("http://localhost:{http_port}/");
+    let req = http_client.post(&url).body(body).send();
+    let res = req
+        .await
+        .context("failed to connect to server")?
+        .error_for_status()
+        .context("failed to get response")?
+        .text()
+        .await
+        .context("failed to get response text")?;
+    assert!(
+        res.contains("link `default` not found for instance `test-components:testing/pingpong`")
+    );
+
+    assert_advertise_link(
+        &ctl_client,
+        COMPONENT_ID,
+        "nonexistent-ponger-component",
+        "default",
+        "test-components",
+        "testing",
+        vec!["pingpong".to_string()],
+        vec![],
+        vec![],
+    )
+    .await
+    .context("failed to advertise link")?;
+
+    // Wait for data to be propagated across lattice
+    sleep(Duration::from_secs(1)).await;
+
+    // Test that ponger component not running is handled gracefully for custom interface
+    let req = http_client.post(&url).body(body).send();
+    let res = req
+        .await
+        .context("failed to connect to server")?
+        .error_for_status()
+        .context("failed to get response")?
+        .text()
+        .await
+        .context("failed to get response text")?;
+    // TODO(brooksmtownsend): this error message can change since it is a result of a timeout,
+    // and depends if the `tx` or `rx` future is polled first.
+    assert!(res.contains("failed to flush outgoing stream"));
+
+    // Test that NATS server not running is handled gracefully for custom interface
+    nats_server.stop().await.context("failed to stop NATS")?;
+    let req = http_client.post(&url).body(body).send();
+    let res = req
+        .await
+        .context("failed to connect to server")?
+        .error_for_status()
+        .context("failed to get response")?
+        .text()
+        .await
+        .context("failed to get response text")?;
+    // TODO(brooksmtownsend): this error message can change since it is a result of a timeout,
+    // and depends if the `tx` or `rx` future is polled first.
+    assert!(res.contains("data transmission timed out"));
+
+    Ok(())
+}

--- a/wit/bus/wit/bus.wit
+++ b/wit/bus/wit/bus.wit
@@ -6,6 +6,16 @@ interface lattice {
         constructor(namespace: string, %package: string, %interface: string);
     }
 
+    record rpc-error {
+        wasmcloud-error: error,
+    }
+
+    variant error {
+        transport(string),
+        wasmcloud(string),
+        wrpc(string),
+    }
+
     /// Set a link name to use for all interfaces specified. This is advanced functionality only
     /// available within wasmcloud and, as such, is exposed here as part of the wasmcloud:bus package.
     /// This is used when you are linking multiple of the same interfaces


### PR DESCRIPTION
## Feature or Problem
This PR adds a new type, `wasmcloud:bus/lattice.rpc-error` which is a specially recognized error variant in the wasmCloud runtime crate. If any function contains the signature `result<T, wasmcloud:bus/lattice.rpc-error>` then we will specially polyfill this function to report any transport or wasmCloud level errors into the error type if they occur. For example, this would allow components using custom interfaces to handle errors when NATS is disconnected, their component isn't linked, or if an invocation times out.

This PR also wires up the Host's RPC timeout value to the invocation timeout instead of using `max_execution_time`, which was a previous oversight. This is a breaking change, though, and we should consider if 2 seconds is too short for RPC.

It's worth noting that the vast majority of changes in this PR are essentially copied lines from https://crates.io/crates/wrpc-runtime-wasmtime, which isn't really ideal. I've marked this PR as a draft for now so that @rvolosatovs and I can discuss some code cleanliness options, making sure that the refactor to wait for results and transmission to finish before writing results is okay, and the design of the error type. We should also discuss the error messages and variants to see if we can add more clarity to them to help with debugging and runtime handling

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wasmCloud 1.7

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
A new error test was added using the pinger component that tests a few scenarios that should be handled:
1. Missing link for custom interface function
2. Target component is not running
3. NATS disconnects

### Manual Verification
I manually verified this worked in a few scenarios
