### PR TITLE
feat: migrate runtime-operator Go module to v2

### DIFF
--- a/.github/workflows/runtime-gateway.yml
+++ b/.github/workflows/runtime-gateway.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     paths:
       - "runtime-gateway/**"
+      - "runtime-operator/**"
+      - "go.work"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,15 +21,16 @@ permissions:
 jobs:
   lint:
     permissions:
-      # Required: allow read access to the content for analysis.
       contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-go
-      - uses: ./.github/actions/lint-go
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
+          version: v2.4
           working-directory: runtime-gateway
+          args: --verbose --path-prefix runtime-gateway --timeout 5m
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/runtime-operator.yml
+++ b/.github/workflows/runtime-operator.yml
@@ -20,6 +20,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  GOWORK: "off"
+
 jobs:
   lint:
     permissions:
@@ -135,3 +138,21 @@ jobs:
       push: true
       tags: |
         type=semver,pattern={{version}},value=${{ github.ref_name }}
+
+  go-module-tag:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Create Go module tag
+        run: |
+          TAG="runtime-operator/${GITHUB_REF_NAME}"
+          if git ls-remote --tags origin "${TAG}" | grep -q "${TAG}"; then
+            echo "Tag ${TAG} already exists, skipping"
+          else
+            git tag "${TAG}"
+            git push origin "${TAG}"
+          fi

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -5,7 +5,7 @@ managed:
   override:
     - file_option: go_package
       # JAF: change this once runtime-operator is moved to wasmCloud
-      value: go.wasmcloud.dev/runtime-operator/pkg/rpc/wasmcloud/runtime/v2
+      value: go.wasmcloud.dev/runtime-operator/v2/pkg/rpc/wasmcloud/runtime/v2
       path: wasmcloud/runtime/v2
 plugins:
   # Docs

--- a/go.work
+++ b/go.work
@@ -4,3 +4,5 @@ use (
 	./runtime-gateway/
 	./runtime-operator/
 )
+
+replace go.wasmcloud.dev/runtime-operator/v2 v2.0.0 => ./runtime-operator

--- a/runtime-gateway/go.mod
+++ b/runtime-gateway/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 tool github.com/air-verse/air
 
 require (
-	go.wasmcloud.dev/runtime-operator v0.1.4
+	go.wasmcloud.dev/runtime-operator/v2 v2.0.0
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
 	sigs.k8s.io/controller-runtime v0.22.3

--- a/runtime-gateway/main.go
+++ b/runtime-gateway/main.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1"
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
 )
 
 var (

--- a/runtime-gateway/reconciler.go
+++ b/runtime-gateway/reconciler.go
@@ -7,7 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1"
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
 )
 
 // WorkloadReconciler

--- a/runtime-operator/PROJECT
+++ b/runtime-operator/PROJECT
@@ -18,7 +18,7 @@ resources:
   domain: wasmcloud.dev
   group: runtime
   kind: Host
-  path: go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1
+  path: go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -27,7 +27,7 @@ resources:
   domain: wasmcloud.dev
   group: runtime
   kind: Artifact
-  path: go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1
+  path: go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -36,7 +36,7 @@ resources:
   domain: wasmcloud.dev
   group: runtime
   kind: Workload
-  path: go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1
+  path: go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -45,7 +45,7 @@ resources:
   domain: wasmcloud.dev
   group: runtime
   kind: WorkloadReplicaSet
-  path: go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1
+  path: go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -54,6 +54,6 @@ resources:
   domain: wasmcloud.dev
   group: runtime
   kind: WorkloadDeployment
-  path: go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1
+  path: go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1
   version: v1alpha1
 version: "3"

--- a/runtime-operator/api/runtime/v1alpha1/artifact_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/artifact_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"go.wasmcloud.dev/runtime-operator/api/condition"
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/runtime-operator/api/runtime/v1alpha1/host_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/host_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"go.wasmcloud.dev/runtime-operator/api/condition"
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/runtime-operator/api/runtime/v1alpha1/workload_deployment_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_deployment_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"go.wasmcloud.dev/runtime-operator/api/condition"
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/runtime-operator/api/runtime/v1alpha1/workload_replicaset_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_replicaset_types.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	"go.wasmcloud.dev/runtime-operator/api/condition"
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/runtime-operator/api/runtime/v1alpha1/workload_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"go.wasmcloud.dev/runtime-operator/api/condition"
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/runtime-operator/buf.gen.yaml
+++ b/runtime-operator/buf.gen.yaml
@@ -5,7 +5,7 @@ managed:
   override:
     - file_option: go_package
       # JAF: change this once runtime-operator is moved to wasmCloud
-      value: go.wasmcloud.dev/runtime-operator/pkg/rpc/wasmcloud/runtime/v2
+      value: go.wasmcloud.dev/runtime-operator/v2/pkg/rpc/wasmcloud/runtime/v2
       path: wasmcloud/runtime/v2
 plugins:
   # Docs

--- a/runtime-operator/cmd/main.go
+++ b/runtime-operator/cmd/main.go
@@ -38,12 +38,12 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"go.wasmcloud.dev/runtime-operator/pkg/wasmbus"
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus"
 
 	"github.com/nats-io/nats.go"
-	runtime_operator "go.wasmcloud.dev/runtime-operator"
+	runtime_operator "go.wasmcloud.dev/runtime-operator/v2"
 
-	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1"
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/runtime-operator/go.mod
+++ b/runtime-operator/go.mod
@@ -1,4 +1,4 @@
-module go.wasmcloud.dev/runtime-operator
+module go.wasmcloud.dev/runtime-operator/v2
 
 go 1.25.0
 

--- a/runtime-operator/internal/controller/runtime/artifact_controller.go
+++ b/runtime-operator/internal/controller/runtime/artifact_controller.go
@@ -9,9 +9,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"go.wasmcloud.dev/runtime-operator/api/condition"
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 
-	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1"
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
 )
 
 const (

--- a/runtime-operator/internal/controller/runtime/host_client.go
+++ b/runtime-operator/internal/controller/runtime/host_client.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	runtimev2 "go.wasmcloud.dev/runtime-operator/pkg/rpc/wasmcloud/runtime/v2"
-	"go.wasmcloud.dev/runtime-operator/pkg/wasmbus"
+	runtimev2 "go.wasmcloud.dev/runtime-operator/v2/pkg/rpc/wasmcloud/runtime/v2"
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"

--- a/runtime-operator/internal/controller/runtime/host_controller.go
+++ b/runtime-operator/internal/controller/runtime/host_controller.go
@@ -13,11 +13,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"go.wasmcloud.dev/runtime-operator/api/condition"
-	"go.wasmcloud.dev/runtime-operator/pkg/wasmbus"
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus"
 
-	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1"
-	runtimev2 "go.wasmcloud.dev/runtime-operator/pkg/rpc/wasmcloud/runtime/v2"
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
+	runtimev2 "go.wasmcloud.dev/runtime-operator/v2/pkg/rpc/wasmcloud/runtime/v2"
 )
 
 const (

--- a/runtime-operator/internal/controller/runtime/utils.go
+++ b/runtime-operator/internal/controller/runtime/utils.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli/config/configfile"
-	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1"
-	runtimev2 "go.wasmcloud.dev/runtime-operator/pkg/rpc/wasmcloud/runtime/v2"
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
+	runtimev2 "go.wasmcloud.dev/runtime-operator/v2/pkg/rpc/wasmcloud/runtime/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/runtime-operator/internal/controller/runtime/workload_controller.go
+++ b/runtime-operator/internal/controller/runtime/workload_controller.go
@@ -10,11 +10,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"go.wasmcloud.dev/runtime-operator/api/condition"
-	"go.wasmcloud.dev/runtime-operator/pkg/wasmbus"
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus"
 
-	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1"
-	runtimev2 "go.wasmcloud.dev/runtime-operator/pkg/rpc/wasmcloud/runtime/v2"
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
+	runtimev2 "go.wasmcloud.dev/runtime-operator/v2/pkg/rpc/wasmcloud/runtime/v2"
 )
 
 const (

--- a/runtime-operator/internal/controller/runtime/workload_deployment_controller.go
+++ b/runtime-operator/internal/controller/runtime/workload_deployment_controller.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"go.wasmcloud.dev/runtime-operator/api/condition"
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 
-	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1"
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
 )
 
 const (

--- a/runtime-operator/internal/controller/runtime/workload_replicaset_controller.go
+++ b/runtime-operator/internal/controller/runtime/workload_replicaset_controller.go
@@ -12,9 +12,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"go.wasmcloud.dev/runtime-operator/api/condition"
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 
-	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/api/runtime/v1alpha1"
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
 )
 
 const (

--- a/runtime-operator/operator.go
+++ b/runtime-operator/operator.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
-	runtime_controllers "go.wasmcloud.dev/runtime-operator/internal/controller/runtime"
-	"go.wasmcloud.dev/runtime-operator/pkg/wasmbus"
+	runtime_controllers "go.wasmcloud.dev/runtime-operator/v2/internal/controller/runtime"
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 

--- a/runtime-operator/pkg/rpc/wasmcloud/runtime/v2/v2connect/host_service.connect.go
+++ b/runtime-operator/pkg/rpc/wasmcloud/runtime/v2/v2connect/host_service.connect.go
@@ -8,7 +8,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v2 "go.wasmcloud.dev/runtime-operator/pkg/rpc/wasmcloud/runtime/v2"
+	v2 "go.wasmcloud.dev/runtime-operator/v2/pkg/rpc/wasmcloud/runtime/v2"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	http "net/http"
 	strings "strings"

--- a/runtime-operator/pkg/rpc/wasmcloud/runtime/v2/v2connect/workload_service.connect.go
+++ b/runtime-operator/pkg/rpc/wasmcloud/runtime/v2/v2connect/workload_service.connect.go
@@ -8,7 +8,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v2 "go.wasmcloud.dev/runtime-operator/pkg/rpc/wasmcloud/runtime/v2"
+	v2 "go.wasmcloud.dev/runtime-operator/v2/pkg/rpc/wasmcloud/runtime/v2"
 	http "net/http"
 	strings "strings"
 )

--- a/runtime-operator/pkg/wasmbus/client_test.go
+++ b/runtime-operator/pkg/wasmbus/client_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"go.wasmcloud.dev/runtime-operator/pkg/wasmbus/wasmbustest"
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus/wasmbustest"
 )
 
 type testMessage struct {

--- a/runtime-operator/pkg/wasmbus/nats_test.go
+++ b/runtime-operator/pkg/wasmbus/nats_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"go.wasmcloud.dev/runtime-operator/pkg/wasmbus/wasmbustest"
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus/wasmbustest"
 )
 
 func TestNatsConnect(t *testing.T) {

--- a/runtime-operator/pkg/wasmbus/server_test.go
+++ b/runtime-operator/pkg/wasmbus/server_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"go.wasmcloud.dev/runtime-operator/pkg/wasmbus/wasmbustest"
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus/wasmbustest"
 )
 
 func TestServerRegisterHandler(t *testing.T) {

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"go.wasmcloud.dev/runtime-operator/test/utils"
+	"go.wasmcloud.dev/runtime-operator/v2/test/utils"
 )
 
 var (

--- a/runtime-operator/test/e2e/e2e_test.go
+++ b/runtime-operator/test/e2e/e2e_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"go.wasmcloud.dev/runtime-operator/test/utils"
+	"go.wasmcloud.dev/runtime-operator/v2/test/utils"
 )
 
 // namespace where the project is deployed in


### PR DESCRIPTION
Migrate go.wasmcloud.dev/runtime-operator to go.wasmcloud.dev/runtime-operator/v2
and update all imports across runtime-operator and runtime-gateway.

Add go-module-tag job to runtime-operator workflow to automatically
create runtime-operator/v* tags when a v* release tag is pushed.

Includes a temporary go.work replace directive until the
runtime-operator/v2.0.0 tag is re-created post-merge.

Signed-off-by: Bailey Hayes <bailey@cosmonic.com>
