### PR TITLE
[CI] Implemented a repo check on conventional-commit action to handle failed command

### DIFF
--- a/.github/workflows/check-conventional-commits.yml
+++ b/.github/workflows/check-conventional-commits.yml
@@ -12,12 +12,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install convco
         uses: taiki-e/install-action@a48a50298f98c47e46a957ae6f82c44cc4878e42 # v2.49.47
         with:
@@ -180,11 +175,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
-        with:
-          egress-policy: audit
-
       - name: Get pull request commits
         id: get_commits
         run: |

--- a/.github/workflows/check-conventional-commits.yml
+++ b/.github/workflows/check-conventional-commits.yml
@@ -12,7 +12,12 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Install convco
         uses: taiki-e/install-action@a48a50298f98c47e46a957ae6f82c44cc4878e42 # v2.49.47
         with:
@@ -175,6 +180,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
       - name: Get pull request commits
         id: get_commits
         run: |

--- a/.github/workflows/check-conventional-commits.yml
+++ b/.github/workflows/check-conventional-commits.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v3
       - name: Install convco
         uses: taiki-e/install-action@a48a50298f98c47e46a957ae6f82c44cc4878e42 # v2.49.47
         with:
@@ -23,6 +24,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: | # shell
           set +e
+
+          if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+            echo "Error: Current directory is not a git repository"
+            exit 1
+          fi
+
           OUTPUT=$(gh pr view ${{ github.event.pull_request.number }} --repo wasmcloud/wasmcloud --json commits --jq '.commits[].messageHeadline' | convco check --from-stdin)
           set -e
 


### PR DESCRIPTION
### Description
The error was caused by the script attempting to interact with the GitHub repository without first confirming whether the current directory was initialized as a valid Git repository. To resolve this, I added an initial check that verifies if the directory contains a valid Git repository before proceeding with the rest of the operations.

Closes #4296 