### PR TITLE
ci: dispatch brew update on release

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -246,3 +246,25 @@ jobs:
           token: ${{ github.token }}
           prerelease: false
           generate_release_notes: true
+
+  update-homebrew:
+    needs: upload-release-assets
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/wash-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION="${GITHUB_REF_NAME#wash-v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch Homebrew tap update
+        env:
+          GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
+        run: |
+          gh api repos/wasmCloud/homebrew-wasmcloud/dispatches \
+            -f event_type=brew-formula-update \
+            -f 'client_payload[tag_prefix]=wash' \
+            -f 'client_payload[tag_version]=${{ steps.version.outputs.version }}'


### PR DESCRIPTION
Add `update-homebrew` job to wash release workflow that triggers after
release assets are uploaded.

Steps:
- On `wash-v*` tag push, dispatches a `brew-formula-update` event to
  `wasmCloud/homebrew-wasmcloud`, which has an existing workflow that
  downloads binaries, generates the formula, and creates a PR
- Uses `WASMCLOUD_BOT_PAT` secret for cross-repo dispatch
  (github.token is not sufficient for cross-repo dispatches)

See:
https://github.com/wasmCloud/homebrew-wasmcloud/blob/main/.github/workflows/update.yml

Tested bot account has access via ` gh api repos/wasmCloud/homebrew-wasmcloud/collaborators/automation-wasmcloud --silent && echo "has access"
has access`