### PR TITLE
ci: update action-gh-release to v2.2.2

### DIFF
--- a/.github/workflows/secrets-nats-kv.yml
+++ b/.github/workflows/secrets-nats-kv.yml
@@ -211,7 +211,7 @@ jobs:
           cp artifacts/secrets-nats-kv-aarch64-linux-musl artifacts/secrets-nats-kv-aarch64-linux
 
       - name: Release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           draft: true
           prerelease: ${{ steps.ctx.outputs.prerelease != '' }}

--- a/.github/workflows/wash-plugins.yml
+++ b/.github/workflows/wash-plugins.yml
@@ -15,31 +15,31 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - name: Extract tag context
-      id: ctx
-      run: |
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Extract tag context
+        id: ctx
+        run: |
           version=${GITHUB_REF_NAME#wash-plugin-v}
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "version is ${version}"
-    - uses: ./.github/actions/configure-wkg
-      with:
-        oci-username: ${{ github.repository_owner }}
-        oci-password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build
-      working-directory: crates/wash-lib
-      run: |
-        wkg wit build -o package.wasm
-    - name: Push version-tagged WebAssembly binary to GHCR
-      working-directory: crates/wash-lib
-      run: |
-        wkg publish package.wasm
-    - name: Create tarball for release
-      working-directory: crates
-      run: |
-        tar czf wash-plugins-${{ steps.ctx.outputs.version }}.tar.gz wash-lib/wit
-    - name: Release
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
-      with:
-        files: crates/wash-plugins-${{ steps.ctx.outputs.version }}.tar.gz
-        make_latest: "false"
+      - uses: ./.github/actions/configure-wkg
+        with:
+          oci-username: ${{ github.repository_owner }}
+          oci-password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        working-directory: crates/wash-lib
+        run: |
+          wkg wit build -o package.wasm
+      - name: Push version-tagged WebAssembly binary to GHCR
+        working-directory: crates/wash-lib
+        run: |
+          wkg publish package.wasm
+      - name: Create tarball for release
+        working-directory: crates
+        run: |
+          tar czf wash-plugins-${{ steps.ctx.outputs.version }}.tar.gz wash-lib/wit
+      - name: Release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        with:
+          files: crates/wash-plugins-${{ steps.ctx.outputs.version }}.tar.gz
+          make_latest: 'false'

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -803,7 +803,7 @@ jobs:
             done
           done
 
-      - uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+      - uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           draft: true
           prerelease: true
@@ -854,7 +854,7 @@ jobs:
             done
           done
 
-      - uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+      - uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         if: startsWith(github.ref, 'refs/tags/wash-v')
         with:
           draft: true

--- a/.github/workflows/wit-wasmcloud-identity.yml
+++ b/.github/workflows/wit-wasmcloud-identity.yml
@@ -3,7 +3,7 @@ name: wit-wasmcloud-identity-publish
 on:
   push:
     tags:
-      - "wit-wasmcloud-identity-v*"
+      - 'wit-wasmcloud-identity-v*'
 
 permissions:
   contents: read
@@ -41,7 +41,7 @@ jobs:
         run: |
           tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit identity/wit
       - name: Release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           files: ${{ steps.ctx.outputs.tarball }}
-          make_latest: "false"
+          make_latest: 'false'

--- a/.github/workflows/wit-wasmcloud-lattice-bus.yml
+++ b/.github/workflows/wit-wasmcloud-lattice-bus.yml
@@ -15,33 +15,33 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      with:
-        sparse-checkout: |
-          wit
-          .github
-    - name: Extract tag context
-      id: ctx
-      run: |
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          sparse-checkout: |
+            wit
+            .github
+      - name: Extract tag context
+        id: ctx
+        run: |
           version=${GITHUB_REF_NAME#wit-wasmcloud-bus-v}
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tarball=wit-wasmcloud-bus-${version}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "version is ${version}"
-    - uses: ./.github/actions/configure-wkg
-      with:
-        oci-username: ${{ github.repository_owner }}
-        oci-password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build
-      working-directory: wit/bus
-      run: wkg wit build -o package.wasm
-    - name: Push version-tagged WebAssembly binary to GHCR
-      working-directory: wit/bus
-      run: wkg publish package.wasm
-    - name: Package tarball for release
-      run: |
-        tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit bus/wit
-    - name: Release
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
-      with:
-        files: ${{ steps.ctx.outputs.tarball }}
-        make_latest: "false"
+      - uses: ./.github/actions/configure-wkg
+        with:
+          oci-username: ${{ github.repository_owner }}
+          oci-password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        working-directory: wit/bus
+        run: wkg wit build -o package.wasm
+      - name: Push version-tagged WebAssembly binary to GHCR
+        working-directory: wit/bus
+        run: wkg publish package.wasm
+      - name: Package tarball for release
+        run: |
+          tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit bus/wit
+      - name: Release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        with:
+          files: ${{ steps.ctx.outputs.tarball }}
+          make_latest: 'false'

--- a/.github/workflows/wit-wasmcloud-postgres.yml
+++ b/.github/workflows/wit-wasmcloud-postgres.yml
@@ -9,40 +9,39 @@ permissions:
   contents: read
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      with:
-        sparse-checkout: |
-          wit
-          .github
-    - name: Extract tag context
-      id: ctx
-      run: |
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          sparse-checkout: |
+            wit
+            .github
+      - name: Extract tag context
+        id: ctx
+        run: |
           version=${GITHUB_REF_NAME#wit-wasmcloud-postgres-v}
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tarball=wit-wasmcloud-postgres-${version}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "version is ${version}"
-    - uses: ./.github/actions/configure-wkg
-      with:
-        oci-username: ${{ github.repository_owner }}
-        oci-password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build
-      working-directory: wit/postgres
-      run: wkg wit build -o package.wasm
-    - name: Push version-tagged WebAssembly binary to GHCR
-      working-directory: wit/postgres
-      run: wkg publish package.wasm
-    - name: Package tarball for release
-      run: |
-        tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit postgres/wit
-    - name: Release
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
-      with:
-        files: ${{ steps.ctx.outputs.tarball }}
-        make_latest: "false"
+      - uses: ./.github/actions/configure-wkg
+        with:
+          oci-username: ${{ github.repository_owner }}
+          oci-password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        working-directory: wit/postgres
+        run: wkg wit build -o package.wasm
+      - name: Push version-tagged WebAssembly binary to GHCR
+        working-directory: wit/postgres
+        run: wkg publish package.wasm
+      - name: Package tarball for release
+        run: |
+          tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit postgres/wit
+      - name: Release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        with:
+          files: ${{ steps.ctx.outputs.tarball }}
+          make_latest: 'false'

--- a/.github/workflows/wit-wasmcloud-secrets.yml
+++ b/.github/workflows/wit-wasmcloud-secrets.yml
@@ -15,33 +15,33 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      with:
-        sparse-checkout: |
-          wit
-          .github
-    - name: Extract tag context
-      id: ctx
-      run: |
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          sparse-checkout: |
+            wit
+            .github
+      - name: Extract tag context
+        id: ctx
+        run: |
           version=${GITHUB_REF_NAME#wit-wasmcloud-secrets-v}
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tarball=wit-wasmcloud-secrets-${version}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "version is ${version}"
-    - uses: ./.github/actions/configure-wkg
-      with:
-        oci-username: ${{ github.repository_owner }}
-        oci-password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build
-      working-directory: wit/secrets
-      run: wkg wit build -o package.wasm
-    - name: Push version-tagged WebAssembly binary to GHCR
-      working-directory: wit/secrets
-      run: wkg publish package.wasm
-    - name: Package tarball for release
-      run: |
-        tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit secrets/wit
-    - name: Release
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
-      with:
-        files: ${{ steps.ctx.outputs.tarball }}
-        make_latest: "false"
+      - uses: ./.github/actions/configure-wkg
+        with:
+          oci-username: ${{ github.repository_owner }}
+          oci-password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        working-directory: wit/secrets
+        run: wkg wit build -o package.wasm
+      - name: Push version-tagged WebAssembly binary to GHCR
+        working-directory: wit/secrets
+        run: wkg publish package.wasm
+      - name: Package tarball for release
+        run: |
+          tar -cvzf ${{ steps.ctx.outputs.tarball }} -C wit secrets/wit
+      - name: Release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        with:
+          files: ${{ steps.ctx.outputs.tarball }}
+          make_latest: 'false'


### PR DESCRIPTION
## Feature or Problem
This PR updates the action-gh-release that previously got downgraded that NOW got upgraded again to a broken version for uploading artifacts

## Related Issues
Uploading artifacts for wasmCloud v1.8.0 failed because of this https://github.com/wasmCloud/wasmCloud/actions/runs/14579950627/job/40894792365

## Release Information
v1.8.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
