### PR TITLE
chore(ci): Replace tj-actions/changed-files action

### DIFF
--- a/.github/actions/install-cached-wash-cli/action.yml
+++ b/.github/actions/install-cached-wash-cli/action.yml
@@ -9,14 +9,16 @@ runs:
     - name: Check for changes that might affect the build for wash
       if: ${{ github.event_name == 'pull_request' }}
       # It'd be a little nicer if we calculated if wash was affected by the changes, but this will do for now
-      id: changed-files
-      uses: tj-actions/changed-files@bab30c2299617f6615ec02a68b9a40d10bd21366 # v45.0.5
+      id: changes
+      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
       with:
-        files_ignore: |
-          adr/**
-          brand/**
-          examples/**
-          **/*.md
+        filters: |
+          changed:
+            - '**'
+            - '!adr/**'
+            - '!brand/**'
+            - '!examples/**'
+            - '!**/*.md'
 
     - name: Set wash revision to build/cache
       id: base-ref
@@ -29,7 +31,7 @@ runs:
         elif [ ${{ github.event.pull_request.base.sha }} == null ]; then
           echo "No base ref, building from the current commit"
           REVISION=${{ github.sha }}
-        elif [ ${{ steps.changed-files.outcome == 'success' && steps.changed-files.outputs.all_changed_and_modified_files_count || 0 }} -eq 0 ]; then
+        elif [ ${{ steps.changes.outcome == 'success' && steps.changes.outputs.changed_count || 0 }} -gt 0 ]; then
           echo "Something changed that might affect the build, building from the current commit"
           REVISION=${{ github.sha }}
         else

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -23,29 +23,30 @@ jobs:
   meta:
     runs-on: ubuntu-latest
     outputs:
-      modified: ${{ steps.changes.outputs.any_changed }}
+      modified: ${{ steps.changes.outputs.changed }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: tj-actions/changed-files@7ac5902a02bbf88c426878d792c0728b55bb97ae
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         with:
-          files: |
-            ./.github/workflows/wash.yml
-            ./.github/actions/install-cached-wash-cli/action.yml
-            Cargo.lock
-            Cargo.toml
-            crates/control-interface/**
-            crates/core/**
-            crates/secrets-types/**
-            crates/tracing/**
-            crates/wash/**
-          files_ignore: |
-            !crates/**/*.md
-            !crates/wash/.devcontainer
+          list-files: shell
+          filters: |
+            changed:
+              - './.github/workflows/wash.yml'
+              - './.github/actions/install-cached-wash-cli/action.yml'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'crates/control-interface/**'
+              - 'crates/core/**'
+              - 'crates/secrets-types/**'
+              - 'crates/tracing/**'
+              - 'crates/wash/**'
+              - '!crates/**/*.md'
+              - '!crates/wash/.devcontainer'
       - name: Changed files
         run: |
-          echo "Changed file(s) (${{ steps.changes.outputs.all_changed_files_count}})"
-          echo "${{ steps.changes.outputs.all_changed_files }}"
+          echo "Changed file(s) (${{ steps.changes.outputs.changed_count }})"
+          echo "${{ steps.changes.outputs.changed_files }}"
 
   unit_tests:
     needs: [meta]

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -96,54 +96,49 @@ jobs:
   meta:
     runs-on: ubuntu-latest
     outputs:
-      wasmcloud_modified: ${{ steps.wasmcloud_changes.outputs.any_changed }}
-      providers_modified: ${{ steps.provider_changes.outputs.any_changed }}
+      wasmcloud_modified: ${{ steps.changes.outputs.wasmcloud }}
+      providers_modified: ${{ steps.changes.outputs.providers }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: tj-actions/changed-files@7ac5902a02bbf88c426878d792c0728b55bb97ae
-        id: wasmcloud_changes
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
         with:
           # Consider wasmCloud changed if any Rust file other than
           # capability providers change
-          files: |
-            ./.github/actions/build-nix/action.yml
-            ./.github/actions/install-nix/action.yml
-            ./.github/workflows/wasmcloud.yml
-            ./.github/workflows/oci.yml
-            ./.config/nextest.toml
-            nix/images/default.nix
-            flake.lock
-            flake.nix
-            Cargo.lock
-            Cargo.toml
-            rust-toolchain.toml
-            crates/**/*.{rs,toml,wit}
-            src/**/*.{rs,toml,wit}
-            tests/**/*.{rs,toml,wit}
-            wit/**/*.wit
+          #
           # Somewhat naive assumption that providers will be under `crates/provider-<interface>-<vendor>`
           # as that is our naming convention for providers.
-          files_ignore: |
-            !crates/provider-*-*
-            !crates/wash-*
-      - uses: tj-actions/changed-files@7ac5902a02bbf88c426878d792c0728b55bb97ae
-        id: provider_changes
-        with:
-          # Consider providers changed if any file in the providers change
-          files: |
-            ./.github/actions/build-nix/action.yml
-            ./.github/actions/install-nix/action.yml
-            ./.github/workflows/provider.yml
-            ./.github/workflows/wasmcloud.yml
-            Cargo.lock
-            Cargo.toml
-            crates/provider-*/*.{rs,toml,wit}
-            flake.lock
-            flake.nix
-            rust-toolchain.toml
-          files_ignore: |
-            !crates/**/*.md
-
+          filters: |
+            wasmcloud:
+              - './.github/actions/build-nix/action.yml'
+              - './.github/actions/install-nix/action.yml'
+              - './.github/workflows/wasmcloud.yml'
+              - './.github/workflows/oci.yml'
+              - './.config/nextest.toml'
+              - 'nix/images/default.nix'
+              - 'flake.lock'
+              - 'flake.nix'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'rust-toolchain.toml'
+              - 'crates/**/*.{rs,toml,wit}'
+              - 'src/**/*.{rs,toml,wit}'
+              - 'tests/**/*.{rs,toml,wit}'
+              - 'wit/**/*.wit'
+              - '!crates/provider-*/**'
+              - '!crates/wash/**'
+            providers:
+              - './.github/actions/build-nix/action.yml'
+              - './.github/actions/install-nix/action.yml'
+              - './.github/workflows/provider.yml'
+              - './.github/workflows/wasmcloud.yml'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'crates/provider-*/*.{rs,toml,wit}'
+              - 'flake.lock'
+              - 'flake.nix'
+              - 'rust-toolchain.toml'
+              - '!crates/**/*.md'
   build-wash-bin:
     needs: [meta]
     if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || startsWith(github.ref, 'refs/tags/wash-v')  || startswith(github.ref, 'refs/tags/provider-') }}


### PR DESCRIPTION
## Feature or Problem

While we're unaffected by the SHA (`0e58ed8671d6b60d0890c21b07f8835ace038e67`) identified by Step Security, we need to stop using the action in question.

For more context, see:
* https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
* https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
