### PR TITLE
ci: re-enable dependabot for main and release-1.9.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,131 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-cargo:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "release-1.9.x"
+    groups:
+      all-cargo-release-1-9:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/runtime-gateway"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-go-runtime-gateway:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/runtime-operator"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-go-runtime-operator:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/helm-publish"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-github-actions-helm-publish:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/lint-go"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-github-actions-lint-go:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/no-diff"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-github-actions-no-diff:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-go"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-github-actions-setup-go:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-rust"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-github-actions-setup-rust:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-docker-root:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/runtime-gateway"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-docker-runtime-gateway:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/runtime-operator"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      all-docker-runtime-operator:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,28 +20,28 @@ updates:
         patterns:
           - "*"
 
+  # Go modules - one PR for runtime-gateway + runtime-operator
   - package-ecosystem: "gomod"
-    directory: "/runtime-gateway"
+    directories:
+      - "/runtime-gateway"
+      - "/runtime-operator"
     schedule:
       interval: "weekly"
     target-branch: "main"
     groups:
-      all-go-runtime-gateway:
+      all-go:
         patterns:
           - "*"
 
-  - package-ecosystem: "gomod"
-    directory: "/runtime-operator"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    groups:
-      all-go-runtime-operator:
-        patterns:
-          - "*"
-
+  # GitHub Actions - single PR for root workflows + in-tree actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/helm-publish"
+      - "/.github/actions/lint-go"
+      - "/.github/actions/no-diff"
+      - "/.github/actions/setup-go"
+      - "/.github/actions/setup-rust"
     schedule:
       interval: "weekly"
     target-branch: "main"
@@ -50,82 +50,16 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/helm-publish"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    groups:
-      all-github-actions-helm-publish:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/lint-go"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    groups:
-      all-github-actions-lint-go:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/no-diff"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    groups:
-      all-github-actions-no-diff:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/setup-go"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    groups:
-      all-github-actions-setup-go:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/setup-rust"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    groups:
-      all-github-actions-setup-rust:
-        patterns:
-          - "*"
-
+  # Docker base images - single PR for all Dockerfiles
   - package-ecosystem: "docker"
-    directory: "/"
+    directories:
+      - "/"
+      - "/runtime-gateway"
+      - "/runtime-operator"
     schedule:
       interval: "weekly"
     target-branch: "main"
     groups:
-      all-docker-root:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "docker"
-    directory: "/runtime-gateway"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    groups:
-      all-docker-runtime-gateway:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "docker"
-    directory: "/runtime-operator"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    groups:
-      all-docker-runtime-operator:
+      all-docker:
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

- restore a repo-local Dependabot config for the current v2 workspace layout
- keep weekly updates on `main` and add the requested monthly cargo updates on `release-1.9.x`
- cover the repo root, Go modules, Dockerfiles, workflow files, and in-tree GitHub Actions so updates target paths that still exist

Fixes #4965

## Validation

- reviewed the current repository layout to remove stale pre-split paths from the old config
- verified the new `.github/dependabot.yml` structure against the repo directories it references