### PR TITLE
release: v2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7046,7 +7046,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 authors = ["The wasmCloud Team"]
 edition = "2024"
 rust-version = "1.91.0"
-version = "2.0.0"
+version = "2.0.1"
 
 [workspace.lints.rust]
 warnings = 'deny' # Treat all warnings as errors

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -92,7 +92,7 @@ runtime:
     registry: ghcr.io
     repository: wasmcloud/wash
     pull_policy: Always
-    tag: "2.0.0"
+    tag: "2.0.1"
   hostGroups:
     - name: default
       replicas: 1


### PR DESCRIPTION
Now that we've aligned go with the rest of the repo, let's rebuild on the same commit/version.