### PR TITLE
Host Config Helm chart: ensure correct indent on pod template in host-config

### DIFF
--- a/charts/wasmcloud-platform/templates/host-config.yaml
+++ b/charts/wasmcloud-platform/templates/host-config.yaml
@@ -160,7 +160,7 @@ spec:
     # Note that you *cannot* set the `containers` field here as it is managed by the controller.
     podTemplateAdditions:
       {{- if .podTemplateAdditions }}
-      {{- tpl (.podTemplateAdditions | toYaml) . | nindent 4 }}
+      {{- tpl (.podTemplateAdditions | toYaml) . | nindent 6 }}
       {{- else }}
       spec:
         nodeSelector:


### PR DESCRIPTION
## Feature or Problem

The `WasmCloudHostConfig` does not render the pod template correctly due to a missing indent. This breaks the chart if this is set in the values.

## Related Issues

None.

## Release Information

Next.

## Consumer Impact

The Helm chart works in more scenarios 😄 

## Testing

I found this bug while trying a "productive" setup where the wasmCloud application platform should be isolated on specific hosts on Kubernetes. Tested only using simple templating.
