### PR TITLE
ci(nix): use pinned nixpkgs

### DIFF
--- a/.github/actions/build-nix/action.yml
+++ b/.github/actions/build-nix/action.yml
@@ -23,7 +23,7 @@ runs:
     shell: bash
   - run: nix build --fallback -L '.#${{ inputs.package }}'
     shell: bash
-  - run: nix run --fallback -L --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=cp -RLv ./result '${{ inputs.package }}'
+  - run: nix run --fallback -L --inputs-from . 'nixpkgs-unstable#coreutils' -- --coreutils-prog=cp -RLv ./result '${{ inputs.package }}'
     shell: bash
   - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
     with:

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -111,7 +111,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
 
       - name: Install `skopeo`
-        run: nix profile install --fallback --inputs-from . 'nixpkgs#skopeo'
+        run: nix profile install --fallback --inputs-from . 'nixpkgs-unstable#skopeo'
 
       - name: Build `${{ inputs.bin }}` image
         run: |

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -147,7 +147,7 @@ jobs:
         config:
           - target: aarch64-unknown-linux-musl
             test-bin: |
-              nix profile install --fallback --inputs-from . 'nixpkgs#qemu'
+              nix profile install --fallback --inputs-from . 'nixpkgs-unstable#qemu'
               qemu-aarch64 ./result/bin/wash --version
             test-oci: docker load < ./result
 
@@ -164,7 +164,7 @@ jobs:
           - target: riscv64gc-unknown-linux-gnu-fhs
             test-bin: |
               nix build --fallback -L '.#wash-riscv64gc-unknown-linux-gnu'
-              nix shell --fallback --inputs-from . 'nixpkgs#qemu' -c qemu-riscv64 ./result/bin/wash --version
+              nix shell --fallback --inputs-from . 'nixpkgs-unstable#qemu' -c qemu-riscv64 ./result/bin/wash --version
 
           - target: x86_64-apple-darwin
             test-bin: |
@@ -174,7 +174,7 @@ jobs:
           # TODO: Build for GNU once https://github.com/rust-lang/rust/issues/92212 is resolved
           #- target: x86_64-pc-windows-gnu
           #  test-bin: |
-          #    nix profile install --fallback --inputs-from . 'nixpkgs#wine64'
+          #    nix profile install --fallback --inputs-from . 'nixpkgs-unstable#wine64'
           #    wine64 ./result/bin/wash.exe --version
           #  test-oci: docker load < ./result
 
@@ -213,7 +213,7 @@ jobs:
         config:
           - target: aarch64-unknown-linux-musl
             test-bin: |
-              nix profile install --fallback --inputs-from . 'nixpkgs#qemu'
+              nix profile install --fallback --inputs-from . 'nixpkgs-unstable#qemu'
               qemu-aarch64 ./result/bin/wasmcloud --version
             test-oci: docker load < ./result
 
@@ -230,7 +230,7 @@ jobs:
           - target: riscv64gc-unknown-linux-gnu-fhs
             test-bin: |
               nix build --fallback -L '.#wasmcloud-riscv64gc-unknown-linux-gnu'
-              nix shell --fallback --inputs-from . 'nixpkgs#qemu' -c qemu-riscv64 ./result/bin/wasmcloud --version
+              nix shell --fallback --inputs-from . 'nixpkgs-unstable#qemu' -c qemu-riscv64 ./result/bin/wasmcloud --version
 
           - target: x86_64-apple-darwin
             test-bin: |
@@ -239,7 +239,7 @@ jobs:
 
           - target: x86_64-pc-windows-gnu
             test-bin: |
-              nix profile install --fallback --inputs-from . 'nixpkgs#wine64'
+              nix profile install --fallback --inputs-from . 'nixpkgs-unstable#wine64'
               wine64 ./result/bin/wasmcloud.exe --version
             test-oci: docker load < ./result
 
@@ -904,7 +904,7 @@ jobs:
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Install NFPM
-        run: nix profile install -L --inputs-from . 'nixpkgs#nfpm'
+        run: nix profile install -L --inputs-from . 'nixpkgs-unstable#nfpm'
 
       - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:


### PR DESCRIPTION
We're trying to install packages from `nixpkgs` input in our flake, but we don't have such an input, so `nixpkgs#` references were falling back to upstream https://github.com/NixOS/nixpkgs, which, incidentally, recently introduced a regression for wine64, which caused Windows builds to fail (we use `wine64` to test execution of binaries)

Fix this by importing from `nixpkgs-unstable`, which is an input we *do* have in our flake

Refs https://github.com/NixOS/nixpkgs/issues/397271
Example failing CI: https://github.com/wasmCloud/wasmCloud/actions/runs/14346060267/job/40215978618