### PR TITLE
feat(ci): Adds docker build the NATS KV secrets implementation

### DIFF
--- a/.github/workflows/secrets-nats-kv.yml
+++ b/.github/workflows/secrets-nats-kv.yml
@@ -218,3 +218,20 @@ jobs:
           generate_release_notes: true
           files: |
             ./artifacts/*
+  image-build:
+    needs:
+      - release-build
+    uses: ./.github/workflows/oci.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      bin: secret-nats-kv
+      prefix: 'secrets-nats-kv-'
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      AZURECR_PUSH_URL: ${{ secrets.AZURECR_PUSH_URL }}
+      AZURECR_PUSH_USER: ${{ secrets.AZURECR_PUSH_USER }}
+      AZURECR_PUSH_PASSWORD: ${{ secrets.AZURECR_PUSH_PASSWORD }}
+      DOCKERHUB_PUSH_USER: ${{ secrets.DOCKERHUB_PUSH_USER }}
+      DOCKERHUB_PUSH_PASSWORD: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}


### PR DESCRIPTION
This uses the existing steps for building with nix so we're releasing with the same base images (and wolfi) as our other images