### PR TITLE
refactor(wash): modernize CLI to clap v4 idioms and improve help output

### DIFF
--- a/crates/wash/src/cli/completion.rs
+++ b/crates/wash/src/cli/completion.rs
@@ -7,7 +7,7 @@ use clap_complete::Shell;
 #[derive(Debug, Clone, Args)]
 pub struct CompletionCommand {
     /// The shell to generate completions for
-    #[clap(value_enum)]
+    #[arg(value_enum)]
     shell: Shell,
 }
 

--- a/crates/wash/src/cli/component_build.rs
+++ b/crates/wash/src/cli/component_build.rs
@@ -19,7 +19,7 @@ use crate::{
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct ComponentBuildCommand {
     /// Skip fetching WIT dependencies, useful for offline builds
-    #[clap(long = "skip-fetch")]
+    #[arg(long = "skip-fetch")]
     skip_fetch: bool,
 }
 

--- a/crates/wash/src/cli/config.rs
+++ b/crates/wash/src/cli/config.rs
@@ -1,5 +1,5 @@
 use anyhow::Context as _;
-use clap::Subcommand;
+use clap::{Parser, Subcommand};
 use tracing::instrument;
 
 use crate::{
@@ -7,16 +7,23 @@ use crate::{
     config::{Config, generate_default_config, load_config, local_config_path},
 };
 
-/// Create a new component project from a template, git repository, or local path
+/// View and manage wash configuration
+#[derive(Parser, Debug, Clone)]
+#[command(subcommand_required = true, arg_required_else_help = true)]
+pub struct ConfigArgs {
+    #[command(subcommand)]
+    command: ConfigCommand,
+}
+
 #[derive(Subcommand, Debug, Clone)]
 pub enum ConfigCommand {
     /// Initialize a new configuration file for wash
     Init {
-        #[clap(long)]
         /// Overwrite existing configuration
+        #[arg(long)]
         force: bool,
-        #[clap(long)]
         /// Overwrite global configuration instead of project
+        #[arg(long)]
         global: bool,
     },
     /// Print the current version and local directories used by wash
@@ -25,6 +32,13 @@ pub enum ConfigCommand {
     Show {},
     // TODO(#27): validate config command
     // TODO(#29): cleanup config command, to clean the dirs we use
+}
+
+impl CliCommand for ConfigArgs {
+    #[instrument(level = "debug", skip_all, name = "config")]
+    async fn handle(&self, ctx: &CliContext) -> anyhow::Result<CommandOutput> {
+        self.command.handle(ctx).await
+    }
 }
 
 impl CliCommand for ConfigCommand {

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -22,6 +22,7 @@ use crate::{
     wit::WitConfig,
 };
 
+/// Start a development server for a Wasm component
 #[derive(Debug, Clone, Args)]
 pub struct DevCommand {}
 

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -14,81 +14,81 @@ use crate::cli::{CliCommand, CliContext, CommandOutput};
 #[derive(Debug, Clone, Args)]
 pub struct HostCommand {
     /// The host group label to assign to the host
-    #[clap(long = "host-group", default_value = "default")]
+    #[arg(long = "host-group", default_value = "default")]
     pub host_group: String,
 
     /// NATS URL for Control Plane communications
-    #[clap(long = "scheduler-nats-url", default_value = "nats://localhost:4222")]
+    #[arg(long = "scheduler-nats-url", default_value = "nats://localhost:4222")]
     pub scheduler_nats_url: String,
 
     /// Path to TLS CA certificate file for NATS Scheduler connection
-    #[clap(long = "scheduler-nats-tls-ca")]
+    #[arg(long = "scheduler-nats-tls-ca")]
     pub scheduler_nats_tls_ca: Option<PathBuf>,
 
     /// Enable TLS handshake first mode for NATS Scheduler connection
-    #[clap(long = "scheduler-nats-tls-first", default_value_t = false)]
+    #[arg(long = "scheduler-nats-tls-first", default_value_t = false)]
     pub scheduler_nats_tls_first: bool,
 
     /// Path to NATS TLS certificate file for NATS Scheduler connection
-    #[clap(long = "scheduler-nats-tls-cert")]
+    #[arg(long = "scheduler-nats-tls-cert")]
     pub scheduler_nats_tls_cert: Option<PathBuf>,
 
     /// Path to NATS TLS private key file for NATS Scheduler connection
-    #[clap(long = "scheduler-nats-tls-key")]
+    #[arg(long = "scheduler-nats-tls-key")]
     pub scheduler_nats_tls_key: Option<PathBuf>,
 
     /// NATS URL for Data Plane communications
-    #[clap(long = "data-nats-url", default_value = "nats://localhost:4222")]
+    #[arg(long = "data-nats-url", default_value = "nats://localhost:4222")]
     pub data_nats_url: String,
 
     /// The path to TLS CA certificate file for NATS Data connection
-    #[clap(long = "data-nats-tls-ca")]
+    #[arg(long = "data-nats-tls-ca")]
     pub data_nats_tls_ca: Option<PathBuf>,
 
     /// Enable TLS handshake first mode for NATS Data connection
-    #[clap(long = "data-nats-tls-first", default_value_t = false)]
+    #[arg(long = "data-nats-tls-first", default_value_t = false)]
     pub data_nats_tls_first: bool,
 
     /// Path to NATS TLS certificate file for NATS Data connection
-    #[clap(long = "data-nats-tls-cert")]
+    #[arg(long = "data-nats-tls-cert")]
     pub data_nats_tls_cert: Option<PathBuf>,
 
     /// Path to NATS TLS private key file for NATS Data connection
-    #[clap(long = "data-nats-tls-key")]
+    #[arg(long = "data-nats-tls-key")]
     pub data_nats_tls_key: Option<PathBuf>,
 
     /// The host name to assign to the host
-    #[clap(long = "host-name")]
+    #[arg(long = "host-name")]
     pub host_name: Option<String>,
 
     /// The address on which the HTTP server will listen
-    #[clap(long = "http-addr")]
+    #[arg(long = "http-addr")]
     pub http_addr: Option<SocketAddr>,
 
     /// Enable WASI WebGPU support
     #[cfg(not(target_os = "windows"))]
-    #[clap(long = "wasi-webgpu", default_value_t = false)]
+    #[arg(long = "wasi-webgpu", default_value_t = false)]
     pub wasi_webgpu: bool,
 
     /// PostgreSQL connection URL for the wasmcloud:postgres plugin
     /// (e.g. postgres://user:pass@bouncer:6432?sslmode=require&pool_size=10)
-    #[clap(long = "postgres-url", env = "WASH_POSTGRES_URL")]
+    #[arg(long = "postgres-url", env = "WASH_POSTGRES_URL")]
     pub postgres_url: Option<String>,
 
     /// Allow insecure OCI Registries
-    #[clap(long = "allow-insecure-registries", default_value_t = false)]
+    #[arg(long = "allow-insecure-registries", default_value_t = false)]
     pub allow_insecure_registries: bool,
 
     /// Timeout for pulling artifacts from OCI registries
-    #[clap(long = "registry-pull-timeout", value_parser = humantime::parse_duration, default_value = "30s")]
+    #[arg(long = "registry-pull-timeout", value_parser = humantime::parse_duration, default_value = "30s")]
     pub registry_pull_timeout: Duration,
 
     /// The directory to use for caching OCI artifacts
-    #[clap(long = "oci-cache-dir")]
+    #[arg(long = "oci-cache-dir")]
     pub oci_cache_dir: Option<PathBuf>,
 
     /// Enable WASI OpenTelemetry plugin
-    #[clap(long = "wasi-otel", default_value_t = false)]
+    #[arg(long = "wasi-otel", default_value_t = false)]
     pub wasi_otel: bool,
 }
 

--- a/crates/wash/src/cli/new.rs
+++ b/crates/wash/src/cli/new.rs
@@ -17,20 +17,19 @@ use crate::{
 /// Create a new component project from a git repository
 #[derive(Args, Debug, Clone)]
 pub struct NewCommand {
-    /// Git repository URL to clone
-    #[clap(help = "Git repository URL to use as project template")]
+    /// Git repository URL to use as project template
     git: String,
 
     /// Project name and local directory to create (defaults to repository/subfolder name)
-    #[clap(long)]
+    #[arg(long)]
     name: Option<String>,
 
     /// Subdirectory within the git repository to use
-    #[clap(long)]
+    #[arg(long)]
     subfolder: Option<String>,
 
     /// Git reference (branch, tag, or commit) to checkout
-    #[clap(long, name = "ref")]
+    #[arg(long)]
     git_ref: Option<String>,
 }
 

--- a/crates/wash/src/cli/oci.rs
+++ b/crates/wash/src/cli/oci.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use anyhow::Context as _;
 use chrono::Utc;
-use clap::{Args, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use tracing::instrument;
 use wash_runtime::oci::{OciConfig, OciPullPolicy, pull_component, push_component};
 use wasm_metadata::Payload;
@@ -12,10 +12,27 @@ pub(crate) const OCI_CACHE_DIR: &str = "oci";
 
 use crate::cli::{CliCommand, CliContext, CommandOutput};
 
+/// Push or pull Wasm components to/from an OCI registry
+#[derive(Parser, Debug, Clone)]
+#[command(subcommand_required = true, arg_required_else_help = true)]
+pub struct OciArgs {
+    #[command(subcommand)]
+    command: OciCommand,
+}
+
 #[derive(Subcommand, Debug, Clone)]
 pub enum OciCommand {
+    /// Pull a Wasm component from an OCI registry
     Pull(PullCommand),
+    /// Push a Wasm component to an OCI registry
     Push(PushCommand),
+}
+
+impl CliCommand for OciArgs {
+    #[instrument(level = "debug", skip_all, name = "oci")]
+    async fn handle(&self, ctx: &CliContext) -> anyhow::Result<CommandOutput> {
+        self.command.handle(ctx).await
+    }
 }
 
 impl CliCommand for OciCommand {
@@ -32,19 +49,18 @@ impl CliCommand for OciCommand {
 #[derive(Args, Debug, Clone)]
 pub struct PullCommand {
     /// The OCI reference to pull
-    #[clap(name = "reference")]
     reference: String,
     /// The path to write the pulled component to
-    #[clap(name = "component_path", default_value = "component.wasm")]
+    #[arg(default_value = "component.wasm")]
     component_path: PathBuf,
     /// Use HTTP or HTTPS protocol
-    #[clap(long = "insecure", default_value_t = false)]
+    #[arg(long = "insecure", default_value_t = false)]
     insecure: bool,
     /// Username for basic authentication
-    #[clap(short, long)]
+    #[arg(short, long)]
     user: Option<String>,
     /// Password for basic authentication
-    #[clap(short, long)]
+    #[arg(short, long)]
     password: Option<String>,
 }
 
@@ -94,19 +110,17 @@ impl PullCommand {
 #[derive(Args, Debug, Clone)]
 pub struct PushCommand {
     /// The OCI reference to push
-    #[clap(name = "reference")]
     reference: String,
     /// The path to the component to push
-    #[clap(name = "component_path")]
     component_path: PathBuf,
     /// Use HTTP or HTTPS protocol
-    #[clap(long = "insecure", default_value_t = false)]
+    #[arg(long = "insecure", default_value_t = false)]
     insecure: bool,
-    #[clap(short, long)]
     /// Username for basic authentication
+    #[arg(short, long)]
     user: Option<String>,
     /// Password for basic authentication
-    #[clap(short, long)]
+    #[arg(short, long)]
     password: Option<String>,
 }
 

--- a/crates/wash/src/cli/update.rs
+++ b/crates/wash/src/cli/update.rs
@@ -60,19 +60,19 @@ pub struct Asset {
 #[derive(Args, Debug, Default, Clone)]
 pub struct UpdateCommand {
     /// Force update even if already on the latest version
-    #[clap(long, short = 'f')]
+    #[arg(long, short = 'f')]
     force: bool,
 
     /// Check for updates without applying them
-    #[clap(long, short = 'd')]
+    #[arg(long, short = 'd')]
     dry_run: bool,
 
     /// Point at a different repository for updates
-    #[clap(long, default_value = REPO)]
+    #[arg(long, default_value = REPO)]
     git: String,
 
     /// GitHub token for private repository access. Can also be set via GITHUB_TOKEN, GH_TOKEN, or GITHUB_ACCESS_TOKEN environment variables
-    #[clap(long, env = "WASH_GITHUB_TOKEN")]
+    #[arg(long, env = "WASH_GITHUB_TOKEN")]
     token: Option<String>,
 }
 

--- a/crates/wash/src/cli/wit.rs
+++ b/crates/wash/src/cli/wit.rs
@@ -107,7 +107,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context as _, Result, bail};
-use clap::Subcommand;
+use clap::{Parser, Subcommand};
 use tracing::{debug, info, instrument};
 
 use crate::{
@@ -117,31 +117,45 @@ use crate::{
 };
 
 /// Manage WIT dependencies for wasmCloud components
+#[derive(Parser, Debug, Clone)]
+#[command(subcommand_required = true, arg_required_else_help = true)]
+pub struct WitArgs {
+    #[command(subcommand)]
+    command: WitCommand,
+}
+
+impl CliCommand for WitArgs {
+    #[instrument(level = "debug", skip_all, name = "wit")]
+    async fn handle(&self, ctx: &CliContext) -> Result<CommandOutput> {
+        self.command.handle(ctx).await
+    }
+}
+
+/// WIT dependency management subcommands
 #[derive(Debug, Clone, Subcommand)]
 pub enum WitCommand {
     /// Fetch WIT dependencies (reads from wit/world.wit imports)
     Fetch {
-        #[clap(long, help = "Remove existing dependencies before fetching")]
+        /// Remove existing dependencies before fetching
+        #[arg(long)]
         clean: bool,
     },
 
     /// Update dependencies to latest compatible versions
     Update {
-        #[clap(
-            help = "Specific package to update (e.g., wasi:http). If not specified, updates all packages"
-        )]
+        /// Specific package to update (e.g., wasi:http). If not specified, updates all packages
         package: Option<String>,
     },
 
     /// Add a new WIT dependency
     Add {
-        #[clap(help = "Package to add (e.g., wasi:keyvalue or wasi:keyvalue@0.2.0-draft)")]
+        /// Package to add (e.g., wasi:keyvalue or wasi:keyvalue@0.2.0-draft)
         package: String,
     },
 
     /// Remove a WIT dependency
     Remove {
-        #[clap(help = "Package to remove (e.g., wasi:keyvalue)")]
+        /// Package to remove (e.g., wasi:keyvalue)
         package: String,
     },
 
@@ -150,10 +164,8 @@ pub enum WitCommand {
 
     /// Build a WIT package into a Wasm binary
     Build {
-        #[clap(
-            long = "output-file",
-            help = "Output file path for the built Wasm package"
-        )]
+        /// Output file path for the built Wasm package
+        #[arg(long = "output-file")]
         output_file: Option<PathBuf>,
     },
 }

--- a/crates/wash/src/main.rs
+++ b/crates/wash/src/main.rs
@@ -15,7 +15,7 @@ use wash::cli::{
 };
 
 #[derive(Debug, Clone, Parser)]
-#[clap(
+#[command(
     name = "wash",
     about,
     version,
@@ -23,57 +23,39 @@ use wash::cli::{
     color = clap::ColorChoice::Auto
 )]
 struct Cli {
-    #[clap(
-        short = 'o',
-        long = "output",
-        default_value = "text",
-        help = "Specify output format (text or json)",
-        global = true
-    )]
+    /// Specify output format (text or json)
+    #[arg(short = 'o', long = "output", default_value = "text", global = true)]
     pub(crate) output: OutputKind,
 
-    #[clap(
-        long = "help-markdown",
-        help = "Print help in markdown format (conflicts with --help and --output json)",
-        hide = true,
-        global = true
-    )]
+    /// Print help in markdown format (conflicts with --help and --output json)
+    #[arg(long = "help-markdown", hide = true, global = true)]
     help_markdown: bool,
 
-    #[clap(
-        short = 'l',
-        long = "log-level",
-        default_value_t = Level::INFO,
-        help = "Set the opentelemetry log level (trace, debug, info, warn, error)",
-        global = true
-    )]
+    /// Set the opentelemetry log level (trace, debug, info, warn, error)
+    #[arg(short = 'l', long = "log-level", default_value_t = Level::INFO, global = true)]
     log_level: Level,
 
-    #[clap(long = "verbose", help = "Enable verbose output", global = true)]
+    /// Enable verbose output
+    #[arg(long = "verbose", global = true)]
     verbose: bool,
 
-    #[clap(
-        long = "non-interactive",
-        help = "Run in non-interactive mode (skip terminal checks for host exec). Automatically enabled when stdin is not a TTY",
-        global = true
-    )]
+    /// Run in non-interactive mode (skip terminal checks for host exec). Automatically enabled when stdin is not a TTY
+    #[arg(long = "non-interactive", global = true)]
     non_interactive: bool,
 
-    #[clap(
-        long = "user-config",
-        help = "Path to user configuration file.",
-        global = true
-    )]
+    /// Path to user configuration file
+    #[arg(long = "user-config", global = true)]
     user_config: Option<PathBuf>,
 
     /// Path to the project directory
-    #[clap(short = 'C', default_value = find_project_root().into_os_string())]
+    #[arg(short = 'C', default_value = find_project_root().into_os_string())]
     project_path: PathBuf,
 
-    #[clap(long = "enable-meters", help = "Enable host meters", global = true)]
+    /// Enable host meters
+    #[arg(long = "enable-meters", global = true)]
     enable_meters: bool,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Option<WashCliCommand>,
 }
 
@@ -82,35 +64,27 @@ struct Cli {
 #[derive(Debug, Clone, Subcommand)]
 enum WashCliCommand {
     /// Build a Wasm component
-    #[clap(name = "build")]
     Build(wash::cli::component_build::ComponentBuildCommand),
     /// Generate shell completions
-    #[clap(name = "completion")]
     Completion(wash::cli::completion::CompletionCommand),
     /// View configuration for wash
-    #[clap(name = "config", subcommand)]
-    Config(wash::cli::config::ConfigCommand),
+    Config(wash::cli::config::ConfigArgs),
     /// Start a development server for a Wasm component
-    #[clap(name = "dev")]
     Dev(wash::cli::dev::DevCommand),
     /// Inspect a Wasm component's embedded WIT
-    #[clap(name = "inspect", hide = true)]
     Inspect(wash::cli::inspect::InspectCommand),
     /// Act as a Host
-    #[clap(name = "host")]
     Host(wash::cli::host::HostCommand),
     /// Create a new project from a template or git repository
-    #[clap(name = "new")]
     New(wash::cli::new::NewCommand),
     /// Push or pull Wasm components to/from an OCI registry
-    #[clap(name = "oci", alias = "docker", subcommand)]
-    Oci(wash::cli::oci::OciCommand),
+    #[command(alias = "docker")]
+    Oci(wash::cli::oci::OciArgs),
     /// Update wash to the latest version
-    #[clap(name = "update", alias = "upgrade")]
+    #[command(alias = "upgrade")]
     Update(wash::cli::update::UpdateCommand),
     /// Manage WIT dependencies
-    #[clap(name = "wit", subcommand)]
-    Wit(wash::cli::wit::WitCommand),
+    Wit(wash::cli::wit::WitArgs),
 }
 
 impl CliCommand for WashCliCommand {
@@ -149,7 +123,21 @@ async fn main() {
         .disable_help_subcommand(true)
         .ignore_errors(true)
         .get_matches();
-    let global_args = Cli::from_arg_matches(&global_parser).unwrap_or_else(|e| e.exit());
+    // Use unwrap_or to provide defaults when the first parse fails.
+    // This can happen when a nested subcommand is missing (e.g., `wash config`
+    // without a subcommand like `init`). By falling through with defaults,
+    // the second parse below can show proper help via arg_required_else_help.
+    let global_args = Cli::from_arg_matches(&global_parser).unwrap_or(Cli {
+        output: OutputKind::Text,
+        help_markdown: false,
+        log_level: Level::INFO,
+        verbose: false,
+        non_interactive: false,
+        user_config: None,
+        project_path: find_project_root(),
+        enable_meters: false,
+        command: None,
+    });
 
     // Check for --non-interactive flag before parsing (to avoid requiring plugin commands to be registered)
     let non_interactive_flag = global_args.non_interactive;


### PR DESCRIPTION
Migrate all clap attributes from deprecated #[clap(...)] to the v4
`#[command(...)]` and `#[arg(...)]` syntax.

Wrap config, oci, and wit subcommands
in Args structs for consistent help display. Remove redundant name = "..."
attributes that match auto-derived names. Convert inline help = "..." to doc
comments for consistency. Unhide the inspect command. Add missing doc comments
on DevCommand, WitCommand, and OciCommand variants.

```code
  wash help — inspect command now visible

  Before

  Commands:
    build       Build a Wasm component
    completion  Generate shell completions
    config      View configuration for wash
    dev         Start a development server for a Wasm component
    host        Act as a Host
    new         Create a new project from a template or git repository
    oci         Push or pull Wasm components to/from an OCI registry
    update      Update wash to the latest version
    wit         Manage WIT dependencies
    help        Print this message or the help of the given subcommand(s)

  After

  Commands:
    build       Build a Wasm component
    completion  Generate shell completions
    config      View configuration for wash
    dev         Start a development server for a Wasm component
    inspect     Inspect a Wasm component's embedded WIT
    host        Act as a Host
    new         Create a new project from a template or git repository
    oci         Push or pull Wasm components to/from an OCI registry
    update      Update wash to the latest version
    wit         Manage WIT dependencies
    help        Print this message or the help of the given subcommand(s)

  ---
  wash config — shows help instead of cryptic error

  Before

  error: a subcommand is required but one was not provided

  After

  View configuration for wash

  Usage: wash config [OPTIONS] <COMMAND>

  Commands:
    init  Initialize a new configuration file for wash
    info  Print the current version and local directories used by wash
    show  Print the current configuration file for wash
    help  Print this message or the help of the given subcommand(s)

  Options:
    -o, --output <OUTPUT>            Specify output format (text or json) [default: text]
    -l, --log-level <LOG_LEVEL>      Set the opentelemetry log level (trace, debug, info, warn, error) [default: INFO]
        --verbose                    Enable verbose output
        --non-interactive            Run in non-interactive mode ...
        --user-config <USER_CONFIG>  Path to user configuration file
        --enable-meters              Enable host meters
    -h, --help                       Print help

  ---
  wash oci — shows help instead of cryptic error

  Before

  error: a subcommand is required but one was not provided

  After

  Push or pull Wasm components to/from an OCI registry

  Usage: wash oci [OPTIONS] <COMMAND>

  Commands:
    pull  Pull a Wasm component from an OCI registry
    push  Push a Wasm component to an OCI registry
    help  Print this message or the help of the given subcommand(s)

  Options:
    ...
    -h, --help                       Print help

  ---
  wash wit — shows help instead of cryptic error

  Before

  error: a subcommand is required but one was not provided

  After

  Manage WIT dependencies

  Usage: wash wit [OPTIONS] <COMMAND>

  Commands:
    fetch   Fetch WIT dependencies (reads from wit/world.wit imports)
    update  Update dependencies to latest compatible versions
    add     Add a new WIT dependency
    remove  Remove a WIT dependency
    clean   Remove fetched dependencies (wit/deps/)
    build   Build a WIT package into a Wasm binary
    help    Print this message or the help of the given subcommand(s)

  Options:
    ...
    -h, --help                       Print help

  ---
  wash config --help / wash oci --help — now works

  Before

  error: a subcommand is required but one was not provided

  After

  Shows full help output (same as wash help config / wash help oci).

  ---
  wash help oci — subcommands now have descriptions

  Before

  Commands:
    pull
    push
    help  Print this message or the help of the given subcommand(s)

  After

  Commands:
    pull  Pull a Wasm component from an OCI registry
    push  Push a Wasm component to an OCI registry
    help  Print this message or the help of the given subcommand(s)
```
