### PR TITLE
chore(host): Reference wasmcloud_core::rpc helper methods consistently

### DIFF
--- a/crates/host/src/nats/provider.rs
+++ b/crates/host/src/nats/provider.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use tracing::instrument;
+use wasmcloud_core::{link_del_subject, link_put_subject};
 use wasmcloud_tracing::context::TraceContextInjector;
 
 use crate::wasmbus::{injector_to_headers, providers::ProviderManager};
@@ -35,7 +36,7 @@ impl ProviderManager for NatsProviderManager {
             serde_json::to_vec(link).context("failed to serialize provider link definition")?;
         self.nats_client
             .publish_with_headers(
-                format!("wasmbus.rpc.{lattice}.{target}.linkdefs.put"),
+                link_put_subject(lattice, target),
                 injector_to_headers(&TraceContextInjector::default_with_span()),
                 payload.into(),
             )
@@ -55,7 +56,7 @@ impl ProviderManager for NatsProviderManager {
             serde_json::to_vec(link).context("failed to serialize provider link definition")?;
         self.nats_client
             .publish_with_headers(
-                format!("wasmbus.rpc.{lattice}.{target}.linkdefs.del"),
+                link_del_subject(lattice, target),
                 injector_to_headers(&TraceContextInjector::default_with_span()),
                 payload.into(),
             )

--- a/crates/host/src/wasmbus/ctl.rs
+++ b/crates/host/src/wasmbus/ctl.rs
@@ -18,6 +18,7 @@ use wasmcloud_control_interface::{
     ProviderAuctionAck, ProviderAuctionRequest, RegistryCredential, ScaleComponentCommand,
     StartProviderCommand, StopHostCommand, StopProviderCommand, UpdateComponentCommand,
 };
+use wasmcloud_core::shutdown_subject;
 use wasmcloud_tracing::context::TraceContextInjector;
 
 use crate::registry::RegistryCredentialExt;
@@ -588,10 +589,7 @@ impl ControlInterfaceServer for Host {
         if let Err(e) = self
             .rpc_nats
             .send_request(
-                format!(
-                    "wasmbus.rpc.{}.{provider_id}.default.shutdown",
-                    self.host_config.lattice
-                ),
+                shutdown_subject(&self.host_config.lattice, provider_id, "default"),
                 req,
             )
             .await

--- a/crates/host/src/wasmbus/providers/mod.rs
+++ b/crates/host/src/wasmbus/providers/mod.rs
@@ -24,7 +24,9 @@ use tokio::task::JoinSet;
 use tracing::{error, instrument, trace, warn};
 use uuid::Uuid;
 use wascap::jwt::{CapabilityProvider, Token};
-use wasmcloud_core::{provider_config_update_subject, HealthCheckResponse, HostData, OtelConfig};
+use wasmcloud_core::{
+    health_subject, provider_config_update_subject, HealthCheckResponse, HostData, OtelConfig,
+};
 use wasmcloud_runtime::capability::secrets::store::SecretValue;
 use wasmcloud_tracing::context::TraceContextInjector;
 
@@ -447,8 +449,7 @@ fn check_health(
     host_id: String,
     provider_id: String,
 ) -> impl Future<Output = ()> {
-    let health_subject =
-        async_nats::Subject::from(format!("wasmbus.rpc.{lattice}.{provider_id}.health"));
+    let health_subject = async_nats::Subject::from(health_subject(&lattice, &provider_id));
 
     // Check the health of the provider every 30 seconds
     let mut health_check = tokio::time::interval(Duration::from_secs(30));


### PR DESCRIPTION
## Feature or Problem

Turns out we were not using the [`wasmcloud_core::rpc` helper methods](https://github.com/wasmCloud/wasmCloud/blob/main/crates/core/src/rpc.rs#L25-L68) for provider subjects consistently.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
