### PR TITLE
fix: building a provider for Windows

### DIFF
--- a/crates/wash/src/lib/build/provider.rs
+++ b/crates/wash/src/lib/build/provider.rs
@@ -197,6 +197,10 @@ fn build_rust_provider(
     }
     provider_path_buf.push(&bin_name);
 
+    if cfg!(windows) {
+        provider_path_buf.set_extension("exe");
+    }
+
     Ok((provider_path_buf, bin_name))
 }
 


### PR DESCRIPTION
## Feature or Problem
Before this fix, building a Windows provider panic on the line

https://github.com/wasmCloud/wasmCloud/blob/5b125d6d33efd55efa5db394a6c5c77937aa7822/crates/wash/src/lib/build/provider.rs#L56-L58

Because the file was searched without an extension

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
