### PR TITLE
fix(keyvalue-redis): use default config for connection manager

### DIFF
--- a/src/bin/keyvalue-redis-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-redis-provider/wasmcloud.toml
@@ -1,7 +1,7 @@
 name = "KV Redis"
 language = "rust"
 type = "provider"
-version = "0.29.1"
+version = "0.30.0"
 wit = "../../../crates/provider-keyvalue-redis/wit"
 
 [rust]


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue where the default values for the connection manager for Redis didn't work properly for retried connections. Now, by default, the provider will be robust and reconnect to the server whether it could establish a connection at first and it was lost, or if the connection didn't establish from the start. Components will be able to gracefully handle an error for a dropped connection, which will resolve after it retries the connection.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
keyvalue-redis 0.30.0 (last release was mistakenly 0.3.0)

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
