### PR TITLE
replace use of `~/.wash` with XDG Base Directory Specification

### DIFF
--- a/crates/wash/src/bin/wash.rs
+++ b/crates/wash/src/bin/wash.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Context};
 use clap::{self, Arg, ArgMatches, Command, FromArgMatches, Parser, Subcommand};
 use console::style;
 use crossterm::style::Stylize;
+use etcetera::AppStrategy;
 use semver::Version;
 use serde_json::json;
 use tracing_subscriber::EnvFilter;
@@ -489,6 +490,17 @@ async fn main() {
             eprintln!("Error while checking for new wash version: {e}");
             std::process::exit(2);
         }
+    }
+
+    let old_config_dir = WASH_DIRECTORIES.home_dir().join(".wash");
+    if tokio::fs::try_exists(&old_config_dir)
+        .await
+        .unwrap_or(false)
+    {
+        eprintln!(
+            "Old configuration directory '{}' found, consider migrating to new configuration structure.",
+            old_config_dir.display(),
+        );
     }
 
     let output_kind = cli.output;

--- a/crates/wash/src/bin/wash.rs
+++ b/crates/wash/src/bin/wash.rs
@@ -23,6 +23,7 @@ use wash::lib::cli::start::StartCommand;
 use wash::lib::cli::stop::StopCommand;
 use wash::lib::cli::update::UpdateCommand;
 use wash::lib::cli::{CommandOutput, OutputKind};
+use wash::lib::config::WASH_DIRECTORIES;
 use wash::lib::drain::Drain as DrainSelection;
 use wash::lib::generate::emoji;
 use wash::lib::plugin::subcommand::{DirMapping, SubcommandRunner};
@@ -49,7 +50,6 @@ use wash::cli::plugin::{self, PluginCommand};
 use wash::cli::secrets::{self, SecretsCliCommand};
 use wash::cli::style::WASH_CLI_STYLE;
 use wash::cli::ui::{self, UiCommand};
-use wash::cli::util::ensure_plugin_dir;
 
 #[derive(Clone)]
 struct HelpTopic {
@@ -745,7 +745,7 @@ fn experimental_error_message(command: &str) -> anyhow::Result<CommandOutput> {
 async fn load_plugins() -> Option<(SubcommandRunner, PathBuf)> {
     // We need to use env vars here because the plugin loading needs to be initialized before
     // the CLI is parsed
-    let plugin_dir = match ensure_plugin_dir(std::env::var("WASH_PLUGIN_DIR").ok()).await {
+    let plugin_dir = match WASH_DIRECTORIES.create_plugins_dir() {
         Ok(dir) => dir,
         Err(e) => {
             tracing::error!(err = ?e, "Could not load wash plugin directory");

--- a/crates/wash/src/cli/cmd/dev/mod.rs
+++ b/crates/wash/src/cli/cmd/dev/mod.rs
@@ -49,7 +49,7 @@ const DEFAULT_PROVIDER_STOP_TIMEOUT_MS: u64 = 3000;
 
 /// The path to the dev directory for wash
 async fn dev_dir() -> Result<PathBuf> {
-    let dir = crate::lib::config::WASH_DEV_DIR.to_path_buf();
+    let dir = crate::lib::config::WASH_DIRECTORIES.dev_dir();
     if !tokio::fs::try_exists(&dir)
         .await
         .context("failed to check if dev dir exists")?

--- a/crates/wash/src/cli/cmd/dev/mod.rs
+++ b/crates/wash/src/cli/cmd/dev/mod.rs
@@ -49,7 +49,7 @@ const DEFAULT_PROVIDER_STOP_TIMEOUT_MS: u64 = 3000;
 
 /// The path to the dev directory for wash
 async fn dev_dir() -> Result<PathBuf> {
-    let dir = crate::lib::config::dev_dir().context("failed to resolve config dir")?;
+    let dir = crate::lib::config::WASH_DEV_DIR.to_path_buf();
     if !tokio::fs::try_exists(&dir)
         .await
         .context("failed to check if dev dir exists")?

--- a/crates/wash/src/cli/cmd/dev/session.rs
+++ b/crates/wash/src/cli/cmd/dev/session.rs
@@ -12,7 +12,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use tokio::process::Child;
 
-use crate::lib::config;
+use crate::lib::config::WASH_DIRECTORIES;
 use crate::lib::generate::emoji;
 use crate::lib::id::ServerId;
 use crate::lib::start::{
@@ -242,7 +242,7 @@ impl WashDevSession {
 
         let session_dir = self.base_dir().await?;
 
-        let install_dir = config::WASH_DOWNLOADS_DIR.to_path_buf();
+        let install_dir = WASH_DIRECTORIES.downloads_dir();
         let nats_host = nats_opts.nats_host.clone().unwrap_or_else(|| {
             wasmcloud_opts
                 .ctl_host

--- a/crates/wash/src/cli/cmd/dev/session.rs
+++ b/crates/wash/src/cli/cmd/dev/session.rs
@@ -12,7 +12,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use tokio::process::Child;
 
-use crate::lib::config::downloads_dir;
+use crate::lib::config;
 use crate::lib::generate::emoji;
 use crate::lib::id::ServerId;
 use crate::lib::start::{
@@ -242,7 +242,7 @@ impl WashDevSession {
 
         let session_dir = self.base_dir().await?;
 
-        let install_dir = downloads_dir()?;
+        let install_dir = config::WASH_DOWNLOADS_DIR.to_path_buf();
         let nats_host = nats_opts.nats_host.clone().unwrap_or_else(|| {
             wasmcloud_opts
                 .ctl_host

--- a/crates/wash/src/cli/cmd/up.rs
+++ b/crates/wash/src/cli/cmd/up.rs
@@ -2,7 +2,7 @@ use crate::lib::app::{load_app_manifest, AppManifest, AppManifestSource};
 use crate::lib::cli::{CommandOutput, OutputKind};
 use crate::lib::common::{CommandGroupUsage, WASMCLOUD_HOST_VERSION_T};
 use crate::lib::config::{
-    create_nats_client_from_opts, downloads_dir, host_pid_file, DEFAULT_NATS_TIMEOUT_MS,
+    self, create_nats_client_from_opts, downloads_dir, host_pid_file, DEFAULT_NATS_TIMEOUT_MS,
     WADM_PID_FILE,
 };
 use crate::lib::context::fs::ContextDir;
@@ -400,7 +400,7 @@ pub async fn handle_command(command: UpCommand, output_kind: OutputKind) -> Resu
 }
 
 pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<CommandOutput> {
-    let install_dir = downloads_dir()?;
+    let install_dir = config::WASH_DOWNLOADS_DIR.to_path_buf();
     create_dir_all(&install_dir).await?;
     let spinner = Spinner::new(&output_kind)?;
 

--- a/crates/wash/src/cli/cmd/up.rs
+++ b/crates/wash/src/cli/cmd/up.rs
@@ -2,8 +2,8 @@ use crate::lib::app::{load_app_manifest, AppManifest, AppManifestSource};
 use crate::lib::cli::{CommandOutput, OutputKind};
 use crate::lib::common::{CommandGroupUsage, WASMCLOUD_HOST_VERSION_T};
 use crate::lib::config::{
-    self, create_nats_client_from_opts, downloads_dir, host_pid_file, DEFAULT_NATS_TIMEOUT_MS,
-    WADM_PID_FILE,
+    create_nats_client_from_opts, host_pid_file, DEFAULT_NATS_TIMEOUT_MS, WADM_PID_FILE,
+    WASH_DIRECTORIES,
 };
 use crate::lib::context::fs::ContextDir;
 use crate::lib::context::ContextManager;
@@ -28,7 +28,6 @@ use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use sysinfo::System;
-use tokio::fs::create_dir_all;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::Child,
@@ -400,8 +399,7 @@ pub async fn handle_command(command: UpCommand, output_kind: OutputKind) -> Resu
 }
 
 pub async fn handle_up(cmd: UpCommand, output_kind: OutputKind) -> Result<CommandOutput> {
-    let install_dir = config::WASH_DOWNLOADS_DIR.to_path_buf();
-    create_dir_all(&install_dir).await?;
+    let install_dir = WASH_DIRECTORIES.create_downloads_dir()?;
     let spinner = Spinner::new(&output_kind)?;
 
     let ctx = ContextDir::new()?

--- a/crates/wash/src/cli/completions.rs
+++ b/crates/wash/src/cli/completions.rs
@@ -4,10 +4,11 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::lib::cli::CommandOutput;
-use crate::lib::config::cfg_dir;
+use crate::lib::config::WASH_DIRECTORIES;
 use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand};
 use clap_complete::{generator::generate_to, shells::Shell};
+use etcetera::AppStrategy;
 
 const TOKEN_FILE: &str = ".completion_suggested";
 const COMPLETION_DOC_URL: &str =
@@ -51,15 +52,14 @@ pub enum ShellSelection {
 
 /// Displays a message one time after wash install
 pub fn first_run_suggestion() -> Result<Option<String>> {
-    let cfg_dir = cfg_dir()?;
-    let token = cfg_dir.join(TOKEN_FILE);
+    let token = WASH_DIRECTORIES.create_in_config_dir(None, Some(TOKEN_FILE))?;
     if token.is_file() {
         return Ok(None);
     }
     let _ = std::fs::File::create(token).with_context(|| {
         format!(
             "can't create completion first-run token in {}",
-            cfg_dir.display()
+            WASH_DIRECTORIES.config_dir().display()
         )
     })?;
     Ok(Some(format!(

--- a/crates/wash/src/cli/completions.rs
+++ b/crates/wash/src/cli/completions.rs
@@ -52,7 +52,7 @@ pub enum ShellSelection {
 
 /// Displays a message one time after wash install
 pub fn first_run_suggestion() -> Result<Option<String>> {
-    let token = WASH_DIRECTORIES.create_in_config_dir(None, Some(TOKEN_FILE))?;
+    let token = WASH_DIRECTORIES.create_in_config_dir(TOKEN_FILE)?;
     if token.is_file() {
         return Ok(None);
     }

--- a/crates/wash/src/cli/down/mod.rs
+++ b/crates/wash/src/cli/down/mod.rs
@@ -4,8 +4,8 @@ use std::process::{Output, Stdio};
 
 use crate::lib::cli::{stop::stop_hosts, CommandOutput, OutputKind};
 use crate::lib::config::{
-    self, create_nats_client_from_opts, host_pid_file, DEFAULT_NATS_HOST,
-    DEFAULT_NATS_PORT, WADM_PID_FILE
+    create_nats_client_from_opts, host_pid_file, DEFAULT_NATS_HOST, DEFAULT_NATS_PORT,
+    WADM_PID_FILE, WASH_DIRECTORIES,
 };
 use crate::lib::id::ServerId;
 use crate::lib::start::{nats_pid_path, NATS_SERVER_BINARY};
@@ -99,7 +99,7 @@ pub async fn handle_command(
 }
 
 pub async fn handle_down(cmd: DownCommand, output_kind: OutputKind) -> Result<CommandOutput> {
-    let install_dir = config::WASH_DOWNLOADS_DIR.to_path_buf();
+    let install_dir = WASH_DIRECTORIES.downloads_dir();
     let sp = Spinner::new(&output_kind)?;
     sp.update_spinner_message(" Stopping wasmCloud ...".to_string());
 

--- a/crates/wash/src/cli/down/mod.rs
+++ b/crates/wash/src/cli/down/mod.rs
@@ -4,8 +4,8 @@ use std::process::{Output, Stdio};
 
 use crate::lib::cli::{stop::stop_hosts, CommandOutput, OutputKind};
 use crate::lib::config::{
-    create_nats_client_from_opts, downloads_dir, host_pid_file, DEFAULT_NATS_HOST,
-    DEFAULT_NATS_PORT, WADM_PID_FILE,
+    self, create_nats_client_from_opts, host_pid_file, DEFAULT_NATS_HOST,
+    DEFAULT_NATS_PORT, WADM_PID_FILE
 };
 use crate::lib::id::ServerId;
 use crate::lib::start::{nats_pid_path, NATS_SERVER_BINARY};
@@ -99,7 +99,7 @@ pub async fn handle_command(
 }
 
 pub async fn handle_down(cmd: DownCommand, output_kind: OutputKind) -> Result<CommandOutput> {
-    let install_dir = downloads_dir()?;
+    let install_dir = config::WASH_DOWNLOADS_DIR.to_path_buf();
     let sp = Spinner::new(&output_kind)?;
     sp.update_spinner_message(" Stopping wasmCloud ...".to_string());
 

--- a/crates/wash/src/cli/keys.rs
+++ b/crates/wash/src/cli/keys.rs
@@ -5,7 +5,7 @@ use clap::Subcommand;
 use nkeys::{KeyPair, KeyPairType};
 use serde_json::json;
 use crate::lib::cli::CommandOutput;
-use crate::lib::config::cfg_dir;
+use crate::lib::config::WASH_DIRECTORIES;
 use crate::lib::keys::{fs::KeyDir, KeyManager};
 
 const NKEYS_EXTENSION: &str = ".nk";
@@ -118,12 +118,7 @@ pub fn list(directory: Option<PathBuf>) -> Result<CommandOutput> {
 }
 
 fn determine_directory(directory: Option<PathBuf>) -> Result<PathBuf> {
-    if let Some(d) = directory {
-        Ok(d)
-    } else {
-        let d = cfg_dir()?.join("keys");
-        Ok(d)
-    }
+    directory.ok_or("no directory").or(WASH_DIRECTORIES.create_keys_dir())
 }
 
 #[cfg(test)]

--- a/crates/wash/src/cli/ui.rs
+++ b/crates/wash/src/cli/ui.rs
@@ -1,7 +1,7 @@
 use crate::lib::{
     cli::{CommandOutput, OutputKind},
     common::{DEFAULT_WASH_UI_PORT, WASHBOARD_VERSION, WASHBOARD_VERSION_T},
-    config,
+    config::WASH_DIRECTORIES,
     start::{
         get_download_client, new_patch_or_pre_1_0_0_minor_version_after_version_string,
         parse_version_string, GITHUB_WASHBOARD_TAG_PREFIX, GITHUB_WASMCLOUD_ORG,
@@ -60,7 +60,7 @@ async fn get_patch_version_or_default(version: Option<String>) -> Version {
 
 pub async fn handle_ui(cmd: UiCommand, _output_kind: OutputKind) -> Result<()> {
     let washboard_version = get_patch_version_or_default(cmd.version).await;
-    let washboard_path = config::WASH_DOWNLOADS_DIR.join("washboard");
+    let washboard_path = WASH_DIRECTORIES.in_downloads_dir("washboard");
     let washboard_assets = ensure_washboard(&washboard_version, washboard_path).await?;
     let static_files = warp::fs::dir(washboard_assets);
     let washboard_port = cmd.port;

--- a/crates/wash/src/cli/ui.rs
+++ b/crates/wash/src/cli/ui.rs
@@ -1,7 +1,7 @@
 use crate::lib::{
     cli::{CommandOutput, OutputKind},
     common::{DEFAULT_WASH_UI_PORT, WASHBOARD_VERSION, WASHBOARD_VERSION_T},
-    config::downloads_dir,
+    config,
     start::{
         get_download_client, new_patch_or_pre_1_0_0_minor_version_after_version_string,
         parse_version_string, GITHUB_WASHBOARD_TAG_PREFIX, GITHUB_WASMCLOUD_ORG,
@@ -60,7 +60,7 @@ async fn get_patch_version_or_default(version: Option<String>) -> Version {
 
 pub async fn handle_ui(cmd: UiCommand, _output_kind: OutputKind) -> Result<()> {
     let washboard_version = get_patch_version_or_default(cmd.version).await;
-    let washboard_path = downloads_dir()?.join("washboard");
+    let washboard_path = config::WASH_DOWNLOADS_DIR.join("washboard");
     let washboard_assets = ensure_washboard(&washboard_version, washboard_path).await?;
     let static_files = warp::fs::dir(washboard_assets);
     let washboard_port = cmd.port;

--- a/crates/wash/src/lib/cli/mod.rs
+++ b/crates/wash/src/lib/cli/mod.rs
@@ -308,7 +308,8 @@ impl CommonPackageArgs {
             }
             // Otherwise we got nothing and attempt to load the default config locations
             (None, None) => {
-                let path = WASH_DIRECTORIES.create_in_config_dir(None, Some("package_config.toml"))?;
+                let path =
+                    WASH_DIRECTORIES.create_in_config_dir(None, Some("package_config.toml"))?;
                 // Check if the config file exists before loading so we can error properly
                 if tokio::fs::metadata(&path).await.is_ok() {
                     let loaded = wasm_pkg_client::Config::from_file(&path)
@@ -648,11 +649,7 @@ mod test {
         let wash_opts = WashConnectionOptions::try_from(cli_opts)?;
         assert_eq!(wash_opts.get_lattice(), "hal9000".to_string());
 
-        let context_dir = ContextDir::from_dir(Some(
-            tempdir
-                .path()
-                .join(format!(".config/wash/contexts")),
-        ))?;
+        let context_dir = ContextDir::from_dir(Some(tempdir.path().join(".config/wash/contexts")))?;
 
         // when opts.lattice.is_none() && opts.context.is_some(), use the lattice from the specified context...
         context_dir.save_context(&WashContext {

--- a/crates/wash/src/lib/cli/mod.rs
+++ b/crates/wash/src/lib/cli/mod.rs
@@ -574,7 +574,7 @@ mod test {
     use serial_test::serial;
 
     use crate::lib::{
-        config::{WashConnectionOptions, DEFAULT_LATTICE},
+        config::{WashConnectionOptions, DEFAULT_LATTICE, WASH_DIRECTORIES},
         context::{fs::ContextDir, ContextManager, WashContext},
     };
 
@@ -798,6 +798,41 @@ mod test {
         assert!(
             assert_registry_mapping(wasmcloud_registry, "adifferentone.com"),
             "Should have the proper registry for wasmcloud",
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_config_directory_overrides() {
+        use etcetera::AppStrategy;
+        let tempdir = tempfile::tempdir().expect("failed to create tempdir");
+        let _xdg_config_home = EnvVar::set("XDG_CONFIG_HOME", tempdir.path().join(".config"));
+        assert_eq!(
+            WASH_DIRECTORIES.config_dir(),
+            tempdir.path().join(".config/wash"),
+            "Should retrieve XDG conform wash config directory"
+        );
+        assert_eq!(
+            WASH_DIRECTORIES.context_dir(),
+            tempdir.path().join(".config/wash/contexts"),
+            "Should retrieve XDG conform wash context directory"
+        );
+        let _wash_config_dir = EnvVar::set("WASH_CONFIG_DIR", tempdir.path().join(".wash"));
+        assert_eq!(
+            WASH_DIRECTORIES.config_dir(),
+            tempdir.path().join(".wash"),
+            "Should retrieve custom wash config directory"
+        );
+        assert_eq!(
+            WASH_DIRECTORIES.context_dir(),
+            tempdir.path().join(".wash/contexts"),
+            "Should retrieve contexts directory in custom wash config directory"
+        );
+        let _wash_context_dir = EnvVar::set("WASH_CONTEXT_DIR", tempdir.path().join("contexts"));
+        assert_eq!(
+            WASH_DIRECTORIES.context_dir(),
+            tempdir.path().join("contexts"),
+            "Should retrieve custom contexts config directory"
         );
     }
 

--- a/crates/wash/src/lib/cli/mod.rs
+++ b/crates/wash/src/lib/cli/mod.rs
@@ -308,8 +308,7 @@ impl CommonPackageArgs {
             }
             // Otherwise we got nothing and attempt to load the default config locations
             (None, None) => {
-                let path =
-                    WASH_DIRECTORIES.create_in_config_dir(None, Some("package_config.toml"))?;
+                let path = WASH_DIRECTORIES.create_in_config_dir("package_config.toml")?;
                 // Check if the config file exists before loading so we can error properly
                 if tokio::fs::metadata(&path).await.is_ok() {
                     let loaded = wasm_pkg_client::Config::from_file(&path)

--- a/crates/wash/src/lib/config.rs
+++ b/crates/wash/src/lib/config.rs
@@ -89,53 +89,20 @@ impl AppStrategy for WashAppStrategy {
     }
 }
 
-macro_rules! in_dir_method {
-    ($self: ident, $path_extra: expr, $dir_method_name: ident) => {{
-        let mut path = $self.$dir_method_name();
-        path.push(Path::new(&$path_extra));
-        path
-    }};
-}
-
-macro_rules! create_dir_method {
-    ($self: ident, $dir_method_name: ident) => {{
-        let path = $self.$dir_method_name();
-        fs::create_dir_all(&path)
-            .with_context(|| format!("failed to create directory `{}`", path.display()))?;
-        Ok(path)
-    }};
-}
-
-macro_rules! create_in_dir_method {
-    ($self: ident, $path_extra: expr, $file_extra: expr, $dir_method_name: ident, $in_dir_method_name: ident) => {{
-        let mut path = if let Some(subdir) = $path_extra {
-            $self.$in_dir_method_name(subdir)
-        } else {
-            $self.$dir_method_name()
-        };
-        fs::create_dir_all(&path)
-            .with_context(|| format!("failed to create directory `{}`", path.display()))?;
-        if let Some(file) = $file_extra {
-            path.push(Path::new(&file));
-        }
-        Ok(path)
-    }};
-}
-
 impl WashAppStrategy {
     /// Creates the directory in which to store configuration in and returns the path to it.
     pub fn create_config_dir(&self) -> Result<PathBuf> {
-        create_dir_method!(self, config_dir)
+        let path = self.config_dir();
+        fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create directory `{}`", path.display()))?;
+        Ok(path)
     }
 
     /// Creates the directory in which to store configuration in and returns the path to it
-    /// potentially concatenated with a filename.
-    pub fn create_in_config_dir<P: AsRef<OsStr>>(
-        &self,
-        subdir: Option<P>,
-        file: Option<P>,
-    ) -> Result<PathBuf> {
-        create_in_dir_method!(self, subdir, file, config_dir, in_config_dir)
+    /// concatenated with a filename.
+    pub fn create_in_config_dir<P: AsRef<OsStr>>(&self, path: P) -> Result<PathBuf> {
+        self.create_config_dir()?;
+        Ok(self.in_config_dir(path))
     }
 
     /// Returns the path to the directory where to store keys.
@@ -145,22 +112,24 @@ impl WashAppStrategy {
 
     /// Concatenates a path in the keys directory.
     pub fn in_keys_dir<P: AsRef<std::ffi::OsStr>>(&self, path: P) -> PathBuf {
-        in_dir_method!(self, path, keys_dir)
+        let mut basepath = self.keys_dir();
+        basepath.push(Path::new(&path));
+        basepath
     }
 
     /// Creates the directory in which to store keys in and returns the path to it.
     pub fn create_keys_dir(&self) -> Result<PathBuf> {
-        create_dir_method!(self, keys_dir)
+        let path = self.keys_dir();
+        fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create directory `{}`", path.display()))?;
+        Ok(path)
     }
 
-    /// Creates the directory in which to store keys in and returns the path to it potentially
+    /// Creates the directory in which to store keys in and returns the path to it
     /// concatenated with a filename.
-    pub fn create_in_keys_dir<P: AsRef<OsStr>>(
-        &self,
-        subdir: Option<P>,
-        file: Option<P>,
-    ) -> Result<PathBuf> {
-        create_in_dir_method!(self, subdir, file, keys_dir, in_keys_dir)
+    pub fn create_in_keys_dir<P: AsRef<OsStr>>(&self, path: P) -> Result<PathBuf> {
+        self.create_keys_dir()?;
+        Ok(self.in_keys_dir(path))
     }
 
     /// Returns the path to the directory where to store logs.
@@ -170,22 +139,24 @@ impl WashAppStrategy {
 
     /// Concatenates a path in the logs directory.
     pub fn in_logs_dir<P: AsRef<std::ffi::OsStr>>(&self, path: P) -> PathBuf {
-        in_dir_method!(self, path, logs_dir)
+        let mut basepath = self.logs_dir();
+        basepath.push(Path::new(&path));
+        basepath
     }
 
     /// Creates the directory in which to store logs in and returns the path to it.
     pub fn create_logs_dir(&self) -> Result<PathBuf> {
-        create_dir_method!(self, logs_dir)
+        let path = self.logs_dir();
+        fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create directory `{}`", path.display()))?;
+        Ok(path)
     }
 
-    /// Creates the directory in which to store logs in and returns the path to it potentially
+    /// Creates the directory in which to store logs in and returns the path to it
     /// concatenated with a filename.
-    pub fn create_in_logs_dir<P: AsRef<OsStr>>(
-        &self,
-        subdir: Option<P>,
-        file: Option<P>,
-    ) -> Result<PathBuf> {
-        create_in_dir_method!(self, subdir, file, logs_dir, in_logs_dir)
+    pub fn create_in_logs_dir<P: AsRef<OsStr>>(&self, path: P) -> Result<PathBuf> {
+        self.create_logs_dir()?;
+        Ok(self.in_logs_dir(path))
     }
 
     /// Returns the path to the directory where to store downloads.
@@ -195,22 +166,24 @@ impl WashAppStrategy {
 
     /// Concatenates a path in the downloads directory.
     pub fn in_downloads_dir<P: AsRef<std::ffi::OsStr>>(&self, path: P) -> PathBuf {
-        in_dir_method!(self, path, downloads_dir)
+        let mut basepath = self.downloads_dir();
+        basepath.push(Path::new(&path));
+        basepath
     }
 
     /// Creates the directory in which to store downloads in and returns the path to it.
     pub fn create_downloads_dir(&self) -> Result<PathBuf> {
-        create_dir_method!(self, downloads_dir)
+        let path = self.downloads_dir();
+        fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create directory `{}`", path.display()))?;
+        Ok(path)
     }
 
-    /// Creates the directory in which to store downloads in and returns the path to it potentially
+    /// Creates the directory in which to store downloads in and returns the path to it
     /// concatenated with a filename.
-    pub fn create_in_downloads_dir<P: AsRef<OsStr>>(
-        &self,
-        subdir: Option<P>,
-        file: Option<P>,
-    ) -> Result<PathBuf> {
-        create_in_dir_method!(self, subdir, file, downloads_dir, in_downloads_dir)
+    pub fn create_in_downloads_dir<P: AsRef<OsStr>>(&self, path: P) -> Result<PathBuf> {
+        self.create_downloads_dir()?;
+        Ok(self.in_downloads_dir(path))
     }
 
     /// Returns the path to the directory where to store plugins.
@@ -220,22 +193,24 @@ impl WashAppStrategy {
 
     /// Concatenates a path in the plugins directory.
     pub fn in_plugins_dir<P: AsRef<std::ffi::OsStr>>(&self, path: P) -> PathBuf {
-        in_dir_method!(self, path, plugins_dir)
+        let mut basepath = self.plugins_dir();
+        basepath.push(Path::new(&path));
+        basepath
     }
 
     /// Creates the directory in which to store plugins in and returns the path to it.
     pub fn create_plugins_dir(&self) -> Result<PathBuf> {
-        create_dir_method!(self, plugins_dir)
+        let path = self.plugins_dir();
+        fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create directory `{}`", path.display()))?;
+        Ok(path)
     }
 
-    /// Creates the directory in which to store plugins in and returns the path to it potentially
+    /// Creates the directory in which to store plugins in and returns the path to it
     /// concatenated with a filename.
-    pub fn create_in_plugins_dir<P: AsRef<OsStr>>(
-        &self,
-        subdir: Option<P>,
-        file: Option<P>,
-    ) -> Result<PathBuf> {
-        create_in_dir_method!(self, subdir, file, plugins_dir, in_plugins_dir)
+    pub fn create_in_plugins_dir<P: AsRef<OsStr>>(&self, path: P) -> Result<PathBuf> {
+        self.create_plugins_dir()?;
+        Ok(self.in_plugins_dir(path))
     }
 
     /// Returns the path to the directory where to store the package cache.
@@ -246,22 +221,24 @@ impl WashAppStrategy {
 
     /// Concatenates a path in the package cache directory.
     pub fn in_package_cache_dir<P: AsRef<std::ffi::OsStr>>(&self, path: P) -> PathBuf {
-        in_dir_method!(self, path, package_cache_dir)
+        let mut basepath = self.package_cache_dir();
+        basepath.push(Path::new(&path));
+        basepath
     }
 
     /// Creates the directory in which to store cached packages in and returns the path to it.
     pub fn create_package_cache_dir(&self) -> Result<PathBuf> {
-        create_dir_method!(self, package_cache_dir)
+        let path = self.package_cache_dir();
+        fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create directory `{}`", path.display()))?;
+        Ok(path)
     }
 
     /// Creates the directory in which to store the package cache in and returns the path to it
-    /// potentially concatenated with a filename.
-    pub fn create_in_package_cache_dir<P: AsRef<OsStr>>(
-        &self,
-        subdir: Option<P>,
-        file: Option<P>,
-    ) -> Result<PathBuf> {
-        create_in_dir_method!(self, subdir, file, package_cache_dir, in_package_cache_dir)
+    /// concatenated with a filename.
+    pub fn create_in_package_cache_dir<P: AsRef<OsStr>>(&self, path: P) -> Result<PathBuf> {
+        self.create_package_cache_dir()?;
+        Ok(self.in_package_cache_dir(path))
     }
 
     /// Returns the path to the directory where to store the development stuff.
@@ -271,22 +248,24 @@ impl WashAppStrategy {
 
     /// Concatenates a path in the development directory.
     pub fn in_dev_dir<P: AsRef<std::ffi::OsStr>>(&self, path: P) -> PathBuf {
-        in_dir_method!(self, path, dev_dir)
+        let mut basepath = self.dev_dir();
+        basepath.push(Path::new(&path));
+        basepath
     }
 
     /// Creates the directory in which to store dev stuff in and returns the path to it.
     pub fn create_dev_dir(&self) -> Result<PathBuf> {
-        create_dir_method!(self, dev_dir)
+        let path = self.dev_dir();
+        fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create directory `{}`", path.display()))?;
+        Ok(path)
     }
 
-    /// Creates the directory in which to store dev in and returns the path to it potentially
+    /// Creates the directory in which to store dev in and returns the path to it
     /// concatenated with a filename.
-    pub fn create_in_dev_dir<P: AsRef<OsStr>>(
-        &self,
-        subdir: Option<P>,
-        file: Option<P>,
-    ) -> Result<PathBuf> {
-        create_in_dir_method!(self, subdir, file, dev_dir, in_dev_dir)
+    pub fn create_in_dev_dir<P: AsRef<OsStr>>(&self, path: P) -> Result<PathBuf> {
+        self.create_dev_dir()?;
+        Ok(self.in_dev_dir(path))
     }
 
     /// Returns the path to the directory where to store contexts.
@@ -296,22 +275,24 @@ impl WashAppStrategy {
 
     /// Concatenates a path in the context directory.
     pub fn in_context_dir<P: AsRef<std::ffi::OsStr>>(&self, path: P) -> PathBuf {
-        in_dir_method!(self, path, context_dir)
+        let mut basepath = self.context_dir();
+        basepath.push(Path::new(&path));
+        basepath
     }
 
     /// Creates the directory in which to store contexts in and returns the path to it.
     pub fn create_context_dir(&self) -> Result<PathBuf> {
-        create_dir_method!(self, context_dir)
+        let path = self.context_dir();
+        fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create directory `{}`", path.display()))?;
+        Ok(path)
     }
 
-    /// Creates the directory in which to store context in and returns the path to it potentially
+    /// Creates the directory in which to store context in and returns the path to it
     /// concatenated with a filename.
-    pub fn create_in_context_dir<P: AsRef<OsStr>>(
-        &self,
-        subdir: Option<P>,
-        file: Option<P>,
-    ) -> Result<PathBuf> {
-        create_in_dir_method!(self, subdir, file, context_dir, in_context_dir)
+    pub fn create_in_context_dir<P: AsRef<OsStr>>(&self, path: P) -> Result<PathBuf> {
+        self.create_context_dir()?;
+        Ok(self.in_context_dir(path))
     }
 }
 
@@ -335,12 +316,12 @@ fn replace_path<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
 
 /// The path to the running wasmCloud Host PID file for wash
 pub fn host_pid_file() -> Result<PathBuf> {
-    WASH_DIRECTORIES.create_in_downloads_dir(None, Some(WASMCLOUD_PID_FILE))
+    WASH_DIRECTORIES.create_in_downloads_dir(WASMCLOUD_PID_FILE)
 }
 
 /// The path to the running wadm PID file for wash
 pub fn wadm_pid_file() -> Result<PathBuf> {
-    WASH_DIRECTORIES.create_in_downloads_dir(None, Some(WADM_PID_FILE))
+    WASH_DIRECTORIES.create_in_downloads_dir(WADM_PID_FILE)
 }
 
 #[derive(Clone, Default)]

--- a/crates/wash/src/lib/config.rs
+++ b/crates/wash/src/lib/config.rs
@@ -29,7 +29,7 @@ pub static WASH_DIRECTORIES: Lazy<WashAppStrategy> = Lazy::new(|| {
         app_name: "wash".to_string(),
     };
 
-    let strategy = app_strategy::choose_app_strategy(args).unwrap();
+    let strategy = app_strategy::choose_app_strategy(args).expect("failed to get AppStrategy");
     #[cfg(target_os = "windows")]
     {
         WashAppStrategy::Windows(strategy)

--- a/crates/wash/src/lib/config.rs
+++ b/crates/wash/src/lib/config.rs
@@ -1,8 +1,11 @@
 //! Common config constants and functions for loading, finding, and consuming configuration data
-use std::{fs, path::PathBuf};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock as Lazy;
 
 use anyhow::{Context, Result};
 use async_nats::Client;
+use etcetera::{app_strategy, AppStrategy, AppStrategyArgs};
 use tokio::io::AsyncReadExt;
 use wasmcloud_control_interface::{Client as CtlClient, ClientBuilder as CtlClientBuilder};
 
@@ -23,11 +26,118 @@ pub const DEFAULT_COMPONENT_OPERATION_TIMEOUT_MS: u64 = 5_000;
 pub const DEFAULT_START_PROVIDER_TIMEOUT_MS: u64 = 60_000;
 pub const DEFAULT_CTX_DIR_NAME: &str = "contexts";
 
+pub static WASH_APP_STRATEGY: Lazy<WashAppStrategy> = Lazy::new(|| {
+    let args = AppStrategyArgs {
+        top_level_domain: "com".to_string(),
+        author: "wasmCloud".to_string(),
+        app_name: "wash".to_string(),
+    };
+
+    let strategy = app_strategy::choose_app_strategy(args).unwrap();
+    #[cfg(target_os = "windows")]
+    {
+        WashAppStrategy::Windows(strategy)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        WashAppStrategy::Xdg(strategy)
+    }
+});
+
+pub enum WashAppStrategy {
+    Xdg(app_strategy::Xdg),
+    Windows(app_strategy::Windows),
+}
+
+impl AppStrategy for WashAppStrategy {
+    fn home_dir(&self) -> &std::path::Path {
+        match self {
+            Self::Xdg(s) => s.home_dir(),
+            Self::Windows(s) => s.home_dir(),
+        }
+    }
+
+    fn config_dir(&self) -> PathBuf {
+        var_path("WASH_CONFIG_DIR").unwrap_or_else(|_| match self {
+            Self::Xdg(s) => s.config_dir(),
+            Self::Windows(s) => s.config_dir(),
+        })
+    }
+
+    fn data_dir(&self) -> PathBuf {
+        var_path("WASH_DATA_DIR").unwrap_or_else(|_| match self {
+            Self::Xdg(s) => s.data_dir(),
+            Self::Windows(s) => s.data_dir(),
+        })
+    }
+
+    fn cache_dir(&self) -> PathBuf {
+        var_path("WASH_CACHE_DIR").unwrap_or_else(|_| match self {
+            Self::Xdg(s) => s.cache_dir(),
+            Self::Windows(s) => s.cache_dir(),
+        })
+    }
+
+    fn state_dir(&self) -> Option<PathBuf> {
+        match self {
+            Self::Xdg(s) => s.state_dir(),
+            Self::Windows(s) => s.state_dir(),
+        }
+    }
+
+    fn runtime_dir(&self) -> Option<PathBuf> {
+        match self {
+            Self::Xdg(s) => s.runtime_dir(),
+            Self::Windows(s) => s.runtime_dir(),
+        }
+    }
+}
+
+pub static WASH_DOWNLOADS_DIR: Lazy<PathBuf> = Lazy::new(|| {
+    var_path("WASH_DOWNLOADS_DIR").unwrap_or_else(|_| WASH_APP_STRATEGY.in_data_dir("downloads"))
+});
+
+pub static WASH_LOGS_DIR: Lazy<PathBuf> = Lazy::new(|| {
+    var_path("WASH_LOGS_DIR").unwrap_or_else(|_| WASH_APP_STRATEGY.in_data_dir("logs"))
+});
+
+pub static WASH_KEYS_DIR: Lazy<PathBuf> = Lazy::new(|| {
+    var_path("WASH_KEYS_DIR").unwrap_or_else(|_| WASH_APP_STRATEGY.in_data_dir("keys"))
+});
+
+pub static WASH_PLUGINS_DIR: Lazy<PathBuf> = Lazy::new(|| {
+    var_path("WASH_PLUGINS_DIR").unwrap_or_else(|_| WASH_APP_STRATEGY.in_data_dir("plugins"))
+});
+
+pub static WASH_PACKAGE_CACHE_DIR: Lazy<PathBuf> = Lazy::new(|| {
+    var_path("WASH_PACKAGE_CACHE_DIR")
+        .unwrap_or_else(|_| WASH_APP_STRATEGY.in_cache_dir("package_cache"))
+});
+
+pub static WASH_DEV_DIR: Lazy<PathBuf> =
+    Lazy::new(|| var_path("WASH_DEV_DIR").unwrap_or_else(|_| WASH_APP_STRATEGY.in_data_dir("dev")));
+
+fn var_path(key: &str) -> Result<PathBuf> {
+    std::env::var_os(key)
+        .map(PathBuf::from)
+        .context("variable not found")
+        .and_then(replace_path)
+}
+
+fn replace_path<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
+    let path = path.as_ref();
+    Ok(match path.starts_with("~/") {
+        true => {
+            let home = etcetera::home_dir().context("no home directory found. Please set $HOME")?;
+            home.join(path.strip_prefix("~/").unwrap())
+        }
+        false => path.to_path_buf(),
+    })
+}
+
 /// Get the path to the `.wash` configuration directory. Creates the directory if it does not exist.
 pub fn cfg_dir() -> Result<PathBuf> {
-    let home = etcetera::home_dir().context("no home directory found. Please set $HOME")?;
-
-    let wash = home.join(WASH_DIR);
+    let wash = WASH_APP_STRATEGY.config_dir();
 
     if !wash.exists() {
         fs::create_dir_all(&wash)
@@ -37,24 +147,14 @@ pub fn cfg_dir() -> Result<PathBuf> {
     Ok(wash)
 }
 
-/// The path to the dev sessions directory for wash
-pub fn dev_dir() -> Result<PathBuf> {
-    Ok(cfg_dir()?.join(DEV_DIR))
-}
-
-/// The path to the downloads directory for wash
-pub fn downloads_dir() -> Result<PathBuf> {
-    Ok(cfg_dir()?.join(DOWNLOADS_DIR))
-}
-
 /// The path to the running wasmCloud Host PID file for wash
 pub fn host_pid_file() -> Result<PathBuf> {
-    Ok(downloads_dir()?.join(WASMCLOUD_PID_FILE))
+    Ok(WASH_DOWNLOADS_DIR.join(WASMCLOUD_PID_FILE))
 }
 
 /// The path to the running wadm PID file for wash
 pub fn wadm_pid_file() -> Result<PathBuf> {
-    Ok(downloads_dir()?.join(WADM_PID_FILE))
+    Ok(WASH_DOWNLOADS_DIR.join(WADM_PID_FILE))
 }
 
 #[derive(Clone, Default)]

--- a/crates/wash/src/lib/context/fs.rs
+++ b/crates/wash/src/lib/context/fs.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
-use crate::lib::config::{cfg_dir, DEFAULT_CTX_DIR_NAME};
+use crate::lib::config::WASH_DIRECTORIES;
 
 use super::{ContextManager, WashContext, HOST_CONFIG_NAME};
 
@@ -101,7 +101,7 @@ impl ContextDir {
 }
 
 fn default_context_dir() -> Result<PathBuf> {
-    Ok(cfg_dir()?.join(DEFAULT_CTX_DIR_NAME))
+    Ok(WASH_DIRECTORIES.context_dir())
 }
 
 fn initialize_context_dir(context_dir: &Path, default_path: &PathBuf) -> Result<()> {

--- a/crates/wash/src/lib/drain.rs
+++ b/crates/wash/src/lib/drain.rs
@@ -2,7 +2,7 @@
 
 use std::{env, fs, io::Result, path::PathBuf};
 
-use crate::lib::config;
+use crate::lib::config::WASH_DIRECTORIES;
 
 /// A type that allows you to clean up (i.e. drain) a set of caches and folders used by wasmcloud
 #[derive(Debug, Clone)]
@@ -29,12 +29,12 @@ impl IntoIterator for &Drain {
             Drain::All => vec![
                 /* Lib    */ env::temp_dir().join("wasmcloudcache"),
                 /* Oci    */ env::temp_dir().join("wasmcloud_ocicache"),
-                /* Downloads */ config::WASH_DOWNLOADS_DIR.to_path_buf(),
+                /* Downloads */ WASH_DIRECTORIES.downloads_dir(),
             ],
             Drain::Lib => vec![env::temp_dir().join("wasmcloudcache")],
             Drain::Oci => vec![env::temp_dir().join("wasmcloud_ocicache")],
-            Drain::Dev => vec![config::WASH_DEV_DIR.to_path_buf()],
-            Drain::Downloads => vec![config::WASH_DOWNLOADS_DIR.to_path_buf()],
+            Drain::Dev => vec![WASH_DIRECTORIES.dev_dir()],
+            Drain::Downloads => vec![WASH_DIRECTORIES.downloads_dir()],
         };
         paths.into_iter()
     }

--- a/crates/wash/src/lib/drain.rs
+++ b/crates/wash/src/lib/drain.rs
@@ -2,7 +2,7 @@
 
 use std::{env, fs, io::Result, path::PathBuf};
 
-use crate::lib::config::{dev_dir, downloads_dir};
+use crate::lib::config;
 
 /// A type that allows you to clean up (i.e. drain) a set of caches and folders used by wasmcloud
 #[derive(Debug, Clone)]
@@ -29,12 +29,12 @@ impl IntoIterator for &Drain {
             Drain::All => vec![
                 /* Lib    */ env::temp_dir().join("wasmcloudcache"),
                 /* Oci    */ env::temp_dir().join("wasmcloud_ocicache"),
-                /* Downloads */ downloads_dir().unwrap_or_default(),
+                /* Downloads */ config::WASH_DOWNLOADS_DIR.to_path_buf(),
             ],
             Drain::Lib => vec![env::temp_dir().join("wasmcloudcache")],
             Drain::Oci => vec![env::temp_dir().join("wasmcloud_ocicache")],
-            Drain::Dev => vec![dev_dir().unwrap_or_default()],
-            Drain::Downloads => vec![downloads_dir().unwrap_or_default()],
+            Drain::Dev => vec![config::WASH_DEV_DIR.to_path_buf()],
+            Drain::Downloads => vec![config::WASH_DOWNLOADS_DIR.to_path_buf()],
         };
         paths.into_iter()
     }

--- a/crates/wash/src/lib/plugin/mod.rs
+++ b/crates/wash/src/lib/plugin/mod.rs
@@ -3,9 +3,6 @@ use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
 
 pub mod subcommand;
 
-/// The directory where plugins are stored.
-pub const PLUGIN_DIR: &str = "plugins";
-
 struct Data {
     table: wasmtime::component::ResourceTable,
     ctx: WasiCtx,

--- a/crates/wash/tests/wash_up.rs
+++ b/crates/wash/tests/wash_up.rs
@@ -377,7 +377,7 @@ async fn integration_up_works_with_specific_wasmcloud_host_version() -> Result<(
 #[tokio::test]
 #[serial]
 async fn integration_up_works_with_specified_wadm_version() -> Result<()> {
-    use wash::lib::config::{DOWNLOADS_DIR, WASH_DIR};
+    use wash::lib::config::WASH_DIRECTORIES;
     use wash::lib::start::WADM_BINARY;
     // 0.12.0 is a sufficient version to test the latest is 0.12.2
     let previous_wadm_version = "v0.12.0";
@@ -387,8 +387,7 @@ async fn integration_up_works_with_specified_wadm_version() -> Result<()> {
     let wadm_path = instance
         .test_dir
         .path()
-        .join(WASH_DIR)
-        .join(DOWNLOADS_DIR)
+        .join(WASH_DIRECTORIES.downloads_dir())
         .join(WADM_BINARY)
         .canonicalize()
         .context("failed to canonicalize wadm binary path")?;

--- a/crates/wash/tests/wash_up.rs
+++ b/crates/wash/tests/wash_up.rs
@@ -2,6 +2,7 @@ use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
+use etcetera::AppStrategy;
 use regex::Regex;
 use semver::Version;
 use serial_test::serial;
@@ -384,10 +385,15 @@ async fn integration_up_works_with_specified_wadm_version() -> Result<()> {
 
     let instance =
         TestWashInstance::create_with_extra_args(["--wadm-version", previous_wadm_version]).await?;
+    let downloads_dir = WASH_DIRECTORIES.downloads_dir();
     let wadm_path = instance
         .test_dir
         .path()
-        .join(WASH_DIRECTORIES.downloads_dir())
+        .join(
+            downloads_dir
+                .strip_prefix(WASH_DIRECTORIES.home_dir())
+                .context("failed to remove home prefix of wash downloads directory")?,
+        )
         .join(WADM_BINARY)
         .canonicalize()
         .context("failed to canonicalize wadm binary path")?;


### PR DESCRIPTION
## Feature or Problem

The current implementation does not really respect best practices on where data should be stored (whether config data, cache data, runtime data, etc). This is an attempt to support best practices using XDG directories on Linux and Mac, and using the standard Windows scheme on Windows. This also slightly refactors the way these directories are accessed from other packages to simplify their usage.

Goal of this PR would be:

- Implement best practices.
- Keep possibility for configuring everything in a fine grained manner as described in the related story.
- Simplify handling on config directories, ensuring they are created upon use.
- Unify the handling of files in the configuration directories a little.

## Related Issues

- #4372

## Release Information

I guess next? This is on the Q2 Roadmap in status "Ready for Work".

## Consumer Impact

This might be a breaking change. With the default configuration, this would move the configuration directories away from `~/.wash` to several other directories:

- `~/.config/wash/`
- `~/.local/share/wash/`
- `~/.cache/wash/`

One can use the env vars described in the issue (`WASH_DOWNLOADS_DIR`, etc) to make `wash` behave as it did before (store everything in `~/.wash/`) but it won't do so by default.

I would very much appreciate a pointer here from the maintainers. Is this a big deal? Or are you fine with having this breaking change. I don't really see how this should be implemented without a breaking change to be honest.

## Testing

### Unit Test(s)

- Added a small unit test to validate that the precedence of env vars is respected.

### Acceptance or Integration

- Updated integration tests to use new directory structure.

### Manual Verification

#### Wash Dev Test

I cleared the `~/.wash` directory, and ran a `wash dev` on the http-jsonify example:

```
$ tree ~/.local/share/wash
/home/f4z3r/.local/share/wash
├── dev
│   ├── 7JdIHS
│   │   ├── nats.log
│   │   ├── wadm.log
│   │   └── wasmcloud.log
│   └── wash-dev-sessions.json
├── downloads
│   ├── nats.conf
│   ├── nats.pid
│   ├── nats-server
│   ├── v1.8.0
│   │   └── wasmcloud_host
│   ├── wadm
│   └── wadm.pid
├── keys
│   ├── f4z3r_account.nk
│   └── http_jsonify_module.nk
└── plugins

7 directories, 12 files

$ tree ~/.config/wash
/home/f4z3r/.config/wash

0 directories, 0 files

$ tree ~/.cache/wash
/home/f4z3r/.cache/wash
└── package_cache
    ├── sha256:5a568e6e2d60c1ce51220e1833cdd5b88db9f615720edc762a9b4a6f36b383bd
    ├── sha256:a1f129cdf1fde55ec2d4ae8d998c39a7e5cf7544a8bd84a831054ac0d2ac64dd
    ├── wasi:http-0.2.0.json
    └── wasi:http-0.2.2.json

2 directories, 4 files
```

#### Wash Up Test

I ran `wash up` to validate where contexts are being written:

```
$ tree ~/.config/wash
/home/f4z3r/.config/wash
└── contexts
    ├── default
    └── host_config.json

2 directories, 2 files
```

#### Test Support for Old Configuration

I wanted to test how easy it would be to keep the old structure:

```
$ rm -rf ~/.local/share/wash ~/.config/wash ~/.cache/wash ~/.wash
$ export WASH_DATA_DIR=~/.wash WASH_CONFIG_DIR=~/.wash WASH_CACHE_DIR=~/.wash
$ wash dev
$ wash up
$ tree ~/.config/wash
/home/f4z3r/.config/wash  [error opening dir]

0 directories, 0 files

$ tree ~/.cache/wash
/home/f4z3r/.cache/wash  [error opening dir]

0 directories, 0 files

$ tree ~/.local/share/wash
/home/f4z3r/.local/share/wash  [error opening dir]

0 directories, 0 files

$ tree ~/.wash
/home/f4z3r/.wash
├── contexts
│   ├── default
│   └── host_config.json
├── dev
│   ├── wash-dev-sessions.json
│   └── xoNnEE
│       ├── nats.log
│       ├── wadm.log
│       └── wasmcloud.log
├── downloads
│   ├── nats.conf
│   ├── nats.log
│   ├── nats.pid
│   ├── nats-server
│   ├── v1.8.0
│   │   └── wasmcloud_host
│   ├── wadm
│   └── wadm.log
├── keys
│   ├── f4z3r_account.nk
│   └── http_jsonify_module.nk
├── package_cache
│   ├── sha256:5a568e6e2d60c1ce51220e1833cdd5b88db9f615720edc762a9b4a6f36b383bd
│   └── wasi:http-0.2.0.json
└── plugins
```