### PR TITLE
ci(provider): remove wash build check

### DIFF
--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -127,37 +127,3 @@ jobs:
         env:
           WASH_REG_USER: ${{ github.repository_owner }}
           WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-
-  # Ensure that `wash build` and `wash app validate` works for all providers
-  wash-build:
-    name: build
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        provider:
-          - bin-path: src/bin/blobstore-azure-provider
-          - bin-path: src/bin/blobstore-fs-provider
-          - bin-path: src/bin/blobstore-nats-provider
-          - bin-path: src/bin/blobstore-s3-provider
-          - bin-path: src/bin/http-client-provider
-          - bin-path: src/bin/http-server-provider
-          - bin-path: src/bin/keyvalue-nats-provider
-          - bin-path: src/bin/keyvalue-redis-provider
-          - bin-path: src/bin/keyvalue-vault-provider
-          - bin-path: src/bin/messaging-kafka-provider
-          - bin-path: src/bin/messaging-nats-provider
-          - bin-path: src/bin/sqldb-postgres-provider
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
-      # Set up wash
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: wash-x86_64-unknown-linux-musl
-          path: artifact
-      - run: chmod +x ./artifact/bin/wash
-
-      - name: build provider
-        run: |
-          ./artifact/bin/wash build -p ${{ matrix.provider.bin-path }}


### PR DESCRIPTION
## Feature or Problem
This PR removes an extra `wash build` step on providers that we run as a part of the reusable provider workflow. The outputs of this check aren't used, and instead when packaging/releasing providers today we rely on the build-provider-bin matrix action. This actually builds _every_ provider for _every_ provider, and the result is 144 provider builds that take about 13 minutes on average. Good to check that, but it's a complete duplicate.

Back of the napkin math says removing this will save ~24 hours of CI time per provider run, and ~13 minutes of real time waiting for checks to finish

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
