### PR TITLE
refactor(wash): remove duplicate constant for wadm.pid filename

### DIFF
--- a/crates/wash/src/cli/cmd/up.rs
+++ b/crates/wash/src/cli/cmd/up.rs
@@ -3,6 +3,7 @@ use crate::lib::cli::{CommandOutput, OutputKind};
 use crate::lib::common::{CommandGroupUsage, WASMCLOUD_HOST_VERSION_T};
 use crate::lib::config::{
     create_nats_client_from_opts, downloads_dir, host_pid_file, DEFAULT_NATS_TIMEOUT_MS,
+    WADM_PID_FILE,
 };
 use crate::lib::context::fs::ContextDir;
 use crate::lib::context::ContextManager;
@@ -12,7 +13,7 @@ use crate::lib::start::{
     new_patch_or_pre_1_0_0_minor_version_after_version_string, parse_version_string,
     start_nats_server, start_wadm, start_wasmcloud_host, NatsConfig, WadmConfig,
     GITHUB_WASMCLOUD_ORG, GITHUB_WASMCLOUD_WADM_REPO, GITHUB_WASMCLOUD_WASMCLOUD_REPO,
-    NATS_SERVER_BINARY, NATS_SERVER_CONF, WADM_PID,
+    NATS_SERVER_BINARY, NATS_SERVER_CONF,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use async_nats::Client;
@@ -1170,7 +1171,7 @@ pub(crate) async fn remove_wadm_pidfile<P>(install_dir: P) -> Result<()>
 where
     P: AsRef<Path>,
 {
-    if let Err(err) = tokio::fs::remove_file(install_dir.as_ref().join(WADM_PID)).await {
+    if let Err(err) = tokio::fs::remove_file(install_dir.as_ref().join(WADM_PID_FILE)).await {
         if err.kind() != ErrorKind::NotFound {
             bail!(err);
         }

--- a/crates/wash/src/lib/start/wadm.rs
+++ b/crates/wash/src/lib/start/wadm.rs
@@ -8,9 +8,9 @@ use tracing::warn;
 
 use super::download_binary_from_github;
 use crate::lib::common::CommandGroupUsage;
+use crate::lib::config::WADM_PID_FILE;
 
 const WADM_GITHUB_RELEASE_URL: &str = "https://github.com/wasmcloud/wadm/releases/download";
-pub const WADM_PID: &str = "wadm.pid";
 #[cfg(target_family = "unix")]
 pub const WADM_BINARY: &str = "wadm";
 #[cfg(target_family = "windows")]
@@ -190,7 +190,7 @@ where
         .id()
         .context("unexpectedly missing pid for spawned process")?;
 
-    let pid_path = state_dir.as_ref().join(WADM_PID);
+    let pid_path = state_dir.as_ref().join(WADM_PID_FILE);
     if let Err(e) = tokio::fs::write(pid_path, pid.to_string()).await {
         warn!("Couldn't write wadm pidfile: {e}");
     }

--- a/crates/wash/tests/start_wadm.rs
+++ b/crates/wash/tests/start_wadm.rs
@@ -1,5 +1,6 @@
 use wash::lib::common::CommandGroupUsage;
-use wash::lib::start::{ensure_wadm, start_wadm, WadmConfig, WADM_BINARY, WADM_PID};
+use wash::lib::config::WADM_PID_FILE;
+use wash::lib::start::{ensure_wadm, start_wadm, WadmConfig, WADM_BINARY};
 
 use anyhow::Result;
 use tempfile::tempdir;
@@ -56,7 +57,7 @@ async fn can_download_and_start_wadm() -> Result<()> {
 
     // Assert that the pid file get created in the expected state_dir,
     // which in this case is set to install_dir.
-    let pid_path = install_dir.path().join(WADM_PID);
+    let pid_path = install_dir.path().join(WADM_PID_FILE);
     assert!(tokio::fs::try_exists(pid_path).await?);
 
     // Different OS-es have different error codes, but all I care about is that wadm executed at all


### PR DESCRIPTION
## Feature or Problem

The `wadm.pid` constant was defined twice in the code. This PR removes one of the declarations and centralizes such declarations in the 'config' module.

## Related Issues

- Might create conflicts with #4558 as code changes are to similar locations.

## Consumer Impact

None