### PR TITLE
set ownership to nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache add protoc protobuf protobuf-dev
 USER nonroot
 
 # copy source code
-COPY . .
+COPY --chown=nonroot:nonroot . .
 
 # build static binary
 RUN cargo build --release --bin wash


### PR DESCRIPTION
- Sets the files copied into the first stage to nonroot, to avoid a permission denied error.
- Final build has no impact

Tested locally w/building docker image

Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
