### PR TITLE
docs: add governance docs updated for wasmCloud v2

### DIFF
--- a/CONTRIBUTION_LADDER.md
+++ b/CONTRIBUTION_LADDER.md
@@ -1,0 +1,132 @@
+# Contribution Ladder
+
+---
+- [Contribution Ladder](#contribution-ladder)
+  - [Community Member](#community-member)
+  - [Contributor](#contributor)
+    - [How to become a contributor](#how-to-become-a-contributor)
+  - [Project Maintainer](#project-maintainer)
+    - [How to become a project maintainer](#how-to-become-a-project-maintainer)
+    - [Community and non-code maintainers](#community-and-non-code-maintainers)
+  - [Org Maintainer](#org-maintainer)
+    - [How to become an org maintainer](#how-to-become-an-org-maintainer)
+  - [Emeritus Maintainers](#emeritus-maintainers)
+---
+
+A contribution ladder defines the path to becoming a maintainer of one or more wasmCloud projects.
+You will need to build trust, demonstrate competence and understanding, and meet the requirements
+of the role.
+
+## Community Member
+
+Everyone is a community member! Here are some ways to get more involved:
+
+- Comment on issues you are interested in.
+- Submit a pull request to fix a bug or add a feature.
+- Report a bug or share a use case.
+- Share a component or provider you built and your experience with it.
+- Come chat with us in [Slack](https://slack.wasmcloud.com/).
+
+All community members must follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Contributor
+
+Contributors have made direct contributions to one or more wasmCloud repositories. This role grants
+basic privileges on the repositories where they are contributors:
+
+- Have issues and pull requests assigned to them
+- Apply labels, milestones, and projects
+- [Mark issues as duplicates](https://help.github.com/en/articles/about-duplicate-issues-and-pull-requests)
+- Close, reopen, and assign issues and pull requests
+
+Contributors must agree to and follow our [Contributing Guide](CONTRIBUTING.md).
+
+### How to become a contributor
+
+Maintainers watch for community members who may make good contributors, but don't be shy — if you
+feel this is you, reach out to a maintainer.
+
+To be recognized as a contributor, the maintainers would like to see you:
+
+- Comment on issues with your experiences and opinions.
+- Add comments and reviews on pull requests.
+- Open pull requests with bug fixes, improvements, or documentation.
+- Open issues with bugs, experience reports, or questions.
+
+## Project Maintainer
+
+Project Maintainers are contributors who are trusted to maintain one or more areas of the project.
+They have elevated capabilities:
+
+- Be a Code Owner and have reviews automatically requested.
+- Review and approve pull requests in their area.
+- Merge pull requests.
+
+Maintainers also take on additional responsibilities:
+
+- Help foster a safe and welcoming environment for all project participants, including understanding
+  and enforcing our [Code of Conduct](CODE_OF_CONDUCT.md).
+- Organize and promote pull request reviews by prompting community members and other maintainers.
+- Triage issues: add labels, promote discussions, and finalize decisions.
+- Help organize community meetings: schedule, organize, and drive the agenda.
+- Make project-level technical decisions together with other maintainers.
+
+Maintainers must agree to and follow the reviewing guidelines in our
+[Contributing Guide](CONTRIBUTING.md).
+
+### How to become a project maintainer
+
+Maintainers regularly discuss promoting contributors. Don't be shy — if you feel ready, reach out
+to a maintainer.
+
+To become a project maintainer we would like to see you:
+
+- Consistently contribute high-quality code, documentation, or issue triage.
+- Demonstrate understanding of the project's design and codebase.
+- Show sound judgment in reviews and discussions.
+- Engage reliably over an extended period (typically several months).
+
+The process:
+1. Any existing maintainer (or the candidate themselves) proposes the candidate by opening a PR to
+   add them to [MAINTAINERS.md](./MAINTAINERS.md) with a brief description of their contributions.
+2. Lazy consensus among existing project maintainers — no objection within 7 days is approval.
+3. Upon merge, the new maintainer is added to the appropriate GitHub team(s).
+
+### Community and non-code maintainers
+
+Not all contributors want to manage code. We also recognize maintainers who take on community
+management roles:
+
+- Managing Slack and other communication channels
+- Planning community meetups and events
+- Coordinating developer meetings
+- Managing and reviewing blog posts
+- Assisting with branding, messaging, and CNCF communications
+
+## Org Maintainer
+
+Org Maintainers are responsible for the overall health and direction of the wasmCloud project. In
+addition to their project maintainer responsibilities they:
+
+- Help manage org-level permissions and access
+- Serve as a tiebreaker in disputes among project maintainers
+- Decide the overall direction of wasmCloud together with other org maintainers
+- Interface with CNCF on behalf of the project
+
+See [GOVERNANCE.md](./GOVERNANCE.md) for full org maintainer rules, voting thresholds, and
+onboarding/offboarding procedures.
+
+### How to become an org maintainer
+
+Not all maintainers will need or want to become an org maintainer. If you are a project maintainer
+who finds yourself wanting to help with administrative tasks or project-wide decisions, reach out to
+one or more org maintainers.
+
+Becoming an org maintainer requires a super-majority vote of existing org maintainers, following
+the nomination process described in [GOVERNANCE.md](./GOVERNANCE.md).
+
+## Emeritus Maintainers
+
+Any maintainer (org or project) who withdraws from active maintainership will be recognized as an
+Emeritus Maintainer as a thank you for their contributions. They have no ongoing responsibilities
+but remain permanently on record as former maintainers unless they request to be removed.

--- a/CONTRIBUTION_LADDER.md
+++ b/CONTRIBUTION_LADDER.md
@@ -24,10 +24,11 @@ Everyone is a community member! Here are some ways to get more involved:
 - Comment on issues you are interested in.
 - Submit a pull request to fix a bug or add a feature.
 - Report a bug or share a use case.
-- Share a component or provider you built and your experience with it.
+- Share a component or example you built and your experience with it.
 - Come chat with us in [Slack](https://slack.wasmcloud.com/).
 
-All community members must follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+All community members must follow the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
 ## Contributor
 
@@ -39,8 +40,6 @@ basic privileges on the repositories where they are contributors:
 - [Mark issues as duplicates](https://help.github.com/en/articles/about-duplicate-issues-and-pull-requests)
 - Close, reopen, and assign issues and pull requests
 
-Contributors must agree to and follow our [Contributing Guide](CONTRIBUTING.md).
-
 ### How to become a contributor
 
 Maintainers watch for community members who may make good contributors, but don't be shy — if you
@@ -50,8 +49,9 @@ To be recognized as a contributor, the maintainers would like to see you:
 
 - Comment on issues with your experiences and opinions.
 - Add comments and reviews on pull requests.
-- Open pull requests with bug fixes, improvements, or documentation.
 - Open issues with bugs, experience reports, or questions.
+- Open pull requests with bug fixes, improvements, or documentation.
+- Add comments and reviews on pull requests.
 
 ## Project Maintainer
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,180 @@
+# wasmCloud Governance
+
+The following document outlines how the wasmCloud project governance operates.
+
+- [wasmCloud Governance](#wasmcloud-governance)
+  - [The wasmCloud Project](#the-wasmcloud-project)
+  - [Maintainers Structure](#maintainers-structure)
+    - [wasmCloud Org Maintainers](#wasmcloud-org-maintainers)
+    - [New Maintainer Onboarding](#new-maintainer-onboarding)
+    - [Stepping down as a maintainer](#stepping-down-as-a-maintainer)
+    - [Taking a leave from being a maintainer](#taking-a-leave-from-being-a-maintainer)
+  - [Decision Making at the wasmCloud org level](#decision-making-at-the-wasmcloud-org-level)
+  - [Decision Making at the wasmCloud project level](#decision-making-at-the-wasmcloud-project-level)
+  - [Communications](#communications)
+  - [Code of Conduct](#code-of-conduct)
+  - [DCO and Licenses](#dco-and-licenses)
+  - [Pull Requests and Reviews](#pull-requests-and-reviews)
+
+## The wasmCloud Project
+
+The wasmCloud project is made up of several codebases and services with different release cycles. A
+list of these projects can be found [here](https://github.com/orgs/wasmCloud/repositories).
+
+## Maintainers Structure
+
+There are two levels of maintainers for wasmCloud. The wasmCloud org maintainers oversee the overall
+project and its health. Project maintainers focus on a single codebase, a group of related
+codebases, a service (e.g., a website), or a supporting area (e.g., CI or community management). See
+the [Contributor Ladder](./CONTRIBUTION_LADDER.md) for more detail on responsibilities and how to
+progress through them.
+
+### wasmCloud Org Maintainers
+
+The wasmCloud Org maintainers are responsible for:
+
+- Maintaining the mission, vision, values, and scope of the project
+- Refining the governance and charter as needed
+- Making project-level decisions
+- Resolving escalated project decisions when a sub-team is blocked
+- Managing the wasmCloud brand
+- Controlling access to wasmCloud assets such as source repositories, hosting, and project calendars
+- Handling code of conduct violations
+- Deciding what sub-groups are part of the wasmCloud project
+- Overseeing the resolution and disclosure of security issues
+- Managing financial decisions related to the project
+
+Changes to org maintainers use the following rules:
+
+- There will be between 2 and 9 people.
+- Any project maintainer of any active (non-archived) wasmCloud organization project is eligible for
+  a position as an org maintainer.
+- An org maintainer may step down by emailing the org maintainers or contacting them via Slack.
+- Org maintainers MUST remain active on the project. If they are unresponsive for > 3 months they
+  will lose org maintainership unless a
+  [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other org
+  maintainers agrees to extend the period.
+- When there is an opening for a new org maintainer, any person who has made a contribution to any
+  repo under the wasmCloud GitHub org may nominate a suitable project maintainer of an active
+  project by contacting the current org maintainers.
+  - The nomination period will be three weeks starting the day after an org maintainer opening
+    becomes available.
+- Org maintainers must vote for a nominated candidate; the vote must pass with a
+  [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote).
+- When an org maintainer steps down, they become an emeritus maintainer.
+
+Once an org maintainer is elected, they remain a maintainer until stepping down (or, in rare cases,
+are removed). Any existing project maintainer is eligible to become an org maintainer.
+
+### New Maintainer Onboarding
+
+When a new **project maintainer** is added, a current maintainer should take the following steps:
+
+1. Open a PR adding the new maintainer to [MAINTAINERS.md](./MAINTAINERS.md) under the appropriate
+   sub-team(s). The PR description should briefly describe the contributor's history and
+   qualifications.
+2. Merge the PR once approved (lazy consensus among existing project maintainers — no objection
+   within 7 days is approval).
+3. Add the new maintainer to the appropriate GitHub team(s) for their project area.
+4. Announce the new maintainer in the wasmCloud Slack (`#wasmcloud-dev` or `#general`) and at the
+   next community call.
+
+When adding a new **org maintainer**, the following additional steps are required after the
+above:
+
+5. Add the new org maintainer to the CNCF
+   [project-maintainers.csv](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
+   via PR.
+6. After the PR is merged, send an email to `cncf-maintainer-changes@cncf.io` noting the addition
+   so they can be added to the `cncf-wasmCloud-maintainers@lists.cncf.io` mailing list.
+
+### Stepping down as a maintainer
+
+To step down, a maintainer should open a PR to remove themselves (and add themselves to the
+Emeritus section) from [MAINTAINERS.md](./MAINTAINERS.md). Upon merge:
+
+1. Another maintainer removes the departing maintainer from their GitHub team(s).
+2. (Encouraged) A thank-you message is sent in Slack and at the next community call.
+
+If an **org maintainer** steps down, the additional steps are:
+
+3. Remove them from the CNCF
+   [project-maintainers.csv](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
+   via PR.
+4. Send an email to `cncf-maintainer-changes@cncf.io` noting the removal.
+
+### Taking a leave from being a maintainer
+
+Any maintainer may take a leave of absence for any reason (which they are not required to
+disclose). To do so, open a PR to mark yourself as "on leave" in [MAINTAINERS.md](./MAINTAINERS.md).
+Maximum leave is 6 months; an additional 6-month extension requires a majority vote of the relevant
+project maintainers. If a maintainer on leave has not contacted other maintainers after 6 months,
+they will be moved to emeritus status. Upon returning, open a PR to remove the "on leave"
+designation — no additional vote required.
+
+## Decision Making at the wasmCloud org level
+
+The default decision-making process is
+[lazy consensus](http://communitymgt.wikia.com/wiki/Lazy_consensus). Any decision is considered
+supported as long as no one objects. Silence is implicit agreement.
+
+When consensus cannot be found a maintainer can call for a
+[majority](https://en.wikipedia.org/wiki/Majority) vote.
+
+The following decisions **must** be put to a vote:
+
+- Enforcing a CoC violation (super-majority)
+- Removing a maintainer for any reason other than inactivity (super-majority)
+- Changing this governance document (super-majority)
+- Licensing and intellectual property changes, including new logos or wordmarks (simple majority)
+- Adding, archiving, or removing sub-projects (simple majority)
+- Utilizing wasmCloud/CNCF funds for anything CNCF deems "not cheap and easy" (simple majority)
+
+Other decisions may be called to a vote at any time by any maintainer; by default such votes
+require a _simple majority_.
+
+## Decision Making at the wasmCloud project level
+
+Project maintainers are free to set their own decision-making processes. The default is
+[lazy consensus](http://communitymgt.wikia.com/wiki/Lazy_consensus).
+
+Day-to-day decisions (e.g., agreeing on ADRs, release timing) can be made by a
+[simple majority](https://en.wikipedia.org/wiki/Majority). When your maintainer group spans multiple
+organizations, aim to include at least one vote from each represented organization.
+
+## Communications
+
+The two primary communication channels for the wasmCloud project are:
+
+- GitHub Issues / PRs / Discussions
+- [wasmCloud Slack](https://slack.wasmcloud.com)
+
+To reach the org maintainers, use the wasmCloud Slack or email
+`cncf-wasmCloud-maintainers@lists.cncf.io`.
+
+## Code of Conduct
+
+This project follows the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Possible violations
+should be reported to the org maintainers.
+
+If the possible violation involves an org maintainer, that maintainer will be recused from the
+decision. Such issues must be escalated to the appropriate CNCF contact, and CNCF may choose to
+intervene.
+
+## DCO and Licenses
+
+The following licenses and contributor agreements apply to wasmCloud projects:
+
+- [Apache 2.0](https://opensource.org/licenses/Apache-2.0) for code
+- [Creative Commons Attribution 4.0 International Public
+  License](https://creativecommons.org/licenses/by/4.0/legalcode) for documentation
+- [Developer Certificate of Origin](https://developercertificate.org/) for new contributions
+
+## Pull Requests and Reviews
+
+Pull requests are reviewed by maintainers and community members. Maintainers are responsible for
+triaging PRs and ensuring they receive appropriate review. Each pull request must pass the
+checks defined for its project area. Project-level required checks are decided at the project level.
+
+Additional contributing guidelines can be found in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,10 +23,11 @@ list of these projects can be found [here](https://github.com/orgs/wasmCloud/rep
 
 ## Maintainers Structure
 
-There are two levels of maintainers for wasmCloud. The wasmCloud org maintainers oversee the overall
-project and its health. Project maintainers focus on a single codebase, a group of related
-codebases, a service (e.g., a website), or a supporting area (e.g., CI or community management). See
-the [Contributor Ladder](./CONTRIBUTION_LADDER.md) for more detail on responsibilities and how to
+There are two levels of maintainers for wasmCloud.
+- **Org maintainers** oversee the overall project and its health.
+- **Project maintainers** focus on a single codebase, a group of related codebases, a service (e.g., a website), or a supporting area (e.g., CI or community management).
+
+See the [Contributor Ladder](./CONTRIBUTION_LADDER.md) for more detail on responsibilities and how to
 progress through them.
 
 ### wasmCloud Org Maintainers
@@ -107,9 +108,9 @@ If an **org maintainer** steps down, the additional steps are:
 
 Any maintainer may take a leave of absence for any reason (which they are not required to
 disclose). To do so, open a PR to mark yourself as "on leave" in [MAINTAINERS.md](./MAINTAINERS.md).
-Maximum leave is 6 months; an additional 6-month extension requires a majority vote of the relevant
-project maintainers. If a maintainer on leave has not contacted other maintainers after 6 months,
-they will be moved to emeritus status. Upon returning, open a PR to remove the "on leave"
+project maintainers. Upon returning, open a PR to remove the "on leave" designation — no additional vote required.
+
+If a maintainer on leave has not contacted other maintainers after 6 months, they may be moved to emeritus status.
 designation — no additional vote required.
 
 ## Decision Making at the wasmCloud org level

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,167 @@
+# MAINTAINERS
+
+The following individuals are responsible for reviewing code, managing issues, and ensuring the
+overall quality of the project. This document is organized by the GitHub team that can be used to
+mention _all_ maintainers of a particular aspect of the project.
+
+Maintainers of projects that are not in this monorepo can be found in their respective repositories;
+including [wadm](https://github.com/wasmCloud/wadm/blob/main/MAINTAINERS.md),
+[wasmcloud-operator](https://github.com/wasmCloud/wasmcloud-operator/blob/main/MAINTAINERS.md), and
+[wasmcloud.com](https://github.com/wasmCloud/wasmcloud.com/blob/main/MAINTAINERS.md) at the time of
+writing this.
+
+## @wasmCloud/org-maintainers
+
+Name: Bailey Hayes  
+GitHub: @ricochet  
+Organization: Cosmonic
+
+Name: Jeremy Tanner <!-- TODO: confirm GitHub handle -->  
+GitHub: @[jeremy-handle]  
+Organization: Cosmonic
+
+## @wasmCloud/runtime-maintainers
+
+_Covers the wasmCloud host runtime, capability provider SDK, observability, and related crates._
+
+Name: Bailey Hayes  
+GitHub: @ricochet  
+Organization: Cosmonic
+
+Name: Brooks Townsend  
+GitHub: @brooksmtownsend  
+Organization: Cosmonic
+
+Name: Roman Volosatovs  
+GitHub: @rvolosatovs  
+Organization: Cosmonic
+
+Name: Victor Adossi  
+GitHub: @vados-cosmonic  
+Organization: Cosmonic
+
+## @wasmCloud/wash-maintainers
+
+_Covers the `wash` CLI and `wash-runtime` crates._
+
+Name: Bailey Hayes  
+GitHub: @ricochet  
+Organization: Cosmonic
+
+Name: Brooks Townsend  
+GitHub: @brooksmtownsend  
+Organization: Cosmonic
+
+Name: Victor Adossi  
+GitHub: @vados-cosmonic  
+Organization: Cosmonic
+
+Name: Colin Murphy  
+GitHub: @cdmurph32  
+Organization: Adobe
+
+Name: ifOne <!-- TODO: confirm full name and GitHub handle -->  
+GitHub: @[ifOne-handle]  
+Organization: [Organization or "Independent"]
+
+## @wasmCloud/go-maintainers
+
+_Covers Go SDK and Go-based tooling._
+
+Name: Bailey Hayes  
+GitHub: @ricochet  
+Organization: Cosmonic
+
+Name: Brooks Townsend  
+GitHub: @brooksmtownsend  
+Organization: Cosmonic
+
+Name: Roman Volosatovs  
+GitHub: @rvolosatovs  
+Organization: Cosmonic
+
+Name: Jordan Rash  
+GitHub: @jordan-rash  
+Organization: Synadia
+
+Name: Lucas Fontes  
+GitHub: @lxfontes  
+Organization: Cosmonic
+
+## @wasmCloud/ci-maintainers
+
+_Covers GitHub Actions workflows, release automation, and CI infrastructure._
+
+Name: Bailey Hayes  
+GitHub: @ricochet  
+Organization: Cosmonic
+
+Name: Brooks Townsend  
+GitHub: @brooksmtownsend  
+Organization: Cosmonic
+
+Name: Roman Volosatovs  
+GitHub: @rvolosatovs  
+Organization: Cosmonic
+
+Name: Victor Adossi  
+GitHub: @vados-cosmonic  
+Organization: Cosmonic
+
+Name: Lachlan Heywood  
+GitHub: @lachieh  
+Organization: Cosmonic
+
+## @wasmCloud/triage-maintainers
+
+_Contributors with triage privileges — can label, assign, and close issues and PRs._
+
+Name: Aditya Salunkhe  
+GitHub: @Aditya1404Sal  
+Organization: Independent
+
+Name: Márk Kővári  
+GitHub: @markkovari  
+Organization: commercetools
+
+Name: Luke Jones  
+GitHub: @LUK3ARK  
+Organization: Lattica
+
+## Emeritus Maintainers
+
+These individuals have contributed significantly to the project but are no longer actively
+maintaining it.
+
+Name: Kevin Hoffman  
+GitHub: @autodidaddict
+
+Name: Steve Schoettler  
+GitHub: @stevelr
+
+Name: Connor Smith  
+GitHub: @connorsmith256
+
+Name: Kaushik Shanadi  
+GitHub: @ks2211
+
+Name: Taylor Thomas  
+GitHub: @thomastaylor312
+
+Name: Liam Randall  
+GitHub: @LiamRandall
+
+Name: Joonas Bergius  
+GitHub: @joonas
+
+Name: Dan Norris  
+GitHub: @protochron
+
+Name: Jiaxiao Zhou  
+GitHub: @Mossaka
+
+Name: Matt Wilkinson  
+GitHub: @mattwilkinsonn
+
+Name: Masoud Baharlouie  
+GitHub: @ossfellow

--- a/RELEASE_RUNBOOK.md
+++ b/RELEASE_RUNBOOK.md
@@ -1,0 +1,109 @@
+# Release Runbook
+
+This guide is a runbook for maintainers preparing to release components of this monorepo.
+
+wasmCloud v2 uses **tag-triggered automation** for all releases. There is no manual workflow
+dispatch or smart-release tooling. Pushing a correctly formatted tag to `main` kicks off the
+appropriate CI pipeline automatically.
+
+## Release artifacts at a glance
+
+| Component | Tag format | What gets published |
+|-----------|-----------|---------------------|
+| `wash` + `runtime-gateway` + `runtime-operator` + Helm charts | `vX.Y.Z` | Binaries, Docker images, Helm chart, GitHub Release |
+| `wash-runtime` (library crate) | `wash-runtime-vX.Y.Z` | crates.io |
+
+> **Note:** A single `vX.Y.Z` tag simultaneously triggers releases for `wash`, `runtime-gateway`,
+> `runtime-operator`, and the Helm chart. These components are co-versioned.
+
+## Canary builds
+
+On every merge to `main` (no tag required):
+
+- `ghcr.io/wasmcloud/wash:canary-v2`
+- `ghcr.io/wasmcloud/runtime-gateway:canary`
+- `ghcr.io/wasmcloud/runtime-operator:canary`
+- Helm chart `runtime-operator:v2-canary`
+
+## Releasing `wash` / `runtime-gateway` / `runtime-operator` / Helm charts
+
+These four components share a version tag and are released together.
+
+1. Update the version in `Cargo.toml` (root workspace) to `X.Y.Z`:
+   ```
+   version = "X.Y.Z"
+   ```
+2. Open a pull request with only this version bump, get it reviewed, and merge to `main`.
+3. Create and push the release tag from `main`:
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+4. The `wash` workflow will:
+   - Build cross-platform binaries (Linux x86\_64/aarch64 musl, macOS x86\_64/aarch64, Windows x86\_64)
+   - Generate SLSA build provenance attestations
+   - Create a GitHub Release with binaries attached and auto-generated release notes
+   - Push `ghcr.io/wasmcloud/wash:vX.Y.Z`
+   - Automatically dispatch a Homebrew tap update
+5. The `runtime-gateway` workflow will push `ghcr.io/wasmcloud/runtime-gateway:vX.Y.Z`.
+6. The `runtime-operator` workflow will:
+   - Push `ghcr.io/wasmcloud/runtime-operator:vX.Y.Z`
+   - Create a Go module tag `runtime-operator/vX.Y.Z`
+7. The `charts` workflow will publish the `runtime-operator` Helm chart to
+   `ghcr.io/wasmcloud/charts/runtime-operator:vX.Y.Z`.
+
+Monitor the [Actions tab](https://github.com/wasmCloud/wasmCloud/actions) to confirm all workflows
+complete successfully.
+
+### Pre-release (e.g., release candidate)
+
+Tag with a pre-release suffix, e.g., `v2.1.0-rc.1`.
+
+## Releasing `wash-runtime` (library crate)
+
+`wash-runtime` is a library crate published independently to crates.io.
+
+1. Update the version in `crates/wash-runtime/Cargo.toml` to `X.Y.Z`.
+2. Open a pull request with the version bump, get it reviewed, and merge to `main`.
+3. Create and push the release tag from `main`:
+   ```bash
+   git tag wash-runtime-vX.Y.Z
+   git push origin wash-runtime-vX.Y.Z
+   ```
+4. The `wash-runtime` workflow will:
+   - Verify the tag version matches the version in `Cargo.toml` (fails fast if mismatched)
+   - Publish the crate to crates.io using the `CRATES_PUBLISH_TOKEN` secret
+
+## Versioning policy
+
+wasmCloud follows [Semantic Versioning](https://semver.org/):
+
+- **Patch** (`X.Y.Z+1`): Bug fixes and backward-compatible changes.
+- **Minor** (`X.Y+1.0`): New backward-compatible features.
+- **Major** (`X+1.0.0`): Breaking changes. Coordinate with maintainers before bumping major.
+
+Conventional commit prefixes used to categorize changes in release notes:
+
+| Prefix | Type |
+|--------|------|
+| `fix:` | Bug fix |
+| `feat:` | New feature |
+| `feat!:` / `BREAKING CHANGE:` | Breaking change |
+| `chore:`, `docs:`, `test:`, `refactor:` | Non-functional (no version bump implied) |
+
+## Checklist before tagging
+
+- [ ] All CI checks pass on `main`
+- [ ] `Cargo.toml` (or crate-specific `Cargo.toml`) version is updated and merged
+- [ ] CHANGELOG or release notes are accurate (auto-generated from conventional commits)
+- [ ] No open regressions targeting this release
+- [ ] For major releases: migration guide is documented
+
+## Checklist after tagging
+
+- [ ] All release workflows completed successfully in GitHub Actions
+- [ ] GitHub Release is visible with correct binaries attached
+- [ ] Docker images are available on GHCR
+- [ ] Homebrew tap updated (check [homebrew-wasmcloud](https://github.com/wasmCloud/homebrew-wasmcloud))
+- [ ] For `wash-runtime`: crate is visible on [crates.io](https://crates.io/crates/wash-runtime)
+- [ ] Announce the release in [Slack](https://slack.wasmcloud.com) `#announcements`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,59 @@
+# wasmCloud Roadmap and Vision
+
+The wasmCloud roadmap is outlined on our documentation site. Please visit the
+[roadmap page](https://wasmcloud.com/docs/roadmap) for the current vision and active work.
+In-progress and upcoming work is tracked using the
+[wasmCloud Roadmap GitHub project](https://github.com/orgs/wasmCloud/projects/7/views/3).
+
+## Roadmap Process
+
+wasmCloud roadmaps are planned quarterly (every three calendar months) at the first community
+meeting of the quarter. If a holiday conflict or majority maintainer absence affects that meeting,
+the roadmap session may be postponed to the following Wednesday. The planning session reviews the
+previous quarter's roadmap for successes and areas of improvement, then sets priorities for the
+coming quarter. An org maintainer should lead each planning session, as they are responsible for
+understanding all areas of the project.
+
+### Step-by-step process
+
+1. One or more wasmCloud Org Maintainers volunteer or are assigned as planners for the quarter.
+2. The planner opens a GitHub Discussion in
+   [wasmCloud/wasmCloud/discussions](https://github.com/wasmCloud/wasmCloud/discussions) for
+   community comments, requests, and discussion. This is the primary feedback mechanism for the
+   next quarter. Optionally, communicate any high-level goal for the quarter in the discussion.
+3. Schedule the community meeting with the primary agenda item:
+   `DISCUSSION: wasmCloud Q[N] [YEAR] Roadmap`.
+4. Before the community meeting, compile feedback from the GitHub discussion into GitHub issues.
+   Place each issue on the `wasmCloud Roadmap` project with:
+   - Work stage: `Now`
+   - Roadmap category: `Documentation`, `New Feature`, or `Improvement`
+   - Quarter: e.g., `Q2 2025`
+5. In the [wasmCloud Roadmap GitHub project](https://github.com/orgs/wasmCloud/projects/7), create
+   a new view for the quarter named `Q[N] [YEAR]` (e.g., `Q2 2025`).
+6. During the community meeting, review the created issues. Reserve at least 15 minutes for items
+   that did not make it into the GitHub discussion.
+7. After the community meeting, finalize the roadmap by updating the high-level initiatives on
+   the [wasmCloud Roadmap](https://wasmcloud.com/docs/roadmap/) page.
+
+## What goes on the Roadmap?
+
+wasmCloud roadmaps reflect community priorities, requests, and feedback. Only issues completable
+within the three-month period should go on the roadmap; larger efforts should be broken into
+smaller increments. There is no minimum or maximum number of items, but each quarterly planning
+session should review whether the previous roadmap was over- or under-scoped.
+
+Roadmap items generally fall into three categories:
+
+1. **Documentation** — Improvements to [wasmcloud.com](https://wasmcloud.com) or in-repo READMEs.
+2. **New Feature** — Features that add functionality to wasmCloud, its SDKs, or its CLIs.
+3. **Improvement** — Bug fixes, developer experience improvements, or rounding out existing
+   features.
+
+Quarterly roadmaps are not commitments to completing all listed work, but they indicate the
+project's priorities. Features requested by community members that qualify as `good-first-issue`s
+are strongly encouraged, as are features that can be completed by the person proposing them.
+
+If you have concerns about roadmap planning or the process, reach out to any
+[wasmCloud organization maintainer](https://github.com/wasmCloud/wasmCloud/blob/main/MAINTAINERS.md)
+or send a message in [Slack](https://slack.wasmcloud.com). If you are a maintainer and would like
+to lead a roadmapping session, reach out to the org maintainers.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,111 @@
+# wasmCloud Security Process and Policy
+
+This document provides details on the wasmCloud security policy and the processes surrounding
+security handling, including how to report a vulnerability for anything within the wasmCloud
+organization.
+
+- [Report A Vulnerability](#report-a-vulnerability)
+  - [When To Send A Report](#when-to-send-a-report)
+  - [When Not To Send A Report](#when-not-to-send-a-report)
+  - [Security Vulnerability Response](#security-vulnerability-response)
+  - [Public Disclosure](#public-disclosure)
+- [Security Team Membership](#security-team-membership)
+  - [Responsibilities](#responsibilities)
+  - [Membership](#membership)
+- [Patch and Release Team](#patch-and-release-team)
+- [Disclosures](#disclosures)
+
+## Report A Vulnerability
+
+We are extremely grateful for security researchers and users who report vulnerabilities to the
+wasmCloud community. All reports are thoroughly investigated by a set of wasmCloud maintainers.
+
+To make a report, email the private security list at **security@wasmcloud.com** with the details.
+You can also use [GitHub's private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+on any repository in the wasmCloud GitHub organization.
+
+Reports are received by the wasmCloud security team, which is a subset of active org maintainers.
+See [Security Team Membership](#security-team-membership) for details.
+
+### When To Send A Report
+
+You believe you have found a vulnerability in a wasmCloud project or in a dependency of a wasmCloud
+project. This includes any repository in the [wasmCloud GitHub
+organization](https://github.com/wasmCloud).
+
+### When Not To Send A Report
+
+- A vulnerability found in an **application deployed to** a wasmCloud host (report to that
+  application's maintainers instead).
+- You are looking for guidance on securing a wasmCloud deployment — see the
+  [documentation](https://wasmcloud.com/docs) or ask in [Slack](https://slack.wasmcloud.com).
+- You are looking for help applying security updates.
+
+### Security Vulnerability Response
+
+Each report will be reviewed and receipt acknowledged within **3 business days**. This begins the
+security review process described below.
+
+Vulnerability information shared with the security team stays within the wasmCloud project and will
+not be shared with others unless it is necessary to fix the issue. Information is shared only on a
+need-to-know basis.
+
+We ask that vulnerability reporters act in good faith by not disclosing the issue to others. We
+strive to act in good faith by responding swiftly and by crediting reporters in writing (with their
+permission).
+
+As the security issue moves through triage, identification, and release, the reporter will be
+notified. We may ask additional questions of the reporter during this process.
+
+### Public Disclosure
+
+A public disclosure of security vulnerabilities is released alongside the release that fixes the
+vulnerability. We aim to fully disclose vulnerabilities once a mitigation strategy is available.
+Our goal is to perform a release and public disclosure quickly and in a timetable that works well
+for users.
+
+CVEs will be assigned to vulnerabilities. Because obtaining a CVE ID takes time, a disclosure may
+be published before the CVE ID is assigned; the disclosure will be updated once the ID is available.
+
+If the vulnerability reporter would like to be credited as part of the disclosure, we are happy to
+do so. We will ask for permission and for how the reporter would like to be identified.
+
+## Security Team Membership
+
+The security team is a subset of active wasmCloud project maintainers who are willing and able to
+respond to vulnerability reports.
+
+### Responsibilities
+
+- Members **MUST** be active project maintainers on active (non-deprecated) wasmCloud projects.
+- Members **SHOULD** engage in each reported vulnerability, at a minimum to ensure it is being
+  handled.
+- Members **MUST** keep vulnerability details private and share only on a need-to-know basis.
+
+### Membership
+
+New members must be active wasmCloud project maintainers willing to fulfill the responsibilities
+above. Members can step down at any time and may join at any time by contacting the org maintainers.
+
+If a security team member is no longer an active maintainer on any active wasmCloud project, they
+will be removed from the team.
+
+## Patch and Release Team
+
+When a vulnerability is acknowledged, a team — including maintainers of the affected wasmCloud
+project — will be assembled to patch the vulnerability, release an update, and publish the
+disclosure. This team may expand beyond the security team as needed but will remain within the pool
+of active wasmCloud project maintainers.
+
+## Disclosures
+
+Vulnerability disclosures are published as GitHub Security Advisories in the relevant project
+repository. Each disclosure will contain:
+
+- An overview of the vulnerability
+- Details about the affected component and versions
+- A fix (typically a new release)
+- A workaround, if one is available
+
+Disclosures are published on the same day as the fixing release, after the release is published.
+Release notes will contain a link to the advisory.


### PR DESCRIPTION
Brings GOVERNANCE.md, MAINTAINERS.md, CONTRIBUTION_LADDER.md, SECURITY.md, ROADMAP.md, and RELEASE_RUNBOOK.md from release-1.9.x, updated for the v2 monorepo structure and current CNCF best practices.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->