### PR TITLE
chore(wash): Bump nats-server version to 2.10.26

### DIFF
--- a/ci/manifests/wasmcloud/kustomization.yaml
+++ b/ci/manifests/wasmcloud/kustomization.yaml
@@ -15,7 +15,7 @@ images:
     newTag: v0.20.1
   - name: nats
     newName: nats
-    newTag: 2.10.22-alpine
+    newTag: 2.10.26-alpine
   - name: nats-config-reloader
     newName: natsio/nats-server-config-reloader
     newTag: 0.16.0

--- a/crates/wash/src/cli/cmd/up.rs
+++ b/crates/wash/src/cli/cmd/up.rs
@@ -102,7 +102,7 @@ pub struct NatsOpts {
     )]
     pub connect_only: bool,
 
-    /// NATS server version to download, e.g. `v2.10.7`. See <https://github.com/nats-io/nats-server/releases>/ for releases
+    /// NATS server version to download, e.g. `v2.10.26`. See <https://github.com/nats-io/nats-server/releases>/ for releases
     #[clap(long = "nats-version", default_value = NATS_SERVER_VERSION, env = "NATS_VERSION")]
     pub nats_version: String,
 
@@ -1243,7 +1243,7 @@ mod tests {
             "--nats-remote-url",
             "tls://remote.global",
             "--nats-version",
-            "v2.10.7",
+            "v2.10.26",
             "--provider-delay",
             "500",
             "--rpc-credsfile",
@@ -1337,7 +1337,7 @@ mod tests {
             up_all_flags.wasmcloud_opts.wasmcloud_js_domain,
             Some("domain".to_string())
         );
-        assert_eq!(up_all_flags.nats_opts.nats_version, "v2.10.7".to_string());
+        assert_eq!(up_all_flags.nats_opts.nats_version, "v2.10.26".to_string());
         assert_eq!(
             up_all_flags.nats_opts.nats_remote_url,
             Some("tls://remote.global".to_string())

--- a/crates/wash/src/lib/common.rs
+++ b/crates/wash/src/lib/common.rs
@@ -13,7 +13,7 @@ use wasmcloud_control_interface::HostInventory;
 use crate::lib::id::{ModuleId, ServerId, ServiceId};
 
 /// Version of the NATS server used by default for wash
-pub const NATS_SERVER_VERSION: &str = "v2.10.20";
+pub const NATS_SERVER_VERSION: &str = "v2.10.26";
 
 /// Default host for the NATS server used by wash
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";

--- a/crates/wash/src/lib/start/mod.rs
+++ b/crates/wash/src/lib/start/mod.rs
@@ -19,7 +19,7 @@
 //!     let install_dir = PathBuf::from("/tmp");
 //!
 //!     // Download NATS if not already installed
-//!     let nats_binary = ensure_nats_server("v2.10.7", &install_dir).await?;
+//!     let nats_binary = ensure_nats_server("v2.10.26", &install_dir).await?;
 //!
 //!     // Start NATS server, redirecting output to a log file
 //!     let nats_log_path = install_dir.join("nats.log");

--- a/crates/wash/src/lib/start/nats.rs
+++ b/crates/wash/src/lib/start/nats.rs
@@ -29,7 +29,7 @@ pub const NATS_SERVER_BINARY: &str = "nats-server.exe";
 /// # #[tokio::main]
 /// # async fn main() {
 /// use crate::lib::start::ensure_nats_server;
-/// let res = ensure_nats_server("v2.10.7", "/tmp/").await;
+/// let res = ensure_nats_server("v2.10.26", "/tmp/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/nats-server");
 /// # }
@@ -59,7 +59,7 @@ where
 /// use crate::lib::start::ensure_nats_server_for_os_arch_pair;
 /// let os = std::env::consts::OS;
 /// let arch = std::env::consts::ARCH;
-/// let res = ensure_nats_server_for_os_arch_pair(os, arch, "v2.10.7", "/tmp/").await;
+/// let res = ensure_nats_server_for_os_arch_pair(os, arch, "v2.10.26", "/tmp/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/nats-server");
 /// # }
@@ -118,7 +118,7 @@ where
 /// # #[tokio::main]
 /// # async fn main() {
 /// use crate::lib::start::download_nats_server;
-/// let res = download_nats_server("v2.10.7", "/tmp/").await;
+/// let res = download_nats_server("v2.10.26", "/tmp/").await;
 /// assert!(res.is_ok());
 /// assert!(res.unwrap().to_string_lossy() == "/tmp/nats-server");
 /// # }


### PR DESCRIPTION
## Feature or Problem

Happen to notice in CI output that we're still shipping [`2.10.7`, which is from December 2023](https://github.com/nats-io/nats-server/releases/tag/v2.10.7) and that has some known vulnerabilities in it's dependencies, so let's bump to the latest version (`2.10.26`).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
