### PR TITLE
Fix CVE-2025-62518 by migrating to astral-tokio-tar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5358,7 +5373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -5378,7 +5393,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5520,6 +5535,7 @@ dependencies = [
 name = "provider-archive"
 version = "0.16.0"
 dependencies = [
+ "astral-tokio-tar",
  "async-compression",
  "data-encoding",
  "ring",
@@ -5527,7 +5543,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tokio-tar",
  "wascap",
 ]
 
@@ -6910,7 +6925,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8509,6 +8524,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "assert-json-diff",
+ "astral-tokio-tar",
  "async-compression",
  "async-nats",
  "bytes",
@@ -8569,7 +8585,6 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tokio-tar",
  "tokio-util",
  "toml 0.8.22",
  "tracing",
@@ -10129,7 +10144,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ members = ["crates/*"]
 anstyle = { version = "1.0.11", default-features = false }
 anyhow = { version = "1", default-features = false }
 assert-json-diff = { version = "2", default-features = false }
+astral-tokio-tar = { version = "0.5.6", default-features = false }
 async-compression = { version = "0.4", default-features = false }
 async-nats = { version = "0.39", default-features = false }
 async-trait = { version = "0.1", default-features = false }
@@ -342,7 +343,6 @@ tokio-postgres = { version = "0.7", default-features = false }
 tokio-postgres-rustls = { version = "0.13", default-features = false }
 tokio-rustls = { version = "0.26", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
-tokio-tar = { version = "0.3", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
 toml = { version = "0.8", default-features = false }
 tower-http = { version = "0.6", default-features = false }

--- a/crates/provider-archive/Cargo.toml
+++ b/crates/provider-archive/Cargo.toml
@@ -13,13 +13,13 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+astral-tokio-tar = { workspace = true }
 async-compression = { workspace = true, features = ["tokio", "gzip"] }
 data-encoding = { workspace = true }
 ring = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["io-util"] }
 tokio-stream = { workspace = true }
-tokio-tar = { workspace = true }
 wascap = { workspace = true }
 
 [dev-dependencies]

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -35,6 +35,7 @@ plugin = ["wasmtime", "wasmtime-wasi", "wasmtime-wasi-http"]
 [dependencies]
 anstyle = { workspace = true }
 anyhow = { workspace = true, features = ["backtrace"] }
+astral-tokio-tar = { workspace = true }
 async-compression = { workspace = true, features = ["tokio", "gzip"] }
 async-nats = { workspace = true, optional = true }
 bytes = { workspace = true, features = ["serde"] }
@@ -99,7 +100,6 @@ thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
-tokio-tar = { workspace = true }
 tokio-util = { workspace = true }
 toml = { workspace = true, features = ["parse"] }
 tracing = { workspace = true, features = ["log"] }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

tokio-tar is abandoned and has a high severity CVE that is addressed by astral-tokio-tar 0.5.6

astral-tokio-tar can be used as an actively maintained drop-in replacement


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
