### PR TITLE
Helm updates for TLS, Annotations, and Labels

### DIFF
--- a/charts/runtime-operator/templates/_helpers.tpl
+++ b/charts/runtime-operator/templates/_helpers.tpl
@@ -43,6 +43,36 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Pod labels for the operator (common labels + operator podLabels)
+*/}}
+{{- define "operator.podLabels" -}}
+{{ include "runtime-operator.labels" . }}
+{{- with .Values.operator.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod labels for NATS (common labels + nats podLabels)
+*/}}
+{{- define "nats.podLabels" -}}
+{{ include "runtime-operator.labels" . }}
+{{- with .Values.nats.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod labels for runtime (common labels + runtime podLabels)
+*/}}
+{{- define "runtime.podLabels" -}}
+{{ include "runtime-operator.labels" . }}
+{{- with .Values.runtime.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "runtime-operator.selectorLabels" -}}

--- a/charts/runtime-operator/templates/certificates.yaml
+++ b/charts/runtime-operator/templates/certificates.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.tls.enabled }}
 {{- if .Values.global.certificates.generate }}
 {{ $ca := genCA "wasmcloud CA" 365 }}
 apiVersion: v1
@@ -67,4 +68,5 @@ data:
   tls.crt: {{ $natsCert.Cert | b64enc }}
   tls.key: {{ $natsCert.Key | b64enc }}
   ca.crt: {{ $ca.Cert | b64enc }}
+{{- end }}
 {{- end }}

--- a/charts/runtime-operator/templates/nats/config.yaml
+++ b/charts/runtime-operator/templates/nats/config.yaml
@@ -12,6 +12,7 @@ data:
     port: 4222
     jetstream: enabled
 
+    {{- if $.Values.global.tls.enabled }}
     tls {
       cert_file: /nats-cert/tls.crt
       key_file: /nats-cert/tls.key
@@ -26,4 +27,5 @@ data:
         { user: "wasmcloud-data" }
       ]
     }
+    {{- end }}
 {{- end }}

--- a/charts/runtime-operator/templates/nats/deployment.yaml
+++ b/charts/runtime-operator/templates/nats/deployment.yaml
@@ -17,15 +17,21 @@ spec:
     metadata:
       labels:
         wasmcloud.com/name: nats
-        {{- include "runtime-operator.labels" . | nindent 8 }}
+        {{- include "nats.podLabels" . | nindent 8 }}
+      {{- with .Values.nats.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       volumes:
         - name: nats-config
           configMap:
             name: nats
+        {{- if $.Values.global.tls.enabled }}
         - name: nats-cert
           secret:
             secretName: {{ .Values.global.certificates.natsCertSecretName }}
+        {{- end }}
       serviceAccountName: {{ include "nats.serviceAccountName" . }}
       {{- include "runtime-operator.imagePullSecrets" . | nindent 6 }}
       containers:
@@ -39,10 +45,12 @@ spec:
           volumeMounts:
             - name: nats-config
               mountPath: /nats-config
+            {{- if $.Values.global.tls.enabled }}
             - name: nats-cert
               mountPath: /nats-cert
+            {{- end }}
           ports:
-            - name: nats
+            - name: tcp-nats
               containerPort: 4222
           securityContext:
             capabilities:

--- a/charts/runtime-operator/templates/nats/service.yaml
+++ b/charts/runtime-operator/templates/nats/service.yaml
@@ -13,7 +13,7 @@ spec:
   type: ClusterIP
   ports: 
     - port: 4222
-      targetPort: nats
+      targetPort: tcp-nats
       protocol: TCP
-      name: nats
+      name: tcp-nats
 {{- end }}

--- a/charts/runtime-operator/templates/operator/clusterrole.yaml
+++ b/charts/runtime-operator/templates/operator/clusterrole.yaml
@@ -64,8 +64,10 @@ rules:
     - get
     - list
     - watch
-  # EndpointSlice permission can be managed in a Role vs ClusterRole since WorkloadDeployments are deployed to a specific namespace.
-  # See https://wasmcloud.com/docs/kubernetes-operator/operator-manual/roles-and-rolebindings/#restricting-access-of-the-operator-to-namespaces for more details.
+  {{- if not .Values.operator.watchNamespaces }}
+  # EndpointSlice permission can be managed in per Namespace since WorkloadDeployments if desired.
+  # See https://wasmcloud.com/docs/kubernetes-operator/operator-manual/roles-and-rolebindings/#restricting-access-of-the-operator-to-namespaces
+  # for more details.
   - apiGroups:
     - discovery.k8s.io
     resources:
@@ -78,4 +80,5 @@ rules:
     - patch
     - update
     - watch
+  {{- end }}
 {{- end }}

--- a/charts/runtime-operator/templates/operator/clusterrole.yaml
+++ b/charts/runtime-operator/templates/operator/clusterrole.yaml
@@ -65,8 +65,9 @@ rules:
     - list
     - watch
   {{- if not .Values.operator.watchNamespaces }}
-  # EndpointSlice permission can be managed in per Namespace since WorkloadDeployments if desired.
-  # See https://wasmcloud.com/docs/kubernetes-operator/operator-manual/roles-and-rolebindings/#restricting-access-of-the-operator-to-namespaces
+  # If the operator is watching all namespaces, it needs permissions to manage EndpointSlices across the cluster. If it's only watching specific
+  # namespaces, a more limited Role and RoleBinding will be created in each namespace instead, and this ClusterRole will not include permissions
+  # for EndpointSlices. See https://wasmcloud.com/docs/kubernetes-operator/operator-manual/roles-and-rolebindings/#restricting-access-of-the-operator-to-namespaces
   # for more details.
   - apiGroups:
     - discovery.k8s.io

--- a/charts/runtime-operator/templates/operator/deployment.yaml
+++ b/charts/runtime-operator/templates/operator/deployment.yaml
@@ -17,12 +17,18 @@ spec:
     metadata:
       labels:
         wasmcloud.com/name: runtime-operator
-        {{- include "runtime-operator.labels" . | nindent 8 }}
+        {{- include "operator.podLabels" . | nindent 8 }}
+      {{- with .Values.operator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- if $.Values.global.tls.enabled }}
       volumes:
         - name: operator-cert
           secret:
             secretName: {{ .Values.global.certificates.operatorCertSecretName }}
+      {{- end }}
       serviceAccountName: {{ include "operator.serviceAccountName" . }}
       {{- include "runtime-operator.imagePullSecrets" . | nindent 6 }}
       containers:
@@ -30,9 +36,11 @@ spec:
           image: {{ if $registry }}{{ printf "%s/%s" $registry .Values.operator.image.repository }}{{ else }}{{ .Values.operator.image.repository }}{{ end }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}
           args:
             - "-nats-url=nats://nats:4222"
+            {{- if $.Values.global.tls.enabled }}
             - "-nats-ca=/operator-cert/ca.crt"
             - "-nats-client-cert=/operator-cert/tls.crt"
             - "-nats-client-key=/operator-cert/tls.key"
+            {{- end }}
             {{- if .Values.operator.watchNamespaces }}
             - "-watch-namespaces={{ .Values.operator.watchNamespaces | join "," }}"
             {{- end }}
@@ -42,10 +50,12 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           imagePullPolicy: {{ .Values.operator.image.pull_policy }}
+          {{- if $.Values.global.tls.enabled }}
           volumeMounts:
             - name: operator-cert
               mountPath: /operator-cert
               readOnly: true
+          {{- end }}
           securityContext:
             capabilities:
               drop:

--- a/charts/runtime-operator/templates/operator/endpointslice-role.yaml
+++ b/charts/runtime-operator/templates/operator/endpointslice-role.yaml
@@ -1,0 +1,42 @@
+# This file contains the ClusterRole and RoleBinding for the EndpointSlice controller, which is only required
+# if the operator is configured to watch specific namespaces. Otherwise, the default ClusterRole will be sufficient
+# for watching all namespaces.
+{{- if and .Values.operator.enabled .Values.operator.serviceAccount.create .Values.operator.watchNamespaces -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "runtime-operator.fullname" . }}-endpointslice
+  labels:
+    {{- include "runtime-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+{{- range .Values.operator.watchNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "runtime-operator.fullname" $ }}-endpointslice
+  namespace: {{ . }}
+  labels:
+    {{- include "runtime-operator.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "runtime-operator.fullname" $ }}-endpointslice
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "operator.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -38,7 +38,6 @@ spec:
           secret:
             secretName: {{ $top.Values.global.certificates.dataCertSecretName }}
         {{- end }}
-            # update this
       serviceAccountName: {{ include "runtime.serviceAccountName" $top }}
       {{- include "runtime-operator.imagePullSecrets" $top | nindent 6 }}
       containers:

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -21,17 +21,23 @@ spec:
       labels:
         wasmcloud.com/name: hostgroup
         wasmcloud.com/hostgroup: {{ .name }}
-        {{- include "runtime-operator.labels" $top | nindent 8 }}
+        {{- include "runtime.podLabels" $top | nindent 8 }}
+      {{- with $top.Values.runtime.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       volumes:
         - name: oci-cache
           emptyDir: {}
+        {{- if $top.Values.global.tls.enabled }}
         - name: runtime-cert
           secret:
             secretName: {{ $top.Values.global.certificates.runtimeCertSecretName }}
         - name: data-cert
           secret:
             secretName: {{ $top.Values.global.certificates.dataCertSecretName }}
+        {{- end }}
             # update this
       serviceAccountName: {{ include "runtime.serviceAccountName" $top }}
       {{- include "runtime-operator.imagePullSecrets" $top | nindent 6 }}
@@ -48,16 +54,20 @@ spec:
             - "--host-name=$(WASMCLOUD_HOST_IP)"
             - "--host-group={{ .name }}"
             - "--scheduler-nats-url=nats://nats:4222"
+            {{- if $top.Values.global.tls.enabled }}
             - "--scheduler-nats-tls-ca=/runtime-cert/ca.crt"
             - "--scheduler-nats-tls-cert=/runtime-cert/tls.crt"
             - "--scheduler-nats-tls-key=/runtime-cert/tls.key"
+            {{- end }}
             - "--data-nats-url=nats://nats:4222"
+            {{- if $top.Values.global.tls.enabled }}
             - "--data-nats-tls-ca=/data-cert/ca.crt"
             - "--data-nats-tls-cert=/data-cert/tls.crt"
             - "--data-nats-tls-key=/data-cert/tls.key"
+            {{- end }}
             - "--oci-cache-dir=/oci-cache"
             {{- if and (.http) (.http.enabled) }}
-            - "--http-addr=0.0.0.0:9191"
+            - "--http-addr=0.0.0.0:{{ .http.port }}"
             {{- end }}
             {{- if and (.webgpu) (.webgpu.enabled) }}
             - "--wasi-webgpu"
@@ -66,12 +76,14 @@ spec:
           volumeMounts:
             - name: oci-cache
               mountPath: /oci-cache
+            {{- if $top.Values.global.tls.enabled }}
             - name: runtime-cert
               mountPath: /runtime-cert
               readOnly: true
             - name: data-cert
               mountPath: /data-cert
               readOnly: true
+            {{- end }}
           {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -79,7 +91,7 @@ spec:
           ports:
             {{- if and (.http) (.http.enabled) }}
             - name: http
-              containerPort: 9191
+              containerPort: {{ .http.port }}
               protocol: TCP
             {{- end }}
           securityContext:

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -11,7 +11,8 @@ global:
     # Set to false when a service mesh (e.g. Istio) provides mTLS.
     enabled: true
   certificates:
-    # -- Enable automatic generation of self-signed TLS certificates for the operator and runtime hosts
+    # -- Enable automatic generation of self-signed TLS certificates for the operator and runtime hosts.
+    # Ignored when global.tls.enabled is false.
     generate: true
     # -- Name of the Kubernetes Secrets holding the Private CA certificate ( NATS )
     caSecretName: wasmcloud-ca
@@ -122,7 +123,7 @@ runtime:
         enabled: false
       http:
         enabled: true
-        port: 80
+        port: 9191
       resources:
         requests:
           memory: "64Mi"

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -6,6 +6,10 @@ global:
     pullSecrets: []
   nameOverride: ""
   fullnameOverride: ""
+  tls:
+    # -- Enable TLS for NATS connections and certificate generation.
+    # Set to false when a service mesh (e.g. Istio) provides mTLS.
+    enabled: true
   certificates:
     # -- Enable automatic generation of self-signed TLS certificates for the operator and runtime hosts
     generate: true
@@ -23,6 +27,10 @@ global:
 # -- Values for installing a basic NATS Server with Ephemeral Storage. If you prefer to install NATS separately, set `enabled` to `false`.
 nats:
   enabled: true
+  # -- Labels to add to the NATS pod template
+  podLabels: {}
+  # -- Annotations to add to the NATS pod template
+  podAnnotations: {}
   image:
     registry: docker.io
     repository: nats
@@ -38,6 +46,10 @@ nats:
 
 operator:
   enabled: true
+  # -- Labels to add to the operator pod template
+  podLabels: {}
+  # -- Annotations to add to the operator pod template
+  podAnnotations: {}
   image:
     registry: ghcr.io
     repository: wasmcloud/runtime-operator
@@ -85,6 +97,10 @@ gateway:
     annotations: {}
 
 runtime:
+  # -- Labels to add to runtime host pod templates
+  podLabels: {}
+  # -- Annotations to add to runtime host pod templates
+  podAnnotations: {}
   serviceAccount:
     # -- Specifies whether a service account should be created
     create: true


### PR DESCRIPTION
Fixes #5036 

### New values.yaml property

```yaml
global:
  tls:
    # -- Enable TLS for NATS connections and certificate generation.
    # Set to false when a service mesh (e.g. Istio) provides mTLS.
    enabled: true
```

This is separate from (and takes precedence over) `global.certificates.generate`. The relationship:

| `global.tls.enabled` | `global.certificates.generate` | Behavior |
|---|---|---|
| `true` (default) | `true` (default) | Self-signed certs generated, TLS args passed to all components, NATS TLS block present. **Current behavior.** |
| `true` | `false` | No certs generated (user supplies their own secrets), TLS args still passed, NATS TLS block present. **Existing BYOC flow.** |
| `false` | (ignored) | No certs generated, no TLS args passed, NATS runs plaintext. **New flow.** |

### EndPointSlice RBAC is defined either cluster scoped or namespace scoped, depending on if `operator.watchNamespaces` is populated.
 
### Pod Labels and Annotations for the Nats, Operator and Runtime deployments
In `values.yaml`, you can now specify  labels and annotations that should be applied to each deployment independently. Example:
```yaml
operator:
  podLabels:
    sidecar.istio.io/inject: "true"
  podAnnotations:
    proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
```
### Additional changes
- Nats service port renamed from `nats` to `tcp-nats`. This protocal prefix allows for service mesh's to know not to treat this port as HTTP.
- `runtime.hostGroups[].http.port` is used as the value for the http port in the host. Previously it was hard-coded.

## Testing
Tested locally with Kind+Istio enabled. Values.yaml file that was used:
```yaml
global:
  # disabling tls, since Istio is used
  tls:
    enabled: false
gateway:
  enabled: false

nats:
  podLabels:
    sidecar.istio.io/inject: "true"
  podAnnotations:
    proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'

operator:
  podLabels:
    sidecar.istio.io/inject: "true"
  podAnnotations:
    proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
  image:
    registry: ""
    repository: controller
    tag: latest
    pull_policy: Never
  watchNamespaces: ["default"]

runtime:
  podLabels:
    sidecar.istio.io/inject: "true"
  podAnnotations:
    proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
  image:
    registry: ""
    repository: wash
    tag: local
    # testing with local image
    pull_policy: Never
  hostGroups:
    - name: default
      replicas: 3
      service:
        type: ClusterIP
      webgpu:
        enabled: false
      http:
        enabled: true
        port: 8080
      resources:
        requests:
          memory: "64Mi"
          cpu: "250m" # 0.25 CPU cores
        limits:
          memory: "512Mi"
          cpu: "500m" # 0.5 CPU cores
```