### PR TITLE
feat(wash): added dynamic autocompletion for app and spy subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e602857739c5a4291dfa33b5a298aeac9006185229a700e5810a3ef7272d971"
 dependencies = [
  "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -3914,6 +3917,15 @@ checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/crates/control-interface/src/types/component.rs
+++ b/crates/control-interface/src/types/component.rs
@@ -12,7 +12,7 @@ use crate::Result;
 pub struct ComponentDescription {
     /// The unique component identifier for this component
     #[serde(default)]
-    pub(crate) id: String,
+    pub id: String,
 
     /// Image reference for this component
     #[serde(default)]

--- a/crates/control-interface/src/types/host.rs
+++ b/crates/control-interface/src/types/host.rs
@@ -215,10 +215,10 @@ impl HostBuilder {
 pub struct HostInventory {
     /// Components running on this host.
     #[serde(alias = "actors")]
-    pub(crate) components: Vec<ComponentDescription>,
+    pub components: Vec<ComponentDescription>,
 
     /// Providers running on this host
-    pub(crate) providers: Vec<ProviderDescription>,
+    pub providers: Vec<ProviderDescription>,
 
     /// The host's unique ID
     #[serde(default)]

--- a/crates/control-interface/src/types/provider.rs
+++ b/crates/control-interface/src/types/provider.rs
@@ -12,7 +12,7 @@ use crate::Result;
 pub struct ProviderDescription {
     /// Provider's unique identifier
     #[serde(default)]
-    pub(crate) id: String,
+    pub id: String,
     /// Image reference for this provider, if applicable
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) image_ref: Option<String>,

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -50,7 +50,7 @@ clap = { workspace = true, features = [
     "std",
     "string",
 ], optional = true }
-clap_complete = { workspace = true }
+clap_complete = { workspace = true, features = ["unstable-dynamic"] }
 clap-markdown = { workspace = true }
 cloudevents-sdk = { workspace = true }
 command-group = { workspace = true, features = ["with-tokio"] }

--- a/crates/wash/src/bin/wash.rs
+++ b/crates/wash/src/bin/wash.rs
@@ -1,230 +1,42 @@
 use std::collections::HashMap;
-use std::fmt::{Display, Formatter};
+use std::env;
 use std::io::{stdout, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context};
-use clap::{self, Arg, ArgMatches, Command, FromArgMatches, Parser, Subcommand};
-use console::style;
-use crossterm::style::Stylize;
+use clap::{self, Arg, ArgMatches, Command, FromArgMatches};
 use etcetera::AppStrategy;
 use semver::Version;
 use serde_json::json;
 use tracing_subscriber::EnvFilter;
-use wash::lib::cli::capture::{CaptureCommand, CaptureSubcommand};
-use wash::lib::cli::claims::ClaimsCliCommand;
-use wash::lib::cli::get::GetCommand;
-use wash::lib::cli::inspect::InspectCliCommand;
-use wash::lib::cli::label::LabelHostCommand;
-use wash::lib::cli::link::LinkCommand;
-use wash::lib::cli::registry::{RegistryPullCommand, RegistryPushCommand};
-use wash::lib::cli::scale::ScaleCommand;
-use wash::lib::cli::spy::SpyCommand;
-use wash::lib::cli::start::StartCommand;
-use wash::lib::cli::stop::StopCommand;
-use wash::lib::cli::update::UpdateCommand;
+use wash::lib::cli::capture::CaptureSubcommand;
 use wash::lib::cli::{CommandOutput, OutputKind};
 use wash::lib::config::WASH_DIRECTORIES;
-use wash::lib::drain::Drain as DrainSelection;
 use wash::lib::generate::emoji;
 use wash::lib::plugin::subcommand::{DirMapping, SubcommandRunner};
 use wash::lib::start::get_wash_versions_newer_than;
 
-use wash::cli::app::{self, AppCliCommand};
-use wash::cli::build::{self, BuildCommand};
-use wash::cli::call::{self, CallCli};
+use wash::cli::app;
+use wash::cli::build;
+use wash::cli::call;
+use wash::cli::cli::{Cli, CliCommand};
 use wash::cli::cmd::config::{self, ConfigCliCommand};
-use wash::cli::cmd::dev::{self, DevCommand};
+use wash::cli::cmd::dev;
 use wash::cli::cmd::link;
-use wash::cli::cmd::up::{self, UpCommand};
-use wash::cli::cmd::wit::{self, WitCommand};
+use wash::cli::cmd::up;
+use wash::cli::cmd::wit;
 use wash::cli::common;
-use wash::cli::completions::{self, CompletionOpts};
+use wash::cli::completions;
 use wash::cli::config::{NATS_SERVER_VERSION, WADM_VERSION, WASMCLOUD_HOST_VERSION};
-use wash::cli::ctx::{self, CtxCommand};
-use wash::cli::down::{self, DownCommand};
+use wash::cli::ctx;
+use wash::cli::down;
 use wash::cli::drain;
-use wash::cli::generate::{self, NewCliCommand};
-use wash::cli::keys::{self, KeysCliCommand};
-use wash::cli::par::{self, ParCliCommand};
-use wash::cli::plugin::{self, PluginCommand};
-use wash::cli::secrets::{self, SecretsCliCommand};
-use wash::cli::style::WASH_CLI_STYLE;
-use wash::cli::ui::{self, UiCommand};
-
-#[derive(Clone)]
-struct HelpTopic {
-    name: &'static str,
-    commands: Vec<(&'static str, &'static str)>,
-}
-
-impl Display for HelpTopic {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        const PADDING_AFTER_LONGEST_SPACES: usize = 3;
-        const DEFAULT_PADDING_START: usize = 25;
-        writeln!(f, "{}", self.name.green().bold())?;
-        let longest_command_length = self
-            .commands
-            .iter()
-            .map(|(name, _)| name.len())
-            .max()
-            .unwrap_or(DEFAULT_PADDING_START)
-            + PADDING_AFTER_LONGEST_SPACES;
-
-        for (name, desc) in &self.commands {
-            let padding = " ".repeat(longest_command_length - name.len());
-            writeln!(f, "  {}{}{}", name.blue(), padding, desc)?;
-        }
-        Ok(())
-    }
-}
-
-struct HelpTopics(Vec<HelpTopic>);
-
-impl Display for HelpTopics {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        for topic in &self.0 {
-            writeln!(f, "{topic}")?;
-        }
-        Ok(())
-    }
-}
-
-impl From<Vec<HelpTopic>> for HelpTopics {
-    fn from(topics: Vec<HelpTopic>) -> Self {
-        HelpTopics(topics)
-    }
-}
-
-fn create_colored_help() -> String {
-    let banner = style(
-        r"
-_________________________________________________________________________________
-                               _____ _                 _    _____ _          _ _
-                              / ____| |               | |  / ____| |        | | |
- __      ____ _ ___ _ __ ___ | |    | | ___  _   _  __| | | (___ | |__   ___| | |
- \ \ /\ / / _` / __| '_ ` _ \| |    | |/ _ \| | | |/ _` |  \___ \| '_ \ / _ \ | |
-  \ V  V / (_| \__ \ | | | | | |____| | (_) | |_| | (_| |  ____) | | | |  __/ | |
-   \_/\_/ \__,_|___/_| |_| |_|\_____|_|\___/ \__,_|\__,_| |_____/|_| |_|\___|_|_|
-_________________________________________________________________________________
-",
-    )
-    .green()
-    .bold();
-
-    let description =
-        "Interact and manage wasmCloud applications, projects, and runtime environments".green();
-
-    let usage_description = format!("{} {}", "Usage:".green(), "[OPTIONS] <COMMAND>".blue());
-
-    let command_descriptions = HelpTopics::from([
-        HelpTopic {
-            name: "Build:",
-            commands: vec![
-                ("new", "Create a new project from a template or git repository"),
-                ("build", "Build (and sign) a wasmCloud component or capability provider"),
-                ("dev", "Start a developer loop to hot-reload a local wasmCloud component"),
-                (
-                    "inspect",
-                    "Inspect a Wasm component or capability provider for signing information and interfaces",
-                ),
-                (
-                    "par",
-                    "Create, inspect, and modify capability provider archive files",
-                ),
-                (
-                    "wit",
-                    "Create wit packages and fetch wit dependencies for a component",
-                ),
-            ],
-        },
-        HelpTopic {
-            name: "Run:",
-            commands: vec![
-                ("up", "Bootstrap a local wasmCloud environment"),
-                (
-                    "down",
-                    "Tear down a local wasmCloud environment (launched with wash up)",
-                ),
-                ("app", "Manage declarative applications and deployments (wadm)"),
-                ("spy", "Spy on all invocations a component sends and receives"),
-                ("ui", "Serve a web UI for wasmCloud"),
-            ],
-        },
-        HelpTopic {
-            name: "Iterate:",
-            commands: vec![
-                ("get", "Get information about different running wasmCloud resources"),
-                ("start", "Start a component or capability provider"),
-                (
-                    "scale",
-                    "Scale a component running in a host to a certain level of concurrency",
-                ),
-                ("stop", "Stop a component, capability provider, or host"),
-                (
-                    "update",
-                    "Update a component running in a host to newer image reference",
-                ),
-                ("link", "Link one component to another on a set of interfaces"),
-                ("call", "Invoke a simple function on a component running in a wasmCloud host"),
-                ("label", "Label (or un-label) a host with a key=value label pair"),
-                (
-                    "config",
-                    "Create configuration for components, capability providers and links",
-                ),
-                (
-                    "secrets",
-                    "Create secret references for components, capability providers and links",
-                ),
-            ],
-        },
-        HelpTopic {
-            name: "Publish:",
-            commands: vec![
-                ("pull", "Pull an artifact from an OCI compliant registry"),
-                ("push", "Push an artifact to an OCI compliant registry"),
-            ],
-        },
-        HelpTopic {
-            name: "Configure:",
-            commands: vec![
-                ("completions", "Generate shell completions for wash"),
-                ("ctx", "Manage wasmCloud host configuration contexts"),
-                ("drain", "Manage contents of local wasmCloud caches"),
-                ("keys", "Generate and manage signing keys"),
-                ("claims", "Generate and manage JWTs for wasmCloud components and capability providers"),
-                ("plugin", "Manage wash plugins"),
-            ],
-        },
-        HelpTopic {
-            name: "Options:",
-            commands: vec![
-                (
-                    "-o, --output <OUTPUT>",
-                    "Specify output format (text or json) [default: text]",
-                ),
-                (
-                    "--experimental",
-                    "Whether or not to enable experimental features [default: false]",
-                ),
-                ("-h, --help", "Print help"),
-                ("-V, --version", "Print version"),
-            ],
-        },
-    ].to_vec());
-
-    format!(
-        r#"
-{banner}
-
-{description}
-
-{usage_description}
-
-{command_descriptions}
-"#
-    )
-}
+use wash::cli::generate;
+use wash::cli::keys;
+use wash::cli::par;
+use wash::cli::plugin;
+use wash::cli::secrets;
+use wash::cli::ui;
 
 /// Helper function to display the version of all the binaries wash runs
 fn version(output: OutputKind) -> String {
@@ -246,140 +58,6 @@ fn version(output: OutputKind) -> String {
             serde_json::to_string_pretty(&versions).unwrap()
         }
     }
-}
-
-#[derive(Debug, Clone, Parser)]
-#[clap(name = "wash", disable_version_flag = true, override_help = create_colored_help())]
-#[command(styles = WASH_CLI_STYLE)]
-struct Cli {
-    #[clap(
-        short = 'o',
-        long = "output",
-        default_value = "text",
-        help = "Specify output format (text or json)",
-        global = true
-    )]
-    pub(crate) output: OutputKind,
-
-    #[clap(
-        long = "experimental",
-        id = "experimental",
-        env = "WASH_EXPERIMENTAL",
-        default_value = "false",
-        help = "Whether or not to enable experimental features",
-        global = true
-    )]
-    pub(crate) experimental: bool,
-
-    #[clap(
-        long = "help-markdown",
-        conflicts_with = "help",
-        hide = true,
-        global = true
-    )]
-    help_markdown: bool,
-
-    #[clap(short = 'V', long = "version", help = "Print version")]
-    version: bool,
-
-    #[clap(subcommand)]
-    command: Option<CliCommand>,
-}
-
-// NOTE: If you change the description here, ensure you also change it in the help text constant above
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Subcommand)]
-enum CliCommand {
-    /// Manage declarative applications and deployments (wadm)
-    #[clap(name = "app", subcommand)]
-    App(AppCliCommand),
-    /// Build (and sign) a wasmCloud component or capability provider
-    #[clap(name = "build")]
-    Build(BuildCommand),
-    /// Invoke a simple function on a component running in a wasmCloud host
-    #[clap(name = "call")]
-    Call(CallCli),
-    /// Capture and debug cluster invocations and state
-    #[clap(name = "capture")]
-    Capture(CaptureCommand),
-    /// Generate shell completions for wash
-    #[clap(name = "completions")]
-    Completions(CompletionOpts),
-    /// Generate and manage JWTs for wasmCloud components and capability providers
-    #[clap(name = "claims", subcommand)]
-    Claims(ClaimsCliCommand),
-    /// Create configuration for components, capability providers and links
-    #[clap(name = "config", subcommand)]
-    Config(ConfigCliCommand),
-    /// Manage wasmCloud host configuration contexts
-    #[clap(name = "ctx", alias = "context", alias = "contexts", subcommand)]
-    Ctx(CtxCommand),
-    /// Start a developer loop to hot-reload a local wasmCloud component
-    #[clap(name = "dev")]
-    Dev(DevCommand),
-    /// Tear down a local wasmCloud environment (launched with wash up)
-    #[clap(name = "down")]
-    Down(DownCommand),
-    /// Manage contents of local wasmCloud caches
-    #[clap(name = "drain", subcommand)]
-    Drain(DrainSelection),
-    /// Get information about different running wasmCloud resources
-    #[clap(name = "get", subcommand)]
-    Get(GetCommand),
-    /// Inspect a Wasm component or capability provider for signing information and interfaces
-    #[clap(name = "inspect")]
-    Inspect(InspectCliCommand),
-    /// Generate and manage signing keys
-    #[clap(name = "keys", alias = "key", subcommand)]
-    Keys(KeysCliCommand),
-    /// Link one component to another on a set of interfaces
-    #[clap(name = "link", alias = "links", subcommand)]
-    Link(LinkCommand),
-    /// Create a new project from a template or git repository
-    #[clap(name = "new", subcommand)]
-    New(NewCliCommand),
-    /// Create, inspect, and modify capability provider archive files
-    #[clap(name = "par", subcommand)]
-    Par(ParCliCommand),
-    /// Manage wash plugins
-    #[clap(name = "plugin", subcommand)]
-    Plugin(PluginCommand),
-    /// Push an artifact to an OCI compliant registry
-    #[clap(name = "push")]
-    RegPush(RegistryPushCommand),
-    /// Pull an artifact from an OCI compliant registry
-    #[clap(name = "pull")]
-    RegPull(RegistryPullCommand),
-    /// Create secret references for components, capability providers and links
-    #[clap(name = "secrets", alias = "secret", subcommand)]
-    Secrets(SecretsCliCommand),
-    /// Spy on all invocations a component sends and receives
-    #[clap(name = "spy")]
-    Spy(SpyCommand),
-    /// Scale a component running in a host to a certain level of concurrency
-    #[clap(name = "scale", subcommand)]
-    Scale(ScaleCommand),
-    /// Start a component or capability provider
-    #[clap(name = "start", subcommand)]
-    Start(StartCommand),
-    /// Stop a component, capability provider, or host
-    #[clap(name = "stop", subcommand)]
-    Stop(StopCommand),
-    /// Label (or un-label) a host with a key=value label pair
-    #[clap(name = "label", alias = "tag")]
-    Label(LabelHostCommand),
-    /// Update a component running in a host to newer image reference
-    #[clap(name = "update", subcommand)]
-    Update(UpdateCommand),
-    /// Bootstrap a local wasmCloud environment
-    #[clap(name = "up")]
-    Up(UpCommand),
-    /// Serve a web UI for wasmCloud
-    #[clap(name = "ui")]
-    Ui(UiCommand),
-    /// Create wit packages and fetch wit dependencies for a component
-    #[clap(name = "wit", subcommand)]
-    Wit(WitCommand),
 }
 
 #[tokio::main]
@@ -455,6 +133,8 @@ async fn main() {
     }
 
     command.build();
+    clap_complete::CompleteEnv::with_factory(|| command.clone()).complete();
+
     let mut matches = command.get_matches_mut();
 
     let cli = match (Cli::from_arg_matches(&matches), resolved_plugins) {

--- a/crates/wash/src/cli/app/autocompletion.rs
+++ b/crates/wash/src/cli/app/autocompletion.rs
@@ -1,0 +1,162 @@
+use anyhow::anyhow;
+use clap_complete::engine::CompletionCandidate;
+use std::ffi::OsStr;
+use std::fs::read_dir;
+use std::path::Path;
+use tokio::runtime::Handle;
+use tokio::task;
+
+use crate::cli::cli::{CliCommand, create_cli, get_connection_opts_from_cli};
+use crate::lib::cli::CliConnectionOpts;
+use crate::lib::config::WashConnectionOptions;
+use wadm_types::api::StatusType;
+
+use super::AppCliCommand;
+
+// Used as input for app_name completer
+#[derive(PartialEq)]
+enum DesiredAppStatusType {
+    All,
+    Deployed,
+    Undeployed,
+}
+
+// Used to identify the app name already specified in order to retrieve candidates for dynamic autocompletion
+// of the respective subcommand.
+fn get_app_name_from_cli() -> anyhow::Result<Option<String>> {
+    match create_cli() {
+        Some(CliCommand::App(AppCliCommand::Delete(cmd))) => Ok(cmd.app_name),
+        Some(CliCommand::App(AppCliCommand::Deploy(cmd))) => Ok(cmd.app_name),
+        Some(CliCommand::App(AppCliCommand::Get(cmd))) => Ok(cmd.app_name),
+        _ => Err(anyhow!("Command did not match any expected patterns")),
+    }
+}
+
+pub fn app_name_completer(_current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
+    task::block_in_place(
+        || Handle::current()
+            .block_on(get_declared_apps(DesiredAppStatusType::All))
+    ).unwrap_or(vec![])
+}
+
+pub fn deployed_app_name_completer(_current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
+    task::block_in_place(
+        || Handle::current()
+            .block_on(get_declared_apps(DesiredAppStatusType::Deployed))
+    ).unwrap_or(vec![])
+}
+
+pub fn undeployed_app_name_completer(_current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
+    task::block_in_place(
+        || Handle::current()
+            .block_on(get_declared_apps(DesiredAppStatusType::Undeployed))
+    ).unwrap_or(vec![])
+}
+
+// Getting the names of declared applications from WADM and filter them as potential candidates
+async fn get_declared_apps(status: DesiredAppStatusType) -> anyhow::Result<Vec<CompletionCandidate>> {
+    let connection_opts =
+        <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(get_connection_opts_from_cli()?)?;
+    let lattice = Some(connection_opts.get_lattice());
+    let client = connection_opts.into_nats_client().await?;
+    let models = crate::lib::app::get_models(&client, lattice).await?;
+
+    let candidates: Vec<CompletionCandidate> = models
+        .iter()
+        .filter(|ms| {
+            match status {
+                DesiredAppStatusType::All => true,
+                DesiredAppStatusType::Deployed => {StatusType::Deployed == ms.detailed_status.info.status_type},
+                DesiredAppStatusType::Undeployed => {StatusType::Undeployed == ms.detailed_status.info.status_type},
+            }
+        })
+        .map(|ms| {
+            CompletionCandidate::new(&ms.name)
+        })
+        .collect();
+
+    Ok(candidates)
+}
+
+pub fn version_completer(_current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
+    task::block_in_place(|| Handle::current().block_on(get_declared_versions())).unwrap_or(vec![])
+}
+
+// Getting the versions of declared applications from WADM as potential candidates
+async fn get_declared_versions() -> anyhow::Result<Vec<CompletionCandidate>> {
+    let connection_opts =
+        <CliConnectionOpts as TryInto<WashConnectionOptions>>::try_into(get_connection_opts_from_cli()?)?;
+    let lattice = Some(connection_opts.get_lattice());
+    let client = connection_opts.into_nats_client().await?;
+    let app_name = get_app_name_from_cli()?.unwrap_or("".to_string());
+    let versions = crate::lib::app::get_model_history(&client, lattice, &app_name).await?;
+
+    let candidates: Vec<CompletionCandidate> = versions
+        .iter()
+        .map(|info| CompletionCandidate::new(&info.version))
+        .collect();
+
+    Ok(candidates)
+}
+
+pub fn path_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
+    task::block_in_place(|| Handle::current().block_on(get_local_manifests(current.to_str().unwrap_or_default()))).unwrap_or(vec![])
+}
+
+// TODO: Currently, if no other candidate exists clap will automatically append a space
+// at the end of the arg, see: https://github.com/clap-rs/clap/issues/5587
+// Once this is configurable, we need to prevent the trailing space for directories.
+async fn get_local_manifests(path: &str) -> anyhow::Result<Vec<CompletionCandidate>> {
+
+    // Setting path for lookup from requested, potentially incomplete path
+    let p= if path.ends_with("/") {
+        // `path` is a valid, relative or absolut path
+        // (e.g. <parent_dir>/manifests/, ./manifests/, manifests/, ...).
+        // Therefore it can be directly used for identifying candidates.
+        Path::new(path)
+    } else if path.contains("/") {
+        // `path` is an incomplete, relative or absolut path as str
+        // (e.g. <parent_dir>/mani, ./, ./mani, ...).
+        // Therefore the parent directory must be used for identifying candidates.
+        Path::new(path).parent().unwrap_or(Path::new("./"))
+    } else {
+        // `path` is an incomplete, relative path as str (e.g. manife).
+        // Therefore we use the current directory for identifying candidates.
+        Path::new("./")
+    };
+
+    let entries = read_dir(p)?;
+    let candidates: Vec<CompletionCandidate> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            use std::os::unix::ffi::OsStrExt;
+            // We want to return non-hidden directories
+            if e.file_type().unwrap().is_dir() && e.file_name().as_os_str().as_bytes()[0] != b'.' {
+                true
+            } else {
+                // Otherwise we want to return non-hidden yaml files
+                e.path().extension() == Some(OsStr::from_bytes(b"yaml")) && e.file_name().as_os_str().as_bytes()[0] != b'.'
+            }
+        })
+        .map(|e| {
+            // Removing prefix for current directory if needed.
+            // This is necessary because we are using that prefix as the default path
+            // for incomplete, relative path (see above).
+            let p = if e.path().starts_with("./") && !path.starts_with("./") {
+                let p = e.path().clone();
+                p.strip_prefix("./").unwrap_or(p.as_path()).to_path_buf()
+            } else {
+                e.path()
+            };
+            if e.file_type().unwrap().is_dir() {
+                // Adding a trailing "/" so that for the next candidate identification
+                // the current path can be used as is - see the initial matching of this function
+                CompletionCandidate::new(p.join(""))
+            } else {
+                CompletionCandidate::new(p)
+            }
+        })
+        .collect();
+
+    Ok(candidates)
+}

--- a/crates/wash/src/cli/cli.rs
+++ b/crates/wash/src/cli/cli.rs
@@ -1,0 +1,376 @@
+use std::env;
+use std::fmt::{Display, Formatter};
+
+use anyhow::anyhow;
+use clap::{self, FromArgMatches, Parser, Subcommand};
+use console::style;
+use crossterm::style::Stylize;
+use crate::lib::cli::CliConnectionOpts;
+use crate::lib::cli::capture::CaptureCommand;
+use crate::lib::cli::claims::ClaimsCliCommand;
+use crate::lib::cli::get::GetCommand;
+use crate::lib::cli::inspect::InspectCliCommand;
+use crate::lib::cli::label::LabelHostCommand;
+use crate::lib::cli::link::LinkCommand;
+use crate::lib::cli::registry::{RegistryPullCommand, RegistryPushCommand};
+use crate::lib::cli::scale::ScaleCommand;
+use crate::lib::cli::spy::SpyCommand;
+use crate::lib::cli::start::StartCommand;
+use crate::lib::cli::stop::StopCommand;
+use crate::lib::cli::update::UpdateCommand;
+use crate::lib::cli::OutputKind;
+use crate::lib::drain::Drain as DrainSelection;
+
+use crate::app::AppCliCommand;
+use crate::build::BuildCommand;
+use crate::call::CallCli;
+use crate::cmd::config::ConfigCliCommand;
+use crate::cmd::dev::DevCommand;
+use crate::cmd::up::UpCommand;
+use crate::cmd::wit::WitCommand;
+use crate::completions::CompletionOpts;
+use crate::ctx::CtxCommand;
+use crate::down::DownCommand;
+use crate::generate::NewCliCommand;
+use crate::keys::KeysCliCommand;
+use crate::par::ParCliCommand;
+use crate::plugin::PluginCommand;
+use crate::secrets::SecretsCliCommand;
+use crate::style::WASH_CLI_STYLE;
+use crate::ui::UiCommand;
+
+#[derive(Clone)]
+struct HelpTopic {
+    name: &'static str,
+    commands: Vec<(&'static str, &'static str)>,
+}
+
+impl Display for HelpTopic {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        const PADDING_AFTER_LONGEST_SPACES: usize = 3;
+        const DEFAULT_PADDING_START: usize = 25;
+        writeln!(f, "{}", self.name.green().bold())?;
+        let longest_command_length = self
+            .commands
+            .iter()
+            .map(|(name, _)| name.len())
+            .max()
+            .unwrap_or(DEFAULT_PADDING_START)
+            + PADDING_AFTER_LONGEST_SPACES;
+
+        for (name, desc) in &self.commands {
+            let padding = " ".repeat(longest_command_length - name.len());
+            writeln!(f, "  {}{}{}", name.blue(), padding, desc)?;
+        }
+        Ok(())
+    }
+}
+
+struct HelpTopics(Vec<HelpTopic>);
+
+impl Display for HelpTopics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for topic in &self.0 {
+            writeln!(f, "{topic}")?;
+        }
+        Ok(())
+    }
+}
+
+impl From<Vec<HelpTopic>> for HelpTopics {
+    fn from(topics: Vec<HelpTopic>) -> Self {
+        HelpTopics(topics)
+    }
+}
+
+fn create_colored_help() -> String {
+    let banner = style(
+        r"
+_________________________________________________________________________________
+                               _____ _                 _    _____ _          _ _
+                              / ____| |               | |  / ____| |        | | |
+ __      ____ _ ___ _ __ ___ | |    | | ___  _   _  __| | | (___ | |__   ___| | |
+ \ \ /\ / / _` / __| '_ ` _ \| |    | |/ _ \| | | |/ _` |  \___ \| '_ \ / _ \ | |
+  \ V  V / (_| \__ \ | | | | | |____| | (_) | |_| | (_| |  ____) | | | |  __/ | |
+   \_/\_/ \__,_|___/_| |_| |_|\_____|_|\___/ \__,_|\__,_| |_____/|_| |_|\___|_|_|
+_________________________________________________________________________________
+",
+    )
+    .green()
+    .bold();
+
+    let description =
+        "Interact and manage wasmCloud applications, projects, and runtime environments".green();
+
+    let usage_description = format!("{} {}", "Usage:".green(), "[OPTIONS] <COMMAND>".blue());
+
+    let command_descriptions = HelpTopics::from([
+        HelpTopic {
+            name: "Build:",
+            commands: vec![
+                ("new", "Create a new project from a template or git repository"),
+                ("build", "Build (and sign) a wasmCloud component or capability provider"),
+                ("dev", "Start a developer loop to hot-reload a local wasmCloud component"),
+                (
+                    "inspect",
+                    "Inspect a Wasm component or capability provider for signing information and interfaces",
+                ),
+                (
+                    "par",
+                    "Create, inspect, and modify capability provider archive files",
+                ),
+                (
+                    "wit",
+                    "Create wit packages and fetch wit dependencies for a component",
+                ),
+            ],
+        },
+        HelpTopic {
+            name: "Run:",
+            commands: vec![
+                ("up", "Bootstrap a local wasmCloud environment"),
+                (
+                    "down",
+                    "Tear down a local wasmCloud environment (launched with wash up)",
+                ),
+                ("app", "Manage declarative applications and deployments (wadm)"),
+                ("spy", "Spy on all invocations a component sends and receives"),
+                ("ui", "Serve a web UI for wasmCloud"),
+            ],
+        },
+        HelpTopic {
+            name: "Iterate:",
+            commands: vec![
+                ("get", "Get information about different running wasmCloud resources"),
+                ("start", "Start a component or capability provider"),
+                (
+                    "scale",
+                    "Scale a component running in a host to a certain level of concurrency",
+                ),
+                ("stop", "Stop a component, capability provider, or host"),
+                (
+                    "update",
+                    "Update a component running in a host to newer image reference",
+                ),
+                ("link", "Link one component to another on a set of interfaces"),
+                ("call", "Invoke a simple function on a component running in a wasmCloud host"),
+                ("label", "Label (or un-label) a host with a key=value label pair"),
+                (
+                    "config",
+                    "Create configuration for components, capability providers and links",
+                ),
+                (
+                    "secrets",
+                    "Create secret references for components, capability providers and links",
+                ),
+            ],
+        },
+        HelpTopic {
+            name: "Publish:",
+            commands: vec![
+                ("pull", "Pull an artifact from an OCI compliant registry"),
+                ("push", "Push an artifact to an OCI compliant registry"),
+            ],
+        },
+        HelpTopic {
+            name: "Configure:",
+            commands: vec![
+                ("completions", "Generate shell completions for wash"),
+                ("ctx", "Manage wasmCloud host configuration contexts"),
+                ("drain", "Manage contents of local wasmCloud caches"),
+                ("keys", "Generate and manage signing keys"),
+                ("claims", "Generate and manage JWTs for wasmCloud components and capability providers"),
+                ("plugin", "Manage wash plugins"),
+            ],
+        },
+        HelpTopic {
+            name: "Options:",
+            commands: vec![
+                (
+                    "-o, --output <OUTPUT>",
+                    "Specify output format (text or json) [default: text]",
+                ),
+                (
+                    "--experimental",
+                    "Whether or not to enable experimental features [default: false]",
+                ),
+                ("-h, --help", "Print help"),
+                ("-V, --version", "Print version"),
+            ],
+        },
+    ].to_vec());
+
+    format!(
+        r#"
+{banner}
+
+{description}
+
+{usage_description}
+
+{command_descriptions}
+"#
+    )
+}
+
+#[derive(Debug, Clone, Parser)]
+#[clap(name = "wash", disable_version_flag = true, override_help = create_colored_help())]
+#[command(styles = WASH_CLI_STYLE)]
+pub struct Cli {
+    #[clap(
+        short = 'o',
+        long = "output",
+        default_value = "text",
+        help = "Specify output format (text or json)",
+        global = true
+    )]
+    pub output: OutputKind,
+
+    #[clap(
+        long = "experimental",
+        id = "experimental",
+        env = "WASH_EXPERIMENTAL",
+        default_value = "false",
+        help = "Whether or not to enable experimental features",
+        global = true
+    )]
+    pub experimental: bool,
+
+    #[clap(
+        long = "help-markdown",
+        conflicts_with = "help",
+        hide = true,
+        global = true
+    )]
+    pub help_markdown: bool,
+
+    #[clap(short = 'V', long = "version", help = "Print version")]
+    pub version: bool,
+
+    #[clap(subcommand)]
+    pub command: Option<CliCommand>,
+}
+
+// NOTE: If you change the description here, ensure you also change it in the help text constant above
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, Subcommand)]
+pub enum CliCommand {
+    /// Manage declarative applications and deployments (wadm)
+    #[clap(name = "app", subcommand)]
+    App(AppCliCommand),
+    /// Build (and sign) a wasmCloud component or capability provider
+    #[clap(name = "build")]
+    Build(BuildCommand),
+    /// Invoke a simple function on a component running in a wasmCloud host
+    #[clap(name = "call")]
+    Call(CallCli),
+    /// Capture and debug cluster invocations and state
+    #[clap(name = "capture")]
+    Capture(CaptureCommand),
+    /// Generate shell completions for wash
+    #[clap(name = "completions")]
+    Completions(CompletionOpts),
+    /// Generate and manage JWTs for wasmCloud components and capability providers
+    #[clap(name = "claims", subcommand)]
+    Claims(ClaimsCliCommand),
+    /// Create configuration for components, capability providers and links
+    #[clap(name = "config", subcommand)]
+    Config(ConfigCliCommand),
+    /// Manage wasmCloud host configuration contexts
+    #[clap(name = "ctx", alias = "context", alias = "contexts", subcommand)]
+    Ctx(CtxCommand),
+    /// Start a developer loop to hot-reload a local wasmCloud component
+    #[clap(name = "dev")]
+    Dev(DevCommand),
+    /// Tear down a local wasmCloud environment (launched with wash up)
+    #[clap(name = "down")]
+    Down(DownCommand),
+    /// Manage contents of local wasmCloud caches
+    #[clap(name = "drain", subcommand)]
+    Drain(DrainSelection),
+    /// Get information about different running wasmCloud resources
+    #[clap(name = "get", subcommand)]
+    Get(GetCommand),
+    /// Inspect a Wasm component or capability provider for signing information and interfaces
+    #[clap(name = "inspect")]
+    Inspect(InspectCliCommand),
+    /// Generate and manage signing keys
+    #[clap(name = "keys", alias = "key", subcommand)]
+    Keys(KeysCliCommand),
+    /// Link one component to another on a set of interfaces
+    #[clap(name = "link", alias = "links", subcommand)]
+    Link(LinkCommand),
+    /// Create a new project from a template or git repository
+    #[clap(name = "new", subcommand)]
+    New(NewCliCommand),
+    /// Create, inspect, and modify capability provider archive files
+    #[clap(name = "par", subcommand)]
+    Par(ParCliCommand),
+    /// Manage wash plugins
+    #[clap(name = "plugin", subcommand)]
+    Plugin(PluginCommand),
+    /// Push an artifact to an OCI compliant registry
+    #[clap(name = "push")]
+    RegPush(RegistryPushCommand),
+    /// Pull an artifact from an OCI compliant registry
+    #[clap(name = "pull")]
+    RegPull(RegistryPullCommand),
+    /// Create secret references for components, capability providers and links
+    #[clap(name = "secrets", alias = "secret", subcommand)]
+    Secrets(SecretsCliCommand),
+    /// Spy on all invocations a component sends and receives
+    #[clap(name = "spy")]
+    Spy(SpyCommand),
+    /// Scale a component running in a host to a certain level of concurrency
+    #[clap(name = "scale", subcommand)]
+    Scale(ScaleCommand),
+    /// Start a component or capability provider
+    #[clap(name = "start", subcommand)]
+    Start(StartCommand),
+    /// Stop a component, capability provider, or host
+    #[clap(name = "stop", subcommand)]
+    Stop(StopCommand),
+    /// Label (or un-label) a host with a key=value label pair
+    #[clap(name = "label", alias = "tag")]
+    Label(LabelHostCommand),
+    /// Update a component running in a host to newer image reference
+    #[clap(name = "update", subcommand)]
+    Update(UpdateCommand),
+    /// Bootstrap a local wasmCloud environment
+    #[clap(name = "up")]
+    Up(UpCommand),
+    /// Serve a web UI for wasmCloud
+    #[clap(name = "ui")]
+    Ui(UiCommand),
+    /// Create wit packages and fetch wit dependencies for a component
+    #[clap(name = "wit", subcommand)]
+    Wit(WitCommand),
+}
+
+// Helper function for dynamic autocompletion to create the CliCommand for the non-executed CLI command.
+pub(crate) fn create_cli() -> Option<CliCommand> {
+    use clap::CommandFactory;
+    let mut args: Vec<String> = env::args().collect();
+    args.drain(0..2);
+    let matches = Cli::command().get_matches_from(args);
+    Cli::from_arg_matches(&matches).unwrap().command
+}
+
+// Used to identify the connection details for retrieving candidates for dynamic autocompletion
+// of the respective subcommand.
+// The used clap_complete::ArgValueCompleter has no information about which subcommand requires candidates.
+// Only the current string for the respective argument can be passed as an input parameter.
+// The subcommand must therefore be recreated to know about its details, e.g. the connection options.
+pub(crate) fn get_connection_opts_from_cli() -> anyhow::Result<CliConnectionOpts> {
+    match create_cli() {
+        Some(CliCommand::App(AppCliCommand::Delete(cmd))) => Ok(cmd.opts),
+        Some(CliCommand::App(AppCliCommand::Deploy(cmd))) => Ok(cmd.opts),
+        Some(CliCommand::App(AppCliCommand::History(cmd))) => Ok(cmd.opts),
+        Some(CliCommand::App(AppCliCommand::Get(cmd))) => Ok(cmd.opts),
+        Some(CliCommand::App(AppCliCommand::Put(cmd))) => Ok(cmd.opts),
+        Some(CliCommand::App(AppCliCommand::Status(cmd))) => Ok(cmd.opts),
+        Some(CliCommand::App(AppCliCommand::Undeploy(cmd))) => Ok(cmd.opts),
+        Some(CliCommand::Spy(cmd)) => Ok(cmd.opts),
+        _ => Err(anyhow!("Command did not match any expected patterns")),
+    }
+}

--- a/crates/wash/src/cli/mod.rs
+++ b/crates/wash/src/cli/mod.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod appearance;
 pub mod build;
 pub mod call;
+pub mod cli;
 pub mod cmd;
 pub mod common;
 pub mod completions;

--- a/crates/wash/src/lib/cli/autocompletion.rs
+++ b/crates/wash/src/lib/cli/autocompletion.rs
@@ -1,0 +1,39 @@
+use anyhow::Context;
+use clap_complete::engine::CompletionCandidate;
+use tokio::runtime::Handle;
+use tokio::task;
+
+use crate::cli::cli::get_connection_opts_from_cli;
+use crate::lib::{
+    common::get_all_inventories,
+    config::WashConnectionOptions,
+};
+
+pub fn component_id_completer(_current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
+    task::block_in_place(|| Handle::current().block_on(get_component_list())).unwrap_or(vec![])
+}
+
+async fn get_component_list() -> anyhow::Result<Vec<CompletionCandidate>> {
+    let connection_opts = get_connection_opts_from_cli()?;
+    let wco: WashConnectionOptions = connection_opts.try_into()?;
+    let client = wco.into_ctl_client(None).await?;
+    let inventories = get_all_inventories(&client)
+        .await
+        .context("unable to fetch all inventory")?;
+
+    let candidates: Vec<CompletionCandidate> = inventories
+        .iter()
+        .flat_map(|i| {
+            i.components
+                .iter()
+                .map(|cd| CompletionCandidate::new(cd.id.clone()))
+                .chain(
+                    i.providers
+                        .iter()
+                        .map(|pd| CompletionCandidate::new(pd.id.clone()))
+                )
+        })
+        .collect();
+
+    Ok(candidates)
+}

--- a/crates/wash/src/lib/cli/mod.rs
+++ b/crates/wash/src/lib/cli/mod.rs
@@ -36,6 +36,7 @@ use crate::lib::{
     },
 };
 
+pub mod autocompletion;
 pub mod capture;
 pub mod claims;
 pub mod dev;

--- a/crates/wash/src/lib/cli/spy.rs
+++ b/crates/wash/src/lib/cli/spy.rs
@@ -5,11 +5,15 @@ use futures::StreamExt;
 use super::{validate_component_id, CliConnectionOpts, CommandOutput};
 use crate::lib::{config::WashConnectionOptions, spier::Spier};
 
+use clap_complete::engine::ArgValueCompleter;
+
+use super::autocompletion;
+
 #[derive(Debug, Parser, Clone)]
 pub struct SpyCommand {
     /// Component ID to spy on, component or capability provider. This is the unique identifier supplied
     /// to the component at startup.
-    #[clap(name = "component_id", value_parser = validate_component_id)]
+    #[clap(name = "component_id", value_parser = validate_component_id, add = ArgValueCompleter::new(autocompletion::component_id_completer))]
     pub component_id: String,
 
     #[clap(flatten)]


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Adding dynamic autocompletion for the `wash app` and `wash spy` subcommands. User can now tab autocomplete the needed information like application name or version for them. For example, if users want to undeploy an application named rust-hello-world, they can do the following to avoid typing in the whole app name:

```sh
wash app undeploy rust<TAB>
```

The implementation is heavily based on the [work of @nm723](https://github.com/wasmCloud/wasmCloud/pull/3495).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

closes: #3258 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

This PR introduces a convenience feature. Therefore, the next release is sufficient.

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

The implementation does not introduce any breaking changes.

However, for convenience reasons I introduced a new flag `-f | --file` for some `wash app` subcommands to implement dynamic autocompletion for WADM manifests. I found that adding autocompletion for manifests as part of the existing `app_name` argument cluttered the output too much. Instead the respective `app_name` arguments support dynamic autocompletion only for declared applications. Moreover, the dynamic look-up filters the application candidates based on the deployment state. Therefore, only undeployed applications are considered as candidates for the `wash app deploy` subcommand and deployed applications for the `wash app undeploy` subcommand. This behaviour is documented in the `--help` information of the respective subcommands.

However, the functionality of the particular `app_name` arguments have not been changed. A path for a WADM manifest can be still specified for it too avoid any breaking changes.

Note: Because of the dynamic look-ups, dynamic autocompletion can be a compute intensive task and sometimes it can take a significant amount of time. Especially for the `wash spy` subcommand.

As already noted in the [original PR](https://github.com/wasmCloud/wasmCloud/pull/3495), users need to enable the dynamic autocompletion in their respective shell. E.g. for zsh:

```sh
echo "source <(COMPLETE=zsh your_program)" >> ~/.zshrc.
```
See the [`clap_complete` docs](https://docs.rs/clap_complete/latest/clap_complete/env/index.html).

## Testing
<!---
Declare the testing information for this pull request
--->

So far I tested the implementation only manually (see below).

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

TDB

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

None.

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

For testing purposes I deployed three applications:
- one application `rust-hello-world`
  - single component and one provider
  - one version
- one application `rust-hello-world2`
  - two components and two provider
  - one version
- one application `hello-world-rust`
  - one component and one provider
  - two versions

For these applications I tested all implemented dynamic autocompletions manually, including their deployment using the new `-f | --file` argument.