### PR TITLE
feat(wash): add dashboard option for dev

### DIFF
--- a/crates/wash/CHANGELOG.md
+++ b/crates/wash/CHANGELOG.md
@@ -68,7 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    the generated link (and related config properties).
  - <csr-id-cd5c01bffa2f5f3ad73b3ab4629d7e06df47daee/> add wadm_component_name alias for manifest targeting
 - <csr-id-0a5d216b6a264bf4c4a9c56b304511561c3fd25a/> check for semver compatible versions of tools
-- add optional `--dashboard` flag for `wash dev` to automatically serve washboard
 
 ### Bug Fixes
 

--- a/crates/wash/CHANGELOG.md
+++ b/crates/wash/CHANGELOG.md
@@ -67,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    This code enables setting `link_config` on an override, which modifies
    the generated link (and related config properties).
  - <csr-id-cd5c01bffa2f5f3ad73b3ab4629d7e06df47daee/> add wadm_component_name alias for manifest targeting
- - <csr-id-0a5d216b6a264bf4c4a9c56b304511561c3fd25a/> check for semver compatible versions of tools
+- <csr-id-0a5d216b6a264bf4c4a9c56b304511561c3fd25a/> check for semver compatible versions of tools
+- add optional `--dashboard` flag for `wash dev` to automatically serve washboard
 
 ### Bug Fixes
 

--- a/crates/wash/CHANGELOG.md
+++ b/crates/wash/CHANGELOG.md
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    This code enables setting `link_config` on an override, which modifies
    the generated link (and related config properties).
  - <csr-id-cd5c01bffa2f5f3ad73b3ab4629d7e06df47daee/> add wadm_component_name alias for manifest targeting
-- <csr-id-0a5d216b6a264bf4c4a9c56b304511561c3fd25a/> check for semver compatible versions of tools
+ - <csr-id-0a5d216b6a264bf4c4a9c56b304511561c3fd25a/> check for semver compatible versions of tools
 
 ### Bug Fixes
 

--- a/crates/wash/tests/wash_dev.rs
+++ b/crates/wash/tests/wash_dev.rs
@@ -54,7 +54,7 @@ async fn integration_dev_hello_component_serial() -> Result<()> {
     let dev_cmd = Arc::new(RwLock::new(
         test_setup
             .base_command()
-            .env("WASH_DEV_DASHBOARD_PORT", ui_port.to_string())
+            .env("WASMCLOUD_WASH_UI_PORT", ui_port.to_string())
             .args([
                 "dev",
                 "--nats-connect-only",


### PR DESCRIPTION
## Feature or Problem
This PR adds a --dashboard flag to the wash dev command to enable running washboard (the web UI) alongside the application during local development. This addresses feedback that wash dev should provide a complete "inner development loop" experience including the visual dashboard interface.

## Related Issues
Fixes #4129 - wash dev should have an option for standing up washboard (wash ui)

## Release Information
_

## Consumer Impact
This change is additive and backward compatible. Existing users of wash dev will experience no changes to their workflow unless they opt-in to the new `--dashboard` flag or set the `WASH_DEV_DASHBOARD` environment variable. The impact is minimal as it only adds optional functionality without modifying existing behavior.

## Testing
### Unit Test(s)
<!---
N/A
--->

### Acceptance or Integration
Added integration test to verify that the UI spins up correctly when the --dashboard flag is used.

### Manual Verification
- Ran `cargo run -- dev -d ./..Projects/wasm-cloud-hello --dashboard` to verify the dashboard starts alongside the development environment against a local project
- Verified the dashboard is accessible via the web interface
- Tested the `WASH_DEV_DASHBOARD` environment variable to ensure it enables the dashboard by default
- Confirmed existing wash dev functionality remains unchanged when the flag is not used
- Verified the integration test passes and correctly validates UI startup
