### PR TITLE
[Fix] Nats race condition when initializing subscriber

### DIFF
--- a/runtime-operator/internal/controller/runtime/host_controller.go
+++ b/runtime-operator/internal/controller/runtime/host_controller.go
@@ -161,7 +161,7 @@ func (h *hostStatusUpdater) Start(ctx context.Context) error {
 		return err
 	}
 
-	go subscription.Handle(func(msg *wasmbus.Message) {
+	subscription.Handle(func(msg *wasmbus.Message) {
 		var req runtimev2.HostHeartbeat
 		if err := protojson.Unmarshal(msg.Data, &req); err != nil {
 			fmt.Println("Failed to decode heartbeat message:", err)

--- a/runtime-operator/pkg/wasmbus/client_test.go
+++ b/runtime-operator/pkg/wasmbus/client_test.go
@@ -122,7 +122,7 @@ func TestLatticeRequest(t *testing.T) {
 		defer func() { _ = sub.Drain() }()
 
 		errCh := make(chan error, 1)
-		go sub.Handle(func(msg *Message) {
+		sub.Handle(func(msg *Message) {
 			resp := &testMessage{}
 			if err := Decode(msg, resp); err != nil {
 				errCh <- err
@@ -178,7 +178,7 @@ func TestLatticeRequest(t *testing.T) {
 		}
 		defer func() { _ = sub.Drain() }()
 
-		go sub.Handle(func(msg *Message) {
+		sub.Handle(func(msg *Message) {
 			respMsg := NewMessage(msg.Reply)
 			respMsg.Header.Set("Content-Type", "bricks")
 			respMsg.Data = []byte("boom")
@@ -215,7 +215,7 @@ func TestLatticeRequest(t *testing.T) {
 		defer func() { _ = sub.Drain() }()
 
 		errCh := make(chan error, 1)
-		go sub.Handle(func(msg *Message) {
+		sub.Handle(func(msg *Message) {
 			resp := &testMessage{}
 			if err := Decode(msg, resp); err != nil {
 				errCh <- err
@@ -268,7 +268,7 @@ func TestLatticeRequest(t *testing.T) {
 		defer func() { _ = sub.Drain() }()
 
 		errCh := make(chan error, 1)
-		go sub.Handle(func(msg *Message) {
+		sub.Handle(func(msg *Message) {
 			resp := &testMessage{}
 			if err := Decode(msg, resp); err != nil {
 				errCh <- err

--- a/runtime-operator/pkg/wasmbus/nats.go
+++ b/runtime-operator/pkg/wasmbus/nats.go
@@ -86,22 +86,28 @@ type NatsSubscription struct {
 }
 
 // Handle implements `Subscription.Handle` for NATS.
+// Starts a goroutine to consume messages and returns once the goroutine is ready to receive.
 func (s *NatsSubscription) Handle(callback SubscriptionCallback) {
+	ready := make(chan struct{})
 	s.wg.Add(1)
-	defer s.wg.Done()
-	for {
-		msg, ok := <-s.ch
-		if !ok {
-			break
+	go func() {
+		defer s.wg.Done()
+		close(ready)
+		for {
+			msg, ok := <-s.ch
+			if !ok {
+				break
+			}
+			callback(&Message{
+				Subject: msg.Subject,
+				Reply:   msg.Reply,
+				Header:  Header(msg.Header),
+				Data:    msg.Data,
+				bus:     s.bus,
+			})
 		}
-		callback(&Message{
-			Subject: msg.Subject,
-			Reply:   msg.Reply,
-			Header:  Header(msg.Header),
-			Data:    msg.Data,
-			bus:     s.bus,
-		})
-	}
+	}()
+	<-ready
 }
 
 // Drain implements `Subscription.Drain` for NATS.

--- a/runtime-operator/pkg/wasmbus/nats_test.go
+++ b/runtime-operator/pkg/wasmbus/nats_test.go
@@ -42,7 +42,7 @@ func TestNatsPublish(t *testing.T) {
 		defer func() { _ = sub.Drain() }()
 		received := make(chan bool, 1)
 
-		go sub.Handle(func(msg *Message) {
+		sub.Handle(func(msg *Message) {
 			if msg.Subject == testSubject {
 				received <- true
 			}
@@ -97,7 +97,7 @@ func TestNatsSubscribe(t *testing.T) {
 		defer func() { _ = sub.Drain() }()
 
 		received := make(chan bool, 1)
-		go sub.Handle(func(msg *Message) {
+		sub.Handle(func(msg *Message) {
 			if msg.Subject == testSubject {
 				received <- true
 			}
@@ -149,7 +149,7 @@ func TestNatsQueueSubscribe(t *testing.T) {
 		}
 		defer func() { _ = sub.Drain() }()
 		received := make(chan bool, 1)
-		go sub.Handle(func(msg *Message) {
+		sub.Handle(func(msg *Message) {
 			if msg.Subject == "success" {
 				received <- true
 			}

--- a/runtime-operator/pkg/wasmbus/server.go
+++ b/runtime-operator/pkg/wasmbus/server.go
@@ -92,7 +92,7 @@ func (s *Server) RegisterHandler(subject string, handler AnyServerHandler) error
 	if err != nil {
 		return err
 	}
-	go sub.Handle(func(msg *Message) {
+	sub.Handle(func(msg *Message) {
 		ctx := s.ContextFunc()
 		if err := handler.HandleMessage(ctx, msg); err != nil {
 			s.reportError(ctx, msg, err)

--- a/runtime-operator/pkg/wasmbus/server_test.go
+++ b/runtime-operator/pkg/wasmbus/server_test.go
@@ -30,7 +30,7 @@ func TestServerRegisterHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	resp, err := server.Request(ctx, NewMessage("test"))

--- a/runtime-operator/pkg/wasmbus/server_test.go
+++ b/runtime-operator/pkg/wasmbus/server_test.go
@@ -30,7 +30,7 @@ func TestServerRegisterHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
 	resp, err := server.Request(ctx, NewMessage("test"))


### PR DESCRIPTION
**Have Handle wait for goroutine to be initialized**

There is no change in the actual logic here. Before, a goroutine was called to `go subscription.Handle()`, which there is a chance (on CI builds esp) that a race condition occurs with posting a test message before the actual handler is registered with the subscription.

This change moves the goroutine into subscription.Handle(), which will not return until the goroutine is actually running. 


Tested locally with `make docker-build` and running the image in a kind cluster. The runtime-operator works as expected. Local tests worked as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->