### PR TITLE
feat(sqldb-postgres)!: allow configuration of max connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8695,7 +8695,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bigdecimal 0.4.7",

--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.8.0"
+version = "0.9.0"
 description = """
 wasmCloud SQL database provider for Postgres
 """

--- a/crates/provider-sqldb-postgres/README.md
+++ b/crates/provider-sqldb-postgres/README.md
@@ -95,13 +95,14 @@ WADM files should not be checked into source control containing secrets.
 
 New named configuration can be specified by using `wash config put`.
 
-| Property                | Example     | Description                                               |
-| ----------------------- | ----------- | --------------------------------------------------------- |
-| `POSTGRES_HOST`         | `localhost` | Postgres cluster hostname                                 |
-| `POSTGRES_PORT`         | `5432`      | Postgres cluster port                                     |
-| `POSTGRES_USERNAME`     | `postgres`  | Postgres cluster username                                 |
-| `POSTGRES_DATABASE`     | `postgres`  | Postgres cluster database                                 |
-| `POSTGRES_TLS_REQUIRED` | `false`     | Whether TLS should be required for al managed connections |
+| Property                | Example     | Description                                                                                                                                                         |
+| ----------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POSTGRES_HOST`         | `localhost` | Postgres cluster hostname                                                                                                                                           |
+| `POSTGRES_PORT`         | `5432`      | Postgres cluster port                                                                                                                                               |
+| `POSTGRES_USERNAME`     | `postgres`  | Postgres cluster username                                                                                                                                           |
+| `POSTGRES_DATABASE`     | `postgres`  | Postgres cluster database                                                                                                                                           |
+| `POSTGRES_TLS_REQUIRED` | `false`     | Whether TLS should be required for all managed connections                                                                                                          |
+| `POSTGRES_POOL_SIZE`    | `12`        | Maximum size of the connection pool (configures [max_size](https://docs.rs/deadpool-postgres/0.14.1/deadpool_postgres/struct.PoolConfig.html#structfield.max_size)) |
 
 Once named configuration with the keys above is created, it can be referenced as `target_config` for a link to this provider.
 
@@ -135,13 +136,13 @@ The `querier` component in the snippet above specifies a link to a `sqldb-postgr
 
 ## 🔐 Secret Settings
 
-While most values can be specified via named configuration, sensitive values like the `POSTGRES_PASSWORD` should be specified via *secrets*.
+While most values can be specified via named configuration, sensitive values like the `POSTGRES_PASSWORD` should be specified via _secrets_.
 
 New secrets be specified by using `wash secrets put`.
 
-| Property                | Example     | Description                                               |
-| ----------------------- | ----------- | --------------------------------------------------------- |
-| `POSTGRES_PASSWORD`     | `postgres`  | Postgres cluster password                                 |
+| Property            | Example    | Description               |
+| ------------------- | ---------- | ------------------------- |
+| `POSTGRES_PASSWORD` | `postgres` | Postgres cluster password |
 
 Once a secret has been created, it can be referenced in the link to the provider.
 

--- a/src/bin/sqldb-postgres-provider/wasmcloud.toml
+++ b/src/bin/sqldb-postgres-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "SQLDB Postgres"
 language = "rust"
 type = "provider"
-version = "0.8.0"
+version = "0.9.0"
 wit = "../../../crates/provider-sqldb-postgres/wit"
 
 [rust]


### PR DESCRIPTION
## Feature or Problem
This PR adds an extra (optional) configuration field to the postgres provider that allows configuring the max connection pool size for an individual component. I also made the `tls_required` field optional, because I thought that by default we would just not require TLS.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
sqldb-postgres 0.9.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
