### PR TITLE
docs: update cargo install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Make sure to move `wash` to somewhere in your `PATH`.
 ```bash
 git clone https://github.com/wasmcloud/wasmCloud.git
 cd wasmCloud
-cargo install --path .
+cargo install --path crates/wash
 ```
 
 ## Quickstart


### PR DESCRIPTION
Exploring wasmcloud and noticed the `cargo install`  path in the readme has gotten out of sync with the folder structure.