### PR TITLE
revert: remove component spec feature

### DIFF
--- a/crates/core/src/otel.rs
+++ b/crates/core/src/otel.rs
@@ -118,7 +118,7 @@ impl OtelConfig {
         // Set sensible defaults if nothing is provided
         match self.protocol {
             OtelProtocol::Grpc => "http://127.0.0.1:4317".to_string(),
-            OtelProtocol::Http => format!("http://127.0.0.1:4318{signal}"),
+            OtelProtocol::Http => format!("http://127.0.0.1:4318{}", signal),
         }
     }
 

--- a/crates/host/README.md
+++ b/crates/host/README.md
@@ -6,40 +6,4 @@ wasmCloud is an open source Cloud Native Computing Foundation (CNCF) project tha
 
 ## Usage
 
-This crate can be used to embed a wasmCloud host in a Rust application. You can refer to the [wasmcloud-main-rs] file of the wasmCloud runtime for an example of this.
-
-This library provides the host runtime for wasmCloud, which is a platform for running WebAssembly (Wasm) components and plugins.
-It includes pluggable support for various extensions and integrations, allowing developers to customize and extend the host's functionality.
-
-## Key Modules
-
-- **[config]**: Implements the `crate::config::ConfigManager` trait for managing a configuration store that can be watched for updates. This is a supertrait of `crate::store::StoreManager` and is implemented by `crate::store::DefaultStore`.
-- **[event]**: Provides the `crate::event::EventManager` trait for handling and dispatching events from the wasmCloud host
-- **[metrics]**: Implements OpenTelemetry metrics for wasmCloud, primarily using the `crate::metrics` module for tracing and monitoring.
-- **[nats]**: Contains the NATS-based implementations for the wasmCloud host extension traits
-- **[oci]**: Offers configuration and utilities for fetching OCI (Open Container Initiative) artifacts
-- **[policy]**: Defines the `crate::policy::PolicyManager` trait for applying additional security policies on top of the wasmCloud host.
-- **[registry]**: Provides the `crate::registry::RegistryCredentialExt` extension trait for working with registry credentials and configurations.
-- **[secrets]**: Contains the `crate::secrets::SecretsManager` trait for securely fetching secrets from a secret store.
-- **[store]**: Defines the `crate::store::StoreManager` trait for managing configuration and data from a backing store.
-- **[wasmbus]**: Contains the core implementation of the wasmCloud host functionality, including the `crate::wasmbus::Host` struct and related configurations.
-- **[workload_identity]**: Experimental module for workload identity implementations, providing tools for identity management.
-
-## Extending the Host
-
-The top-level modules in this crate expose implementable extension traits that allow developers to extend the host's functionality. These traits can be supplied to an embedded host using the `crate::wasmbus::HostBuilder`.
-
-For example, you can implement custom policies, secrets management, or registry configurations to tailor the host to your specific needs.
-
-The wasmCloud [wasmcloud-main-rs] binary uses the implementations in [nats] to provide a NATS-based host runtime. This allows you to run wasmCloud components and plugins in a distributed environment, leveraging NATS for messaging and communication.
-
-## Getting Started
-
-To get started with wasmCloud, refer to [wasmbus] for the core host functionality. From there, you can explore the other modules to add extensions and integrations as needed.
-
-For more information, visit the [wasmcloud-homepage].
-
-<!-- Links used multiple times -->
-
-[wasmcloud-main-rs]: https://github.com/wasmCloud/wasmCloud/blob/main/src/main.rs
-[wasmcloud-homepage]: https://wasmcloud.com
+This crate can be used to embed a wasmCloud host in a Rust application. You can refer to the [main.rs](https://github.com/wasmCloud/wasmCloud/blob/main/src/main.rs) file of the wasmCloud runtime for an example of this.

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -1,48 +1,39 @@
-#![doc = include_str!("../README.md")]
+//! wasmCloud host library
+
 #![warn(missing_docs)]
 #![forbid(clippy::unwrap_used)]
 
-/// [crate::config::ConfigManager] trait for managing a config store which can be watched to receive
-/// updates to the config. This is a supertrait of [crate::store::StoreManager] and is implemented
-/// by [crate::store::DefaultStore].
-pub mod config;
-
-/// [crate::event::EventPublisher] trait for receiving and publishing events from the host
-pub mod event;
-
-/// NATS implementations of [crate::policy::PolicyManager], [crate::secrets::SecretsManager], and
-/// [crate::store::StoreManager] traits for the wasmCloud host.
-pub mod nats;
-
-/// Implementation of OpenTelemetry metrics for wasmCloud, primarily using [wasmcloud_tracing]
-pub mod metrics;
-
-/// Configuration for OCI artifact fetching [crate::oci::Config]
-pub mod oci;
-
-/// [crate::policy::PolicyManager] trait for layering additional security policies on top of the
-/// wasmCloud host
-pub mod policy;
-
-/// [crate::registry::RegistryCredentialExt] extension trait for converting registry credentials
-/// into [wasmcloud_core::RegistryConfig]
-pub mod registry;
-
-/// [crate::secrets::SecretsManager] trait for fetching secrets from a secret store
-pub mod secrets;
-
-/// [crate::store::StoreManager] trait for fetching configuration and data from a backing store
-pub mod store;
-
-/// [crate::wasmbus::Host] implementation
+/// wasmbus host
 pub mod wasmbus;
 
-/// experimental workload identity implementation
+/// OCI artifact fetching
+pub mod oci;
+
+/// wasmCloud policy service
+pub mod policy;
+
+/// Common registry types
+pub mod registry;
+
+/// Secret management
+pub mod secrets;
+
+/// wasmCloud host metrics
+pub(crate) mod metrics;
+
+/// experimental workload identity
 pub mod workload_identity;
 
+pub use metrics::HostMetrics;
 pub use oci::Config as OciConfig;
-pub use policy::{HostInfo as PolicyHostInfo, PolicyManager, Response as PolicyResponse};
+pub use policy::{
+    HostInfo as PolicyHostInfo, Manager as PolicyManager, Response as PolicyResponse,
+};
+pub use secrets::Manager as SecretsManager;
 pub use wasmbus::{Host as WasmbusHost, HostConfig as WasmbusHostConfig};
+pub use wasmcloud_core::{OciFetcher, RegistryAuth, RegistryConfig, RegistryType};
+
+pub use url;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -52,7 +43,6 @@ use tokio::fs;
 use tracing::{debug, instrument, warn};
 use url::Url;
 use wascap::jwt;
-use wasmcloud_core::{OciFetcher, RegistryAuth, RegistryConfig, RegistryType};
 
 /// A reference to a resource, either a file, an OCI image, or a builtin provider
 #[derive(PartialEq)]

--- a/crates/host/src/policy.rs
+++ b/crates/host/src/policy.rs
@@ -1,72 +1,26 @@
+use core::time::Duration;
+
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use anyhow::Context;
+use futures::{
+    stream::{AbortHandle, Abortable},
+    StreamExt,
+};
 use serde::{Deserialize, Serialize};
+use tokio::spawn;
+use tokio::sync::RwLock;
+use tracing::{debug, error, instrument, trace, warn};
+use ulid::Ulid;
 use uuid::Uuid;
 use wascap::jwt;
 
 // NOTE: All requests will be v1 until the schema changes, at which point we can change the version
 // per-request type
-pub(crate) const POLICY_TYPE_VERSION: &str = "v1";
-
-/// A trait for evaluating policy decisions
-#[async_trait::async_trait]
-pub trait PolicyManager: Send + Sync {
-    /// Evaluate whether a component may be started
-    async fn evaluate_start_component(
-        &self,
-        _component_id: &str,
-        _image_ref: &str,
-        _max_instances: u32,
-        _annotations: &BTreeMap<String, String>,
-        _claims: Option<&jwt::Claims<jwt::Component>>,
-    ) -> anyhow::Result<Response> {
-        Ok(Response {
-            request_id: Uuid::new_v4().to_string(),
-            permitted: true,
-            message: None,
-        })
-    }
-
-    /// Evaluate whether a provider may be started
-    async fn evaluate_start_provider(
-        &self,
-        _provider_id: &str,
-        _provider_ref: &str,
-        _annotations: &BTreeMap<String, String>,
-        _claims: Option<&jwt::Claims<jwt::CapabilityProvider>>,
-    ) -> anyhow::Result<Response> {
-        Ok(Response {
-            request_id: Uuid::new_v4().to_string(),
-            permitted: true,
-            message: None,
-        })
-    }
-
-    /// Evaluate whether a component may perform an invocation
-    async fn evaluate_perform_invocation(
-        &self,
-        _component_id: &str,
-        _image_ref: &str,
-        _annotations: &BTreeMap<String, String>,
-        _claims: Option<&jwt::Claims<jwt::Component>>,
-        _interface: String,
-        _function: String,
-    ) -> anyhow::Result<Response> {
-        Ok(Response {
-            request_id: Uuid::new_v4().to_string(),
-            permitted: true,
-            message: None,
-        })
-    }
-}
-
-/// A default policy manager that always returns true for all requests
-/// This is used when no policy manager is configured
-#[derive(Default)]
-pub struct DefaultPolicyManager;
-impl super::PolicyManager for DefaultPolicyManager {}
+const POLICY_TYPE_VERSION: &str = "v1";
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Hash)]
 /// Claims associated with a policy request, if embedded inside the component or provider
@@ -202,23 +156,23 @@ impl From<&RequestBody> for RequestKey {
 
 /// A request for a policy decision
 #[derive(Serialize)]
-pub(crate) struct Request {
+struct Request {
     /// A unique request id. This value is returned in the response
     #[serde(rename = "requestId")]
     #[allow(clippy::struct_field_names)]
-    pub(crate) request_id: String,
+    request_id: String,
     /// The kind of policy request being made
-    pub(crate) kind: RequestKind,
+    kind: RequestKind,
     /// The version of the policy request body
-    pub(crate) version: String,
+    version: String,
     /// The policy request body
-    pub(crate) request: RequestBody,
+    request: RequestBody,
     /// Information about the host making the request
-    pub(crate) host: HostInfo,
+    host: HostInfo,
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
-pub(crate) struct RequestKey {
+struct RequestKey {
     /// The kind of request being made
     kind: RequestKind,
     /// Information about this request combined to form a unique string.
@@ -270,5 +224,221 @@ impl From<&jwt::Claims<jwt::CapabilityProvider>> for PolicyClaims {
             expires_at: claims.expires,
             expired: claims.expires.is_some_and(is_expired),
         }
+    }
+}
+
+/// Encapsulates making requests for policy decisions, and receiving updated decisions
+#[derive(Debug)]
+pub struct Manager {
+    nats: async_nats::Client,
+    host_info: HostInfo,
+    policy_topic: Option<String>,
+    policy_timeout: Duration,
+    decision_cache: Arc<RwLock<HashMap<RequestKey, Response>>>,
+    request_to_key: Arc<RwLock<HashMap<String, RequestKey>>>,
+    /// An abort handle for the policy changes subscription
+    pub policy_changes: AbortHandle,
+}
+
+impl Manager {
+    /// Construct a new policy manager. Can fail if policy_changes_topic is set but we fail to subscribe to it
+    #[instrument(skip(nats))]
+    pub async fn new(
+        nats: async_nats::Client,
+        host_info: HostInfo,
+        policy_topic: Option<String>,
+        policy_timeout: Option<Duration>,
+        policy_changes_topic: Option<String>,
+    ) -> anyhow::Result<Arc<Self>> {
+        const DEFAULT_POLICY_TIMEOUT: Duration = Duration::from_secs(1);
+
+        let (policy_changes_abort, policy_changes_abort_reg) = AbortHandle::new_pair();
+
+        let manager = Manager {
+            nats: nats.clone(),
+            host_info,
+            policy_topic,
+            policy_timeout: policy_timeout.unwrap_or(DEFAULT_POLICY_TIMEOUT),
+            decision_cache: Arc::default(),
+            request_to_key: Arc::default(),
+            policy_changes: policy_changes_abort,
+        };
+        let manager = Arc::new(manager);
+
+        if let Some(policy_changes_topic) = policy_changes_topic {
+            let policy_changes = nats
+                .subscribe(policy_changes_topic)
+                .await
+                .context("failed to subscribe to policy changes")?;
+
+            let _policy_changes = spawn({
+                let manager = Arc::clone(&manager);
+                Abortable::new(policy_changes, policy_changes_abort_reg).for_each(move |msg| {
+                    let manager = Arc::clone(&manager);
+                    async move {
+                        if let Err(e) = manager.override_decision(msg).await {
+                            error!("failed to process policy decision override: {}", e);
+                        }
+                    }
+                })
+            });
+        }
+
+        Ok(manager)
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    /// Use the policy manager to evaluate whether a component may be started
+    pub async fn evaluate_start_component(
+        &self,
+        component_id: impl AsRef<str>,
+        image_ref: impl AsRef<str>,
+        max_instances: u32,
+        annotations: &BTreeMap<String, String>,
+        claims: Option<&jwt::Claims<jwt::Component>>,
+    ) -> anyhow::Result<Response> {
+        let request = ComponentInformation {
+            component_id: component_id.as_ref().to_string(),
+            image_ref: image_ref.as_ref().to_string(),
+            max_instances,
+            annotations: annotations.clone(),
+            claims: claims.map(PolicyClaims::from),
+        };
+        self.evaluate_action(RequestBody::StartComponent(request))
+            .await
+    }
+
+    /// Use the policy manager to evaluate whether a provider may be started
+    #[instrument(level = "trace", skip_all)]
+    pub async fn evaluate_start_provider(
+        &self,
+        provider_id: impl AsRef<str>,
+        provider_ref: impl AsRef<str>,
+        annotations: &BTreeMap<String, String>,
+        claims: Option<&jwt::Claims<jwt::CapabilityProvider>>,
+    ) -> anyhow::Result<Response> {
+        let request = ProviderInformation {
+            provider_id: provider_id.as_ref().to_string(),
+            image_ref: provider_ref.as_ref().to_string(),
+            annotations: annotations.clone(),
+            claims: claims.map(PolicyClaims::from),
+        };
+        self.evaluate_action(RequestBody::StartProvider(request))
+            .await
+    }
+
+    /// Use the policy manager to evaluate whether a component may be invoked
+    #[instrument(level = "trace", skip_all)]
+    pub async fn evaluate_perform_invocation(
+        &self,
+        component_id: impl AsRef<str>,
+        image_ref: impl AsRef<str>,
+        annotations: &BTreeMap<String, String>,
+        claims: Option<&jwt::Claims<jwt::Component>>,
+        interface: String,
+        function: String,
+    ) -> anyhow::Result<Response> {
+        let request = PerformInvocationRequest {
+            interface,
+            function,
+            target: ComponentInformation {
+                component_id: component_id.as_ref().to_string(),
+                image_ref: image_ref.as_ref().to_string(),
+                max_instances: 0,
+                annotations: annotations.clone(),
+                claims: claims.map(PolicyClaims::from),
+            },
+        };
+        self.evaluate_action(RequestBody::PerformInvocation(request))
+            .await
+    }
+
+    /// Sends a policy request to the policy server and caches the response
+    #[instrument(level = "trace", skip_all)]
+    pub async fn evaluate_action(&self, request: RequestBody) -> anyhow::Result<Response> {
+        let Some(policy_topic) = self.policy_topic.clone() else {
+            // Ensure we short-circuit and allow the request if no policy topic is configured
+            return Ok(Response {
+                request_id: String::new(),
+                permitted: true,
+                message: None,
+            });
+        };
+
+        let kind = match request {
+            RequestBody::StartComponent(_) => RequestKind::StartComponent,
+            RequestBody::StartProvider(_) => RequestKind::StartProvider,
+            RequestBody::PerformInvocation(_) => RequestKind::PerformInvocation,
+            RequestBody::Unknown => RequestKind::Unknown,
+        };
+        let cache_key = (&request).into();
+        if let Some(entry) = self.decision_cache.read().await.get(&cache_key) {
+            trace!(?cache_key, ?entry, "using cached policy decision");
+            return Ok(entry.clone());
+        }
+
+        let request_id = Uuid::from_u128(Ulid::new().into()).to_string();
+        trace!(?cache_key, "requesting policy decision");
+        let payload = serde_json::to_vec(&Request {
+            request_id: request_id.clone(),
+            request,
+            kind,
+            version: POLICY_TYPE_VERSION.to_string(),
+            host: self.host_info.clone(),
+        })
+        .context("failed to serialize policy request")?;
+        let request = async_nats::Request::new()
+            .payload(payload.into())
+            .timeout(Some(self.policy_timeout));
+        let res = self
+            .nats
+            .send_request(policy_topic, request)
+            .await
+            .context("policy request failed")?;
+        let decision = serde_json::from_slice::<Response>(&res.payload)
+            .context("failed to deserialize policy response")?;
+
+        self.decision_cache
+            .write()
+            .await
+            .insert(cache_key.clone(), decision.clone()); // cache policy decision
+        self.request_to_key
+            .write()
+            .await
+            .insert(request_id, cache_key); // cache request id -> decision key
+        Ok(decision)
+    }
+
+    #[instrument(skip(self))]
+    async fn override_decision(&self, msg: async_nats::Message) -> anyhow::Result<()> {
+        let Response {
+            request_id,
+            permitted,
+            message,
+        } = serde_json::from_slice(&msg.payload)
+            .context("failed to deserialize policy decision override")?;
+
+        debug!(request_id, "received policy decision override");
+
+        let mut decision_cache = self.decision_cache.write().await;
+        let request_to_key = self.request_to_key.read().await;
+
+        if let Some(key) = request_to_key.get(&request_id) {
+            decision_cache.insert(
+                key.clone(),
+                Response {
+                    request_id: request_id.clone(),
+                    permitted,
+                    message,
+                },
+            );
+        } else {
+            warn!(
+                request_id,
+                "received policy decision override for unknown request id"
+            );
+        }
+
+        Ok(())
     }
 }

--- a/crates/host/src/registry.rs
+++ b/crates/host/src/registry.rs
@@ -1,11 +1,7 @@
-use std::collections::{hash_map::Entry, HashMap};
-
 use anyhow::Result;
-use tracing::{debug, instrument, warn};
+use tracing::warn;
 use wasmcloud_control_interface::RegistryCredential;
 use wasmcloud_core::{RegistryAuth, RegistryConfig, RegistryType};
-
-use crate::OciConfig;
 
 /// Extension trait to enable converting between registry credentials
 pub trait RegistryCredentialExt {
@@ -37,76 +33,4 @@ impl RegistryCredentialExt for RegistryCredential {
             .additional_ca_paths(Vec::new())
             .build()
     }
-}
-
-#[derive(Debug, Default)]
-/// A struct to hold supplemental [RegistryConfig] for the host.
-pub struct SupplementalConfig {
-    /// A map of registry URLs to [RegistryConfig] to use for it when
-    /// fetching images from OCI registries.
-    pub registry_config: Option<HashMap<String, RegistryConfig>>,
-}
-
-/// A helper function to merge [crate::oci::Config] into the given registry configuration
-#[instrument(level = "debug", skip_all)]
-pub async fn merge_registry_config(
-    registry_config: &mut HashMap<String, RegistryConfig>,
-    oci_opts: OciConfig,
-) {
-    let allow_latest = oci_opts.allow_latest;
-    let additional_ca_paths = oci_opts.additional_ca_paths;
-
-    // update auth for specific registry, if provided
-    if let Some(reg) = oci_opts.oci_registry {
-        match registry_config.entry(reg.clone()) {
-            Entry::Occupied(_entry) => {
-                // note we don't update config here, since the config service should take priority
-                warn!(oci_registry_url = %reg, "ignoring OCI registry config, overridden by config service");
-            }
-            Entry::Vacant(entry) => {
-                debug!(oci_registry_url = %reg, "set registry config");
-                entry.insert(
-                    RegistryConfig::builder()
-                        .reg_type(RegistryType::Oci)
-                        .auth(RegistryAuth::from((
-                            oci_opts.oci_user,
-                            oci_opts.oci_password,
-                        )))
-                        .build()
-                        .expect("failed to build registry config"),
-                );
-            }
-        }
-    }
-
-    // update or create entry for all registries in allowed_insecure
-    oci_opts.allowed_insecure.into_iter().for_each(|reg| {
-        match registry_config.entry(reg.clone()) {
-            Entry::Occupied(mut entry) => {
-                debug!(oci_registry_url = %reg, "set allowed_insecure");
-                entry.get_mut().set_allow_insecure(true);
-            }
-            Entry::Vacant(entry) => {
-                debug!(oci_registry_url = %reg, "set allowed_insecure");
-                entry.insert(
-                    RegistryConfig::builder()
-                        .reg_type(RegistryType::Oci)
-                        .allow_insecure(true)
-                        .build()
-                        .expect("failed to build registry config"),
-                );
-            }
-        }
-    });
-
-    // update allow_latest for all registries
-    registry_config.iter_mut().for_each(|(url, config)| {
-        if !additional_ca_paths.is_empty() {
-            config.set_additional_ca_paths(additional_ca_paths.clone());
-        }
-        if allow_latest {
-            debug!(oci_registry_url = %url, "set allow_latest");
-        }
-        config.set_allow_latest(allow_latest);
-    });
 }

--- a/crates/host/src/secrets.rs
+++ b/crates/host/src/secrets.rs
@@ -1,30 +1,177 @@
 //! Module with structs for use in managing and accessing secrets in a wasmCloud lattice
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use anyhow::{bail, ensure, Context as _};
+use async_nats::{jetstream::kv::Store, Client};
+use futures::stream;
+use futures::stream::{StreamExt, TryStreamExt};
 use secrecy::SecretBox;
+use tokio::sync::RwLock;
+use tracing::instrument;
 use wasmcloud_runtime::capability::secrets::store::SecretValue;
+use wasmcloud_secrets_client::Client as WasmcloudSecretsClient;
+use wasmcloud_secrets_types::{Secret as WasmcloudSecret, SecretConfig};
 
-/// A trait for fetching secrets from a secret store. This is used by the host to fetch secrets
-/// from a configured secret store.
-///
-/// By default, this implementation does nothing and returns an empty map. This is useful for
-/// testing or when no secret fetching is required.
-#[async_trait::async_trait]
-pub trait SecretsManager: Send + Sync {
-    /// Fetch secrets by name from the secret store. Additional information is provided that can be
-    /// sent to the secret store, such as the entity JWT and host JWT, for additional validation.
-    async fn fetch_secrets(
-        &self,
-        _secret_names: Vec<String>,
-        _entity_jwt: Option<&String>,
-        _host_jwt: &str,
-        _application: Option<&String>,
-    ) -> anyhow::Result<HashMap<String, SecretBox<SecretValue>>> {
-        Ok(HashMap::with_capacity(0))
-    }
+#[derive(Debug)]
+/// A manager for fetching secrets from a secret store, caching secrets clients for efficiency.
+pub struct Manager {
+    config_store: Store,
+    /// The topic to use for configuring clients to fetch secrets from the secret store.
+    secret_store_topic: Option<String>,
+    nats_client: Client,
+    /// A map of backend names, e.g. nats-kv or vault, to secrets clients, used to cache clients for efficiency.
+    backend_clients: Arc<RwLock<HashMap<String, Arc<WasmcloudSecretsClient>>>>,
 }
 
-/// A default implementation of the SecretsManager trait that has no secrets.
-#[derive(Default)]
-pub struct DefaultSecretsManager {}
-impl SecretsManager for DefaultSecretsManager {}
+impl Manager {
+    /// Create a new secret manager with the given configuration store, secret store topic, and NATS client.
+    ///
+    /// All secret references will be fetched from this configuration store and the actual secrets will be
+    /// fetched by sending requests to the configured topic. If the provided secret_store_topic is None, this manager
+    /// will always return an error if [`Self::fetch_secrets`] is called with a list of secrets.
+    pub fn new(
+        config_store: &Store,
+        secret_store_topic: Option<&String>,
+        nats_client: &Client,
+    ) -> Self {
+        Self {
+            config_store: config_store.clone(),
+            secret_store_topic: secret_store_topic.cloned(),
+            nats_client: nats_client.clone(),
+            backend_clients: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Get the secrets client for the provided backend, creating a new client if one does not already exist.
+    ///
+    /// Returns an error if the secret store topic is not configured, or if the client could not be created.
+    async fn get_or_create_secrets_client(
+        &self,
+        backend: &str,
+    ) -> anyhow::Result<Arc<WasmcloudSecretsClient>> {
+        let Some(secret_store_topic) = self.secret_store_topic.as_ref() else {
+            return Err(anyhow::anyhow!(
+                "secret store not configured, could not create secrets client"
+            ));
+        };
+
+        // If we already have a client for this backend, return it
+        // NOTE(brooksmtownsend): This is block scoped to ensure we drop the read lock
+        let client = {
+            match self.backend_clients.read().await.get(backend) {
+                Some(existing) => return Ok(existing.clone()),
+                None => Arc::new(
+                    WasmcloudSecretsClient::new(
+                        backend,
+                        secret_store_topic,
+                        self.nats_client.clone(),
+                    )
+                    .await
+                    .context("failed to create secrets client")?,
+                ),
+            }
+        };
+
+        self.backend_clients
+            .write()
+            .await
+            .insert(backend.to_string(), client.clone());
+        Ok(client)
+    }
+
+    /// Fetches secret references from the CONFIGDATA bucket by name and then fetches the actual secrets
+    /// from the configured secret store. Any error returned from this function should result in a failure
+    /// to start a component, start a provider, or establish a link as a missing secret is a critical
+    /// error.
+    ///
+    /// # Arguments
+    /// * `secret_names` - A list of secret names to fetch from the secret store
+    /// * `entity_jwt` - The JWT of the entity requesting the secrets. Must be provided unless this [`Manager`] is not
+    ///  configured with a secret store topic.
+    /// * `host_jwt` - The JWT of the host requesting the secrets
+    /// * `application` - The name of the application the entity is a part of, if any
+    ///
+    /// # Returns
+    /// A HashMap from secret name to the [`secrecy::Secret`] wrapped [`SecretValue`].
+    #[instrument(level = "debug", skip(host_jwt))]
+    pub async fn fetch_secrets(
+        &self,
+        secret_names: Vec<String>,
+        entity_jwt: Option<&String>,
+        host_jwt: &str,
+        application: Option<&String>,
+    ) -> anyhow::Result<HashMap<String, SecretBox<SecretValue>>> {
+        // If we're not fetching any secrets, return empty map successfully
+        if secret_names.is_empty() {
+            return Ok(HashMap::with_capacity(0));
+        }
+
+        // Attempting to fetch secrets without a secret store topic is always an error
+        ensure!(
+            self.secret_store_topic.is_some(),
+            "secret store not configured, could not fetch secrets"
+        );
+
+        // If we don't have an entity JWT, we can't provide its identity to the secrets backend
+        let entity_jwt = entity_jwt.context("entity did not have an embedded JWT, required to fetch secrets (was this entity signed during build?)")?;
+
+        let secrets = stream::iter(secret_names.into_iter())
+            // Fetch the secret reference from the config store
+            .then(|secret_name| async move {
+                match self.config_store.get(&secret_name).await {
+                    Ok(Some(secret)) => serde_json::from_slice::<SecretConfig>(&secret)
+                        .with_context(|| format!("failed to deserialize secret reference from config store, ensure {secret_name} is a secret reference and not configuration")),
+                    Ok(None) => bail!(
+                        "Secret config {secret_name} not found in config store, could not create secret request"
+                    ),
+                    Err(e) => bail!(e),
+                }
+            })
+            // Retrieve the actual secret from the secrets backend
+            .and_then(|secret_config| async move {
+                let secrets_client = self
+                    .get_or_create_secrets_client(&secret_config.backend)
+                    .await?;
+                let secret_name = secret_config.name.clone();
+                let request = secret_config.try_into_request(entity_jwt, host_jwt, application).context("failed to create secret request")?;
+                secrets_client
+                    .get(request, nkeys::XKey::new())
+                    .await
+                    .map(|secret| (secret_name, secret))
+                    .map_err(|e| anyhow::anyhow!(e))
+            })
+            // Build the map of secrets depending on if the secret is a string or bytes
+            .try_fold(HashMap::new(), |mut secrets, (secret_name, secret_result)| async move {
+                match secret_result {
+                    // NOTE(brooksmtownsend): We create this map using the `secret_name` passed in on from the secret reference
+                    // because that's the name that the component/provider will use to look up the secret.
+                    WasmcloudSecret {
+                        string_secret: Some(string_secret),
+                        ..
+                    } => secrets.insert(
+                        secret_name,
+                        SecretBox::new(SecretValue::String(string_secret).into()),
+                    ),
+                    WasmcloudSecret {
+                        binary_secret: Some(binary_secret),
+                        ..
+                    } => {
+                        secrets.insert(
+                            secret_name,
+                            SecretBox::new(SecretValue::Bytes(binary_secret).into()),
+                        )
+                    }
+                    WasmcloudSecret {
+                        string_secret: None,
+                        binary_secret: None,
+                        ..
+                    } => bail!("secret {secret_name} did not contain a value"),
+                };
+                Ok(secrets)
+            })
+            .await?;
+
+        Ok(secrets)
+    }
+}

--- a/crates/host/src/wasmbus/claims.rs
+++ b/crates/host/src/wasmbus/claims.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 
 use tracing::{instrument, trace};
 use wascap::{jwt, prelude::ClaimsBuilder};
-
 // TODO: remove StoredClaims in #1093
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -259,14 +258,14 @@ impl From<StoredClaims> for Claims {
 
 impl super::Host {
     #[instrument(level = "debug", skip_all)]
-    /// Store claims in the data store
     pub(crate) async fn store_claims(&self, claims: Claims) -> anyhow::Result<()> {
         match &claims {
             Claims::Component(claims) => {
                 self.store_component_claims(claims.clone()).await?;
             }
             Claims::Provider(claims) => {
-                self.store_provider_claims(claims.clone()).await?;
+                let mut provider_claims = self.provider_claims.write().await;
+                provider_claims.insert(claims.subject.clone(), claims.clone());
             }
         };
         let claims: StoredClaims = claims.try_into()?;
@@ -280,50 +279,10 @@ impl super::Host {
         let bytes = serde_json::to_vec(&claims)
             .context("failed to serialize claims")?
             .into();
-        self.data_store
-            .put(&key, bytes)
+        self.data
+            .put(key, bytes)
             .await
             .context("failed to put claims")?;
-        Ok(())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    /// Store claims in the host in-memory cache
-    pub(crate) async fn store_component_claims(
-        &self,
-        claims: jwt::Claims<jwt::Component>,
-    ) -> anyhow::Result<()> {
-        self.component_claims
-            .write()
-            .await
-            .insert(claims.subject.clone(), claims);
-        Ok(())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    /// Remove claims from the host in-memory cache
-    pub(crate) async fn delete_component_claims(&self, subject: &str) -> anyhow::Result<()> {
-        self.component_claims.write().await.remove(subject);
-        Ok(())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    /// Store claims in the host in-memory cache
-    pub(crate) async fn store_provider_claims(
-        &self,
-        claims: jwt::Claims<jwt::CapabilityProvider>,
-    ) -> anyhow::Result<()> {
-        self.provider_claims
-            .write()
-            .await
-            .insert(claims.subject.clone(), claims);
-        Ok(())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    /// Remove claims from the host in-memory cache
-    pub(crate) async fn delete_provider_claims(&self, subject: &str) -> anyhow::Result<()> {
-        self.provider_claims.write().await.remove(subject);
         Ok(())
     }
 }

--- a/crates/host/src/wasmbus/config.rs
+++ b/crates/host/src/wasmbus/config.rs
@@ -1,15 +1,14 @@
 //! Module with structs for use in managing and accessing config used by various wasmCloud entities
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
-use anyhow::{bail, Context as _};
-use futures::{future::AbortHandle, stream::Abortable};
+use anyhow::{bail, Context};
+use async_nats::jetstream::kv::{Operation, Store};
+use futures::{future::AbortHandle, stream::Abortable, TryStreamExt};
 use tokio::sync::{
     watch::{self, Receiver, Sender},
     RwLock, RwLockReadGuard,
 };
 use tracing::{error, warn, Instrument};
-
-use crate::config::ConfigManager;
 
 type LockedConfig = Arc<RwLock<HashMap<String, String>>>;
 /// A cache of named config mapped to an existing receiver
@@ -193,17 +192,19 @@ impl ConfigBundle {
 /// A struct used for generating a config bundle given a list of named configs
 #[derive(Clone)]
 pub struct BundleGenerator {
-    store: Arc<dyn ConfigManager>,
+    store: Store,
     watch_cache: WatchCache,
+    watch_handles: Arc<RwLock<AbortHandles>>,
 }
 
 impl BundleGenerator {
     /// Create a new bundle generator
     #[must_use]
-    pub fn new(store: Arc<dyn ConfigManager>) -> Self {
+    pub fn new(store: Store) -> Self {
         Self {
             store,
             watch_cache: Arc::default(),
+            watch_handles: Arc::default(),
         }
     }
 
@@ -227,16 +228,105 @@ impl BundleGenerator {
             });
         }
 
-        let receiver = self
-            .store
-            .watch(&name)
-            .await
-            .context(format!("error setting up watcher for {name}"))?;
+        // We need to actually try and fetch the config here. If we don't do this, then a watch will
+        // just blindly watch even if the key doesn't exist. We should return an error if the config
+        // doesn't exist or has data issues. It also allows us to set the initial value
+        let config: HashMap<String, String> = match self.store.get(&name).await {
+            Ok(Some(data)) => serde_json::from_slice(&data)
+                .context("Data corruption error, unable to decode data from store")?,
+            Ok(None) => return Err(anyhow::anyhow!("Config {} does not exist", name)),
+            Err(e) => return Err(anyhow::anyhow!("Error fetching config {}: {}", name, e)),
+        };
+
+        // Otherwise we need to setup the watcher. We start by setting up the watch so we don't miss
+        // any events after we query the initial config
+        let (tx, rx) = watch::channel(config);
+        let (done, wait) = tokio::sync::oneshot::channel();
+        let (handle, reg) = AbortHandle::new_pair();
+        tokio::task::spawn(Abortable::new(
+            watcher_loop(self.store.clone(), name.clone(), tx, done),
+            reg,
+        ));
+
+        wait.await
+            .context("Error waiting for watcher to start")?
+            .context("Error waiting for watcher to start")?;
+
+        // NOTE(thomastaylor312): We should probably find a way to clear out this cache. The Sender
+        // part of the channel can tell you how many receivers it has, but we pass that along to the
+        // watcher, so there would need to be more work to expose that, probably via a struct. We
+        // could also do something with a resource counter and track that way with a cleanup task.
+        // But for now going the easy route as we already cache everything anyway
+        self.watch_handles.write().await.handles.push(handle);
         self.watch_cache
             .write()
             .await
-            .insert(name.clone(), receiver.clone());
-        Ok(ConfigReceiver { name, receiver })
+            .insert(name.clone(), rx.clone());
+
+        Ok(ConfigReceiver { name, receiver: rx })
+    }
+}
+
+async fn watcher_loop(
+    store: Store,
+    name: String,
+    tx: watch::Sender<HashMap<String, String>>,
+    done: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
+) {
+    // We need to watch with history so we can get the initial config.
+    let mut watcher = match store.watch(&name).await {
+        Ok(watcher) => {
+            done.send(Ok(())).expect(
+                "Receiver for watcher setup should not have been dropped. This is programmer error",
+            );
+            watcher
+        }
+        Err(e) => {
+            done.send(Err(anyhow::anyhow!(
+                "Error setting up watcher for {}: {}",
+                name,
+                e
+            )))
+            .expect(
+                "Receiver for watcher setup should not have been dropped. This is programmer error",
+            );
+            return;
+        }
+    };
+    loop {
+        match watcher.try_next().await {
+            Ok(Some(entry)) if matches!(entry.operation, Operation::Delete | Operation::Purge) => {
+                // NOTE(thomastaylor312): We should probably do something and notify something up
+                // the chain if we get a delete or purge event of a config that is still being used.
+                // For now we just zero it out
+                tx.send_replace(HashMap::new());
+            }
+            Ok(Some(entry)) => {
+                let config: HashMap<String, String> = match serde_json::from_slice(&entry.value) {
+                    Ok(config) => config,
+                    Err(e) => {
+                        error!(%name, error = %e, "Error decoding config from store during watch");
+                        continue;
+                    }
+                };
+                tx.send_if_modified(|current| {
+                    if current == &config {
+                        false
+                    } else {
+                        *current = config;
+                        true
+                    }
+                });
+            }
+            Ok(None) => {
+                error!(%name, "Watcher for config has closed");
+                return;
+            }
+            Err(e) => {
+                error!(%name, error = %e, "Error reading from watcher for config. Will wait for next entry");
+                continue;
+            }
+        }
     }
 }
 

--- a/crates/host/src/wasmbus/ctl.rs
+++ b/crates/host/src/wasmbus/ctl.rs
@@ -18,12 +18,12 @@ use wasmcloud_control_interface::{
     ProviderAuctionAck, ProviderAuctionRequest, RegistryCredential, ScaleComponentCommand,
     StartProviderCommand, StopHostCommand, StopProviderCommand, UpdateComponentCommand,
 };
-use wasmcloud_core::shutdown_subject;
 use wasmcloud_tracing::context::TraceContextInjector;
 
 use crate::registry::RegistryCredentialExt;
 use crate::wasmbus::{
-    human_friendly_uptime, injector_to_headers, Annotations, Claims, Host, Provider, StoredClaims,
+    event, human_friendly_uptime, injector_to_headers, Annotations, Claims, Host, Provider,
+    StoredClaims,
 };
 use crate::ResourceRef;
 
@@ -32,8 +32,7 @@ use crate::ResourceRef;
 /// This trait is not a part of the `wasmcloud_control_interface` crate yet to allow
 /// for the initial implementation to be done in the `wasmcloud_host` (pre 1.0) crate. This
 /// will likely move to that crate in the future.
-#[async_trait::async_trait]
-pub trait ControlInterfaceServer: Send + Sync {
+pub(crate) trait ControlInterfaceServer {
     /// Handle an auction request for a component. This method should return `Ok(None)` if the host
     /// does not want to respond to the auction request.
     async fn handle_auction_component(
@@ -148,7 +147,6 @@ pub trait ControlInterfaceServer: Send + Sync {
     ) -> anyhow::Result<CtlResponse<wasmcloud_control_interface::Host>>;
 }
 
-#[async_trait::async_trait]
 impl ControlInterfaceServer for Host {
     #[instrument(level = "debug", skip_all)]
     async fn handle_auction_component(
@@ -231,11 +229,14 @@ impl ControlInterfaceServer for Host {
         info!(?timeout, "handling stop host");
 
         self.ready.store(false, Ordering::Relaxed);
+
         self.heartbeat.abort();
+        self.data_watch.abort();
+        self.queue.abort();
+        self.policy_manager.policy_changes.abort();
         let deadline =
             timeout.and_then(|timeout| Instant::now().checked_add(Duration::from_millis(timeout)));
         self.stop_tx.send_replace(deadline);
-
         Ok(CtlResponse::<()>::success(
             "successfully handled stop host".into(),
         ))
@@ -321,10 +322,9 @@ impl ControlInterfaceServer for Host {
                 Ok((wasm, Ok(claims_token))) => (Some(wasm), claims_token, None),
                 Ok((_, Err(e))) => {
                     if let Err(e) = self
-                        .event_publisher
                         .publish_event(
                             "component_scale_failed",
-                            crate::event::component_scale_failed(
+                            event::component_scale_failed(
                                 None,
                                 &annotations,
                                 host_id,
@@ -361,10 +361,9 @@ impl ControlInterfaceServer for Host {
             {
                 error!(%component_ref, %component_id, err = ?e, "failed to scale component");
                 if let Err(e) = self
-                    .event_publisher
                     .publish_event(
                         "component_scale_failed",
-                        crate::event::component_scale_failed(
+                        event::component_scale_failed(
                             claims_token.map(|c| c.claims).as_ref(),
                             &annotations,
                             host_id,
@@ -527,15 +526,9 @@ impl ControlInterfaceServer for Host {
             {
                 error!(provider_ref, provider_id, ?err, "failed to start provider");
                 if let Err(err) = self
-                    .event_publisher
                     .publish_event(
                         "provider_start_failed",
-                        crate::event::provider_start_failed(
-                            provider_ref,
-                            provider_id,
-                            host_id,
-                            &err,
-                        ),
+                        event::provider_start_failed(provider_ref, provider_id, host_id, &err),
                     )
                     .await
                 {
@@ -590,7 +583,10 @@ impl ControlInterfaceServer for Host {
         if let Err(e) = self
             .rpc_nats
             .send_request(
-                shutdown_subject(&self.host_config.lattice, provider_id, "default"),
+                format!(
+                    "wasmbus.rpc.{}.{provider_id}.default.shutdown",
+                    self.host_config.lattice
+                ),
                 req,
             )
             .await
@@ -608,12 +604,11 @@ impl ControlInterfaceServer for Host {
         tasks.abort_all();
 
         info!(provider_id, "provider stopped");
-        self.event_publisher
-            .publish_event(
-                "provider_stopped",
-                crate::event::provider_stopped(annotations, host_id, provider_id, "stop"),
-            )
-            .await?;
+        self.publish_event(
+            "provider_stopped",
+            event::provider_stopped(annotations, host_id, provider_id, "stop"),
+        )
+        .await?;
         Ok(CtlResponse::<()>::success(
             "successfully stopped provider".into(),
         ))
@@ -659,7 +654,7 @@ impl ControlInterfaceServer for Host {
     #[instrument(level = "trace", skip(self))]
     async fn handle_config_get(&self, config_name: &str) -> anyhow::Result<Vec<u8>> {
         trace!(%config_name, "handling get config");
-        if let Some(config_bytes) = self.config_store.get(config_name).await? {
+        if let Some(config_bytes) = self.config_data.get(config_name).await? {
             let config_map: HashMap<String, String> = serde_json::from_slice(&config_bytes)
                 .context("config data should be a map of string -> string")?;
             serde_json::to_vec(&CtlResponse::ok(config_map)).map_err(anyhow::Error::from)
@@ -675,13 +670,12 @@ impl ControlInterfaceServer for Host {
     async fn handle_config_delete(&self, config_name: &str) -> anyhow::Result<CtlResponse<()>> {
         debug!("handle config entry deletion");
 
-        self.config_store
-            .del(config_name)
+        self.config_data
+            .purge(config_name)
             .await
             .context("Unable to delete config data")?;
 
-        self.event_publisher
-            .publish_event("config_deleted", crate::event::config_deleted(config_name))
+        self.publish_event("config_deleted", event::config_deleted(config_name))
             .await?;
 
         Ok(CtlResponse::<()>::success(
@@ -713,13 +707,12 @@ impl ControlInterfaceServer for Host {
             }
         }
 
-        self.event_publisher
-            .publish_event(
-                "labels_changed",
-                crate::event::labels_changed(host_id, HashMap::from_iter(labels.clone())),
-            )
-            .await
-            .context("failed to publish labels_changed event")?;
+        self.publish_event(
+            "labels_changed",
+            event::labels_changed(host_id, HashMap::from_iter(labels.clone())),
+        )
+        .await
+        .context("failed to publish labels_changed event")?;
 
         Ok(CtlResponse::<()>::success("successfully put label".into()))
     }
@@ -742,20 +735,21 @@ impl ControlInterfaceServer for Host {
         };
 
         info!(key, "removed label");
-        self.event_publisher
-            .publish_event(
-                "labels_changed",
-                crate::event::labels_changed(host_id, HashMap::from_iter(labels.clone())),
-            )
-            .await
-            .context("failed to publish labels_changed event")?;
+        self.publish_event(
+            "labels_changed",
+            event::labels_changed(host_id, HashMap::from_iter(labels.clone())),
+        )
+        .await
+        .context("failed to publish labels_changed event")?;
 
         Ok(CtlResponse::<()>::success(
             "successfully deleted label".into(),
         ))
     }
 
-    /// Handle a new link by modifying the relevant source [crate::wasmbus::ComponentSpecification].
+    /// Handle a new link by modifying the relevant source [ComponentSpecification]. Once
+    /// the change is written to the LATTICEDATA store, each host in the lattice (including this one)
+    /// will handle the new specification and update their own internal link maps via [process_component_spec_put].
     #[instrument(level = "debug", skip_all)]
     async fn handle_link_put(&self, request: Link) -> anyhow::Result<CtlResponse<()>> {
         let link_set_result: anyhow::Result<()> = async {
@@ -831,13 +825,6 @@ impl ControlInterfaceServer for Host {
             // Update component specification with the new link
             self.store_component_spec(&source_id, &component_spec)
                 .await?;
-            // NOTE: We rely on the NATS watcher to call update_host_with_spec asynchronously.
-            // Previously, we called it directly here, but this caused a race condition where
-            // self.links would be updated before the NATS watcher processed the change,
-            // preventing provider links from being sent on re-add scenarios.
-            // debug!(source_id, "calling update_host_with_spec directly from handle_link_put");
-            // self.update_host_with_spec(&source_id, &component_spec)
-            //     .await?;
 
             self.put_backwards_compat_provider_link(&request)
                 .await?;
@@ -847,16 +834,14 @@ impl ControlInterfaceServer for Host {
         .await;
 
         if let Err(e) = link_set_result {
-            self.event_publisher
-                .publish_event(
-                    "linkdef_set_failed",
-                    crate::event::linkdef_set_failed(&request, &e),
-                )
-                .await?;
+            self.publish_event(
+                "linkdef_set_failed",
+                event::linkdef_set_failed(&request, &e),
+            )
+            .await?;
             Ok(CtlResponse::error(e.to_string().as_ref()))
         } else {
-            self.event_publisher
-                .publish_event("linkdef_set", crate::event::linkdef_set(&request))
+            self.publish_event("linkdef_set", event::linkdef_set(&request))
                 .await?;
             Ok(CtlResponse::<()>::success("successfully set link".into()))
         }
@@ -910,8 +895,6 @@ impl ControlInterfaceServer for Host {
             // Update component specification with the deleted link
             self.store_component_spec(&source_id, &component_spec)
                 .await?;
-            self.update_host_with_spec(&source_id, &component_spec)
-                .await?;
 
             // Send the link to providers for deletion
             self.del_provider_link(link).await?;
@@ -921,19 +904,18 @@ impl ControlInterfaceServer for Host {
         let deleted_link_target = deleted_link
             .as_ref()
             .map(|link| String::from(link.target()));
-        self.event_publisher
-            .publish_event(
-                "linkdef_deleted",
-                crate::event::linkdef_deleted(
-                    source_id,
-                    deleted_link_target.as_ref(),
-                    link_name,
-                    wit_namespace,
-                    wit_package,
-                    deleted_link.as_ref().map(|link| link.interfaces()),
-                ),
-            )
-            .await?;
+        self.publish_event(
+            "linkdef_deleted",
+            event::linkdef_deleted(
+                source_id,
+                deleted_link_target.as_ref(),
+                link_name,
+                wit_namespace,
+                wit_package,
+                deleted_link.as_ref().map(|link| link.interfaces()),
+            ),
+        )
+        .await?;
 
         Ok(CtlResponse::<()>::success(
             "successfully deleted link".into(),
@@ -979,14 +961,13 @@ impl ControlInterfaceServer for Host {
         // Validate that the data is of the proper type by deserialing it
         serde_json::from_slice::<HashMap<String, String>>(&data)
             .context("config data should be a map of string -> string")?;
-        self.config_store
+        self.config_data
             .put(config_name, data)
             .await
             .context("unable to store config data")?;
         // We don't write it into the cached data and instead let the caching thread handle it as we
         // won't need it immediately.
-        self.event_publisher
-            .publish_event("config_set", crate::event::config_set(config_name))
+        self.publish_event("config_set", event::config_set(config_name))
             .await?;
 
         Ok(CtlResponse::<()>::success("successfully put config".into()))
@@ -1006,7 +987,7 @@ impl ControlInterfaceServer for Host {
             .uptime_seconds(uptime.as_secs())
             .uptime_human(human_friendly_uptime(uptime))
             .version(self.host_config.version.clone())
-            .ctl_host(self.host_config.rpc_nats_url.to_string())
+            .ctl_host(self.host_config.ctl_nats_url.to_string())
             .rpc_host(self.host_config.rpc_nats_url.to_string())
             .lattice(self.host_config.lattice.to_string());
 

--- a/crates/host/src/wasmbus/event.rs
+++ b/crates/host/src/wasmbus/event.rs
@@ -1,0 +1,304 @@
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::Context;
+use cloudevents::{EventBuilder, EventBuilderV10};
+use serde_json::json;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use tracing::{instrument, warn};
+use ulid::Ulid;
+use uuid::Uuid;
+use wascap::jwt;
+use wasmcloud_control_interface::Link;
+
+fn format_component_claims(claims: &jwt::Claims<jwt::Component>) -> serde_json::Value {
+    let issuer = &claims.issuer;
+    let not_before_human = claims
+        .not_before
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "never".to_string());
+    let expires_human = claims
+        .expires
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "never".to_string());
+    if let Some(component) = &claims.metadata {
+        json!({
+            "call_alias": component.call_alias,
+            "issuer": issuer,
+            "tags": component.tags,
+            "name": component.name,
+            "version": component.ver,
+            "revision": component.rev,
+            "not_before_human": not_before_human,
+            "expires_human": expires_human,
+        })
+    } else {
+        json!({
+            "issuer": issuer,
+            "not_before_human": not_before_human,
+            "expires_human": expires_human,
+        })
+    }
+}
+
+pub fn component_scaled(
+    claims: Option<&jwt::Claims<jwt::Component>>,
+    annotations: &BTreeMap<String, String>,
+    host_id: impl AsRef<str>,
+    max_instances: impl Into<usize>,
+    image_ref: impl AsRef<str>,
+    component_id: impl AsRef<str>,
+) -> serde_json::Value {
+    if let Some(claims) = claims {
+        json!({
+            "public_key": claims.subject,
+            "claims": format_component_claims(claims),
+            "annotations": annotations,
+            "host_id": host_id.as_ref(),
+            "image_ref": image_ref.as_ref(),
+            "max_instances": max_instances.into(),
+            "component_id": component_id.as_ref(),
+        })
+    } else {
+        json!({
+            "annotations": annotations,
+            "host_id": host_id.as_ref(),
+            "image_ref": image_ref.as_ref(),
+            "max_instances": max_instances.into(),
+            "component_id": component_id.as_ref(),
+        })
+    }
+}
+
+pub fn component_scale_failed(
+    claims: Option<&jwt::Claims<jwt::Component>>,
+    annotations: &BTreeMap<String, String>,
+    host_id: impl AsRef<str>,
+    image_ref: impl AsRef<str>,
+    component_id: impl AsRef<str>,
+    max_instances: u32,
+    error: &anyhow::Error,
+) -> serde_json::Value {
+    if let Some(claims) = claims {
+        json!({
+            "public_key": claims.subject,
+            "component_id": component_id.as_ref(),
+            "annotations": annotations,
+            "host_id": host_id.as_ref(),
+            "image_ref": image_ref.as_ref(),
+            "max_instances": max_instances,
+            "error": format!("{error:#}"),
+        })
+    } else {
+        json!({
+            "annotations": annotations,
+            "component_id": component_id.as_ref(),
+            "host_id": host_id.as_ref(),
+            "image_ref": image_ref.as_ref(),
+            "max_instances": max_instances,
+            "error": format!("{error:#}"),
+        })
+    }
+}
+
+pub fn linkdef_set(link: &Link) -> serde_json::Value {
+    json!({
+        "source_id": link.source_id(),
+        "target": link.target(),
+        "name": link.name(),
+        "wit_namespace": link.wit_namespace(),
+        "wit_package": link.wit_package(),
+        "interfaces": link.interfaces(),
+        "source_config": link.source_config(),
+        "target_config": link.target_config(),
+    })
+}
+
+pub fn linkdef_set_failed(link: &Link, error: &anyhow::Error) -> serde_json::Value {
+    json!({
+        "source_id": link.source_id(),
+        "target": link.target(),
+        "name": link.name(),
+        "wit_namespace": link.wit_namespace(),
+        "wit_package": link.wit_package(),
+        "interfaces": link.interfaces(),
+        "source_config": link.source_config(),
+        "target_config": link.target_config(),
+        "error": format!("{error:#}"),
+    })
+}
+
+pub fn linkdef_deleted(
+    source_id: impl AsRef<str>,
+    target: Option<&String>,
+    name: impl AsRef<str>,
+    wit_namespace: impl AsRef<str>,
+    wit_package: impl AsRef<str>,
+    interfaces: Option<&Vec<String>>,
+) -> serde_json::Value {
+    // Target and interfaces aren't known if the link didn't exist, so we omit them from the
+    // event data in that case.
+    if let (Some(target), Some(interfaces)) = (target, interfaces) {
+        json!({
+            "source_id": source_id.as_ref(),
+            "target": target,
+            "name": name.as_ref(),
+            "wit_namespace": wit_namespace.as_ref(),
+            "wit_package": wit_package.as_ref(),
+            "interfaces": interfaces,
+        })
+    } else {
+        json!({
+            "source_id": source_id.as_ref(),
+            "name": name.as_ref(),
+            "wit_namespace": wit_namespace.as_ref(),
+            "wit_package": wit_package.as_ref(),
+        })
+    }
+}
+
+pub fn provider_started(
+    claims: Option<&jwt::Claims<jwt::CapabilityProvider>>,
+    annotations: &BTreeMap<String, String>,
+    host_id: impl AsRef<str>,
+    image_ref: impl AsRef<str>,
+    provider_id: impl AsRef<str>,
+) -> serde_json::Value {
+    if let Some(claims) = claims {
+        let not_before_human = claims
+            .not_before
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "never".to_string());
+        let expires_human = claims
+            .expires
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "never".to_string());
+        let metadata = claims.metadata.as_ref();
+        json!({
+            "host_id": host_id.as_ref(),
+            "image_ref": image_ref.as_ref(),
+            "provider_id": provider_id.as_ref(),
+            "annotations": annotations,
+            "claims": {
+                "issuer": &claims.issuer,
+                "tags": None::<Vec<()>>, // present in OTP, but hardcoded to `None`
+                "name": metadata.map(|jwt::CapabilityProvider { name, .. }| name),
+                "version": metadata.map(|jwt::CapabilityProvider { ver, .. }| ver),
+                "not_before_human": not_before_human,
+                "expires_human": expires_human,
+            },
+            // TODO(#1548): remove these fields when we don't depend on them
+            "instance_id": provider_id.as_ref(),
+            "public_key": provider_id.as_ref(),
+            "link_name": "default",
+        })
+    } else {
+        json!({
+            "host_id": host_id.as_ref(),
+            "image_ref": image_ref.as_ref(),
+            "provider_id": provider_id.as_ref(),
+            "annotations": annotations,
+        })
+    }
+}
+
+pub fn provider_start_failed(
+    provider_ref: impl AsRef<str>,
+    provider_id: impl AsRef<str>,
+    host_id: impl AsRef<str>,
+    error: &anyhow::Error,
+) -> serde_json::Value {
+    json!({
+        "provider_ref": provider_ref.as_ref(),
+        "provider_id": provider_id.as_ref(),
+        "host_id": host_id.as_ref(),
+        "error": format!("{error:#}"),
+        // TODO(#1548): remove this field when we don't depend on it
+        "link_name": "default",
+    })
+}
+
+pub fn provider_stopped(
+    annotations: &BTreeMap<String, String>,
+    host_id: impl AsRef<str>,
+    provider_id: impl AsRef<str>,
+    reason: impl AsRef<str>,
+) -> serde_json::Value {
+    json!({
+        "host_id": host_id.as_ref(),
+        "provider_id": provider_id.as_ref(),
+        "annotations": annotations,
+        "reason": reason.as_ref(),
+        // TODO(#1548): remove these fields when we don't depend on them
+        "instance_id": provider_id.as_ref(),
+        "public_key": provider_id.as_ref(),
+        "link_name": "default",
+    })
+}
+
+pub fn provider_health_check(
+    host_id: impl AsRef<str>,
+    provider_id: impl AsRef<str>,
+) -> serde_json::Value {
+    json!({
+        "host_id": host_id.as_ref(),
+        "provider_id": provider_id.as_ref(),
+    })
+}
+
+pub fn config_set(config_name: impl AsRef<str>) -> serde_json::Value {
+    json!({
+        "config_name": config_name.as_ref(),
+    })
+}
+
+pub fn config_deleted(config_name: impl AsRef<str>) -> serde_json::Value {
+    json!({
+        "config_name": config_name.as_ref(),
+    })
+}
+
+pub fn labels_changed(
+    host_id: impl AsRef<str>,
+    labels: impl Into<HashMap<String, String>>,
+) -> serde_json::Value {
+    json!({
+        "host_id": host_id.as_ref(),
+        "labels": labels.into(),
+    })
+}
+
+#[instrument(level = "debug", skip(event_builder, ctl_nats, data))]
+pub(crate) async fn publish(
+    event_builder: &EventBuilderV10,
+    ctl_nats: &async_nats::Client,
+    lattice: &str,
+    name: &str,
+    data: serde_json::Value,
+) -> anyhow::Result<()> {
+    let now = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .context("failed to format current time")?;
+    let ev = event_builder
+        .clone()
+        .ty(format!("com.wasmcloud.lattice.{name}"))
+        .id(Uuid::from_u128(Ulid::new().into()).to_string())
+        .time(now)
+        .data("application/json", data)
+        .build()
+        .context("failed to build cloud event")?;
+    let ev = serde_json::to_vec(&ev).context("failed to serialize event")?;
+    let max_payload = ctl_nats.server_info().max_payload;
+    if ev.len() > max_payload {
+        warn!(
+            size = ev.len(),
+            max_size = max_payload,
+            event = name,
+            lattice = lattice,
+            "event payload is too large to publish and may fail",
+        );
+    }
+    ctl_nats
+        .publish(format!("wasmbus.evt.{lattice}.{name}"), ev.into())
+        .await
+        .with_context(|| format!("failed to publish `{name}` event"))
+}

--- a/crates/host/src/wasmbus/experimental.rs
+++ b/crates/host/src/wasmbus/experimental.rs
@@ -71,36 +71,6 @@ impl Features {
         self.rpc_interface = true;
         self
     }
-
-    /// Check if the built-in HTTP server capability provider is enabled
-    pub fn builtin_http_server_enabled(&self) -> bool {
-        self.builtin_http_server
-    }
-
-    /// Check if the built-in NATS messaging capability provider is enabled
-    pub fn builtin_messaging_nats_enabled(&self) -> bool {
-        self.builtin_messaging_nats
-    }
-
-    /// Check if the wasmcloud:messaging@v3 interface support is enabled
-    pub fn wasmcloud_messaging_v3_enabled(&self) -> bool {
-        self.wasmcloud_messaging_v3
-    }
-
-    /// Check if workload identity authentication is enabled
-    pub fn workload_identity_auth_enabled(&self) -> bool {
-        self.workload_identity_auth
-    }
-
-    /// Check if the wasmcloud:identity interface support is enabled
-    pub fn workload_identity_interface_enabled(&self) -> bool {
-        self.workload_identity_interface
-    }
-
-    /// Check if the wrpc:rpc interface support is enabled
-    pub fn rpc_interface_enabled(&self) -> bool {
-        self.rpc_interface
-    }
 }
 
 /// This enables unioning feature flags together

--- a/crates/host/src/wasmbus/handler.rs
+++ b/crates/host/src/wasmbus/handler.rs
@@ -1227,7 +1227,7 @@ async fn parse_selectors_from_host_labels(host_labels: &BTreeMap<String, String>
                 // Remove the leading "wasmcloud"
                 .split_once(":")
                 // Map the remaining part of the label key together with the value `` to make it a selector
-                .map(|(_, selector)| format!("{selector}:{value}"))
+                .map(|(_, selector)| format!("{}:{}", selector, value))
                 // This should never get triggered, but just in case.
                 .unwrap_or("unknown".to_string());
 

--- a/crates/host/src/wasmbus/host_config.rs
+++ b/crates/host/src/wasmbus/host_config.rs
@@ -19,6 +19,16 @@ use crate::wasmbus::experimental::Features;
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug)]
 pub struct Host {
+    /// NATS URL to connect to for control interface connection
+    pub ctl_nats_url: Url,
+    /// Authentication JWT for control interface connection, must be specified with `ctl_key`
+    pub ctl_jwt: Option<String>,
+    /// Authentication key pair for control interface connection, must be specified with `ctl_jwt`
+    pub ctl_key: Option<Arc<KeyPair>>,
+    /// Whether to require TLS for control interface connection
+    pub ctl_tls: bool,
+    /// The topic prefix to use for control interface subscriptions, defaults to `wasmbus.ctl`
+    pub ctl_topic_prefix: String,
     /// NATS URL to connect to for component RPC
     pub rpc_nats_url: Url,
     /// Timeout period for all RPC calls
@@ -36,7 +46,7 @@ pub struct Host {
     /// Labels (key-value pairs) to add to the host
     pub labels: HashMap<String, String>,
     /// The server key pair used by this host to generate its public key
-    pub host_key: Arc<KeyPair>,
+    pub host_key: Option<Arc<KeyPair>>,
     /// The amount of time to wait for a provider to gracefully shut down before terminating it
     pub provider_shutdown_delay: Option<Duration>,
     /// Configuration for downloading artifacts from OCI registries
@@ -51,6 +61,10 @@ pub struct Host {
     pub config_service_enabled: bool,
     /// configuration for OpenTelemetry tracing
     pub otel_config: OtelConfig,
+    /// configuration for wasmCloud policy service
+    pub policy_service_config: PolicyService,
+    /// topic for wasmCloud secrets backend
+    pub secrets_topic_prefix: Option<String>,
     /// The semver version of the host. This is used by a consumer of this crate to indicate the
     /// host version (which may differ from the crate version)
     pub version: String,
@@ -90,6 +104,12 @@ pub struct PolicyService {
 impl Default for Host {
     fn default() -> Self {
         Self {
+            ctl_nats_url: Url::parse("nats://localhost:4222")
+                .expect("failed to parse control NATS URL"),
+            ctl_jwt: None,
+            ctl_key: None,
+            ctl_tls: false,
+            ctl_topic_prefix: "wasmbus.ctl".to_string(),
             rpc_nats_url: Url::parse("nats://localhost:4222")
                 .expect("failed to parse RPC NATS URL"),
             rpc_timeout: Duration::from_millis(2000),
@@ -99,7 +119,7 @@ impl Default for Host {
             lattice: "default".into(),
             js_domain: None,
             labels: HashMap::default(),
-            host_key: Arc::new(KeyPair::new_server()),
+            host_key: None,
             provider_shutdown_delay: None,
             oci_opts: OciConfig::default(),
             allow_file_load: false,
@@ -107,6 +127,8 @@ impl Default for Host {
             log_level: LogLevel::Info,
             config_service_enabled: false,
             otel_config: OtelConfig::default(),
+            policy_service_config: PolicyService::default(),
+            secrets_topic_prefix: None,
             version: env!("CARGO_PKG_VERSION").to_string(),
             max_execution_time: Duration::from_millis(10 * 60 * 1000),
             // 10 MB

--- a/crates/host/src/wasmbus/jetstream.rs
+++ b/crates/host/src/wasmbus/jetstream.rs
@@ -1,0 +1,299 @@
+//! Host interactions with JetStream, including processing of KV entries and
+//! storing/retrieving component specifications.
+
+use anyhow::{anyhow, ensure, Context as _};
+use async_nats::jetstream::kv::{Entry as KvEntry, Operation, Store};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument, warn};
+use wasmcloud_control_interface::Link;
+
+use crate::wasmbus::claims::{Claims, StoredClaims};
+use crate::wasmbus::component_import_links;
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+/// The specification of a component that is or did run in the lattice. This contains all of the information necessary to
+/// instantiate a component in the lattice (url and digest) as well as configuration and links in order to facilitate
+/// runtime execution of the component. Each `import` in a component's WIT world will need a corresponding link for the
+/// host runtime to route messages to the correct component.
+pub struct ComponentSpecification {
+    /// The URL of the component, file, OCI, or otherwise
+    pub(crate) url: String,
+    /// All outbound links from this component to other components, used for routing when calling a component `import`
+    #[serde(default)]
+    pub(crate) links: Vec<Link>,
+    ////
+    // Possible additions in the future, left in as comments to facilitate discussion
+    ////
+    // /// The claims embedded in the component, if present
+    // claims: Option<Claims>,
+    // /// SHA256 digest of the component, used for checking uniqueness of component IDs
+    // digest: String
+    // /// (Advanced) Additional routing topics to subscribe on in addition to the component ID.
+    // routing_groups: Vec<String>,
+}
+
+impl ComponentSpecification {
+    /// Create a new empty component specification with the given ID and URL
+    pub fn new(url: impl AsRef<str>) -> Self {
+        Self {
+            url: url.as_ref().to_string(),
+            links: Vec::new(),
+        }
+    }
+}
+
+impl super::Host {
+    /// Retrieve a component specification based on the provided ID. The outer Result is for errors
+    /// accessing the store, and the inner option indicates if the spec exists.
+    #[instrument(level = "debug", skip_all)]
+    pub(crate) async fn get_component_spec(
+        &self,
+        id: &str,
+    ) -> anyhow::Result<Option<ComponentSpecification>> {
+        let key = format!("COMPONENT_{id}");
+        let spec = self
+            .data
+            .get(key)
+            .await
+            .context("failed to get component spec")?
+            .map(|spec_bytes| serde_json::from_slice(&spec_bytes))
+            .transpose()
+            .context(format!(
+                "failed to deserialize stored component specification for {id}"
+            ))?;
+        Ok(spec)
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    pub(crate) async fn store_component_spec(
+        &self,
+        id: impl AsRef<str>,
+        spec: &ComponentSpecification,
+    ) -> anyhow::Result<()> {
+        let id = id.as_ref();
+        let key = format!("COMPONENT_{id}");
+        let bytes = serde_json::to_vec(spec)
+            .context("failed to serialize component spec")?
+            .into();
+        self.data
+            .put(key, bytes)
+            .await
+            .context("failed to put component spec")?;
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    pub(crate) async fn process_component_spec_put(
+        &self,
+        id: impl AsRef<str>,
+        value: impl AsRef<[u8]>,
+    ) -> anyhow::Result<()> {
+        let id = id.as_ref();
+        debug!(id, "process component spec put");
+
+        let spec: ComponentSpecification = serde_json::from_slice(value.as_ref())
+            .context("failed to deserialize component specification")?;
+
+        // Compute all new links that do not exist in the host map, which we'll use to
+        // publish to any running providers that are the source or target of the link.
+        // Computing this ahead of time is a tradeoff to hold only one lock at the cost of
+        // allocating an extra Vec. This may be a good place to optimize allocations.
+        let new_links = {
+            let all_links = self.links.read().await;
+            spec.links
+                .iter()
+                .filter(|spec_link| {
+                    // Retain only links that do not exist in the host map
+                    !all_links
+                        .iter()
+                        .filter_map(|(source_id, links)| {
+                            // Only consider links that are either the source or target of the new link
+                            if source_id == spec_link.source_id() || source_id == spec_link.target()
+                            {
+                                Some(links)
+                            } else {
+                                None
+                            }
+                        })
+                        .flatten()
+                        .any(|host_link| *spec_link == host_link)
+                })
+                .collect::<Vec<_>>()
+        };
+
+        {
+            // Acquire lock once in this block to avoid continually trying to acquire it.
+            let providers = self.providers.read().await;
+            // For every new link, if a provider is running on this host as the source or target,
+            // send the link to the provider for handling based on the xkey public key.
+            for link in new_links {
+                if let Some(provider) = providers.get(link.source_id()) {
+                    if let Err(e) = self.put_provider_link(provider, link).await {
+                        error!(?e, "failed to put provider link");
+                    }
+                }
+                if let Some(provider) = providers.get(link.target()) {
+                    if let Err(e) = self.put_provider_link(provider, link).await {
+                        error!(?e, "failed to put provider link");
+                    }
+                }
+            }
+        }
+
+        // If the component is already running, update the links
+        if let Some(component) = self.components.write().await.get(id) {
+            *component.handler.instance_links.write().await = component_import_links(&spec.links);
+            // NOTE(brooksmtownsend): We can consider updating the component if the image URL changes
+        };
+
+        // Insert the links into host map
+        self.links.write().await.insert(id.to_string(), spec.links);
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    pub(crate) async fn process_component_spec_delete(
+        &self,
+        id: impl AsRef<str>,
+    ) -> anyhow::Result<()> {
+        let id = id.as_ref();
+        debug!(id, "process component delete");
+        // TODO: TBD: stop component if spec deleted?
+        if self.components.write().await.get(id).is_some() {
+            warn!(
+                component_id = id,
+                "component spec deleted, but component is still running"
+            );
+        }
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    pub(crate) async fn process_claims_put(
+        &self,
+        pubkey: impl AsRef<str>,
+        value: impl AsRef<[u8]>,
+    ) -> anyhow::Result<()> {
+        let pubkey = pubkey.as_ref();
+
+        debug!(pubkey, "process claim entry put");
+
+        let stored_claims: StoredClaims =
+            serde_json::from_slice(value.as_ref()).context("failed to decode stored claims")?;
+        let claims = Claims::from(stored_claims);
+
+        ensure!(claims.subject() == pubkey, "subject mismatch");
+        match claims {
+            Claims::Component(claims) => self.store_component_claims(claims).await,
+            Claims::Provider(claims) => {
+                let mut provider_claims = self.provider_claims.write().await;
+                provider_claims.insert(claims.subject.clone(), claims);
+                Ok(())
+            }
+        }
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    pub(crate) async fn process_claims_delete(
+        &self,
+        pubkey: impl AsRef<str>,
+        value: impl AsRef<[u8]>,
+    ) -> anyhow::Result<()> {
+        let pubkey = pubkey.as_ref();
+
+        debug!(pubkey, "process claim entry deletion");
+
+        let stored_claims: StoredClaims =
+            serde_json::from_slice(value.as_ref()).context("failed to decode stored claims")?;
+        let claims = Claims::from(stored_claims);
+
+        ensure!(claims.subject() == pubkey, "subject mismatch");
+
+        match claims {
+            Claims::Component(claims) => {
+                let mut component_claims = self.component_claims.write().await;
+                component_claims.remove(&claims.subject);
+            }
+            Claims::Provider(claims) => {
+                let mut provider_claims = self.provider_claims.write().await;
+                provider_claims.remove(&claims.subject);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    pub(crate) async fn process_entry(
+        &self,
+        KvEntry {
+            key,
+            value,
+            operation,
+            ..
+        }: KvEntry,
+    ) {
+        let key_id = key.split_once('_');
+        let res = match (operation, key_id) {
+            (Operation::Put, Some(("COMPONENT", id))) => {
+                self.process_component_spec_put(id, value).await
+            }
+            (Operation::Delete, Some(("COMPONENT", id))) => {
+                self.process_component_spec_delete(id).await
+            }
+            (Operation::Put, Some(("LINKDEF", _id))) => {
+                debug!("ignoring deprecated LINKDEF put operation");
+                Ok(())
+            }
+            (Operation::Delete, Some(("LINKDEF", _id))) => {
+                debug!("ignoring deprecated LINKDEF delete operation");
+                Ok(())
+            }
+            (Operation::Put, Some(("CLAIMS", pubkey))) => {
+                self.process_claims_put(pubkey, value).await
+            }
+            (Operation::Delete, Some(("CLAIMS", pubkey))) => {
+                self.process_claims_delete(pubkey, value).await
+            }
+            (operation, Some(("REFMAP", id))) => {
+                // TODO: process REFMAP entries
+                debug!(?operation, id, "ignoring REFMAP entry");
+                Ok(())
+            }
+            _ => {
+                warn!(key, ?operation, "unsupported KV bucket entry");
+                Ok(())
+            }
+        };
+        if let Err(error) = &res {
+            error!(key, ?operation, ?error, "failed to process KV bucket entry");
+        }
+    }
+}
+
+#[instrument(level = "debug", skip_all)]
+pub(crate) async fn create_bucket(
+    jetstream: &async_nats::jetstream::Context,
+    bucket: &str,
+) -> anyhow::Result<Store> {
+    // Don't create the bucket if it already exists
+    if let Ok(store) = jetstream.get_key_value(bucket).await {
+        info!(%bucket, "bucket already exists. Skipping creation.");
+        return Ok(store);
+    }
+
+    match jetstream
+        .create_key_value(async_nats::jetstream::kv::Config {
+            bucket: bucket.to_string(),
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(store) => {
+            info!(%bucket, "created bucket with 1 replica");
+            Ok(store)
+        }
+        Err(err) => Err(anyhow!(err).context(format!("failed to create bucket '{bucket}'"))),
+    }
+}

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -2,6 +2,7 @@
 
 use core::sync::atomic::Ordering;
 
+use std::collections::hash_map::Entry;
 use std::collections::{hash_map, BTreeMap, HashMap};
 use std::env::consts::{ARCH, FAMILY, OS};
 use std::future::Future;
@@ -15,14 +16,19 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, ensure, Context as _};
+use async_nats::jetstream::kv::Store;
 use bytes::{BufMut, Bytes, BytesMut};
 use claims::{Claims, StoredClaims};
-use futures::stream::{AbortHandle, Abortable};
-use futures::{join, stream, Stream, StreamExt, TryStreamExt};
+use cloudevents::{EventBuilder, EventBuilderV10};
+use ctl::ControlInterfaceServer;
+use futures::future::Either;
+use futures::stream::{AbortHandle, Abortable, SelectAll};
+use futures::{join, stream, try_join, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use nkeys::{KeyPair, KeyPairType, XKey};
 use providers::Provider;
 use secrecy::SecretBox;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sysinfo::System;
 use tokio::io::AsyncWrite;
@@ -42,7 +48,7 @@ use wasmcloud_control_interface::{
     ScaleComponentCommand, StartProviderCommand, StopHostCommand, StopProviderCommand,
     UpdateComponentCommand,
 };
-use wasmcloud_core::ComponentId;
+use wasmcloud_core::{ComponentId, CTL_API_VERSION_1};
 use wasmcloud_runtime::capability::secrets::store::SecretValue;
 use wasmcloud_runtime::component::{from_string_map, Limits, WrpcServeEvent};
 use wasmcloud_runtime::Runtime;
@@ -50,43 +56,48 @@ use wasmcloud_secrets_types::SECRET_PREFIX;
 use wasmcloud_tracing::context::TraceContextInjector;
 use wasmcloud_tracing::{global, InstrumentationScope, KeyValue};
 
-use crate::event::{DefaultEventPublisher, EventPublisher};
-use crate::metrics::HostMetrics;
-use crate::nats::connect_nats;
-use crate::nats::provider::NatsProviderManager;
-use crate::policy::DefaultPolicyManager;
-use crate::secrets::{DefaultSecretsManager, SecretsManager};
-use crate::store::{DefaultStore, StoreManager};
-use crate::wasmbus::ctl::ControlInterfaceServer;
+use crate::registry::RegistryCredentialExt;
+use crate::wasmbus::jetstream::create_bucket;
 use crate::workload_identity::WorkloadIdentityConfig;
-use crate::{fetch_component, PolicyManager, PolicyResponse, RegistryConfig, ResourceRef};
+use crate::{
+    fetch_component, HostMetrics, OciConfig, PolicyHostInfo, PolicyManager, PolicyResponse,
+    RegistryAuth, RegistryConfig, RegistryType, ResourceRef, SecretsManager,
+};
 
-mod component_spec;
+mod claims;
+mod ctl;
+mod event;
 mod experimental;
 mod handler;
+mod jetstream;
+mod providers;
 
-pub(crate) mod claims;
-pub(crate) mod providers;
-
-/// Control interface implementation
-pub mod ctl;
-
-/// Configuration service
 pub mod config;
-
 /// wasmCloud host configuration
 pub mod host_config;
 
 pub use self::experimental::Features;
 pub use self::host_config::Host as HostConfig;
-pub use component_spec::ComponentSpecification;
-pub use providers::ProviderManager;
+pub use jetstream::ComponentSpecification;
 
 use self::config::{BundleGenerator, ConfigBundle};
 use self::handler::Handler;
 
 const MAX_INVOCATION_CHANNEL_SIZE: usize = 5000;
 const MIN_INVOCATION_CHANNEL_SIZE: usize = 256;
+
+#[derive(Debug)]
+struct Queue {
+    all_streams: SelectAll<async_nats::Subscriber>,
+}
+
+impl Stream for Queue {
+    type Item = async_nats::Message;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.all_streams.poll_next_unpin(cx)
+    }
+}
 
 #[derive(Clone, Default)]
 struct AsyncBytesMut(Arc<std::sync::Mutex<BytesMut>>);
@@ -129,6 +140,70 @@ impl TryFrom<AsyncBytesMut> for Vec<u8> {
     }
 }
 
+impl Queue {
+    #[instrument]
+    async fn new(
+        nats: &async_nats::Client,
+        topic_prefix: &str,
+        lattice: &str,
+        host_key: &KeyPair,
+        component_auction: bool,
+        provider_auction: bool,
+    ) -> anyhow::Result<Self> {
+        let host_id = host_key.public_key();
+        let mut subs = vec![
+            Either::Left(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.registry.put",
+            ))),
+            Either::Left(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.host.ping",
+            ))),
+            Either::Right(nats.queue_subscribe(
+                format!("{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.link.*"),
+                format!("{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.link",),
+            )),
+            Either::Right(nats.queue_subscribe(
+                format!("{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.claims.get"),
+                format!("{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.claims"),
+            )),
+            Either::Left(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.component.*.{host_id}"
+            ))),
+            Either::Left(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.provider.*.{host_id}"
+            ))),
+            Either::Left(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.label.*.{host_id}"
+            ))),
+            Either::Left(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.host.*.{host_id}"
+            ))),
+            Either::Right(nats.queue_subscribe(
+                format!("{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.config.>"),
+                format!("{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.config"),
+            )),
+        ];
+        if component_auction {
+            subs.push(Either::Left(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.component.auction",
+            ))));
+        }
+        if provider_auction {
+            subs.push(Either::Left(nats.subscribe(format!(
+                "{topic_prefix}.{CTL_API_VERSION_1}.{lattice}.provider.auction",
+            ))));
+        }
+        let streams = futures::future::join_all(subs)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, async_nats::SubscribeError>>()
+            .context("failed to subscribe to queues")?;
+        Ok(Self {
+            all_streams: futures::stream::select_all(streams),
+        })
+    }
+}
+
 type Annotations = BTreeMap<String, String>;
 
 #[derive(Debug)]
@@ -162,7 +237,7 @@ struct WrpcServer {
     id: Arc<str>,
     image_reference: Arc<str>,
     annotations: Arc<Annotations>,
-    policy_manager: Arc<dyn PolicyManager>,
+    policy_manager: Arc<PolicyManager>,
     metrics: Arc<HostMetrics>,
 }
 
@@ -239,25 +314,25 @@ impl wrpc_transport::Serve for WrpcServer {
                     span.set_parent(wasmcloud_tracing::context::get_span_context(&trace_context));
                 }
 
-                    let PolicyResponse {
-                        request_id,
-                        permitted,
-                        message,
-                    } = policy_manager
-                        .evaluate_perform_invocation(
-                            &id,
-                            &image_reference,
-                            &annotations,
-                            claims.as_deref(),
-                            instance.to_string(),
-                            func.to_string(),
-                        )
-                        .instrument(debug_span!(parent: &span, "policy_check"))
-                        .await?;
-                    ensure!(
-                        permitted,
-                        "policy denied request to invoke component `{request_id}`: `{message:?}`",
-                    );
+                let PolicyResponse {
+                    request_id,
+                    permitted,
+                    message,
+                } = policy_manager
+                    .evaluate_perform_invocation(
+                        &id,
+                        &image_reference,
+                        &annotations,
+                        claims.as_deref(),
+                        instance.to_string(),
+                        func.to_string(),
+                    )
+                    .instrument(debug_span!(parent: &span, "policy_check"))
+                    .await?;
+                ensure!(
+                    permitted,
+                    "policy denied request to invoke component `{request_id}`: `{message:?}`",
+                );
 
                 Ok((
                     InvocationContext{
@@ -280,128 +355,283 @@ impl wrpc_transport::Serve for WrpcServer {
 }
 
 /// wasmCloud Host
-/// Represents the core host structure for managing components, providers, links, and other
-/// functionalities in a wasmCloud host environment.
 pub struct Host {
-    /// A user-friendly name for the host.
-    friendly_name: String,
-
-    /// Handle to abort the heartbeat task.
-    heartbeat: AbortHandle,
-
-    /// Configuration settings for the host.
-    host_config: HostConfig,
-
-    /// The cryptographic key pair associated with the host.
-    host_key: Arc<KeyPair>,
-
-    /// The JWT token representing the host's identity.
-    host_token: Arc<jwt::Token<jwt::Host>>,
-
-    /// A map of labels associated with the host, used for metadata and identification.
-    labels: Arc<RwLock<BTreeMap<String, String>>>,
-
-    /// The maximum allowed execution time for tasks within the host.
-    max_execution_time: Duration,
-
-    /// The timestamp indicating when the host started.
-    start_at: Instant,
-
-    /// A channel to send a stop event to the host, signaling it to shut down.
-    pub stop_tx: watch::Sender<Option<Instant>>,
-
-    /// A channel to receive a stop event from the host, signaling it to shut down.
-    pub stop_rx: watch::Receiver<Option<Instant>>,
-
-    /// Experimental features enabled in the host for gated functionality.
-    experimental_features: Features,
-
-    /// Indicates whether the host is ready to process requests.
-    ready: Arc<AtomicBool>,
-
-    /// The encryption key used to secure secrets when transmitting over NATS.
-    secrets_xkey: Arc<XKey>,
-
-    /// A map of components managed by the host, keyed by their component IDs.
     components: Arc<RwLock<HashMap<ComponentId, Arc<Component>>>>,
-
-    /// A map of claims associated with components, keyed by their component IDs.
-    component_claims: Arc<RwLock<HashMap<ComponentId, jwt::Claims<jwt::Component>>>>,
-
-    /// A map of component IDs to their associated links.
+    event_builder: EventBuilderV10,
+    friendly_name: String,
+    heartbeat: AbortHandle,
+    host_config: HostConfig,
+    host_key: Arc<KeyPair>,
+    host_token: Arc<jwt::Token<jwt::Host>>,
+    /// The Xkey used to encrypt secrets when sending them over NATS
+    secrets_xkey: Arc<XKey>,
+    labels: Arc<RwLock<BTreeMap<String, String>>>,
+    ctl_topic_prefix: String,
+    /// NATS client to use for control interface subscriptions and jetstream queries
+    ctl_nats: async_nats::Client,
+    /// NATS client to use for RPC calls
+    rpc_nats: Arc<async_nats::Client>,
+    data: Store,
+    /// Task to watch for changes in the LATTICEDATA store
+    data_watch: AbortHandle,
+    config_data: Store,
+    config_generator: BundleGenerator,
+    policy_manager: Arc<PolicyManager>,
+    secrets_manager: Arc<SecretsManager>,
+    /// The provider map is a map of provider component ID to provider
+    providers: RwLock<HashMap<String, Provider>>,
+    registry_config: RwLock<HashMap<String, RegistryConfig>>,
+    runtime: Runtime,
+    start_at: Instant,
+    stop_tx: watch::Sender<Option<Instant>>,
+    stop_rx: watch::Receiver<Option<Instant>>,
+    queue: AbortHandle,
+    // Component ID -> All Links
     links: RwLock<HashMap<String, Vec<Link>>>,
-
-    /// A map of messaging links for NATS clients, organized by component and link names.
+    component_claims: Arc<RwLock<HashMap<ComponentId, jwt::Claims<jwt::Component>>>>, // TODO: use a single map once Claims is an enum
+    provider_claims: Arc<RwLock<HashMap<String, jwt::Claims<jwt::CapabilityProvider>>>>,
+    metrics: Arc<HostMetrics>,
+    max_execution_time: Duration,
     messaging_links:
         Arc<RwLock<HashMap<Arc<str>, Arc<RwLock<HashMap<Box<str>, async_nats::Client>>>>>>,
-
-    /// A map of providers managed by the host, keyed by their identifiers.
-    providers: RwLock<HashMap<String, Provider>>,
-
-    /// A map of claims associated with capability providers, keyed by their identifiers.
-    provider_claims: Arc<RwLock<HashMap<String, jwt::Claims<jwt::CapabilityProvider>>>>,
-
-    /// The runtime environment used by the host for executing tasks.
-    runtime: Runtime,
-
-    /// Optional overrides for registry configuration settings.
-    registry_config: RwLock<HashMap<String, RegistryConfig>>,
-
-    /// The NATS client used for making RPC calls.
-    rpc_nats: Arc<async_nats::Client>,
-
-    /// The manager for communicating with capability providers.
-    provider_manager: Arc<dyn ProviderManager>,
-
-    /// Configured OpenTelemetry metrics for monitoring the host.
-    metrics: Arc<HostMetrics>,
-
-    /// The event publisher used for emitting events from the host.
-    pub(crate) event_publisher: Arc<dyn EventPublisher>,
-
-    /// The policy manager used for evaluating policy decisions.
-    policy_manager: Arc<dyn PolicyManager>,
-
-    /// The secrets manager used for managing and retrieving secrets.
-    secrets_manager: Arc<dyn SecretsManager>,
-
-    /// The configuration manager for managing component, provider, link, and secret configurations.
-    config_store: Arc<dyn StoreManager>,
-
-    /// The data store for managing links, claims, and component specifications.
-    data_store: Arc<dyn StoreManager>,
-
-    /// The generator for creating configuration bundles.
-    config_generator: BundleGenerator,
-
-    /// A set of tasks managed by the host.
+    /// Experimental features to enable in the host that gate functionality
+    experimental_features: Features,
+    ready: Arc<AtomicBool>,
+    /// A set of host tasks
     #[allow(unused)]
     tasks: JoinSet<()>,
 }
 
-/// HostBuilder is used to construct a new Host instance
-#[derive(Default)]
-pub struct HostBuilder {
-    config: HostConfig,
-
-    /// Additional configuration of OCI registries
-    registry_config: HashMap<String, RegistryConfig>,
-
-    // Host trait extensions
-    bundle_generator: Option<BundleGenerator>,
-    /// The configuration store to use for managing configuration data
-    config_store: Option<Arc<dyn StoreManager>>,
-    /// The data store to use for managing data
-    data_store: Option<Arc<dyn StoreManager>>,
-    /// The event publisher to use for sending events
-    event_publisher: Option<Arc<dyn EventPublisher>>,
-    /// The policy manager to use for evaluating policy decisions
-    policy_manager: Option<Arc<dyn PolicyManager>>,
-    /// The secrets manager to use for managing secrets
-    secrets_manager: Option<Arc<dyn SecretsManager>>,
+/// Given the NATS address, authentication jwt, seed, tls requirement and optional request timeout,
+/// attempt to establish connection.
+///
+/// This function should be used to create a NATS client for Host communication, for non-host NATS
+/// clients we recommend using async-nats directly.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Only one of JWT or seed is specified, as we cannot authenticate with only one of them
+/// - Connection fails
+pub async fn connect_nats(
+    addr: impl async_nats::ToServerAddrs,
+    jwt: Option<&String>,
+    key: Option<Arc<KeyPair>>,
+    require_tls: bool,
+    request_timeout: Option<Duration>,
+    workload_identity_config: Option<WorkloadIdentityConfig>,
+) -> anyhow::Result<async_nats::Client> {
+    let opts = match (jwt, key, workload_identity_config) {
+        (Some(jwt), Some(key), None) => {
+            async_nats::ConnectOptions::with_jwt(jwt.to_string(), move |nonce| {
+                let key = key.clone();
+                async move { key.sign(&nonce).map_err(async_nats::AuthError::new) }
+            })
+            .name("wasmbus")
+        }
+        (Some(_), None, _) | (None, Some(_), _) => {
+            bail!("cannot authenticate if only one of jwt or seed is specified")
+        }
+        (jwt, key, Some(wid_cfg)) => {
+            setup_workload_identity_nats_connect_options(jwt, key, wid_cfg).await?
+        }
+        _ => async_nats::ConnectOptions::new().name("wasmbus"),
+    };
+    let opts = if let Some(timeout) = request_timeout {
+        opts.request_timeout(Some(timeout))
+    } else {
+        opts
+    };
+    let opts = opts.require_tls(require_tls);
+    opts.connect(addr)
+        .await
+        .context("failed to connect to NATS")
 }
 
-impl HostBuilder {
+#[cfg(unix)]
+async fn setup_workload_identity_nats_connect_options(
+    jwt: Option<&String>,
+    key: Option<Arc<KeyPair>>,
+    wid_cfg: WorkloadIdentityConfig,
+) -> anyhow::Result<async_nats::ConnectOptions> {
+    let wid_cfg = Arc::new(wid_cfg);
+    let jwt = jwt.map(String::to_string).map(Arc::new);
+    let key = key.clone();
+
+    // Return an auth callback that'll get called any time the
+    // NATS connection needs to be (re-)established. This is
+    // necessary to ensure that we always provide a recently
+    // issued JWT-SVID.
+    Ok(
+        async_nats::ConnectOptions::with_auth_callback(move |nonce| {
+            let key = key.clone();
+            let jwt = jwt.clone();
+            let wid_cfg = wid_cfg.clone();
+
+            let fetch_svid_handle = tokio::spawn(async move {
+                let mut client = spiffe::WorkloadApiClient::default()
+                    .await
+                    .map_err(async_nats::AuthError::new)?;
+                client
+                    .fetch_jwt_svid(&[wid_cfg.auth_service_audience.as_str()], None)
+                    .await
+                    .map_err(async_nats::AuthError::new)
+            });
+
+            async move {
+                let svid = fetch_svid_handle
+                    .await
+                    .map_err(async_nats::AuthError::new)?
+                    .map_err(async_nats::AuthError::new)?;
+
+                let mut auth = async_nats::Auth::new();
+                if let Some(key) = key {
+                    let signature = key.sign(&nonce).map_err(async_nats::AuthError::new)?;
+                    auth.signature = Some(signature);
+                }
+                if let Some(jwt) = jwt {
+                    auth.jwt = Some(jwt.to_string());
+                }
+                auth.token = Some(svid.token().into());
+                Ok(auth)
+            }
+        })
+        .name("wasmbus"),
+    )
+}
+
+#[cfg(target_family = "windows")]
+async fn setup_workload_identity_nats_connect_options(
+    jwt: Option<&String>,
+    key: Option<Arc<KeyPair>>,
+    wid_cfg: WorkloadIdentityConfig,
+) -> anyhow::Result<async_nats::ConnectOptions> {
+    bail!("workload identity is not supported on Windows")
+}
+
+#[derive(Debug, Default)]
+struct SupplementalConfig {
+    registry_config: Option<HashMap<String, RegistryConfig>>,
+}
+
+#[instrument(level = "debug", skip_all)]
+async fn load_supplemental_config(
+    ctl_nats: &async_nats::Client,
+    lattice: &str,
+    labels: &BTreeMap<String, String>,
+) -> anyhow::Result<SupplementalConfig> {
+    #[derive(Deserialize, Default)]
+    struct SerializedSupplementalConfig {
+        #[serde(default, rename = "registryCredentials")]
+        registry_credentials: Option<HashMap<String, RegistryCredential>>,
+    }
+
+    let cfg_topic = format!("wasmbus.cfg.{lattice}.req");
+    let cfg_payload = serde_json::to_vec(&json!({
+        "labels": labels,
+    }))
+    .context("failed to serialize config payload")?;
+
+    debug!("requesting supplemental config");
+    match ctl_nats.request(cfg_topic, cfg_payload.into()).await {
+        Ok(resp) => {
+            match serde_json::from_slice::<SerializedSupplementalConfig>(resp.payload.as_ref()) {
+                Ok(ser_cfg) => Ok(SupplementalConfig {
+                    registry_config: ser_cfg.registry_credentials.and_then(|creds| {
+                        creds
+                            .into_iter()
+                            .map(|(k, v)| {
+                                debug!(registry_url = %k, "set registry config");
+                                v.into_registry_config().map(|v| (k, v))
+                            })
+                            .collect::<anyhow::Result<_>>()
+                            .ok()
+                    }),
+                }),
+                Err(e) => {
+                    error!(
+                        ?e,
+                        "failed to deserialize supplemental config. Defaulting to empty config"
+                    );
+                    Ok(SupplementalConfig::default())
+                }
+            }
+        }
+        Err(e) => {
+            error!(
+                ?e,
+                "failed to request supplemental config. Defaulting to empty config"
+            );
+            Ok(SupplementalConfig::default())
+        }
+    }
+}
+
+#[instrument(level = "debug", skip_all)]
+async fn merge_registry_config(
+    registry_config: &RwLock<HashMap<String, RegistryConfig>>,
+    oci_opts: OciConfig,
+) -> () {
+    let mut registry_config = registry_config.write().await;
+    let allow_latest = oci_opts.allow_latest;
+    let additional_ca_paths = oci_opts.additional_ca_paths;
+
+    // update auth for specific registry, if provided
+    if let Some(reg) = oci_opts.oci_registry {
+        match registry_config.entry(reg.clone()) {
+            Entry::Occupied(_entry) => {
+                // note we don't update config here, since the config service should take priority
+                warn!(oci_registry_url = %reg, "ignoring OCI registry config, overridden by config service");
+            }
+            Entry::Vacant(entry) => {
+                debug!(oci_registry_url = %reg, "set registry config");
+                entry.insert(
+                    RegistryConfig::builder()
+                        .reg_type(RegistryType::Oci)
+                        .auth(RegistryAuth::from((
+                            oci_opts.oci_user,
+                            oci_opts.oci_password,
+                        )))
+                        .build()
+                        .expect("failed to build registry config"),
+                );
+            }
+        }
+    }
+
+    // update or create entry for all registries in allowed_insecure
+    oci_opts.allowed_insecure.into_iter().for_each(|reg| {
+        match registry_config.entry(reg.clone()) {
+            Entry::Occupied(mut entry) => {
+                debug!(oci_registry_url = %reg, "set allowed_insecure");
+                entry.get_mut().set_allow_insecure(true);
+            }
+            Entry::Vacant(entry) => {
+                debug!(oci_registry_url = %reg, "set allowed_insecure");
+                entry.insert(
+                    RegistryConfig::builder()
+                        .reg_type(RegistryType::Oci)
+                        .allow_insecure(true)
+                        .build()
+                        .expect("failed to build registry config"),
+                );
+            }
+        }
+    });
+
+    // update allow_latest for all registries
+    registry_config.iter_mut().for_each(|(url, config)| {
+        if !additional_ca_paths.is_empty() {
+            config.set_additional_ca_paths(additional_ca_paths.clone());
+        }
+        if allow_latest {
+            debug!(oci_registry_url = %url, "set allow_latest");
+        }
+        config.set_allow_latest(allow_latest);
+    });
+}
+
+impl Host {
     const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 
     const NAME_ADJECTIVES: &'static str = "
@@ -436,77 +666,24 @@ impl HostBuilder {
         names::Generator::new(&adjectives, &nouns, names::Name::Numbered).next()
     }
 
-    /// Create a new [HostBuilder] instance with the default configuration
-    pub fn new() -> Self {
-        HostBuilder::default()
-    }
-
-    /// Initialize the host with the given event publisher for sending events
-    pub fn with_event_publisher(self, event_publisher: Option<Arc<dyn EventPublisher>>) -> Self {
-        Self {
-            event_publisher,
-            ..self
-        }
-    }
-
-    /// Initialize the host with the given policy manager for evaluating policy decisions
-    pub fn with_policy_manager(self, policy_manager: Option<Arc<dyn PolicyManager>>) -> Self {
-        Self {
-            policy_manager,
-            ..self
-        }
-    }
-
-    /// Initialize the host with the given registry configuration
-    pub fn with_registry_config(self, registry_config: HashMap<String, RegistryConfig>) -> Self {
-        Self {
-            registry_config,
-            ..self
-        }
-    }
-
-    /// Initialize the host with the given secrets manager for managing secrets
-    pub fn with_secrets_manager(self, secrets_manager: Option<Arc<dyn SecretsManager>>) -> Self {
-        Self {
-            secrets_manager,
-            ..self
-        }
-    }
-
-    /// Initialize the host with the given configuration store
-    pub fn with_config_store(self, config_store: Option<Arc<dyn StoreManager>>) -> Self {
-        Self {
-            config_store,
-            ..self
-        }
-    }
-
-    /// Initialize the host with the given data store
-    pub fn with_data_store(self, data_store: Option<Arc<dyn StoreManager>>) -> Self {
-        Self { data_store, ..self }
-    }
-
-    /// Initialize the host with the given configuration watching bundle
-    pub fn with_bundle_generator(self, bundle_generator: Option<BundleGenerator>) -> Self {
-        Self {
-            bundle_generator,
-            ..self
-        }
-    }
-
-    /// Build a new [Host] instance with the given configuration
+    /// Construct a new [Host] returning a tuple of its [Arc] and an async shutdown function.
     #[instrument(level = "debug", skip_all)]
-    pub async fn build(
-        self,
-    ) -> anyhow::Result<(Arc<Host>, impl Future<Output = anyhow::Result<()>>)> {
-        ensure!(self.config.host_key.key_pair_type() == KeyPairType::Server);
+    pub async fn new(
+        config: HostConfig,
+    ) -> anyhow::Result<(Arc<Self>, impl Future<Output = anyhow::Result<()>>)> {
+        let host_key = if let Some(host_key) = &config.host_key {
+            ensure!(host_key.key_pair_type() == KeyPairType::Server);
+            Arc::clone(host_key)
+        } else {
+            Arc::new(KeyPair::new(KeyPairType::Server))
+        };
 
         let mut labels = BTreeMap::from([
             ("hostcore.arch".into(), ARCH.into()),
             ("hostcore.os".into(), OS.into()),
             ("hostcore.osfamily".into(), FAMILY.into()),
         ]);
-        labels.extend(self.config.labels.clone().into_iter());
+        labels.extend(config.labels.clone().into_iter());
         let friendly_name =
             Self::generate_friendly_name().context("failed to generate friendly name")?;
 
@@ -514,7 +691,7 @@ impl HostBuilder {
         let claims = jwt::Claims::<jwt::Host>::new(
             friendly_name.clone(),
             host_issuer.public_key(),
-            self.config.host_key.public_key().clone(),
+            host_key.public_key().clone(),
             Some(HashMap::from_iter([(
                 "self_signed".to_string(),
                 "true".to_string(),
@@ -525,46 +702,148 @@ impl HostBuilder {
             .context("failed to encode host claims")?;
         let host_token = Arc::new(jwt::Token { jwt, claims });
 
-        let workload_identity_config = if self.config.experimental_features.workload_identity_auth {
+        let start_evt = json!({
+            "friendly_name": friendly_name,
+            "labels": labels,
+            "uptime_seconds": 0,
+            "version": config.version,
+        });
+
+        let workload_identity_config = if config.experimental_features.workload_identity_auth {
             Some(WorkloadIdentityConfig::from_env()?)
         } else {
             None
         };
 
-        debug!(
-            rpc_nats_url = self.config.rpc_nats_url.as_str(),
-            "connecting to NATS RPC server"
-        );
-        let rpc_nats = Arc::new(
-            connect_nats(
-                self.config.rpc_nats_url.as_str(),
-                self.config.rpc_jwt.as_ref(),
-                self.config.rpc_key.clone(),
-                self.config.rpc_tls,
-                Some(self.config.rpc_timeout),
-                workload_identity_config.clone(),
-            )
-            .await
-            .context("failed to establish NATS RPC server connection")?,
-        );
+        let ((ctl_nats, queue), rpc_nats) = try_join!(
+            async {
+                debug!(
+                    ctl_nats_url = config.ctl_nats_url.as_str(),
+                    "connecting to NATS control server"
+                );
+                let ctl_nats = connect_nats(
+                    config.ctl_nats_url.as_str(),
+                    config.ctl_jwt.as_ref(),
+                    config.ctl_key.clone(),
+                    config.ctl_tls,
+                    None,
+                    workload_identity_config.clone(),
+                )
+                .await
+                .context("failed to establish NATS control server connection")?;
+                let queue = Queue::new(
+                    &ctl_nats,
+                    &config.ctl_topic_prefix,
+                    &config.lattice,
+                    &host_key,
+                    config.enable_component_auction,
+                    config.enable_provider_auction,
+                )
+                .await
+                .context("failed to initialize queue")?;
+                ctl_nats.flush().await.context("failed to flush")?;
+                Ok((ctl_nats, queue))
+            },
+            async {
+                debug!(
+                    rpc_nats_url = config.rpc_nats_url.as_str(),
+                    "connecting to NATS RPC server"
+                );
+                connect_nats(
+                    config.rpc_nats_url.as_str(),
+                    config.rpc_jwt.as_ref(),
+                    config.rpc_key.clone(),
+                    config.rpc_tls,
+                    Some(config.rpc_timeout),
+                    workload_identity_config.clone(),
+                )
+                .await
+                .context("failed to establish NATS RPC server connection")
+            }
+        )?;
+
+        let start_at = Instant::now();
+
+        let heartbeat_interval = config
+            .heartbeat_interval
+            .unwrap_or(Self::DEFAULT_HEARTBEAT_INTERVAL);
+        let heartbeat_start_at = start_at
+            .checked_add(heartbeat_interval)
+            .context("failed to compute heartbeat start time")?;
+        let heartbeat = IntervalStream::new(interval_at(heartbeat_start_at, heartbeat_interval));
 
         let (stop_tx, stop_rx) = watch::channel(None);
 
         let (runtime, _epoch) = Runtime::builder()
-            .max_execution_time(self.config.max_execution_time)
-            .max_linear_memory(self.config.max_linear_memory)
-            .max_components(self.config.max_components)
-            .max_core_instances_per_component(self.config.max_core_instances_per_component)
-            .max_component_size(self.config.max_component_size)
-            .experimental_features(self.config.experimental_features.into())
+            .max_execution_time(config.max_execution_time)
+            .max_linear_memory(config.max_linear_memory)
+            .max_components(config.max_components)
+            .max_core_instances_per_component(config.max_core_instances_per_component)
+            .max_component_size(config.max_component_size)
+            .experimental_features(config.experimental_features.into())
             .build()
             .context("failed to build runtime")?;
+        let event_builder = EventBuilderV10::new().source(host_key.public_key());
+
+        let ctl_jetstream = if let Some(domain) = config.js_domain.as_ref() {
+            async_nats::jetstream::with_domain(ctl_nats.clone(), domain)
+        } else {
+            async_nats::jetstream::new(ctl_nats.clone())
+        };
+        let bucket = format!("LATTICEDATA_{}", config.lattice);
+        let data = create_bucket(&ctl_jetstream, &bucket).await?;
+
+        let config_bucket = format!("CONFIGDATA_{}", config.lattice);
+        let config_data = create_bucket(&ctl_jetstream, &config_bucket).await?;
+
+        let (queue_abort, queue_abort_reg) = AbortHandle::new_pair();
+        let (heartbeat_abort, heartbeat_abort_reg) = AbortHandle::new_pair();
+        let (data_watch_abort, data_watch_abort_reg) = AbortHandle::new_pair();
+
+        let supplemental_config = if config.config_service_enabled {
+            load_supplemental_config(&ctl_nats, &config.lattice, &labels).await?
+        } else {
+            SupplementalConfig::default()
+        };
+
+        let registry_config = RwLock::new(supplemental_config.registry_config.unwrap_or_default());
+        merge_registry_config(&registry_config, config.oci_opts.clone()).await;
+
+        let policy_manager = PolicyManager::new(
+            ctl_nats.clone(),
+            PolicyHostInfo {
+                public_key: host_key.public_key(),
+                lattice: config.lattice.to_string(),
+                labels: HashMap::from_iter(labels.clone()),
+            },
+            config.policy_service_config.policy_topic.clone(),
+            config.policy_service_config.policy_timeout_ms,
+            config.policy_service_config.policy_changes_topic.clone(),
+        )
+        .await?;
+
+        // If provided, secrets topic must be non-empty
+        // TODO(#2411): Validate secrets topic prefix as a valid NATS subject
+        ensure!(
+            config.secrets_topic_prefix.is_none()
+                || config
+                    .secrets_topic_prefix
+                    .as_ref()
+                    .is_some_and(|topic| !topic.is_empty()),
+            "secrets topic prefix must be non-empty"
+        );
+
+        let secrets_manager = Arc::new(SecretsManager::new(
+            &config_data,
+            config.secrets_topic_prefix.as_ref(),
+            &ctl_nats,
+        ));
 
         let scope = InstrumentationScope::builder("wasmcloud-host")
-            .with_version(self.config.version.clone())
+            .with_version(config.version.clone())
             .with_attributes(vec![
-                KeyValue::new("host.id", self.config.host_key.public_key()),
-                KeyValue::new("host.version", self.config.version.clone()),
+                KeyValue::new("host.id", host_key.public_key()),
+                KeyValue::new("host.version", config.version.clone()),
                 KeyValue::new("host.arch", ARCH),
                 KeyValue::new("host.os", OS),
                 KeyValue::new("host.osfamily", FAMILY),
@@ -580,16 +859,21 @@ impl HostBuilder {
         let meter = global::meter_with_scope(scope);
         let metrics = HostMetrics::new(
             &meter,
-            self.config.host_key.public_key(),
-            self.config.lattice.to_string(),
+            host_key.public_key(),
+            config.lattice.to_string(),
             None,
         )
         .context("failed to create HostMetrics instance")?;
 
-        debug!("Feature flags: {:?}", self.config.experimental_features);
+        let config_generator = BundleGenerator::new(config_data.clone());
+
+        let max_execution_time_ms = config.max_execution_time;
+
+        debug!("Feature flags: {:?}", config.experimental_features);
+
         let mut tasks = JoinSet::new();
         let ready = Arc::new(AtomicBool::new(true));
-        if let Some(addr) = self.config.http_admin {
+        if let Some(addr) = config.http_admin {
             let socket = TcpListener::bind(addr)
                 .await
                 .context("failed to bind on HTTP administration endpoint")?;
@@ -661,72 +945,105 @@ impl HostBuilder {
             });
         }
 
-        let (heartbeat_abort, heartbeat_abort_reg) = AbortHandle::new_pair();
-        let start_at = Instant::now();
-
         let host = Host {
-            components: Arc::new(RwLock::new(HashMap::new())),
-            providers: RwLock::new(HashMap::new()),
+            components: Arc::default(),
+            event_builder,
             friendly_name,
             heartbeat: heartbeat_abort.clone(),
-            host_key: self.config.host_key.clone(),
+            ctl_topic_prefix: config.ctl_topic_prefix.clone(),
+            host_key,
             host_token,
             secrets_xkey: Arc::new(XKey::new()),
             labels: Arc::new(RwLock::new(labels)),
-            experimental_features: self.config.experimental_features,
+            ctl_nats,
+            rpc_nats: Arc::new(rpc_nats),
+            experimental_features: config.experimental_features,
+            host_config: config,
+            data: data.clone(),
+            data_watch: data_watch_abort.clone(),
+            config_data: config_data.clone(),
+            config_generator,
+            policy_manager,
+            secrets_manager,
+            providers: RwLock::default(),
+            registry_config,
             runtime,
             start_at,
             stop_rx,
             stop_tx,
-            links: RwLock::new(HashMap::new()),
-            component_claims: Arc::new(RwLock::new(HashMap::new())),
-            provider_claims: Arc::new(RwLock::new(HashMap::new())),
+            queue: queue_abort.clone(),
+            links: RwLock::default(),
+            component_claims: Arc::default(),
+            provider_claims: Arc::default(),
             metrics: Arc::new(metrics),
-            max_execution_time: self.config.max_execution_time,
+            max_execution_time: max_execution_time_ms,
             messaging_links: Arc::default(),
             ready: Arc::clone(&ready),
             tasks,
-            rpc_nats: Arc::clone(&rpc_nats),
-            registry_config: RwLock::new(self.registry_config),
-            // Extension traits that we fallback to defaults for
-            event_publisher: self
-                .event_publisher
-                .unwrap_or_else(|| Arc::new(DefaultEventPublisher::default())),
-            policy_manager: self
-                .policy_manager
-                .unwrap_or_else(|| Arc::new(DefaultPolicyManager)),
-            secrets_manager: self
-                .secrets_manager
-                .unwrap_or_else(|| Arc::new(DefaultSecretsManager::default())),
-            data_store: self
-                .data_store
-                .unwrap_or_else(|| Arc::new(DefaultStore::default())),
-            config_store: self
-                .config_store
-                .unwrap_or_else(|| Arc::new(DefaultStore::default())),
-            config_generator: self
-                .bundle_generator
-                .unwrap_or_else(|| BundleGenerator::new(Arc::new(DefaultStore::default()))),
-            // TODO(#4407): This trait abstraction isn't actually abstracted since all capability
-            // providers are NATS based. As we revise communication with providers, we can update
-            // this to be a trait object from the builder instead.
-            provider_manager: Arc::new(NatsProviderManager::new(
-                rpc_nats,
-                self.config.lattice.to_string(),
-            )),
-            host_config: self.config,
         };
 
         let host = Arc::new(host);
+        let queue = spawn({
+            let host = Arc::clone(&host);
+            async move {
+                let mut queue = Abortable::new(queue, queue_abort_reg);
+                queue
+                    .by_ref()
+                    .for_each_concurrent(None, {
+                        let host = Arc::clone(&host);
+                        move |msg| {
+                            let host = Arc::clone(&host);
+                            async move { host.handle_ctl_message(msg).await }
+                        }
+                    })
+                    .await;
+                let deadline = { *host.stop_rx.borrow() };
+                host.stop_tx.send_replace(deadline);
+                if queue.is_aborted() {
+                    info!("control interface queue task gracefully stopped");
+                } else {
+                    error!("control interface queue task unexpectedly stopped");
+                }
+            }
+        });
 
-        let heartbeat_interval = host
-            .host_config
-            .heartbeat_interval
-            .unwrap_or(Self::DEFAULT_HEARTBEAT_INTERVAL);
-        let heartbeat_start_at = start_at
-            .checked_add(heartbeat_interval)
-            .context("failed to compute heartbeat start time")?;
-        let heartbeat = IntervalStream::new(interval_at(heartbeat_start_at, heartbeat_interval));
+        let data_watch: JoinHandle<anyhow::Result<_>> = spawn({
+            let data = data.clone();
+            let host = Arc::clone(&host);
+            async move {
+                let data_watch = data
+                    .watch_all()
+                    .await
+                    .context("failed to watch lattice data bucket")?;
+                let mut data_watch = Abortable::new(data_watch, data_watch_abort_reg);
+                data_watch
+                    .by_ref()
+                    .for_each({
+                        let host = Arc::clone(&host);
+                        move |entry| {
+                            let host = Arc::clone(&host);
+                            async move {
+                                match entry {
+                                    Err(error) => {
+                                        error!("failed to watch lattice data bucket: {error}");
+                                    }
+                                    Ok(entry) => host.process_entry(entry).await,
+                                }
+                            }
+                        }
+                    })
+                    .await;
+                let deadline = { *host.stop_rx.borrow() };
+                host.stop_tx.send_replace(deadline);
+                if data_watch.is_aborted() {
+                    info!("data watch task gracefully stopped");
+                } else {
+                    error!("data watch task unexpectedly stopped");
+                }
+                Ok(())
+            }
+        });
+
         let heartbeat = spawn({
             let host = Arc::clone(&host);
             async move {
@@ -746,10 +1063,8 @@ impl HostBuilder {
                                     }
                                 };
 
-                                if let Err(e) = host
-                                    .event_publisher
-                                    .publish_event("host_heartbeat", heartbeat)
-                                    .await
+                                if let Err(e) =
+                                    host.publish_event("host_heartbeat", heartbeat).await
                                 {
                                     error!("failed to publish heartbeat: {e}");
                                 }
@@ -767,15 +1082,25 @@ impl HostBuilder {
             }
         });
 
-        let start_evt = json!({
-            "id": host.host_key.public_key(),
-            "friendly_name": host.friendly_name,
-            "labels": *host.labels.read().await,
-            "uptime_seconds": 0,
-            "version": host.host_config.version,
-        });
-        host.event_publisher
-            .publish_event("host_started", start_evt)
+        // Process existing data without emitting events
+        data.keys()
+            .await
+            .context("failed to read keys of lattice data bucket")?
+            .map_err(|e| anyhow!(e).context("failed to read lattice data stream"))
+            .try_filter_map(|key| async {
+                data.entry(key)
+                    .await
+                    .context("failed to get entry in lattice data bucket")
+            })
+            .for_each(|entry| async {
+                match entry {
+                    Ok(entry) => host.process_entry(entry).await,
+                    Err(err) => error!(%err, "failed to read entry from lattice data bucket"),
+                }
+            })
+            .await;
+
+        host.publish_event("host_started", start_evt)
             .await
             .context("failed to publish start event")?;
         info!(
@@ -786,41 +1111,24 @@ impl HostBuilder {
         Ok((Arc::clone(&host), async move {
             ready.store(false, Ordering::Relaxed);
             heartbeat_abort.abort();
-            heartbeat.await.context("failed to await heartbeat")?;
-            host.event_publisher
-                .publish_event(
-                    "host_stopped",
-                    json!({
-                        "labels": *host.labels.read().await,
-                    }),
-                )
-                .await
-                .context("failed to publish stop event")?;
+            queue_abort.abort();
+            data_watch_abort.abort();
+            host.policy_manager.policy_changes.abort();
+            let _ = try_join!(queue, data_watch, heartbeat).context("failed to await tasks")?;
+            host.publish_event(
+                "host_stopped",
+                json!({
+                    "labels": *host.labels.read().await,
+                }),
+            )
+            .await
+            .context("failed to publish stop event")?;
             // Before we exit, make sure to flush all messages or we may lose some that we've
             // thought were sent (like the host_stopped event)
-            host.rpc_nats
-                .flush()
-                .await
+            try_join!(host.ctl_nats.flush(), host.rpc_nats.flush())
                 .context("failed to flush NATS clients")?;
             Ok(())
         }))
-    }
-}
-
-impl From<HostConfig> for HostBuilder {
-    fn from(config: HostConfig) -> Self {
-        HostBuilder {
-            config,
-            ..Default::default()
-        }
-    }
-}
-
-impl Host {
-    /// Create a new HostBuilder
-    #[instrument(level = "debug", skip_all)]
-    pub fn builder() -> HostBuilder {
-        HostBuilder::default()
     }
 
     /// Waits for host to be stopped via lattice commands and returns the shutdown deadline on
@@ -837,18 +1145,6 @@ impl Host {
             .await
             .context("failed to wait for stop")?;
         Ok(*self.stop_rx.borrow())
-    }
-
-    /// Returns the host's unique identifier
-    #[instrument(level = "trace", skip_all)]
-    pub fn id(&self) -> String {
-        self.host_key.public_key()
-    }
-
-    /// Returns the lattice the host is running on
-    #[instrument(level = "trace", skip_all)]
-    pub fn lattice(&self) -> &str {
-        &self.host_config.lattice
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -954,6 +1250,18 @@ impl Host {
     async fn heartbeat(&self) -> anyhow::Result<serde_json::Value> {
         trace!("generating heartbeat");
         Ok(serde_json::to_value(self.inventory().await)?)
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    async fn publish_event(&self, name: &str, data: serde_json::Value) -> anyhow::Result<()> {
+        event::publish(
+            &self.event_builder,
+            &self.ctl_nats,
+            &self.host_config.lattice,
+            name,
+            data,
+        )
+        .await
     }
 
     /// Instantiate a component
@@ -1188,19 +1496,18 @@ impl Host {
             .context("failed to instantiate component")?;
 
         info!(?component_ref, "component started");
-        self.event_publisher
-            .publish_event(
-                "component_scaled",
-                crate::event::component_scaled(
-                    claims.as_ref(),
-                    annotations,
-                    self.host_key.public_key(),
-                    max_instances,
-                    &component_ref,
-                    &component_id,
-                ),
-            )
-            .await?;
+        self.publish_event(
+            "component_scaled",
+            event::component_scaled(
+                claims.as_ref(),
+                annotations,
+                self.host_key.public_key(),
+                max_instances,
+                &component_ref,
+                &component_id,
+            ),
+        )
+        .await?;
 
         Ok(entry.insert(component))
     }
@@ -1227,8 +1534,18 @@ impl Host {
         .context("failed to fetch component")
     }
 
+    #[instrument(level = "trace", skip_all)]
+    async fn store_component_claims(
+        &self,
+        claims: jwt::Claims<jwt::Component>,
+    ) -> anyhow::Result<()> {
+        let mut component_claims = self.component_claims.write().await;
+        component_claims.insert(claims.subject.clone(), claims);
+        Ok(())
+    }
+
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_auction_component(
+    async fn handle_auction_component(
         &self,
         payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<Option<CtlResponse<ComponentAuctionAck>>> {
@@ -1238,7 +1555,7 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_auction_provider(
+    async fn handle_auction_provider(
         &self,
         payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<Option<CtlResponse<ProviderAuctionAck>>> {
@@ -1248,7 +1565,7 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_stop_host(
+    async fn handle_stop_host(
         &self,
         payload: impl AsRef<[u8]>,
         transport_host_id: &str,
@@ -1294,7 +1611,7 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_scale_component(
+    async fn handle_scale_component(
         self: Arc<Self>,
         payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<CtlResponse<()>> {
@@ -1357,7 +1674,7 @@ impl Host {
         ) {
             // No component is running and we requested to scale to zero, noop.
             // We still publish the event to indicate that the component has been scaled to zero
-            (hash_map::Entry::Vacant(_), None) => crate::event::component_scaled(
+            (hash_map::Entry::Vacant(_), None) => event::component_scaled(
                 claims.as_ref(),
                 annotations,
                 host_id,
@@ -1390,7 +1707,7 @@ impl Host {
                         )
                         .await?;
 
-                        crate::event::component_scaled(
+                        event::component_scaled(
                             claims.as_ref(),
                             annotations,
                             host_id,
@@ -1402,10 +1719,9 @@ impl Host {
                     Err(e) => {
                         error!(%component_ref, %component_id, err = ?e, "failed to scale component");
                         if let Err(e) = self
-                            .event_publisher
                             .publish_event(
                                 "component_scale_failed",
-                                crate::event::component_scale_failed(
+                                event::component_scale_failed(
                                     claims_token.map(|c| c.claims.clone()).as_ref(),
                                     annotations,
                                     host_id,
@@ -1431,7 +1747,7 @@ impl Host {
                     .context("failed to stop component in response to scale to zero")?;
 
                 info!(?component_ref, "component stopped");
-                crate::event::component_scaled(
+                event::component_scaled(
                     claims.as_ref(),
                     &component.annotations,
                     host_id,
@@ -1448,7 +1764,7 @@ impl Host {
 
                 // Create the event first to avoid borrowing the component
                 // This event is idempotent.
-                let event = crate::event::component_scaled(
+                let event = event::component_scaled(
                     claims.as_ref(),
                     &component.annotations,
                     host_id,
@@ -1497,9 +1813,7 @@ impl Host {
             }
         };
 
-        self.event_publisher
-            .publish_event("component_scaled", scaled_event)
-            .await?;
+        self.publish_event("component_scaled", scaled_event).await?;
 
         Ok(())
     }
@@ -1508,7 +1822,7 @@ impl Host {
     // design thinking around how update component should work. Should it be limited to a single host or latticewide?
     // Should it also update configuration, or is that separate? Should scaling be done via an update?
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_update_component(
+    async fn handle_update_component(
         self: Arc<Self>,
         payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<CtlResponse<()>> {
@@ -1570,37 +1884,35 @@ impl Host {
             };
 
             info!(%new_component_ref, "component updated");
-            self.event_publisher
-                .publish_event(
-                    "component_scaled",
-                    crate::event::component_scaled(
-                        new_claims.as_ref(),
-                        &component.annotations,
-                        host_id,
-                        max,
-                        new_component_ref,
-                        &component_id,
-                    ),
-                )
-                .await?;
+            self.publish_event(
+                "component_scaled",
+                event::component_scaled(
+                    new_claims.as_ref(),
+                    &component.annotations,
+                    host_id,
+                    max,
+                    new_component_ref,
+                    &component_id,
+                ),
+            )
+            .await?;
 
             // TODO(#1548): If this errors, we need to rollback
             self.stop_component(&component, host_id)
                 .await
                 .context("failed to stop old component")?;
-            self.event_publisher
-                .publish_event(
-                    "component_scaled",
-                    crate::event::component_scaled(
-                        component.claims(),
-                        &component.annotations,
-                        host_id,
-                        0_usize,
-                        &component.image_reference,
-                        &component.id,
-                    ),
-                )
-                .await?;
+            self.publish_event(
+                "component_scaled",
+                event::component_scaled(
+                    component.claims(),
+                    &component.annotations,
+                    host_id,
+                    0_usize,
+                    &component.image_reference,
+                    &component.id,
+                ),
+            )
+            .await?;
 
             component
         };
@@ -1613,7 +1925,7 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_start_provider(
+    async fn handle_start_provider(
         self: Arc<Self>,
         payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<Option<CtlResponse<()>>> {
@@ -1686,8 +1998,6 @@ impl Host {
 
         self.store_component_spec(&provider_id, &component_specification)
             .await?;
-        self.update_host_with_spec(&provider_id, &component_specification)
-            .await?;
 
         let mut providers = self.providers.write().await;
         if let hash_map::Entry::Vacant(entry) = providers.entry(provider_id.into()) {
@@ -1757,18 +2067,17 @@ impl Host {
                 provider_ref = provider_ref.as_ref(),
                 provider_id, "provider started"
             );
-            self.event_publisher
-                .publish_event(
-                    "provider_started",
-                    crate::event::provider_started(
-                        claims.as_ref(),
-                        &annotations,
-                        host_id,
-                        &provider_ref,
-                        provider_id,
-                    ),
-                )
-                .await?;
+            self.publish_event(
+                "provider_started",
+                event::provider_started(
+                    claims.as_ref(),
+                    &annotations,
+                    host_id,
+                    &provider_ref,
+                    provider_id,
+                ),
+            )
+            .await?;
 
             // Add the provider
             entry.insert(Provider {
@@ -1787,7 +2096,7 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_stop_provider(
+    async fn handle_stop_provider(
         &self,
         payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<CtlResponse<()>> {
@@ -1797,29 +2106,27 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_inventory(&self) -> anyhow::Result<CtlResponse<HostInventory>> {
+    async fn handle_inventory(&self) -> anyhow::Result<CtlResponse<HostInventory>> {
         <Self as ControlInterfaceServer>::handle_inventory(self).await
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub(crate) async fn handle_claims(
-        &self,
-    ) -> anyhow::Result<CtlResponse<Vec<HashMap<String, String>>>> {
+    async fn handle_claims(&self) -> anyhow::Result<CtlResponse<Vec<HashMap<String, String>>>> {
         <Self as ControlInterfaceServer>::handle_claims(self).await
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub(crate) async fn handle_links(&self) -> anyhow::Result<Vec<u8>> {
+    async fn handle_links(&self) -> anyhow::Result<Vec<u8>> {
         <Self as ControlInterfaceServer>::handle_links(self).await
     }
 
     #[instrument(level = "trace", skip(self))]
-    pub(crate) async fn handle_config_get(&self, config_name: &str) -> anyhow::Result<Vec<u8>> {
+    async fn handle_config_get(&self, config_name: &str) -> anyhow::Result<Vec<u8>> {
         <Self as ControlInterfaceServer>::handle_config_get(self, config_name).await
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_label_put(
+    async fn handle_label_put(
         &self,
         host_id: &str,
         payload: impl AsRef<[u8]>,
@@ -1830,7 +2137,7 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_label_del(
+    async fn handle_label_del(
         &self,
         host_id: &str,
         payload: impl AsRef<[u8]>,
@@ -1844,10 +2151,7 @@ impl Host {
     /// the change is written to the LATTICEDATA store, each host in the lattice (including this one)
     /// will handle the new specification and update their own internal link maps via [process_component_spec_put].
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_link_put(
-        &self,
-        payload: impl AsRef<[u8]>,
-    ) -> anyhow::Result<CtlResponse<()>> {
+    async fn handle_link_put(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<CtlResponse<()>> {
         let link: Link = serde_json::from_slice(payload.as_ref())
             .context("failed to deserialize wrpc link definition")?;
         <Self as ControlInterfaceServer>::handle_link_put(self, link).await
@@ -1855,17 +2159,14 @@ impl Host {
 
     #[instrument(level = "debug", skip_all)]
     /// Remove an interface link on a source component for a specific package
-    pub(crate) async fn handle_link_del(
-        &self,
-        payload: impl AsRef<[u8]>,
-    ) -> anyhow::Result<CtlResponse<()>> {
+    async fn handle_link_del(&self, payload: impl AsRef<[u8]>) -> anyhow::Result<CtlResponse<()>> {
         let req = serde_json::from_slice::<DeleteInterfaceLinkDefinitionRequest>(payload.as_ref())
             .context("failed to deserialize wrpc link definition")?;
         <Self as ControlInterfaceServer>::handle_link_del(self, req).await
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_registries_put(
+    async fn handle_registries_put(
         &self,
         payload: impl AsRef<[u8]>,
     ) -> anyhow::Result<CtlResponse<()>> {
@@ -1876,7 +2177,7 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all, fields(%config_name))]
-    pub(crate) async fn handle_config_put(
+    async fn handle_config_put(
         &self,
         config_name: &str,
         data: Bytes,
@@ -1888,22 +2189,204 @@ impl Host {
     }
 
     #[instrument(level = "debug", skip_all, fields(%config_name))]
-    pub(crate) async fn handle_config_delete(
-        &self,
-        config_name: &str,
-    ) -> anyhow::Result<CtlResponse<()>> {
+    async fn handle_config_delete(&self, config_name: &str) -> anyhow::Result<CtlResponse<()>> {
         <Self as ControlInterfaceServer>::handle_config_delete(self, config_name).await
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_ping_hosts(
+    async fn handle_ping_hosts(
         &self,
     ) -> anyhow::Result<CtlResponse<wasmcloud_control_interface::Host>> {
         <Self as ControlInterfaceServer>::handle_ping_hosts(self).await
     }
 
-    // NOTE(brooksmtownsend): This is only necessary when running capability providers that were
-    // build for wasmCloud versions before 1.2. This is a backwards-compatible
+    #[instrument(level = "trace", skip_all, fields(subject = %message.subject))]
+    async fn handle_ctl_message(self: Arc<Self>, message: async_nats::Message) {
+        // NOTE: if log level is not `trace`, this won't have an effect, since the current span is
+        // disabled. In most cases that's fine, since we aren't aware of any control interface
+        // requests including a trace context
+        opentelemetry_nats::attach_span_context(&message);
+        // Skip the topic prefix, the version, and the lattice
+        // e.g. `wasmbus.ctl.v1.{prefix}`
+        let subject = message.subject;
+        let mut parts = subject
+            .trim()
+            .trim_start_matches(&self.ctl_topic_prefix)
+            .trim_start_matches('.')
+            .split('.')
+            .skip(2);
+        trace!(%subject, "handling control interface request");
+
+        // This response is a wrapped Result<Option<Result<Vec<u8>>>> for a good reason.
+        // The outer Result is for reporting protocol errors in handling the request, e.g. failing to
+        //    deserialize the request payload.
+        // The Option is for the case where the request is handled successfully, but the handler
+        //    doesn't want to send a response back to the client, like with an auction.
+        // The inner Result is purely for the success or failure of serializing the [CtlResponse], which
+        //    should never fail but it's a result we must handle.
+        // And finally, the Vec<u8> is the serialized [CtlResponse] that we'll send back to the client
+        let ctl_response = match (parts.next(), parts.next(), parts.next(), parts.next()) {
+            // Component commands
+            (Some("component"), Some("auction"), None, None) => self
+                .handle_auction_component(message.payload)
+                .await
+                .map(serialize_ctl_response),
+            (Some("component"), Some("scale"), Some(_host_id), None) => Arc::clone(&self)
+                .handle_scale_component(message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            (Some("component"), Some("update"), Some(_host_id), None) => Arc::clone(&self)
+                .handle_update_component(message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Provider commands
+            (Some("provider"), Some("auction"), None, None) => self
+                .handle_auction_provider(message.payload)
+                .await
+                .map(serialize_ctl_response),
+            (Some("provider"), Some("start"), Some(_host_id), None) => Arc::clone(&self)
+                .handle_start_provider(message.payload)
+                .await
+                .map(serialize_ctl_response),
+            (Some("provider"), Some("stop"), Some(_host_id), None) => self
+                .handle_stop_provider(message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Host commands
+            (Some("host"), Some("get"), Some(_host_id), None) => self
+                .handle_inventory()
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            (Some("host"), Some("ping"), None, None) => self
+                .handle_ping_hosts()
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            (Some("host"), Some("stop"), Some(host_id), None) => self
+                .handle_stop_host(message.payload, host_id)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Claims commands
+            (Some("claims"), Some("get"), None, None) => self
+                .handle_claims()
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Link commands
+            (Some("link"), Some("del"), None, None) => self
+                .handle_link_del(message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            (Some("link"), Some("get"), None, None) => {
+                // Explicitly returning a Vec<u8> for non-cloning efficiency within handle_links
+                self.handle_links().await.map(|bytes| Some(Ok(bytes)))
+            }
+            (Some("link"), Some("put"), None, None) => self
+                .handle_link_put(message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Label commands
+            (Some("label"), Some("del"), Some(host_id), None) => self
+                .handle_label_del(host_id, message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            (Some("label"), Some("put"), Some(host_id), None) => self
+                .handle_label_put(host_id, message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Registry commands
+            (Some("registry"), Some("put"), None, None) => self
+                .handle_registries_put(message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Config commands
+            (Some("config"), Some("get"), Some(config_name), None) => self
+                .handle_config_get(config_name)
+                .await
+                .map(|bytes| Some(Ok(bytes))),
+            (Some("config"), Some("put"), Some(config_name), None) => self
+                .handle_config_put(config_name, message.payload)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            (Some("config"), Some("del"), Some(config_name), None) => self
+                .handle_config_delete(config_name)
+                .await
+                .map(Some)
+                .map(serialize_ctl_response),
+            // Topic fallback
+            _ => {
+                warn!(%subject, "received control interface request on unsupported subject");
+                Ok(serialize_ctl_response(Some(CtlResponse::error(
+                    "unsupported subject",
+                ))))
+            }
+        };
+
+        if let Err(err) = &ctl_response {
+            error!(%subject, ?err, "failed to handle control interface request");
+        } else {
+            trace!(%subject, "handled control interface request");
+        }
+
+        if let Some(reply) = message.reply {
+            let headers = injector_to_headers(&TraceContextInjector::default_with_span());
+
+            let payload: Option<Bytes> = match ctl_response {
+                Ok(Some(Ok(payload))) => Some(payload.into()),
+                // No response from the host (e.g. auctioning provider)
+                Ok(None) => None,
+                Err(e) => Some(
+                    serde_json::to_vec(&CtlResponse::error(&e.to_string()))
+                        .context("failed to encode control interface response")
+                        // This should never fail to serialize, but the fallback ensures that we send
+                        // something back to the client even if we somehow fail.
+                        .unwrap_or_else(|_| format!(r#"{{"success":false,"error":"{e}"}}"#).into())
+                        .into(),
+                ),
+                // This would only occur if we failed to serialize a valid CtlResponse. This is
+                // programmer error.
+                Ok(Some(Err(e))) => Some(
+                    serde_json::to_vec(&CtlResponse::error(&e.to_string()))
+                        .context("failed to encode control interface response")
+                        .unwrap_or_else(|_| format!(r#"{{"success":false,"error":"{e}"}}"#).into())
+                        .into(),
+                ),
+            };
+
+            if let Some(payload) = payload {
+                let max_payload = self.ctl_nats.server_info().max_payload;
+                if payload.len() > max_payload {
+                    warn!(
+                        size = payload.len(),
+                        max_size = max_payload,
+                        "ctl response payload is too large to publish and may fail",
+                    );
+                }
+                if let Err(err) = self
+                    .ctl_nats
+                    .publish_with_headers(reply.clone(), headers, payload)
+                    .err_into::<anyhow::Error>()
+                    .and_then(|()| self.ctl_nats.flush().err_into::<anyhow::Error>())
+                    .await
+                {
+                    error!(%subject, ?err, "failed to publish reply to control interface request");
+                }
+            }
+        }
+    }
+
+    // TODO: Remove this before wasmCloud 1.2 is released. This is a backwards-compatible
     // provider link definition put that is published to the provider's id, which is what
     // providers built for wasmCloud 1.0 expected.
     //
@@ -1928,10 +2411,18 @@ impl Host {
             .resolve_link_config(link.clone(), None, None, &XKey::new())
             .await
             .context("failed to resolve link config")?;
+        let lattice = &self.host_config.lattice;
+        let payload: Bytes = serde_json::to_vec(&provider_link)
+            .context("failed to serialize provider link definition")?
+            .into();
 
         if let Err(e) = self
-            .provider_manager
-            .put_link(&provider_link, link.source_id())
+            .rpc_nats
+            .publish_with_headers(
+                format!("wasmbus.rpc.{lattice}.{}.linkdefs.put", link.source_id()),
+                injector_to_headers(&TraceContextInjector::default_with_span()),
+                payload.clone(),
+            )
             .await
         {
             warn!(
@@ -1941,8 +2432,12 @@ impl Host {
         }
 
         if let Err(e) = self
-            .provider_manager
-            .put_link(&provider_link, link.target())
+            .rpc_nats
+            .publish_with_headers(
+                format!("wasmbus.rpc.{lattice}.{}.linkdefs.put", link.target()),
+                injector_to_headers(&TraceContextInjector::default_with_span()),
+                payload,
+            )
             .await
         {
             warn!(
@@ -1966,9 +2461,20 @@ impl Host {
             )
             .await
             .context("failed to resolve link config and secrets")?;
+        let lattice = &self.host_config.lattice;
+        let payload: Bytes = serde_json::to_vec(&provider_link)
+            .context("failed to serialize provider link definition")?
+            .into();
 
-        self.provider_manager
-            .put_link(&provider_link, &provider.xkey.public_key())
+        self.rpc_nats
+            .publish_with_headers(
+                format!(
+                    "wasmbus.rpc.{lattice}.{}.linkdefs.put",
+                    provider.xkey.public_key()
+                ),
+                injector_to_headers(&TraceContextInjector::default_with_span()),
+                payload.clone(),
+            )
             .await
             .context("failed to publish provider link definition put")
     }
@@ -1979,6 +2485,7 @@ impl Host {
     /// is linked to a provider (which it should never be.)
     #[instrument(level = "debug", skip(self))]
     async fn del_provider_link(&self, link: &Link) -> anyhow::Result<()> {
+        let lattice = &self.host_config.lattice;
         // The provider expects the [`wasmcloud_core::InterfaceLinkDefinition`]
         let link = wasmcloud_core::InterfaceLinkDefinition {
             source_id: link.source_id().to_string(),
@@ -1992,10 +2499,21 @@ impl Host {
         };
         let source_id = &link.source_id;
         let target = &link.target;
+        let payload: Bytes = serde_json::to_vec(&link)
+            .context("failed to serialize provider link definition for deletion")?
+            .into();
 
         let (source_result, target_result) = futures::future::join(
-            self.provider_manager.delete_link(&link, source_id),
-            self.provider_manager.delete_link(&link, target),
+            self.rpc_nats.publish_with_headers(
+                format!("wasmbus.rpc.{lattice}.{source_id}.linkdefs.del"),
+                injector_to_headers(&TraceContextInjector::default_with_span()),
+                payload.clone(),
+            ),
+            self.rpc_nats.publish_with_headers(
+                format!("wasmbus.rpc.{lattice}.{target}.linkdefs.del"),
+                injector_to_headers(&TraceContextInjector::default_with_span()),
+                payload,
+            ),
         )
         .await;
 
@@ -2038,7 +2556,7 @@ impl Host {
     where
         I: IntoIterator<Item: AsRef<str>>,
     {
-        let config_store = self.config_store.clone();
+        let config_store = self.config_data.clone();
         let validation_errors =
             futures::future::join_all(config_names.into_iter().map(|config_name| {
                 let config_store = config_store.clone();
@@ -2188,6 +2706,13 @@ fn component_import_links(links: &[Link]) -> HashMap<Box<str>, HashMap<Box<str>,
     m
 }
 
+/// Helper function to serialize `CtlResponse`<T> into a Vec<u8> if the response is Some
+fn serialize_ctl_response<T: Serialize>(
+    ctl_response: Option<CtlResponse<T>>,
+) -> Option<anyhow::Result<Vec<u8>>> {
+    ctl_response.map(|resp| serde_json::to_vec(&resp).map_err(anyhow::Error::from))
+}
+
 fn human_friendly_uptime(uptime: Duration) -> String {
     // strip sub-seconds, then convert to human-friendly format
     humantime::format_duration(
@@ -2196,8 +2721,7 @@ fn human_friendly_uptime(uptime: Duration) -> String {
     .to_string()
 }
 
-/// Helper function to inject trace context into NATS headers
-pub fn injector_to_headers(injector: &TraceContextInjector) -> async_nats::header::HeaderMap {
+fn injector_to_headers(injector: &TraceContextInjector) -> async_nats::header::HeaderMap {
     injector
         .iter()
         .filter_map(|(k, v)| {

--- a/crates/provider-archive/Cargo.toml
+++ b/crates/provider-archive/Cargo.toml
@@ -13,13 +13,13 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-astral-tokio-tar = { workspace = true }
 async-compression = { workspace = true, features = ["tokio", "gzip"] }
 data-encoding = { workspace = true }
 ring = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["io-util"] }
 tokio-stream = { workspace = true }
+astral-tokio-tar = { workspace = true }
 wascap = { workspace = true }
 
 [dev-dependencies]

--- a/crates/provider-blobstore-azure/tests/integration.rs
+++ b/crates/provider-blobstore-azure/tests/integration.rs
@@ -94,7 +94,7 @@ impl TestEnv {
 
     // Uses the emulator path with custom port: https://github.com/Azure/azure-sdk-for-rust/blob/v2024-04-24/sdk/storage/src/cloud_location.rs#L46-L48
     pub fn azurite_endpoint(address: &str) -> String {
-        format!("http://{address}/devstoreaccount1")
+        format!("http://{}/devstoreaccount1", address)
     }
 
     pub fn azurite_blob_client(&self) -> azure_storage_blobs::prelude::BlobServiceClient {
@@ -111,7 +111,7 @@ impl TestEnv {
     }
 
     pub fn nats_endpoint(address: &str) -> String {
-        format!("nats://{address}")
+        format!("nats://{}", address)
     }
 
     async fn nats_client(&self) -> Result<async_nats::Client> {
@@ -461,7 +461,7 @@ async fn test_list_container_objects() -> Result<()> {
     let test_blob_name = "test.blob";
     let test_blob_body = test_suite_name;
     let mut test_blob_names = (1..=3)
-        .map(|blob_id| format!("{test_blob_name}.{blob_id:0>3}"))
+        .map(|blob_id| format!("{test_blob_name}.{:0>3}", blob_id))
         .collect::<Vec<_>>();
 
     let env = TestEnv::new(lattice_name, test_suite_name)
@@ -780,7 +780,7 @@ async fn test_delete_objects() -> Result<()> {
     let test_blob_name = "test.blob";
     let test_blob_body = test_suite_name;
     let test_blob_names = (1..=3)
-        .map(|blob_id| format!("{test_blob_name}-{blob_id:0>3}"))
+        .map(|blob_id| format!("{test_blob_name}-{:0>3}", blob_id))
         .collect::<Vec<_>>();
 
     let env = TestEnv::new(lattice_name, test_suite_name)

--- a/crates/provider-blobstore-nats/tests/integration.rs
+++ b/crates/provider-blobstore-nats/tests/integration.rs
@@ -45,7 +45,7 @@ impl TestEnv {
             .get_host_port_ipv4(4222)
             .await
             .context("should get host port")?;
-        let nats_address = format!("0.0.0.0:{port}");
+        let nats_address = format!("0.0.0.0:{}", port);
 
         // Longer initial wait for server stability
         tokio::time::sleep(Duration::from_secs(5)).await;
@@ -74,7 +74,7 @@ impl TestEnv {
                 target_config: HashMap::from([
                     (
                         "CONFIG_NATS_URI".to_string(),
-                        format!("nats://{nats_address}"),
+                        format!("nats://{}", nats_address),
                     ),
                     ("CONFIG_NATS_MAX_WRITE_WAIT".to_string(), "30".to_string()),
                 ]),
@@ -94,7 +94,7 @@ impl TestEnv {
     }
 
     pub fn nats_endpoint(address: &str) -> String {
-        format!("nats://{address}")
+        format!("nats://{}", address)
     }
 
     async fn nats_client(&self) -> Result<async_nats::Client> {
@@ -256,7 +256,7 @@ async fn test_create_container() -> Result<()> {
     })?;
     match res {
         Ok(()) => (), // creation succeeded
-        Err(e) => panic!("Failed to create container: {e}"),
+        Err(e) => panic!("Failed to create container: {}", e),
     }
 
     // Ensure the container does exist after we attempted to create it
@@ -532,7 +532,7 @@ async fn test_write_container_data() -> Result<()> {
     // Write the blob
     let (res, io) = blobstore::write_container_data(&wrpc, env.wrpc_context(), &test_object, input)
         .await
-        .inspect_err(|e| println!("write operation failed: {e}"))?;
+        .inspect_err(|e| println!("write operation failed: {}", e))?;
     assert!(res.is_ok());
 
     // Wait for IO completion with timeout
@@ -576,7 +576,7 @@ async fn test_list_container_objects() -> Result<()> {
     let test_blob_name = "test.blob";
     let test_blob_body = test_suite_name;
     let mut test_blob_names = (1..=3)
-        .map(|blob_id| format!("{test_blob_name}-{blob_id:0>3}"))
+        .map(|blob_id| format!("{test_blob_name}-{:0>3}", blob_id))
         .collect::<Vec<_>>();
 
     let env = TestEnv::new(lattice_name, test_suite_name)
@@ -734,7 +734,7 @@ async fn test_clear_container() -> Result<()> {
     })?;
     match res {
         Ok(()) => println!("Clear operation succeeded"),
-        Err(e) => panic!("Failed to clear container: {e}"),
+        Err(e) => panic!("Failed to clear container: {}", e),
     }
 
     // Add a longer delay to allow clearing to complete
@@ -812,7 +812,7 @@ async fn test_delete_container() -> Result<()> {
     })?;
     match res {
         Ok(()) => (), // deletion succeeded
-        Err(e) => panic!("Failed to delete container: {e}"),
+        Err(e) => panic!("Failed to delete container: {}", e),
     }
 
     // Ensure that the container does not exist after we attempted to delete it
@@ -897,7 +897,7 @@ async fn test_has_object() -> Result<()> {
     })?;
     match res_has_object {
         Ok(exists) => assert!(exists),
-        Err(e) => panic!("Failed to check object existence: {e}"),
+        Err(e) => panic!("Failed to check object existence: {}", e),
     }
 
     // Shutdown
@@ -987,7 +987,7 @@ async fn test_get_object_info() -> Result<()> {
             assert_eq!(meta.size, nats_object_meta.size);
             assert_eq!(meta.created_at, nats_object_meta.created_at);
         }
-        Err(e) => panic!("Failed to get object info: {e}"),
+        Err(e) => panic!("Failed to get object info: {}", e),
     }
 
     // Shutdown
@@ -1066,7 +1066,7 @@ async fn test_copy_object_within_container() -> Result<()> {
     })?;
     match res {
         Ok(()) => (), // copy succeeded
-        Err(e) => panic!("Failed to copy object: {e}"),
+        Err(e) => panic!("Failed to copy object: {}", e),
     }
 
     // Ensure the destination blob exists and has the content of the source blob
@@ -1605,7 +1605,7 @@ async fn test_delete_object() -> Result<()> {
     // Verify blob exists before deletion
     match nats_container.get(test_blob_name).await {
         Ok(_) => println!("Blob exists before deletion"),
-        Err(e) => println!("Error checking blob before deletion: {e}"),
+        Err(e) => println!("Error checking blob before deletion: {}", e),
     }
 
     let test_object = ObjectId {
@@ -1626,7 +1626,7 @@ async fn test_delete_object() -> Result<()> {
     })?;
     match res {
         Ok(()) => println!("Delete operation succeeded"),
-        Err(e) => panic!("Failed to delete object: {e}"),
+        Err(e) => panic!("Failed to delete object: {}", e),
     }
 
     // Add a longer delay to allow deletion to complete
@@ -1671,7 +1671,7 @@ async fn test_delete_objects() -> Result<()> {
     let lattice_name = "default";
     let test_blob_body = test_suite_name;
     let test_blob_names = (1..=3)
-        .map(|blob_id| format!("test.blob-{blob_id:0>3}"))
+        .map(|blob_id| format!("test.blob-{:0>3}", blob_id))
         .collect::<Vec<_>>();
 
     let env = TestEnv::new(lattice_name, test_suite_name)

--- a/crates/provider-keyvalue-nats/src/lib.rs
+++ b/crates/provider-keyvalue-nats/src/lib.rs
@@ -178,13 +178,15 @@ impl KvNatsProvider {
                 Some(kv_stores) => kv_stores,
                 None => {
                     return Err(keyvalue::store::Error::Other(format!(
-                        "consumer component not linked: {source_id}"
+                        "consumer component not linked: {}",
+                        source_id
                     )));
                 }
             };
             kv_stores.get(&bucket_id).cloned().ok_or_else(|| {
                 keyvalue::store::Error::Other(format!(
-                    "No NATS Kv store found for bucket id (link name): {bucket_id}"
+                    "No NATS Kv store found for bucket id (link name): {}",
+                    bucket_id
                 ))
             })
         } else {
@@ -253,7 +255,7 @@ impl Provider for KvNatsProvider {
                 }
             }
         };
-        println!("NATS Kv configuration: {nats_config:?}");
+        println!("NATS Kv configuration: {:?}", nats_config);
 
         let LinkConfig {
             source_id,

--- a/crates/provider-keyvalue-redis/src/lib.rs
+++ b/crates/provider-keyvalue-redis/src/lib.rs
@@ -742,7 +742,7 @@ impl Provider for KvRedisProvider {
                 };
                 let watched_keys = self_clone.watched_keys.read().await;
                 for key in watched_keys.keys() {
-                    let channel = format!("__keyspace@0__:{key}");
+                    let channel = format!("__keyspace@0__:{}", key);
                     let _ = pubsub
                         .psubscribe(&channel)
                         .await

--- a/crates/provider-sqldb-postgres/src/bindings.rs
+++ b/crates/provider-sqldb-postgres/src/bindings.rs
@@ -1125,7 +1125,7 @@ impl FromSql<'_> for PgValue {
             )),
 
             // All other types are unsupported
-            t => Err(format!("unsupported type [{t}], consider using a cast like 'value'::string or 'value'::jsonb").into()),
+            t => Err(format!("unsupported type [{}], consider using a cast like 'value'::string or 'value'::jsonb", t).into()),
         }
     }
 

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -811,11 +811,11 @@ where
         self
     }
 
-    /// Reads the WebAssembly binary asynchronously and calls [Component::new].
+    /// Reads the WebAssembly binary asynchronously and calls [`Component::new`].
     ///
     /// # Errors
     ///
-    /// Fails if either reading `wasm` fails or [Self::new] fails
+    /// Fails if either reading `wasm` fails or [`Self::new`] fails
     #[instrument(level = "trace", skip_all)]
     pub async fn read(rt: &Runtime, mut wasm: impl AsyncRead + Unpin) -> anyhow::Result<Self> {
         let mut buf = Vec::new();
@@ -825,11 +825,11 @@ where
         Self::new(rt, &buf, None)
     }
 
-    /// Reads the WebAssembly binary synchronously and calls [Component::new].
+    /// Reads the WebAssembly binary synchronously and calls [`Component::new`].
     ///
     /// # Errors
     ///
-    /// Fails if either reading `wasm` fails or [Self::new] fails
+    /// Fails if either reading `wasm` fails or [`Self::new`] fails
     #[instrument(level = "trace", skip_all)]
     pub fn read_sync(rt: &Runtime, mut wasm: impl std::io::Read) -> anyhow::Result<Self> {
         let mut buf = Vec::new();
@@ -862,7 +862,7 @@ where
 
     /// Serve all exports of this [Component] using supplied [`wrpc_transport::Serve`]
     ///
-    /// The returned [Vec] contains an [InvocationStream] per each function exported by the component.
+    /// The returned [Vec] contains an [`InvocationStream`] per each function exported by the component.
     /// A [`WrpcServeEvent`] containing the incoming [`wrpc_transport::Serve::Context`] will be sent
     /// on completion of each invocation.
     /// The supplied [`Handler`] will be used to satisfy imports.

--- a/crates/secrets-client/src/lib.rs
+++ b/crates/secrets-client/src/lib.rs
@@ -46,7 +46,7 @@ struct SecretsTopic(String);
 impl SecretsTopic {
     pub(crate) fn new(prefix: &str, backend: &str, api_version: Option<&str>) -> Self {
         let version = api_version.unwrap_or(DEFAULT_API_VERSION);
-        Self(format!("{prefix}.{version}.{backend}"))
+        Self(format!("{}.{}.{}", prefix, version, backend))
     }
 
     pub fn get(&self) -> String {

--- a/crates/secrets-nats-kv/tests/api.rs
+++ b/crates/secrets-nats-kv/tests/api.rs
@@ -63,7 +63,7 @@ async fn integration_test_kvstore_basic() -> anyhow::Result<()> {
     let resp = client
         .request(format!("{base_sub}.server_xkey"), "".into())
         .await?;
-    println!("{resp:?}");
+    println!("{:?}", resp);
     let payload = resp.payload;
     let s = std::str::from_utf8(&payload).unwrap();
     let key = XKey::from_public_key(s).unwrap();
@@ -132,7 +132,7 @@ async fn integration_test_kvstore_put_secret() -> anyhow::Result<()> {
             payload.into(),
         )
         .await?;
-    println!("{response:?}");
+    println!("{:?}", response);
     assert_eq!(response.payload.to_vec(), b"ok");
 
     let host_key = KeyPair::new_server();
@@ -241,7 +241,7 @@ async fn integration_test_kvstore_version() -> anyhow::Result<()> {
             payload.into(),
         )
         .await?;
-    println!("{response:?}");
+    println!("{:?}", response);
     assert_eq!(response.payload.to_vec(), b"ok");
 
     let host_key = KeyPair::new_server();
@@ -290,7 +290,7 @@ fn setup_api(client: Client, enc_seed: String, server_seed: String) -> (Api, Str
         .take(10)
         .map(char::from)
         .collect::<String>();
-    let name = format!("{NAME_BASE}-{suffix}");
+    let name = format!("{}-{}", NAME_BASE, suffix);
 
     (
         Api::new(

--- a/crates/test-util/src/host.rs
+++ b/crates/test-util/src/host.rs
@@ -1,6 +1,5 @@
 //! Utilities for managing wasmCloud hosts locally or remotely via the lattice
 
-use std::collections::{BTreeMap, HashMap};
 use std::pin::Pin;
 use std::time::Duration;
 use std::{future::Future, sync::Arc};
@@ -8,11 +7,9 @@ use std::{future::Future, sync::Arc};
 use anyhow::{anyhow, Context as _, Result};
 use async_nats::{Client as NatsClient, ServerAddr};
 use nkeys::KeyPair;
-use tokio::task::JoinSet;
 use url::Url;
 
 use wasmcloud_control_interface::{Client as WasmcloudCtlClient, ClientBuilder};
-use wasmcloud_host::nats::connect_nats;
 use wasmcloud_host::wasmbus::host_config::PolicyService;
 use wasmcloud_host::wasmbus::{Features, Host, HostConfig};
 
@@ -56,7 +53,6 @@ pub struct WasmCloudTestHost {
     cluster_key: Arc<KeyPair>,
     host_key: Arc<KeyPair>,
     nats_url: ServerAddr,
-    ctl_server_handle: JoinSet<anyhow::Result<()>>,
     lattice_name: String,
     host: Arc<Host>,
     shutdown_hook: Pin<Box<dyn Future<Output = Result<()>>>>,
@@ -105,66 +101,28 @@ impl WasmCloudTestHost {
                 .enable_wasmcloud_messaging_v3()
         });
 
-        let host_config = HostConfig {
+        let mut host_config = HostConfig {
+            ctl_nats_url: nats_url.clone(),
             rpc_nats_url: nats_url.clone(),
             lattice: lattice_name.into(),
-            host_key: Arc::clone(&host_key),
+            host_key: Some(Arc::clone(&host_key)),
             provider_shutdown_delay: Some(Duration::from_millis(300)),
             allow_file_load: true,
+            secrets_topic_prefix,
             experimental_features,
             ..Default::default()
         };
+        if let Some(psc) = policy_service_config {
+            host_config.policy_service_config = psc;
+        }
 
-        let nats_client = connect_nats(nats_url.as_str(), None, None, false, None, None)
-            .await
-            .context("failed to connect to NATS")?;
-
-        let nats_builder = wasmcloud_host::nats::builder::NatsHostBuilder::new(
-            nats_client.clone(),
-            None,
-            lattice_name.into(),
-            None,
-            None,
-            BTreeMap::new(),
-            false,
-            true,
-            true,
-        )
-        .await?
-        .with_event_publisher(host_key.public_key());
-
-        let nats_builder = if let Some(secrets_topic_prefix) = secrets_topic_prefix {
-            nats_builder.with_secrets_manager(secrets_topic_prefix)?
-        } else {
-            nats_builder
-        };
-
-        let nats_builder = if let Some(psc) = policy_service_config {
-            nats_builder
-                .with_policy_manager(
-                    host_key.clone(),
-                    HashMap::new(),
-                    psc.policy_topic,
-                    psc.policy_timeout_ms,
-                    psc.policy_changes_topic,
-                )
-                .await?
-        } else {
-            nats_builder
-        };
-
-        let (host_builder, ctl_server) = nats_builder.build(host_config).await?;
-        let (host, shutdown_hook) = host_builder
-            .build()
+        let (host, shutdown_hook) = Host::new(host_config)
             .await
             .context("failed to initialize host")?;
-
-        let ctl_server_handle = ctl_server.start(host.clone()).await?;
 
         Ok(Self {
             cluster_key,
             host_key,
-            ctl_server_handle,
             nats_url: ServerAddr::from_url(nats_url.clone())
                 .context("failed to build NATS server address from URL")?,
             lattice_name: lattice_name.into(),

--- a/crates/test-util/src/testcontainers/nats_server.rs
+++ b/crates/test-util/src/testcontainers/nats_server.rs
@@ -26,7 +26,7 @@ impl NatsServer {
             ExecCommand::new(vec![
                 "/bin/sh",
                 "-c",
-                &format!("echo '{json}' > {NATS_CONFIG_PATH}"),
+                &format!("echo '{json}' > {}", NATS_CONFIG_PATH),
             ])
         } else {
             ExecCommand::new(vec!["/bin/true"])

--- a/crates/test-util/tests/common/mod.rs
+++ b/crates/test-util/tests/common/mod.rs
@@ -38,7 +38,7 @@ impl BackgroundServer {
         let mut child = cmd
             .kill_on_drop(true)
             .spawn()
-            .context("failed to spawn child")?;
+            .with_context(|| format!("failed to spawn child [{cmd:#?}]"))?;
         let (stop_tx, stop_rx) = oneshot::channel();
         let handle = tokio::spawn(async move {
             tokio::select!(

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -35,7 +35,6 @@ plugin = ["wasmtime", "wasmtime-wasi", "wasmtime-wasi-http"]
 [dependencies]
 anstyle = { workspace = true }
 anyhow = { workspace = true, features = ["backtrace"] }
-astral-tokio-tar = { workspace = true }
 async-compression = { workspace = true, features = ["tokio", "gzip"] }
 async_zip = { workspace = true, features = ["tokio", "deflate"] }
 async-nats = { workspace = true, optional = true }
@@ -101,6 +100,7 @@ thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
+astral-tokio-tar = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
 toml = { workspace = true, features = ["parse"] }
 tracing = { workspace = true, features = ["log"] }

--- a/crates/wash/src/bin/wash.rs
+++ b/crates/wash/src/bin/wash.rs
@@ -84,7 +84,7 @@ struct HelpTopics(Vec<HelpTopic>);
 impl Display for HelpTopics {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         for topic in &self.0 {
-            writeln!(f, "{topic}")?;
+            writeln!(f, "{}", topic)?;
         }
         Ok(())
     }
@@ -696,7 +696,7 @@ async fn run_plugin(
     let dir = match ensure_plugin_scratch_dir_exists(plugin_dir, id).await {
         Ok(dir) => dir,
         Err(e) => {
-            eprintln!("Error creating plugin scratch directory: {e}");
+            eprintln!("Error creating plugin scratch directory: {}", e);
             std::process::exit(1);
         }
     };

--- a/crates/wash/src/lib/start/github/api.rs
+++ b/crates/wash/src/lib/start/github/api.rs
@@ -115,7 +115,7 @@ async fn new_releases_after(
     let main_releases = releases
         .into_iter()
         .filter(|release| {
-            release.satisfies_constraint(&format!("{op}{after_version}, >{after_version}"))
+            release.satisfies_constraint(&format!("{op}{v}, >{v}", v = after_version))
         })
         .collect::<Vec<GitHubRelease>>();
     Ok(main_releases)

--- a/crates/wash/tests/common/mod.rs
+++ b/crates/wash/tests/common/mod.rs
@@ -1315,7 +1315,7 @@ async fn kill_processes_by_name(process_name: &str) -> Result<()> {
             nix::sys::signal::Signal::SIGKILL,
         ) {
             // Ignore errors here - process might have already terminated
-            eprintln!("Note: Failed to send SIGKILL to process {pid}: {e}");
+            eprintln!("Note: Failed to send SIGKILL to process {}: {}", pid, e);
         }
     }
 
@@ -1338,7 +1338,8 @@ async fn kill_processes_by_name(process_name: &str) -> Result<()> {
     })
     .await
     .context(format!(
-        "Timed out waiting for {process_name} processes to terminate"
+        "Timed out waiting for {} processes to terminate",
+        process_name
     ))?;
 
     Ok(())

--- a/crates/wash/tests/github_fetch_test.rs
+++ b/crates/wash/tests/github_fetch_test.rs
@@ -106,7 +106,7 @@ async fn test_http_proxy_without_auth() {
     }
 
     // GET|http://httpbin.org/get|200|wash-lib/0.21.1|-
-    let http_log_entry = format!("GET|{http_endpoint}|200|{DOWNLOAD_CLIENT_USER_AGENT}|-");
+    let http_log_entry = format!("GET|{http_endpoint}|200|{}|-", DOWNLOAD_CLIENT_USER_AGENT);
     assert!(
         stderr.contains(&http_log_entry),
         "Didn't find connection log entry, logs:\n {}",
@@ -173,8 +173,10 @@ async fn test_http_proxy_with_basic_auth() {
     }
 
     // GET|http://httpbin.org/get|200|wash-lib/0.21.1|wasmcloud
-    let http_log_entry =
-        format!("GET|{http_endpoint}|200|{DOWNLOAD_CLIENT_USER_AGENT}|{proxy_username}");
+    let http_log_entry = format!(
+        "GET|{http_endpoint}|200|{}|{proxy_username}",
+        DOWNLOAD_CLIENT_USER_AGENT
+    );
     assert!(
         stderr.contains(&http_log_entry),
         "Didn't find connection log entry, logs:\n {}",

--- a/crates/wash/tests/wash.rs
+++ b/crates/wash/tests/wash.rs
@@ -78,9 +78,9 @@ fn integration_version_works() -> Result<()> {
         .context("failed to display wash version")
         .and_then(|output| output_to_string(output).context("failed to extract stdout"))?;
     assert!(stdout.contains(format!("wash          v{}", clap::crate_version!()).as_str()));
-    assert!(stdout.contains(format!("├ nats-server {NATS_SERVER_VERSION}").as_str()));
-    assert!(stdout.contains(format!("├ wadm        {WADM_VERSION}").as_str()));
-    assert!(stdout.contains(format!("└ wasmcloud   {WASMCLOUD_HOST_VERSION}").as_str()));
+    assert!(stdout.contains(format!("├ nats-server {}", NATS_SERVER_VERSION).as_str()));
+    assert!(stdout.contains(format!("├ wadm        {}", WADM_VERSION).as_str()));
+    assert!(stdout.contains(format!("└ wasmcloud   {}", WASMCLOUD_HOST_VERSION).as_str()));
     Ok(())
 }
 

--- a/crates/wash/tests/wash_dev.rs
+++ b/crates/wash/tests/wash_dev.rs
@@ -1365,7 +1365,7 @@ async fn integration_dev_hello_component_piped_stdout() -> Result<()> {
         match stderr1_reader.read_line(&mut line).await {
             Ok(0) => break,
             Ok(_) => {
-                write!(&mut stderr, "{line}")?;
+                write!(&mut stderr, "{}", line)?;
                 stderr1_out.push_str(&line);
                 if line.contains(stderr1_pattern) {
                     break;
@@ -1426,7 +1426,7 @@ async fn integration_dev_hello_component_piped_stdout() -> Result<()> {
 
         match stderr1_reader.read_line(&mut line).await {
             Ok(0) => break,
-            Ok(_) => write!(&mut stderr, "{line}")?,
+            Ok(_) => write!(&mut stderr, "{}", line)?,
             Err(_) => break,
         }
     }

--- a/examples/rust/components/http-keyvalue-watcher/src/lib.rs
+++ b/examples/rust/components/http-keyvalue-watcher/src/lib.rs
@@ -25,7 +25,7 @@ impl KvWatcherDemoGuest for KvWatcher {
         let req = outgoing_handler::OutgoingRequest::new(Fields::new());
         req.set_scheme(Some(&Scheme::Http)).unwrap();
         req.set_authority(Some("localhost:3001")).unwrap();
-        req.set_path_with_query(Some(format!("/alert?{key}={val}").as_ref()))
+        req.set_path_with_query(Some(format!("/alert?{}={}", key, val).as_ref()))
             .unwrap();
 
         match outgoing_handler::handle(req, None) {
@@ -45,7 +45,7 @@ impl KvWatcherDemoGuest for KvWatcher {
                         log(
                             Level::Error,
                             "kv-watch-export",
-                            format!("HTTP request failed with code {code}").as_str(),
+                            format!("HTTP request failed with code {}", code).as_str(),
                         );
                     }
                     _ => {
@@ -61,7 +61,7 @@ impl KvWatcherDemoGuest for KvWatcher {
                 log(
                     Level::Error,
                     "kv-watch-export",
-                    format!("Failed to send HTTP request: {e:?}").as_str(),
+                    format!("Failed to send HTTP request: {:?}", e).as_str(),
                 );
             }
         }
@@ -72,13 +72,17 @@ impl KvWatcherDemoGuest for KvWatcher {
         log(
             Level::Info,
             "kv-watch-export",
-            format!("the value of key : {key} was deleted in {bucket:?} bucket",).as_str(),
+            format!(
+                "the value of key : {} was deleted in {:?} bucket",
+                &key, &bucket
+            )
+            .as_str(),
         );
 
         let req = outgoing_handler::OutgoingRequest::new(Fields::new());
         req.set_scheme(Some(&Scheme::Http)).unwrap();
         req.set_authority(Some("localhost:3001")).unwrap();
-        req.set_path_with_query(Some(format!("/alert?{key}=nil").as_ref()))
+        req.set_path_with_query(Some(format!("/alert?{}=nil", key).as_ref()))
             .unwrap();
 
         match outgoing_handler::handle(req, None) {
@@ -98,7 +102,7 @@ impl KvWatcherDemoGuest for KvWatcher {
                         log(
                             Level::Error,
                             "kv-watch-export",
-                            format!("HTTP request failed with code {code}").as_str(),
+                            format!("HTTP request failed with code {}", code).as_str(),
                         );
                     }
                     _ => {
@@ -114,7 +118,7 @@ impl KvWatcherDemoGuest for KvWatcher {
                 log(
                     Level::Error,
                     "kv-watch-export",
-                    format!("Failed to send HTTP request: {e:?}").as_str(),
+                    format!("Failed to send HTTP request: {:?}", e).as_str(),
                 );
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,14 +14,13 @@ use tokio::time::{timeout, timeout_at};
 use tokio::{select, signal};
 use tracing::{warn, Level as TracingLogLevel};
 use tracing_subscriber::util::SubscriberInitExt as _;
-use url::Url;
 use wasmcloud_core::logging::Level as WasmcloudLogLevel;
 use wasmcloud_core::{OtelConfig, OtelProtocol};
-use wasmcloud_host::nats::builder::NatsHostBuilder;
 use wasmcloud_host::oci::Config as OciConfig;
-use wasmcloud_host::workload_identity::WorkloadIdentityConfig;
+use wasmcloud_host::url::Url;
+use wasmcloud_host::wasmbus::host_config::PolicyService as PolicyServiceConfig;
+use wasmcloud_host::wasmbus::Features;
 use wasmcloud_host::WasmbusHostConfig;
-use wasmcloud_host::{nats::connect_nats, wasmbus::Features};
 use wasmcloud_tracing::configure_observability;
 
 #[derive(Debug, Parser)]
@@ -480,8 +479,7 @@ async fn main() -> anyhow::Result<()> {
         .map(KeyPair::from_seed)
         .transpose()
         .context("failed to construct host key pair from seed")?
-        .map(Arc::new)
-        .unwrap_or_else(|| Arc::new(KeyPair::new_server()));
+        .map(Arc::new);
     let (nats_jwt, nats_key) =
         parse_nats_credentials(args.nats_creds, args.nats_jwt, args.nats_seed)
             .await
@@ -500,7 +498,17 @@ async fn main() -> anyhow::Result<()> {
         oci_user: args.oci_user,
         oci_password: args.oci_password,
     };
-
+    if let Some(policy_topic) = args.policy_topic.as_deref() {
+        anyhow::ensure!(
+            validate_nats_subject(policy_topic).is_ok(),
+            "Invalid policy topic"
+        );
+    }
+    let policy_service_config = PolicyServiceConfig {
+        policy_topic: args.policy_topic,
+        policy_changes_topic: args.policy_changes_topic,
+        policy_timeout_ms: args.policy_timeout_ms,
+    };
     let mut labels = args
         .label
         .unwrap_or_default()
@@ -530,106 +538,45 @@ async fn main() -> anyhow::Result<()> {
             "Invalid secrets topic"
         );
     }
-
-    // NOTE(brooksmtownsend): Summing the feature flags "OR"s the multiple flags together.
-    let experimental_features: Features = args.experimental_features.into_iter().sum();
-    let workload_identity_config = if experimental_features.workload_identity_auth_enabled() {
-        Some(WorkloadIdentityConfig::from_env()?)
-    } else {
-        None
-    };
-    let ctl_nats = connect_nats(
-        ctl_nats_url.as_str(),
-        ctl_jwt.or_else(|| nats_jwt.clone()).as_ref(),
-        ctl_key.or_else(|| nats_key.clone()),
-        args.ctl_tls,
-        None,
-        workload_identity_config.clone(),
-    )
+    let (host, shutdown) = Box::pin(wasmcloud_host::wasmbus::Host::new(WasmbusHostConfig {
+        ctl_nats_url,
+        lattice: Arc::from(args.lattice),
+        host_key,
+        config_service_enabled: args.config_service_enabled,
+        js_domain: args.js_domain,
+        labels,
+        provider_shutdown_delay: Some(args.provider_shutdown_delay),
+        oci_opts,
+        ctl_jwt: ctl_jwt.or_else(|| nats_jwt.clone()),
+        ctl_key: ctl_key.or_else(|| nats_key.clone()),
+        ctl_tls: args.ctl_tls,
+        ctl_topic_prefix: args.ctl_topic_prefix,
+        rpc_nats_url,
+        rpc_timeout: args.rpc_timeout_ms,
+        rpc_jwt: rpc_jwt.or_else(|| nats_jwt.clone()),
+        rpc_key: rpc_key.or_else(|| nats_key.clone()),
+        rpc_tls: args.rpc_tls,
+        allow_file_load: args.allow_file_load,
+        log_level,
+        enable_structured_logging: args.enable_structured_logging,
+        otel_config,
+        policy_service_config,
+        secrets_topic_prefix: args.secrets_topic_prefix,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        max_execution_time: args.max_execution_time,
+        max_linear_memory: args.max_linear_memory,
+        max_component_size: args.max_component_size,
+        max_components: args.max_components,
+        max_core_instances_per_component: args.max_core_instances_per_component,
+        heartbeat_interval: args.heartbeat_interval,
+        // NOTE(brooks): Summing the feature flags "OR"s the multiple flags together.
+        experimental_features: args.experimental_features.into_iter().sum(),
+        http_admin: args.http_admin,
+        enable_component_auction: args.enable_component_auction.unwrap_or(true),
+        enable_provider_auction: args.enable_provider_auction.unwrap_or(true),
+    }))
     .await
-    .context("failed to establish NATS control connection")?;
-
-    let builder = NatsHostBuilder::new(
-        ctl_nats,
-        Some(args.ctl_topic_prefix),
-        args.lattice.clone(),
-        args.js_domain.clone(),
-        Some(oci_opts.clone()),
-        labels.clone().into_iter().collect(),
-        args.config_service_enabled,
-        args.enable_component_auction.unwrap_or(true),
-        args.enable_provider_auction.unwrap_or(true),
-    )
-    .await?
-    .with_event_publisher(host_key.public_key());
-
-    let builder = if let Some(policy_topic) = args.policy_topic.as_deref() {
-        anyhow::ensure!(
-            validate_nats_subject(policy_topic).is_ok(),
-            "Invalid policy topic"
-        );
-        builder
-            .with_policy_manager(
-                host_key.clone(),
-                labels.clone(),
-                args.policy_topic.clone(),
-                args.policy_timeout_ms,
-                args.policy_changes_topic.clone(),
-            )
-            .await?
-    } else {
-        builder
-    };
-
-    let builder = if let Some(secrets_topic) = args.secrets_topic_prefix {
-        anyhow::ensure!(
-            validate_nats_subject(&secrets_topic).is_ok(),
-            "Invalid secrets topic"
-        );
-        builder.with_secrets_manager(secrets_topic)?
-    } else {
-        builder
-    };
-
-    let (host_builder, nats_ctl_server) = builder
-        .build(WasmbusHostConfig {
-            lattice: Arc::from(args.lattice.clone()),
-            host_key: host_key.clone(),
-            config_service_enabled: args.config_service_enabled,
-            js_domain: args.js_domain,
-            labels,
-            provider_shutdown_delay: Some(args.provider_shutdown_delay),
-            oci_opts,
-            rpc_nats_url,
-            rpc_timeout: args.rpc_timeout_ms,
-            rpc_jwt: rpc_jwt.or_else(|| nats_jwt.clone()),
-            rpc_key: rpc_key.or_else(|| nats_key.clone()),
-            rpc_tls: args.rpc_tls,
-            allow_file_load: args.allow_file_load,
-            log_level,
-            enable_structured_logging: args.enable_structured_logging,
-            otel_config,
-            version: env!("CARGO_PKG_VERSION").to_string(),
-            max_execution_time: args.max_execution_time,
-            max_linear_memory: args.max_linear_memory,
-            max_component_size: args.max_component_size,
-            max_components: args.max_components,
-            max_core_instances_per_component: args.max_core_instances_per_component,
-            heartbeat_interval: args.heartbeat_interval,
-            experimental_features,
-            http_admin: args.http_admin,
-            enable_component_auction: args.enable_component_auction.unwrap_or(true),
-            enable_provider_auction: args.enable_provider_auction.unwrap_or(true),
-        })
-        .await?;
-    let (host, shutdown) = host_builder
-        .build()
-        .await
-        .context("failed to initialize host")?;
-
-    // Start the control interface server
-    let mut ctl = nats_ctl_server.start(host.clone()).await?;
-
+    .context("failed to initialize host")?;
     #[cfg(unix)]
     let deadline = {
         let mut terminate = signal::unix::signal(signal::unix::SignalKind::terminate())?;
@@ -650,8 +597,6 @@ async fn main() -> anyhow::Result<()> {
         },
         deadline = host.stopped() => deadline?,
     };
-    // TODO(brooksmtownsend): Consider a drain of sorts that can wrap up pending persistent work
-    ctl.abort_all();
     drop(host);
     if let Some(deadline) = deadline {
         timeout_at(deadline, shutdown)
@@ -851,7 +796,7 @@ mod tests {
         let creds = format!(
             r#"
 -----BEGIN NATS USER JWT-----
-{expected_jwt}
+{}
 ------END NATS USER JWT------
 
 ************************* IMPORTANT *************************
@@ -859,11 +804,12 @@ NKEY Seed printed below can be used to sign and prove identity.
 NKEYs are sensitive and should be treated as secrets.
 
 -----BEGIN USER NKEY SEED-----
-{expected_seed}
+{}
 ------END USER NKEY SEED------
 
 *************************************************************
-"#
+"#,
+            expected_jwt, expected_seed
         );
 
         let (jwt, kp) = parse_jwt_and_key_from_creds(&creds)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -49,7 +49,7 @@ impl BackgroundServer {
         let mut child = cmd
             .kill_on_drop(true)
             .spawn()
-            .context("failed to spawn child")?;
+            .with_context(|| format!("failed to spawn child [{cmd:#?}]"))?;
         let (stop_tx, stop_rx) = oneshot::channel();
         let handle = tokio::spawn(async move {
             tokio::select!(

--- a/tests/common/secrets.rs
+++ b/tests/common/secrets.rs
@@ -114,6 +114,6 @@ impl NatsKvSecretsBackend {
     }
 
     fn topic(&self, operation: &str) -> String {
-        format!("wasmcloud.secrets.v1alpha1.nats-kv.{operation}")
+        format!("wasmcloud.secrets.v1alpha1.nats-kv.{}", operation)
     }
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -50,7 +50,7 @@ async fn config_updates() -> Result<()> {
         .await
         .context("Unable to set up NATS KV store for test")?;
 
-    let generator = BundleGenerator::new(Arc::new(store.clone()));
+    let generator = BundleGenerator::new(store.clone());
 
     // First test that a non-existent config item returns an error
     generator

--- a/tests/example-rust-http-keyvalue-watcher.rs
+++ b/tests/example-rust-http-keyvalue-watcher.rs
@@ -39,7 +39,10 @@ async fn start_alert_server() -> anyhow::Result<impl std::future::Future<Output 
                 let received_alerts = received_alerts_clone.clone();
                 async move {
                     for (key, value) in query.0 {
-                        received_alerts.lock().await.push(format!("{key}={value}"));
+                        received_alerts
+                            .lock()
+                            .await
+                            .push(format!("{}={}", key, value));
                     }
                     "OK"
                 }

--- a/tests/workload_identity.rs
+++ b/tests/workload_identity.rs
@@ -21,7 +21,7 @@ use tokio::time::sleep;
 use tokio::try_join;
 use tracing_subscriber::prelude::*;
 use wasmcloud_core::tls::NativeRootsExt as _;
-use wasmcloud_host::nats::connect_nats;
+use wasmcloud_host::wasmbus::connect_nats;
 use wasmcloud_host::workload_identity::WorkloadIdentityConfig;
 use wasmcloud_test_util::component::assert_scale_component;
 use wasmcloud_test_util::env::EnvVarGuard;
@@ -221,7 +221,7 @@ async fn workload_identity_component_interface() -> anyhow::Result<()> {
     register_spiffe_workload(
         host_spiffe_id,
         component_spiffe_id,
-        format!("wasmcloud:component:{COMPONENT_ID}").as_str(),
+        format!("wasmcloud:component:{}", COMPONENT_ID).as_str(),
         &spire_server_socket_path,
     )
     .await


### PR DESCRIPTION
This commit removes the component spec feature that was introduced in 2025, leaving the rest of the other changes that occurred in the meantime intact.

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

In preparation for a future wasmCloud release, as the component spec feature was not quite used, we're removing but keeping all the other features that we developed and bugfixes in the meantime. 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

Consumers should *not* be impacted by this change, as the component spec feature was not used (and the release that contained it was not fully rolled out). 

This update *will* enable us to get a new version out this week with some much needed fixes and small new features to wasmCloud v1 for those who are still on it and yet to start really diving into v2.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
