### PR TITLE
release: v2.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 authors = ["The wasmCloud Team"]
 edition = "2024"
 rust-version = "1.91.0"
-version = "2.0.2"
+version = "2.0.3"
 
 [workspace.lints.rust]
 warnings = 'deny' # Treat all warnings as errors

--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.2"
+appVersion: "2.0.3"


### PR DESCRIPTION
Bump workspace version to 2.0.3 and Helm chart version to 0.2.0
to account for chart template changes since v2.0.2.

Signed-off-by: Bailey Hayes <bailey@cosmonic.com>
