### PR TITLE
feat(runtime-gateway): add path based routing

### DIFF
--- a/runtime-gateway/reconciler.go
+++ b/runtime-gateway/reconciler.go
@@ -34,10 +34,11 @@ func (a *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	var hostname string
-
+	var path string
 	for _, iface := range workload.Spec.HostInterfaces {
 		if iface.Namespace == "wasi" && iface.Package == "http" && slices.Contains(iface.Interfaces, "incoming-handler") {
 			if h, ok := iface.Config["host"]; ok {
+				path = iface.Config["path"]
 				hostname = h
 				break
 			}
@@ -52,7 +53,7 @@ func (a *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	log.Info("Reconciling Workload")
 
 	if workload.DeletionTimestamp != nil {
-		if err := a.Registry.DeregisterWorkload(ctx, workload.Status.HostID, workload.Status.WorkloadID, hostname); err != nil {
+		if err := a.Registry.DeregisterWorkload(ctx, workload.Status.HostID, workload.Status.WorkloadID, hostname, path); err != nil {
 			log.Error(err, "failed to deregister workload")
 			return ctrl.Result{}, err
 		}
@@ -60,12 +61,12 @@ func (a *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if workload.Status.IsAvailable() {
-		if err := a.Registry.RegisterWorkload(ctx, workload.Status.HostID, workload.Status.WorkloadID, hostname); err != nil {
+		if err := a.Registry.RegisterWorkload(ctx, workload.Status.HostID, workload.Status.WorkloadID, hostname, path); err != nil {
 			log.Error(err, "failed to register workload")
 			return ctrl.Result{}, err
 		}
 	} else {
-		if err := a.Registry.DeregisterWorkload(ctx, workload.Status.HostID, workload.Status.WorkloadID, hostname); err != nil {
+		if err := a.Registry.DeregisterWorkload(ctx, workload.Status.HostID, workload.Status.WorkloadID, hostname, path); err != nil {
 			log.Error(err, "failed to deregister workload")
 			return ctrl.Result{}, err
 		}

--- a/runtime-gateway/tracker.go
+++ b/runtime-gateway/tracker.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -30,13 +31,20 @@ type HostRegistry interface {
 }
 
 type WorkloadRegistry interface {
-	RegisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string) error
-	DeregisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string) error
+	RegisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string, path string) error
+	DeregisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string, path string) error
 }
 
 var _ HostResolver = (*HostTracker)(nil)
 var _ HostRegistry = (*HostTracker)(nil)
 var _ WorkloadRegistry = (*HostTracker)(nil)
+
+// RouteKey identifies a route by hostname and optional path prefix.
+// An empty Path acts as a catch-all for the hostname.
+type RouteKey struct {
+	Hostname string
+	Path     string
+}
 
 type HostTracker struct {
 	// where to send requests that have no registered workloads
@@ -45,8 +53,8 @@ type HostTracker struct {
 	lock sync.RWMutex
 	// HostID to "hostname:port"
 	hosts map[string]string
-	// hostname to WorkloadID
-	hostnames map[string]sets.Set[string]
+	// RouteKey to WorkloadIDs
+	hostnames map[RouteKey]sets.Set[string]
 	// WorkloadID to HostID
 	workloads map[string]string
 }
@@ -57,31 +65,73 @@ func (ht *HostTracker) SetupWithManager(ctx context.Context, manager ctrl.Manage
 
 func (ht *HostTracker) Start(ctx context.Context) error {
 	ht.hosts = make(map[string]string)
-	ht.hostnames = make(map[string]sets.Set[string])
+	ht.hostnames = make(map[RouteKey]sets.Set[string])
 	ht.workloads = make(map[string]string)
 	<-ctx.Done()
 	return nil
+}
+
+// resolve finds the best matching workload set for the given request.
+// It first tries the longest registered path prefix, then falls back to
+// the catch-all route (empty path) for the hostname.
+func (ht *HostTracker) resolve(hostname, urlPath string) (sets.Set[string], bool) {
+	var bestKey RouteKey
+	var bestWorkloads sets.Set[string]
+	found := false
+
+	for key, workloads := range ht.hostnames {
+		if key.Hostname != hostname || key.Path == "" {
+			continue
+		}
+		if rest, ok := strings.CutPrefix(urlPath, key.Path); ok {
+			atBoundary := rest == "" || rest[0] == '/' || rest[0] == '?'
+			if atBoundary && len(key.Path) > len(bestKey.Path) {
+				bestKey = key
+				bestWorkloads = workloads
+				found = true
+			}
+		}
+	}
+
+	if found {
+		return bestWorkloads, true
+	}
+
+	// Fall back to catch-all route for this hostname
+	workloads, ok := ht.hostnames[RouteKey{Hostname: hostname}]
+	return workloads, ok
+}
+
+// hostnameKnown reports whether any route (path-specific or catch-all) is
+// registered for the given hostname.
+func (ht *HostTracker) hostnameKnown(hostname string) bool {
+	for key := range ht.hostnames {
+		if key.Hostname == hostname {
+			return true
+		}
+	}
+	return false
 }
 
 func (ht *HostTracker) Resolve(ctx context.Context, req *http.Request) LookupResult {
 	ht.lock.RLock()
 	defer ht.lock.RUnlock()
 
-	workloads, ok := ht.hostnames[req.Host]
+	hostname := req.Host
+
+	workloads, ok := ht.resolve(hostname, req.URL.Path)
 	if !ok {
-		scheme, endpoint := ht.Fallback.InvalidHostname(req.Host)
-		return LookupResult{
-			Hostname: endpoint,
-			Scheme:   scheme,
+		if !ht.hostnameKnown(hostname) {
+			scheme, endpoint := ht.Fallback.InvalidHostname(hostname)
+			return LookupResult{Hostname: endpoint, Scheme: scheme}
 		}
+		scheme, endpoint := ht.Fallback.NoWorkloads(hostname)
+		return LookupResult{Hostname: endpoint, Scheme: scheme}
 	}
 
 	if workloads.Len() == 0 {
-		scheme, endpoint := ht.Fallback.NoWorkloads(req.Host)
-		return LookupResult{
-			Hostname: endpoint,
-			Scheme:   scheme,
-		}
+		scheme, endpoint := ht.Fallback.NoWorkloads(hostname)
+		return LookupResult{Hostname: endpoint, Scheme: scheme}
 	}
 
 	// pick a random workload
@@ -91,26 +141,20 @@ func (ht *HostTracker) Resolve(ctx context.Context, req *http.Request) LookupRes
 	// (should always exist if the workload exists)
 	hostID, ok := ht.workloads[workloadID]
 	if !ok {
-		scheme, endpoint := ht.Fallback.NoWorkloads(req.Host)
-		return LookupResult{
-			Hostname: endpoint,
-			Scheme:   scheme,
-		}
+		scheme, endpoint := ht.Fallback.NoWorkloads(hostname)
+		return LookupResult{Hostname: endpoint, Scheme: scheme}
 	}
 
 	// find the hostname:port for the host
 	// (should always exist if the host is healthy)
-	hostname, ok := ht.hosts[hostID]
+	hostAddr, ok := ht.hosts[hostID]
 	if !ok {
-		scheme, endpoint := ht.Fallback.NoWorkloads(req.Host)
-		return LookupResult{
-			Hostname: endpoint,
-			Scheme:   scheme,
-		}
+		scheme, endpoint := ht.Fallback.NoWorkloads(hostname)
+		return LookupResult{Hostname: endpoint, Scheme: scheme}
 	}
 
 	return LookupResult{
-		Hostname:   hostname,
+		Hostname:   hostAddr,
 		Scheme:     "http",
 		WorkloadID: workloadID,
 	}
@@ -132,28 +176,36 @@ func (ht *HostTracker) DeregisterHost(ctx context.Context, hostID string) error 
 	return nil
 }
 
-func (ht *HostTracker) RegisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string) error {
+func (ht *HostTracker) RegisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string, path string) error {
 	ht.lock.Lock()
 	defer ht.lock.Unlock()
 
+	if path != "" && !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	key := RouteKey{Hostname: hostname, Path: path}
 	ht.workloads[workloadID] = hostID
-	if workloadSet, ok := ht.hostnames[hostname]; !ok {
-		ht.hostnames[hostname] = sets.New(workloadID)
+	if workloadSet, ok := ht.hostnames[key]; !ok {
+		ht.hostnames[key] = sets.New(workloadID)
 	} else {
 		workloadSet.Insert(workloadID)
 	}
 	return nil
 }
 
-func (ht *HostTracker) DeregisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string) error {
+func (ht *HostTracker) DeregisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string, path string) error {
 	ht.lock.Lock()
 	defer ht.lock.Unlock()
 
+	if path != "" && !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	key := RouteKey{Hostname: hostname, Path: path}
 	delete(ht.workloads, workloadID)
-	if workloadSet, ok := ht.hostnames[hostname]; ok {
+	if workloadSet, ok := ht.hostnames[key]; ok {
 		workloadSet.Delete(workloadID)
 		if workloadSet.Len() == 0 {
-			delete(ht.hostnames, hostname)
+			delete(ht.hostnames, key)
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description
- Add path based routing to runtime gateway
  - Add `path` key to host interfaces config
  - Match for path with longest matching prefix
  - If config key not present then routing works as before

## Example
Testing was done using the `deploy/k3s` and `examples/http-hello-world` example deployment.

## Scenario - Path Routing
Add `path` key to config:
```yaml diff
hostInterfaces:
  - namespace: wasi
    package: http
    interfaces:
      - incoming-handler
    config:
      host: localhost
      path: /hello
```

Matches to `/hello` and all other paths with prefix:
```sh
$ curl localhost:80/hello
Hello from wasmCloud!
$ curl localhost:80/hello/long/path
Hello from wasmCloud!
```
But still falls back if no path matches:
```sh
$ curl localhost:80/
No backend available
```

## Scenario - No Path Routing
Config with no path:
```yaml
hostInterfaces:
  - namespace: wasi
    package: http
    interfaces:
      - incoming-handler
    config:
      host: localhost
```
Matches with all paths, just as before:
```sh
$ curl localhost:80/hello
Hello from wasmCloud!
$ curl localhost:80/hello/long/path
Hello from wasmCloud!
$ curl localhost:80/
Hello from wasmCloud!
```