### PR TITLE
ci(wash): Don't build throwaway files

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -13,6 +13,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0         # Don't waste time writing out incremental build files
+  CARGO_PROFILE_TEST_DEBUG: 0  # These are thrown away anyways, don't produce them
   GO_VERSION: '1.24.1'
   TINYGO_VERSION: '0.36.0'
 


### PR DESCRIPTION
## Feature or Problem
CI is doing too much work

## Related Issues
- Probably.

## Release Information
- Next release

## Consumer Impact
- Faster CI

## Testing
- All previous CI

### Unit Test(s)


### Acceptance or Integration
- No longer producing debug info for tests

### Manual Verification
- Waiting on CI