### PR TITLE
Update TLS support for both wash dev and wash host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "astral-tokio-tar"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,6 +1594,20 @@ dependencies = [
  "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -3819,6 +3872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "olpc-cjson"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4938,14 +5000,15 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
+ "aws-lc-rs",
  "pem",
- "ring",
  "rustls-pki-types",
  "time",
+ "x509-parser",
  "yasna",
 ]
 
@@ -5179,6 +5242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -7106,6 +7178,7 @@ dependencies = [
  "pg_bigdecimal",
  "postgres-types",
  "prost 0.14.3",
+ "rcgen",
  "redis",
  "reqwest",
  "rustix 1.1.4",
@@ -8807,6 +8880,24 @@ dependencies = [
  "der",
  "spki",
  "tls_codec",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static 1.5.0",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/charts/runtime-operator/templates/certificates.yaml
+++ b/charts/runtime-operator/templates/certificates.yaml
@@ -68,5 +68,30 @@ data:
   tls.crt: {{ $natsCert.Cert | b64enc }}
   tls.key: {{ $natsCert.Key | b64enc }}
   ca.crt: {{ $ca.Cert | b64enc }}
+---
+{{- range .Values.runtime.hostGroups }}
+{{- if and (.http) (.http.enabled) (.http.tls) (.http.tls.enabled) }}
+{{- $cert := .http.tls.certificate | default dict }}
+{{- $genCert := $cert.generate | default dict }}
+{{- if and (not $cert.secretName) ($genCert.enabled) }}
+{{- $cn := $genCert.commonName | default (printf "hostgroup-%s" .name) }}
+{{- $domains := $genCert.domains | default (list (printf "hostgroup-%s" .name) (printf "hostgroup-%s.%s.svc.cluster.local" .name $.Release.Namespace)) }}
+{{ $httpCert := genSignedCert $cn nil $domains ($genCert.validity | default 365 | int) $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hostgroup-{{ .name }}-http-tls
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "runtime-operator.labels" $ | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $httpCert.Cert | b64enc }}
+  tls.key: {{ $httpCert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/runtime-operator/templates/operator/endpointslice-role.yaml
+++ b/charts/runtime-operator/templates/operator/endpointslice-role.yaml
@@ -1,7 +1,7 @@
+{{- if and .Values.operator.enabled .Values.operator.serviceAccount.create .Values.operator.watchNamespaces -}}
 # This file contains the ClusterRole and RoleBinding for the EndpointSlice controller, which is only required
 # if the operator is configured to watch specific namespaces. Otherwise, the default ClusterRole will be sufficient
 # for watching all namespaces.
-{{- if and .Values.operator.enabled .Values.operator.serviceAccount.create .Values.operator.watchNamespaces -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -37,6 +37,11 @@ spec:
         - name: data-cert
           secret:
             secretName: {{ $top.Values.global.certificates.dataCertSecretName }}
+        {{- if and (.http) (.http.enabled) (.http.tls) (.http.tls.enabled) }}
+        - name: tls-cert
+          secret:
+            secretName: {{ if and (.http.tls.certificate) (.http.tls.certificate.secretName) }}{{ .http.tls.certificate.secretName }}{{ else }}hostgroup-{{ .name }}-http-tls{{ end }}
+        {{- end }}
         {{- end }}
       serviceAccountName: {{ include "runtime.serviceAccountName" $top }}
       {{- include "runtime-operator.imagePullSecrets" $top | nindent 6 }}
@@ -67,9 +72,16 @@ spec:
             - "--oci-cache-dir=/oci-cache"
             {{- if and (.http) (.http.enabled) }}
             - "--http-addr=0.0.0.0:{{ .http.port }}"
+            {{- if and ($top.Values.global.tls.enabled) (.http.tls) (.http.tls.enabled) }}
+            - "--tls-cert-path=/tls-cert/tls.crt"
+            - "--tls-key-path=/tls-cert/tls.key"
+            {{- end }}
             {{- end }}
             {{- if and (.webgpu) (.webgpu.enabled) }}
             - "--wasi-webgpu"
+            {{- end }}
+            {{- if and (.wasip3) (.wasip3.enabled) }}
+            - "--wasip3"
             {{- end }}
           imagePullPolicy: {{ $top.Values.runtime.image.pull_policy }}
           volumeMounts:
@@ -82,6 +94,11 @@ spec:
             - name: data-cert
               mountPath: /data-cert
               readOnly: true
+            {{- if and (.http) (.http.enabled) (.http.tls) (.http.tls.enabled) }}
+            - name: tls-cert
+              mountPath: /tls-cert
+              readOnly: true
+            {{- end }}
             {{- end }}
           {{- with .resources }}
           resources:

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -121,9 +121,29 @@ runtime:
         type: ClusterIP
       webgpu:
         enabled: false
+      wasip3:
+        enabled: false
       http:
         enabled: true
         port: 9191
+        tls:
+          # -- Enable TLS for the HTTP server. Requires global.tls.enabled to be true.
+          # When enabled, a certificate is generated (if global.certificates.generate is true)
+          # and the host serves HTTPS instead of HTTP.
+          enabled: false
+          certificate:
+            # -- Name of the Kubernetes Secret holding the TLS server certificate for this host group. Ignored if global.certificates.generate is true.
+            secretName: ""
+            generate:
+              # -- Whether to generate a self-signed TLS certificate for this host group. Ignored if global.certificates.generate is false or if certificate.secretName is set.
+              enabled: false
+              # -- Validity period (in days) for the generated TLS certificate. Ignored if global.certificates.generate is false.
+              validity: 365
+              # -- Common Name (CN) for the generated TLS certificate.
+              commonName: ""
+              # -- List of DNS Subject Alternative Names (SANs) for the generated TLS certificate.
+              # Example: ["myapp.example.com", "myapp.default.svc.cluster.local"]
+              domains: []
       resources:
         requests:
           memory: "64Mi"

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -126,4 +126,5 @@ tracing-subscriber = { workspace = true }
 reqwest = { workspace = true }
 wat = { workspace = true, features = ["component-model"] }
 gag = "1.0"
+rcgen = { version = "0.14.7", default-features = false, features = ["crypto", "aws_lc_rs", "pem"] }
 testcontainers = { workspace = true }

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -480,7 +480,12 @@ impl<T: Router> HostHandler for HttpServer<T> {
             .await
             .take()
             .context("HTTP server listener already consumed")?;
-        info!(addr = ?addr, "HTTP server listening");
+        let protocol = if self.tls_acceptor.is_some() {
+            "HTTPS"
+        } else {
+            "HTTP"
+        };
+        info!(addr = ?addr, protocol = protocol, "{protocol} server listening");
         // Start the HTTP server, any incoming requests call Host::handle and then it's routed
         // to the workload based on host header.
         let handler = self.router.clone();
@@ -499,13 +504,6 @@ impl<T: Router> HostHandler for HttpServer<T> {
                 error!(err = ?e, addr = ?addr, "HTTP server error");
             }
         });
-
-        let protocol = if self.tls_acceptor.is_some() {
-            "HTTPS"
-        } else {
-            "HTTP"
-        };
-        debug!(addr = ?addr, protocol = protocol, "HTTP server starting");
         Ok(())
     }
 

--- a/crates/wash-runtime/tests/integration_http_tls.rs
+++ b/crates/wash-runtime/tests/integration_http_tls.rs
@@ -269,7 +269,7 @@ async fn test_https_rejects_plain_http() -> Result<()> {
     .await;
 
     match result {
-        Err(_) => {} // Timeout — expected
+        Err(_) => {}     // Timeout — expected
         Ok(Err(_)) => {} // Connection error — expected
         Ok(Ok(resp)) => {
             panic!(

--- a/crates/wash-runtime/tests/integration_http_tls.rs
+++ b/crates/wash-runtime/tests/integration_http_tls.rs
@@ -1,0 +1,283 @@
+//! Integration test for TLS-enabled HTTP server
+//!
+//! Verifies that HTTPS requests are correctly handled when the HTTP server
+//! is configured with TLS via `HttpServer::new_with_tls()`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use anyhow::{Context, Result};
+use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::{
+        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
+        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
+    },
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+    wit::WitInterface,
+};
+
+const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
+
+/// Ensure the rustls CryptoProvider is installed exactly once per process.
+fn init_crypto() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .expect("failed to install crypto provider");
+    });
+}
+
+/// Generate a self-signed certificate and private key for `localhost`,
+/// write them to a temp directory, and return the paths.
+///
+/// The returned `TempDir` must be held alive for the duration of the test.
+fn generate_test_certs() -> Result<(tempfile::TempDir, std::path::PathBuf, std::path::PathBuf)> {
+    let dir = tempfile::TempDir::new()?;
+
+    let certified_key = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .context("failed to generate self-signed certificate")?;
+
+    let cert_path = dir.path().join("server.crt");
+    let key_path = dir.path().join("server.key");
+
+    std::fs::write(&cert_path, certified_key.cert.pem())?;
+    std::fs::write(&key_path, certified_key.signing_key.serialize_pem())?;
+
+    Ok((dir, cert_path, key_path))
+}
+
+/// Build a `reqwest::Client` that trusts the given self-signed certificate.
+fn build_tls_client(cert_path: &Path) -> Result<reqwest::Client> {
+    let cert_pem = std::fs::read(cert_path)?;
+    let cert = reqwest::Certificate::from_pem(&cert_pem)?;
+    reqwest::Client::builder()
+        .add_root_certificate(cert)
+        .build()
+        .context("failed to build TLS client")
+}
+
+/// Start a host with TLS-enabled HTTP server and the standard set of plugins.
+async fn start_host_with_tls(
+    cert_path: &Path,
+    key_path: &Path,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new_with_tls(
+        DevRouter::default(),
+        "127.0.0.1:0".parse()?,
+        cert_path,
+        key_path,
+        None,
+    )
+    .await?;
+    let bound_addr = http_server.addr();
+
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
+        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
+        .with_plugin(Arc::new(TracingLogger::default()))?
+        .with_plugin(Arc::new(DynamicConfig::default()))?
+        .build()?;
+
+    let host = host.start().await.context("Failed to start host")?;
+    Ok((bound_addr, host))
+}
+
+/// Standard host interfaces for the http-counter component.
+fn http_counter_host_interfaces(http_host_config: &str) -> Vec<WitInterface> {
+    vec![
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "http".to_string(),
+            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+            version: Some(semver::Version::parse("0.2.2").unwrap()),
+            config: {
+                let mut config = HashMap::new();
+                config.insert("host".to_string(), http_host_config.to_string());
+                config
+            },
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "blobstore".to_string(),
+            interfaces: [
+                "blobstore".to_string(),
+                "container".to_string(),
+                "types".to_string(),
+            ]
+            .into_iter()
+            .collect(),
+            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "keyvalue".to_string(),
+            interfaces: ["store".to_string(), "atomics".to_string()]
+                .into_iter()
+                .collect(),
+            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "logging".to_string(),
+            interfaces: ["logging".to_string()].into_iter().collect(),
+            version: Some(semver::Version::parse("0.1.0-draft").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "config".to_string(),
+            interfaces: ["store".to_string()].into_iter().collect(),
+            version: Some(semver::Version::parse("0.2.0-rc.1").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+    ]
+}
+
+fn http_counter_workload_request(http_host_config: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "http-counter-tls".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "http-counter.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_COUNTER_WASM),
+                local_resources: LocalResources {
+                    memory_limit_mb: 256,
+                    cpu_limit: 1,
+                    config: HashMap::from([
+                        ("test_key".to_string(), "test_value".to_string()),
+                        ("counter_enabled".to_string(), "true".to_string()),
+                    ]),
+                    environment: HashMap::new(),
+                    volume_mounts: vec![],
+                    allowed_hosts: Default::default(),
+                },
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces: http_counter_host_interfaces(http_host_config),
+            volumes: vec![],
+        },
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_https_request_succeeds() -> Result<()> {
+    init_crypto();
+
+    let (_dir, cert_path, key_path) = generate_test_certs()?;
+    let (addr, host) = start_host_with_tls(&cert_path, &key_path).await?;
+
+    let req = http_counter_workload_request("foo");
+    host.workload_start(req)
+        .await
+        .context("Failed to start http-counter workload")?;
+
+    let client = build_tls_client(&cert_path)?;
+
+    // First request should initialize counter to 1
+    let first_response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("https://localhost:{}/", addr.port()))
+            .header("HOST", "foo")
+            .send(),
+    )
+    .await
+    .context("First request timed out")?
+    .context("Failed to make first HTTPS request")?;
+
+    assert!(
+        first_response.status().is_success(),
+        "First HTTPS request failed with status {}",
+        first_response.status(),
+    );
+
+    let first_text = first_response.text().await?;
+    assert_eq!(
+        first_text.trim(),
+        "1",
+        "First request should return counter value of 1"
+    );
+
+    // Second request should increment counter
+    let second_response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("https://localhost:{}/", addr.port()))
+            .header("HOST", "foo")
+            .send(),
+    )
+    .await
+    .context("Second request timed out")?
+    .context("Failed to make second HTTPS request")?;
+
+    assert!(second_response.status().is_success());
+
+    let second_count: u64 = second_response
+        .text()
+        .await?
+        .trim()
+        .parse()
+        .expect("Response should be a valid number");
+    assert!(
+        second_count >= 1,
+        "Second request should return counter >= 1, got {second_count}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_https_rejects_plain_http() -> Result<()> {
+    init_crypto();
+
+    let (_dir, cert_path, key_path) = generate_test_certs()?;
+    let (addr, _host) = start_host_with_tls(&cert_path, &key_path).await?;
+
+    // A plain HTTP client should not be able to talk to an HTTPS server
+    let client = reqwest::Client::new();
+    let result = timeout(
+        Duration::from_secs(5),
+        client
+            .get(format!("http://localhost:{}/", addr.port()))
+            .send(),
+    )
+    .await;
+
+    match result {
+        Err(_) => {} // Timeout — expected
+        Ok(Err(_)) => {} // Connection error — expected
+        Ok(Ok(resp)) => {
+            panic!(
+                "Plain HTTP request to HTTPS server should fail, got status {}",
+                resp.status()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -75,7 +75,7 @@ pbjson-build = { workspace = true, default-features = true }
 bytes = { version = "1", default-features = false }
 http = { version = "1.3.1", default-features = false }
 http-body-util = { version = "0.1.3", default-features = false }
-rcgen = { version = "0.13", default-features = false, features = ["crypto", "ring", "pem"] }
+rcgen = { version = "0.14.7", default-features = false, features = ["crypto", "aws_lc_rs", "pem"] }
 scopeguard = { version = "1.2", default-features = false }
 tempfile = { version = "3.0", default-features = false }
 tokio = { version = "1.45.1", default-features = false, features = ["full"] }

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -28,6 +28,10 @@ pub struct DevCommand {}
 
 impl CliCommand for DevCommand {
     async fn handle(&self, ctx: &CliContext) -> anyhow::Result<CommandOutput> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .map_err(|e| anyhow::anyhow!(format!("failed to install crypto provider: {e:?}")))?;
+
         let project_dir = ctx.project_dir();
         info!(path = ?project_dir, "starting development session for project");
 

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -189,22 +189,21 @@ impl CliCommand for HostCommand {
 
         if let Some(addr) = self.http_addr {
             let http_router = wash_runtime::host::http::DynamicRouter::default();
-            let http_server =
-                if let (Some(cert_path), Some(key_path)) = (&self.tls_cert_path, &self.tls_key_path)
-                {
-                    wash_runtime::host::http::HttpServer::new_with_tls(
-                        http_router,
-                        addr,
-                        cert_path,
-                        key_path,
-                        self.tls_ca_path.as_deref(),
-                    )
-                    .await?
-                } else {
-                    wash_runtime::host::http::HttpServer::new(http_router, addr).await?
-                };
-            cluster_host_builder =
-                cluster_host_builder.with_http_handler(Arc::new(http_server));
+            let http_server = if let (Some(cert_path), Some(key_path)) =
+                (&self.tls_cert_path, &self.tls_key_path)
+            {
+                wash_runtime::host::http::HttpServer::new_with_tls(
+                    http_router,
+                    addr,
+                    cert_path,
+                    key_path,
+                    self.tls_ca_path.as_deref(),
+                )
+                .await?
+            } else {
+                wash_runtime::host::http::HttpServer::new(http_router, addr).await?
+            };
+            cluster_host_builder = cluster_host_builder.with_http_handler(Arc::new(http_server));
         }
 
         // Enable otel plugin

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -65,6 +65,18 @@ pub struct HostCommand {
     #[arg(long = "http-addr")]
     pub http_addr: Option<SocketAddr>,
 
+    /// Path to TLS certificate file for the HTTP server
+    #[arg(long = "tls-cert-path", requires = "tls_key_path")]
+    pub tls_cert_path: Option<PathBuf>,
+
+    /// Path to TLS private key file for the HTTP server
+    #[arg(long = "tls-key-path", requires = "tls_cert_path")]
+    pub tls_key_path: Option<PathBuf>,
+
+    /// Path to CA certificate file for mutual TLS on the HTTP server
+    #[arg(long = "tls-ca-path")]
+    pub tls_ca_path: Option<PathBuf>,
+
     /// Enable WASI WebGPU support
     #[cfg(not(target_os = "windows"))]
     #[arg(long = "wasi-webgpu", default_value_t = false)]
@@ -177,9 +189,22 @@ impl CliCommand for HostCommand {
 
         if let Some(addr) = self.http_addr {
             let http_router = wash_runtime::host::http::DynamicRouter::default();
-            cluster_host_builder = cluster_host_builder.with_http_handler(Arc::new(
-                wash_runtime::host::http::HttpServer::new(http_router, addr).await?,
-            ));
+            let http_server =
+                if let (Some(cert_path), Some(key_path)) = (&self.tls_cert_path, &self.tls_key_path)
+                {
+                    wash_runtime::host::http::HttpServer::new_with_tls(
+                        http_router,
+                        addr,
+                        cert_path,
+                        key_path,
+                        self.tls_ca_path.as_deref(),
+                    )
+                    .await?
+                } else {
+                    wash_runtime::host::http::HttpServer::new(http_router, addr).await?
+                };
+            cluster_host_builder =
+                cluster_host_builder.with_http_handler(Arc::new(http_server));
         }
 
         // Enable otel plugin


### PR DESCRIPTION
## Unify TLS support across `wash dev` and `wash host`, standardize on `aws-lc-rs`

Fixes #5047

Fixed bug in [Helm chart](https://github.com/wasmCloud/wasmCloud/pull/5048/changes#diff-bd198a38cdc987e309dfbd6a84035cd06b169714155104173ffb5ac040bc84ccR1) where if you provide a list of namespaces to create a RoleBinding for EndpointSlices, a yaml formatting error will occur

Adds `hostGroups.wasip3.enabled` property in the helm chart to allow for enabling wasip3 support for the hosts in the group. 

### Summary

- Fixed `wash dev` panicking when TLS was configured due to missing rustls `CryptoProvider` initialization
- Added `--tls-cert-path`, `--tls-key-path`, and `--tls-ca-path` CLI flags to `wash host` so both commands now support TLS for their HTTP servers
- Removed `ring` crypto backend dependency and standardized on `aws-lc-rs` across the entire TLS stack (`rustls`, `rcgen`, `async-nats`, `tonic`), enabling a future path to FIPS compliance via `aws-lc-rs/fips`
- Upgraded `rcgen` from 0.13 to 0.14.7 to pick up bug fixes in the previous version
- Added TLS integration tests that generate certificates at test time and validate HTTPS requests end-to-end

### Changes

**`crates/wash/src/cli/dev.rs`**
- Added `rustls::crypto::aws_lc_rs::default_provider().install_default()` to fix the runtime panic when TLS config was present

**`crates/wash/src/cli/host.rs`**
- Added `--tls-cert-path`, `--tls-key-path`, `--tls-ca-path` CLI flags with mutual requirement validation via clap
- Updated HTTP server setup to use `HttpServer::new_with_tls()` when TLS flags are provided

**`crates/wash/Cargo.toml`**
- Upgraded `rcgen` from 0.13 to 0.14.7
- Switched `rcgen` crypto backend from `ring` to `aws_lc_rs`

**`crates/wash-runtime/Cargo.toml`**
- Added `rcgen` 0.14.7 as a dev-dependency with `aws_lc_rs` backend

**`crates/wash-runtime/tests/integration_http_tls.rs`**
- New integration test file with two tests:
  - `test_https_request_succeeds` — generates self-signed certs, starts a TLS host, deploys `http-counter`, verifies HTTPS requests return correct responses
  - `test_https_rejects_plain_http` — confirms plain HTTP connections to the TLS server are rejected

### Test plan

- [x] `cargo test -p wash-runtime --test integration_http_tls` — both new TLS tests pass
- [x] `cargo test -p wash-runtime --test integration_http_counter` — existing HTTP tests unaffected
- [x] `cargo check -p wash` — compiles cleanly
- [x] Manual: `wash dev` with TLS config in `.wash/config.yaml` serves HTTPS and responds to `curl -k https://localhost:8443/`
- [x] Manual: `wash host --http-addr 0.0.0.0:8443 --tls-cert-path ... --tls-key-path ...` serves HTTPS
