### PR TITLE
chore(CONTRIBUTING): update to suggest wasmcloud/contrib

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,10 @@ to help get your contribution accepted.
 In general, most repos in the wasmCloud project have linters and other coding standards to follow.
 Those standards should be followed when you contribute your code.
 
+## How to contribute a project
+
+If you're looking to a contribute a project to wasmCloud, please refer to the [wasmcloud/contrib](https://github.com/wasmCloud/contrib) repository. This repository is where community capability providers, reusable components and experiments can be contributed and maintained without being subject to the lifecycle of the main project. If your project requires (or strongly benefits from) its own repository in the wasmCloud organization, please file an issue in the [wasmcloud/contrib](https://github.com/wasmCloud/contrib/issues/new) repository and the maintainers can determine how to best accept your contribution.
+
 ## Pull Requests
 
 Like any good open source project, we use Pull Requests (PRs) to track code changes.


### PR DESCRIPTION
## Feature or Problem
After seeing such an awesome contribution in things like https://github.com/wasmCloud/wasmCloud/issues/4674, #4061 , etc, it's becoming apparent that we need to organize where we're accepting newer community contributions, especially capability providers.

In our previous roadmapping session we called out the difficulty of maintaining multiple capability providers and projects in this repository, and noted that a possible way to improve this flow is to make projects either have their own standalone repository or a place in the wasmcloud/contrib repository. I'd like to note in the CONTRIBUTING.md that we're accepting contributions for capability providers, and even moving some of the ones in this repository, over to that repo.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
