### PR TITLE
ci(nix): switch from vault to vault-bin package to speed-up flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -157,7 +157,7 @@
                   pkgs.redis
                   pkgs.spire-agent
                   pkgs.spire-server
-                  pkgs.vault
+                  pkgs.vault-bin
 
                   pkgs.pkgsUnstable.nats-server
                 ];
@@ -653,7 +653,7 @@
               pkgs.skopeo
               pkgs.spire-agent
               pkgs.tinygo
-              pkgs.vault
+              pkgs.vault-bin
               pkgs.wit-deps
 
               pkgs.pkgsUnstable.go


### PR DESCRIPTION
## Feature or Problem

Using vault-bin instead of vault allows to skip compiling the entirety of Vault when evaluating the flake. This reduces the flake devShell initial evaluation by around 5 minutes with barely any downside (from locally compiling the binary).

## Consumer Impact

None.

## Testing

### Manual Verification

I test built stuff like `nix build .#keyvalue-vault-provider-oci`, but I am guessing the Vault binary is mostly used for integration testing. I don't think I can "test" this locally very well.
