### PR TITLE
fix(helm): correct template scope for allowedInsecure in host-config

### DIFF
--- a/charts/wasmcloud-platform/templates/host-config.yaml
+++ b/charts/wasmcloud-platform/templates/host-config.yaml
@@ -60,7 +60,7 @@ spec:
   # Optional: Allow the host to pull artifacts from OCI registries insecurely.
   {{- with .allowedInsecure }}{{- if ne (len .) 0 }}
   allowedInsecure:
-    {{- range .allowedInsecure }}
+    {{- range . }}
     - {{ . }}
     {{- end }}
   {{- end }}{{- end }}


### PR DESCRIPTION



## Feature or Problem
This PR solves a bug in the host-config.yaml Helm template that caused deployments to fail.

## Related Issues
Closes #4725

## Release Information
Next patch release


## Consumer Impact
This change is non-breaking and has a positive impact.

## Testing

### Unit Test(s)
No unit tests were added or modified, as this change is confined to a Helm template file.

### Acceptance or Integration
No changes.

### Manual Verification
#### Before Fix
1. In `values.yaml,` set a value for `hostConfig.allowedInsecure` and set a value `hostConfig.enable` `true`.
2. Run helm `template .`
3. Observe that the command fails with the following error:
> Error: UPGRADE FAILED: template: wasmcloud-platform/templates/host-config.yaml:63:14: executing "wasmcloud-platform/templates/host-config.yaml" at <.allowedInsecure>: can't evaluate field allowedInsecure in type []interface {}

#### After Fix
1. In `values.yaml,` set a value for `hostConfig.allowedInsecure` and set a value `hostConfig.enable` to `true`.
2. Run helm `template .`
3. Confirm that the command now succeeds and correctly renders the `WasmCloudHostConfig` resource with the `allowedInsecure` field populated:
```helm
  allowedInsecure:
    - my-registry:5000
```