### PR TITLE
Remove default tag to use chart.yaml appVersion

### DIFF
--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -113,7 +113,7 @@ runtime:
     registry: ghcr.io
     repository: wasmcloud/wash
     pull_policy: Always
-    tag: "2.0.2"
+    tag: ""
   hostGroups:
     - name: default
       replicas: 1


### PR DESCRIPTION
This change simply removes the value in the `runtime.image.tag` in `values.yaml` so that the default image tag will be `appVersion` in `Chart.yaml` like the other containers deployed by this helm chart.


Tested w/Kind locally.

Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
