### PR TITLE
feat(wash): wip: support compositions after build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5095,7 +5095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -7619,7 +7619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -7858,6 +7858,39 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wac-graph"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d94268a683b67ae20210565b5f91e106fe05034c36b931e739fe90377ed80b98"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.7.1",
+ "log",
+ "petgraph",
+ "semver",
+ "thiserror 1.0.69",
+ "wac-types",
+ "wasm-encoder 0.202.0",
+ "wasm-metadata 0.202.0",
+ "wasmparser 0.202.0",
+]
+
+[[package]]
+name = "wac-types"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5028a15e266f4c8fed48beb95aebb76af5232dcd554fd849a305a4e5cce1563"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.7.1",
+ "semver",
+ "wasm-encoder 0.202.0",
+ "wasmparser 0.202.0",
+]
 
 [[package]]
 name = "wadm-client"
@@ -8171,6 +8204,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wac-graph",
  "wadm-client",
  "wadm-types",
  "walkdir",
@@ -8335,6 +8369,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.202.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd106365a7f5f7aa3c1916a98cbb3ad477f5ff96ddb130285a91c6e7429e67a"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.218.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "491f7e48672d0a1efdeadf897d98ac1f45942c26c3829cb44a6b828f6f26155f"
@@ -8390,6 +8433,22 @@ checksum = "b854b1461005a7b3365742310f7faa3cac3add809d66928c64a40c7e9e842ebb"
 dependencies = [
  "byteorder 0.5.3",
  "leb128",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.202.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094aea3cb90e09f16ee25a4c0e324b3e8c934e7fd838bfa039aef5352f44a917"
+dependencies = [
+ "anyhow",
+ "indexmap 2.7.1",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.202.0",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]
@@ -9128,6 +9187,17 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.202.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
+dependencies = [
+ "bitflags 2.8.0",
+ "indexmap 2.7.1",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.218.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059739c2eac26eea736389a7d6d30b41a8201490bea204d0facde19183359849"
@@ -9594,7 +9664,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,6 +353,7 @@ unicase = { version = "2.8.1", default-features = false }
 url = { version = "2" }
 uuid = { version = "1", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
+wac-graph = { version = "0.6.1", default-features = false }
 wadm = { git = "https://github.com/wasmcloud/wadm", branch = "main", version = "0.20", default-features = false }
 wadm-client = { git = "https://github.com/wasmcloud/wadm", branch = "main", version = "0.9.0", default-features = false }
 wadm-types = { git = "https://github.com/wasmcloud/wadm", branch = "main", version = "0.8.2", default-features = false }

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -97,6 +97,7 @@ toml = { workspace = true, features = ["parse"] }
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "fmt", "json", "std"] }
 url = { workspace = true }
+wac-graph = { workspace = true}
 wadm-client = { workspace = true }
 wadm-types = { workspace = true, optional = true }
 walkdir = { workspace = true }
@@ -113,6 +114,7 @@ wasmparser = { workspace = true }
 wasmtime = { workspace = true, optional = true, features = ["cranelift", "cache", "component-model", "gc"] }
 wasmtime-wasi = { workspace = true, optional = true }
 wasmtime-wasi-http = { workspace = true, optional = true }
+wat = { workspace = true }
 which = { workspace = true }
 wit-bindgen-wrpc = { workspace = true }
 wit-component = { workspace = true }
@@ -120,7 +122,6 @@ wit-parser = { workspace = true }
 wrpc-interface-http = { workspace = true, features = ["http-body"] }
 wrpc-transport = { workspace = true }
 wrpc-transport-nats = { workspace = true }
-wat = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 notify = { workspace = true, features = ["macos_fsevent"] }

--- a/crates/wash/src/lib/build/mod.rs
+++ b/crates/wash/src/lib/build/mod.rs
@@ -158,7 +158,14 @@ pub async fn build_project(
 
     match &config.project_type {
         TypeConfig::Component(component_config) => {
-            build_component(component_config, &config.language, &config.common, signing).await
+            build_component(
+                component_config,
+                &config.language,
+                &config.common,
+                signing,
+                &config.composition_config,
+            )
+            .await
         }
         TypeConfig::Provider(provider_config) => {
             build_provider(provider_config, &config.language, &config.common, signing).await

--- a/crates/wash/src/lib/parser/mod.rs
+++ b/crates/wash/src/lib/parser/mod.rs
@@ -357,6 +357,17 @@ impl TryFrom<RegistryPullSource> for RegistryMapping {
     }
 }
 
+/// Configuration for WebAssembly compositions
+#[derive(Default, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct CompositionConfig {
+    /// The component with imports
+    pub socket: Option<PathBuf>,
+    /// The component with exports
+    #[serde(default)]
+    pub plugs: Vec<PathBuf>,
+    // TODO: also support a wac file
+}
+
 /// Configuration common among all project types & languages.
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct CommonConfig {
@@ -1077,6 +1088,10 @@ pub struct WasmcloudDotToml {
     /// Configuration for image registry usage
     #[serde(default)]
     pub registry: RegistryConfig,
+
+    /// Configuration for WebAssembly compositions
+    #[serde(default)]
+    pub composition: CompositionConfig,
 }
 
 impl WasmcloudDotToml {
@@ -1287,6 +1302,7 @@ impl WasmcloudDotToml {
 
         Ok(ProjectConfig {
             dev: self.dev,
+            composition_config: self.composition,
             project_type: project_type_config,
             language: language_config,
             common: common_config,
@@ -1311,6 +1327,8 @@ pub struct ProjectConfig {
     pub dev: DevConfig,
     /// Configuration for package tooling
     pub package_config: PackageConfig,
+    /// Configuration for composing WebAssembly components
+    pub composition_config: CompositionConfig,
     /// The directory where the project wasmcloud.toml file is located
     #[serde(skip)]
     pub wasmcloud_toml_dir: PathBuf,


### PR DESCRIPTION
## Feature or Problem
WIP PR

This PR adds in a relatively inflexible programmatic composition of components during `wash build`. This will support the BytecodeAlliance's [wac](https://github.com/bytecodealliance/wac) tooling for plugs and sockets for composition. I have a TODO to explore also supporting the `.wac` file which I can test with.

I did validate this works, but leaving this as a draft until I write up some tests + clean up the code.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
