### PR TITLE
feat(sqldb-postgres): support connection pool sharing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9329,6 +9329,7 @@ dependencies = [
  "postgres-types",
  "rustls 0.23.26",
  "serde_json",
+ "sha2",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",

--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -26,6 +26,7 @@ postgres-types = { workspace = true, features = [ "with-cidr-0_2" ] }
 rustls = { workspace = true }
 webpki-roots = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = { workspace = true, features = [ "runtime", "with-serde_json-1", "with-chrono-0_4", "with-uuid-0_8", "with-geo-types-0_7", "array-impls", "with-bit-vec-0_6", "with-uuid-1" ]  }
 tokio-postgres-rustls = { workspace = true }

--- a/crates/provider-sqldb-postgres/README.md
+++ b/crates/provider-sqldb-postgres/README.md
@@ -105,6 +105,7 @@ New named configuration can be specified by using `wash config put`.
 | `POSTGRES_DATABASE`     | `postgres`  | Postgres cluster database                                                                                                                                           |
 | `POSTGRES_TLS_REQUIRED` | `false`     | Whether TLS should be required for all managed connections                                                                                                          |
 | `POSTGRES_POOL_SIZE`    | `12`        | Maximum size of the connection pool (configures [max_size](https://docs.rs/deadpool-postgres/0.14.1/deadpool_postgres/struct.PoolConfig.html#structfield.max_size)) |
+| `POSTGRES_SHARE_CONNECTIONS_BY_URL` | `false` | Whether connection pools should be shared for identical connections |
 
 Once named configuration with the keys above is created, it can be referenced as `target_config` for a link to this provider.
 


### PR DESCRIPTION
## Feature or Problem
This PR allows folks who aren't already using a server-side load balancing framework like PgBouncer to do some connection pool sharing at the provider layer.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next minor provider-sqldb-postgres

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
