### PR TITLE
fix: add wasm-tools to dev dependencies for `wash`

### DIFF
--- a/crates/wash/tools/deps_check.py
+++ b/crates/wash/tools/deps_check.py
@@ -16,6 +16,11 @@ if tinygo is None:
     print('tinygo not found. Please install it from https://tinygo.org/')
     exit(1)
 
+wasmtools = shutil.which('wasm-tools')
+if wasmtools is None:
+    print('wasm-tools not found. Installing..."')
+    subprocess.run('cargo install wasm-tools --locked', shell=True)
+
 targets = subprocess.run("rustup target list --installed", shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True).stdout
 if "wasm32-unknown-unknown" not in targets:
     print('Rust wasm32-unknown-unknown target not found. Installing..."')

--- a/flake.nix
+++ b/flake.nix
@@ -655,6 +655,7 @@
               pkgs.tinygo
               pkgs.vault
               pkgs.wit-deps
+              pkgs.wasm-tools
 
               pkgs.pkgsUnstable.go
               pkgs.pkgsUnstable.kubectl


### PR DESCRIPTION
## Feature or Problem

Various elements require wasm-tools to be installed in the devShell. For instance, the wash test `lib::build::component::tests::golang_generate_bindgen_component_multi_world` requires it. However, the flake devShell does not contain it as a dependency, nor does `make deps-check` ensure that it is present.

## Related Issues

None. I didn't bother creating an issue but if needed I can create one.

## Consumer Impact

No consumer impact.

## Testing

Tests such as the one mentioned above no longer fail when running `make test-unit` in the `wash` crate (when using `direnv` and the [provided `.envrc`](https://github.com/wasmCloud/wasmCloud/blob/main/.envrc)).

### Manual Verification

Ran `make deps-check` without `wasm-tools` to ensure that it triggers and install. Ran the unit tests for `wash` with and without `wasm-tools`, passing and failing respectively.
