### PR TITLE
refactor: change allow-insecure-registries cli argument to force-http…

### DIFF
--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -782,7 +782,7 @@ impl std::fmt::Debug for Host {
 /// Config for the [`Host`]
 #[derive(Clone, Debug)]
 pub struct HostConfig {
-    pub allow_oci_insecure: bool,
+    pub force_http_oci_registries: bool,
     pub oci_pull_timeout: Option<Duration>,
     pub oci_cache_dir: Option<PathBuf>,
 }
@@ -790,7 +790,7 @@ pub struct HostConfig {
 impl Default for HostConfig {
     fn default() -> Self {
         Self {
-            allow_oci_insecure: false,
+            force_http_oci_registries: false,
             oci_pull_timeout: Duration::from_secs(30).into(),
             oci_cache_dir: None,
         }

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -330,7 +330,7 @@ fn image_pull_secret_to_oci_config(
         None => OciConfig::default(),
     };
     oci_config.cache_dir = config.oci_cache_dir.clone();
-    oci_config.insecure = config.allow_oci_insecure;
+    oci_config.insecure = config.force_http_oci_registries;
     oci_config.timeout = config.oci_pull_timeout;
 
     oci_config
@@ -678,7 +678,7 @@ mod tests {
     #[tokio::test]
     async fn test_image_pull_secret_to_oci_config_none() {
         let host_config = HostConfig {
-            allow_oci_insecure: false,
+            force_http_oci_registries: false,
             ..Default::default()
         };
         let secret: Option<types::v2::ImagePullSecret> = None;
@@ -695,7 +695,7 @@ mod tests {
         });
 
         let host_config = HostConfig {
-            allow_oci_insecure: false,
+            force_http_oci_registries: false,
             ..Default::default()
         };
         let config = image_pull_secret_to_oci_config(&host_config, &secret);

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -75,9 +75,9 @@ pub struct HostCommand {
     #[arg(long = "postgres-url", env = "WASH_POSTGRES_URL")]
     pub postgres_url: Option<String>,
 
-    /// Allow insecure OCI Registries
-    #[arg(long = "allow-insecure-registries", default_value_t = false)]
-    pub allow_insecure_registries: bool,
+    /// Force usage of HTTP for OCI Registries
+    #[arg(long = "force-http-oci-registries", default_value_t = false)]
+    pub force_http_oci_registries: bool,
 
     /// Timeout for pulling artifacts from OCI registries
     #[arg(long = "registry-pull-timeout", value_parser = humantime::parse_duration, default_value = "30s")]
@@ -126,7 +126,7 @@ impl CliCommand for HostCommand {
         let data_nats_client = Arc::new(data_nats_client);
 
         let host_config = wash_runtime::host::HostConfig {
-            allow_oci_insecure: self.allow_insecure_registries,
+            force_http_oci_registries: self.force_http_oci_registries,
             oci_pull_timeout: Some(self.registry_pull_timeout),
             oci_cache_dir: self.oci_cache_dir.clone(),
         };


### PR DESCRIPTION
I ran into an issue where I needed to use both HTTP (internal) and HTTPS (ghcr.io) OCI registries.
The `--allow-insecure-registries` gave me the impression it would allow both, which I know now is flawed as you only define a URL without protocol.
This PR just intends to eliminate the confusion the flag could give other people who aren't familiar with the codebase by changing the flag to `--force-http-oci-registries`.

This is a breaking change as the old flag `--allow-insecure-registries` will no longer be recognized.