### PR TITLE
fix(wasmbus): expect when we should've mapped

### DIFF
--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -863,12 +863,7 @@ impl Host {
                         .image_ref(component.image_reference.to_string())
                         .annotations(component.annotations.clone().into_iter().collect())
                         .max_instances(component.max_instances.get().try_into().unwrap_or(u32::MAX))
-                        .limits(Some(
-                            component
-                                .limits
-                                .expect("component limits should be set")
-                                .to_string_map(),
-                        ))
+                        .limits(component.limits.map(|limits| limits.to_string_map()))
                         .revision(
                             component
                                 .claims()
@@ -1565,11 +1560,7 @@ impl Host {
                     Arc::clone(&new_component_ref),
                     Arc::clone(&component_id),
                     max,
-                    Some(
-                        existing_component
-                            .limits
-                            .expect("component limits should be set"),
-                    ),
+                    existing_component.limits,
                     new_component,
                     existing_component.handler.copy_for_new(),
                 )


### PR DESCRIPTION
## Feature or Problem
This PR fixes an area in the host inventory related to component limits where we were calling `expect` when an option map would do.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
v1.9

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
