### PR TITLE
fix(examples): set default OTEL_EXPORTER_OTLP_ENDPOINT in docker-comp…

### DIFF
--- a/examples/docker/docker-compose-full.yml
+++ b/examples/docker/docker-compose-full.yml
@@ -81,7 +81,7 @@ services:
       WASMCLOUD_ALLOW_FILE_LOAD: "true"
       WASMCLOUD_OCI_ALLOWED_INSECURE: registry:5000
       WASMCLOUD_OBSERVABILITY_ENABLED: "true"
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4318
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318
     ports:
       - "8000-8100:8000-8100" # Expose ports 8000-8100 for examples that use an HTTP server
 

--- a/examples/docker/docker-compose-full.yml
+++ b/examples/docker/docker-compose-full.yml
@@ -81,6 +81,7 @@ services:
       WASMCLOUD_ALLOW_FILE_LOAD: "true"
       WASMCLOUD_OCI_ALLOWED_INSECURE: registry:5000
       WASMCLOUD_OBSERVABILITY_ENABLED: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4318
     ports:
       - "8000-8100:8000-8100" # Expose ports 8000-8100 for examples that use an HTTP server
 


### PR DESCRIPTION
…ose-full.yml

## Feature or Problem
eventhough docker-compose-full gives you the full setup, neither metrics nor traces nor logs are sent to OTEL collector (and according error is logged)

## Related Issues
-

## Release Information
-

## Consumer Impact
easier accessible "docker-compose-full" example

## Testing
-

### Unit Test(s)
-

### Acceptance or Integration
-

### Manual Verification
`docker-compose-up -f docker-compose-full.yml up`
No 
> wasmcloud-1   | Failed to configure observability: failed to create OTEL http exporter

or comparable errors should appear
