### PR TITLE
chore(ci): Disable cron for benchmark tests

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,8 +8,6 @@ on:
         required: true
         default: 'main'
         type: string
-  schedule:
-    - cron: '0 0 * * SAT'
 
 permissions:
   contents: read


### PR DESCRIPTION
Due to issues with oracle cloud, we can never seem to get a stable k8s environment. To avoid any issues and spending credits (even if only a small amount), we should disable running these on a cron until people have time to actually go configure a proper test environment. See #4022 for more details