### PR TITLE
feat(control-interface)!: add wait_for_completion on long tasks

### DIFF
--- a/crates/control-interface/src/client.rs
+++ b/crates/control-interface/src/client.rs
@@ -616,6 +616,7 @@ impl Client {
             component_id: IdentifierKind::is_component_id(existing_component_id)?,
             new_component_ref: IdentifierKind::is_component_ref(new_component_ref)?,
             annotations,
+            wait_for_completion: false,
         })?;
         match self.request_timeout(subject, bytes, self.timeout).await {
             Ok(msg) => Ok(json_deserialize(&msg.payload)?),


### PR DESCRIPTION
## Feature or Problem
This PR adds a `wait_for_completion` field on the component scale, component update, and provider start control interface commands that will, instead of returning an ack after validating the payload, will wait for the entire operation to complete before returning a success or error message.

## Related Issues
Fixes #4089, if you're needing a synchronous operation to complete before taking other actions this will do the trick

## Release Information
wasmCloud control interface next minor
wasmCloud v1.9

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Below is a demonstration of hitting the host with each variety of a provider start, first without waiting for completion (notably even with an invalid OCI reference we get a success) and then waiting for completion and getting the actual response.

```bash
➜ nats req "wasmbus.ctl.v1.default.provider.st16:42:43 [5/81]
FMQDNP4Y55HPMIM62GIEQCJWHYD7HWYFERJACWDLIYUFT" '{"provider_id": "http5", "provider_ref": "ghcr.dio/wasmcloud/http-client:0.9.0", "wait_for_completion": false}'
16:41:49 Sending request on "wasmbus.ctl.v1.default.provider.start.NBEQTHIHUMWFMQDNP4Y55HPMIM62GIEQCJWHYD7HWYFERJACWDLIYUFT"
16:41:49 Received with rtt 1.491292ms
{"success":true,"message":"received request, starting provider"}

 ➜ nats req "wasmbus.ctl.v1.default.provider.start.NBEQTHIHUMW
FMQDNP4Y55HPMIM62GIEQCJWHYD7HWYFERJACWDLIYUFT" '{"provider_id": "http6", "provider_ref": "ghcr.io/wasmcloud/http-client:0.9.0", "wait_for_completion": false}'
16:42:11 Sending request on "wasmbus.ctl.v1.default.provider.start.NBEQTHIHUMWFMQDNP4Y55HPMIM62GIEQCJWHYD7HWYFERJACWDLIYUFT"
16:42:11 Received with rtt 1.801625ms
{"success":true,"message":"received request, starting provider"}

➜ nats req "wasmbus.ctl.v1.default.provider.start.NBEQTHIHUMWFMQDNP4Y55HPMIM62GIEQCJWHYD7HWYFERJACWDLIYUFT" '{"provider_id": "http8", "provider_ref": "ghdcr.io/wasmcloud/http-client:0.9.0", "wait_for_completion": true}'
16:47:49 Sending request on "wasmbus.ctl.v1.default.provider.start.NBEQTHIHUMWFMQDNP4Y55HPMIM62GIEQCJWHYD7HWYFERJACWDLIYUFT"
16:47:49 Received with rtt 96.642375ms
{"success":false,"message":"failed to fetch provider"}

➜ nats req "wasmbus.ctl.v1.default.provider.start.NBEQTHIHUMW
FMQDNP4Y55HPMIM62GIEQCJWHYD7HWYFERJACWDLIYUFT" '{"provider_id": "http7", "provider_ref": "ghcr.io/wasmcloud/http-client:0.9.0", "wait_for_completion": true}'
16:42:35 Sending request on "wasmbus.ctl.v1.default.provider.start.NBEQTHIHUMWFMQDNP4Y55HPMIM62GIEQCJWHYD7HWYFERJACWDLIYUFT"
16:42:36 Received with rtt 1.175606291s
{"success":true,"message":"successfully started provider"}
```
