### PR TITLE
fix(examples): explicit str type for WORKER_ID

### DIFF
--- a/examples/rust/components/messaging-image-processor-worker/src/processing.rs
+++ b/examples/rust/components/messaging-image-processor-worker/src/processing.rs
@@ -103,7 +103,7 @@ impl ImageProcessingRequest {
         };
 
         // Attempt to lease the task
-        let lease_id = match tasks::lease_task(&task_id, &WORKER_ID.into()) {
+        let lease_id = match tasks::lease_task(&task_id, &String::from(WORKER_ID)) {
             Ok(lid) => lid,
             Err(e) => {
                 log(


### PR DESCRIPTION
The code &WORKER_ID.into() relied on type inference to determine the conversion target. With newer Rust (or potentially changes from the wit-bindgen bump), the inference fails because:
1. WORKER_ID is &str
2. .into() needs to know what type to convert to
3. The outer & infers to `&str`, so it tries `&str` → `str`, which is impossible