### PR TITLE
fix(otel): add default endpoints for OpenTelemetry collectors

### DIFF
--- a/crates/wascap/src/errors.rs
+++ b/crates/wascap/src/errors.rs
@@ -132,7 +132,7 @@ impl From<std::io::Error> for Error {
 
 impl From<BinaryReaderError> for Error {
     fn from(source: BinaryReaderError) -> Error {
-        let io_error = ::std::io::Error::new(::std::io::ErrorKind::Other, source.to_string());
+        let io_error = ::std::io::Error::other(source.to_string());
         Error(Box::new(ErrorKind::IO(io_error)))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,6 +290,10 @@ struct Args {
     enable_logs: Option<bool>,
 
     /// Overrides the OpenTelemetry endpoint used for emitting traces, metrics and logs.
+    ///
+    /// If not provided, defaults to:
+    ///   - HTTP: http://127.0.0.1:4318/v1/<signal> (e.g., /v1/traces, /v1/metrics, /v1/logs)
+    ///   - gRPC: http://127.0.0.1:4317
     #[clap(
         long = "override-observability-endpoint",
         env = "OTEL_EXPORTER_OTLP_ENDPOINT"
@@ -297,6 +301,10 @@ struct Args {
     observability_endpoint: Option<String>,
 
     /// Overrides the OpenTelemetry endpoint used for emitting traces.
+    ///
+    /// If not provided, defaults to:
+    ///   - HTTP: http://127.0.0.1:4318/v1/traces
+    ///   - gRPC: http://127.0.0.1:4317
     #[clap(
         long = "override-traces-endpoint",
         env = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
@@ -305,6 +313,10 @@ struct Args {
     traces_endpoint: Option<String>,
 
     /// Overrides the OpenTelemetry endpoint used for emitting metrics.
+    ///
+    /// If not provided, defaults to:
+    ///   - HTTP: http://127.0.0.1:4318/v1/metrics
+    ///   - gRPC: http://127.0.0.1:4317
     #[clap(
         long = "override-metrics-endpoint",
         env = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
@@ -313,6 +325,10 @@ struct Args {
     metrics_endpoint: Option<String>,
 
     /// Overrides the OpenTelemetry endpoint used for emitting logs.
+    ///
+    /// If not provided, defaults to:
+    ///   - HTTP: http://127.0.0.1:4318/v1/logs
+    ///   - gRPC: http://127.0.0.1:4317
     #[clap(
         long = "override-logs-endpoint",
         env = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
@@ -426,6 +442,17 @@ async fn main() -> anyhow::Result<()> {
             dispatch
                 .try_init()
                 .context("failed to init observability for host")?;
+
+            // Now that tracing is initialized, log the effective OTEL configuration
+            tracing::debug!(
+                ?otel_config,
+                traces_endpoint = %otel_config.traces_endpoint(),
+                metrics_endpoint = %otel_config.metrics_endpoint(),
+                logs_endpoint = %otel_config.logs_endpoint(),
+                protocol = ?otel_config.protocol,
+                "Effective OpenTelemetry configuration after merging CLI args, environment variables, and defaults"
+            );
+
             Some(guard)
         }
         Err(e) => {


### PR DESCRIPTION
Add sensible default endpoints when no explicit OTEL endpoints are provided:
- HTTP protocol: http://127.0.0.1:4318/v1/<signal> (traces/metrics/logs)
- gRPC protocol: http://127.0.0.1:4317

This resolves the issue where wasmCloud would fail to configure OTEL exporters with "invalid URI empty string" errors when no endpoints were explicitly configured.

Also includes:
- Updated CLI documentation to reflect default endpoints
- Fixed clippy warning using std::io::Error::other()
- Updated tests to expect new default behavior

## Feature or Problem
Adding default OTEL endpoints

## Related Issues
Fixes #4397

## Release Information
Next release

## Consumer Impact
This should improve the user experience

## Testing
Successfully used the `docker-compose-otel.yaml` and the locally built wasmCloud host to validate the defaults are set.

### Unit Test(s)
Passed
