### PR TITLE
feat(wash): bump to v0.43.0 with wasmcloud v1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8443,7 +8443,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash"
-version = "0.42.0"
+version = "0.43.0"
 categories = ["wasm", "command-line-utilities"]
 description = "wasmCloud Shell (wash) - CLI tool and library for wasmCloud development"
 keywords = ["webassembly", "wasmcloud", "wash", "cli"]

--- a/crates/wash/src/lib/common.rs
+++ b/crates/wash/src/lib/common.rs
@@ -36,8 +36,8 @@ pub const WASHBOARD_VERSION: &str = "v0.7.1";
 pub const WASHBOARD_VERSION_T: Version = Version::new(0, 7, 1);
 
 /// Version of wasmCloud host used by default for wash
-pub const WASMCLOUD_HOST_VERSION: &str = "v1.8.0";
-pub const WASMCLOUD_HOST_VERSION_T: Version = Version::new(1, 8, 0);
+pub const WASMCLOUD_HOST_VERSION: &str = "v1.9.0";
+pub const WASMCLOUD_HOST_VERSION_T: Version = Version::new(1, 9, 0);
 
 /// Default path to the `git` command (assumes it exists on PATH)
 const DEFAULT_GIT_PATH: &str = "git";


### PR DESCRIPTION
## Summary

This PR bumps wash to version 0.43.0 and updates the embedded wasmcloud version from v1.8.0 to v1.9.0.

### Changes
- Bump wash version from 0.42.0 to 0.43.0 in `crates/wash/Cargo.toml`
- Update embedded wasmcloud version from v1.8.0 to v1.9.0 in `crates/wash/src/lib/common.rs`

### Release Notes

This release stages wash for its 0.43.0 release. **This will be the last planned minor release for pre-1.0 wash and it's essentially a feature freeze for the current version.**

For more information about wash, visit: https://github.com/wasmCloud/wash

🤖 Generated with [Claude Code](https://claude.ai/code)