### PR TITLE
fix(ci): stop using deprecated runners

### DIFF
--- a/.github/workflows/secrets-nats-kv.yml
+++ b/.github/workflows/secrets-nats-kv.yml
@@ -78,11 +78,11 @@ jobs:
             rust-target: x86_64-unknown-linux-musl
           - os: darwin
             arch: amd64
-            runs-on: macos-13
+            runs-on: macos-15-intel
             rust-target: x86_64-apple-darwin
           - os: darwin
             arch: aarch64
-            runs-on: macos-14
+            runs-on: macos-15
             rust-target: aarch64-apple-darwin
           - os: windows
             arch: amd64

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false # Ensure we can run the full suite even if one OS fails
       matrix:
-        os: [ubuntu-latest-4-cores, windows-latest, macos-13]
+        os: [ubuntu-latest-4-cores, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020

--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -412,7 +412,7 @@ jobs:
       - run: codesign --verify ./bin/wash
 
   test-wash-macos-x86_64:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs:
       - build-wash-bin
       - build-wash-lipo
@@ -477,7 +477,7 @@ jobs:
       - run: codesign --verify ./bin/wasmcloud
 
   test-wasmcloud-macos-x86_64:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs:
       - build-wasmcloud-bin
       - build-wasmcloud-lipo


### PR DESCRIPTION
`macos-13` runners are deprecated and don't run anymore https://github.com/actions/runner-images/issues/13046