### PR TITLE
feat(ci): Starts process of moving release pipelines away from Nix

### DIFF
--- a/.github/workflows/release-and-build.yml
+++ b/.github/workflows/release-and-build.yml
@@ -1,0 +1,199 @@
+# NOTE: This is the in-progress new release flow for wasmCloud that replaces the old Nix based
+# release flow.
+name: wasmCloud Release
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v[0-9].[0-9]+.[0-9]+'
+      - 'v[0-9].[0-9]+.[0-9]+-*'
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: build release assets
+    runs-on: ${{ matrix.config.runnerOs }}
+    outputs:
+      version_output: ${{ steps.version_output.outputs.version }}
+    strategy:
+      matrix:
+        config:
+          - {
+              runnerOs: 'ubuntu-latest',
+              buildCommand: 'cargo zigbuild',
+              target: 'x86_64-unknown-linux-musl',
+              uploadArtifactSuffix: 'linux-amd64',
+              buildOutputPath: 'target/x86_64-unknown-linux-musl/release/wasmcloud',
+            }
+          - {
+              runnerOs: 'ubuntu-latest',
+              buildCommand: 'cargo zigbuild',
+              target: 'aarch64-unknown-linux-musl',
+              uploadArtifactSuffix: 'linux-aarch64',
+              buildOutputPath: 'target/aarch64-unknown-linux-musl/release/wasmcloud',
+            }
+          - {
+              runnerOs: 'macos-latest',
+              buildCommand: 'cargo build',
+              target: 'x86_64-apple-darwin',
+              uploadArtifactSuffix: 'macos-amd64',
+              buildOutputPath: 'target/x86_64-apple-darwin/release/wasmcloud',
+            }
+          - {
+              runnerOs: 'macos-latest',
+              buildCommand: 'cargo build',
+              target: 'aarch64-apple-darwin',
+              uploadArtifactSuffix: 'macos-aarch64',
+              buildOutputPath: 'target/aarch64-apple-darwin/release/wasmcloud',
+            }
+          - {
+              runnerOs: 'windows-latest',
+              buildCommand: 'cargo build',
+              target: 'x86_64-pc-windows-msvc',
+              uploadArtifactSuffix: 'windows-amd64',
+              buildOutputPath: 'target/x86_64-pc-windows-msvc/release/wasmcloud.exe',
+            }
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: set the release version (tag)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: set the release version (main)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
+
+      - name: Output Version
+        id: version_output
+        run: echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Install Zig
+        if: ${{ contains(matrix.config.buildCommand, 'zigbuild') }}
+        uses: mlugg/setup-zig@7dccf5e6d09267c55f815f2db29495f30ba2ebca # v2.0.1
+        with:
+          version: 0.14.1
+
+      - name: Install latest Rust stable toolchain
+        uses: dtolnay/rust-toolchain@1ff72ee08e3cb84d84adba594e0a297990fc1ed3 # stable
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+          target: ${{ matrix.config.target }}
+
+      - name: Install cargo zigbuild
+        if: ${{ contains(matrix.config.buildCommand, 'zigbuild') }}
+        uses: taiki-e/install-action@cfe1303741c2e620e5f7daa667105e0da1316db9 # v2.53.0
+        with:
+          tool: cargo-zigbuild
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+
+      - name: Build wasmcloud
+        run: |
+          ${{ matrix.config.buildCommand }} --release --bin wasmcloud --target ${{ matrix.config.target }}
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: wasmcloud-${{ env.RELEASE_VERSION }}-${{ matrix.config.uploadArtifactSuffix }}
+          if-no-files-found: error
+          path: |
+            ${{ matrix.config.buildOutputPath }}
+
+  # TODO: Add the publish step for crate and GH release from the old workflow when we're ready
+
+  docker-image:
+    name: Build and push docker images
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RELEASE_VERSION: ${{ needs.build.outputs.version_output }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ./artifacts
+          pattern: '*linux*'
+
+      - name: Prepare container artifacts
+        working-directory: ./artifacts
+        run: |
+          for dir in */; do
+            name="${dir%/}"
+            mv "${name}/wasmcloud" wasmcloud
+            chmod +x wasmcloud
+            rmdir "${name}"
+            mv wasmcloud "${name}"
+          done
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_PUSH_USER }}
+          password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
+
+      - name: lowercase repository owner
+        run: |
+          echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
+      - name: Set the formatted release version for the docker tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          echo "RELEASE_VERSION_DOCKER_TAG=${RELEASE_VERSION#v}" >> $GITHUB_ENV
+
+      - name: Build and push (tag)
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          context: ./
+          build-args: |
+            BIN_ARM64=./artifacts/wasmcloud-${{ env.RELEASE_VERSION }}-linux-aarch64
+            BIN_AMD64=./artifacts/wasmcloud-${{ env.RELEASE_VERSION }}-linux-amd64
+          tags: |
+            ghcr.io/${{ env.OWNER }}/wasmcloud:latest
+            ghcr.io/${{ env.OWNER }}/wasmcloud:${{ env.RELEASE_VERSION_DOCKER_TAG }}
+            ${{ env.OWNER }}/wasmcloud:latest
+            ${{ env.OWNER }}/wasmcloud:${{ env.RELEASE_VERSION_DOCKER_TAG }}
+
+      - name: Build and push (main)
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        # if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          context: ./
+          build-args: |
+            BIN_ARM64=./artifacts/wasmcloud-${{ env.RELEASE_VERSION }}-linux-aarch64
+            BIN_AMD64=./artifacts/wasmcloud-${{ env.RELEASE_VERSION }}-linux-amd64
+          tags: |
+            ghcr.io/${{ env.OWNER }}/wasmcloud:canary
+            ${{ env.OWNER }}/wasmcloud:canary

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -214,17 +214,14 @@ jobs:
             test-bin: |
               nix profile install --fallback --inputs-from . 'nixpkgs-unstable#qemu'
               qemu-aarch64 ./result/bin/wasmcloud --version
-            test-oci: docker load < ./result
 
           - target: aarch64-apple-darwin
             test-bin: |
               file ./result/bin/wasmcloud
-            test-oci: docker load < ./result
 
           - target: aarch64-linux-android
             test-bin: |
               file ./result/bin/wasmcloud
-            test-oci: docker load < ./result
 
           - target: riscv64gc-unknown-linux-gnu-fhs
             test-bin: |
@@ -234,20 +231,15 @@ jobs:
           - target: x86_64-apple-darwin
             test-bin: |
               file ./result/bin/wasmcloud
-            test-oci: docker load < ./result
 
           - target: x86_64-pc-windows-gnu
             test-bin: |
               nix profile install --fallback --inputs-from . 'nixpkgs-unstable#wine64'
               wine64 ./result/bin/wasmcloud.exe --version
-            test-oci: docker load < ./result
 
           - target: x86_64-unknown-linux-musl
             test-bin: |
               ./result/bin/wasmcloud --version
-            test-oci: |
-              docker load < ./result
-              docker run --rm wasmcloud:$(nix eval --raw .#wasmcloud-x86_64-unknown-linux-musl-oci.imageTag) wasmcloud --version
 
     name: wasmcloud-${{ matrix.config.target }}
     runs-on: ubuntu-24.04
@@ -262,12 +254,6 @@ jobs:
         with:
           package: wasmcloud-${{ matrix.config.target }}
       - run: ${{ matrix.config.test-bin }}
-      - uses: ./.github/actions/build-nix
-        if: ${{ !endsWith(matrix.config.target, 'fhs') }}
-        with:
-          package: wasmcloud-${{ matrix.config.target }}-oci
-      - run: ${{ matrix.config.test-oci }}
-        if: ${{ !endsWith(matrix.config.target, 'fhs') }}
 
   build-provider-bin:
     needs: [meta]
@@ -461,20 +447,6 @@ jobs:
           name: wasmcloud-aarch64-unknown-linux-musl
       - run: chmod +x ./bin/wasmcloud
       - run: ./bin/wasmcloud --version
-
-  test-wasmcloud-linux-aarch64-oci:
-    runs-on: ubuntu-24.04-arm
-    needs: build-wasmcloud-bin
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: ./.github/actions/install-nix
-        with:
-          cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: wasmcloud-aarch64-unknown-linux-musl-oci
-      - run: docker load < ./wasmcloud-aarch64-unknown-linux-musl-oci
-      - run: docker run --rm wasmcloud:$(nix eval --raw .#wasmcloud-aarch64-unknown-linux-musl-oci.imageTag) wasmcloud --version
 
   test-wasmcloud-linux-x86_64:
     runs-on: ubuntu-24.04
@@ -737,23 +709,6 @@ jobs:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       DOCKERHUB_PUSH_USER: ${{ secrets.DOCKERHUB_PUSH_USER }}
       DOCKERHUB_PUSH_PASSWORD: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
-  oci-wasmcloud:
-    needs:
-      - build-wasmcloud-bin
-      - test-wasmcloud-linux-aarch64
-      - test-wasmcloud-linux-aarch64-oci
-      - test-wasmcloud-linux-x86_64
-    uses: ./.github/workflows/oci.yml
-    permissions:
-      contents: read
-      packages: write
-    with:
-      bin: wasmcloud
-      prefix: ''
-    secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      DOCKERHUB_PUSH_USER: ${{ secrets.DOCKERHUB_PUSH_USER }}
-      DOCKERHUB_PUSH_PASSWORD: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
 
   release-wasmcloud:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -763,9 +718,7 @@ jobs:
       - build-wasmcloud-lipo
       - cargo
       - cargo-nextest
-      - oci-wasmcloud
       - test-wasmcloud-linux-aarch64
-      - test-wasmcloud-linux-aarch64-oci
       - test-wasmcloud-linux-x86_64
       - test-wasmcloud-macos-aarch64
       - test-wasmcloud-macos-x86_64
@@ -1094,7 +1047,6 @@ jobs:
       - providers
       - deploy-doc
       - oci-wash
-      - oci-wasmcloud
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -1122,7 +1074,6 @@ jobs:
           echo 'needs.providers.result: ${{ needs.providers.result }}'
           echo 'needs.deploy-doc.result: ${{ needs.deploy-doc.result }}'
           echo 'needs.oci-wash.result: ${{ needs.oci-wash.result }}'
-          echo 'needs.oci-wasmcloud.result: ${{ needs.oci-wasmcloud.result }}'
       - name: Verify jobs
         # All jobs must succeed or be skipped.
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM cgr.dev/chainguard/wolfi-base:latest AS base
+
+FROM base AS base-amd64
+ARG BIN_AMD64
+ARG BIN=$BIN_AMD64
+
+FROM base AS base-arm64
+ARG BIN_ARM64
+ARG BIN=$BIN_ARM64
+
+FROM base-$TARGETARCH
+
+# Copy application binary from disk
+COPY ${BIN} /usr/local/bin/wasmcloud
+
+# Run the application
+ENTRYPOINT ["/usr/local/bin/wasmcloud"]


### PR DESCRIPTION
This starts by adding a Dockerfile that can be used to build the image with the given binary. I started by copying what we had in wadm and adjusted from there. We can slowly migrate things over, but this removes the image build step from the nix build for now.

Please note that this gets rid of our debian only builds in favor of the wolfi images only. They have been our default for a while now. If desired, we can still publish a `-wolfi` suffixed tag if we want to. This pipeline constantly overwrites a canary tag rather than continuously adding sha tagged versions as well