### PR TITLE
chore: examples as templates via symlinks

### DIFF
--- a/templates/http-hello-world
+++ b/templates/http-hello-world
@@ -1,0 +1,1 @@
+../examples/http-hello-world


### PR DESCRIPTION
This commit adds a symlink for the `http-hello-world` example under the templates directory so it can be used as an template via `wash`.

The following command was tested on linux:

```
wash new https://github.com/vados-cosmonic/wasmCloud.git \
    --name http-hello-world \
    --subfolder templates/http-hello-world
```

Other OSes *should* also be able to work with this solution, but it's worth trying out in a few other places before we take this. That said, the approach *does* work and I think avoids the problem of copying the codebases to ensure they exist as examples and templates.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->