### PR TITLE
release: wash 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8443,7 +8443,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "0.42.0"
+version = "1.0.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash"
-version = "0.42.0"
+version = "1.0.0"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) - CLI tool and library for wasmCloud development"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash/src/lib/common.rs
+++ b/crates/wash/src/lib/common.rs
@@ -13,8 +13,10 @@ use wasmcloud_control_interface::HostInventory;
 
 use crate::lib::id::{ModuleId, ServerId, ServiceId};
 
+// NOTE(brooksmtownsend): This is pinned to v2.10.26 because v2.11 introduces .zip archives for
+// windows which is incompatible with our tooling at the moment.
 /// Version of the NATS server used by default for wash
-pub const NATS_SERVER_VERSION: &str = "v2.11.3";
+pub const NATS_SERVER_VERSION: &str = "v2.10.26";
 
 /// Default host for the NATS server used by wash
 pub const DEFAULT_NATS_HOST: &str = "127.0.0.1";


### PR DESCRIPTION
- **chore(wash): bump to 1.0.0 for release**
- **fix(wash): pin nats-server to v2.10.26**

## Feature or Problem
Prepping wash for a 1.0.0 release

Draft waiting for wasmCloud 1.9 to fully release.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
