### PR TITLE
fix(host): ignore auctions for builtin providers when disabled

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1880,7 +1880,7 @@ impl Host {
     async fn handle_start_provider(
         self: Arc<Self>,
         payload: impl AsRef<[u8]>,
-    ) -> anyhow::Result<CtlResponse<()>> {
+    ) -> anyhow::Result<Option<CtlResponse<()>>> {
         let cmd = serde_json::from_slice::<StartProviderCommand>(payload.as_ref())
             .context("failed to deserialize provider start command")?;
         <Self as ControlInterfaceServer>::handle_start_provider(self, cmd).await
@@ -2194,7 +2194,6 @@ impl Host {
             (Some("provider"), Some("start"), Some(_host_id), None) => Arc::clone(&self)
                 .handle_start_provider(message.payload)
                 .await
-                .map(Some)
                 .map(serialize_ctl_response),
             (Some("provider"), Some("stop"), Some(_host_id), None) => self
                 .handle_stop_provider(message.payload)

--- a/crates/test-util/src/provider.rs
+++ b/crates/test-util/src/provider.rs
@@ -95,6 +95,34 @@ pub async fn assert_start_provider(
     Ok(())
 }
 
+/// Start a provider, ensuring that the host does not respond
+///
+/// While this cannot guarantee that the host has not undertaken this operation,
+/// for operations that should return quickly, it suggests the host has ignored
+/// the message.
+///
+/// # Errors
+///
+/// Returns an `Err` if the host responds
+pub async fn assert_start_provider_timeout(
+    StartProviderArgs {
+        client,
+        host_id,
+        provider_id,
+        provider_ref,
+        config,
+    }: StartProviderArgs<'_>,
+) -> Result<()> {
+    if let Err(e) = client
+        .start_provider(host_id, provider_ref, provider_id, None, config)
+        .await
+    {
+        ensure!(e.to_string().contains("timed out"));
+        return Ok(());
+    }
+    anyhow::bail!("start_provider should not have received a response")
+}
+
 /// Stop a provider, ensuring that the provider stops properly
 ///
 /// # Errors


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit enables hosts to ignore auctions for builtin providers if they are enabled. While in the past a response to start_provider was assumed for every message, we loosen that to return an optional response.

Resolves #4232 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
