### PR TITLE
fix(wash): use of no-arg plugins

### DIFF
--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -133,6 +133,8 @@ wasmtime = { workspace = true, optional = true, features = [
     "cache",
     "component-model",
     "gc",
+    "gc-drc",
+    "gc-null",
 ] }
 wasmtime-wasi = { workspace = true, optional = true }
 wasmtime-wasi-http = { workspace = true, optional = true }


### PR DESCRIPTION
This commit fixes a bug with wash where a no-argument plugin command (e.g. `wash hello`) was being interpreted as a wash command (but with no actual internal wash command matching), and printing help.

Resolves https://github.com/wasmCloud/wasmCloud/issues/4287

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

I tested this locally after building a no-argument plugin (and a regular one)

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
