### PR TITLE
blobby: Finish upload stream

### DIFF
--- a/examples/rust/components/blobby/src/lib.rs
+++ b/examples/rust/components/blobby/src/lib.rs
@@ -232,6 +232,7 @@ fn put_object(
                 .to_string(),
         )
     } else {
+        OutgoingValue::finish(result_value).map_err(|e| e.to_string())?;
         Ok(())
     }
 }


### PR DESCRIPTION
exercising `finish` so the OutgoingValue knows we are done with the stream.