### PR TITLE
refactor!: Removes dependencies from host on provider libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8732,10 +8732,12 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-nats",
+ "base64 0.22.1",
+ "http 1.3.1",
  "hyper-rustls 0.27.5",
  "hyper-util",
  "oci-client",
@@ -8749,9 +8751,12 @@ dependencies = [
  "secrecy 0.10.3",
  "semver",
  "serde",
+ "serde_json",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-rustls 0.26.2",
  "tracing",
+ "unicase",
  "url",
  "wascap",
  "webpki-roots",
@@ -8793,8 +8798,6 @@ dependencies = [
  "wascap",
  "wasmcloud-control-interface",
  "wasmcloud-core",
- "wasmcloud-provider-http-server",
- "wasmcloud-provider-messaging-nats",
  "wasmcloud-provider-sdk",
  "wasmcloud-runtime",
  "wasmcloud-secrets-client",
@@ -8915,6 +8918,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "unicase",
+ "wasmcloud-core",
  "wasmcloud-provider-sdk",
  "wasmcloud-test-util",
  "wrpc-interface-http",
@@ -9003,7 +9007,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9017,13 +9021,14 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "wascap",
+ "wasmcloud-core",
  "wasmcloud-provider-sdk",
  "wit-bindgen-wrpc",
 ]
 
 [[package]]
 name = "wasmcloud-provider-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9102,7 +9107,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-runtime"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9186,7 +9191,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-tracing"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -369,7 +369,7 @@ wasm-encoder = { version = "0.224", default-features = false }
 wasm-gen = { version = "0.1", default-features = false }
 wasmcloud-component = { version = "0", path = "crates/component", default-features = false }
 wasmcloud-control-interface = { version = "2.4.0", path = "./crates/control-interface", default-features = false }
-wasmcloud-core = { version = "^0.17.0", path = "./crates/core", default-features = false }
+wasmcloud-core = { version = "^0.18.0", path = "./crates/core", default-features = false }
 wasmcloud-host = { version = "^0.25.0", path = "./crates/host", default-features = false }
 wasmcloud-provider-blobstore-azure = { version = "*", path = "./crates/provider-blobstore-azure", default-features = false }
 wasmcloud-provider-blobstore-fs = { version = "*", path = "./crates/provider-blobstore-fs", default-features = false }
@@ -380,15 +380,15 @@ wasmcloud-provider-keyvalue-nats = { version = "*", path = "./crates/provider-ke
 wasmcloud-provider-keyvalue-redis = { version = "*", path = "./crates/provider-keyvalue-redis", default-features = false }
 wasmcloud-provider-keyvalue-vault = { version = "*", path = "./crates/provider-keyvalue-vault", default-features = false }
 wasmcloud-provider-messaging-kafka = { version = "*", path = "./crates/provider-messaging-kafka", default-features = false }
-wasmcloud-provider-messaging-nats = { version = "^0.26.0", path = "./crates/provider-messaging-nats", default-features = false }
-wasmcloud-provider-sdk = { version = "^0.14.0", path = "./crates/provider-sdk", default-features = false }
+wasmcloud-provider-messaging-nats = { version = "^0.27.0", path = "./crates/provider-messaging-nats", default-features = false }
+wasmcloud-provider-sdk = { version = "^0.15.0", path = "./crates/provider-sdk", default-features = false }
 wasmcloud-provider-sqldb-postgres = { version = "*", path = "./crates/provider-sqldb-postgres", default-features = false }
 wasmcloud-provider-wadm = { version = "*", path = "./crates/provider-wadm", default-features = false }
-wasmcloud-runtime = { version = "^0.9.0", path = "./crates/runtime", default-features = false }
+wasmcloud-runtime = { version = "^0.10.0", path = "./crates/runtime", default-features = false }
 wasmcloud-secrets-client = { version = "^0.7.0", path = "./crates/secrets-client", default-features = false }
 wasmcloud-secrets-types = { version = "^0.6.0", path = "./crates/secrets-types", default-features = false }
 wasmcloud-test-util = { version = "^0.17.0", path = "./crates/test-util", default-features = false }
-wasmcloud-tracing = { version = "^0.13.0", path = "./crates/tracing", default-features = false }
+wasmcloud-tracing = { version = "^0.14.0", path = "./crates/tracing", default-features = false }
 wasmparser = { version = "0.225", default-features = false }
 wasmtime = { version = "26", default-features = false }
 wasmtime-wasi = { version = "26", default-features = false }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-core"
-version = "0.17.0"
+version = "0.18.0"
 description = "wasmCloud core functionality shared throughout the ecosystem"
 
 authors.workspace = true
@@ -22,10 +22,20 @@ hyper-rustls = ["dep:hyper-rustls", "dep:hyper-util"]
 tokio-rustls = ["dep:tokio-rustls"]
 otel = []
 oci = ["dep:oci-client", "dep:oci-wasm"]
+http = [
+    "dep:base64",
+    "dep:http",
+    "dep:unicase",
+    "dep:serde_json",
+    "dep:thiserror",
+]
+messaging = ["dep:serde_json"]
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 async-nats = { workspace = true, features = ["ring"] }
+base64 = { workspace = true, optional = true }
+http = { workspace = true, optional = true }
 hyper-rustls = { workspace = true, features = [
     "http2",
     "ring",
@@ -43,8 +53,11 @@ tokio-rustls = { workspace = true, optional = true }
 semver = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+unicase = { workspace = true, optional = true }
 url = { workspace = true }
 wascap = { workspace = true }
 webpki-roots = { workspace = true, optional = true }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -32,6 +32,12 @@ pub mod secrets;
 pub mod wit;
 pub use wit::*;
 
+#[cfg(feature = "http")]
+pub mod http;
+
+#[cfg(feature = "messaging")]
+pub mod messaging;
+
 /// The 1.0 version of the wasmCloud control API, used in topic strings for the control API
 pub const CTL_API_VERSION_1: &str = "v1";
 

--- a/crates/core/src/messaging.rs
+++ b/crates/core/src/messaging.rs
@@ -1,0 +1,175 @@
+//! Common configuration settings for both the NATS messaging provider and the builtin messaging
+//! provider for the host. This module requires the `messaging` feature to be enabled
+use std::collections::HashMap;
+
+use anyhow::{bail, Context as _, Result};
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_NATS_URI: &str = "0.0.0.0:4222";
+pub const CONFIG_NATS_SUBSCRIPTION: &str = "subscriptions";
+pub const CONFIG_NATS_CONSUMERS: &str = "consumers";
+pub const CONFIG_NATS_URI: &str = "cluster_uris";
+pub const CONFIG_NATS_CLIENT_JWT: &str = "client_jwt";
+pub const CONFIG_NATS_CLIENT_SEED: &str = "client_seed";
+pub const CONFIG_NATS_TLS_CA: &str = "tls_ca";
+pub const CONFIG_NATS_CUSTOM_INBOX_PREFIX: &str = "custom_inbox_prefix";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConsumerConfig {
+    pub stream: Box<str>,
+    pub consumer: Box<str>,
+    pub max_messages: Option<usize>,
+    pub max_bytes: Option<usize>,
+}
+
+/// Configuration for connecting a nats client.
+/// More options are available if you use the json than variables in the values string map.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConnectionConfig {
+    /// List of topics to subscribe to
+    #[serde(default)]
+    pub subscriptions: Box<[async_nats::Subject]>,
+
+    /// List of JetStream consumers
+    #[serde(default)]
+    pub consumers: Box<[ConsumerConfig]>,
+
+    /// Cluster(s) to make a subscription on and connect to
+    #[serde(default)]
+    pub cluster_uris: Box<[Box<str>]>,
+
+    /// Auth JWT to use (if necessary)
+    #[serde(default)]
+    pub auth_jwt: Option<Box<str>>,
+
+    /// Auth seed to use (if necessary)
+    #[serde(default)]
+    pub auth_seed: Option<Box<str>>,
+
+    /// TLS Certificate Authority, encoded as a string
+    #[serde(default)]
+    pub tls_ca: Option<Box<str>>,
+
+    /// TLS Certificate Authority, as a path on disk
+    #[serde(default)]
+    pub tls_ca_file: Option<Box<str>>,
+
+    /// Ping interval in seconds
+    #[serde(default)]
+    pub ping_interval_sec: Option<u16>,
+
+    /// Inbox prefix to use (by default
+    #[serde(default)]
+    pub custom_inbox_prefix: Option<Box<str>>,
+}
+
+impl ConnectionConfig {
+    /// Merge a given [`ConnectionConfig`] with another, coalescing fields and overriding
+    /// where necessary
+    pub fn merge(&self, extra: &ConnectionConfig) -> ConnectionConfig {
+        let mut out = self.clone();
+        if !extra.subscriptions.is_empty() {
+            out.subscriptions.clone_from(&extra.subscriptions);
+        }
+        if !extra.consumers.is_empty() {
+            out.consumers.clone_from(&extra.consumers);
+        }
+        // If the default configuration has a URL in it, and then the link definition
+        // also provides a URL, the assumption is to replace/override rather than combine
+        // the two into a potentially incompatible set of URIs
+        if !extra.cluster_uris.is_empty() {
+            out.cluster_uris.clone_from(&extra.cluster_uris);
+        }
+        if extra.auth_jwt.is_some() {
+            out.auth_jwt.clone_from(&extra.auth_jwt);
+        }
+        if extra.auth_seed.is_some() {
+            out.auth_seed.clone_from(&extra.auth_seed);
+        }
+        if extra.tls_ca.is_some() {
+            out.tls_ca.clone_from(&extra.tls_ca);
+        }
+        if extra.tls_ca_file.is_some() {
+            out.tls_ca_file.clone_from(&extra.tls_ca_file);
+        }
+        if extra.ping_interval_sec.is_some() {
+            out.ping_interval_sec = extra.ping_interval_sec;
+        }
+        if extra.custom_inbox_prefix.is_some() {
+            out.custom_inbox_prefix
+                .clone_from(&extra.custom_inbox_prefix);
+        }
+        out
+    }
+}
+
+impl Default for ConnectionConfig {
+    fn default() -> ConnectionConfig {
+        ConnectionConfig {
+            subscriptions: Box::default(),
+            consumers: Box::default(),
+            cluster_uris: Box::from([DEFAULT_NATS_URI.into()]),
+            auth_jwt: None,
+            auth_seed: None,
+            tls_ca: None,
+            tls_ca_file: None,
+            ping_interval_sec: None,
+            custom_inbox_prefix: None,
+        }
+    }
+}
+
+impl ConnectionConfig {
+    /// Construct configuration from the passed hostdata config
+    pub fn from_map(values: &HashMap<String, String>) -> Result<ConnectionConfig> {
+        let mut config = ConnectionConfig::default();
+
+        if let Some(sub) = values.get(CONFIG_NATS_SUBSCRIPTION) {
+            config.subscriptions = sub.split(',').map(async_nats::Subject::from).collect();
+        }
+        if let Some(cons) = values.get(CONFIG_NATS_CONSUMERS) {
+            config.consumers = serde_json::from_str(cons).context("failed to parse `consumers`")?;
+        }
+        if let Some(url) = values.get(CONFIG_NATS_URI) {
+            config.cluster_uris = url.split(',').map(Box::from).collect();
+        }
+        if let Some(custom_inbox_prefix) = values.get(CONFIG_NATS_CUSTOM_INBOX_PREFIX) {
+            config.custom_inbox_prefix = Some(custom_inbox_prefix.as_str().into());
+        }
+        if let Some(jwt) = values.get(CONFIG_NATS_CLIENT_JWT) {
+            config.auth_jwt = Some(jwt.as_str().into());
+        }
+        if let Some(seed) = values.get(CONFIG_NATS_CLIENT_SEED) {
+            config.auth_seed = Some(seed.as_str().into());
+        }
+        if let Some(tls_ca) = values.get(CONFIG_NATS_TLS_CA) {
+            config.tls_ca = Some(tls_ca.as_str().into());
+        }
+        if config.auth_jwt.is_some() && config.auth_seed.is_none() {
+            bail!("if you specify jwt, you must also specify a seed");
+        }
+
+        Ok(config)
+    }
+}
+
+/// Adds the given CA cert to the provided [`async_nats::ConnectOptions`].
+///
+/// This follows the builder pattern in that it returns the same `ConnectOptions` with TLS
+/// configured
+pub fn add_tls_ca(
+    tls_ca: &str,
+    opts: async_nats::ConnectOptions,
+) -> anyhow::Result<async_nats::ConnectOptions> {
+    let ca = rustls_pemfile::read_one(&mut tls_ca.as_bytes()).context("failed to read CA")?;
+    let mut roots = async_nats::rustls::RootCertStore::empty();
+    if let Some(rustls_pemfile::Item::X509Certificate(ca)) = ca {
+        roots.add_parsable_certificates([ca]);
+    } else {
+        bail!("tls ca: invalid certificate type, must be a DER encoded PEM file")
+    };
+    let tls_client = async_nats::rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Ok(opts.tls_client_config(tls_client).require_tls(true))
+}

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -54,9 +54,9 @@ wasmcloud-core = { workspace = true, features = [
     "oci",
     "otel",
     "rustls-native-certs",
+    "http",
+    "messaging",
 ] }
-wasmcloud-provider-http-server = { workspace = true }
-wasmcloud-provider-messaging-nats = { workspace = true }
 wasmcloud-provider-sdk = { workspace = true }
 wasmcloud-runtime = { workspace = true }
 wasmcloud-secrets-client = { workspace = true }

--- a/crates/host/src/wasmbus/providers/http_server/address.rs
+++ b/crates/host/src/wasmbus/providers/http_server/address.rs
@@ -12,7 +12,7 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinSet;
 use tokio::time::Instant;
 use tracing::{info_span, instrument, trace_span, Instrument as _, Span};
-use wasmcloud_provider_http_server::{load_settings, ServiceSettings};
+use wasmcloud_core::http::{load_settings, ServiceSettings};
 use wasmcloud_provider_sdk::{LinkConfig, LinkDeleteInfo};
 use wasmcloud_tracing::KeyValue;
 use wrpc_interface_http::ServeIncomingHandlerWasmtime as _;

--- a/crates/host/src/wasmbus/providers/http_server/mod.rs
+++ b/crates/host/src/wasmbus/providers/http_server/mod.rs
@@ -10,8 +10,7 @@ use nkeys::XKey;
 use tokio::sync::{broadcast, Mutex};
 use tokio::task::JoinSet;
 use tracing::{error, instrument};
-use wasmcloud_core::HostData;
-use wasmcloud_provider_http_server::default_listen_address;
+use wasmcloud_core::{http::default_listen_address, HostData};
 use wasmcloud_provider_sdk::provider::{
     handle_provider_commands, receive_link_for_provider, ProviderCommandReceivers,
 };

--- a/crates/host/src/wasmbus/providers/messaging_nats.rs
+++ b/crates/host/src/wasmbus/providers/messaging_nats.rs
@@ -10,9 +10,8 @@ use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::task::JoinSet;
 use tokio::time::Instant;
 use tracing::{debug, error, instrument, trace_span, warn, Instrument as _, Span};
+use wasmcloud_core::messaging::{add_tls_ca, ConnectionConfig, ConsumerConfig};
 use wasmcloud_core::HostData;
-use wasmcloud_provider_messaging_nats::ConnectionConfig;
-use wasmcloud_provider_messaging_nats::{add_tls_ca, ConsumerConfig};
 use wasmcloud_provider_sdk::provider::{
     handle_provider_commands, receive_link_for_provider, ProviderCommandReceivers,
 };

--- a/crates/provider-http-server/Cargo.toml
+++ b/crates/provider-http-server/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { workspace = true, features = ["macros"] }
 tower-http = { workspace = true, features = ["cors"] }
 tracing = { workspace = true }
 unicase = { workspace = true }
+wasmcloud-core = { workspace = true, features = ["http"] }
 wasmcloud-provider-sdk = { workspace = true, features = ["otel"] }
 wrpc-interface-http = { workspace = true, features = ["http-body"] }
 

--- a/crates/provider-http-server/src/address.rs
+++ b/crates/provider-http-server/src/address.rs
@@ -15,15 +15,12 @@ use axum::handler::Handler;
 use axum_server::tls_rustls::RustlsConfig;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, instrument};
+use wasmcloud_core::http::{default_listen_address, load_settings, ServiceSettings};
 use wasmcloud_provider_sdk::core::LinkName;
 use wasmcloud_provider_sdk::provider::WrpcClient;
 use wasmcloud_provider_sdk::{get_connection, HostData, LinkConfig, LinkDeleteInfo, Provider};
 
-use crate::settings::default_listen_address;
-use crate::{
-    build_request, get_cors_layer, get_tcp_listener, invoke_component, load_settings,
-    ServiceSettings,
-};
+use crate::{build_request, get_cors_layer, get_tcp_listener, invoke_component};
 
 /// Lookup for handlers by socket
 ///

--- a/crates/provider-http-server/src/lib.rs
+++ b/crates/provider-http-server/src/lib.rs
@@ -39,6 +39,7 @@ use tokio::task::JoinHandle;
 use tokio::{spawn, time};
 use tower_http::cors::{self, CorsLayer};
 use tracing::{debug, info, trace};
+use wasmcloud_core::http::{load_settings, ServiceSettings};
 use wasmcloud_provider_sdk::provider::WrpcClient;
 use wasmcloud_provider_sdk::{initialize_observability, load_host_data, run_provider};
 use wrpc_interface_http::InvokeIncomingHandler as _;
@@ -46,8 +47,6 @@ use wrpc_interface_http::InvokeIncomingHandler as _;
 mod address;
 mod host;
 mod path;
-mod settings;
-pub use settings::{default_listen_address, load_settings, ServiceSettings};
 
 pub async fn run() -> anyhow::Result<()> {
     initialize_observability!(

--- a/crates/provider-messaging-nats/Cargo.toml
+++ b/crates/provider-messaging-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-messaging-nats"
-version = "0.26.0"
+version = "0.27.0"
 description = """
 A capability provider that satisfies the 'wasmcloud:messaging' contract using NATS as a backend.
 """
@@ -27,5 +27,6 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
 wascap = { workspace = true }
+wasmcloud-core = { workspace = true, features = ["messaging"] }
 wasmcloud-provider-sdk = { workspace = true, features = ["otel"] }
 wit-bindgen-wrpc = { workspace = true }

--- a/crates/provider-messaging-nats/src/connection.rs
+++ b/crates/provider-messaging-nats/src/connection.rs
@@ -1,190 +1,40 @@
 use std::collections::HashMap;
 
-use anyhow::{bail, Context as _, Result};
-use serde::{Deserialize, Serialize};
 use tracing::warn;
+use wasmcloud_core::messaging::{
+    ConnectionConfig, CONFIG_NATS_CLIENT_JWT, CONFIG_NATS_CLIENT_SEED,
+};
 use wasmcloud_provider_sdk::{core::secrets::SecretValue, LinkConfig};
 
-const DEFAULT_NATS_URI: &str = "0.0.0.0:4222";
+/// Create a [`ConnectionConfig`] from a given [`LinkConfig`]
+pub fn from_link_config(
+    LinkConfig {
+        secrets, config, ..
+    }: &LinkConfig,
+) -> anyhow::Result<ConnectionConfig> {
+    let mut map = HashMap::clone(config);
 
-const CONFIG_NATS_SUBSCRIPTION: &str = "subscriptions";
-const CONFIG_NATS_CONSUMERS: &str = "consumers";
-const CONFIG_NATS_URI: &str = "cluster_uris";
-const CONFIG_NATS_CLIENT_JWT: &str = "client_jwt";
-const CONFIG_NATS_CLIENT_SEED: &str = "client_seed";
-const CONFIG_NATS_TLS_CA: &str = "tls_ca";
-const CONFIG_NATS_CUSTOM_INBOX_PREFIX: &str = "custom_inbox_prefix";
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ConsumerConfig {
-    pub stream: Box<str>,
-    pub consumer: Box<str>,
-    pub max_messages: Option<usize>,
-    pub max_bytes: Option<usize>,
-}
-
-/// Configuration for connecting a nats client.
-/// More options are available if you use the json than variables in the values string map.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ConnectionConfig {
-    /// List of topics to subscribe to
-    #[serde(default)]
-    pub subscriptions: Box<[async_nats::Subject]>,
-
-    /// List of JetStream consumers
-    #[serde(default)]
-    pub consumers: Box<[ConsumerConfig]>,
-
-    /// Cluster(s) to make a subscription on and connect to
-    #[serde(default)]
-    pub cluster_uris: Box<[Box<str>]>,
-
-    /// Auth JWT to use (if necessary)
-    #[serde(default)]
-    pub auth_jwt: Option<Box<str>>,
-
-    /// Auth seed to use (if necessary)
-    #[serde(default)]
-    pub auth_seed: Option<Box<str>>,
-
-    /// TLS Certificate Authority, encoded as a string
-    #[serde(default)]
-    pub tls_ca: Option<Box<str>>,
-
-    /// TLS Certificate Authority, as a path on disk
-    #[serde(default)]
-    pub tls_ca_file: Option<Box<str>>,
-
-    /// Ping interval in seconds
-    #[serde(default)]
-    pub ping_interval_sec: Option<u16>,
-
-    /// Inbox prefix to use (by default
-    #[serde(default)]
-    pub custom_inbox_prefix: Option<Box<str>>,
-}
-
-impl ConnectionConfig {
-    /// Merge a given [`ConnectionConfig`] with another, coalescing fields and overriding
-    /// where necessary
-    pub fn merge(&self, extra: &ConnectionConfig) -> ConnectionConfig {
-        let mut out = self.clone();
-        if !extra.subscriptions.is_empty() {
-            out.subscriptions.clone_from(&extra.subscriptions);
-        }
-        if !extra.consumers.is_empty() {
-            out.consumers.clone_from(&extra.consumers);
-        }
-        // If the default configuration has a URL in it, and then the link definition
-        // also provides a URL, the assumption is to replace/override rather than combine
-        // the two into a potentially incompatible set of URIs
-        if !extra.cluster_uris.is_empty() {
-            out.cluster_uris.clone_from(&extra.cluster_uris);
-        }
-        if extra.auth_jwt.is_some() {
-            out.auth_jwt.clone_from(&extra.auth_jwt);
-        }
-        if extra.auth_seed.is_some() {
-            out.auth_seed.clone_from(&extra.auth_seed);
-        }
-        if extra.tls_ca.is_some() {
-            out.tls_ca.clone_from(&extra.tls_ca);
-        }
-        if extra.tls_ca_file.is_some() {
-            out.tls_ca_file.clone_from(&extra.tls_ca_file);
-        }
-        if extra.ping_interval_sec.is_some() {
-            out.ping_interval_sec = extra.ping_interval_sec;
-        }
-        if extra.custom_inbox_prefix.is_some() {
-            out.custom_inbox_prefix
-                .clone_from(&extra.custom_inbox_prefix);
-        }
-        out
-    }
-}
-
-impl Default for ConnectionConfig {
-    fn default() -> ConnectionConfig {
-        ConnectionConfig {
-            subscriptions: Box::default(),
-            consumers: Box::default(),
-            cluster_uris: Box::from([DEFAULT_NATS_URI.into()]),
-            auth_jwt: None,
-            auth_seed: None,
-            tls_ca: None,
-            tls_ca_file: None,
-            ping_interval_sec: None,
-            custom_inbox_prefix: None,
-        }
-    }
-}
-
-impl ConnectionConfig {
-    /// Create a [`ConnectionConfig`] from a given [`LinkConfig`]
-    pub fn from_link_config(
-        LinkConfig {
-            secrets, config, ..
-        }: &LinkConfig,
-    ) -> Result<ConnectionConfig> {
-        let mut map = HashMap::clone(config);
-
-        if let Some(jwt) = secrets
-            .get(CONFIG_NATS_CLIENT_JWT)
-            .and_then(SecretValue::as_string)
-            .or_else(|| {
-                warn!("secret value [{CONFIG_NATS_CLIENT_JWT}] was found not found in secrets. Prefer using secrets for sensitive values.");
-                config.get(CONFIG_NATS_CLIENT_JWT).map(String::as_str)
-            })
-        {
-            map.insert(CONFIG_NATS_CLIENT_JWT.into(), jwt.to_string());
-        }
-
-        if let Some(seed) = secrets
-            .get(CONFIG_NATS_CLIENT_SEED)
-            .and_then(SecretValue::as_string)
-            .or_else(|| {
-                warn!("secret value [{CONFIG_NATS_CLIENT_SEED}] was found not found in secrets. Prefer using secrets for sensitive values.");
-                config.get(CONFIG_NATS_CLIENT_SEED).map(String::as_str)
-            })
-        {
-            map.insert(CONFIG_NATS_CLIENT_SEED.into(), seed.to_string());
-        }
-
-        Self::from_map(&map)
+    if let Some(jwt) = secrets
+        .get(CONFIG_NATS_CLIENT_JWT)
+        .and_then(SecretValue::as_string)
+        .or_else(|| {
+            warn!("secret value [{CONFIG_NATS_CLIENT_JWT}] was found not found in secrets. Prefer using secrets for sensitive values.");
+            config.get(CONFIG_NATS_CLIENT_JWT).map(String::as_str)
+        })
+    {
+        map.insert(CONFIG_NATS_CLIENT_JWT.into(), jwt.to_string());
     }
 
-    /// Construct configuration Struct from the passed hostdata config
-    ///
-    /// NOTE: Prefer [`Self::from_link_config`] rather than this method directly
-    pub fn from_map(values: &HashMap<String, String>) -> Result<ConnectionConfig> {
-        let mut config = ConnectionConfig::default();
-
-        if let Some(sub) = values.get(CONFIG_NATS_SUBSCRIPTION) {
-            config.subscriptions = sub.split(',').map(async_nats::Subject::from).collect();
-        }
-        if let Some(cons) = values.get(CONFIG_NATS_CONSUMERS) {
-            config.consumers = serde_json::from_str(cons).context("failed to parse `consumers`")?;
-        }
-        if let Some(url) = values.get(CONFIG_NATS_URI) {
-            config.cluster_uris = url.split(',').map(Box::from).collect();
-        }
-        if let Some(custom_inbox_prefix) = values.get(CONFIG_NATS_CUSTOM_INBOX_PREFIX) {
-            config.custom_inbox_prefix = Some(custom_inbox_prefix.as_str().into());
-        }
-        if let Some(jwt) = values.get(CONFIG_NATS_CLIENT_JWT) {
-            config.auth_jwt = Some(jwt.as_str().into());
-        }
-        if let Some(seed) = values.get(CONFIG_NATS_CLIENT_SEED) {
-            config.auth_seed = Some(seed.as_str().into());
-        }
-        if let Some(tls_ca) = values.get(CONFIG_NATS_TLS_CA) {
-            config.tls_ca = Some(tls_ca.as_str().into());
-        }
-        if config.auth_jwt.is_some() && config.auth_seed.is_none() {
-            bail!("if you specify jwt, you must also specify a seed");
-        }
-
-        Ok(config)
+    if let Some(seed) = secrets
+        .get(CONFIG_NATS_CLIENT_SEED)
+        .and_then(SecretValue::as_string)
+        .or_else(|| {
+            warn!("secret value [{CONFIG_NATS_CLIENT_SEED}] was found not found in secrets. Prefer using secrets for sensitive values.");
+            config.get(CONFIG_NATS_CLIENT_SEED).map(String::as_str)
+        })
+    {
+        map.insert(CONFIG_NATS_CLIENT_SEED.into(), seed.to_string());
     }
+
+    ConnectionConfig::from_map(&map)
 }

--- a/crates/provider-messaging-nats/src/lib.rs
+++ b/crates/provider-messaging-nats/src/lib.rs
@@ -14,6 +14,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, instrument, warn};
 use tracing_futures::Instrument;
 use wascap::prelude::KeyPair;
+use wasmcloud_core::messaging::ConnectionConfig;
 use wasmcloud_provider_sdk::core::HostData;
 use wasmcloud_provider_sdk::provider::WrpcClient;
 use wasmcloud_provider_sdk::wasmcloud_tracing::context::TraceContextInjector;
@@ -23,7 +24,6 @@ use wasmcloud_provider_sdk::{
 };
 
 mod connection;
-pub use connection::{ConnectionConfig, ConsumerConfig};
 
 mod bindings {
     wit_bindgen_wrpc::generate!({
@@ -269,7 +269,7 @@ impl Provider for NatsMessagingProvider {
             self.default_config.clone()
         } else {
             // create a config from the supplied values and merge that with the existing default
-            match ConnectionConfig::from_link_config(&link_config) {
+            match connection::from_link_config(&link_config) {
                 Ok(cc) => self.default_config.merge(&ConnectionConfig {
                     subscriptions: Box::default(),
                     ..cc
@@ -304,7 +304,7 @@ impl Provider for NatsMessagingProvider {
             self.default_config.clone()
         } else {
             // create a config from the supplied values and merge that with the existing default
-            match ConnectionConfig::from_link_config(&link_config) {
+            match connection::from_link_config(&link_config) {
                 Ok(cc) => self.default_config.merge(&cc),
                 Err(e) => {
                     error!("Failed to build connection configuration: {e:?}");

--- a/crates/provider-sdk/Cargo.toml
+++ b/crates/provider-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-sdk"
-version = "0.14.0"
+version = "0.15.0"
 description = "wasmCloud provider SDK"
 readme = "README.md"
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-runtime"
-version = "0.9.0"
+version = "0.10.0"
 description = "wasmCloud runtime library"
 readme = "README.md"
 

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-tracing"
-version = "0.13.0"
+version = "0.14.0"
 description = "wasmCloud tracing functionality"
 
 authors.workspace = true


### PR DESCRIPTION
Our current host had a circular dependency loop with itself because it depended on the http and messaging providers. In order to break this, I moved the common http and messaging types we use for builtins into `wasmcloud-core` behind feature flags that aren't on by default. As such, this is a breaking change as I moved stuff around, but mostly didn't change any code.

Please note that I only bumped version numbers on things we had released already (and anything else we already released that depends on core). Some of these crates had not yet been released and do not need another bump