### PR TITLE
fix: lint errors in runtime-operator

### DIFF
--- a/.github/workflows/runtime-operator.yml
+++ b/.github/workflows/runtime-operator.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - "runtime-operator/**"
       - "proto/**"
+      - "charts/runtime-operator/**"
+      - "kind-config.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -42,24 +44,68 @@ jobs:
         working-directory: runtime-operator
         run: make test
 
-  test-e2e:
+  build:
     needs: [lint, test]
     runs-on: ubuntu-latest
-    # NOTE(lxf): Disabled until we update prometheus/cert-manager in the test setup
-    if: false
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Build operator image
+        working-directory: runtime-operator
+        run: make docker-build IMG=example.com/operator:v0.0.1
+      - name: Save operator image
+        run: docker save example.com/operator:v0.0.1 -o /tmp/operator-image.tar
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: operator-image
+          path: /tmp/operator-image.tar
+          retention-days: 1
+
+  test-e2e:
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-go
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: operator-image
+          path: /tmp
+      - name: Load operator image
+        run: docker load -i /tmp/operator-image.tar
       - uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          cluster_name: kind
-      - name: Running Test e2e
+          cluster_name: wasmcloud-e2e
+          config: kind-config.yaml
+      - name: Run e2e tests
         working-directory: runtime-operator
         run: make test-e2e
+        env:
+          SKIP_IMAGE_BUILD: "true"
+          PROMETHEUS_INSTALL_SKIP: "true"
+          CERT_MANAGER_INSTALL_SKIP: "true"
+          KIND_CLUSTER_NAME: wasmcloud-e2e
+      - name: Dump diagnostics
+        if: failure()
+        run: |
+          echo "=== Pod Status ==="
+          kubectl get pods -n wasmcloud-system -o wide
+          echo "=== Events ==="
+          kubectl get events -n wasmcloud-system --sort-by=.lastTimestamp
+          echo "=== Operator Logs ==="
+          kubectl logs -n wasmcloud-system -l wasmcloud.com/name=runtime-operator --tail=200 || true
+          echo "=== Gateway Logs ==="
+          kubectl logs -n wasmcloud-system -l wasmcloud.com/name=runtime-gateway --tail=200 || true
+          echo "=== Host Logs ==="
+          kubectl logs -n wasmcloud-system -l wasmcloud.com/name=hostgroup --tail=200 || true
+          echo "=== CRD Resources ==="
+          kubectl get hosts.runtime.wasmcloud.dev -A -o yaml || true
+          kubectl get workloaddeployments.runtime.wasmcloud.dev -A -o yaml || true
+          kubectl get workloads.runtime.wasmcloud.dev -A -o yaml || true
 
   canary:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'canary')
-    needs: [lint, test]
+    needs: [lint, test, test-e2e]
     permissions:
       contents: write
       packages: write
@@ -75,7 +121,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [lint, test]
+    needs: [lint, test, test-e2e]
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-operator.yml
+++ b/.github/workflows/runtime-operator.yml
@@ -7,8 +7,11 @@ on:
       - "v*"
   pull_request:
     paths:
+      - ".github/workflows/runtime-operator.yml"
       - "runtime-operator/**"
       - "proto/**"
+      - "charts/runtime-operator/**"
+      - "kind-config.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -42,24 +45,68 @@ jobs:
         working-directory: runtime-operator
         run: make test
 
-  test-e2e:
+  build:
     needs: [lint, test]
     runs-on: ubuntu-latest
-    # NOTE(lxf): Disabled until we update prometheus/cert-manager in the test setup
-    if: false
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Build operator image
+        working-directory: runtime-operator
+        run: make docker-build IMG=example.com/operator:v0.0.1
+      - name: Save operator image
+        run: docker save example.com/operator:v0.0.1 -o /tmp/operator-image.tar
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: operator-image
+          path: /tmp/operator-image.tar
+          retention-days: 1
+
+  test-e2e:
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-go
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: operator-image
+          path: /tmp
+      - name: Load operator image
+        run: docker load -i /tmp/operator-image.tar
       - uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          cluster_name: kind
-      - name: Running Test e2e
+          cluster_name: wasmcloud-e2e
+          config: kind-config.yaml
+      - name: Run e2e tests
         working-directory: runtime-operator
         run: make test-e2e
+        env:
+          SKIP_IMAGE_BUILD: "true"
+          PROMETHEUS_INSTALL_SKIP: "true"
+          CERT_MANAGER_INSTALL_SKIP: "true"
+          KIND_CLUSTER_NAME: wasmcloud-e2e
+      - name: Dump diagnostics
+        if: failure()
+        run: |
+          echo "=== Pod Status ==="
+          kubectl get pods -n wasmcloud-system -o wide
+          echo "=== Events ==="
+          kubectl get events -n wasmcloud-system --sort-by=.lastTimestamp
+          echo "=== Operator Logs ==="
+          kubectl logs -n wasmcloud-system -l wasmcloud.com/name=runtime-operator --tail=200 || true
+          echo "=== Gateway Logs ==="
+          kubectl logs -n wasmcloud-system -l wasmcloud.com/name=runtime-gateway --tail=200 || true
+          echo "=== Host Logs ==="
+          kubectl logs -n wasmcloud-system -l wasmcloud.com/name=hostgroup --tail=200 || true
+          echo "=== CRD Resources ==="
+          kubectl get hosts.runtime.wasmcloud.dev -A -o yaml || true
+          kubectl get workloaddeployments.runtime.wasmcloud.dev -A -o yaml || true
+          kubectl get workloads.runtime.wasmcloud.dev -A -o yaml || true
 
   canary:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'canary')
-    needs: [lint, test]
+    needs: [lint, test, test-e2e]
     permissions:
       contents: write
       packages: write
@@ -75,7 +122,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [lint, test]
+    needs: [lint, test, test-e2e]
     permissions:
       contents: write
       packages: write

--- a/runtime-operator/Makefile
+++ b/runtime-operator/Makefile
@@ -69,11 +69,9 @@ test: manifests generate fmt vet envtest ## Run tests.
 # - PROMETHEUS_INSTALL_SKIP=true
 # - CERT_MANAGER_INSTALL_SKIP=true
 .PHONY: test-e2e
-test-e2e: manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	@kind get clusters | grep -q 'kind' || { \
-		echo "No Kind cluster is running. Please start a Kind cluster before running the e2e tests."; \
-		exit 1; \
-	}
+test-e2e: ## Run the e2e tests. Expected an isolated environment using Kind.
+	@command -v kind >/dev/null 2>&1 || { echo "kind is required"; exit 1; }
+	@kind get clusters | grep -q "$${KIND_CLUSTER_NAME:-kind}" || { echo "Kind cluster not found"; exit 1; }
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint

--- a/runtime-operator/pkg/crdtools/spec_helpers.go
+++ b/runtime-operator/pkg/crdtools/spec_helpers.go
@@ -51,7 +51,7 @@ func MergeEnvVar(envs ...[]corev1.EnvVar) []corev1.EnvVar {
 		}
 	}
 
-	keys := make([]string, 0)
+	keys := make([]string, 0, len(idx))
 	for k := range idx {
 		keys = append(keys, k)
 	}

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -30,26 +30,32 @@ import (
 
 var (
 	// Optional Environment Variables:
-	// - PROMETHEUS_INSTALL_SKIP=true: Skips Prometheus Operator installation during test setup.
-	// - CERT_MANAGER_INSTALL_SKIP=true: Skips CertManager installation during test setup.
-	// These variables are useful if Prometheus or CertManager is already installed, avoiding
-	// re-installation and conflicts.
-	skipPrometheusInstall  = os.Getenv("PROMETHEUS_INSTALL_SKIP") == "true"
-	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
+	// - PROMETHEUS_INSTALL_SKIP=true: Skips Prometheus Operator installation during test setup (default: true).
+	// - CERT_MANAGER_INSTALL_SKIP=true: Skips CertManager installation during test setup (default: true).
+	skipPrometheusInstall  = os.Getenv("PROMETHEUS_INSTALL_SKIP") != "false"
+	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") != "false"
 	// isPrometheusOperatorAlreadyInstalled will be set true when prometheus CRDs be found on the cluster
 	isPrometheusOperatorAlreadyInstalled = false
 	// isCertManagerAlreadyInstalled will be set true when CertManager CRDs be found on the cluster
 	isCertManagerAlreadyInstalled = false
 
-	// projectImage is the name of the image which will be build and loaded
-	// with the code source changes to be tested.
-	projectImage = "example.com/operator:v0.0.1"
+	// skipImageBuild skips the docker build step (set SKIP_IMAGE_BUILD=true when image is pre-built)
+	skipImageBuild = os.Getenv("SKIP_IMAGE_BUILD") == "true"
+
+	// operatorImageRepo and operatorImageTag are used for Helm --set overrides
+	operatorImageRepo = "example.com/operator"
+	operatorImageTag  = "v0.0.1"
+	// projectImage is the full image name built and loaded into Kind
+	projectImage = fmt.Sprintf("%s:%s", operatorImageRepo, operatorImageTag)
+
+	// helmChartPath points to the runtime-operator Helm chart relative to the project dir (runtime-operator/)
+	helmChartPath = "../charts/runtime-operator"
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
 // temporary environment to validate project changes with the the purposed to be used in CI jobs.
-// The default setup requires Kind, builds/loads the Manager Docker image locally, and installs
-// CertManager and Prometheus.
+// The default setup requires Kind, builds/loads the Manager Docker image locally, and deploys
+// the full stack via Helm.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting operator integration test suite\n")
@@ -57,33 +63,44 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	By("Ensure that Prometheus is enabled")
-	_ = utils.UncommentCode("config/default/kustomization.yaml", "#- ../prometheus", "#")
+	if !skipImageBuild {
+		By("building the operator image")
+		cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the operator image")
+	}
 
-	By("generating files")
-	cmd := exec.Command("make", "generate")
-	_, err := utils.Run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to run make generate")
+	By("loading the operator image into Kind")
+	err := utils.LoadImageToKindClusterWithName(projectImage)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the operator image into Kind")
 
-	By("generating manifests")
-	cmd = exec.Command("make", "manifests")
+	By("installing the runtime-operator via Helm")
+	cmd := exec.Command("helm", "upgrade", "--install", "--create-namespace",
+		"-n", namespace,
+		"--set", fmt.Sprintf("operator.image.registry=%s", ""),
+		"--set", fmt.Sprintf("operator.image.repository=%s", operatorImageRepo),
+		"--set", fmt.Sprintf("operator.image.tag=%s", operatorImageTag),
+		"--set", "operator.image.pull_policy=Never",
+		"--set", "gateway.image.tag=canary",
+		"--set", "gateway.service.type=NodePort",
+		"--set", "gateway.service.nodePort=30950",
+		"--set", "runtime.image.tag=canary-v2",
+		"--set", "runtime.hostGroups[0].name=default",
+		"--set", "runtime.hostGroups[0].replicas=1",
+		"--set", "runtime.hostGroups[0].service.type=ClusterIP",
+		"--set", "runtime.hostGroups[0].http.enabled=true",
+		"--set", "runtime.hostGroups[0].http.port=80",
+		"--set", "runtime.hostGroups[0].webgpu.enabled=false",
+		"--set", "runtime.hostGroups[0].resources.requests.memory=64Mi",
+		"--set", "runtime.hostGroups[0].resources.requests.cpu=250m",
+		"--set", "runtime.hostGroups[0].resources.limits.memory=512Mi",
+		"--set", "runtime.hostGroups[0].resources.limits.cpu=500m",
+		"--wait", "--timeout=5m",
+		"operator-e2e", helmChartPath,
+	)
 	_, err = utils.Run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to run make manifests")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to install the runtime-operator via Helm")
 
-	By("building the manager(Operator) image")
-	cmd = exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
-	_, err = utils.Run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
-
-	// TODO(user): If you want to change the e2e test vendor from Kind, ensure the image is
-	// built and available before running the tests. Also, remove the following block.
-	By("loading the manager(Operator) image on Kind")
-	err = utils.LoadImageToKindClusterWithName(projectImage)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
-
-	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
-	// To prevent errors when tests run in environments with Prometheus or CertManager already installed,
-	// we check for their presence before execution.
 	// Setup Prometheus and CertManager before the suite if not skipped and if not already installed
 	if !skipPrometheusInstall {
 		By("checking if prometheus is installed already")
@@ -108,6 +125,10 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	By("uninstalling the Helm release")
+	cmd := exec.Command("helm", "delete", "-n", namespace, "operator-e2e")
+	_, _ = utils.Run(cmd)
+
 	// Teardown Prometheus and CertManager after the suite if not skipped and if they were not already installed
 	if !skipPrometheusInstall && !isPrometheusOperatorAlreadyInstalled {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling Prometheus Operator...\n")

--- a/runtime-operator/test/e2e/e2e_test.go
+++ b/runtime-operator/test/e2e/e2e_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 // namespace where the project is deployed in
-const namespace = "operator-system"
+const namespace = "wasmcloud-system"
 
 // serviceAccountName created for the project
 const serviceAccountName = "operator-controller-manager"
@@ -45,52 +45,14 @@ const metricsRoleBindingName = "operator-metrics-binding"
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
 
-	// Before running the tests, set up the environment by creating the namespace,
-	// installing CRDs, and deploying the controller.
-	BeforeAll(func() {
-		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("installing CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-	})
-
-	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
-	// and deleting the namespace.
-	AfterAll(func() {
-		By("cleaning up the curl pod for metrics")
-		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
-		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
-
-		By("removing manager namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", namespace)
-		_, _ = utils.Run(cmd)
-	})
-
 	// After each test, check for failures and collect logs, events,
 	// and pod descriptions for debugging.
 	AfterEach(func() {
 		specReport := CurrentSpecReport()
 		if specReport.Failed() {
 			By("Fetching controller manager pod logs")
-			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
+			cmd := exec.Command("kubectl", "logs", "-n", namespace,
+				"-l", "wasmcloud.com/name=runtime-operator", "--tail=200")
 			controllerLogs, err := utils.Run(cmd)
 			if err == nil {
 				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n %s", controllerLogs)
@@ -107,22 +69,13 @@ var _ = Describe("Manager", Ordered, func() {
 				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events: %s", err)
 			}
 
-			By("Fetching curl-metrics logs")
-			cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
-			metricsOutput, err := utils.Run(cmd)
+			By("Fetching all pod status")
+			cmd = exec.Command("kubectl", "get", "pods", "-n", namespace, "-o", "wide")
+			podOutput, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Metrics logs:\n %s", metricsOutput)
+				_, _ = fmt.Fprintf(GinkgoWriter, "Pod status:\n%s", podOutput)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get curl-metrics logs: %s", err)
-			}
-
-			By("Fetching controller manager pod description")
-			cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", namespace)
-			podDescription, err := utils.Run(cmd)
-			if err == nil {
-				fmt.Println("Pod description:\n", podDescription)
-			} else {
-				fmt.Println("Failed to describe controller pod")
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get pod status: %s", err)
 			}
 		}
 	})
@@ -134,9 +87,8 @@ var _ = Describe("Manager", Ordered, func() {
 		It("should run successfully", func() {
 			By("validating that the controller-manager pod is running as expected")
 			verifyControllerUp := func(g Gomega) {
-				// Get the name of the controller-manager pod
 				cmd := exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
+					"pods", "-l", "wasmcloud.com/name=runtime-operator",
 					"-o", "go-template={{ range .items }}"+
 						"{{ if not .metadata.deletionTimestamp }}"+
 						"{{ .metadata.name }}"+
@@ -149,7 +101,6 @@ var _ = Describe("Manager", Ordered, func() {
 				podNames := utils.GetNonEmptyLines(podOutput)
 				g.Expect(podNames).To(HaveLen(1), "expected 1 controller pod running")
 				controllerPodName = podNames[0]
-				g.Expect(controllerPodName).To(ContainSubstring("controller-manager"))
 
 				// Validate the pod's status
 				cmd = exec.Command("kubectl", "get",
@@ -164,6 +115,10 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 
 		It("should ensure the metrics endpoint is serving metrics", func() {
+			if skipPrometheusInstall {
+				Skip("Prometheus not installed, skipping metrics test")
+			}
+
 			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
 			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
 				"--clusterrole=operator-metrics-reader",
@@ -235,15 +190,101 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 
 		// +kubebuilder:scaffold:e2e-webhooks-checks
+	})
 
-		// TODO: Customize the e2e test suite with scenarios specific to your project.
-		// Consider applying sample/CR(s) and check their status and/or verifying
-		// the reconciliation by using the metrics, i.e.:
-		// metricsOutput := getMetricsOutput()
-		// Expect(metricsOutput).To(ContainSubstring(
-		//    fmt.Sprintf(`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
-		//    strings.ToLower(<Kind>),
-		// ))
+	Context("Infrastructure", func() {
+		It("should have all pods running", func() {
+			for _, label := range []string{"nats", "runtime-operator", "runtime-gateway", "hostgroup"} {
+				verifyPodReady := func(g Gomega) {
+					cmd := exec.Command("kubectl", "wait", "--for=condition=Ready",
+						"pod", "-l", fmt.Sprintf("wasmcloud.com/name=%s", label),
+						"-n", namespace, "--timeout=10s")
+					_, err := utils.Run(cmd)
+					g.Expect(err).NotTo(HaveOccurred())
+				}
+				Eventually(verifyPodReady).WithTimeout(3 * time.Minute).Should(Succeed())
+			}
+		})
+	})
+
+	Context("Host Registration", func() {
+		It("should register at least one host", func() {
+			verifyHostRegistered := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "hosts.runtime.wasmcloud.dev",
+					"-n", namespace, "-o", "jsonpath={.items}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(Equal("[]"), "no hosts registered yet")
+			}
+			Eventually(verifyHostRegistered).WithTimeout(2 * time.Minute).Should(Succeed())
+		})
+	})
+
+	Context("Workload Lifecycle", func() {
+		const sampleDeployment = "config/samples/deployment.yaml"
+
+		It("should deploy a workload and become ready", func() {
+			By("applying the sample WorkloadDeployment")
+			cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", sampleDeployment)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for WorkloadDeployment to become Ready")
+			verifyWorkloadReady := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "workloaddeployment", "hello",
+					"-n", namespace,
+					"-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"))
+			}
+			Eventually(verifyWorkloadReady).WithTimeout(3 * time.Minute).Should(Succeed())
+
+			By("verifying WorkloadReplicaSet was created")
+			cmd = exec.Command("kubectl", "get", "workloadreplicasets.runtime.wasmcloud.dev",
+				"-n", namespace, "-o", "jsonpath={.items}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(Equal("[]"))
+
+			By("verifying Workload CR was created")
+			cmd = exec.Command("kubectl", "get", "workloads.runtime.wasmcloud.dev",
+				"-n", namespace, "-o", "jsonpath={.items}")
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(Equal("[]"))
+		})
+
+		It("should serve HTTP traffic through the gateway", func() {
+			verifyHTTP := func(g Gomega) {
+				cmd := exec.Command("curl", "-s", "-o", "/dev/null",
+					"-w", "%{http_code}",
+					"-H", "Host: hello.localhost.direct",
+					"http://localhost:80")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("200"))
+			}
+			Eventually(verifyHTTP).WithTimeout(1 * time.Minute).Should(Succeed())
+		})
+
+		It("should clean up workload resources on delete", func() {
+			By("deleting the WorkloadDeployment")
+			cmd := exec.Command("kubectl", "delete", "workloaddeployment", "hello",
+				"-n", namespace)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for Workload CRs to be cleaned up")
+			verifyCleanup := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "workloads.runtime.wasmcloud.dev",
+					"-n", namespace, "-o", "jsonpath={.items}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("[]"))
+			}
+			Eventually(verifyCleanup).WithTimeout(1 * time.Minute).Should(Succeed())
+		})
 	})
 })
 

--- a/runtime-operator/test/utils/utils.go
+++ b/runtime-operator/test/utils/utils.go
@@ -17,8 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -168,7 +166,7 @@ func IsCertManagerCRDsInstalled() bool {
 // LoadImageToKindClusterWithName loads a local docker image to the kind cluster
 func LoadImageToKindClusterWithName(name string) error {
 	cluster := "kind"
-	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
+	if v, ok := os.LookupEnv("KIND_CLUSTER_NAME"); ok {
 		cluster = v
 	}
 	kindOptions := []string{"load", "docker-image", name, "--name", cluster}
@@ -199,53 +197,4 @@ func GetProjectDir() (string, error) {
 	}
 	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
-}
-
-// UncommentCode searches for target in the file and remove the comment prefix
-// of the target content. The target content may span multiple lines.
-func UncommentCode(filename, target, prefix string) error {
-	// false positive
-	// nolint:gosec
-	content, err := os.ReadFile(filename)
-	if err != nil {
-		return err
-	}
-	strContent := string(content)
-
-	idx := strings.Index(strContent, target)
-	if idx < 0 {
-		return fmt.Errorf("unable to find the code %s to be uncomment", target)
-	}
-
-	out := new(bytes.Buffer)
-	_, err = out.Write(content[:idx])
-	if err != nil {
-		return err
-	}
-
-	scanner := bufio.NewScanner(bytes.NewBufferString(target))
-	if !scanner.Scan() {
-		return nil
-	}
-	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
-		}
-		// Avoid writing a newline in case the previous line was the last in target.
-		if !scanner.Scan() {
-			break
-		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
-		}
-	}
-
-	_, err = out.Write(content[idx+len(target):])
-	if err != nil {
-		return err
-	}
-	// false positive
-	// nolint:gosec
-	return os.WriteFile(filename, out.Bytes(), 0o644)
 }

--- a/runtime-operator/test/utils/utils.go
+++ b/runtime-operator/test/utils/utils.go
@@ -17,8 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -168,7 +166,7 @@ func IsCertManagerCRDsInstalled() bool {
 // LoadImageToKindClusterWithName loads a local docker image to the kind cluster
 func LoadImageToKindClusterWithName(name string) error {
 	cluster := "kind"
-	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
+	if v, ok := os.LookupEnv("KIND_CLUSTER_NAME"); ok {
 		cluster = v
 	}
 	kindOptions := []string{"load", "docker-image", name, "--name", cluster}
@@ -201,51 +199,3 @@ func GetProjectDir() (string, error) {
 	return wd, nil
 }
 
-// UncommentCode searches for target in the file and remove the comment prefix
-// of the target content. The target content may span multiple lines.
-func UncommentCode(filename, target, prefix string) error {
-	// false positive
-	// nolint:gosec
-	content, err := os.ReadFile(filename)
-	if err != nil {
-		return err
-	}
-	strContent := string(content)
-
-	idx := strings.Index(strContent, target)
-	if idx < 0 {
-		return fmt.Errorf("unable to find the code %s to be uncomment", target)
-	}
-
-	out := new(bytes.Buffer)
-	_, err = out.Write(content[:idx])
-	if err != nil {
-		return err
-	}
-
-	scanner := bufio.NewScanner(bytes.NewBufferString(target))
-	if !scanner.Scan() {
-		return nil
-	}
-	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
-		}
-		// Avoid writing a newline in case the previous line was the last in target.
-		if !scanner.Scan() {
-			break
-		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
-		}
-	}
-
-	_, err = out.Write(content[idx+len(target):])
-	if err != nil {
-		return err
-	}
-	// false positive
-	// nolint:gosec
-	return os.WriteFile(filename, out.Bytes(), 0o644)
-}

--- a/runtime-operator/test/utils/utils.go
+++ b/runtime-operator/test/utils/utils.go
@@ -198,4 +198,3 @@ func GetProjectDir() (string, error) {
 	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }
-


### PR DESCRIPTION
- remove trailing space
- initialize make to length of keys to idx
Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
