### PR TITLE
chore(examples): improve clarity of echo-messaging wadm example

### DIFF
--- a/examples/rust/components/echo-messaging/wadm.yaml
+++ b/examples/rust/components/echo-messaging/wadm.yaml
@@ -30,11 +30,19 @@ spec:
         # (i.e. making interacting with the messaging system, in this case NATS)
         - type: link
           properties:
-            target:
-              name: nats
             namespace: wasmcloud
             package: messaging
             interfaces: [consumer]
+            source:
+              name: echo
+            target:
+              name: nats
+              # This configures the (component -> provider) link
+              config:
+                - name: provider-tgt
+                  properties:
+                    subscriptions: wasmcloud.echo
+                    # cluster_uris: "nats://your-custom-nats:4222,nats://your-second-nats:5222"
 
     # Add a capability provider that implements `wasmcloud:messaging` using NATS
     - name: nats
@@ -58,13 +66,16 @@ spec:
         # so that so the provider can deliver messages to the component (by invoking the wasmcloud:messaging/handler interface) .
         - type: link
           properties:
-            target:
-              name: echo
             namespace: wasmcloud
             package: messaging
             interfaces: [handler]
+            target:
+              name: echo
+            # This configures the (provider -> component) link
             source:
+              name: nats
               config:
-                - name: simple-subscription
+                - name: provider-src
                   properties:
                     subscriptions: wasmcloud.echo
+                    # cluster_uris: "nats://your-custom-nats:4222,nats://your-second-nats:5222"


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

A user on slack using a docker-compose setup where `nats` was running at `nats:4222` (rather than the default `localhost`) ran into an issue with the `echo-messaging` example since it:

- assumes the `localhost:4222` NATS normally available in a non-docker environment
- didn't properly configure the provider -> component *and* component -> provider connections

This PR improves the non-local `wadm.yaml`, making it a bit clearer how and what to change, and fixing the config.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
