### PR TITLE
build(nix): use latest tools

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -429,10 +429,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1741865919,
+        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixify": "nixify",
         "nixlib": "nixlib_3",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "wit-deps": "wit-deps"
       }
     },


### PR DESCRIPTION
Use `k8s`, `go` and `nats-server` from `nixpkgs-unstable` (i.e. bleeding edge, latest versions)

Unfortunately, it appears that `tinygo` is currently broken on `nixpkgs-unstable` (at least on Mac), so keep using the *stable* version of it, at least for now. (https://github.com/NixOS/nixpkgs/pull/389791)

~Blocked on #4215~