### PR TITLE
fix(wash): windows build suffix

### DIFF
--- a/crates/wash/src/lib/start/wasmcloud.rs
+++ b/crates/wash/src/lib/start/wasmcloud.rs
@@ -257,7 +257,7 @@ fn wasmcloud_url(version: &Version) -> String {
     let os = "unknown-linux-gnu";
 
     #[cfg(target_os = "windows")]
-    let os = "pc-windows-msvc.exe";
+    let os = "pc-windows-gnu.exe";
     format!(
         "{WASMCLOUD_GITHUB_RELEASE_URL}/v{version}/wasmcloud-{arch}-{os}",
         arch = std::env::consts::ARCH,


### PR DESCRIPTION
This commit fixes the windows build suffix that has been used for wash, as we moved from publishing a -pc-windows-msvc version to pc-windows-gnu

Resolves #4485 

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
