### PR TITLE
fix: use allow-latest for allow_latest, default registry config improvement

### DIFF
--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -120,7 +120,7 @@ impl RegistryConfigBuilder {
             } else {
                 self.auth.context("missing registry auth")?
             },
-            allow_latest: self.allow_insecure.unwrap_or_default(),
+            allow_latest: self.allow_latest.unwrap_or_default(),
             allow_insecure,
             additional_ca_paths: self.additional_ca_paths.unwrap_or_default(),
         })

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -52,7 +52,7 @@ use tokio::fs;
 use tracing::{debug, instrument, warn};
 use url::Url;
 use wascap::jwt;
-use wasmcloud_core::{OciFetcher, RegistryConfig};
+use wasmcloud_core::{OciFetcher, RegistryAuth, RegistryConfig, RegistryType};
 
 /// A reference to a resource, either a file, an OCI image, or a builtin provider
 #[derive(PartialEq)]
@@ -138,11 +138,11 @@ impl ResourceRef<'_> {
 }
 
 /// Fetch an component from a reference.
-#[instrument(level = "debug", skip(allow_file_load, registry_config))]
+#[instrument(level = "debug", skip(default_config, registry_config))]
 pub async fn fetch_component(
     component_ref: &str,
     allow_file_load: bool,
-    additional_ca_paths: &Vec<PathBuf>,
+    default_config: &oci::Config,
     registry_config: &HashMap<String, RegistryConfig>,
 ) -> anyhow::Result<Vec<u8>> {
     match ResourceRef::try_from(component_ref)? {
@@ -159,8 +159,28 @@ pub async fn fetch_component(
             .authority()
             .and_then(|authority| registry_config.get(authority))
             .map(OciFetcher::from)
-            .unwrap_or_default()
-            .with_additional_ca_paths(additional_ca_paths)
+            .unwrap_or_else(|| {
+                OciFetcher::from(
+                    RegistryConfig::builder()
+                        .reg_type(RegistryType::Oci)
+                        .additional_ca_paths(default_config.additional_ca_paths.clone())
+                        .allow_latest(default_config.allow_latest)
+                        .allow_insecure(
+                            oci_ref
+                                .authority()
+                                .map(|authority| {
+                                    default_config
+                                        .allowed_insecure
+                                        .contains(&authority.to_string())
+                                })
+                                .unwrap_or(false),
+                        )
+                        .auth(RegistryAuth::Anonymous)
+                        .build()
+                        .unwrap_or_default(),
+                )
+            })
+            .with_additional_ca_paths(&default_config.additional_ca_paths)
             .fetch_component(component_ref)
             .await
             .with_context(|| {
@@ -176,7 +196,7 @@ pub(crate) async fn fetch_provider(
     provider_ref: &ResourceRef<'_>,
     host_id: impl AsRef<str>,
     allow_file_load: bool,
-    additional_ca_paths: &Vec<PathBuf>,
+    default_config: &oci::Config,
     registry_config: &HashMap<String, RegistryConfig>,
 ) -> anyhow::Result<(PathBuf, Option<jwt::Token<jwt::CapabilityProvider>>)> {
     match provider_ref {
@@ -198,8 +218,28 @@ pub(crate) async fn fetch_provider(
             .authority()
             .and_then(|authority| registry_config.get(authority))
             .map(OciFetcher::from)
-            .unwrap_or_default()
-            .with_additional_ca_paths(additional_ca_paths)
+            .unwrap_or_else(|| {
+                OciFetcher::from(
+                    RegistryConfig::builder()
+                        .reg_type(RegistryType::Oci)
+                        .additional_ca_paths(default_config.additional_ca_paths.clone())
+                        .allow_latest(default_config.allow_latest)
+                        .allow_insecure(
+                            oci_ref
+                                .authority()
+                                .map(|authority| {
+                                    default_config
+                                        .allowed_insecure
+                                        .contains(&authority.to_string())
+                                })
+                                .unwrap_or(false),
+                        )
+                        .auth(RegistryAuth::Anonymous)
+                        .build()
+                        .unwrap_or_default(),
+                )
+            })
+            .with_additional_ca_paths(&default_config.additional_ca_paths)
             .fetch_provider(provider_ref, host_id)
             .await
             .with_context(|| {

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -1225,7 +1225,7 @@ impl Host {
         fetch_component(
             component_ref,
             self.host_config.allow_file_load,
-            &self.host_config.oci_opts.additional_ca_paths,
+            &self.host_config.oci_opts,
             &registry_config,
         )
         .await
@@ -1652,7 +1652,7 @@ impl Host {
                     &provider_ref,
                     host_id,
                     self.host_config.allow_file_load,
-                    &self.host_config.oci_opts.additional_ca_paths,
+                    &self.host_config.oci_opts,
                     &registry_config,
                 )
                 .await


### PR DESCRIPTION
## Feature or Problem
An unfortunate error that led to frustrating failures when enabling `ALLOW_LATEST`, actually not taking effect.

~I've made this fix, but it doesn't fully address the issue and I know where it's coming from. So I'll mark this as draft for now and follow up tomorrow.~

There was an additional step in the host that was necessary to fix which is that if there is not a registry explicitly configured, we should fall back on the provided defaults as given to wasmCloud at startup. Instead of defaulting to the defaults of the `RegistryConfig` struct (e.g. allow_latest: false) we will now fall back to the provided additional CA certs, allow insecure, allow latest, and anonymous auth.

## Related Issues
Fixes #4298

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
