### PR TITLE
http-body support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8936,8 +8936,11 @@ name = "wasmcloud-component"
 version = "0.2.1"
 dependencies = [
  "anyhow",
+ "bytes",
  "futures",
  "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "rand 0.9.1",
  "tokio",
  "uuid 1.16.0",

--- a/crates/component/Cargo.toml
+++ b/crates/component/Cargo.toml
@@ -14,14 +14,19 @@ repository.workspace = true
 default = [
     "futures",
     "http",
+    "http-body",
     "rand",
     "tokio",
     "uuid",
 ]
+http-body = ["dep:http-body", "dep:http-body-util", "dep:bytes", "http"]
 
 [dependencies]
 anyhow = { workspace = true }
 http = { workspace = true, optional = true }
+http-body = { workspace = true, optional = true }
+http-body-util = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
 futures = { workspace = true, optional = true, features = ["std"] }
 rand = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/component/src/wrappers/http.rs
+++ b/crates/component/src/wrappers/http.rs
@@ -352,8 +352,8 @@ impl<T: Read> OutgoingBody for ReadBody<T> {
 /// for this type will read the bytes from the stream and write them to the
 /// output stream.
 pub struct IncomingBody {
-    stream: InputStream,
-    body: wasi::http::types::IncomingBody,
+    pub(crate) stream: InputStream,
+    pub(crate) body: wasi::http::types::IncomingBody,
 }
 
 impl TryFrom<wasi::http::types::IncomingBody> for IncomingBody {

--- a/crates/component/src/wrappers/http_body.rs
+++ b/crates/component/src/wrappers/http_body.rs
@@ -1,0 +1,62 @@
+use bytes::Buf;
+use futures::StreamExt;
+
+const CHUNK_SIZE: u64 = 1024 * 1024;
+
+impl http_body::Body for crate::http::IncomingBody {
+    type Data = bytes::Bytes;
+
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        std::task::Poll::Ready(match self.stream.read(CHUNK_SIZE) {
+            Ok(d) => Some(Ok(http_body::Frame::data(d.into()))),
+            Err(_e) => todo!(),
+        })
+    }
+}
+
+pub async fn write_axum_response_to_wasi<T: http_body::Body>(
+    response: http::Response<T>,
+    outparam: wasi::http::types::ResponseOutparam,
+) {
+    let (
+        http::response::Parts {
+            status, headers, ..
+        },
+        body,
+    ) = response.into_parts();
+    let headers = crate::TryInto::try_into(headers).unwrap();
+    let resp_tx = wasi::http::types::OutgoingResponse::new(headers);
+    if let Err(()) = resp_tx.set_status_code(status.as_u16()) {
+        todo!("failed to set status code");
+    }
+
+    let Ok(resp_body) = resp_tx.body() else {
+        todo!("failed to get body");
+    };
+
+    wasi::http::types::ResponseOutparam::set(outparam, Ok(resp_tx));
+
+    let out = resp_body.write().expect("outgoing stream");
+    let body_stream = http_body_util::BodyDataStream::new(body);
+    body_stream
+        .for_each(|chunk| {
+            match chunk {
+                Ok(chunk) => {
+                    let chunk = chunk.chunk();
+                    out.write(chunk).expect("writing response");
+                }
+                Err(_) => todo!(),
+            };
+            std::future::ready(())
+        })
+        .await;
+
+    out.blocking_flush().unwrap();
+    drop(out);
+    wasi::http::types::OutgoingBody::finish(resp_body, None).unwrap();
+}

--- a/crates/component/src/wrappers/mod.rs
+++ b/crates/component/src/wrappers/mod.rs
@@ -5,6 +5,9 @@ mod random;
 #[cfg(feature = "http")]
 pub mod http;
 
+#[cfg(feature = "http-body")]
+pub mod http_body;
+
 pub use io::*;
 #[allow(unused_imports)]
 pub use logging::*;


### PR DESCRIPTION
## Feature or Problem
Adds http-body support to wasmcloud-component, which intern enables basic axum support.
Example at https://github.com/MendyBerger/axum-wasi-example

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
Next

## Consumer Impact
New features only, so hopefully no real impact.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

Not sure I'll have the time to finish this PR, so if anyone is interested in finishing it up feel free. I think it's close, just needs error handling.