### PR TITLE
chore(runtime): Expose wasmtime linker

### DIFF
--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -54,10 +54,14 @@ use url::Url;
 use wascap::jwt;
 use wasmcloud_core::{OciFetcher, RegistryConfig};
 
+/// A reference to a resource, either a file, an OCI image, or a builtin provider
 #[derive(PartialEq)]
-enum ResourceRef<'a> {
+pub enum ResourceRef<'a> {
+    /// A file reference
     File(PathBuf),
+    /// An OCI reference
     Oci(&'a str),
+    /// A builtin provider reference
     Builtin(&'a str),
 }
 


### PR DESCRIPTION
Exposes wasmtime linker & context object so host authors can bring their own WIT interfaces without going through wrpc.
Also changing visibility on ResourceRef as it provides differentiation between local,remote, and built-in artifacts.