### PR TITLE
fix(nix): remove reference to nonexistent function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -237,7 +237,6 @@
               secrets-nats-kv =
                 rust.mkAttrs {
                   inherit
-                    overrideVendorCargoPackage
                     src
                     targets
                     ;


### PR DESCRIPTION
Looks like this was missed in 3ccffe1d9

refs https://github.com/wasmCloud/wasmCloud/issues/4266