### PR TITLE
feat(host): track active component instances

### DIFF
--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -5,7 +5,7 @@ use heck::ToKebabCase;
 #[cfg(feature = "otel")]
 pub use opentelemetry::{
     global,
-    metrics::{Counter, Histogram, Meter, ObservableGauge},
+    metrics::{Counter, Histogram, Meter, ObservableGauge, UpDownCounter},
     InstrumentationScope, KeyValue,
 };
 use wasmcloud_core::logging::Level;

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -5,7 +5,7 @@ use heck::ToKebabCase;
 #[cfg(feature = "otel")]
 pub use opentelemetry::{
     global,
-    metrics::{Counter, Histogram, Meter, ObservableGauge, UpDownCounter},
+    metrics::{Counter, Gauge, Histogram, Meter, ObservableGauge, UpDownCounter},
     InstrumentationScope, KeyValue,
 };
 use wasmcloud_core::logging::Level;


### PR DESCRIPTION
## Feature or Problem
This PR adds a new metric, `wasmcloud_host.component.active_instances`, which tracks the number of currently executing instances of a component. This is extremely useful to be able to measure the actual number of components executing at any given time. This lets you understand if your scale is correct, if you need to scale up, down, etc.

Additionally, this lets you setup alerts if you're approaching your max instances.

A followup commit also adds `wasmcloud_host.component.max_instances` so that you can create views and alerts based on saturation, e.g. `component_active_instances / component_max_instances > 0.8`

## Related Issues
This PR also adds a timeout for the component future which will ensure that semaphores are dropped after a component stops executing, even if it's killed by the epoch counter. Fixes #2530 

## Release Information
wasmCloud 1.8.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Here's an example of the active instances metric tracking over a couple different hosts.

<img width="1572" alt="image" src="https://github.com/user-attachments/assets/9d41ee69-7daa-4f6d-9fbe-4d1f749af9c1" />

And expressed as a ratio:

<img width="1569" alt="image" src="https://github.com/user-attachments/assets/17de897f-8b50-4b5c-8d53-c8bd123c6d4e" />