### PR TITLE
feat/sqldb postgres secret config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8855,7 +8855,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-azure"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8876,7 +8876,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8893,7 +8893,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -8918,7 +8918,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-client"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8941,7 +8941,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-http-server"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8970,7 +8970,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-nats"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9008,7 +9008,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-keyvalue-vault"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9035,7 +9035,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-messaging-kafka"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -9099,7 +9099,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bigdecimal 0.4.8",

--- a/crates/provider-blobstore-azure/Cargo.toml
+++ b/crates/provider-blobstore-azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-azure"
-version = "0.6.0"
+version = "0.6.1"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/provider-blobstore-fs/Cargo.toml
+++ b/crates/provider-blobstore-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.11.0"
+version = "0.11.1"
 description = """
 Blobstore for wasmCloud, leveraging the filesystem. This package provides a capability provider that satisfies the 'wasmcloud:blobstore' contract.
 """

--- a/crates/provider-blobstore-s3/Cargo.toml
+++ b/crates/provider-blobstore-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.12.0"
+version = "0.12.1"
 description = """
 S3-compatible object store capability provider for wasmcloud, satisfying the 'wasmcloud:blobstore' capability contract.
 """

--- a/crates/provider-http-client/Cargo.toml
+++ b/crates/provider-http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-client"
-version = "0.13.0"
+version = "0.13.1"
 description = """
 HTTP client for wasmCloud, using hyper. This package provides a capability provider that satisfies the 'wrpc:http/outgoing-handler' contract.
 """

--- a/crates/provider-http-server/Cargo.toml
+++ b/crates/provider-http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-http-server"
-version = "0.27.0"
+version = "0.27.1"
 description = "Http server for wasmcloud, using Axum. This package provides a library, and a capability provider"
 
 authors.workspace = true

--- a/crates/provider-keyvalue-nats/Cargo.toml
+++ b/crates/provider-keyvalue-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-nats"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 A capability provider that satisfies the 'wasi:keyvalue' contract using NATS as a backend.
 """

--- a/crates/provider-keyvalue-redis/Cargo.toml
+++ b/crates/provider-keyvalue-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-redis"
-version = "0.29.0"
+version = "0.29.1"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/provider-keyvalue-vault/Cargo.toml
+++ b/crates/provider-keyvalue-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-keyvalue-vault"
-version = "0.12.0"
+version = "0.12.1"
 description = """
 Hashicorp Vault capability provider for the 'wrpc:keyvalue' capability contract
 """

--- a/crates/provider-messaging-kafka/Cargo.toml
+++ b/crates/provider-messaging-kafka/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-messaging-kafka"
-version = "0.6.0"
+version = "0.6.1"
 description = """
 A capability provider that satisfies the 'wasmcloud:messaging' contract using Kafka as a backend.
 """

--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.9.0"
+version = "0.10.0"
 description = """
 wasmCloud SQL database provider for Postgres
 """

--- a/src/bin/blobstore-azure-provider/wasmcloud.toml
+++ b/src/bin/blobstore-azure-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Blobstore Azure"
 language = "rust"
 type = "provider"
-version = "0.6.0"
+version = "0.6.1"
 wit = "../../../crates/provider-blobstore-azure/wit"
 
 [rust]

--- a/src/bin/blobstore-fs-provider/wasmcloud.toml
+++ b/src/bin/blobstore-fs-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Blobstore FS"
 language = "rust"
 type = "provider"
-version = "0.11.0"
+version = "0.11.1"
 wit = "../../../crates/provider-blobstore-fs/wit"
 
 [rust]

--- a/src/bin/blobstore-s3-provider/wasmcloud.toml
+++ b/src/bin/blobstore-s3-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "Blobstore S3"
 language = "rust"
-version = "0.12.0"
+version = "0.12.1"
 type = "provider"
 wit = "../../../crates/provider-blobstore-s3/wit"
 

--- a/src/bin/http-client-provider/wasmcloud.toml
+++ b/src/bin/http-client-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "HTTP Client"
 language = "rust"
-version = "0.13.0"
+version = "0.13.1"
 type = "provider"
 
 [rust]

--- a/src/bin/http-server-provider/wasmcloud.toml
+++ b/src/bin/http-server-provider/wasmcloud.toml
@@ -1,6 +1,6 @@
 name = "HTTP Server"
 language = "rust"
-version = "0.26.0"
+version = "0.26.1"
 type = "provider"
 
 [rust]

--- a/src/bin/keyvalue-nats-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-nats-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Nats"
 language = "rust"
 type = "provider"
-version = "0.4.0"
+version = "0.4.1"
 wit = "../../../crates/provider-keyvalue-nats/wit"
 
 [rust]

--- a/src/bin/keyvalue-redis-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-redis-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Redis"
 language = "rust"
 type = "provider"
-version = "0.29.0"
+version = "0.29.1"
 wit = "../../../crates/provider-keyvalue-redis/wit"
 
 [rust]

--- a/src/bin/keyvalue-vault-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-vault-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Vault"
 language = "rust"
 type = "provider"
-version = "0.12.0"
+version = "0.12.1"
 wit = "../../../crates/provider-keyvalue-vault/wit"
 
 [rust]

--- a/src/bin/messaging-kafka-provider/wasmcloud.toml
+++ b/src/bin/messaging-kafka-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Messaging Kafka"
 language = "rust"
 type = "provider"
-version = "0.6.0"
+version = "0.6.1"
 wit = "../../../crates/provider-messaging-kafka/wit"
 
 [rust]

--- a/src/bin/messaging-nats-provider/wasmcloud.toml
+++ b/src/bin/messaging-nats-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "Messaging NATS"
 language = "rust"
 type = "provider"
-version = "0.25.0"
+version = "0.27.0"
 wit = "../../../crates/provider-messaging-nats/wit"
 
 [rust]

--- a/src/bin/sqldb-postgres-provider/wasmcloud.toml
+++ b/src/bin/sqldb-postgres-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "SQLDB Postgres"
 language = "rust"
 type = "provider"
-version = "0.9.0"
+version = "0.10.0"
 wit = "../../../crates/provider-sqldb-postgres/wit"
 
 [rust]


### PR DESCRIPTION
- **feat(sqldb-postgres)!: support loading config from secrets**
- **chore(providers): bump all for release with otel fixes**

## Feature or Problem
This PR implements support in the postgres provider for loading all config values from secrets, in case all configuration is in the secret store.

I also went ahead and bumped each provider here to save the CI cycle to release the otel fixes from last week.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
`next` all providers

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
