### PR TITLE
chore: Moves back to wadm from crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -7156,9 +7156,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.39"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
  "itoa",
@@ -7172,15 +7172,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7953,8 +7953,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wadm-client"
-version = "0.9.0"
-source = "git+https://github.com/wasmcloud/wadm?branch=main#a329be44a30afce03006c09a2ba2acce56c4c5bd"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da1f9ce2c2106150659973236178099e526e7f8b5a86ac9a5f1a2f6a9fc7b66"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7969,8 +7970,9 @@ dependencies = [
 
 [[package]]
 name = "wadm-types"
-version = "0.8.2"
-source = "git+https://github.com/wasmcloud/wadm?branch=main#a329be44a30afce03006c09a2ba2acce56c4c5bd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "205203215d5af9328178e080e1deb40f54e355a2f4ab45f0b87ef0773b4eb64c"
 dependencies = [
  "anyhow",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,7 +223,7 @@ async-compression = { version = "0.4", default-features = false }
 async-nats = { version = "0.39", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 aws-config = { version = "1.5", default-features = false }
-aws-sdk-s3 = { version = "=1.68", default-features = false }                                               # more recent versions depend on `cbindgen`, using MPL-2.0, not permitted by CNCF
+aws-sdk-s3 = { version = "=1.68", default-features = false } # more recent versions depend on `cbindgen`, using MPL-2.0, not permitted by CNCF
 aws-smithy-runtime = { version = "1.7", default-features = false }
 axum = { version = "0.8", default-features = false }
 axum-extra = { version = "0.10", default-features = false }
@@ -353,9 +353,9 @@ unicase = { version = "2.8.1", default-features = false }
 url = { version = "2" }
 uuid = { version = "1", default-features = false }
 vaultrs = { version = "0.7", default-features = false }
-wadm = { git = "https://github.com/wasmcloud/wadm", branch = "main", version = "0.20", default-features = false }
-wadm-client = { git = "https://github.com/wasmcloud/wadm", branch = "main", version = "0.9.0", default-features = false }
-wadm-types = { git = "https://github.com/wasmcloud/wadm", branch = "main", version = "0.8.2", default-features = false }
+wadm = { version = "0.21", default-features = false }
+wadm-client = { version = "0.10", default-features = false }
+wadm-types = { version = "0.8.3", default-features = false }
 walkdir = { version = "2", default-features = false }
 warp = { version = "0.3", default-features = false }
 wascap = { version = "^0.16.0", path = "./crates/wascap", default-features = false }


### PR DESCRIPTION
Now that the new wadm version is out, we can use it from crates again