### PR TITLE
fix: Threading OCI Cache for 'wash host'

### DIFF
--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -24,6 +24,8 @@ spec:
         {{- include "runtime-operator.labels" $top | nindent 8 }}
     spec:
       volumes:
+        - name: oci-cache
+          emptyDir: {}
         - name: runtime-cert
           secret:
             secretName: {{ $top.Values.global.certificates.runtimeCertSecretName }}
@@ -53,6 +55,7 @@ spec:
             - "--data-nats-tls-ca=/data-cert/ca.crt"
             - "--data-nats-tls-cert=/data-cert/tls.crt"
             - "--data-nats-tls-key=/data-cert/tls.key"
+            - "--oci-cache-dir=/oci-cache"
             {{- if and (.http) (.http.enabled) }}
             - "--http-addr=0.0.0.0:9191"
             {{- end }}
@@ -61,6 +64,8 @@ spec:
             {{- end }}
           imagePullPolicy: {{ $top.Values.runtime.image.pull_policy }}
           volumeMounts:
+            - name: oci-cache
+              mountPath: /oci-cache
             - name: runtime-cert
               mountPath: /runtime-cert
               readOnly: true

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -695,7 +695,7 @@ impl ResolvedWorkload {
                             // This is expected for host-provided interfaces (e.g. wasi:*).
                             // If it's not host-provided, linking will fail later with a
                             // clear error from wasmtime.
-                            warn!(
+                            debug!(
                                 name = import_name,
                                 "import not found in component exports, assuming host-provided"
                             );

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -83,6 +83,10 @@ pub struct HostCommand {
     #[clap(long = "registry-pull-timeout", value_parser = humantime::parse_duration, default_value = "30s")]
     pub registry_pull_timeout: Duration,
 
+    /// The directory to use for caching OCI artifacts
+    #[clap(long = "oci-cache-dir")]
+    pub oci_cache_dir: Option<PathBuf>,
+
     /// Enable WASI OpenTelemetry plugin
     #[clap(long = "wasi-otel", default_value_t = false)]
     pub wasi_otel: bool,
@@ -124,7 +128,7 @@ impl CliCommand for HostCommand {
         let host_config = wash_runtime::host::HostConfig {
             allow_oci_insecure: self.allow_insecure_registries,
             oci_pull_timeout: Some(self.registry_pull_timeout),
-            ..Default::default()
+            oci_cache_dir: self.oci_cache_dir.clone(),
         };
 
         let engine = Engine::builder()


### PR DESCRIPTION
Needed for `ImagePullPolicy: IfNotPresent | Never`.

Pointing `oci-cache-dir` to an `emptyDir` in Kubernetes to guarantee artifacts don't land on a tmpfs / shmfs ( consuming host memory ).