### PR TITLE
fix(scripts): improve install scripts for smoother one-step installation

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,25 +1,27 @@
 # Install script for wash - The Wasm Shell (Windows PowerShell)
 # Usage: iwr -useb https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.ps1 | iex
-# Usage with options: ./install.ps1 -InstallDir "C:\tools" -Version "v2.0.1" -Verify -AddToPath -Force
+# Usage with options: ./install.ps1 -InstallDir "C:\tools" -Version "v2.0.1" -Verify -NoModifyPath -Force
+# Note: -AddToPath is deprecated (PATH is now modified by default; use -NoModifyPath to opt out)
 #
 # Parameters:
-# - InstallDir: Directory to install wash binary (default: current directory)
+# - InstallDir: Directory to install wash binary (default: %USERPROFILE%\.wash\bin)
 # - Version: Install a specific version (e.g., "v2.0.1", or "wash-v2.0.0-rc.8" for pre-2.0 releases)
 # - Verify: Enable signature verification (requires GitHub CLI)
-# - AddToPath: Automatically add install directory to user PATH
+# - NoModifyPath: Don't modify the user PATH environment variable
 # - Force: Overwrite existing installation without prompting
 #
 # Environment variables:
 # - $env:GITHUB_TOKEN: GitHub personal access token (optional, for higher API rate limits)
-# - $env:INSTALL_DIR: Directory to install wash binary (overrides -InstallDir)
+# - $env:INSTALL_DIR: Directory to install wash binary (overrides -InstallDir, default: %USERPROFILE%\.wash\bin)
 
 param(
-    [string]$InstallDir = $(if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { $PWD }),
+    [string]$InstallDir = $(if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { Join-Path $env:USERPROFILE ".wash\bin" }),
     [string]$GitHubToken = $env:GITHUB_TOKEN,
     [string]$Version = "",
     [switch]$Verify,
-    [switch]$AddToPath,
-    [switch]$Force
+    [switch]$NoModifyPath,
+    [switch]$Force,
+    [switch]$AddToPath  # Deprecated: PATH is now modified by default. Use -NoModifyPath to opt out.
 )
 
 # Set strict mode
@@ -57,23 +59,39 @@ function Cleanup {
     }
 }
 
-# Add directory to PATH
-function Add-ToPath {
+# Automatically add directory to user PATH unless opted out or in CI
+function Add-ToPathAuto {
     param([string]$Directory)
-    
+
     $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-    
-    # Check if directory is already in PATH
-    if ($currentPath -split ';' | Where-Object { $_ -eq $Directory }) {
-        Write-Info "Directory $Directory is already in PATH"
+
+    # Check if directory is already in PATH (case-insensitive for Windows)
+    if ($currentPath -and ($currentPath -split ';' | Where-Object { $_ -ieq $Directory })) {
+        Write-Info "$Directory is already in PATH"
         return
     }
-    
+
+    # Skip if -NoModifyPath was passed
+    if ($NoModifyPath) {
+        Write-Info "Skipping PATH modification (-NoModifyPath)"
+        Write-Info "Manually add $Directory to your PATH"
+        return
+    }
+
+    # Skip in CI environments
+    if ($env:CI -eq "true") {
+        Write-Info "CI environment detected, skipping PATH modification"
+        Write-Info "Add $Directory to your PATH to use wash"
+        return
+    }
+
     try {
         $newPath = if ($currentPath) { "$currentPath;$Directory" } else { $Directory }
         [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+        # Also update the current session
+        $env:PATH = "$env:PATH;$Directory"
         Write-Success "Added $Directory to user PATH"
-        Write-Info "Please restart your terminal or run: refreshenv"
+        Write-Info "PATH is updated for this session and future sessions"
     }
     catch {
         Write-Error "Failed to add $Directory to PATH: $($_.Exception.Message)"
@@ -304,8 +322,6 @@ function Install-Wash {
         [string]$TargetVersion
     )
 
-    $binaryName = "wash-$Platform"
-
     Write-Info "Detected platform: $Platform"
     Write-Info "Version: $TargetVersion"
 
@@ -417,33 +433,27 @@ function Install-Wash {
         Write-Warn "Could not verify installation. Try running: $installPath --help"
     }
     
+    # Configure PATH
+    Add-ToPathAuto $InstallDir
+
     # Show next steps
     Write-Host ""
     Write-Info "Next steps:"
-    Write-Host "  1. Add $InstallDir to your PATH if not already included"
-    Write-Host "  2. Run 'wash --help' to see available commands"
-    Write-Host "  3. Run 'wash new' to create your first WebAssembly component"
-    Write-Host ""
-    
-    # Handle PATH addition
-    if ($AddToPath) {
-        Add-ToPath $InstallDir
-    } else {
-        Write-Info "To add to PATH for current session:"
-        Write-Host "  `$env:PATH += ';$InstallDir'"
-        Write-Host ""
-        Write-Info "To add to PATH permanently:"
-        Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `$env:PATH + ';$InstallDir', 'User')"
-        Write-Host ""
-        Write-Info "Or run the installer again with -AddToPath flag"
-    }
+    Write-Host "  1. Run 'wash --help' to see available commands"
+    Write-Host "  2. Run 'wash new' to create your first WebAssembly component"
 }
 
 # Main execution
 function Main {
     Write-Info "Installing wash - The Wasm Shell"
+    Write-Info "Install directory: $InstallDir"
     Write-Host ""
-    
+
+    # Warn on deprecated -AddToPath flag
+    if ($AddToPath) {
+        Write-Warn "-AddToPath is deprecated: PATH is now modified by default. Use -NoModifyPath to opt out."
+    }
+
     # Check for GitHub token (optional, for higher API rate limits)
     if (-not $GitHubToken) {
         Write-Info "No GitHub token provided. Using anonymous API access (subject to rate limits)"

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 #
 # Environment variables:
 # - GITHUB_TOKEN: GitHub personal access token (optional, for higher API rate limits)
-# - INSTALL_DIR: Directory to install wash binary (default: current directory)
+# - INSTALL_DIR: Directory to install wash binary (default: ~/.wash/bin)
 # - WASH_VERSION: Specific version to install (default: latest). Can also be set via --version flag.
 
 set -euo pipefail
@@ -20,9 +20,10 @@ NC='\033[0m' # No Color
 
 # Constants
 REPO="wasmcloud/wasmCloud"
-INSTALL_DIR="${INSTALL_DIR:-$(pwd)}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.wash/bin}"
 TMP_DIR="/tmp/wash-install-$$"
 VERIFY_SIGNATURE=false
+NO_MODIFY_PATH=false
 VERSION="${WASH_VERSION:-}"
 
 # Helper functions
@@ -210,8 +211,6 @@ install_wash() {
     local platform="$1"
     local version="$2"
     
-    local binary_name="wash-${platform}"
-    
     log_info "Detected platform: ${platform}"
     log_info "Latest version: ${version}"
     
@@ -286,12 +285,96 @@ install_wash() {
         log_warn "Could not verify installation. Try running: ${INSTALL_DIR}/wash --help"
     fi
     
+    # Configure PATH
+    configure_path
+
     # Show next steps
     echo >&2
     log_info "Next steps:"
-    echo "  1. Add ${INSTALL_DIR} to your PATH if not already included" >&2
-    echo "  2. Run 'wash --help' to see available commands" >&2
-    echo "  3. Run 'wash new' to create your first WebAssembly component" >&2
+    echo "  1. Run 'wash --help' to see available commands" >&2
+    echo "  2. Run 'wash new' to create your first WebAssembly component" >&2
+}
+
+# Add INSTALL_DIR to the user's shell profile
+configure_path() {
+    # Check if INSTALL_DIR is already in PATH
+    case ":$PATH:" in
+        *":${INSTALL_DIR}:"*)
+            log_info "${INSTALL_DIR} is already in PATH"
+            return 0
+            ;;
+    esac
+
+    # Skip profile modification if --no-modify-path was passed
+    if [ "$NO_MODIFY_PATH" = "true" ]; then
+        log_info "Skipping PATH modification (--no-modify-path)"
+        log_info "Manually add ${INSTALL_DIR} to your PATH"
+        return 0
+    fi
+
+    # Skip profile modification in CI or non-interactive shells
+    if [ "${CI:-}" = "true" ] || [ ! -t 2 ]; then
+        log_info "Non-interactive environment detected, skipping PATH modification"
+        log_info "Add ${INSTALL_DIR} to your PATH to use wash"
+        return 0
+    fi
+
+    local shell_name
+    shell_name=$(basename "${SHELL:-}")
+
+    case "$shell_name" in
+        zsh)
+            _patch_profile "${HOME}/.zshrc"
+            ;;
+        bash)
+            # Prefer .bashrc; fall back to .bash_profile
+            if [ -f "${HOME}/.bashrc" ]; then
+                _patch_profile "${HOME}/.bashrc"
+            else
+                _patch_profile "${HOME}/.bash_profile"
+            fi
+            ;;
+        fish)
+            _patch_fish_profile
+            ;;
+        *)
+            log_warn "Unknown shell '${shell_name}' — manually add ${INSTALL_DIR} to your PATH"
+            ;;
+    esac
+}
+
+# Append an export line to a POSIX shell profile, skipping if already present
+_patch_profile() {
+    local profile_file="$1"
+    local line="export PATH=\"${INSTALL_DIR}:\$PATH\""
+
+    if [ -f "$profile_file" ] && grep -qF "${INSTALL_DIR}" "$profile_file"; then
+        log_info "${INSTALL_DIR} already referenced in ${profile_file}"
+        return 0
+    fi
+
+    echo "" >> "$profile_file"
+    echo "# Added by wash installer" >> "$profile_file"
+    echo "$line" >> "$profile_file"
+    log_success "Added ${INSTALL_DIR} to PATH in ${profile_file}"
+    log_info "Restart your shell or run: source ${profile_file}"
+}
+
+# Append a fish-style PATH entry, skipping if already present
+_patch_fish_profile() {
+    local config_file="${HOME}/.config/fish/config.fish"
+
+    if [ -f "$config_file" ] && grep -qF "${INSTALL_DIR}" "$config_file"; then
+        log_info "${INSTALL_DIR} already referenced in ${config_file}"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$config_file")"
+    echo "" >> "$config_file"
+    echo "# Added by wash installer" >> "$config_file"
+    echo "fish_add_path ${INSTALL_DIR}" >> "$config_file"
+    log_success "Added ${INSTALL_DIR} to PATH in ${config_file}"
+    log_info "Restart your shell or run: source ${config_file}"
 }
 
 # Parse command line arguments
@@ -300,6 +383,10 @@ parse_args() {
         case $1 in
             -v|--verify)
                 VERIFY_SIGNATURE=true
+                shift
+                ;;
+            --no-modify-path)
+                NO_MODIFY_PATH=true
                 shift
                 ;;
             --version)
@@ -332,13 +419,14 @@ Install script for wash - The Wasm Shell
 Usage: $0 [OPTIONS]
 
 Options:
-  -v, --verify       Enable signature verification (requires GitHub CLI)
-  --version VERSION  Install a specific version (e.g., v2.0.1, or wash-v2.0.0-rc.8 for pre-2.0 releases)
-  -h, --help         Show this help message
+  -v, --verify         Enable signature verification (requires GitHub CLI)
+  --version VERSION    Install a specific version (e.g., v2.0.1, or wash-v2.0.0-rc.8 for pre-2.0 releases)
+  --no-modify-path     Don't modify shell profile to add wash to PATH
+  -h, --help           Show this help message
 
 Environment variables:
   GITHUB_TOKEN    GitHub personal access token (optional, for higher API rate limits)
-  INSTALL_DIR     Directory to install wash binary (default: current directory)
+  INSTALL_DIR     Directory to install wash binary (default: ~/.wash/bin)
 
 Examples:
   # Standard installation (latest version)
@@ -404,6 +492,7 @@ main() {
     parse_args "$@"
 
     log_info "Installing wash - The Wasm Shell"
+    log_info "Install directory: ${INSTALL_DIR}"
     echo >&2
 
     # Check dependencies


### PR DESCRIPTION
Improves both install scripts (`install.sh` and `install.ps1`) to enable a smooth, one-step installation experience.

## What changed

**Fix for stable v2 release (both scripts):** Updates `get_release_by_version` to try the tag as-is first and fall back to the `wash-v` prefix only if not found, enabling setup-wash-action to bump to v2.0.1 cleanly (see wasmcloud/setup-wash-action#13).

**New improvements (both scripts):**
- Default `INSTALL_DIR` to `~/.wash/bin` (Unix) / `%USERPROFILE%\.wash\bin` (Windows) instead of the current working directory — the `$(pwd)` default was the root cause of the awkward post-install PATH step
- Auto-patch the user's shell profile on install (zsh/bash/fish on Unix; User PATH registry entry on Windows), matching the convention used by bun, deno, and flyctl
- Skip profile patching in CI environments (`$CI=true`)
- Add `--no-modify-path` / `-NoModifyPath` escape hatch for users who manage their own dotfiles
- Guard against duplicate PATH entries before appending