### PR TITLE
--nats replaces --rpc and --ctl with backward capability

### DIFF
--- a/examples/rust/components/messaging-image-processor-worker/src/processing.rs
+++ b/examples/rust/components/messaging-image-processor-worker/src/processing.rs
@@ -103,7 +103,7 @@ impl ImageProcessingRequest {
         };
 
         // Attempt to lease the task
-        let lease_id = match tasks::lease_task(&task_id, &String::from(WORKER_ID)) {
+        let lease_id = match tasks::lease_task(&task_id, WORKER_ID) {
             Ok(lid) => lid,
             Err(e) => {
                 log(


### PR DESCRIPTION
### Fixes [3327](https://github.com/wasmCloud/wasmCloud/issues/3327)