### PR TITLE
feat: add OCI push/pull e2e test with testcontainers

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Test
         env:
           RUST_BACKTRACE: "1"
+          OCI_INTEGRATION_TESTS: ${{ matrix.os == 'ubuntu-latest' && '1' || '' }}
         run: |
           cargo test --workspace
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash 2.1.1",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +353,28 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -598,6 +636,80 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bollard"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bitflags",
+ "bollard-buildkit-proto",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "num",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-buildkit-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+dependencies = [
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost 0.14.3",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "time",
 ]
 
 [[package]]
@@ -877,7 +989,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1810,6 +1922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,6 +1973,17 @@ dependencies = [
  "cfg-if",
  "rustix 1.1.4",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "ferroid"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
+dependencies = [
+ "portable-atomic",
+ "rand 0.9.2",
+ "web-time",
 ]
 
 [[package]]
@@ -2538,6 +2671,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +2739,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3890,6 +4053,31 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn",
 ]
 
 [[package]]
@@ -5671,6 +5859,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5846,6 +6057,37 @@ checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c0624faaa317c56d6d19136580be889677259caf5c897941c6f446b4655068"
+dependencies = [
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera 0.11.0",
+ "ferroid",
+ "futures",
+ "http",
+ "itertools 0.14.0",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -6566,6 +6808,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf-8",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6575,7 +6844,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -6799,6 +7075,7 @@ dependencies = [
  "serde_yaml_ng",
  "tar",
  "tempfile",
+ "testcontainers",
  "tokio",
  "tonic-prost-build",
  "tracing",
@@ -8481,6 +8758,16 @@ dependencies = [
  "der",
  "spki",
  "tls_codec",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ sha2 = { version = "0.10.8", default-features = false }
 sysinfo = { version = "0.32", default-features = false, features = ["system"] }
 tar = { version = "0.4", default-features = false }
 tempfile = { version = "3.15.0", default-features = false }
+testcontainers = { version = "0.27", default-features = false }
 tokio = { version = "1.45.1", default-features = false, features = ["full"] }
 tokio-util = { version = "0.7", default-features = false }
 tokio-rustls = { version = "0.26", default-features = false }

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -78,6 +78,7 @@ tempfile = { version = "3.0", default-features = false }
 tokio = { version = "1.45.1", default-features = false, features = ["full"] }
 reqwest = { workspace = true, features = ["json"] }
 wash-runtime = { workspace = true, features = ["wasi-keyvalue", "wasi-blobstore"] }
+testcontainers = { workspace = true }
 wat = { workspace = true }
 
 [package.metadata.binstall]

--- a/crates/wash/src/cli/oci.rs
+++ b/crates/wash/src/cli/oci.rs
@@ -49,19 +49,19 @@ impl CliCommand for OciCommand {
 #[derive(Args, Debug, Clone)]
 pub struct PullCommand {
     /// The OCI reference to pull
-    reference: String,
+    pub reference: String,
     /// The path to write the pulled component to
     #[arg(default_value = "component.wasm")]
-    component_path: PathBuf,
+    pub component_path: PathBuf,
     /// Use HTTP or HTTPS protocol
     #[arg(long = "insecure", default_value_t = false)]
-    insecure: bool,
+    pub insecure: bool,
     /// Username for basic authentication
     #[arg(short, long)]
-    user: Option<String>,
+    pub user: Option<String>,
     /// Password for basic authentication
     #[arg(short, long)]
-    password: Option<String>,
+    pub password: Option<String>,
 }
 
 impl PullCommand {
@@ -110,18 +110,18 @@ impl PullCommand {
 #[derive(Args, Debug, Clone)]
 pub struct PushCommand {
     /// The OCI reference to push
-    reference: String,
+    pub reference: String,
     /// The path to the component to push
-    component_path: PathBuf,
+    pub component_path: PathBuf,
     /// Use HTTP or HTTPS protocol
     #[arg(long = "insecure", default_value_t = false)]
-    insecure: bool,
+    pub insecure: bool,
     /// Username for basic authentication
     #[arg(short, long)]
-    user: Option<String>,
+    pub user: Option<String>,
     /// Password for basic authentication
     #[arg(short, long)]
-    password: Option<String>,
+    pub password: Option<String>,
 }
 
 impl PushCommand {

--- a/crates/wash/tests/integration_oci.rs
+++ b/crates/wash/tests/integration_oci.rs
@@ -1,0 +1,135 @@
+//! Integration tests for `wash oci push` / `wash oci pull` round-trip.
+//!
+//! Requires Docker and the `OCI_INTEGRATION_TESTS` env var to be set.
+//! Skips gracefully otherwise.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tempfile::TempDir;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage};
+use tokio::time::timeout;
+use wash::cli::CliContext;
+use wash::cli::oci::{PullCommand, PushCommand};
+
+/// Start a local OCI registry container (distribution/distribution) on a random host port.
+async fn start_registry() -> Result<(ContainerAsync<GenericImage>, u16)> {
+    let container = GenericImage::new("distribution/distribution", "edge")
+        .with_exposed_port(5000.into())
+        .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
+            "listening on",
+        ))
+        .start()
+        .await
+        .context("failed to start registry container")?;
+
+    let port = container
+        .get_host_port_ipv4(5000)
+        .await
+        .context("failed to get mapped port")?;
+
+    Ok((container, port))
+}
+
+#[tokio::test]
+async fn oci_push_pull_round_trip() -> Result<()> {
+    // Gate on env var — matches pattern from wash-runtime OCI tests
+    if std::env::var("OCI_INTEGRATION_TESTS")
+        .unwrap_or_default()
+        .is_empty()
+    {
+        eprintln!("Skipping OCI integration test (set OCI_INTEGRATION_TESTS=1 to enable)");
+        return Ok(());
+    }
+
+    // Start local registry
+    let (_container, port) = start_registry().await?;
+    let reference = format!("localhost:{port}/test/wash-e2e:v1");
+
+    // Create a minimal valid wasm component
+    let component_bytes = wat::parse_str("(component)").context("failed to parse WAT")?;
+
+    // Write component to a temp file
+    let temp = TempDir::new().context("failed to create temp dir")?;
+    let push_path = temp.path().join("push.wasm");
+    tokio::fs::write(&push_path, &component_bytes)
+        .await
+        .context("failed to write component to temp file")?;
+
+    // Build CLI context
+    let ctx = CliContext::builder()
+        .non_interactive(true)
+        .project_dir(temp.path().to_path_buf())
+        .build()
+        .await
+        .context("failed to create CLI context")?;
+
+    // Push
+    let push_cmd = PushCommand {
+        reference: reference.clone(),
+        component_path: push_path,
+        insecure: true,
+        user: None,
+        password: None,
+    };
+    let push_result = timeout(Duration::from_secs(30), push_cmd.handle(&ctx))
+        .await
+        .context("push timed out")?
+        .context("push failed")?;
+
+    assert!(
+        push_result.is_success(),
+        "push should succeed: {push_result:?}"
+    );
+
+    let push_digest = push_result
+        .json()
+        .and_then(|j| j.get("digest"))
+        .and_then(|d| d.as_str())
+        .context("push result missing digest")?
+        .to_string();
+
+    // Pull to a different path
+    let pull_path = temp.path().join("pulled.wasm");
+    let pull_cmd = PullCommand {
+        reference: reference.clone(),
+        component_path: pull_path.clone(),
+        insecure: true,
+        user: None,
+        password: None,
+    };
+    let pull_result = timeout(Duration::from_secs(30), pull_cmd.handle(&ctx))
+        .await
+        .context("pull timed out")?
+        .context("pull failed")?;
+
+    assert!(
+        pull_result.is_success(),
+        "pull should succeed: {pull_result:?}"
+    );
+
+    let pull_digest = pull_result
+        .json()
+        .and_then(|j| j.get("digest"))
+        .and_then(|d| d.as_str())
+        .context("pull result missing digest")?
+        .to_string();
+
+    // Verify round-trip integrity
+    let pulled_bytes = tokio::fs::read(&pull_path)
+        .await
+        .context("failed to read pulled component")?;
+    assert_eq!(
+        component_bytes, pulled_bytes,
+        "pulled bytes should match original"
+    );
+
+    // Verify digests match
+    assert_eq!(
+        push_digest, pull_digest,
+        "push and pull digests should match"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Add a self-contained integration test that validates the wash oci
push/pull round-trip using a local registry via testcontainers-rs.
The test is gated behind the OCI_INTEGRATION_TESTS env var and
enabled in CI on ubuntu-latest where Docker is available.

Signed-off-by: Bailey Hayes <bailey@cosmonic.com>
