### PR TITLE
Interface-driven extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6625,11 +6625,11 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
+ "spiffe",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "wascap",
  "wasmcloud-secrets-client",
  "wasmcloud-secrets-types",
 ]
@@ -7470,7 +7470,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "url",
- "wascap",
  "wasi-preview1-component-adapter-provider",
  "wit-component 0.224.1",
 ]
@@ -8778,7 +8777,6 @@ dependencies = [
  "oci-wasm 0.3.0",
  "once_cell",
  "path-absolutize",
- "provider-archive",
  "rand 0.9.2",
  "regex",
  "reqwest",
@@ -8813,7 +8811,6 @@ dependencies = [
  "wadm-types",
  "walkdir",
  "warp",
- "wascap",
  "wasi-preview1-component-adapter-provider",
  "wasm-encoder 0.232.0",
  "wasm-pkg-client",
@@ -9218,7 +9215,6 @@ dependencies = [
  "nats-jwt-rs",
  "nkeys",
  "once_cell",
- "provider-archive",
  "rand 0.9.2",
  "redis",
  "regex",
@@ -9293,6 +9289,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
+ "wit-bindgen-wrpc 0.9.0",
 ]
 
 [[package]]
@@ -9313,7 +9310,6 @@ dependencies = [
  "oci-client 0.15.0",
  "oci-wasm 0.3.0",
  "once_cell",
- "provider-archive",
  "reqwest",
  "rustls 0.23.35",
  "rustls-native-certs 0.8.2",
@@ -9329,9 +9325,11 @@ dependencies = [
  "tracing",
  "unicase",
  "url",
+ "uuid 1.18.1",
  "wascap",
  "wasmtime-wasi-http",
  "webpki-roots 1.0.4",
+ "wit-bindgen-wrpc 0.9.0",
  "wrpc-interface-http",
 ]
 
@@ -9383,6 +9381,7 @@ dependencies = [
  "wasmcloud-tracing",
  "wasmtime-wasi-http",
  "webpki-roots 1.0.4",
+ "wit-bindgen-wrpc 0.9.0",
  "wrpc-interface-http",
  "wrpc-transport",
  "wrpc-transport-nats",
@@ -9405,6 +9404,7 @@ dependencies = [
  "tracing",
  "wasmcloud-provider-sdk",
  "wasmcloud-test-util",
+ "wit-bindgen-wrpc 0.9.0",
  "wrpc-interface-blobstore",
  "wrpc-transport-nats",
 ]
@@ -9423,6 +9423,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "wasmcloud-provider-sdk",
+ "wit-bindgen-wrpc 0.9.0",
  "wrpc-interface-blobstore",
 ]
 
@@ -9445,6 +9446,7 @@ dependencies = [
  "wascap",
  "wasmcloud-provider-sdk",
  "wasmcloud-test-util",
+ "wit-bindgen-wrpc 0.9.0",
  "wrpc-interface-blobstore",
  "wrpc-transport-nats",
 ]
@@ -9471,6 +9473,7 @@ dependencies = [
  "tracing",
  "wasmcloud-provider-sdk",
  "wasmcloud-test-util",
+ "wit-bindgen-wrpc 0.9.0",
  "wrpc-interface-blobstore",
 ]
 
@@ -9495,6 +9498,7 @@ dependencies = [
  "wasmcloud-core",
  "wasmcloud-provider-sdk",
  "webpki-roots 1.0.4",
+ "wit-bindgen-wrpc 0.9.0",
  "wrpc-interface-http",
 ]
 
@@ -9524,6 +9528,7 @@ dependencies = [
  "wasmcloud-core",
  "wasmcloud-provider-sdk",
  "wasmcloud-test-util",
+ "wit-bindgen-wrpc 0.9.0",
  "wrpc-interface-http",
 ]
 
@@ -9589,7 +9594,6 @@ dependencies = [
  "async-nats",
  "tokio",
  "tracing",
- "wascap",
  "wasmcloud-control-interface",
 ]
 
@@ -9647,12 +9651,14 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "wasmcloud-core",
  "wasmcloud-tracing",
+ "wit-bindgen-wrpc 0.9.0",
  "wrpc-transport",
  "wrpc-transport-nats",
 ]
@@ -9705,7 +9711,6 @@ dependencies = [
  "tracing-opentelemetry",
  "wadm-client",
  "wadm-types",
- "wascap",
  "wasmcloud-provider-sdk",
  "wit-bindgen-wrpc 0.9.0",
 ]
@@ -9787,7 +9792,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "wascap",
  "wasmcloud-control-interface",
  "wasmcloud-core",
  "wasmcloud-host",

--- a/crates/provider-sdk/src/provider.rs
+++ b/crates/provider-sdk/src/provider.rs
@@ -367,12 +367,6 @@ impl Context {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-struct ShutdownMessage {
-    /// The ID of the host that sent the message
-    pub host_id: String,
-}
-
 /// Handle shutdown for providers.
 /// Shutdown can be triggered via:
 /// - wRPC manageable::Handler::shutdown() method (signals quit channel)

--- a/src/main.rs
+++ b/src/main.rs
@@ -627,7 +627,6 @@ async fn main() -> anyhow::Result<()> {
             http_admin: args.http_admin,
             enable_component_auction: args.enable_component_auction.unwrap_or(true),
             enable_provider_auction: args.enable_provider_auction.unwrap_or(true),
-            enable_deprecated_v1_providers: args.enable_deprecated_v1_providers.unwrap_or(false),
         })
         .await?;
     let (host, shutdown) = host_builder


### PR DESCRIPTION
## Externalization of providers

# NOTES
- I use provider and extension interchangeably, extension is the new form of a provider which is more general and dynamic
- ALL naming is subject to change for interfaces and software if this architectural change is beneficial
- I need to fix tests which I will do once I get some feedback on the architecture
- This is for issue https://github.com/wasmCloud/wasmCloud/issues/4642


Wasmcloud hosts lattices. Lattices are composed of a bunch of linked components and providers. Providers are currently specific to wasmcloud and require very specific custom support and can cause a lot of blockers. Currently:
- Providers can only be made in rust and go with the help of first party SDKs
- Providers must follow a very strict flow
- Providers have to be internally managed and ran by the host itself
- Providers cannot horizontally scale the same way as components
- Providers are currently the bottleneck in terms of the amount of requests that can enter and exit into the lattice

Currently, architecture emerges like so
<img width="1153" height="713" alt="image" src="https://github.com/user-attachments/assets/75622692-4e7f-46bb-b0e7-2f764d82a800" />


with the new approach, providers become extensions and allow a lattice to emerge as a consequence of existing/external infrastructure and the set of hosts

<img width="1299" height="711" alt="image" src="https://github.com/user-attachments/assets/3421f900-7ad0-4c59-ab8e-a44de162cde6" />

The benefits of this are:
- opportunities to remove responsibility of the host
- Users can now decide whether to give the host responsibility of managing an extension or just connect to the host from an external system
- More permutations of systems can be made
- lower cost for integrating wasmCloud into existing business infrastructure and systems


## Interface-driven extensions
Now that providers are extensions, we need a way of interacting with them outside of the domain of the host. A provider currently is monolothic and requires a lot of custom logic in order to operate. The only interfaces a provider satisfies is the functionality it was built for, e.g. postgres for a postgres provider or wasi:keyvalue for a redis keyvalue store. This is great,  but we can do better.

We can generalise extensions (providers) by decomposing the things it is responsible for into separate interfaces:
<img width="818" height="622" alt="image" src="https://github.com/user-attachments/assets/bf7617d0-4f96-49a4-b3ec-f834f18edbe5" />

Currently 2 interfaces have been made
1) Manageable - the manageable interface is the single mandatory interface required for a extension to satisfy to allow a host to connect and 'bind' to it. this is just a handshake and allows for the exchange of important information such as workload identities and extension keys to allow secure secret distribution. A shutdown function is also implemented, meaning logic can be created and controlled by wasm components, software and hosts.
    - Easier to make CI/CD processes and infrastructure (even wasm-controlled CI/CD)
    - programmatic, declarative control of shutdown sequences for any variety of reasons
    - Anyone can choose how to implement these as required, a user might not want to give back an ecnryption key because they do not need to use secrets, or a user might only want to expose certain functionality through the shutdown interface

2) Configurable
Inside interface-driven lattices, there is contextual execution. this means the execution of a component or extension might differ based on the link it traverses. links need to store specific configuration which defines how a extension behaves based on the source that is calling it. This is currently done with links, which store configuration.
    - Extensions/components need to have confgiuration supplied to decide how it works
    - They need link-speicfic configuration supplied to decide how it works based on 'who' is asking or receiving these RPC invocations.
    - 'Confgurable' interface is not mandatory.

... 
In the future, more interfaces can be added and implemented so that the host can interact in different ways with different extensions without forcing an extension to implement ALL interfaces.


### CTL protocol for extensions
If an extension is added, we could potentially serve the extension interfaces with the same wrpc client (and therefore prefix) as the extensions functionality (using the RPC lattice protocol). This causes a couple of issues though:
    - If there are multiple providers running and linked to the same subject, it is unpredictable about which one would react to CTL messages. this is amazing for RPC calls, we can distribute workload globally. This is terrible for CTL calls, as an extension shutdown message might shutdown a extension we didnt want to shutdown, or configure an extension we didnt want to configure.
    - We lose individual host context. We dont know which host is running what extensions (whether managed or externally)

This is fixed by serving the extension interfaces on a ctl subject like so:
`"wasmbus.ctl.v1.{lattice}.extension.{extension-id}.{host-id}"

This maintains the context of the host id we want to issue the invocation to so that we can individually configure, shutdown, check, etc. extension-id on different hosts

## Extensions still 'live' on a host
Even though the functionality of extensions need to globally contribute to the lattice, as said earlier we need to maintain uniqueness for congfiguration and management purposes. Because of this, regarldess if an extension is managed or external, it needs to connect to an individual host. Therefore, we make sure an individual host is responsible for the bind and management of these extensions. This compliments existing topologies of how lattices are setup and connected together over nats. Config watchers are still spawned for external extensions as the host is still responsible for making sure its up to date.

<img width="1213" height="753" alt="image" src="https://github.com/user-attachments/assets/aef18fe8-0fe8-4028-8927-8559308d19f7" />




# Further requirements and finalization
- We need a way of deterministically knowing which extension satisfies what interfaces. In a perfect world, this can be done by adjusting the wit-bindgen macro to export the list of served exports from the extension WIT package and automatically adding them to the bind request or in its own manageable function such as satisfied_interfaces(). For now, it would still be sufficient to just force the binary to implement this method and return back a list of interfaces it satisfies, or attempt to gather this information from a deployment manifest.
- Secret distribution still requires JWT claims, but this isnt stored inside the binaries anymore. Need some guidance on new secret management if wascap and nkeys are going away. See https://github.com/wasmCloud/wasmCloud/issues/4639
- How to deal with workload identity?
- External extensions that get a Host ID to extend do not currently validate the host id exists. This is not a concern for internal providers because its provided by the host itself that is running it
- How do external providers interact with policy managers?
