### PR TITLE
fix(host): start provider from file by CLI

### DIFF
--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -86,7 +86,7 @@ impl<'a> TryFrom<&'a str> for ResourceRef<'a> {
                 match url.scheme() {
                     "file" => url
                         .to_file_path()
-                        .map(|path| Self::File(path))
+                        .map(Self::File)
                         .map_err(|()| anyhow!("failed to convert `{url}` to a file path")),
                     "oci" => {
                         // Note: oci is not a scheme, but using this as a prefix takes out the guesswork

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -70,7 +70,7 @@ impl AsRef<str> for ResourceRef<'_> {
         match self {
             // Resource ref must have originated from a URL, which can only be constructed from a
             // valid string
-            ResourceRef::File(url, _) => &url,
+            ResourceRef::File(url, _) => url,
             ResourceRef::Oci(s) => s,
             ResourceRef::Builtin(s) => s,
         }

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -58,7 +58,7 @@ use wasmcloud_core::{OciFetcher, RegistryConfig};
 #[derive(PartialEq)]
 pub enum ResourceRef<'a> {
     /// A file reference
-    File(String, PathBuf),
+    File(PathBuf),
     /// An OCI reference
     Oci(&'a str),
     /// A builtin provider reference
@@ -70,7 +70,7 @@ impl AsRef<str> for ResourceRef<'_> {
         match self {
             // Resource ref must have originated from a URL, which can only be constructed from a
             // valid string
-            ResourceRef::File(url, _) => url,
+            ResourceRef::File(path) => path.to_str().expect("invalid file reference URL"),
             ResourceRef::Oci(s) => s,
             ResourceRef::Builtin(s) => s,
         }
@@ -86,7 +86,7 @@ impl<'a> TryFrom<&'a str> for ResourceRef<'a> {
                 match url.scheme() {
                     "file" => url
                         .to_file_path()
-                        .map(|path| Self::File(s.to_string(), path))
+                        .map(|path| Self::File(path))
                         .map_err(|()| anyhow!("failed to convert `{url}` to a file path")),
                     "oci" => {
                         // Note: oci is not a scheme, but using this as a prefix takes out the guesswork
@@ -127,7 +127,7 @@ impl<'a> TryFrom<&'a str> for ResourceRef<'a> {
 impl ResourceRef<'_> {
     fn authority(&self) -> Option<&str> {
         match self {
-            ResourceRef::File(_, _) => None,
+            ResourceRef::File(_) => None,
             ResourceRef::Oci(s) => {
                 let (l, _) = s.split_once('/')?;
                 Some(l)
@@ -146,7 +146,7 @@ pub async fn fetch_component(
     registry_config: &HashMap<String, RegistryConfig>,
 ) -> anyhow::Result<Vec<u8>> {
     match ResourceRef::try_from(component_ref)? {
-        ResourceRef::File(_, component_ref) => {
+        ResourceRef::File(component_ref) => {
             ensure!(
                 allow_file_load,
                 "unable to start component from file, file loading is disabled"
@@ -180,7 +180,7 @@ pub(crate) async fn fetch_provider(
     registry_config: &HashMap<String, RegistryConfig>,
 ) -> anyhow::Result<(PathBuf, Option<jwt::Token<jwt::CapabilityProvider>>)> {
     match provider_ref {
-        ResourceRef::File(_, provider_path) => {
+        ResourceRef::File(provider_path) => {
             ensure!(
                 allow_file_load,
                 "unable to start provider from file, file loading is disabled"
@@ -215,7 +215,7 @@ fn parse_references() -> anyhow::Result<()> {
     let file_url = "file:///tmp/foo_s.wasm";
     ensure!(
         ResourceRef::try_from(file_url).expect("failed to parse")
-            == ResourceRef::File("file:///tmp/foo_s.wasm".into(), "/tmp/foo_s.wasm".into()),
+            == ResourceRef::File("/tmp/foo_s.wasm".into()),
         "file reference should be parsed as file and converted to path"
     );
 

--- a/crates/wash/src/lib/wait.rs
+++ b/crates/wash/src/lib/wait.rs
@@ -197,8 +197,11 @@ pub async fn wait_for_provider_start_event(
         match cloud_event.event_type.as_str() {
             "com.wasmcloud.lattice.provider_started" => {
                 let image_ref = get_string_data_from_json(&cloud_event.data, "image_ref")?;
+                let stripped_provider_ref = provider_ref
+                    .strip_prefix("file://")
+                    .unwrap_or(&provider_ref);
 
-                if image_ref == provider_ref {
+                if image_ref == stripped_provider_ref {
                     let provider_id = get_string_data_from_json(&cloud_event.data, "provider_id")?;
 
                     return Ok(EventCheckOutcome::Success(ProviderStartedInfo {


### PR DESCRIPTION
## Feature or Problem
Incorrect `provider_ref` was sent to `provider_started` event if it was a file.

## Related Issues
Closes #4645 

## Consumer Impact
None

## Testing

### Unit Test(s)
`parse_references` was modified in `crates/host/src/lib.rs:212`

### Acceptance or Integration

### Manual Verification

Now it works successfully
```
wash start provider ./bin_ollama_provider.par.gz my-id --host-id NC645VOKJPRD23O7LZH5RFTWP3TRWAXVHY5TUJZW3MXKX5OEJEMKRCL4

Provider [my-id] (ref: [file:///home/pagafonov/projects/kuber-boring/components/ollama_provider/build/bin_ollama_provider.par.gz]) started on host [NC645VOKJPRD23O7LZH5RFTWP3TRWAXVHY5TUJZW3MXKX5OEJEMKRCL4]
```
