### PR TITLE
SPIKE: WRPC Plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.8.5",
  "regex",
+ "ring",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile",
  "rustls-webpki 0.102.8",
@@ -2956,6 +2957,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "leb128-tokio"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1f734b00871cae8f137d83d53cf4b5ee3f0d87224a87a4347dab4cde11a7a3"
+dependencies = [
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5172,6 +5184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "send-future"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224e328af6e080cddbab3c770b1cf50f0351ba0577091ef2410c3951d835ff87"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5956,6 +5974,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5966,6 +5985,7 @@ checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",
@@ -5986,6 +6006,7 @@ dependencies = [
  "http",
  "httparse",
  "rand 0.8.5",
+ "ring",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -6422,6 +6443,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-tokio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692aa1d5479fe22dac6ce581e8c6e83a9f8d90238250c1036b0139019a783a87"
+dependencies = [
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6730,6 +6761,9 @@ dependencies = [
  "wat",
  "webpki-roots 0.26.11",
  "wit-component 0.244.0",
+ "wrpc-runtime-wasmtime",
+ "wrpc-transport",
+ "wrpc-transport-nats",
 ]
 
 [[package]]
@@ -7060,6 +7094,19 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasm-tokio"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db8d9df11ba3f83f9a9fb2c159579e6ef7b368fa6650b8f7f01febb75784cef"
+dependencies = [
+ "leb128-tokio",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "utf8-tokio",
 ]
 
 [[package]]
@@ -8202,6 +8249,20 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
+version = "0.220.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2a7999ed18efe59be8de2db9cb2b7f84d88b27818c79353dfc53131840fe1a"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.12.0",
+ "log",
+ "semver",
+ "unicode-xid",
+]
+
+[[package]]
+name = "wit-parser"
 version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3477d8d0acb530d76beaa8becbdb1e3face08929db275f39934963eb4f716f8"
@@ -8271,6 +8332,70 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "wrpc-introspect"
+version = "0.7.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=59cd471a#59cd471a3346a944daaba7479a56ac62d955f0bc"
+dependencies = [
+ "wit-parser 0.220.1",
+]
+
+[[package]]
+name = "wrpc-runtime-wasmtime"
+version = "0.31.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=59cd471a#59cd471a3346a944daaba7479a56ac62d955f0bc"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "wasm-tokio",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wit-parser 0.220.1",
+ "wrpc-introspect",
+ "wrpc-transport",
+]
+
+[[package]]
+name = "wrpc-transport"
+version = "0.29.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=59cd471a#59cd471a3346a944daaba7479a56ac62d955f0bc"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "pin-project-lite",
+ "send-future",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "wasi 0.14.3+wasi-0.2.4",
+ "wasm-tokio",
+]
+
+[[package]]
+name = "wrpc-transport-nats"
+version = "0.31.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=59cd471a#59cd471a3346a944daaba7479a56ac62d955f0bc"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "bytes",
+ "futures",
+ "nuid",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "wasm-tokio",
+ "wrpc-transport",
+]
 
 [[package]]
 name = "x509-cert"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,11 @@ tokio-postgres-rustls = { version = "0.13", default-features = false }
 ulid = { version = "1", default-features = false }
 webpki-roots = { version = "0.26", default-features = false }
 
+# wrpc deps
+wrpc-transport = { git = "https://github.com/bytecodealliance/wrpc", rev = "59cd471a", default-features = false }
+wrpc-transport-nats = { git = "https://github.com/bytecodealliance/wrpc", rev = "59cd471a", default-features = false }
+wrpc-runtime-wasmtime = { git = "https://github.com/bytecodealliance/wrpc", rev = "59cd471a", default-features = false }
+
 # socket deps (used by wash-runtime sockets module)
 cap-net-ext = "3.4.4"
 cap-std = "3.4.4"

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [features]
 default = ["wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "washlet"]
 oci = ["dep:oci-client", "dep:oci-wasm", "dep:docker_credential", "dep:sha2", "dep:wit-component"]
-washlet = ["oci"]
+washlet = ["oci", "wrpc"]
 wasi-config = []
 wasi-logging = []
 wasi-blobstore = []
@@ -30,6 +30,7 @@ wasmcloud-postgres = [
     "dep:bit-vec", "dep:cidr", "dep:geo-types",
     "dep:ulid", "dep:webpki-roots",
 ]
+wrpc = ["dep:wrpc-transport", "dep:wrpc-transport-nats", "dep:wrpc-runtime-wasmtime"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -61,7 +62,7 @@ rustls-pemfile = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio-rustls = { workspace = true }
-tokio-util = { workspace = true, features = ["rt"] }
+tokio-util = { workspace = true, features = ["rt", "codec"] }
 tonic = { workspace = true, features = [
     "gzip",
     "tls-aws-lc",
@@ -105,6 +106,11 @@ tokio-postgres-rustls = { optional = true, workspace = true }
 ulid = { optional = true, workspace = true, features = ["std"] }
 url = { workspace = true }
 webpki-roots = { optional = true, workspace = true }
+
+# wRPC dependencies (optional, behind 'wrpc' feature)
+wrpc-transport = { optional = true, workspace = true }
+wrpc-transport-nats = { optional = true, workspace = true }
+wrpc-runtime-wasmtime = { optional = true, workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true, default-features = true }

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -25,6 +25,10 @@ pub struct SharedCtx {
     pub table: wasmtime::component::ResourceTable,
     /// Contexts for linked components
     pub contexts: HashMap<Arc<str>, Ctx>,
+    /// wRPC context providing the routing invoker for `link_instance` import polyfilling,
+    /// and resource table access during encode/decode for export serving.
+    #[cfg(feature = "wrpc")]
+    pub(crate) wrpc_ctx: crate::plugin::wrpc::codec::WrpcState,
 }
 
 impl SharedCtx {
@@ -33,6 +37,8 @@ impl SharedCtx {
             active_ctx: context,
             table: ResourceTable::new(),
             contexts: Default::default(),
+            #[cfg(feature = "wrpc")]
+            wrpc_ctx: Default::default(),
         }
     }
 
@@ -174,6 +180,23 @@ impl WasiHttpView for SharedCtx {
             None => Err(wasmtime_wasi_http::HttpError::trap(anyhow::anyhow!(
                 "http client not available"
             ))),
+        }
+    }
+}
+
+// Implement WrpcView for wrpc-runtime-wasmtime codec support.
+// The NoopInvoker is never actually used for transport — real wRPC invocations
+// go through captured `wrpc_transport_nats::Client` instances in plugin closures.
+#[cfg(feature = "wrpc")]
+impl wrpc_runtime_wasmtime::WrpcView for SharedCtx {
+    type Invoke = crate::plugin::wrpc::codec::RoutingInvoker;
+
+    fn wrpc(
+        &mut self,
+    ) -> wrpc_runtime_wasmtime::WrpcCtxView<'_, crate::plugin::wrpc::codec::RoutingInvoker> {
+        wrpc_runtime_wasmtime::WrpcCtxView {
+            ctx: &mut self.wrpc_ctx,
+            table: &mut self.table,
         }
     }
 }

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -61,6 +61,10 @@ pub struct WorkloadMetadata {
     loopback: Arc<std::sync::Mutex<loopback::Network>>,
     /// Linked component ids
     linked_components: HashSet<Arc<str>>,
+    /// wRPC routing invoker for import polyfilling via `link_instance`.
+    /// Populated during plugin binding when interfaces have `wrpc:name` config.
+    #[cfg(feature = "wrpc")]
+    wrpc_invoker: crate::plugin::wrpc::codec::RoutingInvoker,
 }
 
 impl WorkloadMetadata {
@@ -84,9 +88,26 @@ impl WorkloadMetadata {
         &self.workload_namespace
     }
 
+    /// Returns a reference to the wasmtime [`Component`].
+    pub fn component(&self) -> &Component {
+        &self.component
+    }
+
     /// Returns a reference to the wasmtime engine used to compile this component.
     pub fn engine(&self) -> &wasmtime::Engine {
         self.component.engine()
+    }
+
+    /// Returns a mutable reference to the wRPC routing invoker.
+    #[cfg(feature = "wrpc")]
+    pub fn wrpc_invoker_mut(&mut self) -> &mut crate::plugin::wrpc::codec::RoutingInvoker {
+        &mut self.wrpc_invoker
+    }
+
+    /// Returns a clone of the wRPC routing invoker.
+    #[cfg(feature = "wrpc")]
+    pub fn wrpc_invoker(&self) -> &crate::plugin::wrpc::codec::RoutingInvoker {
+        &self.wrpc_invoker
     }
 
     /// Returns a mutable reference to the component's linker.
@@ -249,6 +270,8 @@ impl WorkloadService {
                 plugins: None,
                 loopback,
                 linked_components: Default::default(),
+                #[cfg(feature = "wrpc")]
+                wrpc_invoker: Default::default(),
             },
             handle: None,
             max_restarts,
@@ -315,6 +338,8 @@ impl WorkloadComponent {
                 plugins: None,
                 loopback,
                 linked_components: Default::default(),
+                #[cfg(feature = "wrpc")]
+                wrpc_invoker: Default::default(),
             },
             name: component_name.into(),
             // TODO: Implement pooling and instance limits
@@ -1091,6 +1116,13 @@ impl ResolvedWorkload {
                 .insert(linked_component_id.clone(), linked_component_ctx);
         }
 
+        // Populate the wRPC routing invoker from binding-time configuration
+        #[cfg(feature = "wrpc")]
+        {
+            shared_ctx.wrpc_ctx =
+                crate::plugin::wrpc::codec::WrpcState::new(metadata.wrpc_invoker.clone());
+        }
+
         let store = wasmtime::Store::new(metadata.engine(), shared_ctx);
 
         Ok(store)
@@ -1318,8 +1350,10 @@ impl UnresolvedWorkload {
                 // Find interfaces that this plugin can satisfy for this component
                 let mut matching_interfaces = HashSet::new();
                 for wit_interface in required_interfaces.iter() {
-                    // Check if plugin supports this interface
-                    if plugin_interfaces.includes_bidirectional(wit_interface) {
+                    // Check if plugin supports this interface (static world match or dynamic can_handle)
+                    if p.can_handle(wit_interface)
+                        || plugin_interfaces.includes_bidirectional(wit_interface)
+                    {
                         matching_interfaces.insert(wit_interface.clone());
                     }
                 }

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -51,6 +51,9 @@ pub mod wasmcloud_messaging;
 #[cfg(all(feature = "wasi-webgpu", not(target_os = "windows")))]
 pub mod wasi_webgpu;
 
+#[cfg(feature = "wrpc")]
+pub mod wrpc;
+
 /// The [`HostPlugin`] trait provides an interface for implementing built-in plugins for the host.
 /// A plugin is primarily responsible for implementing a specific [`WitWorld`] as a collection of
 /// imports and exports that will be directly linked to the workload's [`wasmtime::component::Linker`].
@@ -80,6 +83,18 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
     /// # Returns
     /// A `WitWorld` containing the plugin's imports and exports.
     fn world(&self) -> WitWorld;
+
+    /// Returns whether this plugin can dynamically handle the given interface.
+    ///
+    /// This is checked in addition to the static [`HostPlugin::world`] matching.
+    /// Plugins that handle arbitrary interfaces (e.g., wrpc bridging) can override
+    /// this to match based on interface configuration rather than a fixed world.
+    ///
+    /// # Returns
+    /// `true` if this plugin can handle the interface, `false` otherwise.
+    fn can_handle(&self, _interface: &crate::wit::WitInterface) -> bool {
+        false
+    }
 
     /// Called when the plugin is started during host initialization.
     ///

--- a/crates/wash-runtime/src/plugin/wrpc/codec.rs
+++ b/crates/wash-runtime/src/plugin/wrpc/codec.rs
@@ -1,0 +1,98 @@
+//! wRPC transport integration types for `WrpcView` on `SharedCtx`.
+//!
+//! Provides a `RoutingInvoker` that implements `wrpc_transport::Invoke` by
+//! delegating to the appropriate `wrpc_transport_nats::Client` based on the
+//! WIT instance name. This allows `wrpc_runtime_wasmtime::link_instance` to
+//! handle all encoding/decoding automatically.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Routes wRPC invocations to the correct NATS client based on WIT instance name.
+///
+/// During binding, import interfaces with `wrpc:name` config are mapped to
+/// `wrpc_transport_nats::Client` instances. When `link_instance` calls
+/// `store.data_mut().wrpc().ctx.client().invoke(cx, instance, func, ...)`,
+/// the RoutingInvoker looks up the instance name and delegates to the
+/// corresponding NATS client.
+#[derive(Clone, Default)]
+pub struct RoutingInvoker {
+    /// Map from WIT instance name (e.g. "ns:pkg/iface@0.1.0") to the NATS client
+    /// that handles that interface.
+    routes: HashMap<Arc<str>, Arc<wrpc_transport_nats::Client>>,
+}
+
+impl RoutingInvoker {
+    /// Create a new empty routing invoker.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a route from a WIT instance name to a NATS client.
+    pub fn add_route(
+        &mut self,
+        instance_name: impl Into<Arc<str>>,
+        client: Arc<wrpc_transport_nats::Client>,
+    ) {
+        self.routes.insert(instance_name.into(), client);
+    }
+}
+
+impl wrpc_transport::Invoke for RoutingInvoker {
+    type Context = Option<async_nats::HeaderMap>;
+    type Outgoing = wrpc_transport_nats::ParamWriter;
+    type Incoming = wrpc_transport_nats::Reader;
+
+    async fn invoke<P>(
+        &self,
+        cx: Self::Context,
+        instance: &str,
+        func: &str,
+        params: bytes::Bytes,
+        paths: impl AsRef<[P]> + Send,
+    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    where
+        P: AsRef<[Option<usize>]> + Send + Sync,
+    {
+        let client = self.routes.get(instance).ok_or_else(|| {
+            anyhow::anyhow!("no wrpc route configured for instance '{instance}'")
+        })?;
+        client.invoke(cx, instance, func, params, paths).await
+    }
+}
+
+/// wRPC context that provides the RoutingInvoker to `link_instance`.
+pub struct WrpcState {
+    invoker: RoutingInvoker,
+    shared_resources: wrpc_runtime_wasmtime::SharedResourceTable,
+}
+
+impl WrpcState {
+    pub fn new(invoker: RoutingInvoker) -> Self {
+        Self {
+            invoker,
+            shared_resources: Default::default(),
+        }
+    }
+}
+
+impl Default for WrpcState {
+    fn default() -> Self {
+        Self::new(RoutingInvoker::new())
+    }
+}
+
+impl wrpc_runtime_wasmtime::WrpcCtx<RoutingInvoker> for WrpcState {
+    fn context(&self) -> <RoutingInvoker as wrpc_transport::Invoke>::Context {
+        None // No custom NATS headers
+    }
+
+    fn client(&self) -> &RoutingInvoker {
+        &self.invoker
+    }
+
+    fn shared_resources(&mut self) -> &mut wrpc_runtime_wasmtime::SharedResourceTable {
+        &mut self.shared_resources
+    }
+}
+

--- a/crates/wash-runtime/src/plugin/wrpc/invoke.rs
+++ b/crates/wash-runtime/src/plugin/wrpc/invoke.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use tracing::{debug, instrument};
+use tracing::{debug, info, instrument};
 use wasmtime::component::types::ComponentItem;
 
 use crate::engine::ctx::SharedCtx;
@@ -41,16 +41,27 @@ pub(super) async fn bind_imports(
             None => continue,
         };
 
-        let instance_name = interface.instance();
-
         // Find this interface in the component's imports
         for (import_name, import_item) in component_type.imports(engine) {
-            if import_name != instance_name {
-                continue;
-            }
             let ComponentItem::ComponentInstance(instance_ty) = import_item else {
                 continue;
             };
+
+            let wit_import = WitInterface::from(import_name);
+            if interface.contains(&wit_import) {
+                info!(
+                    import_name = %import_name,
+                    routing_key = %routing_key,
+                    "interface matches component import, collecting functions"
+                );
+            } else {
+                info!(
+                    import_name = %import_name,
+                    routing_key = %routing_key,
+                    "interface does not match component import, skipping"
+                );
+                continue;
+            }
 
             let wrpc_prefix = format!("{prefix}.{routing_key}");
 
@@ -66,25 +77,24 @@ pub(super) async fn bind_imports(
             );
 
             debug!(
-                instance = %instance_name,
+                import_name = %import_name,
                 routing_key = %routing_key,
                 "binding wrpc import via link_instance"
             );
 
             // Register the route so the RoutingInvoker can delegate to this client
-            item.wrpc_invoker_mut()
-                .add_route(instance_name.as_str(), wrpc_client);
+            item.wrpc_invoker_mut().add_route(import_name, wrpc_client);
 
             // Use wrpc-runtime-wasmtime's link_instance to polyfill all functions
             let linker = item.linker();
-            let mut linker_instance = linker.instance(&instance_name)?;
+            let mut linker_instance = linker.instance(import_name)?;
             wrpc_runtime_wasmtime::link_instance::<SharedCtx>(
                 engine,
                 &mut linker_instance,
-                [],                    // guest_resources: none
+                [],                                               // guest_resources: none
                 HashMap::<Box<str>, HashMap<Box<str>, _>>::new(), // host_resources: none
                 instance_ty,
-                instance_name.as_str(),
+                import_name,
             )?;
         }
     }

--- a/crates/wash-runtime/src/plugin/wrpc/invoke.rs
+++ b/crates/wash-runtime/src/plugin/wrpc/invoke.rs
@@ -1,0 +1,93 @@
+//! Import bridging: polyfill component imports by invoking remote services via wRPC/NATS.
+//!
+//! For each component import that has a `wrpc:name` config key, this module uses
+//! `wrpc_runtime_wasmtime::link_instance` to bind linker entries. All encoding/decoding
+//! is handled by wrpc-runtime-wasmtime internally — the plugin only needs to configure
+//! the routing invoker on the store's `WrpcView` so `link_instance` can find the
+//! correct NATS client for each interface.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use tracing::{debug, instrument};
+use wasmtime::component::types::ComponentItem;
+
+use crate::engine::ctx::SharedCtx;
+use crate::engine::workload::WorkloadItem;
+use crate::wit::WitInterface;
+
+/// Bind import functions for all wrpc-matched interfaces on this component.
+///
+/// For each interface in `interfaces` that the component imports:
+/// 1. Creates a `wrpc_transport_nats::Client` for the routing key
+/// 2. Registers the route on the component's `WorkloadMetadata` routing invoker
+/// 3. Uses `wrpc_runtime_wasmtime::link_instance` to polyfill all functions
+///    in that interface — wrpc handles all encoding/decoding automatically
+#[instrument(skip_all)]
+pub(super) async fn bind_imports(
+    nats_client: &Arc<async_nats::Client>,
+    prefix: &str,
+    item: &mut WorkloadItem<'_>,
+    interfaces: &std::collections::HashSet<WitInterface>,
+) -> anyhow::Result<()> {
+    let component = item.component().clone();
+    let engine = component.engine();
+    let component_type = component.component_type();
+
+    for interface in interfaces {
+        let routing_key = match interface.config.get("wrpc:name") {
+            Some(key) => key.clone(),
+            None => continue,
+        };
+
+        let instance_name = interface.instance();
+
+        // Find this interface in the component's imports
+        for (import_name, import_item) in component_type.imports(engine) {
+            if import_name != instance_name {
+                continue;
+            }
+            let ComponentItem::ComponentInstance(instance_ty) = import_item else {
+                continue;
+            };
+
+            let wrpc_prefix = format!("{prefix}.{routing_key}");
+
+            // Create a wrpc NATS client for this routing key
+            let wrpc_client = Arc::new(
+                wrpc_transport_nats::Client::new(
+                    nats_client.clone(),
+                    Arc::from(wrpc_prefix.as_str()),
+                    None,
+                )
+                .await
+                .context("failed to create wrpc NATS client")?,
+            );
+
+            debug!(
+                instance = %instance_name,
+                routing_key = %routing_key,
+                "binding wrpc import via link_instance"
+            );
+
+            // Register the route so the RoutingInvoker can delegate to this client
+            item.wrpc_invoker_mut()
+                .add_route(instance_name.as_str(), wrpc_client);
+
+            // Use wrpc-runtime-wasmtime's link_instance to polyfill all functions
+            let linker = item.linker();
+            let mut linker_instance = linker.instance(&instance_name)?;
+            wrpc_runtime_wasmtime::link_instance::<SharedCtx>(
+                engine,
+                &mut linker_instance,
+                [],                    // guest_resources: none
+                HashMap::<Box<str>, HashMap<Box<str>, _>>::new(), // host_resources: none
+                instance_ty,
+                instance_name.as_str(),
+            )?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/wash-runtime/src/plugin/wrpc/mod.rs
+++ b/crates/wash-runtime/src/plugin/wrpc/mod.rs
@@ -1,0 +1,249 @@
+//! wRPC plugin for bridging arbitrary WIT interfaces over NATS.
+//!
+//! This plugin allows components to call remote services (imports) and be called
+//! remotely (exports) via the wRPC protocol over NATS transport. Components declare
+//! which interfaces to bridge using a `wrpc:name` config key in their interface
+//! declarations.
+//!
+//! ## Architecture
+//!
+//! - **Imports**: Polyfilled via `wrpc_runtime_wasmtime::link_instance` which handles
+//!   all encoding/decoding automatically. A `RoutingInvoker` on the store's `WrpcView`
+//!   maps WIT instance names to `wrpc_transport_nats::Client` instances.
+//! - **Exports**: Served via `wrpc_transport_nats::Client::serve()` with handler
+//!   tasks that delegate to `wrpc_runtime_wasmtime::call`.
+//! - **SharedCtx integration**: `WrpcView` on `SharedCtx` provides the `RoutingInvoker`
+//!   for import polyfilling and resource table access for export serving.
+//!
+//! ## NATS Subject Pattern
+//!
+//! Each routing key maps to a wRPC NATS client with prefix `{plugin_prefix}.{routing_key}`.
+//! wRPC internally appends `.wrpc.0.0.1.{instance}.{func}` to form the final subject.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use tracing::{debug, info, instrument};
+use wasmtime::component::types::ComponentItem;
+
+use crate::engine::workload::{ResolvedWorkload, WorkloadItem};
+use crate::plugin::{HostPlugin, WorkloadTracker};
+use crate::wit::{WitInterface, WitWorld};
+
+pub const PLUGIN_WRPC_ID: &str = "wrpc";
+
+pub(crate) mod codec;
+mod invoke;
+mod serve;
+
+/// Metadata about an export function to be served via wRPC.
+#[derive(Clone)]
+struct ExportInfo {
+    instance_name: String,
+    func_name: String,
+    param_types: Vec<wasmtime::component::Type>,
+    result_types: Vec<wasmtime::component::Type>,
+}
+
+/// Per-component tracking data for the wRPC plugin.
+struct ComponentData {
+    /// Export functions grouped by routing key.
+    exports: HashMap<String, Vec<ExportInfo>>,
+    /// Cancellation token for stopping export serving tasks.
+    cancel_token: tokio_util::sync::CancellationToken,
+}
+
+/// Plugin that bridges WIT interfaces over wRPC/NATS.
+///
+/// Components declare which interfaces to bridge by setting `wrpc:name` in the
+/// interface config. The value is a routing key that determines the NATS subject
+/// prefix for that interface.
+pub struct WrpcPlugin {
+    nats_client: Arc<async_nats::Client>,
+    prefix: String,
+    tracker: Arc<RwLock<WorkloadTracker<(), ComponentData>>>,
+}
+
+impl WrpcPlugin {
+    /// Create a new wRPC plugin.
+    ///
+    /// # Arguments
+    /// * `nats_client` - The NATS client to use for wRPC transport
+    /// * `prefix` - Base prefix for NATS subjects (e.g., "wash")
+    pub fn new(nats_client: Arc<async_nats::Client>, prefix: impl Into<String>) -> Self {
+        Self {
+            nats_client,
+            prefix: prefix.into(),
+            tracker: Arc::new(RwLock::new(WorkloadTracker::default())),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl HostPlugin for WrpcPlugin {
+    fn id(&self) -> &'static str {
+        PLUGIN_WRPC_ID
+    }
+
+    fn world(&self) -> WitWorld {
+        WitWorld::default()
+    }
+
+    fn can_handle(&self, interface: &WitInterface) -> bool {
+        info!(
+            interface = %interface,
+            has_wrpc_name = interface.config.contains_key("wrpc:name"),
+            "checking if wrpc plugin can handle interface"
+        );
+        interface.config.contains_key("wrpc:name")
+    }
+
+    #[instrument(skip_all, fields(plugin = PLUGIN_WRPC_ID))]
+    async fn on_workload_item_bind<'a>(
+        &self,
+        item: &mut WorkloadItem<'a>,
+        interfaces: HashSet<WitInterface>,
+    ) -> anyhow::Result<()> {
+        info!("binding imports");
+        // Bind import functions (component calls out via wrpc)
+        invoke::bind_imports(&self.nats_client, &self.prefix, item, &interfaces).await?;
+
+        info!("collecting exports");
+        // Collect export function metadata for on_workload_resolved
+        let exports = collect_exports(item, &interfaces)?;
+
+        if !exports.is_empty() {
+            let WorkloadItem::Component(component_handle) = item else {
+                anyhow::bail!("wrpc export serving requires a component, not a service");
+            };
+            info!(
+                num_export_interfaces = exports.len(),
+                "bound wrpc exports for component"
+            );
+
+            self.tracker.write().await.add_component(
+                component_handle,
+                ComponentData {
+                    exports,
+                    cancel_token: tokio_util::sync::CancellationToken::new(),
+                },
+            );
+        }
+
+        Ok(())
+    }
+
+    #[instrument(skip_all, fields(plugin = PLUGIN_WRPC_ID, component_id = %component_id))]
+    async fn on_workload_resolved(
+        &self,
+        workload: &ResolvedWorkload,
+        component_id: &str,
+    ) -> anyhow::Result<()> {
+        debug!("starting wrpc export serving for resolved workload");
+        let (cancel_token, exports) = {
+            let lock = self.tracker.read().await;
+            match lock.get_component_data(component_id) {
+                Some(data) => (data.cancel_token.clone(), data.exports.clone()),
+                None => return Ok(()),
+            }
+        };
+
+        if exports.is_empty() {
+            debug!(
+                component_id = %component_id,
+                "no wrpc exports to serve for this component"
+            );
+            return Ok(());
+        }
+
+        serve::serve_exports(
+            &self.nats_client,
+            &self.prefix,
+            workload,
+            component_id,
+            &exports,
+            cancel_token,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn on_workload_unbind(
+        &self,
+        workload_id: &str,
+        _interfaces: HashSet<WitInterface>,
+    ) -> anyhow::Result<()> {
+        self.tracker
+            .write()
+            .await
+            .remove_workload_with_cleanup(
+                workload_id,
+                |_| async {},
+                |data: ComponentData| async move {
+                    data.cancel_token.cancel();
+                },
+            )
+            .await;
+
+        Ok(())
+    }
+}
+
+/// Collect export function metadata from the component for interfaces that have `wrpc:name`.
+/// Returns a map from routing_key → list of export functions.
+fn collect_exports(
+    item: &WorkloadItem<'_>,
+    interfaces: &HashSet<WitInterface>,
+) -> anyhow::Result<HashMap<String, Vec<ExportInfo>>> {
+    let component = item.component().clone();
+    let engine = component.engine();
+    let component_type = component.component_type();
+    let mut exports_by_key: HashMap<String, Vec<ExportInfo>> = HashMap::new();
+
+    for interface in interfaces {
+        let routing_key = match interface.config.get("wrpc:name") {
+            Some(key) => key.clone(),
+            None => continue,
+        };
+        info!(
+            interface = %interface,
+            routing_key = %routing_key,
+            "collecting exports for interface with wrpc:name"
+        );
+
+        // Find this interface in the component's exports
+        for (export_name, export_item) in component_type.exports(engine) {
+            let ComponentItem::ComponentInstance(instance_ty) = export_item else {
+                continue;
+            };
+
+            info!(
+                export_name= %export_name,
+                routing_key = %routing_key,
+                "collecting wrpc export functions"
+            );
+
+            for (func_name, item_ty) in instance_ty.exports(engine) {
+                let ComponentItem::ComponentFunc(func_ty) = item_ty else {
+                    continue;
+                };
+
+                let param_types: Vec<_> = func_ty.params().map(|(_, ty)| ty).collect();
+                let result_types: Vec<_> = func_ty.results().collect();
+                exports_by_key
+                    .entry(routing_key.clone())
+                    .or_default()
+                    .push(ExportInfo {
+                        instance_name: export_name.into(),
+                        func_name: func_name.to_string(),
+                        param_types,
+                        result_types,
+                    });
+            }
+        }
+    }
+
+    Ok(exports_by_key)
+}

--- a/crates/wash-runtime/src/plugin/wrpc/mod.rs
+++ b/crates/wash-runtime/src/plugin/wrpc/mod.rs
@@ -219,6 +219,22 @@ fn collect_exports(
                 continue;
             };
 
+            let wit_export = WitInterface::from(export_name);
+            if interface.contains(&wit_export) {
+                info!(
+                    export_name = %export_name,
+                    routing_key = %routing_key,
+                    "interface matches component export, collecting functions"
+                );
+            } else {
+                info!(
+                    export_name = %export_name,
+                    routing_key = %routing_key,
+                    "interface does not match component export, skipping"
+                );
+                continue;
+            }
+
             info!(
                 export_name= %export_name,
                 routing_key = %routing_key,

--- a/crates/wash-runtime/src/plugin/wrpc/serve.rs
+++ b/crates/wash-runtime/src/plugin/wrpc/serve.rs
@@ -1,0 +1,199 @@
+//! Export bridging: serve component exports via wRPC/NATS so remote callers can invoke them.
+//!
+//! For each component export that has a `wrpc:name` config key, this module subscribes
+//! to wRPC NATS subjects and spawns tasks that use `wrpc_runtime_wasmtime::call` to
+//! handle the full decode → call → encode cycle.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use futures::stream::StreamExt;
+use tracing::{debug, instrument, trace, warn};
+use wasmtime::component::{Func, Type};
+use wrpc_transport::Serve as _;
+
+use super::ExportInfo;
+use crate::engine::workload::ResolvedWorkload;
+
+/// Serve exported functions for a component via wRPC NATS.
+///
+/// For each export interface with a `wrpc:name` config key, subscribes to wRPC
+/// NATS subjects and spawns handler tasks that delegate to
+/// `wrpc_runtime_wasmtime::call`.
+#[instrument(skip_all, fields(component_id = %component_id))]
+pub(super) async fn serve_exports(
+    nats_client: &Arc<async_nats::Client>,
+    prefix: &str,
+    workload: &ResolvedWorkload,
+    component_id: &str,
+    exports: &HashMap<String, Vec<ExportInfo>>,
+    cancel_token: tokio_util::sync::CancellationToken,
+) -> anyhow::Result<()> {
+    debug!(
+        component_id = %component_id,
+        num_export_interfaces = exports.len(),
+        "setting up wrpc export serving for component"
+    );
+    for (routing_key, export_infos) in exports {
+        let wrpc_prefix = format!("{prefix}.{routing_key}");
+
+        let wrpc_client = wrpc_transport_nats::Client::new(
+            nats_client.clone(),
+            Arc::from(wrpc_prefix.as_str()),
+            None,
+        )
+        .await
+        .context("failed to create wrpc NATS client for serving")?;
+
+        debug!(
+            routing_key = %routing_key,
+            num_functions = export_infos.len(),
+            "setting up wrpc export subscriptions"
+        );
+
+        for export_info in export_infos {
+            let instance_name = export_info.instance_name.clone();
+            let func_name = export_info.func_name.clone();
+            let param_types = export_info.param_types.clone();
+            let result_types = export_info.result_types.clone();
+
+            let invocations = wrpc_client
+                .serve(&instance_name, &func_name, [])
+                .await
+                .with_context(|| {
+                    format!("failed to subscribe to wrpc export {instance_name}/{func_name}")
+                })?;
+
+            let workload = workload.clone();
+            let component_id = component_id.to_string();
+            let cancel = cancel_token.clone();
+            let instance_name_clone = instance_name.clone();
+            let func_name_clone = func_name.clone();
+
+            tokio::spawn(async move {
+                let mut invocations = std::pin::pin!(invocations);
+                loop {
+                    tokio::select! {
+                        maybe_invocation = invocations.next() => {
+                            let invocation = match maybe_invocation {
+                                None => break,
+                                Some(Ok(inv)) => inv,
+                                Some(Err(e)) => {
+                                    warn!(
+                                        instance = %instance_name_clone,
+                                        func = %func_name_clone,
+                                        error = %e,
+                                        "wrpc serve stream error"
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            if let Err(e) = handle_invocation(
+                                invocation,
+                                &workload,
+                                &component_id,
+                                &instance_name_clone,
+                                &func_name_clone,
+                                &param_types,
+                                &result_types,
+                            ).await {
+                                warn!(
+                                    instance = %instance_name_clone,
+                                    func = %func_name_clone,
+                                    error = %e,
+                                    "wrpc export invocation failed"
+                                );
+                            }
+                        }
+                        _ = cancel.cancelled() => {
+                            debug!(
+                                instance = %instance_name_clone,
+                                func = %func_name_clone,
+                                "wrpc export serving cancelled"
+                            );
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Handle a single wRPC invocation using `wrpc_runtime_wasmtime::call`.
+#[instrument(skip_all, fields(instance = %instance_name, func = %func_name))]
+async fn handle_invocation<Tx, Rx>(
+    (_cx, tx, rx): (wrpc_transport_nats::NatsContext, Tx, Rx),
+    workload: &ResolvedWorkload,
+    component_id: &str,
+    instance_name: &str,
+    func_name: &str,
+    param_types: &[Type],
+    result_types: &[Type],
+) -> anyhow::Result<()>
+where
+    Tx: tokio::io::AsyncWrite + wrpc_transport::Index<Tx> + Send + Sync + Unpin + 'static,
+    Rx: tokio::io::AsyncRead + wrpc_transport::Index<Rx> + Send + Sync + Unpin + 'static,
+{
+    trace!("handling wrpc invocation");
+
+    // Create a fresh store and instantiate the component
+    let mut store = workload
+        .new_store(component_id)
+        .await
+        .context("failed to create store for wrpc export")?;
+
+    let instance_pre = workload
+        .instantiate_pre(component_id)
+        .await
+        .context("failed to get instance pre for wrpc export")?;
+
+    let instance = instance_pre
+        .instantiate_async(&mut store)
+        .await
+        .context("failed to instantiate component for wrpc export")?;
+
+    // Find the exported function
+    let func = find_export_func(&instance, &mut store, instance_name, func_name)
+        .context("failed to find exported function")?;
+
+    // Delegate the full decode → call → encode cycle to wrpc-runtime-wasmtime
+    wrpc_runtime_wasmtime::call(
+        &mut store,
+        rx,
+        tx,
+        &[],             // guest_resources: none (no resource bridging)
+        &HashMap::new(), // host_resources: none
+        param_types.iter(),
+        result_types,
+        func,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("wrpc export call failed: {e}"))?;
+
+    trace!("wrpc invocation handled successfully");
+    Ok(())
+}
+
+/// Find an exported function by instance and function name within a component instance.
+fn find_export_func(
+    instance: &wasmtime::component::Instance,
+    store: &mut wasmtime::Store<crate::engine::ctx::SharedCtx>,
+    instance_name: &str,
+    func_name: &str,
+) -> anyhow::Result<Func> {
+    // First look up the export instance index, then the function within it
+    let instance_index = instance
+        .get_export_index(&mut *store, None, instance_name)
+        .with_context(|| format!("export instance '{instance_name}' not found"))?;
+    let func_index = instance
+        .get_export_index(&mut *store, Some(&instance_index), func_name)
+        .with_context(|| format!("export function '{func_name}' not found in '{instance_name}'"))?;
+    instance
+        .get_func(&mut *store, func_index)
+        .with_context(|| format!("'{instance_name}/{func_name}' is not a function"))
+}

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -123,6 +123,10 @@ impl CliCommand for HostCommand {
             .with_host_config(host_config)
             .with_nats_client(Arc::new(scheduler_nats_client))
             .with_host_group(self.host_group.clone())
+            .with_plugin(Arc::new(plugin::wrpc::WrpcPlugin::new(
+                data_nats_client.clone(),
+                self.host_group.clone(),
+            )))?
             .with_plugin(Arc::new(plugin::wasi_config::DynamicConfig::new(true)))?
             .with_plugin(Arc::new(plugin::wasi_logging::TracingLogger::default()))?
             .with_plugin(Arc::new(plugin::wasi_blobstore::NatsBlobstore::new(

--- a/runtime-operator/config/samples/wrpc.yaml
+++ b/runtime-operator/config/samples/wrpc.yaml
@@ -1,0 +1,18 @@
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: hello
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostInterfaces:
+        - namespace: wrpc-examples
+          package: hello
+          interfaces:
+            - handler
+          config:
+            "wrpc:name": hello
+      components:
+        - name: hello-world
+          image: ttl.sh/lxfontes/wrpc-server:test


### PR DESCRIPTION
> [!NOTE]
> 📋 **Copied from https://github.com/wasmCloud/wash/pull/295**

Getting this up  for discussion / ergonomics. 

WRPC NATS Only, using the `data` NATS settings.
The WRPC Plugin looks for `host_interfaces` with config key `wrpc:name`,forwarding imports/exports for that particular 'namespace + package' to wrpc layer. The `wrpc:name` is used as part of the wrpc subject.

There is no process supervision or interactions with wasmcloud provider sdk.

## WRPC Routing

We pivot identifiers from `workload_namespace & workload_name` to `host_group & wrpc_name`, resembling wasmcloud's v1 Lattice approach.

`{host_group}.{wrpc_name}.[wrpc-lib-subject]`

This happens for a few reasons:
- Guarantee no crosstalk across hostgroups
- `wrpc_name` has to remain stable across restart, and can't use `Workload` names here as they are ephemeral (would be nice to use `WorkloadDeployment` names)

Crosstalk can still be achieved via NATS subject mappings, however it is an advanced use-case.

Example:

All exported interfaces from `wrpc-examples/hello` found on the component will be served over WRPC.

```
     hostInterfaces:
        - namespace: wrpc-examples
          package: hello
          interfaces:
            - handler
          config:
            "wrpc:name": wasmcloudrpchello
```

Client:

```
rpc ❯ ./target/debug/hello-nats-client default.wasmcloudrpchello
2026-02-23T20:37:01.480694Z  INFO async_nats::connector: connected successfully server=4222 max_payload=1048576
2026-02-23T20:37:01.480974Z  INFO async_nats: event: connected
default.wasmcloudrpchello: hello from Rust
```

### Identity ( WRPC Headers )

(still to be coded)

Headers help external WRPC endpoints identify the caller & multiplex interfaces:

- `From`: `{wrpc_name}` from the source
- `X-Wasmcloud-Workload`: `{workload_namespace}/{workload_name}`
- `X-Wasmcloud-Workload-Id`: `{workload_id}`

Also considering passing any additional Interface `config` as header.

## Questions

**How to handle different `wrpc:name` for import/export on the same package?**

This is a limitation of `host_interfaces`. Today all import/exports land on the same `WitInterface`  with a single configuration.

**HostPlugin or not?**

Seems weird to pluck a specific `HostPlugin` within `wash_runtime::engine`.

I feel this warrants another "engine-plugin" like HTTP.

**Target Switching (Links)**

[v1 linking at runtime](https://wasmcloud.com/docs/concepts/linking-components/linking-at-runtime/)

Besides similar challenges with `host_interfaces`, we also have:
- Scope: WRPC-only links or for components/HostPlugins too?
- Link Switch Mechanism: v1 has dedicated WIT Interface for Link change


IMO: WRPC-Only with similar WIT Interface for Link change


---------

From comment by @lxfontes 

Using the existing cron-service & cron-component combo:

```
# This will become a WRPC Server (nats subscription)
apiVersion: runtime.wasmcloud.dev/v1alpha1
kind: WorkloadDeployment
metadata:
  name: cron-component
spec:
  replicas: 1
  template:
    spec:
      hostInterfaces:
        - namespace: wasmcloud
          package: example
          interfaces:
            - cron
          config:
            "wrpc:name": crontest
      components:
        - name: hello
          image: ttl.sh/lxfontes/cron-component:test
---
# This will become a WRPC Invoker
apiVersion: runtime.wasmcloud.dev/v1alpha1
kind: WorkloadDeployment
metadata:
  name: cron-service
spec:
  replicas: 1
  template:
    spec:
      hostInterfaces:
        - namespace: wasmcloud
          package: example
          interfaces:
            - cron
          config:
            "wrpc:name": crontest
      service:
        image: ttl.sh/lxfontes/cron-service:test
```


<img width="1943" height="807" alt="Screenshot 2026-02-23 at 4 59 50 PM" src="https://github.com/user-attachments/assets/3137323e-9bf5-4b4f-9ec4-03772148c40f" />
