### PR TITLE
fix(wadm-provider): some fixes

### DIFF
--- a/crates/provider-wadm/src/config.rs
+++ b/crates/provider-wadm/src/config.rs
@@ -74,8 +74,8 @@ impl Default for ClientConfig {
         ClientConfig {
             lattice: default_lattice(),
             app_name: None,
-            ctl_host: String::new(),
-            ctl_port: 0,
+            ctl_host: default_ctl_host(),
+            ctl_port: default_ctl_port(),
             ctl_jwt: None,
             ctl_seed: None,
             ctl_credsfile: None,

--- a/crates/provider-wadm/src/lib.rs
+++ b/crates/provider-wadm/src/lib.rs
@@ -129,7 +129,7 @@ impl WadmProvider {
             ca_path,
         };
 
-        let client = Client::new(&cfg.lattice, Some(&cfg.lattice), client_opts).await?;
+        let client = Client::new(&cfg.lattice, None, client_opts).await?;
 
         let mut sub_handles = Vec::new();
         if make_status_sub {
@@ -410,10 +410,9 @@ impl exports::wasmcloud::wadm::client::Handler<Option<Context>> for WadmProvider
     ) -> anyhow::Result<Result<(String, String), String>> {
         let client = self.get_client(ctx).await?;
 
-        let manifest_bytes =
-            serde_json::to_vec(&manifest).context("Failed to serialize OAM manifest")?;
+        let manifest = wadm_types::Manifest::from(manifest);
 
-        match client.put_manifest(manifest_bytes).await {
+        match client.put_manifest(manifest).await {
             Ok(response) => Ok(Ok(response)),
             Err(err) => {
                 error!("Failed to store manifest: {err}");


### PR DESCRIPTION
## Feature or Problem

I have encountered several problems with the put model.

Fixes:
- Fixed the default ClientConfig values
- The prefix for wadm client was overwritten with the value from `cfg.lattice`, which is incorrect
- Unnecessary deserialization of `OamManifest`, which led to an error. Error related to `api_version` / `apiVersion`. It seems to me that this is due to the fact that the `Serialize` and `Deserialize` traits are implemented automatically, but there is no additional attribute to the `api_version` field, as is done in `wadm_types`.

## Related Issues

## Release Information


## Consumer Impact

## Testing

### Unit Test(s)

### Acceptance or Integration


### Manual Verification
