### PR TITLE
chore(host): Match non-workload identity first

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -422,17 +422,17 @@ pub async fn connect_nats(
     workload_identity_config: Option<WorkloadIdentityConfig>,
 ) -> anyhow::Result<async_nats::Client> {
     let opts = match (jwt, key, workload_identity_config) {
-        (jwt, key, Some(wid_cfg)) => {
-            setup_workload_identity_nats_connect_options(jwt, key, wid_cfg).await?
-        }
         (Some(jwt), Some(key), None) => {
             async_nats::ConnectOptions::with_jwt(jwt.to_string(), move |nonce| {
                 let key = key.clone();
                 async move { key.sign(&nonce).map_err(async_nats::AuthError::new) }
             })
         }
-        (Some(_), None, None) | (None, Some(_), None) => {
+        (Some(_), None, _) | (None, Some(_), _) => {
             bail!("cannot authenticate if only one of jwt or seed is specified")
+        }
+        (jwt, key, Some(wid_cfg)) => {
+            setup_workload_identity_nats_connect_options(jwt, key, wid_cfg).await?
         }
         _ => async_nats::ConnectOptions::new(),
     };


### PR DESCRIPTION
## Feature or Problem

Following up on [the comment @brooksmtownsend](https://github.com/wasmCloud/wasmCloud/pull/4118#discussion_r1996234888) left in the PR to initially introduce workload identity before I merged things in.

@brooksmtownsend PTAL and let me know if this is the change you had in mind or if I maybe misinterpreted?

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
