### PR TITLE
feat(ci): ensure templates install

### DIFF
--- a/.github/workflows/wash-e2e.yml
+++ b/.github/workflows/wash-e2e.yml
@@ -1,0 +1,55 @@
+name: wash-e2e
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/wash.yml"
+      - "crates/**"
+      - "src/**"
+      - "tests/**"
+      - "Cargo.*"
+      - "rust-toolchain.toml"
+      - "rustfmt.toml"
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  templates:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Setup protoc
+        uses: arduino/setup-protoc@f4d5893b897028ff5739576ea0409746887fa536 # v3.0.0
+        with:
+          version: "29.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build wash
+        run: cargo build -p wash
+
+      - name: Check wash template installation
+        run: |
+          wash new https://github.com/wasmcloud/wasmCloud.git --name service-tcp
+          wash new https://github.com/wasmcloud/wasmCloud.git --name http-api-with-distributed-workloads

--- a/templates/http-hello-world
+++ b/templates/http-hello-world
@@ -1,0 +1,1 @@
+../examples/http-hello-world

--- a/templates/http-hello-world
+++ b/templates/http-hello-world
@@ -1,1 +1,0 @@
-../examples/http-hello-world


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->

This commit adds CI checks that ensure that `wash` loads available templates properly after being built.

~~Before merging this we should of course change away from [my fork](https://github.com/vados-cosmonic/wasmcloud).~~