### PR TITLE
feat(tracing): Adds support for resource attributes

### DIFF
--- a/crates/host/src/wasmbus/providers/mod.rs
+++ b/crates/host/src/wasmbus/providers/mod.rs
@@ -395,6 +395,13 @@ async fn provider_command(path: &Path, host_data: Vec<u8>) -> anyhow::Result<pro
         let _ = child_cmd.env("RUST_LOG", rust_log);
     }
 
+    // Pass through any OTEL configuration options to the provider as well
+    for (k, v) in env::vars() {
+        if k.starts_with("OTEL_") {
+            let _ = child_cmd.env(k, v);
+        }
+    }
+
     let mut child = child_cmd
         .stdin(Stdio::piped())
         .kill_on_drop(true)

--- a/crates/tracing/src/metrics.rs
+++ b/crates/tracing/src/metrics.rs
@@ -41,6 +41,9 @@ pub fn configure_metrics(
     let meter_provider = SdkMeterProvider::builder()
         .with_resource(
             opentelemetry_sdk::Resource::builder_empty()
+                .with_detector(Box::new(
+                    opentelemetry_sdk::resource::EnvResourceDetector::new(),
+                ))
                 .with_attribute(opentelemetry::KeyValue::new(
                     "service.name",
                     service_name.to_string(),

--- a/crates/tracing/src/traces.rs
+++ b/crates/tracing/src/traces.rs
@@ -295,6 +295,9 @@ where
         .with_sampler(sampler)
         .with_resource(
             opentelemetry_sdk::Resource::builder_empty()
+                .with_detector(Box::new(
+                    opentelemetry_sdk::resource::EnvResourceDetector::new(),
+                ))
                 .with_attribute(opentelemetry::KeyValue::new(
                     "service.name",
                     service_name.to_string(),
@@ -352,6 +355,9 @@ where
     let log_provider = opentelemetry_sdk::logs::SdkLoggerProvider::builder()
         .with_resource(
             opentelemetry_sdk::Resource::builder_empty()
+                .with_detector(Box::new(
+                    opentelemetry_sdk::resource::EnvResourceDetector::new(),
+                ))
                 .with_attribute(opentelemetry::KeyValue::new(
                     "service.name",
                     service_name.to_string(),


### PR DESCRIPTION
We weren't properly discovering resource attributes from the environment. This should fix the issue in both the host and provider. This also changes our start provider process to proxy through all OTEL env vars to the process