### PR TITLE
fix: update lock file to address RUSTSEC-2026-0007

### DIFF
--- a/examples/grpc-hello-world/Cargo.lock
+++ b/examples/grpc-hello-world/Cargo.lock
@@ -179,9 +179,9 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"


### PR DESCRIPTION
bytes is now at 1.11.1 in `examples/grpc-hello-world/Cargo.lock``,
which resolves RUSTSEC-2026-0007 (integer overflow in BytesMut::reserve)

The only change needed was updating the lockfile. The Cargo.toml
dependency spec (bytes = "1") already allows 1.11.1.

Signed-off-by: Bailey Hayes <bailey@cosmonic.com>
