### PR TITLE
fix(examples): full OTEL-stack in docker-compose-full.yml

### DIFF
--- a/examples/docker/docker-compose-full.yml
+++ b/examples/docker/docker-compose-full.yml
@@ -1,7 +1,7 @@
 # This docker-compose file starts an entire wasmCloud ecosystem, including:
 #   a NATS server
 #   a local OCI registry
-#   grafana + prometheus + tempo for metrics and tracing
+#   grafana + otel-collector + loki + prometheus + tempo for logs, metrics and traces
 #   a wasmCloud host
 #   a WADM server for managing applications
 
@@ -24,46 +24,59 @@ services:
     image: grafana/grafana:10.0.10
     ports:
       - 5050:3000
-    volumes:
-      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
+    volumes:
+      - ./config/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     depends_on:
+      - loki
       - prometheus
       - tempo
 
   otelcol:
-    depends_on:
-      - prometheus
-      - tempo
     image: otel/opentelemetry-collector-contrib:0.93.0
+    command:
+      - '--config=/etc/otelcol/config.yaml'
+    volumes:
+      - ./config/otel-collector.yaml:/etc/otelcol/config.yaml
     ports:
       - 4317:4317
       - 4318:4318
+    depends_on:
+      - loki
+      - prometheus
+      - tempo
+
+  loki:
+    image: grafana/loki:2.9.4
     command:
-      - "--config=/etc/otelcol/config.yaml"
+      - '-config.file=/etc/loki/config.yaml'
     volumes:
-      - ./otel-collector.yaml:/etc/otelcol/config.yaml
+      - ./config/loki.yaml:/etc/loki/config.yaml
+    ports:
+      - 3100:3100
+    restart: unless-stopped
 
   prometheus:
     image: prom/prometheus:v2.49.1
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--config.file=/etc/prometheus/config.yaml'
       - '--web.enable-remote-write-receiver'
       - '--enable-feature=native-histograms'
+    volumes:
+      - ./config/prometheus.yaml:/etc/prometheus/config.yaml
     ports:
       - 9090:9090
     restart: unless-stopped
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
 
   tempo:
     image: grafana/tempo:2.3.1
-    command: ["-config.file=/etc/tempo.yaml"]
+    command:
+      - '-config.file=/etc/tempo/config.yaml'
     volumes:
-      - ./tempo.yaml:/etc/tempo.yaml
+      - ./config/tempo.yaml:/etc/tempo/config.yaml
     ports:
       - 4318 # This port is used for sending traces from otel-collector to tempo
       - 7999:7999 # tempo


### PR DESCRIPTION
## Feature or Problem
docker-compose-full.yaml is actually not full. It only contains half the OTEL stack and configuration-wise not much is working there. When it comes to OTEL, this fix applies exactly what docker-compose-otel.yaml does already (without touching anything else)

I can imagine to take this even further and:
a) question the usefulness of docker-compose-auxiliary.yml / docker-compose-websockets.yml
b) subseqently remove those configs not located in "/config"-folder
c) even question docker-compose-otel.yml (DRY + if you only want to use OTEL, you can opt to not start nats, registry, wasmcloud and wadm)

## Related Issues
/

## Release Information
/

## Consumer Impact
Blast radius is restricted to the docker-compose-examples so no one should be harmed in production. Newbies tho get OTEL running faster and with less hassle.

## Testing
/

### Unit Test(s)
/

### Acceptance or Integration
/

### Manual Verification
`docker-compose -f docker-compose-full.yml up` 
=> http://localhost:5050/ (Grafana) has working Datasources for Loki, Prometheus and Tempo out of the box
