### PR TITLE
chore: update wit-bindgen in rust examples

### DIFF
--- a/examples/rust/components/dog-fetcher/Cargo.toml
+++ b/examples/rust/components/dog-fetcher/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 wasi = "0.13.2"
-wit-bindgen = "0.32"
+wit-bindgen = "0.43"

--- a/examples/rust/components/echo-messaging-0-3-0/Cargo.toml
+++ b/examples/rust/components/echo-messaging-0-3-0/Cargo.toml
@@ -9,4 +9,4 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "0.32"
+wit-bindgen = "0.43"

--- a/examples/rust/components/echo-messaging/Cargo.toml
+++ b/examples/rust/components/echo-messaging/Cargo.toml
@@ -9,4 +9,4 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "0.32"
+wit-bindgen = "0.43"

--- a/examples/rust/components/ferris-says/Cargo.toml
+++ b/examples/rust/components/ferris-says/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 [dependencies]
 ferris-says = "0.3.1"
 humantime = "2.1"
-wit-bindgen = "0.32"
+wit-bindgen = "0.43"

--- a/examples/rust/components/http-blobstore/Cargo.toml
+++ b/examples/rust/components/http-blobstore/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "0.32"
+wit-bindgen = "0.43"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"

--- a/examples/rust/components/http-jsonify/Cargo.toml
+++ b/examples/rust/components/http-jsonify/Cargo.toml
@@ -18,4 +18,4 @@ crate-type = [ "cdylib" ]
 [dependencies]
 anyhow = "1"
 serde_json = "1"
-wit-bindgen = "0.32"
+wit-bindgen = "0.43"

--- a/examples/rust/components/keyvalue-messaging/Cargo.toml
+++ b/examples/rust/components/keyvalue-messaging/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "0.32"
+wit-bindgen = "0.43"
 
 [profile.release]
 # Optimize for small code size

--- a/examples/rust/components/sqldb-postgres-query/Cargo.toml
+++ b/examples/rust/components/sqldb-postgres-query/Cargo.toml
@@ -12,4 +12,4 @@ An example component that performs queries with the wasmcloud-sqldb-postgres pro
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "0.32"
+wit-bindgen = "0.43"

--- a/examples/rust/components/wadm-status-receiver/Cargo.toml
+++ b/examples/rust/components/wadm-status-receiver/Cargo.toml
@@ -12,4 +12,4 @@ An example component that is triggered upon a status update of an application in
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "0.32"
+wit-bindgen = "0.43"

--- a/examples/rust/components/wash-plugin-rust/Cargo.toml
+++ b/examples/rust/components/wash-plugin-rust/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-wit-bindgen = "0.32"
+wit-bindgen = "0.43"


### PR DESCRIPTION
## Feature or Problem
This PR updates the wit-bindgen version in examples which was causing some pointer misalignment issues.

## Related Issues
Fixes #3894

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
