### PR TITLE
[WIP] feat: Use humantime instead of milliseconds for time values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8919,6 +8919,7 @@ dependencies = [
  "clap-markdown",
  "futures",
  "http-body-util",
+ "humantime",
  "hyper 1.6.0",
  "hyper-util",
  "nats-jwt-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ clap = { workspace = true, features = [
   "usage",
 ], optional = true }
 clap-markdown = { workspace = true, optional = true }
+humantime = { workspace = true }
 nkeys = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }

--- a/crates/wash/src/cli/cmd/up.rs
+++ b/crates/wash/src/cli/cmd/up.rs
@@ -27,6 +27,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use sysinfo::System;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
@@ -39,22 +40,24 @@ use crate::app::deploy_model_from_manifest;
 use crate::appearance::spinner::Spinner;
 use crate::config::{
     configure_host_env, DEFAULT_ALLOW_FILE_LOAD, DEFAULT_LATTICE, DEFAULT_MAX_EXECUTION_TIME_MS,
-    DEFAULT_NATS_HOST, DEFAULT_NATS_PORT, DEFAULT_NATS_WEBSOCKET_PORT,
-    DEFAULT_PROV_SHUTDOWN_DELAY_MS, DEFAULT_RPC_TIMEOUT_MS, DEFAULT_STRUCTURED_LOG_LEVEL,
-    NATS_SERVER_VERSION, WADM_VERSION, WASMCLOUD_ALLOW_FILE_LOAD, WASMCLOUD_CLUSTER_ISSUERS,
-    WASMCLOUD_CLUSTER_SEED, WASMCLOUD_CONFIG_SERVICE, WASMCLOUD_CTL_CREDSFILE, WASMCLOUD_CTL_HOST,
-    WASMCLOUD_CTL_JWT, WASMCLOUD_CTL_PORT, WASMCLOUD_CTL_SEED, WASMCLOUD_CTL_TLS,
-    WASMCLOUD_CTL_TLS_CA_FILE, WASMCLOUD_CTL_TLS_FIRST, WASMCLOUD_ENABLE_IPV6,
-    WASMCLOUD_HOST_LOG_PATH, WASMCLOUD_HOST_PATH, WASMCLOUD_HOST_SEED, WASMCLOUD_HOST_VERSION,
-    WASMCLOUD_JS_DOMAIN, WASMCLOUD_LATTICE, WASMCLOUD_LOG_LEVEL, WASMCLOUD_MAX_EXECUTION_TIME_MS,
-    WASMCLOUD_OCI_ALLOWED_INSECURE, WASMCLOUD_OCI_ALLOW_LATEST, WASMCLOUD_POLICY_TOPIC,
+    DEFAULT_NATS_HOST, DEFAULT_NATS_PORT, DEFAULT_NATS_WEBSOCKET_PORT, DEFAULT_PROV_SHUTDOWN_DELAY,
+    DEFAULT_PROV_SHUTDOWN_DELAY_MS, DEFAULT_RPC_TIMEOUT, DEFAULT_RPC_TIMEOUT_MS,
+    DEFAULT_STRUCTURED_LOG_LEVEL, NATS_SERVER_VERSION, WADM_VERSION, WASMCLOUD_ALLOW_FILE_LOAD,
+    WASMCLOUD_CLUSTER_ISSUERS, WASMCLOUD_CLUSTER_SEED, WASMCLOUD_CONFIG_SERVICE,
+    WASMCLOUD_CTL_CREDSFILE, WASMCLOUD_CTL_HOST, WASMCLOUD_CTL_JWT, WASMCLOUD_CTL_PORT,
+    WASMCLOUD_CTL_SEED, WASMCLOUD_CTL_TLS, WASMCLOUD_CTL_TLS_CA_FILE, WASMCLOUD_CTL_TLS_FIRST,
+    WASMCLOUD_ENABLE_IPV6, WASMCLOUD_HOST_LOG_PATH, WASMCLOUD_HOST_PATH, WASMCLOUD_HOST_SEED,
+    WASMCLOUD_HOST_VERSION, WASMCLOUD_JS_DOMAIN, WASMCLOUD_LATTICE, WASMCLOUD_LOG_LEVEL,
+    WASMCLOUD_MAX_EXECUTION_TIME, WASMCLOUD_MAX_EXECUTION_TIME_MS, WASMCLOUD_OCI_ALLOWED_INSECURE,
+    WASMCLOUD_OCI_ALLOW_LATEST, WASMCLOUD_POLICY_TOPIC, WASMCLOUD_PROV_SHUTDOWN_DELAY,
     WASMCLOUD_PROV_SHUTDOWN_DELAY_MS, WASMCLOUD_RPC_CREDSFILE, WASMCLOUD_RPC_HOST,
-    WASMCLOUD_RPC_JWT, WASMCLOUD_RPC_PORT, WASMCLOUD_RPC_SEED, WASMCLOUD_RPC_TIMEOUT_MS,
-    WASMCLOUD_RPC_TLS, WASMCLOUD_RPC_TLS_CA_FILE, WASMCLOUD_RPC_TLS_FIRST, WASMCLOUD_SECRETS_TOPIC,
-    WASMCLOUD_STRUCTURED_LOGGING_ENABLED,
+    WASMCLOUD_RPC_JWT, WASMCLOUD_RPC_PORT, WASMCLOUD_RPC_SEED, WASMCLOUD_RPC_TIMEOUT,
+    WASMCLOUD_RPC_TIMEOUT_MS, WASMCLOUD_RPC_TLS, WASMCLOUD_RPC_TLS_CA_FILE,
+    WASMCLOUD_RPC_TLS_FIRST, WASMCLOUD_SECRETS_TOPIC, WASMCLOUD_STRUCTURED_LOGGING_ENABLED,
 };
 
 use crate::down::stop_nats;
+use crate::util::parse_duration_fallback_ms;
 
 #[derive(Parser, Debug, Clone)]
 pub struct UpCommand {
@@ -186,8 +189,12 @@ pub struct WasmcloudOpts {
     pub rpc_seed: Option<String>,
 
     /// Timeout in milliseconds for all RPC calls
-    #[clap(long = "rpc-timeout-ms", default_value = DEFAULT_RPC_TIMEOUT_MS, env = WASMCLOUD_RPC_TIMEOUT_MS)]
+    #[clap(long = "rpc-timeout-ms", default_value = DEFAULT_RPC_TIMEOUT_MS, env = WASMCLOUD_RPC_TIMEOUT_MS, hide = true, conflicts_with = "rpc_timeout")]
     pub rpc_timeout_ms: Option<u64>,
+
+    /// Timeout duration for all RPC calls
+    #[clap(long = "rpc-timeout", default_value = DEFAULT_RPC_TIMEOUT, env = WASMCLOUD_RPC_TIMEOUT, value_parser = parse_duration_fallback_ms)]
+    pub rpc_timeout: Option<Duration>,
 
     /// A user JWT to use to authenticate to NATS for RPC messages
     #[clap(long = "rpc-jwt", env = WASMCLOUD_RPC_JWT, requires = "rpc_seed")]
@@ -250,8 +257,12 @@ pub struct WasmcloudOpts {
     pub cluster_issuers: Option<Vec<String>>,
 
     /// Delay, in milliseconds, between requesting a provider shut down and forcibly terminating its process
-    #[clap(long = "provider-delay", default_value = DEFAULT_PROV_SHUTDOWN_DELAY_MS, env = WASMCLOUD_PROV_SHUTDOWN_DELAY_MS)]
-    pub provider_delay: u32,
+    #[clap(long = "provider-delay-ms", default_value = DEFAULT_PROV_SHUTDOWN_DELAY_MS, env = WASMCLOUD_PROV_SHUTDOWN_DELAY_MS, hide = true, conflicts_with = "provider_delay")]
+    pub provider_delay_ms: u32,
+
+    /// Delay duration between requesting a provider shut down and forcibly terminating its process
+    #[clap(long = "provider-delay", default_value = DEFAULT_PROV_SHUTDOWN_DELAY, env = WASMCLOUD_PROV_SHUTDOWN_DELAY, value_parser = parse_duration_fallback_ms)]
+    pub provider_delay: Duration,
 
     /// Determines whether OCI images tagged latest are allowed to be pulled from OCI registries and started
     #[clap(long = "allow-latest", env = WASMCLOUD_OCI_ALLOW_LATEST)]
@@ -301,8 +312,12 @@ pub struct WasmcloudOpts {
     pub multi_local: bool,
 
     /// Defines the Max Execution time (in ms) that the host runtime will execute for
-    #[clap(long = "max-execution-time-ms", alias = "max-time-ms", env = WASMCLOUD_MAX_EXECUTION_TIME_MS, default_value = DEFAULT_MAX_EXECUTION_TIME_MS)]
-    pub max_execution_time: u64,
+    #[clap(long = "max-execution-time-ms", alias = "max-time-ms", env = WASMCLOUD_MAX_EXECUTION_TIME_MS, default_value = DEFAULT_MAX_EXECUTION_TIME_MS, hide = true, conflicts_with = "max_execution_time")]
+    pub max_execution_time_ms: u64,
+
+    /// Defines the Max Execution time (in ms) that the host runtime will execute for
+    #[clap(long = "max-execution-time", alias = "max-time", env = WASMCLOUD_MAX_EXECUTION_TIME, default_value = DEFAULT_MAX_EXECUTION_TIME_MS, value_parser = parse_duration_fallback_ms)]
+    pub max_execution_time: Duration,
 
     /// If provided, enables interfacing with a secrets backend for secret retrieval over the given topic prefix.
     #[clap(long = "secrets-topic", env = WASMCLOUD_SECRETS_TOPIC)]
@@ -1203,6 +1218,7 @@ mod tests {
     use super::UpCommand;
     use anyhow::Result;
     use clap::Parser;
+    use std::time::Duration;
 
     const LOCAL_REGISTRY: &str = "localhost:5001";
 
@@ -1348,7 +1364,10 @@ mod tests {
             up_all_flags.nats_opts.nats_remote_url,
             Some("tls://remote.global".to_string())
         );
-        assert_eq!(up_all_flags.wasmcloud_opts.provider_delay, 500);
+        assert_eq!(
+            up_all_flags.wasmcloud_opts.provider_delay,
+            Duration::from_millis(500)
+        );
         assert!(up_all_flags.detached);
 
         Ok(())

--- a/crates/wash/src/cli/cmd/up.rs
+++ b/crates/wash/src/cli/cmd/up.rs
@@ -1280,6 +1280,8 @@ mod tests {
             "SUALIKDKMIUAKRT5536EXKC3CX73TJD3CFXZMJSHIKSP3LTYIIUQGCUVGA",
             "--rpc-timeout-ms",
             "500",
+            "--max-execution-time",
+            "500ms",
             "--rpc-tls",
             "--structured-log-level",
             "warn",

--- a/crates/wash/src/cli/config.rs
+++ b/crates/wash/src/cli/config.rs
@@ -23,13 +23,16 @@ pub const WASMCLOUD_CLUSTER_ISSUERS: &str = "WASMCLOUD_CLUSTER_ISSUERS";
 pub const WASMCLOUD_CLUSTER_SEED: &str = "WASMCLOUD_CLUSTER_SEED";
 pub const WASMCLOUD_HOST_SEED: &str = "WASMCLOUD_HOST_SEED";
 pub const WASMCLOUD_MAX_EXECUTION_TIME_MS: &str = "WASMCLOUD_MAX_EXECUTION_TIME_MS";
+pub const WASMCLOUD_MAX_EXECUTION_TIME: &str = "WASMCLOUD_MAX_EXECUTION_TIME";
 pub const DEFAULT_MAX_EXECUTION_TIME_MS: &str = "600000";
 
 // NATS RPC connection configuration
 pub const WASMCLOUD_RPC_HOST: &str = "WASMCLOUD_RPC_HOST";
 pub const WASMCLOUD_RPC_PORT: &str = "WASMCLOUD_RPC_PORT";
 pub const WASMCLOUD_RPC_TIMEOUT_MS: &str = "WASMCLOUD_RPC_TIMEOUT_MS";
+pub const WASMCLOUD_RPC_TIMEOUT: &str = "WASMCLOUD_RPC_TIMEOUT";
 pub const DEFAULT_RPC_TIMEOUT_MS: &str = "2000";
+pub const DEFAULT_RPC_TIMEOUT: &str = "2000ms";
 pub const WASMCLOUD_RPC_JWT: &str = "WASMCLOUD_RPC_JWT";
 pub const WASMCLOUD_RPC_SEED: &str = "WASMCLOUD_RPC_SEED";
 pub const WASMCLOUD_RPC_CREDSFILE: &str = "WASMCLOUD_RPC_CREDSFILE";
@@ -49,7 +52,9 @@ pub const WASMCLOUD_CTL_TLS_CA_FILE: &str = "WASMCLOUD_CTL_TLS_CA_FILE";
 
 // NATS Provider RPC connection configuration
 pub const WASMCLOUD_PROV_SHUTDOWN_DELAY_MS: &str = "WASMCLOUD_PROV_SHUTDOWN_DELAY_MS";
+pub const WASMCLOUD_PROV_SHUTDOWN_DELAY: &str = "WASMCLOUD_PROV_SHUTDOWN_DELAY";
 pub const DEFAULT_PROV_SHUTDOWN_DELAY_MS: &str = "300";
+pub const DEFAULT_PROV_SHUTDOWN_DELAY: &str = "300ms";
 pub const WASMCLOUD_OCI_ALLOWED_INSECURE: &str = "WASMCLOUD_OCI_ALLOWED_INSECURE";
 pub const WASMCLOUD_OCI_ALLOW_LATEST: &str = "WASMCLOUD_OCI_ALLOW_LATEST";
 
@@ -94,7 +99,11 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
     }
     host_config.insert(
         WASMCLOUD_MAX_EXECUTION_TIME_MS.to_string(),
-        wasmcloud_opts.max_execution_time.to_string(),
+        wasmcloud_opts.max_execution_time_ms.to_string(),
+    );
+    host_config.insert(
+        WASMCLOUD_MAX_EXECUTION_TIME_MS.to_string(),
+        wasmcloud_opts.max_execution_time.as_millis().to_string(),
     );
     if let Some(policy_topic) = wasmcloud_opts.policy_topic {
         host_config.insert(WASMCLOUD_POLICY_TOPIC.to_string(), policy_topic);
@@ -125,6 +134,12 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
         host_config.insert(
             WASMCLOUD_RPC_TIMEOUT_MS.to_string(),
             rpc_timeout_ms.to_string(),
+        );
+    }
+    if let Some(rpc_timeout) = wasmcloud_opts.rpc_timeout {
+        host_config.insert(
+            WASMCLOUD_RPC_TIMEOUT_MS.to_string(),
+            rpc_timeout.as_millis().to_string(),
         );
     }
     if let Some(path) = wasmcloud_opts.rpc_credsfile {
@@ -170,7 +185,11 @@ pub async fn configure_host_env(wasmcloud_opts: WasmcloudOpts) -> Result<HashMap
 
     host_config.insert(
         WASMCLOUD_PROV_SHUTDOWN_DELAY_MS.to_string(),
-        wasmcloud_opts.provider_delay.to_string(),
+        wasmcloud_opts.provider_delay_ms.to_string(),
+    );
+    host_config.insert(
+        WASMCLOUD_PROV_SHUTDOWN_DELAY_MS.to_string(),
+        wasmcloud_opts.provider_delay.as_millis().to_string(),
     );
 
     // Extras configuration

--- a/crates/wash/src/cli/util.rs
+++ b/crates/wash/src/cli/util.rs
@@ -2,6 +2,8 @@ use std::{
     fs::File,
     io::Read,
     path::{Path, PathBuf},
+    str::FromStr,
+    time::Duration,
 };
 
 use crate::lib::{
@@ -36,6 +38,23 @@ pub const fn default_timeout_ms() -> u64 {
     DEFAULT_NATS_TIMEOUT_MS
 }
 
+pub fn default_timeout() -> Duration {
+    Duration::from_millis(default_timeout_ms())
+}
+
+pub fn parse_duration_fallback_ms(dur: &str) -> anyhow::Result<Duration> {
+    if let Ok(duration) = humantime::Duration::from_str(dur) {
+        return Ok(duration.into());
+    }
+    if let Ok(millis) = dur.parse::<u64>() {
+        return Ok(std::time::Duration::from_millis(millis));
+    }
+
+    Err(anyhow::anyhow!(
+        "Invalid duration: '{}'. Expected duration: '5s', '1m', '100ms'",
+        dur
+    ))
+}
 /// Transform a json string (e.g. "{"hello": "world"}") into msgpack bytes
 pub fn json_str_to_msgpack_bytes(payload: &str) -> Result<Vec<u8>> {
     let json: serde_json::Value =

--- a/crates/wash/src/cli/util.rs
+++ b/crates/wash/src/cli/util.rs
@@ -192,6 +192,8 @@ const fn empty_table_style() -> TableStyle {
 }
 
 mod test {
+    use std::time::Duration;
+
     #[test]
     fn test_safe_base64_parse_option() {
         let base64_option = "config_b64=eyJhZGRyZXNzIjogIjAuMC4wLjA6ODA4MCJ9Cg==".to_string();
@@ -202,5 +204,37 @@ mod test {
         );
         let output = crate::lib::cli::input_vec_to_hashmap(vec![base64_option]).unwrap();
         assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn test_parse_duration_fallback_ms() {
+        // Test humantime format
+        assert_eq!(
+            crate::util::parse_duration_fallback_ms("5s").unwrap(),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            crate::util::parse_duration_fallback_ms("100ms").unwrap(),
+            Duration::from_millis(100)
+        );
+        assert_eq!(
+            crate::util::parse_duration_fallback_ms("2m").unwrap(),
+            Duration::from_secs(120)
+        );
+
+        // Test milliseconds fallback
+        assert_eq!(
+            crate::util::parse_duration_fallback_ms("1000").unwrap(),
+            Duration::from_millis(1000)
+        );
+        assert_eq!(
+            crate::util::parse_duration_fallback_ms("500").unwrap(),
+            Duration::from_millis(500)
+        );
+
+        // Test error cases
+        assert!(crate::util::parse_duration_fallback_ms("invalid").is_err());
+        assert!(crate::util::parse_duration_fallback_ms("").is_err());
+        assert!(crate::util::parse_duration_fallback_ms("abc123").is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use core::net::SocketAddr;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
@@ -80,7 +81,10 @@ struct Args {
     #[clap(long = "host-seed", env = "WASMCLOUD_HOST_SEED")]
     host_seed: Option<String>,
     /// Delay, in milliseconds, between requesting a provider shut down and forcibly terminating its process
-    #[clap(long = "provider-shutdown-delay-ms", alias = "provider-shutdown-delay", default_value = "300", env = "WASMCLOUD_PROV_SHUTDOWN_DELAY_MS", value_parser = parse_duration_millis)]
+    #[clap(long = "provider-shutdown-delay-ms", default_value = "300", env = "WASMCLOUD_PROV_SHUTDOWN_DELAY_MS", value_parser = parse_duration_millis, hide = true, conflicts_with = "provider_shutdown_delay")]
+    provider_shutdown_delay_ms: Duration,
+    /// Delay between requesting a provider shut down and forcibly terminating its process
+    #[clap(long = "provider-shutdown-delay", alias = "provider-shutdown-delay", default_value = "300ms", env = "WASMCLOUD_PROV_SHUTDOWN_DELAY", value_parser = parse_duration_fallback_ms)]
     provider_shutdown_delay: Duration,
     /// Determines whether OCI images tagged latest are allowed to be pulled from OCI registries and started
     #[clap(long = "allow-latest", env = "WASMCLOUD_OCI_ALLOW_LATEST")]
@@ -186,8 +190,11 @@ struct Args {
     #[clap(long = "rpc-creds", env = "WASMCLOUD_RPC_CREDS", hide = true, conflicts_with_all = ["rpc_jwt", "rpc_seed"])]
     rpc_creds: Option<PathBuf>,
     /// Timeout in milliseconds for all RPC calls
-    #[clap(long = "rpc-timeout-ms", default_value = "2000", env = "WASMCLOUD_RPC_TIMEOUT_MS", value_parser = parse_duration_millis, hide = true)]
+    #[clap(long = "rpc-timeout-ms", default_value = "2000", env = "WASMCLOUD_RPC_TIMEOUT_MS", value_parser = parse_duration_millis, hide = true, conflicts_with = "rpc_timeout")]
     rpc_timeout_ms: Duration,
+    /// Timeout for all RPC calls
+    #[clap(long = "rpc-timeout", default_value = "2000ms", env = "WASMCLOUD_RPC_TIMEOUT", value_parser = parse_duration_fallback_ms, hide = true)]
+    rpc_timeout: Duration,
     /// Optional flag to require host communication over TLS with a NATS server for RPC messages
     #[clap(long = "rpc-tls", env = "WASMCLOUD_RPC_TLS", hide = true)]
     rpc_tls: bool,
@@ -203,7 +210,10 @@ struct Args {
     )]
     policy_changes_topic: Option<String>,
     /// If provided, allows to set a custom Max Execution time for the Host in ms.
-    #[clap(long = "max-execution-time-ms", default_value = "600000", env = "WASMCLOUD_MAX_EXECUTION_TIME_MS", value_parser = parse_duration_millis)]
+    #[clap(long = "max-execution-time-ms", default_value = "600000", env = "WASMCLOUD_MAX_EXECUTION_TIME_MS", value_parser = parse_duration_millis, hide = true, conflicts_with = "max_execution_time")]
+    max_execution_time_ms: Duration,
+    /// If provided, allows to set a custom Max Execution time for the Host.
+    #[clap(long = "max-execution-time", default_value = "10m", env = "WASMCLOUD_MAX_EXECUTION_TIME", value_parser = parse_duration_fallback_ms)]
     max_execution_time: Duration,
     /// The maximum amount of memory bytes that a component can allocate (default 256 MiB)
     #[clap(long = "max-linear-memory-bytes", default_value_t = 256 * 1024 * 1024, env = "WASMCLOUD_MAX_LINEAR_MEMORY")]
@@ -230,11 +240,21 @@ struct Args {
     /// If provided, allows setting a custom timeout for requesting policy decisions. Defaults to one second. Requires `policy_topic` to be set.
     #[clap(
         long = "policy-timeout-ms",
-        env = "WASMCLOUD_POLICY_TIMEOUT",
+        env = "WASMCLOUD_POLICY_TIMEOUT_MS",
         requires = "policy_topic",
         value_parser = parse_duration_millis,
+        hide = true,
+        conflicts_with = "policy_timeout",
     )]
     policy_timeout_ms: Option<Duration>,
+    /// If provided, allows setting a custom timeout for requesting policy decisions. Defaults to one second. Requires `policy_topic` to be set.
+    #[clap(
+        long = "policy-timeout",
+        env = "WASMCLOUD_POLICY_TIMEOUT",
+        requires = "policy_topic",
+        value_parser = parse_duration_fallback_ms,
+    )]
+    policy_timeout: Option<Duration>,
 
     /// If provided, enables interfacing with a secrets backend for secret retrieval over the given topic prefix. Must not be empty.
     #[clap(long = "secrets-topic", env = "WASMCLOUD_SECRETS_TOPIC")]
@@ -357,7 +377,11 @@ struct Args {
     pub tls_ca_paths: Option<Vec<PathBuf>>,
 
     /// If provided, overrides the default heartbeat interval of every 30 seconds. Provided value is interpreted as seconds.
-    #[arg(long = "heartbeat-interval-seconds", env = "WASMCLOUD_HEARTBEAT_INTERVAL", value_parser = parse_duration_secs, hide = true)]
+    #[arg(long = "heartbeat-interval-seconds", env = "WASMCLOUD_HEARTBEAT_INTERVAL_SECONDS", value_parser = parse_duration_secs, hide = true, conflicts_with = "heartbeat_interval")]
+    heartbeat_interval_seconds: Option<Duration>,
+
+    /// If provided, overrides the default heartbeat interval of every 30 seconds. Provided value is interpreted as seconds.
+    #[arg(long = "heartbeat-interval", env = "WASMCLOUD_HEARTBEAT_INTERVAL", value_parser = parse_duration_fallback_secs, hide = true)]
     heartbeat_interval: Option<Duration>,
 
     /// Experimental features to enable in the host. This is a repeatable option.
@@ -598,10 +622,22 @@ async fn main() -> anyhow::Result<()> {
             config_service_enabled: args.config_service_enabled,
             js_domain: args.js_domain,
             labels,
-            provider_shutdown_delay: Some(args.provider_shutdown_delay),
+            // once previous option (provider_shutdown_delay_ms) is fully deprecated, uncomment below and remove `get_preffered_arg`
+            // provider_shutdown_delay: Some(args.provider_shutdown_delay),
+            provider_shutdown_delay: Some(get_preferred_arg(
+                args.provider_shutdown_delay_ms,
+                args.provider_shutdown_delay,
+                Duration::from_millis(300),
+            )),
             oci_opts,
             rpc_nats_url,
-            rpc_timeout: args.rpc_timeout_ms,
+            // once previous option (rpc_timeout) is fully deprecated, uncomment below and remove `get_preffered_arg`
+            // rpc_timeout: args.rpc_timeout,
+            rpc_timeout: get_preferred_arg(
+                args.rpc_timeout_ms,
+                args.rpc_timeout,
+                Duration::from_millis(2000),
+            ),
             rpc_jwt: rpc_jwt.or_else(|| nats_jwt.clone()),
             rpc_key: rpc_key.or_else(|| nats_key.clone()),
             rpc_tls: args.rpc_tls,
@@ -610,12 +646,25 @@ async fn main() -> anyhow::Result<()> {
             enable_structured_logging: args.enable_structured_logging,
             otel_config,
             version: env!("CARGO_PKG_VERSION").to_string(),
-            max_execution_time: args.max_execution_time,
+            // once previous option (max_execution_time_ms) is fully deprecated, uncomment below and remove `get_preffered_arg`
+            // max_execution_time: args.max_execution_time,
+            max_execution_time: get_preferred_arg(
+                args.max_execution_time_ms,
+                args.max_execution_time,
+                Duration::from_millis(600000),
+            ),
             max_linear_memory: args.max_linear_memory,
             max_component_size: args.max_component_size,
             max_components: args.max_components,
             max_core_instances_per_component: args.max_core_instances_per_component,
-            heartbeat_interval: args.heartbeat_interval,
+            // once previous option (heartbeat_interval_seconds) is fully deprecated, uncomment below and remove `get_preffered_arg`
+            // heartbeat_interval: args.heartbeat_interval,
+            heartbeat_interval: Some(get_preferred_arg(
+                args.heartbeat_interval_seconds
+                    .unwrap_or(Duration::from_secs(30)),
+                args.heartbeat_interval.unwrap_or(Duration::from_secs(30)),
+                Duration::from_secs(30),
+            )),
             experimental_features,
             http_admin: args.http_admin,
             enable_component_auction: args.enable_component_auction.unwrap_or(true),
@@ -668,6 +717,55 @@ fn parse_duration_millis(arg: &str) -> anyhow::Result<Duration> {
     arg.parse()
         .map(Duration::from_millis)
         .map_err(|e| anyhow::anyhow!(e))
+}
+
+#[derive(Debug)]
+enum TimeUnit {
+    Ms,
+    Sec,
+}
+
+fn parse_duration(arg: &str, unit: TimeUnit) -> anyhow::Result<Duration> {
+    if let Ok(duration) = humantime::Duration::from_str(arg) {
+        return Ok(duration.into());
+    }
+    match unit {
+        TimeUnit::Sec => {
+            if let Ok(secs) = arg.parse::<u64>() {
+                return Ok(std::time::Duration::from_secs(secs));
+            }
+        }
+        TimeUnit::Ms => {
+            if let Ok(millis) = arg.parse::<u64>() {
+                return Ok(std::time::Duration::from_millis(millis));
+            }
+        }
+    }
+    Err(
+        anyhow::anyhow!("Invalid duration: '{}', unit: '{:?}'. Expected duration: '5s', '1m', '100ms', or an integer with unit: Ms, Sec", arg, unit),
+    )
+}
+
+fn parse_duration_fallback_secs(arg: &str) -> anyhow::Result<Duration> {
+    parse_duration(arg, TimeUnit::Sec)
+}
+
+fn parse_duration_fallback_ms(arg: &str) -> anyhow::Result<Duration> {
+    parse_duration(arg, TimeUnit::Ms)
+}
+
+/// Temporary helper method to help with moving to using `humantime` compatible values for command line arguments
+/// that takes in the old CLI flag value, the new one, and the default, and returns the preferred argument, i.e.
+/// the argument provided by the user.
+/// This function should be removed once the older duration options are fully deprecated.
+fn get_preferred_arg(old: Duration, new: Duration, default: Duration) -> Duration {
+    let return_value = match (old, new) {
+        (a, b) if a == b => a,
+        (a, b) if a == default => b,
+        (a, b) if b == default => a,
+        _ => default,
+    };
+    return return_value;
 }
 
 /// Validates that a subject string (e.g. secrets-topic and policy-topic) adheres to the rules and conventions


### PR DESCRIPTION
## Feature or Problem

This PR continues the work of standardizing CLI options to use [`humantime`] for time-based values.
Previously, options like `--some-option-ms 100` accepted milliseconds.
With this change, we aim to enable more human-readable formats such as `--some-option 100ms`, enhancing user experience and clarity in CLI interactions.

## Related Issues

#3257 #3440

## Release Information

`next`

## Consumer Impact

This change is taking care to be backward compatible, and maintains the existing options and environment variables. The new functionality supports falling back to the existing functionality as well (e.g. setting SOME_ENV_VAR to 100 and 100ms will have the same effect).

## Testing
### Unit Test(s)
Add tests for duration parsing.

### Acceptance or Integration

### Manual Verification
