### PR TITLE
chore(async-nats)!: upgrade to 0.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.36.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71e5a1bab60f46b0b005f4808b8ee83ef6d577608923de938403393c9a30cf8"
+checksum = "a798aab0c0203b31d67d501e5ed1f3ac6c36a329899ce47fc93c3bea53f3ae89"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -309,6 +309,7 @@ dependencies = [
  "nkeys",
  "nuid",
  "once_cell",
+ "pin-project",
  "portable-atomic",
  "rand 0.8.5",
  "regex",
@@ -325,6 +326,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-util",
+ "tokio-websockets",
  "tracing",
  "tryhard",
  "url",
@@ -1198,7 +1200,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1226,7 +1228,7 @@ dependencies = [
  "ipnet",
  "maybe-owned",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -2410,7 +2412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2587,7 +2589,7 @@ checksum = "5e2e6123af26f0f2c51cc66869137080199406754903cc926a7690401ce09cb4"
 dependencies = [
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3560,7 +3562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5186,7 +5188,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5650,7 +5652,7 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.4.15",
  "once_cell",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5663,7 +5665,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6587,7 +6589,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -6608,7 +6610,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7058,6 +7060,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.2.0",
+ "httparse",
+ "rand 0.8.5",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util",
+ "webpki-roots",
+]
+
+[[package]]
 name = "toml"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7356,7 +7379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -7598,9 +7621,8 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wadm-client"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6496035592c8a7fad0b212cad71182cd404dd9995e9563204f849f5603325"
+version = "0.9.0"
+source = "git+https://github.com/wasmcloud/wadm?branch=main#14f7ed1bab3d2e52569d18b829fd190c93222658"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7616,8 +7638,7 @@ dependencies = [
 [[package]]
 name = "wadm-types"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ef0d0cd2de68fe64452256500bf1c9c1a5524a197383178083811ea9918e0e"
+source = "git+https://github.com/wasmcloud/wadm?branch=main#14f7ed1bab3d2e52569d18b829fd190c93222658"
 dependencies = [
  "anyhow",
  "regex",
@@ -8362,7 +8383,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9573,7 +9594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.8.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9987,9 +10008,9 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a226edc7f6fd721b10260aa7fe083c71ccb29d464eb8f7121d634afc5e8c355b"
+checksum = "0abde341b0c2cecc4030ec7371d333c9ffdaf0edeac2e8ef8ec7bd30c644407b"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ anstyle = { version = "1.0.10", default-features = false }
 anyhow = { version = "1", default-features = false }
 assert-json-diff = { version = "2", default-features = false }
 async-compression = { version = "0.3", default-features = false }
-async-nats = { version = "0.36", default-features = false }
+async-nats = { version = "0.39", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 aws-config = { version = "1.5", default-features = false }
 aws-sdk-s3 = { version = "=1.68", default-features = false } # more recent versions depend on `cbindgen`, using MPL-2.0, not permitted by CNCF
@@ -346,9 +346,9 @@ unicase = { version = "2.8.1", default-features = false }
 url = { version = "2" }
 uuid = { version = "1", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
-wadm = { version = "0.20.2", default-features = false }
-wadm-client = { version = "0.8.2", default-features = false }
-wadm-types = { version = "0.8.2", default-features = false }
+wadm = { git = "https://github.com/wasmcloud/wadm", branch = "main", version = "0.20", default-features = false }
+wadm-client = { git = "https://github.com/wasmcloud/wadm", branch = "main", version = "0.9.0", default-features = false }
+wadm-types = { git = "https://github.com/wasmcloud/wadm", branch = "main", version = "0.8.2", default-features = false }
 walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
 wascap = { version = "^0.15.3", path = "./crates/wascap", default-features = false }
@@ -399,8 +399,8 @@ wrpc-interface-blobstore = { version = "0.21", default-features = false }
 wrpc-interface-http = { version = "0.31", default-features = false }
 wrpc-runtime-wasmtime = { version = "0.25", default-features = false }
 wrpc-transport = { version = "0.28", default-features = false }
-wrpc-transport-nats = { version = "0.27.1", default-features = false, features = [
-    "async-nats-0_36",
+wrpc-transport-nats = { version = "0.28", default-features = false, features = [
+    "async-nats-0_39",
 ] }
 
 [package.metadata.cargo-machete]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,7 +360,7 @@ wasi-preview1-component-adapter-provider = { version = "25", default-features = 
 wasm-encoder = { version = "0.224", default-features = false }
 wasm-gen = { version = "0.1", default-features = false }
 wasmcloud-component = { version = "0", path = "crates/component", default-features = false }
-wasmcloud-control-interface = { version = "2.3.0", path = "./crates/control-interface", default-features = false }
+wasmcloud-control-interface = { version = "2.4.0", path = "./crates/control-interface", default-features = false }
 wasmcloud-core = { version = "^0.16.0", path = "./crates/core", default-features = false }
 wasmcloud-host = { version = "^0.24.0", path = "./crates/host", default-features = false }
 wasmcloud-provider-blobstore-azure = { version = "*", path = "./crates/provider-blobstore-azure", default-features = false }

--- a/crates/control-interface/Cargo.toml
+++ b/crates/control-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "2.3.0"
+version = "2.4.0"
 homepage = "https://wasmcloud.com"
 description = "A client library for communicating with hosts on a wasmCloud lattice"
 documentation = "https://docs.rs/wasmcloud-control-interface"

--- a/crates/provider-sdk/src/lib.rs
+++ b/crates/provider-sdk/src/lib.rs
@@ -85,12 +85,14 @@ pub const DEFAULT_RPC_TIMEOUT_MILLIS: Duration = Duration::from_millis(2000);
 pub fn with_connection_event_logging(opts: ConnectOptions) -> ConnectOptions {
     opts.event_callback(|event| async move {
         match event {
-            Event::Disconnected => warn!("nats client disconnected"),
             Event::Connected => info!("nats client connected"),
-            Event::ClientError(err) => error!("nats client error: '{:?}'", err),
-            Event::ServerError(err) => error!("nats server error: '{:?}'", err),
-            Event::SlowConsumer(val) => warn!("nats slow consumer detected ({})", val),
+            Event::Disconnected => warn!("nats client disconnected"),
+            Event::Draining => warn!("nats client draining"),
             Event::LameDuckMode => warn!("nats lame duck mode"),
+            Event::SlowConsumer(val) => warn!("nats slow consumer detected ({val})"),
+            Event::ClientError(err) => error!("nats client error: '{err:?}'"),
+            Event::ServerError(err) => error!("nats server error: '{err:?}'"),
+            Event::Closed => error!("nats client closed"),
         }
     })
 }


### PR DESCRIPTION
## Feature or Problem
PR for upgrading async-nats to 0.39, pointing at a few branches / upstream repositories where needed. 

~This PR currently doesn't build because of trait mismatches which I think can be resolved with a better patch / upgrade to use all new released wrpc crate versions~

## Related Issues
Depends on https://github.com/wasmCloud/wadm/pull/620 which depends on this. I think what we will do is merge the wadm PR, point this PR at `wadm` in main, then release crates until we get to the control interface, release new version of wadm-client, and finally depend on the new version of wadm-client for wash.

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
