### PR TITLE
chore: Publish wasmcloud:identity WIT

### DIFF
--- a/.github/workflows/wit-wasmcloud-identity.yml
+++ b/.github/workflows/wit-wasmcloud-identity.yml
@@ -1,0 +1,47 @@
+name: wit-wasmcloud-identity-publish
+
+on:
+  push:
+    tags:
+      - "wit-wasmcloud-identity-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          sparse-checkout: |
+            wit
+            .github
+      - name: Extract tag context
+        id: ctx
+        run: |
+          version=${GITHUB_REF_NAME#wit-wasmcloud-identity-v}
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tarball=wit-wasmcloud-identity-${version}.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "version is ${version}"
+      - uses: ./.github/actions/configure-wkg
+        with:
+          oci-username: ${{ github.repository_owner }}
+          oci-password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        working-directory: wit/identity
+        run: wkg wit build -o package.wasm
+      - name: Push version-tagged WebAssembly binary to GHCR
+        working-directory: wit/identity
+        run: wkg publish package.wasm
+      - name: Package tarball for release
+        run: |
+          tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit identity/wit
+      - name: Release
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
+        with:
+          files: ${{ steps.ctx.outputs.tarball }}
+          make_latest: "false"


### PR DESCRIPTION
Release https://github.com/wasmCloud/wasmCloud/releases/tag/v1.7.0 went out but the wit interface didn't.

This is a copy/pasta from postgres.