### PR TITLE
fix: sequential message handling

### DIFF
--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -367,30 +367,34 @@ impl HostPlugin for InMemoryMessaging {
                             reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"),
                         );
 
-                        let result = fuel_meter.observe(
-                            &[
-                                KeyValue::new("plugin", PLUGIN_MESSAGING_MEMORY_ID),
-                                KeyValue::new("subject", msg.subject.to_string()),
-                            ],
-                            &mut store,
-                            async move |store| {
-                                proxy
-                                    .wasmcloud_messaging_handler()
-                                    .call_handle_message(store, &msg)
-                                    .instrument(span)
-                                    .await
-                                    .map_err(Into::into)
-                            }
-                        ).await;
+                        let fuel_meter = fuel_meter.clone();
 
-                        match result {
-                            Ok(_) => {
-                                debug!("Message handled successfully");
-                            }
-                            Err(e) => {
-                                warn!("Error handling message: {e}");
-                            }
-                        };
+                        tokio::spawn(async move {
+                            let result = fuel_meter.observe(
+                                &[
+                                    KeyValue::new("plugin", PLUGIN_MESSAGING_MEMORY_ID),
+                                    KeyValue::new("subject", msg.subject.to_string()),
+                                ],
+                                &mut store,
+                                async move |store| {
+                                    proxy
+                                        .wasmcloud_messaging_handler()
+                                        .call_handle_message(store, &msg)
+                                        .instrument(span)
+                                        .await
+                                        .map_err(Into::into)
+                                }
+                            ).await;
+
+                            match result {
+                                Ok(_) => {
+                                    debug!("Message handled successfully");
+                                }
+                                Err(e) => {
+                                    warn!("Error handling message: {e}");
+                                }
+                            };
+                        });
                     }
                 }
             }

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -261,31 +261,34 @@ impl HostPlugin for NatsMessaging {
                             reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"),
                         );
 
-                        let result = fuel_meter.observe(
-                            &[
-                                KeyValue::new("plugin", PLUGIN_MESSAGING_ID),
-                                KeyValue::new("subject", msg.subject.to_string()),
-                            ],
-                            &mut store,
-                            async move |store| {
-                                proxy
-                                    .wasmcloud_messaging_handler()
-                                    .call_handle_message(store, &msg)
-                                    .instrument(span)
-                                    .await
-                                    .map_err(Into::into)
-                            }
-                        ).await;
+                        let fuel_meter = fuel_meter.clone();
 
-                        match result {
-                            Ok(_) => {
-                                debug!("Message handled successfully");
-                            }
-                            Err(e) => {
-                                warn!("Error handling message: {e}");
-                            }
-                        };
+                        tokio::spawn(async move {
+                            let result = fuel_meter.observe(
+                                &[
+                                    KeyValue::new("plugin", PLUGIN_MESSAGING_ID),
+                                    KeyValue::new("subject", msg.subject.to_string()),
+                                ],
+                                &mut store,
+                                async move |store| {
+                                    proxy
+                                        .wasmcloud_messaging_handler()
+                                        .call_handle_message(store, &msg)
+                                        .instrument(span)
+                                        .await
+                                        .map_err(Into::into)
+                                }
+                            ).await;
 
+                            match result {
+                                Ok(_) => {
+                                    debug!("Message handled successfully");
+                                }
+                                Err(e) => {
+                                    warn!("Error handling message: {e}");
+                                }
+                            };
+                        });
                     }
                     _ = cancel_token.cancelled() => {
                         break;


### PR DESCRIPTION
Currently, messages for the same topic are processed sequentially. If there are multiple messages, this introduces unnecessary latency in message handling.

The most interesting part is that I encountered a kind of deadlock (if that’s the right term) in the following scenario:
→ (incoming message) Component A → (WIT interface) My Plugin → (NATS request) Component A