### PR TITLE
feat(ci): add a github workflow to build/push examples

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,0 +1,156 @@
+name: examples
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/wash.yml"
+      - "crates/**"
+      - "examples/**"
+      - "Cargo.*"
+      - "rust-toolchain.toml"
+      - "rustfmt.toml"
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  local-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Remove unused files
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        # based on https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg
+        run: |
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/julia*
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /opt/microsoft /opt/google
+          sudo rm -rf /opt/az
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /opt/hostedtoolcache
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Setup protoc
+        uses: arduino/setup-protoc@f4d5893b897028ff5739576ea0409746887fa536 # v3.0.0
+        with:
+          version: "29.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Build
+        run: cargo build -p wash --release
+      - name: Archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wash-exe
+          path: |
+            target/release/wash
+
+  wash-build:
+    name: ${{ matrix.project.folder }} (wash@${{ matrix.wash-version }})
+    runs-on: ubuntu-latest
+    needs:
+      - local-release
+    permissions:
+      contents: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        wash-version:
+          - current
+        project:
+          - folder: blobby
+            artifact: blobby/target/wasm32-wasip2/release/blobby.wasm
+          - folder: go-hello-world
+            artifact: go-hello-world/go-hello-world.wasm
+          - folder: grpc-hello-world/component-client
+            artifact: grpc-hello-world/target/wasm32-wasip2/release/component_client.wasm
+          - folder: grpc-hello-world/component-server
+            artifact: grpc-hello-world/target/wasm32-wasip2/release/component_server.wasm
+          - folder: http-hello-world
+            artifact: http-hello-world/target/wasm32-wasip2/release/hello_world.wasm
+          - folder: key-value
+            artifact: key-value/target/wasm32-wasip2/release/redis_keyvalue.wasm
+          - folder: otel-http
+            artifact: otel-http/target/wasm32-wasip2/release/otel_http.wasm
+          - folder: qrcode
+            artifact: qrcode/target/wasm32-wasip2/release/qrcode.wasm
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Login to ghcr.io
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Node.js
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: "22"
+      - name: Setup Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: "^1.25.0"
+          cache: false
+      - name: Setup TinyGo
+        uses: acifani/setup-tinygo@b2ba42b249c7d3efdfe94166ec0f48b3191404f7 # v2.0.0
+        with:
+          tinygo-version: "0.40.1"
+      - name: Setup wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@d742827944dcb656569399571a8a45261b5089f6 # v1.1.0
+        with:
+          version: "1.223.1"
+      - name: Setup protoc
+        uses: arduino/setup-protoc@f4d5893b897028ff5739576ea0409746887fa536 # v3.0.0
+        with:
+          version: "29.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Download a single artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: wash-exe
+          path: /home/runner/downloader/bin
+      - name: check version
+        run: |
+          chmod u+x /home/runner/downloader/bin/wash
+          wash --version
+      - name: build project
+        working-directory: examples/${{ matrix.project.folder }}
+        run: |
+          echo $HOME
+          wash build
+      - name: Login to ghcr.io
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: push project
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        working-directory: examples
+        run: |
+          export REF=${{ github.ref }}
+          export TAG=${REF#refs/tags/v}
+          wash oci push ghcr.io/${{ github.repository_owner }}/${{ matrix.project.folder }}:${TAG} ./${{ matrix.project.artifact }}


### PR DESCRIPTION
This PR is related to issue #4937 . I really like your work and am interested to learn. I have reviewed both the contributing guide and code of conduct. Thank you for your help and patience.

I did ask a number of questions in the issue so that I can better understand what is needed. That is better I think to answer in the issue since it is for everyone.

## Content

This PR is an opinionated first answer and will obviously evolve with your help. To summarize the proposed solution:

- It creates a separated workflow called `examples` in .github/workflow. The workflow is triggered on almost any PR, push to main and tag. The reason there is a single file is to ease the review and prevent side effects.
- the `local-release` job builds an artifact of the wash cli and make it available for linux/x64 only
- the `wash-build` job
  - installs all the dependencies to build the components
  - builds the various projects
  - connects to the ghcr.io registry
  - **If there is a tag v(something)**, pushes the artifact with `wash oci push`.

## Comments about the implementation

A couple of comments:
- The naming convention includes `examples` in the registry is not compliant with the convention of release-1.9.x
- The build time is not awesome because of `local-release`, however it most cases it has to be done anyway.. 
- The biggest question for now is "Should we version the components with the version of the project or not?". I used the same version convention, i.e. `vx.y.z`.
 
> Note 1 (about the last item): in the release-1.9.x branch, the workflow relies on a specific tag per component. The reason I did not go that road is because (1) the component versioning is not obvious and differ between languages and (2) it is definitely more complex to maintain versions that way.
> Note 2: (about the last item): another (better!) strategy would be to *NOT* version the component at all and tag it with the commit SHA.

## About the tests

Regarding the tests, 2 separated tests have been performed that are available on the [Google Action tab of the fork](https://github.com/gregoryguillou/wasmCloud/actions/workflows/examples.yaml)

- test 1: build but not published. When we perform changes on the main branch (of the fork), jobs succeed and there is nothing published
- test 2: build from tag, got published. A 2nd workflow has been triggered by a tag that complies to what is expected. In that case, the components are pushed into the registries.. You can see in [the registry associated with the fork](https://github.com/gregoryguillou?tab=packages&repo_name=wasmCloud) those components.

## A last comment

Not sure about your policy regarding the use of LLM (I did not find anything in the project): I did not use any. The content is mostly adaptation from the wash.yml workflow and the workflow that was building components withing the release-1.9.x branch I have adapted and simplified.