### PR TITLE
ci: ignore unspecified paths-filter paths

### DIFF
--- a/.github/actions/install-cached-wash-cli/action.yml
+++ b/.github/actions/install-cached-wash-cli/action.yml
@@ -19,6 +19,7 @@ runs:
             - '!brand/**'
             - '!examples/**'
             - '!**/*.md'
+            - '!**'  # Exclude everything else not already matched above
 
     - name: Set wash revision to build/cache
       id: base-ref

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -13,8 +13,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0         # Don't waste time writing out incremental build files
-  CARGO_PROFILE_TEST_DEBUG: 0  # These are thrown away anyways, don't produce them
+  CARGO_INCREMENTAL: 0 # Don't waste time writing out incremental build files
+  CARGO_PROFILE_TEST_DEBUG: 0 # These are thrown away anyways, don't produce them
   GO_VERSION: '1.24.1'
   TINYGO_VERSION: '0.36.0'
 
@@ -43,8 +43,6 @@ jobs:
               - 'crates/secrets-types/**'
               - 'crates/tracing/**'
               - 'crates/wash/**'
-              - '!crates/**/*.md'
-              - '!crates/wash/.devcontainer'
       - name: Changed files
         run: |
           echo "Changed file(s) (${{ steps.changes.outputs.changed_count }})"

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -104,7 +104,7 @@ jobs:
         id: changes
         with:
           # Consider wasmCloud changed if any Rust file other than
-          # capability providers change
+          # capability providers or wash change
           #
           # Somewhat naive assumption that providers will be under `crates/provider-<interface>-<vendor>`
           # as that is our naming convention for providers.
@@ -121,12 +121,10 @@ jobs:
               - 'Cargo.lock'
               - 'Cargo.toml'
               - 'rust-toolchain.toml'
-              - 'crates/**/*.{rs,toml,wit}'
+              - 'crates/!(wash|provider-*)/**/*.{rs,toml,wit}'
               - 'src/**/*.{rs,toml,wit}'
               - 'tests/**/*.{rs,toml,wit}'
               - 'wit/**/*.wit'
-              - '!crates/provider-*/**'
-              - '!crates/wash/**'
             providers:
               - './.github/actions/build-nix/action.yml'
               - './.github/actions/install-nix/action.yml'
@@ -138,7 +136,6 @@ jobs:
               - 'flake.lock'
               - 'flake.nix'
               - 'rust-toolchain.toml'
-              - '!crates/**/*.md'
   build-wash-bin:
     needs: [meta]
     if: ${{ needs.meta.outputs.wasmcloud_modified == 'true' || startsWith(github.ref, 'refs/tags/wash-v')  || startswith(github.ref, 'refs/tags/provider-') }}


### PR DESCRIPTION
## Feature or Problem
Turns out, if you write exclusion rules, you HAVE to include `matches: all` or else the `!` rule will actually match on all the things.

I tested this out in my fork to confirm https://github.com/brooksmtownsend/wasmCloud/actions/runs/15909932422/job/44874450038?pr=21

This PR will trigger both wash and wasmCloud since the actions change but in later PRs it will be improved.

## Related Issues
Resolves https://github.com/wasmCloud/wasmCloud/issues/4600

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
