### PR TITLE
feat(policy): add TTL for cached policy decisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7736,6 +7736,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -9312,6 +9313,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-opentelemetry",
  "ulid",

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -47,6 +47,7 @@ tokio = { workspace = true, features = [
 ] }
 tokio-rustls = { workspace = true }
 tokio-stream = { workspace = true, features = ["net", "time"] }
+tokio-util = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 ulid = { workspace = true, features = ["std"] }

--- a/crates/host/src/cache.rs
+++ b/crates/host/src/cache.rs
@@ -1,0 +1,264 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    fmt::Debug,
+    hash::Hash,
+    marker::PhantomData,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use tokio::sync::RwLock;
+use tokio::time::Duration;
+use tokio_util::time::{delay_queue, DelayQueue};
+
+#[derive(Debug)]
+struct CacheEntry<V>
+where
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    value: V,
+    created_at: Instant,
+}
+
+impl<V> CacheEntry<V>
+where
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    fn new(value: V) -> Self {
+        Self {
+            value,
+            created_at: Instant::now(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CacheInternal<K, V>
+where
+    K: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    data: HashMap<K, (CacheEntry<V>, delay_queue::Key)>,
+    expirations: DelayQueue<K>,
+    ttl: Duration,
+    lazy_expiration: bool,
+}
+
+impl<K, V> CacheInternal<K, V>
+where
+    K: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    fn new(ttl: Duration) -> Self {
+        Self {
+            data: HashMap::new(),
+            expirations: DelayQueue::new(),
+            ttl,
+            lazy_expiration: true,
+        }
+    }
+
+    fn insert(&mut self, key: K, value: V) {
+        match self.data.entry(key.clone()) {
+            Entry::Occupied(mut entry) => {
+                self.expirations.remove(&entry.get().1);
+                let expiration = self.expirations.insert(key, self.ttl);
+                entry.insert((CacheEntry::new(value), expiration));
+            }
+            Entry::Vacant(entry) => {
+                let expiration = self.expirations.insert(key, self.ttl);
+                entry.insert((CacheEntry::new(value), expiration));
+            }
+        }
+    }
+
+    fn get(&mut self, key: &K) -> Option<V> {
+        match self.data.entry(key.clone()) {
+            Entry::Occupied(entry) if entry.get().0.created_at.elapsed() < self.ttl => {
+                Some(entry.get().0.value.clone())
+            }
+            Entry::Occupied(entry) => {
+                if self.lazy_expiration {
+                    let (_, expiration) = entry.remove();
+                    self.expirations.remove(&expiration);
+                }
+                None
+            }
+            Entry::Vacant(_) => None,
+        }
+    }
+
+    fn poll_purge(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        while let Poll::Ready(Some(entry)) = self.expirations.poll_expired(cx) {
+            self.data.remove(entry.get_ref());
+        }
+
+        Poll::Ready(())
+    }
+}
+
+/// A thread-safe TTL cache with lazy expiration and optional purge cycles.
+pub(crate) struct Cache<K, V>
+where
+    K: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    internal: Arc<RwLock<CacheInternal<K, V>>>,
+    purge_cycles: Option<u32>,
+    purge_cycle_count: Arc<AtomicU32>,
+}
+
+impl<K, V> Cache<K, V>
+where
+    K: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    pub(crate) fn builder() -> CacheBuilder<K, V> {
+        CacheBuilder::default()
+    }
+
+    pub(crate) async fn insert(&self, key: K, value: V) {
+        self.check_purge().await;
+        self.internal.write().await.insert(key, value);
+    }
+
+    pub(crate) async fn get(&self, key: &K) -> Option<V> {
+        self.internal.write().await.get(key)
+    }
+
+    async fn poll_purge_once(&self) {
+        let mut cache = self.internal.write().await;
+        std::future::poll_fn(|cx| cache.poll_purge(cx)).await;
+        self.purge_cycle_count.store(0, Ordering::Relaxed);
+    }
+
+    async fn check_purge(&self) {
+        if let Some(purge_cycles) = self.purge_cycles {
+            if self.purge_cycle_count.fetch_add(1, Ordering::Relaxed) + 1 >= purge_cycles {
+                self.poll_purge_once().await;
+            }
+        }
+    }
+}
+
+impl<K, V> Clone for Cache<K, V>
+where
+    K: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            internal: Arc::clone(&self.internal),
+            purge_cycles: self.purge_cycles,
+            purge_cycle_count: Arc::clone(&self.purge_cycle_count),
+        }
+    }
+}
+
+impl<K, V> Debug for Cache<K, V>
+where
+    K: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Cache")
+            .field("purge_cycles", &self.purge_cycles)
+            .field(
+                "purge_cycle_count",
+                &self.purge_cycle_count.load(Ordering::Relaxed),
+            )
+            .finish()
+    }
+}
+
+pub(crate) struct CacheBuilder<K, V>
+where
+    K: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    ttl: Duration,
+    purge_cycles: Option<u32>,
+    lazy_expiration: bool,
+    _marker: PhantomData<(K, V)>,
+}
+
+impl<K, V> Default for CacheBuilder<K, V>
+where
+    K: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self {
+            ttl: Duration::from_secs(300),
+            purge_cycles: None,
+            lazy_expiration: true,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<K, V> CacheBuilder<K, V>
+where
+    K: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    V: Clone + Debug + Send + Sync + 'static,
+{
+    pub(crate) fn with_ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = ttl;
+        self
+    }
+
+    pub(crate) fn with_purge_cycles(mut self, purge_cycles: u32) -> Self {
+        self.purge_cycles = Some(purge_cycles);
+        self
+    }
+
+    pub(crate) fn with_lazy_expiration(mut self, lazy_expiration: bool) -> Self {
+        self.lazy_expiration = lazy_expiration;
+        self
+    }
+
+    pub(crate) fn build(self) -> Cache<K, V> {
+        let mut internal = CacheInternal::new(self.ttl);
+        internal.lazy_expiration = self.lazy_expiration;
+
+        Cache {
+            internal: Arc::new(RwLock::new(internal)),
+            purge_cycles: self.purge_cycles,
+            purge_cycle_count: Arc::new(AtomicU32::new(0)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cache;
+    use tokio::time::{sleep, Duration};
+
+    #[tokio::test]
+    async fn returns_cached_value_before_ttl() {
+        let cache = Cache::<String, String>::builder()
+            .with_ttl(Duration::from_millis(100))
+            .build();
+
+        cache.insert("key".into(), "value".into()).await;
+
+        assert_eq!(cache.get(&"key".to_string()).await, Some("value".into()));
+    }
+
+    #[tokio::test]
+    async fn expires_cached_value_after_ttl() {
+        let cache = Cache::<String, String>::builder()
+            .with_ttl(Duration::from_millis(50))
+            .with_purge_cycles(1)
+            .build();
+
+        cache.insert("key".into(), "value".into()).await;
+        sleep(Duration::from_millis(75)).await;
+
+        assert_eq!(cache.get(&"key".to_string()).await, None);
+    }
+}

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -6,6 +6,9 @@
 /// wasmbus host
 pub mod wasmbus;
 
+/// Host-local TTL cache helpers
+pub(crate) mod cache;
+
 /// OCI artifact fetching
 pub mod oci;
 

--- a/crates/host/src/policy.rs
+++ b/crates/host/src/policy.rs
@@ -18,6 +18,8 @@ use ulid::Ulid;
 use uuid::Uuid;
 use wascap::jwt;
 
+use crate::cache::Cache;
+
 // NOTE: All requests will be v1 until the schema changes, at which point we can change the version
 // per-request type
 const POLICY_TYPE_VERSION: &str = "v1";
@@ -234,7 +236,7 @@ pub struct Manager {
     host_info: HostInfo,
     policy_topic: Option<String>,
     policy_timeout: Duration,
-    decision_cache: Arc<RwLock<HashMap<RequestKey, Response>>>,
+    decision_cache: Cache<RequestKey, Response>,
     request_to_key: Arc<RwLock<HashMap<String, RequestKey>>>,
     /// An abort handle for the policy changes subscription
     pub policy_changes: AbortHandle,
@@ -249,17 +251,24 @@ impl Manager {
         policy_topic: Option<String>,
         policy_timeout: Option<Duration>,
         policy_changes_topic: Option<String>,
+        decision_cache_ttl: Option<Duration>,
     ) -> anyhow::Result<Arc<Self>> {
         const DEFAULT_POLICY_TIMEOUT: Duration = Duration::from_secs(1);
 
         let (policy_changes_abort, policy_changes_abort_reg) = AbortHandle::new_pair();
+
+        let decision_cache = Cache::builder()
+            .with_lazy_expiration(true)
+            .with_purge_cycles(1000)
+            .with_ttl(decision_cache_ttl.unwrap_or(Duration::from_secs(300)))
+            .build();
 
         let manager = Manager {
             nats: nats.clone(),
             host_info,
             policy_topic,
             policy_timeout: policy_timeout.unwrap_or(DEFAULT_POLICY_TIMEOUT),
-            decision_cache: Arc::default(),
+            decision_cache,
             request_to_key: Arc::default(),
             policy_changes: policy_changes_abort,
         };
@@ -372,9 +381,9 @@ impl Manager {
             RequestBody::Unknown => RequestKind::Unknown,
         };
         let cache_key = (&request).into();
-        if let Some(entry) = self.decision_cache.read().await.get(&cache_key) {
+        if let Some(entry) = self.decision_cache.get(&cache_key).await {
             trace!(?cache_key, ?entry, "using cached policy decision");
-            return Ok(entry.clone());
+            return Ok(entry);
         }
 
         let request_id = Uuid::from_u128(Ulid::new().into()).to_string();
@@ -399,9 +408,8 @@ impl Manager {
             .context("failed to deserialize policy response")?;
 
         self.decision_cache
-            .write()
-            .await
-            .insert(cache_key.clone(), decision.clone()); // cache policy decision
+            .insert(cache_key.clone(), decision.clone())
+            .await; // cache policy decision
         self.request_to_key
             .write()
             .await
@@ -420,18 +428,19 @@ impl Manager {
 
         debug!(request_id, "received policy decision override");
 
-        let mut decision_cache = self.decision_cache.write().await;
         let request_to_key = self.request_to_key.read().await;
 
         if let Some(key) = request_to_key.get(&request_id) {
-            decision_cache.insert(
-                key.clone(),
-                Response {
-                    request_id: request_id.clone(),
-                    permitted,
-                    message,
-                },
-            );
+            self.decision_cache
+                .insert(
+                    key.clone(),
+                    Response {
+                        request_id: request_id.clone(),
+                        permitted,
+                        message,
+                    },
+                )
+                .await;
         } else {
             warn!(
                 request_id,

--- a/crates/host/src/wasmbus/host_config.rs
+++ b/crates/host/src/wasmbus/host_config.rs
@@ -99,6 +99,8 @@ pub struct PolicyService {
     pub policy_changes_topic: Option<String>,
     /// The timeout for policy requests
     pub policy_timeout_ms: Option<Duration>,
+    /// The host-local TTL for cached policy decisions
+    pub policy_cache_ttl: Option<Duration>,
 }
 
 impl Default for Host {

--- a/crates/host/src/wasmbus/mod.rs
+++ b/crates/host/src/wasmbus/mod.rs
@@ -819,6 +819,7 @@ impl Host {
             config.policy_service_config.policy_topic.clone(),
             config.policy_service_config.policy_timeout_ms,
             config.policy_service_config.policy_changes_topic.clone(),
+            config.policy_service_config.policy_cache_ttl,
         )
         .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,13 @@ struct Args {
         requires = "policy_topic"
     )]
     policy_changes_topic: Option<String>,
+    /// Policy response cache TTL in seconds
+    #[clap(
+        long = "policy-cache-ttl",
+        env = "WASMCLOUD_POLICY_CACHE_TTL",
+        value_parser = parse_duration_secs
+    )]
+    policy_cache_ttl: Option<Duration>,
     /// If provided, allows to set a custom Max Execution time for the Host in ms.
     #[clap(long = "max-execution-time-ms", default_value = "600000", env = "WASMCLOUD_MAX_EXECUTION_TIME_MS", value_parser = parse_duration_millis)]
     max_execution_time: Duration,
@@ -508,6 +515,7 @@ async fn main() -> anyhow::Result<()> {
         policy_topic: args.policy_topic,
         policy_changes_topic: args.policy_changes_topic,
         policy_timeout_ms: args.policy_timeout_ms,
+        policy_cache_ttl: args.policy_cache_ttl,
     };
     let mut labels = args
         .label

--- a/tests/policy.rs
+++ b/tests/policy.rs
@@ -2,7 +2,14 @@
 
 use core::time::Duration;
 
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
 use anyhow::Context as _;
+use futures::StreamExt as _;
+use serde_json::json;
 
 use wasmcloud_host::wasmbus::host_config::PolicyService;
 use wasmcloud_test_util::provider::{assert_start_provider, StartProviderArgs};
@@ -50,6 +57,7 @@ async fn policy_always_deny() -> anyhow::Result<()> {
             policy_topic: Some("test-policy".into()),
             policy_changes_topic: Some("test-policy-changes".into()),
             policy_timeout_ms: Some(Duration::from_millis(100)),
+            policy_cache_ttl: None,
         }),
         None,
         None,
@@ -86,6 +94,109 @@ async fn policy_always_deny() -> anyhow::Result<()> {
         "scaling actors should fail"
     );
 
+    nats_server.stop().await.context("failed to stop NATS")?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn policy_cache_respects_ttl() -> anyhow::Result<()> {
+    let (nats_server, nats_url, nats_client) = start_nats(None, true)
+        .await
+        .map(|res| (res.0, res.1, res.2.unwrap()))
+        .context("failed to start NATS")?;
+
+    let ctl_client = wasmcloud_control_interface::ClientBuilder::new(nats_client.clone())
+        .lattice(LATTICE.to_string())
+        .build();
+
+    let policy_requests = Arc::new(AtomicUsize::new(0));
+    let mut policy_sub = nats_client
+        .subscribe("test-policy")
+        .await
+        .context("failed to subscribe to test policy topic")?;
+    let policy_client = nats_client.clone();
+    let policy_requests_for_task = Arc::clone(&policy_requests);
+    let policy_server = tokio::spawn(async move {
+        while let Some(msg) = policy_sub.next().await {
+            let request = serde_json::from_slice::<serde_json::Value>(&msg.payload)
+                .context("failed to deserialize policy request")?;
+            let request_id = request
+                .get("requestId")
+                .and_then(serde_json::Value::as_str)
+                .context("missing requestId in policy request")?;
+            let permitted = policy_requests_for_task.fetch_add(1, Ordering::SeqCst) > 0;
+
+            if let Some(reply) = msg.reply {
+                policy_client
+                    .publish(
+                        reply,
+                        serde_json::to_vec(&json!({
+                            "requestId": request_id,
+                            "permitted": permitted,
+                        }))?
+                        .into(),
+                    )
+                    .await
+                    .context("failed to publish policy response")?;
+            }
+        }
+
+        Ok::<(), anyhow::Error>(())
+    });
+
+    let rust_http_client = providers::rust_http_client().await;
+    let rust_http_client_url = rust_http_client.url();
+    let rust_http_client_id = rust_http_client.subject.public_key();
+
+    let host = WasmCloudTestHost::start_custom(
+        &nats_url,
+        LATTICE,
+        None,
+        None,
+        Some(PolicyService {
+            policy_topic: Some("test-policy".into()),
+            policy_changes_topic: None,
+            policy_timeout_ms: Some(Duration::from_millis(100)),
+            policy_cache_ttl: Some(Duration::from_millis(100)),
+        }),
+        None,
+        None,
+    )
+    .await
+    .context("failed to start test host")?;
+    let host_key = host.host_key();
+
+    assert!(
+        assert_start_provider(StartProviderArgs {
+            client: &ctl_client,
+            host_id: &host_key.public_key(),
+            provider_id: &rust_http_client_id,
+            provider_ref: rust_http_client_url.as_str(),
+            config: vec![],
+        })
+        .await
+        .is_err(),
+        "first start should be denied by the policy response"
+    );
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert!(
+        assert_start_provider(StartProviderArgs {
+            client: &ctl_client,
+            host_id: &host_key.public_key(),
+            provider_id: &rust_http_client_id,
+            provider_ref: rust_http_client_url.as_str(),
+            config: vec![],
+        })
+        .await
+        .is_ok(),
+        "second start should re-query policy after the cache TTL expires"
+    );
+    assert_eq!(policy_requests.load(Ordering::SeqCst), 2);
+
+    host.stop().await.context("failed to stop host")?;
+    policy_server.abort();
     nats_server.stop().await.context("failed to stop NATS")?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add a host-local TTL for cached policy decisions so v1 hosts can re-evaluate policy changes without restarting
- thread the new TTL through the v1 host config and CLI, and add a reusable cache implementation in the host crate
- add regression coverage proving cached decisions expire and the host re-queries the policy service

## Context
- replaces the closed PR #4549, which could not be reopened after the v2 repository restructure @ricochet 
- related to #3950

