### PR TITLE
feat(providers): improve http server error message

### DIFF
--- a/crates/provider-http-server/src/address.rs
+++ b/crates/provider-http-server/src/address.rs
@@ -130,13 +130,19 @@ impl Provider for HttpServerProvider {
             // If a handler does not already exist, make a new server and insert
             std::collections::hash_map::Entry::Vacant(v) => {
                 // Start a server instance that calls the given component
-                let http_server = HttpServerCore::new(
+                let http_server = match HttpServerCore::new(
                     Arc::new(settings),
                     link_config.target_id,
                     self.handlers_by_socket.clone(),
                 )
                 .await
-                .context("httpserver failed to start listener for component")?;
+                {
+                    Ok(s) => s,
+                    Err(e) => {
+                        error!("failed to start listener for component: {e:?}");
+                        bail!(e);
+                    }
+                };
                 v.insert((Arc::new(http_server), vec![component_meta]));
             }
         }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit improves the error message produced by the HTTP server provider when it cannot create a link, printing the error message out via tracing as well as bubbling up to the host.

Note that while the host will still only see the minimal message (which does not show *why*), looking at the host output stream should reveal the cause.


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
