### PR TITLE
fix(wash): pass host key seed to infer host id rather than read from log

### DIFF
--- a/crates/wash/src/cli/cmd/dev/mod.rs
+++ b/crates/wash/src/cli/cmd/dev/mod.rs
@@ -255,6 +255,7 @@ pub async fn handle_command(
     };
 
     // See if the host is running by retrieving an inventory
+    std::thread::sleep(std::time::Duration::from_secs(1));
     if let Err(_e) = ctl_client.get_host_inventory(&host_id).await {
         eprintln!(
             "{} Failed to retrieve inventory from host [{host_id}]... Exiting developer loop",

--- a/crates/wash/src/cli/cmd/dev/mod.rs
+++ b/crates/wash/src/cli/cmd/dev/mod.rs
@@ -518,7 +518,7 @@ pub async fn is_host_up(
         backoff: tokio::time::Duration,
     ) -> Result<()> {
         loop {
-            if let Ok(_) = ctl_client.get_host_inventory(host_id).await {
+            if (ctl_client.get_host_inventory(host_id).await).is_ok() {
                 break;
             }
             tokio::time::sleep(backoff).await;

--- a/crates/wash/src/cli/cmd/dev/session.rs
+++ b/crates/wash/src/cli/cmd/dev/session.rs
@@ -10,7 +10,6 @@ use console::style;
 use rand::{distr::Alphanumeric, Rng};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncBufReadExt as _;
 use tokio::process::Child;
 
 use crate::lib::config::downloads_dir;
@@ -341,7 +340,6 @@ impl WashDevSession {
             .into_std()
             .await
             .into();
-        let host_env = configure_host_env(wasmcloud_opts.clone()).await?;
 
         let (wasmcloud_child, host_id) = if let Some(host_id) = host_id {
             eprintln!(
@@ -354,6 +352,11 @@ impl WashDevSession {
             );
             (None, host_id.to_string())
         } else {
+            let key_server = nkeys::KeyPair::new_server();
+            let host_id = key_server.public_key();
+            wasmcloud_opts.host_seed =
+                Some(key_server.seed().expect("Should have a seed for the host"));
+            let host_env = configure_host_env(wasmcloud_opts.clone()).await?;
             let wasmcloud_child = match start_wasmcloud_host(
                 &wasmcloud_binary,
                 std::process::Stdio::null(),
@@ -379,16 +382,6 @@ impl WashDevSession {
                 }
             };
 
-            // Read the log until we get output that
-            let _wasmcloud_log_path = wasmcloud_log_path.clone();
-            let host_id = tokio::time::timeout(
-                tokio::time::Duration::from_secs(1),
-                get_host_id(_wasmcloud_log_path),
-            )
-            .await
-            .context("timeout expired while reading for Host ID in logs")?
-            .context("failed to retrieve host ID from logs")?;
-
             eprintln!(
                 "{} {}",
                 emoji::GREEN_CHECK,
@@ -405,57 +398,5 @@ impl WashDevSession {
         self.host_data = Some((host_id, wasmcloud_log_path));
 
         Ok((nats_child, wadm_child, wasmcloud_child))
-    }
-}
-
-async fn get_host_id(log_path: PathBuf) -> anyhow::Result<String> {
-    let log_file = tokio::fs::File::open(&log_path)
-        .await
-        .with_context(|| format!("failed to open log file @ [{}]", &log_path.display()))?;
-
-    // looks for the two variations of the log line containing the host_id:
-    //   JSON: "host_id":"ABC123"
-    //   LOG:  host_id="ABC123"
-    let re = regex::Regex::new(r#"(?:\"host_id\":\s?\"|host_id=\")([A-Z0-9]+)\""#)
-        .context("failed to compile regex")?;
-
-    let mut lines = tokio::io::BufReader::new(log_file).lines();
-    loop {
-        if let Some(line) = lines
-            .next_line()
-            .await
-            .context("failed to read line from file")?
-        {
-            // if there's no captures, this line doesn't contain the host_id, keep looking
-            if let Some(captures) = re.captures(&line) {
-                return Ok(captures
-                    .get(1)
-                    .context("failed to get capture group")?
-                    .as_str()
-                    .to_string());
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::NamedTempFile;
-
-    #[tokio::test]
-    async fn test_get_host_id_from_standard_logging_pattern() {
-        let log_path = NamedTempFile::new().unwrap().path().to_path_buf();
-        tokio::fs::write(&log_path, "2024-12-13T17:17:07.287574Z  INFO wasmcloud_host::wasmbus: wasmCloud host started host_id=\"ABC123\"").await.unwrap();
-        let host_id = get_host_id(log_path.clone()).await.unwrap();
-        assert_eq!(host_id, "ABC123");
-    }
-
-    #[tokio::test]
-    async fn test_get_host_id_from_structured_logging_pattern() {
-        let log_path = NamedTempFile::new().unwrap().path().to_path_buf();
-        tokio::fs::write(&log_path, "{{\"timestamp\":\"2024-12-12T01:43:53.749961Z\",\"level\":\"INFO\",\"fields\":{{\"message\":\"wasmCloud host started\",\"host_id\":\"DEF456\"}},\"target\":\"wasmcloud_host::wasmbus\",\"span\":{{\"name\":\"new\"}},\"spans\":[{{\"name\":\"new\"}}]}}").await.unwrap();
-        let host_id = get_host_id(log_path.clone()).await.unwrap();
-        assert_eq!(host_id, "DEF456");
     }
 }


### PR DESCRIPTION
## Feature or Problem

Wash reads the host ID from the hosts it starts with `dev` from the log file. This is not very nice. Instead, we are passing a key seed to infer the ID the host will use. This avoids having to go through logs.

## Related Issues

- #3823

## Consumer Impact

None

## Testing

### Unit Test(s)

- Removed the tests that checked the parsing of the logs.

### Acceptance or Integration

None

### Manual Verification

- Ran `wash dev` a couple of times. Validated that the ID in the logs matches the one inferred by the code (by additionally logging it to stdout).
