### PR TITLE
Add micro benchmarks for http invocation

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -93,6 +93,10 @@ jobs:
       - name: Test with wasip3
         run: |
           cargo test -p wash-runtime --features wasip3
+      - name: Build benchmarks
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cargo bench -p wash-runtime --features wasip3 --no-run
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -96,6 +96,10 @@ jobs:
       - name: Test with wasip3
         run: |
           cargo test -p wash-runtime --features wasip3
+      - name: Build benchmarks
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cargo bench -p wash-runtime --features wasip3 --no-run
 
   lint:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,6 +883,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +933,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1334,6 +1373,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -3008,10 +3085,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3913,6 +4010,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4410,6 +4513,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polling"
@@ -6266,6 +6397,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7170,6 +7311,7 @@ dependencies = [
  "cap-std",
  "chrono",
  "cidr",
+ "criterion",
  "deadpool-postgres",
  "docker_credential",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +889,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +950,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1373,6 +1412,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -3041,10 +3118,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3961,6 +4058,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,6 +4549,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polling"
@@ -6261,6 +6392,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7153,6 +7294,7 @@ dependencies = [
  "cap-std",
  "chrono",
  "cidr",
+ "criterion",
  "deadpool-postgres",
  "docker_credential",
  "futures",

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -31,7 +31,11 @@ wasmcloud-postgres = [
     "dep:bit-vec", "dep:cidr", "dep:geo-types",
     "dep:ulid",
 ]
-wasip3 = ["wasmtime-wasi/p3", "wasmtime-wasi-http/p3"]
+wasip3 = [
+    "wasmtime-wasi/p3",
+    "wasmtime-wasi-http/p3",
+    "wasmtime-wasi-http/component-model-async",
+]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -128,3 +132,20 @@ wat = { workspace = true, features = ["component-model"] }
 gag = "1.0"
 rcgen = { version = "0.14.7", default-features = false, features = ["crypto", "aws_lc_rs", "pem"] }
 testcontainers = { workspace = true }
+criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
+
+[[bench]]
+name = "http_invoke"
+harness = false
+required-features = ["wasip3"]
+
+[[bench]]
+name = "wasmtime_baseline"
+harness = false
+required-features = ["wasip3"]
+
+[[bench]]
+name = "wasmtime_serve"
+harness = false
+required-features = ["wasip3"]
+

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -53,7 +53,11 @@ wasmcloud-postgres = [
     "dep:bit-vec", "dep:cidr", "dep:geo-types",
     "dep:ulid",
 ]
-wasip3 = ["wasmtime-wasi/p3", "wasmtime-wasi-http/p3"]
+wasip3 = [
+    "wasmtime-wasi/p3",
+    "wasmtime-wasi-http/p3",
+    "wasmtime-wasi-http/component-model-async",
+]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -149,3 +153,20 @@ wat = { workspace = true, features = ["component-model"] }
 gag = "1.0"
 rcgen = { version = "0.14.7", default-features = false, features = ["crypto", "aws_lc_rs", "pem"] }
 testcontainers = { workspace = true }
+criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
+
+[[bench]]
+name = "http_invoke"
+harness = false
+required-features = ["wasip3"]
+
+[[bench]]
+name = "wasmtime_baseline"
+harness = false
+required-features = ["wasip3"]
+
+[[bench]]
+name = "wasmtime_serve"
+harness = false
+required-features = ["wasip3"]
+

--- a/crates/wash-runtime/benches/common/mod.rs
+++ b/crates/wash-runtime/benches/common/mod.rs
@@ -1,0 +1,31 @@
+const HTTP_HANDLER_P2_WASM: &[u8] = include_bytes!("../../tests/wasm/http_handler_p2.wasm");
+const HTTP_HANDLER_P3_WASM: &[u8] = include_bytes!("../../tests/wasm/http_handler_p3.wasm");
+
+#[derive(Copy, Clone, Debug)]
+pub enum Flavor {
+    P2,
+    P3,
+}
+
+impl Flavor {
+    pub fn name(self) -> &'static str {
+        match self {
+            Flavor::P2 => "p2",
+            Flavor::P3 => "p3",
+        }
+    }
+
+    pub fn wasm(self) -> &'static [u8] {
+        match self {
+            Flavor::P2 => HTTP_HANDLER_P2_WASM,
+            Flavor::P3 => HTTP_HANDLER_P3_WASM,
+        }
+    }
+
+    pub fn expected_body(self) -> &'static str {
+        match self {
+            Flavor::P2 => "hello from p2",
+            Flavor::P3 => "hello from p3",
+        }
+    }
+}

--- a/crates/wash-runtime/benches/http_invoke.rs
+++ b/crates/wash-runtime/benches/http_invoke.rs
@@ -1,0 +1,293 @@
+//! HTTP invocation benchmarks for wash-runtime.
+//!
+//! Measures three dimensions for both WASIP2 and WASIP3 components:
+//!
+//! 1. **Cold invocation**  - end-to-end cost of building a host, starting a
+//!    workload, and serving the first HTTP request. This captures component
+//!    compilation, linker + `InstancePre` construction, and first-instance
+//!    setup.
+//! 2. **Hot invocation**  - steady-state single-request latency on a warm
+//!    host (workload already resolved). This captures per-request cost:
+//!    store/context allocation, instantiation, invocation, and response.
+//! 3. **Throughput (RPS)**  - concurrent request throughput against the warm
+//!    host. Uses N parallel clients to saturate the HTTP plane.
+//!
+//! The fixtures are intentionally minimal  - each returns a static body with
+//! no plugin-backed host calls  - so that results isolate the runtime and are
+//! directly comparable to `wasmtime serve` running the same component.
+//!
+//! Run with:
+//! ```text
+//! cargo bench -p wash-runtime --features wasip3 --bench http_invoke
+//! ```
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use common::Flavor;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+    wit::WitInterface,
+};
+
+fn flavor_host_header(flavor: Flavor) -> &'static str {
+    match flavor {
+        Flavor::P2 => "bench-p2",
+        Flavor::P3 => "bench-p3",
+    }
+}
+
+fn engine() -> Engine {
+    // Enable P3 unconditionally so the same engine can serve both flavors.
+    Engine::builder()
+        .with_wasip3(true)
+        .build()
+        .expect("failed to build engine with wasip3")
+}
+
+fn http_host_interfaces(host: &str) -> Vec<WitInterface> {
+    let mut config = HashMap::new();
+    config.insert("host".to_string(), host.to_string());
+    vec![WitInterface {
+        namespace: "wasi".to_string(),
+        package: "http".to_string(),
+        interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.2.2").unwrap()),
+        config,
+        name: None,
+    }]
+}
+
+/// Holds a warm host bound to a concrete address with a workload resolved and
+/// ready to serve requests. Kept alive for the duration of a benchmark group.
+struct WarmHost {
+    _host: Box<dyn std::any::Any + Send + Sync>,
+    addr: std::net::SocketAddr,
+    client: reqwest::Client,
+    host_header: &'static str,
+}
+
+async fn start_warm_host(flavor: Flavor) -> anyhow::Result<WarmHost> {
+    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_server.addr();
+
+    let host = HostBuilder::new()
+        .with_engine(engine())
+        .with_http_handler(Arc::new(http_server))
+        .build()?;
+
+    let host = host.start().await?;
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "bench".to_string(),
+            name: format!("bench-{}", flavor.name()),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: format!("hello-{}.wasm", flavor.name()),
+                digest: None,
+                bytes: bytes::Bytes::from_static(flavor.wasm()),
+                local_resources: LocalResources::default(),
+                // 0/0 → the runtime picks sensible defaults. For the P3
+                // instance-reuse path this means 128 reuses × 16 concurrent
+                // (matches `wasmtime serve`). The non-reuse path ignores
+                // both fields.
+                pool_size: 0,
+                max_invocations: 0,
+            }],
+            host_interfaces: http_host_interfaces(flavor_host_header(flavor)),
+            volumes: vec![],
+        },
+    };
+    host.workload_start(req).await?;
+
+    // Reuse one HTTP/1.1 client with connection pooling so we are measuring
+    // runtime work, not TCP/TLS handshakes.
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(64)
+        .tcp_nodelay(true)
+        .build()?;
+
+    // Correctness check  - also primes any one-time lazy caches before bench.
+    let warmup = client
+        .get(format!("http://{addr}/"))
+        .header("HOST", flavor_host_header(flavor))
+        .send()
+        .await?;
+    anyhow::ensure!(
+        warmup.status().is_success(),
+        "warmup request failed for {:?}: {}",
+        flavor,
+        warmup.status()
+    );
+    let body = warmup.text().await?;
+    anyhow::ensure!(
+        body == flavor.expected_body(),
+        "unexpected warmup body for {:?}: {body:?}",
+        flavor
+    );
+
+    Ok(WarmHost {
+        _host: Box::new(host),
+        addr,
+        client,
+        host_header: flavor_host_header(flavor),
+    })
+}
+
+/// Cold invocation: builds host, starts workload, sends one request, drops.
+/// Measures the full "first request" cost which is what matters for
+/// scale-from-zero and short-lived workloads.
+async fn cold_invocation(flavor: Flavor) -> anyhow::Result<()> {
+    let warm = start_warm_host(flavor).await?;
+    // start_warm_host already sends and validates one request.
+    drop(warm);
+    Ok(())
+}
+
+/// Hot invocation: one request on an already-warm host. Measures per-request
+/// runtime cost (store + instance + invoke + response).
+async fn hot_invocation(warm: &WarmHost) -> anyhow::Result<()> {
+    let resp = warm
+        .client
+        .get(format!("http://{}/", warm.addr))
+        .header("HOST", warm.host_header)
+        .send()
+        .await?;
+    anyhow::ensure!(resp.status().is_success(), "non-2xx: {}", resp.status());
+    // Consume body so the server-side stream completes before timing stops.
+    let _ = resp.bytes().await?;
+    Ok(())
+}
+
+fn bench_cold(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("cold_invocation");
+    // Cold path is heavy (component compile + host build); keep sample count
+    // low so runs are tolerable.
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(15));
+
+    for flavor in [Flavor::P2, Flavor::P3] {
+        group.bench_function(BenchmarkId::from_parameter(flavor.name()), |b| {
+            b.to_async(&rt)
+                .iter(|| async move { cold_invocation(flavor).await.unwrap() });
+        });
+    }
+    group.finish();
+}
+
+fn bench_hot_latency(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("hot_invocation");
+    group.throughput(Throughput::Elements(1));
+    group.measurement_time(Duration::from_secs(10));
+
+    for flavor in [Flavor::P2, Flavor::P3] {
+        let warm = rt.block_on(start_warm_host(flavor)).expect("warm host");
+        group.bench_function(BenchmarkId::from_parameter(flavor.name()), |b| {
+            b.to_async(&rt)
+                .iter(|| async { hot_invocation(&warm).await.unwrap() });
+        });
+        drop(warm);
+    }
+    group.finish();
+}
+
+/// Throughput benchmark: measures RPS with N concurrent in-flight requests.
+/// Each sample fires `BATCH` requests across `CONCURRENCY` workers and
+/// criterion reports throughput in elements/sec = RPS.
+fn bench_throughput(c: &mut Criterion) {
+    const CONCURRENCY: usize = 32;
+    const BATCH: usize = 256;
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let mut group = c.benchmark_group("http_throughput");
+    group.throughput(Throughput::Elements(BATCH as u64));
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(15));
+
+    for flavor in [Flavor::P2, Flavor::P3] {
+        let warm = rt.block_on(start_warm_host(flavor)).expect("warm host");
+        let url = format!("http://{}/", warm.addr);
+        let host_header = warm.host_header;
+        let client = warm.client.clone();
+
+        let failures = Arc::new(AtomicUsize::new(0));
+        let failures_ref = failures.clone();
+        group.bench_function(BenchmarkId::from_parameter(flavor.name()), |b| {
+            b.to_async(&rt).iter_custom(|iters| {
+                let url = url.clone();
+                let client = client.clone();
+                let failures = failures_ref.clone();
+                async move {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let start = Instant::now();
+                        let mut handles = Vec::with_capacity(CONCURRENCY);
+                        let per_worker = BATCH / CONCURRENCY;
+                        for _ in 0..CONCURRENCY {
+                            let client = client.clone();
+                            let url = url.clone();
+                            let failures = failures.clone();
+                            handles.push(tokio::spawn(async move {
+                                for _ in 0..per_worker {
+                                    match client.get(&url).header("HOST", host_header).send().await
+                                    {
+                                        Ok(resp) if resp.status().is_success() => {
+                                            let _ = resp.bytes().await;
+                                        }
+                                        _ => {
+                                            failures.fetch_add(1, Ordering::Relaxed);
+                                        }
+                                    }
+                                }
+                            }));
+                        }
+                        for h in handles {
+                            h.await.expect("worker");
+                        }
+                        total += start.elapsed();
+                    }
+                    total
+                }
+            });
+        });
+        let failed = failures.load(Ordering::Relaxed);
+        if failed > 0 {
+            eprintln!(
+                "[http_throughput/{}] {failed} requests failed during bench run",
+                flavor.name()
+            );
+        }
+        drop(warm);
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_cold, bench_hot_latency, bench_throughput);
+criterion_main!(benches);

--- a/crates/wash-runtime/benches/wasmtime_baseline.rs
+++ b/crates/wash-runtime/benches/wasmtime_baseline.rs
@@ -1,0 +1,519 @@
+//! Pure-wasmtime HTTP baseline benchmark.
+//!
+//! Mirrors `http_invoke.rs` but replaces the wash-runtime host with a
+//! hand-rolled hyper + wasmtime-wasi-http server  - the same primitives used
+//! by `wasmtime serve`, without wash-runtime's routing, workload model, or
+//! plugin scaffolding.
+//!
+//! This lets us run **the same component bytes** through a minimal wasmtime
+//! pipeline and compare against `http_invoke.rs` directly. The delta between
+//! the two reports is what wash-runtime's extra layers cost per request.
+//!
+//! Strategy choice: this baseline uses **one instance per request**, matching
+//! wash-runtime's current strategy so the comparison isolates wrapper
+//! overhead (routing, cloning, SharedCtx setup, ProxyPre wrapping, P3 body
+//! collection, etc.) rather than the instance-reuse policy itself. See
+//! `wasmtime_serve.rs` for the instance-reuse variant that uses
+//! `wasmtime_wasi_http::handler::ProxyHandler`.
+//!
+//! Run with:
+//! ```text
+//! cargo bench -p wash-runtime --features wasip3 --bench wasmtime_baseline
+//! ```
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::{
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use common::Flavor;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use http_body_util::BodyExt;
+use hyper::body::Incoming;
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo, TokioTimer},
+    server::conn::auto,
+};
+use tokio::{net::TcpListener, runtime::Runtime, task::JoinHandle};
+use wasmtime::{
+    Engine, Store,
+    component::{Component, Linker, ResourceTable},
+};
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+use wasmtime_wasi_http::{
+    WasiHttpCtx,
+    p2::{
+        bindings::{ProxyPre, http::types::Scheme as P2Scheme},
+        body::HyperOutgoingBody,
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Store context  - the bare minimum: WasiCtx + ResourceTable + WasiHttpCtx.
+// ---------------------------------------------------------------------------
+
+struct Ctx {
+    wasi: WasiCtx,
+    http: WasiHttpCtx,
+    table: ResourceTable,
+}
+
+impl Ctx {
+    fn new() -> Self {
+        Self {
+            wasi: WasiCtxBuilder::new().build(),
+            http: WasiHttpCtx::new(),
+            table: ResourceTable::new(),
+        }
+    }
+}
+
+impl WasiView for Ctx {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.wasi,
+            table: &mut self.table,
+        }
+    }
+}
+
+impl wasmtime_wasi_http::p2::WasiHttpView for Ctx {
+    fn http(&mut self) -> wasmtime_wasi_http::p2::WasiHttpCtxView<'_> {
+        wasmtime_wasi_http::p2::WasiHttpCtxView {
+            ctx: &mut self.http,
+            table: &mut self.table,
+            hooks: Default::default(),
+        }
+    }
+}
+
+#[cfg(feature = "wasip3")]
+impl wasmtime_wasi_http::p3::WasiHttpView for Ctx {
+    fn http(&mut self) -> wasmtime_wasi_http::p3::WasiHttpCtxView<'_> {
+        wasmtime_wasi_http::p3::WasiHttpCtxView {
+            ctx: &mut self.http,
+            table: &mut self.table,
+            hooks: wasmtime_wasi_http::p3::default_hooks(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine + Linker construction
+// ---------------------------------------------------------------------------
+
+fn build_engine() -> anyhow::Result<Engine> {
+    let mut cfg = wasmtime::Config::default();
+    // async_support is implied by current wasmtime; the explicit setter is
+    // deprecated, so we rely on the default.
+    let mut pool = wasmtime::PoolingAllocationConfig::default();
+    pool.total_memories(100);
+    pool.total_tables(100);
+    pool.total_component_instances(100);
+    cfg.allocation_strategy(wasmtime::InstanceAllocationStrategy::Pooling(pool));
+    #[cfg(feature = "wasip3")]
+    cfg.wasm_component_model_async(true);
+    Ok(Engine::new(&cfg)?)
+}
+
+/// Build a linker that can serve both P2 and P3 proxy components.
+fn build_linker(engine: &Engine) -> anyhow::Result<Linker<Ctx>> {
+    let mut linker: Linker<Ctx> = Linker::new(engine);
+
+    // P2 WASI + wasi:http bindings.
+    wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
+    wasmtime_wasi_http::p2::add_only_http_to_linker_async(&mut linker)?;
+
+    // P3 WASI + wasi:http bindings (only present when the wasip3 feature is on).
+    #[cfg(feature = "wasip3")]
+    {
+        wasmtime_wasi::p3::add_to_linker(&mut linker)?;
+        wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
+    }
+
+    Ok(linker)
+}
+
+// ---------------------------------------------------------------------------
+// Per-request handlers  - one Store per request for apples-to-apples with wash.
+// ---------------------------------------------------------------------------
+
+/// Handle a P2 request via `wasi:http/incoming-handler`.
+async fn handle_p2(
+    pre: wasmtime::component::InstancePre<Ctx>,
+    req: hyper::Request<Incoming>,
+) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
+    let mut store = Store::new(pre.component().engine(), Ctx::new());
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+
+    let scheme = match req.uri().scheme() {
+        Some(s) if s == &hyper::http::uri::Scheme::HTTP => P2Scheme::Http,
+        Some(s) if s == &hyper::http::uri::Scheme::HTTPS => P2Scheme::Https,
+        Some(s) => P2Scheme::Other(s.as_str().to_string()),
+        None => P2Scheme::Http,
+    };
+
+    let wasi_req = wasmtime_wasi_http::p2::WasiHttpView::http(store.data_mut())
+        .new_incoming_request(scheme, req)?;
+    let out = wasmtime_wasi_http::p2::WasiHttpView::http(store.data_mut())
+        .new_response_outparam(sender)?;
+    let proxy_pre = ProxyPre::new(pre)?;
+
+    let task: JoinHandle<anyhow::Result<()>> = tokio::task::spawn(async move {
+        let proxy = proxy_pre.instantiate_async(&mut store).await?;
+        proxy
+            .wasi_http_incoming_handler()
+            .call_handle(&mut store, wasi_req, out)
+            .await?;
+        Ok(())
+    });
+
+    match receiver.await {
+        Ok(Ok(resp)) => Ok(resp),
+        Ok(Err(e)) => Err(e.into()),
+        Err(_) => {
+            task.await??;
+            anyhow::bail!("oneshot channel closed but no response was sent")
+        }
+    }
+}
+
+/// Handle a P3 request via `wasi:http/handler@0.3.x`.
+#[cfg(feature = "wasip3")]
+async fn handle_p3(
+    pre: wasmtime::component::InstancePre<Ctx>,
+    req: hyper::Request<Incoming>,
+) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
+    use wasmtime_wasi_http::p2::bindings::http::types::ErrorCode as P2ErrorCode;
+    use wasmtime_wasi_http::p3::bindings::ServicePre;
+    use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode as P3ErrorCode;
+
+    let mut store = Store::new(pre.component().engine(), Ctx::new());
+    let service_pre = ServicePre::new(pre)?;
+
+    let (parts, body) = req.into_parts();
+    let body = body
+        .map_err(|e| P3ErrorCode::InternalError(Some(e.to_string())))
+        .boxed_unsync();
+    let req = hyper::Request::from_parts(parts, body);
+    let (wasi_req, req_io) = wasmtime_wasi_http::p3::Request::from_http(req);
+
+    let service = service_pre.instantiate_async(&mut store).await?;
+
+    let collected: hyper::Response<http_body_util::Collected<bytes::Bytes>> =
+        store
+            .run_concurrent(async move |store| {
+                let handler_fut = async {
+                    match service.handle(store, wasi_req).await {
+                        Ok(Ok(response)) => {
+                            let http_response: hyper::Response<_> =
+                                store.with(|s| response.into_http(s, async { Ok(()) }))?;
+                            let (parts, body) = http_response.into_parts();
+                            let body = body
+                                .collect()
+                                .await
+                                .map_err(|e| anyhow::anyhow!("collect body: {e:?}"))?;
+                            Ok::<
+                                hyper::Response<http_body_util::Collected<bytes::Bytes>>,
+                                anyhow::Error,
+                            >(hyper::Response::from_parts(parts, body))
+                        }
+                        Ok(Err(code)) => {
+                            let body = http_body_util::Empty::<bytes::Bytes>::new()
+                                .collect()
+                                .await
+                                .map_err(|e| anyhow::anyhow!("collect empty: {e:?}"))?;
+                            Ok(hyper::Response::builder()
+                                .status(500)
+                                .body(body)
+                                .unwrap_or_else(|_| {
+                                    panic!("failed to build error response: {code:?}")
+                                }))
+                        }
+                        Err(e) => Err(anyhow::anyhow!(e).context("P3 handler trap")),
+                    }
+                };
+                let io_fut = async {
+                    let _ = req_io.await;
+                };
+                let (r, _) = tokio::join!(handler_fut, io_fut);
+                r
+            })
+            .await??;
+
+    // Convert the collected response back to a streaming hyper body suitable
+    // for the outgoing connection. `HyperOutgoingBody` uses P2's ErrorCode as
+    // its error type, but our body is infallible so no mapping is needed.
+    let _ = P2ErrorCode::InternalError(None); // keep the import in scope
+    let (parts, body) = collected.into_parts();
+    let body: HyperOutgoingBody = http_body_util::Full::new(body.to_bytes())
+        .map_err(|never| match never {})
+        .boxed_unsync();
+    Ok(hyper::Response::from_parts(parts, body))
+}
+
+// ---------------------------------------------------------------------------
+// Hyper server  - binds to 127.0.0.1:0, serves requests until dropped.
+// ---------------------------------------------------------------------------
+
+struct Server {
+    addr: SocketAddr,
+    shutdown: tokio::sync::oneshot::Sender<()>,
+    _join: JoinHandle<()>,
+}
+
+impl Server {
+    async fn start(flavor: Flavor) -> anyhow::Result<Self> {
+        let engine = build_engine()?;
+        let linker = build_linker(&engine)?;
+        let component = Component::from_binary(&engine, flavor.wasm())?;
+        let pre = linker.instantiate_pre(&component)?;
+        let pre = Arc::new(pre);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let flavor_copy = flavor;
+
+        let join = tokio::spawn(async move {
+            loop {
+                let accept = tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    res = listener.accept() => res,
+                };
+                let (stream, _) = match accept {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                stream.set_nodelay(true).ok();
+                let pre = pre.clone();
+                tokio::spawn(async move {
+                    let io = TokioIo::new(stream);
+                    let service =
+                        hyper::service::service_fn(move |req: hyper::Request<Incoming>| {
+                            let pre = (*pre).clone();
+                            async move {
+                                let resp = match flavor_copy {
+                                    Flavor::P2 => handle_p2(pre, req).await,
+                                    #[cfg(feature = "wasip3")]
+                                    Flavor::P3 => handle_p3(pre, req).await,
+                                    #[cfg(not(feature = "wasip3"))]
+                                    Flavor::P3 => unreachable!("wasip3 feature disabled"),
+                                };
+                                match resp {
+                                    Ok(r) => Ok::<_, hyper::Error>(r),
+                                    Err(e) => {
+                                        tracing::error!(err = ?e, "handler error");
+                                        Ok(error_response(500))
+                                    }
+                                }
+                            }
+                        });
+                    let builder = auto::Builder::new(TokioExecutor::new());
+                    let builder = {
+                        let mut b = builder;
+                        b.http1().timer(TokioTimer::new());
+                        b.http2().timer(TokioTimer::new());
+                        b
+                    };
+                    let _ = builder.serve_connection(io, service).await;
+                });
+            }
+        });
+
+        Ok(Server {
+            addr,
+            shutdown: shutdown_tx,
+            _join: join,
+        })
+    }
+
+    fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        // shutdown_rx is a oneshot  - sending () wakes the accept loop.
+        // Replacing with a fresh channel so we can move out of &mut self.
+        let (tx, _rx) = tokio::sync::oneshot::channel::<()>();
+        let old = std::mem::replace(&mut self.shutdown, tx);
+        let _ = old.send(());
+    }
+}
+
+fn error_response(status: u16) -> hyper::Response<HyperOutgoingBody> {
+    let body: HyperOutgoingBody = http_body_util::Empty::<bytes::Bytes>::new()
+        .map_err(|never| match never {})
+        .boxed_unsync();
+    hyper::Response::builder()
+        .status(status)
+        .body(body)
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark harness
+// ---------------------------------------------------------------------------
+
+struct Warm {
+    server: Server,
+    client: reqwest::Client,
+}
+
+async fn start_warm(flavor: Flavor) -> anyhow::Result<Warm> {
+    let server = Server::start(flavor).await?;
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(64)
+        .tcp_nodelay(true)
+        .build()?;
+    let warmup = client
+        .get(format!("http://{}/", server.addr()))
+        .send()
+        .await?;
+    anyhow::ensure!(
+        warmup.status().is_success(),
+        "warmup failed for {:?}: {}",
+        flavor,
+        warmup.status()
+    );
+    let body = warmup.text().await?;
+    anyhow::ensure!(
+        body == flavor.expected_body(),
+        "unexpected warmup body for {:?}: {body:?}",
+        flavor
+    );
+    Ok(Warm { server, client })
+}
+
+async fn cold_once(flavor: Flavor) -> anyhow::Result<()> {
+    let warm = start_warm(flavor).await?;
+    drop(warm);
+    Ok(())
+}
+
+async fn hot_once(warm: &Warm) -> anyhow::Result<()> {
+    let resp = warm
+        .client
+        .get(format!("http://{}/", warm.server.addr()))
+        .send()
+        .await?;
+    anyhow::ensure!(resp.status().is_success(), "non-2xx: {}", resp.status());
+    let _ = resp.bytes().await?;
+    Ok(())
+}
+
+fn bench_cold(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("wasmtime_cold_invocation");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(15));
+
+    for flavor in [Flavor::P2, Flavor::P3] {
+        group.bench_function(BenchmarkId::from_parameter(flavor.name()), |b| {
+            b.to_async(&rt)
+                .iter(|| async move { cold_once(flavor).await.unwrap() });
+        });
+    }
+    group.finish();
+}
+
+fn bench_hot(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("wasmtime_hot_invocation");
+    group.throughput(Throughput::Elements(1));
+    group.measurement_time(Duration::from_secs(10));
+
+    for flavor in [Flavor::P2, Flavor::P3] {
+        let warm = rt.block_on(start_warm(flavor)).expect("warm");
+        group.bench_function(BenchmarkId::from_parameter(flavor.name()), |b| {
+            b.to_async(&rt)
+                .iter(|| async { hot_once(&warm).await.unwrap() });
+        });
+        drop(warm);
+    }
+    group.finish();
+}
+
+fn bench_throughput(c: &mut Criterion) {
+    const CONCURRENCY: usize = 32;
+    const BATCH: usize = 256;
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let mut group = c.benchmark_group("wasmtime_http_throughput");
+    group.throughput(Throughput::Elements(BATCH as u64));
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(15));
+
+    for flavor in [Flavor::P2, Flavor::P3] {
+        let warm = rt.block_on(start_warm(flavor)).expect("warm");
+        let url = format!("http://{}/", warm.server.addr());
+        let client = warm.client.clone();
+
+        let failures = Arc::new(AtomicUsize::new(0));
+        let failures_ref = failures.clone();
+        group.bench_function(BenchmarkId::from_parameter(flavor.name()), |b| {
+            b.to_async(&rt).iter_custom(|iters| {
+                let url = url.clone();
+                let client = client.clone();
+                let failures = failures_ref.clone();
+                async move {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let start = Instant::now();
+                        let mut handles = Vec::with_capacity(CONCURRENCY);
+                        let per_worker = BATCH / CONCURRENCY;
+                        for _ in 0..CONCURRENCY {
+                            let client = client.clone();
+                            let url = url.clone();
+                            let failures = failures.clone();
+                            handles.push(tokio::spawn(async move {
+                                for _ in 0..per_worker {
+                                    match client.get(&url).send().await {
+                                        Ok(resp) if resp.status().is_success() => {
+                                            let _ = resp.bytes().await;
+                                        }
+                                        _ => {
+                                            failures.fetch_add(1, Ordering::Relaxed);
+                                        }
+                                    }
+                                }
+                            }));
+                        }
+                        for h in handles {
+                            h.await.ok();
+                        }
+                        total += start.elapsed();
+                    }
+                    total
+                }
+            });
+        });
+        let failed = failures.load(Ordering::Relaxed);
+        if failed > 0 {
+            eprintln!(
+                "[wasmtime_http_throughput/{}] {failed} requests failed during bench run",
+                flavor.name()
+            );
+        }
+        drop(warm);
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_cold, bench_hot, bench_throughput);
+criterion_main!(benches);

--- a/crates/wash-runtime/benches/wasmtime_serve.rs
+++ b/crates/wash-runtime/benches/wasmtime_serve.rs
@@ -1,0 +1,593 @@
+//! "wasmtime serve"–equivalent HTTP benchmark.
+//!
+//! Uses `wasmtime_wasi_http::handler::ProxyHandler`  - the same dispatch path
+//! `wasmtime serve` uses  - to get instance reuse and concurrent reuse. The
+//! defaults mirror wasmtime serve:
+//!
+//!   * P2: `max_instance_reuse_count = 1` (no reuse; fresh instance per request)
+//!   * P3: `max_instance_reuse_count = 128`, `max_instance_concurrent_reuse_count = 16`
+//!
+//! Compare against `wasmtime_baseline.rs` (no-reuse, per-request instantiation)
+//! and `http_invoke.rs` (wash-runtime). The three benches together give a
+//! decomposition of where the 5× gap against `wasmtime serve` lives:
+//!
+//!   `http_invoke`           =  wasmtime + wash-runtime wrappers
+//!   `wasmtime_baseline`     =  wasmtime, per-request instance (our strategy)
+//!   `wasmtime_serve`        =  wasmtime + ProxyHandler (wasmtime serve's strategy)
+//!
+//! Run with:
+//! ```text
+//! cargo bench -p wash-runtime --features wasip3 --bench wasmtime_serve
+//! ```
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::{
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use anyhow::Context as _;
+use common::Flavor;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use http_body_util::BodyExt;
+use hyper::body::Incoming;
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo, TokioTimer},
+    server::conn::auto,
+};
+use tokio::{net::TcpListener, runtime::Runtime, sync::oneshot, task::JoinHandle};
+use wasmtime::{
+    Engine, Store,
+    component::{Component, Linker, ResourceTable},
+};
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+use wasmtime_wasi_http::{
+    WasiHttpCtx,
+    handler::{HandlerState, Proxy, ProxyHandler, ProxyPre as HandlerProxyPre, StoreBundle},
+    p2::body::HyperOutgoingBody,
+};
+
+// Defaults lifted from wasmtime-cli/src/commands/serve.rs.
+const DEFAULT_WASIP3_MAX_INSTANCE_REUSE_COUNT: usize = 128;
+const DEFAULT_WASIP2_MAX_INSTANCE_REUSE_COUNT: usize = 1;
+const DEFAULT_WASIP3_MAX_INSTANCE_CONCURRENT_REUSE_COUNT: usize = 16;
+
+// ---------------------------------------------------------------------------
+// Store context
+// ---------------------------------------------------------------------------
+
+struct Ctx {
+    wasi: WasiCtx,
+    http: WasiHttpCtx,
+    table: ResourceTable,
+}
+
+impl Ctx {
+    fn new() -> Self {
+        Self {
+            wasi: WasiCtxBuilder::new().build(),
+            http: WasiHttpCtx::new(),
+            table: ResourceTable::new(),
+        }
+    }
+}
+
+impl WasiView for Ctx {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.wasi,
+            table: &mut self.table,
+        }
+    }
+}
+
+impl wasmtime_wasi_http::p2::WasiHttpView for Ctx {
+    fn http(&mut self) -> wasmtime_wasi_http::p2::WasiHttpCtxView<'_> {
+        wasmtime_wasi_http::p2::WasiHttpCtxView {
+            ctx: &mut self.http,
+            table: &mut self.table,
+            hooks: Default::default(),
+        }
+    }
+}
+
+#[cfg(feature = "wasip3")]
+impl wasmtime_wasi_http::p3::WasiHttpView for Ctx {
+    fn http(&mut self) -> wasmtime_wasi_http::p3::WasiHttpCtxView<'_> {
+        wasmtime_wasi_http::p3::WasiHttpCtxView {
+            ctx: &mut self.http,
+            table: &mut self.table,
+            hooks: wasmtime_wasi_http::p3::default_hooks(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine + Linker
+// ---------------------------------------------------------------------------
+
+fn max_instance_reuse(flavor: Flavor) -> usize {
+    match flavor {
+        Flavor::P2 => DEFAULT_WASIP2_MAX_INSTANCE_REUSE_COUNT,
+        Flavor::P3 => DEFAULT_WASIP3_MAX_INSTANCE_REUSE_COUNT,
+    }
+}
+
+fn max_concurrent_reuse(flavor: Flavor) -> usize {
+    match flavor {
+        Flavor::P2 => 1,
+        Flavor::P3 => DEFAULT_WASIP3_MAX_INSTANCE_CONCURRENT_REUSE_COUNT,
+    }
+}
+
+fn build_engine() -> anyhow::Result<Engine> {
+    let mut cfg = wasmtime::Config::default();
+    let mut pool = wasmtime::PoolingAllocationConfig::default();
+    pool.total_memories(100);
+    pool.total_tables(100);
+    pool.total_component_instances(100);
+    cfg.allocation_strategy(wasmtime::InstanceAllocationStrategy::Pooling(pool));
+    #[cfg(feature = "wasip3")]
+    cfg.wasm_component_model_async(true);
+    Ok(Engine::new(&cfg)?)
+}
+
+fn build_linker(engine: &Engine) -> anyhow::Result<Linker<Ctx>> {
+    let mut linker: Linker<Ctx> = Linker::new(engine);
+    wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
+    wasmtime_wasi_http::p2::add_only_http_to_linker_async(&mut linker)?;
+    #[cfg(feature = "wasip3")]
+    {
+        wasmtime_wasi::p3::add_to_linker(&mut linker)?;
+        wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
+    }
+    Ok(linker)
+}
+
+// ---------------------------------------------------------------------------
+// HandlerState  - tells ProxyHandler how to produce Stores and bound reuse
+// ---------------------------------------------------------------------------
+
+struct State {
+    engine: Engine,
+    max_instance_reuse_count: usize,
+    max_instance_concurrent_reuse_count: usize,
+}
+
+impl HandlerState for State {
+    type StoreData = Ctx;
+
+    fn new_store(&self, _req_id: Option<u64>) -> wasmtime::Result<StoreBundle<Ctx>> {
+        let store = Store::new(&self.engine, Ctx::new());
+        Ok(StoreBundle {
+            store,
+            write_profile: Box::new(|_| ()),
+        })
+    }
+
+    fn request_timeout(&self) -> Duration {
+        Duration::MAX
+    }
+
+    fn idle_instance_timeout(&self) -> Duration {
+        // Short enough that idle workers don't linger across bench groups,
+        // long enough that it never fires mid-run.
+        Duration::from_secs(60)
+    }
+
+    fn max_instance_reuse_count(&self) -> usize {
+        self.max_instance_reuse_count
+    }
+
+    fn max_instance_concurrent_reuse_count(&self) -> usize {
+        self.max_instance_concurrent_reuse_count
+    }
+
+    fn handle_worker_error(&self, error: wasmtime::Error) {
+        eprintln!("[wasmtime_serve bench] worker error: {error:?}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Request dispatch  - mirrors wasmtime-cli/src/commands/serve.rs::handle_request
+// ---------------------------------------------------------------------------
+
+type P2Response = Result<
+    hyper::Response<HyperOutgoingBody>,
+    wasmtime_wasi_http::p2::bindings::http::types::ErrorCode,
+>;
+type P3Response =
+    hyper::Response<http_body_util::combinators::UnsyncBoxBody<bytes::Bytes, wasmtime::Error>>;
+
+enum Sender {
+    P2(oneshot::Sender<P2Response>),
+    P3(oneshot::Sender<P3Response>),
+}
+
+enum Receiver {
+    P2(oneshot::Receiver<P2Response>),
+    P3(oneshot::Receiver<P3Response>),
+}
+
+async fn handle_request(
+    handler: ProxyHandler<State>,
+    req: hyper::Request<Incoming>,
+) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
+    let req_id = handler.next_req_id();
+
+    let (tx, rx) = match handler.instance_pre() {
+        HandlerProxyPre::P2(_) => {
+            let (tx, rx) = oneshot::channel();
+            (Sender::P2(tx), Receiver::P2(rx))
+        }
+        HandlerProxyPre::P3(_) => {
+            let (tx, rx) = oneshot::channel();
+            (Sender::P3(tx), Receiver::P3(rx))
+        }
+    };
+
+    handler.spawn(
+        if handler.state().max_instance_reuse_count() == 1 {
+            Some(req_id)
+        } else {
+            None
+        },
+        Box::new(move |accessor, proxy| {
+            Box::pin(async move {
+                let result: wasmtime::Result<()> = match proxy {
+                    Proxy::P2(proxy) => {
+                        let Sender::P2(tx) = tx else { unreachable!() };
+                        let setup: wasmtime::Result<_> = accessor.with(move |mut store| {
+                            let req = wasmtime_wasi_http::p2::WasiHttpView::http(store.data_mut())
+                                .new_incoming_request(
+                                    wasmtime_wasi_http::p2::bindings::http::types::Scheme::Http,
+                                    req,
+                                )?;
+                            let out = wasmtime_wasi_http::p2::WasiHttpView::http(store.data_mut())
+                                .new_response_outparam(tx)?;
+                            wasmtime::error::Ok((req, out))
+                        });
+                        let (req, out) = match setup {
+                            Ok(v) => v,
+                            Err(e) => return eprintln!("[{req_id}] setup: {e:?}"),
+                        };
+                        proxy
+                            .wasi_http_incoming_handler()
+                            .call_handle(accessor, req, out)
+                            .await
+                    }
+                    Proxy::P3(proxy) => {
+                        let Sender::P3(tx) = tx else { unreachable!() };
+                        use wasmtime_wasi_http::p3::bindings::http::types::{ErrorCode, Request};
+
+                        let (parts, body) = req.into_parts();
+                        let body = body.map_err(ErrorCode::from_hyper_request_error);
+                        let req = hyper::Request::from_parts(parts, body);
+                        let (request, request_io_result) = Request::from_http(req);
+
+                        let res = match proxy.handle(accessor, request).await {
+                            Ok(Ok(r)) => r,
+                            Ok(Err(code)) => {
+                                return eprintln!("[{req_id}] handler err: {code:?}");
+                            }
+                            Err(e) => return eprintln!("[{req_id}] trap: {e:?}"),
+                        };
+
+                        let res =
+                            accessor.with(|mut store| res.into_http(&mut store, request_io_result));
+                        let res = match res {
+                            Ok(r) => r,
+                            Err(e) => return eprintln!("[{req_id}] into_http: {e:?}"),
+                        };
+
+                        let res = res.map(|body| body.map_err(|e| e.into()).boxed_unsync());
+                        let _ = tx.send(res);
+                        Ok(())
+                    }
+                };
+                if let Err(e) = result {
+                    eprintln!("[{req_id}] :: {e:?}");
+                }
+            })
+        }),
+    );
+
+    match rx {
+        Receiver::P2(rx) => {
+            let resp = rx
+                .await
+                .context("guest never invoked response-outparam::set")?;
+            Ok(resp.map_err(wasmtime::Error::from)?)
+        }
+        Receiver::P3(rx) => {
+            let resp = rx.await?;
+            let (parts, body) = resp.into_parts();
+            // Collect and re-wrap so the outer response body type matches the
+            // P2 path. For the minimal fixtures this is cheap (tiny payload).
+            let body = body
+                .collect()
+                .await
+                .map_err(|e| anyhow::anyhow!("collect p3 body: {e:?}"))?
+                .to_bytes();
+            let body: HyperOutgoingBody = http_body_util::Full::new(body)
+                .map_err(|never| match never {})
+                .boxed_unsync();
+            Ok(hyper::Response::from_parts(parts, body))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hyper server  - binds, accepts, dispatches through ProxyHandler.
+// ---------------------------------------------------------------------------
+
+struct Server {
+    addr: SocketAddr,
+    shutdown: oneshot::Sender<()>,
+    _join: JoinHandle<()>,
+}
+
+impl Server {
+    async fn start(flavor: Flavor) -> anyhow::Result<Self> {
+        let engine = build_engine()?;
+        let linker = build_linker(&engine)?;
+        let component = Component::from_binary(&engine, flavor.wasm())?;
+        let instance_pre = linker.instantiate_pre(&component)?;
+
+        // Wrap InstancePre in the right handler::ProxyPre variant.
+        let handler_pre = match flavor {
+            Flavor::P2 => HandlerProxyPre::P2(
+                wasmtime_wasi_http::handler::p2::bindings::ProxyPre::new(instance_pre)?,
+            ),
+            #[cfg(feature = "wasip3")]
+            Flavor::P3 => HandlerProxyPre::P3(wasmtime_wasi_http::p3::bindings::ServicePre::new(
+                instance_pre,
+            )?),
+            #[cfg(not(feature = "wasip3"))]
+            Flavor::P3 => anyhow::bail!("wasip3 feature disabled"),
+        };
+
+        let handler = ProxyHandler::new(
+            State {
+                engine,
+                max_instance_reuse_count: max_instance_reuse(flavor),
+                max_instance_concurrent_reuse_count: max_concurrent_reuse(flavor),
+            },
+            handler_pre,
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+
+        let join = tokio::spawn(async move {
+            loop {
+                let accept = tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    res = listener.accept() => res,
+                };
+                let (stream, _) = match accept {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                stream.set_nodelay(true).ok();
+                let handler = handler.clone();
+                tokio::spawn(async move {
+                    let io = TokioIo::new(stream);
+                    let service =
+                        hyper::service::service_fn(move |req: hyper::Request<Incoming>| {
+                            let handler = handler.clone();
+                            async move {
+                                match handle_request(handler, req).await {
+                                    Ok(r) => Ok::<_, hyper::Error>(r),
+                                    Err(e) => {
+                                        tracing::error!(err = ?e, "handler error");
+                                        Ok(error_response(500))
+                                    }
+                                }
+                            }
+                        });
+                    let builder = {
+                        let mut b = auto::Builder::new(TokioExecutor::new());
+                        b.http1().timer(TokioTimer::new());
+                        b.http2().timer(TokioTimer::new());
+                        b
+                    };
+                    let _ = builder.serve_connection(io, service).await;
+                });
+            }
+        });
+
+        Ok(Server {
+            addr,
+            shutdown: shutdown_tx,
+            _join: join,
+        })
+    }
+
+    fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let (tx, _rx) = oneshot::channel::<()>();
+        let old = std::mem::replace(&mut self.shutdown, tx);
+        let _ = old.send(());
+    }
+}
+
+fn error_response(status: u16) -> hyper::Response<HyperOutgoingBody> {
+    let body: HyperOutgoingBody = http_body_util::Empty::<bytes::Bytes>::new()
+        .map_err(|never| match never {})
+        .boxed_unsync();
+    hyper::Response::builder()
+        .status(status)
+        .body(body)
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark harness
+// ---------------------------------------------------------------------------
+
+struct Warm {
+    server: Server,
+    client: reqwest::Client,
+}
+
+async fn start_warm(flavor: Flavor) -> anyhow::Result<Warm> {
+    let server = Server::start(flavor).await?;
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(64)
+        .tcp_nodelay(true)
+        .build()?;
+    let warmup = client
+        .get(format!("http://{}/", server.addr()))
+        .send()
+        .await?;
+    anyhow::ensure!(
+        warmup.status().is_success(),
+        "warmup failed for {:?}: {}",
+        flavor,
+        warmup.status()
+    );
+    let body = warmup.text().await?;
+    anyhow::ensure!(
+        body == flavor.expected_body(),
+        "unexpected warmup body for {:?}: {body:?}",
+        flavor
+    );
+    Ok(Warm { server, client })
+}
+
+async fn cold_once(flavor: Flavor) -> anyhow::Result<()> {
+    let warm = start_warm(flavor).await?;
+    drop(warm);
+    Ok(())
+}
+
+async fn hot_once(warm: &Warm) -> anyhow::Result<()> {
+    let resp = warm
+        .client
+        .get(format!("http://{}/", warm.server.addr()))
+        .send()
+        .await?;
+    anyhow::ensure!(resp.status().is_success(), "non-2xx: {}", resp.status());
+    let _ = resp.bytes().await?;
+    Ok(())
+}
+
+fn bench_cold(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("serve_cold_invocation");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(15));
+
+    for flavor in [Flavor::P2, Flavor::P3] {
+        group.bench_function(BenchmarkId::from_parameter(flavor.name()), |b| {
+            b.to_async(&rt)
+                .iter(|| async move { cold_once(flavor).await.unwrap() });
+        });
+    }
+    group.finish();
+}
+
+fn bench_hot(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("serve_hot_invocation");
+    group.throughput(Throughput::Elements(1));
+    group.measurement_time(Duration::from_secs(10));
+
+    for flavor in [Flavor::P2, Flavor::P3] {
+        let warm = rt.block_on(start_warm(flavor)).expect("warm");
+        group.bench_function(BenchmarkId::from_parameter(flavor.name()), |b| {
+            b.to_async(&rt)
+                .iter(|| async { hot_once(&warm).await.unwrap() });
+        });
+        drop(warm);
+    }
+    group.finish();
+}
+
+fn bench_throughput(c: &mut Criterion) {
+    const CONCURRENCY: usize = 32;
+    const BATCH: usize = 256;
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let mut group = c.benchmark_group("serve_http_throughput");
+    group.throughput(Throughput::Elements(BATCH as u64));
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(15));
+
+    for flavor in [Flavor::P2, Flavor::P3] {
+        let warm = rt.block_on(start_warm(flavor)).expect("warm");
+        let url = format!("http://{}/", warm.server.addr());
+        let client = warm.client.clone();
+
+        let failures = Arc::new(AtomicUsize::new(0));
+        let failures_ref = failures.clone();
+        group.bench_function(BenchmarkId::from_parameter(flavor.name()), |b| {
+            b.to_async(&rt).iter_custom(|iters| {
+                let url = url.clone();
+                let client = client.clone();
+                let failures = failures_ref.clone();
+                async move {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let start = Instant::now();
+                        let mut handles = Vec::with_capacity(CONCURRENCY);
+                        let per_worker = BATCH / CONCURRENCY;
+                        for _ in 0..CONCURRENCY {
+                            let client = client.clone();
+                            let url = url.clone();
+                            let failures = failures.clone();
+                            handles.push(tokio::spawn(async move {
+                                for _ in 0..per_worker {
+                                    match client.get(&url).send().await {
+                                        Ok(resp) if resp.status().is_success() => {
+                                            let _ = resp.bytes().await;
+                                        }
+                                        _ => {
+                                            failures.fetch_add(1, Ordering::Relaxed);
+                                        }
+                                    }
+                                }
+                            }));
+                        }
+                        for h in handles {
+                            h.await.ok();
+                        }
+                        total += start.elapsed();
+                    }
+                    total
+                }
+            });
+        });
+        let failed = failures.load(Ordering::Relaxed);
+        if failed > 0 {
+            eprintln!(
+                "[serve_http_throughput/{}] {failed} requests failed during bench run",
+                flavor.name()
+            );
+        }
+        drop(warm);
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_cold, bench_hot, bench_throughput);
+criterion_main!(benches);

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -234,7 +234,7 @@ impl Router for DynamicRouter {
 /// Development router that routes all requests to the last resolved workload
 #[derive(Default)]
 pub struct DevRouter {
-    last_workload_id: tokio::sync::Mutex<Option<String>>,
+    last_workload_id: std::sync::RwLock<Option<String>>,
 }
 
 #[async_trait::async_trait]
@@ -244,13 +244,19 @@ impl Router for DevRouter {
         resolved_handle: &ResolvedWorkload,
         _component_id: &str,
     ) -> anyhow::Result<()> {
-        let mut lock = self.last_workload_id.lock().await;
+        let mut lock = self
+            .last_workload_id
+            .write()
+            .map_err(|e| anyhow::anyhow!("DevRouter write lock poisoned: {e}"))?;
         lock.replace(resolved_handle.id().to_string());
         Ok(())
     }
 
     async fn on_workload_unbind(&self, workload_id: &str) -> anyhow::Result<()> {
-        let mut lock = self.last_workload_id.lock().await;
+        let mut lock = self
+            .last_workload_id
+            .write()
+            .map_err(|e| anyhow::anyhow!("DevRouter write lock poisoned: {e}"))?;
         if let Some(current_id) = &*lock
             && current_id == workload_id
         {
@@ -274,7 +280,10 @@ impl Router for DevRouter {
         &self,
         _req: &hyper::Request<hyper::body::Incoming>,
     ) -> anyhow::Result<String> {
-        let lock = self.last_workload_id.try_lock()?;
+        let lock = self
+            .last_workload_id
+            .read()
+            .map_err(|e| anyhow::anyhow!("DevRouter read lock poisoned: {e}"))?;
         match &*lock {
             Some(id) => Ok(id.clone()),
             None => anyhow::bail!("no workload available to route request"),

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -286,7 +286,7 @@ impl Router for DynamicRouter {
 /// Development router that routes all requests to the last resolved workload
 #[derive(Default)]
 pub struct DevRouter {
-    last_workload_id: tokio::sync::Mutex<Option<String>>,
+    last_workload_id: std::sync::RwLock<Option<String>>,
 }
 
 #[async_trait::async_trait]
@@ -296,13 +296,19 @@ impl Router for DevRouter {
         resolved_handle: &ResolvedWorkload,
         _component_id: &str,
     ) -> anyhow::Result<()> {
-        let mut lock = self.last_workload_id.lock().await;
+        let mut lock = self
+            .last_workload_id
+            .write()
+            .map_err(|e| anyhow::anyhow!("DevRouter write lock poisoned: {e}"))?;
         lock.replace(resolved_handle.id().to_string());
         Ok(())
     }
 
     async fn on_workload_unbind(&self, workload_id: &str) -> anyhow::Result<()> {
-        let mut lock = self.last_workload_id.lock().await;
+        let mut lock = self
+            .last_workload_id
+            .write()
+            .map_err(|e| anyhow::anyhow!("DevRouter write lock poisoned: {e}"))?;
         if let Some(current_id) = &*lock
             && current_id == workload_id
         {
@@ -328,7 +334,7 @@ impl Router for DevRouter {
     ) -> Result<String, RouteError> {
         let lock = self
             .last_workload_id
-            .try_lock()
+            .try_read()
             .map_err(|_| RouteError::Unavailable)?;
         match &*lock {
             Some(id) => Ok(id.clone()),

--- a/crates/wash-runtime/tests/integration_router_dev.rs
+++ b/crates/wash-runtime/tests/integration_router_dev.rs
@@ -9,7 +9,7 @@
 //!   matches the currently-bound workload; stopping any other workload is a
 //!   no-op for routing.
 //! - Concurrent reads racing a workload swap all resolve to a response (no
-//!   hangs, no panics from `try_lock` contention).
+//!   hangs, no panics from `try_read` contention).
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -171,7 +171,7 @@ async fn test_dev_router_unbind_clears_only_matching() -> Result<()> {
 }
 
 /// Concurrent reads during a workload swap must all resolve (success or
-/// graceful 5xx). Exercises `try_lock()` contention on `last_workload_id`.
+/// graceful 5xx). Exercises `try_read()` contention on `last_workload_id`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_dev_router_concurrent_reads_during_swap() -> Result<()> {
     let (addr, host) = start_host_with_dev_router("127.0.0.1:0").await?;


### PR DESCRIPTION
Adds 3 criterion **HTTP invocation benchmarks**, measuring cold start, hot latency, and throughput (RPS) for both WASIP2 and WASIP3.

This infrastructure caught and was used to fix a real bug in DevRouter http router included in this PR.

## Design

The three benches form a decomposition:

| Bench | What it measures |
|---|---|
| `http_invoke` | wasmtime + wash-runtime wrappers (routing, SharedCtx, plugin scaffolding) |
| `wasmtime_baseline` | wasmtime only, per-request instantiation (our current strategy) |
| `wasmtime_serve` | wasmtime + ProxyHandler (`wasmtime serve`'s instance-reuse strategy) |

Comparing `http_invoke` vs `wasmtime_baseline` isolates wash-runtime overhead. Comparing `wasmtime_baseline` vs `wasmtime_serve` isolates the instance-reuse benefit. I have an additional incoming change that will add instance reuse.

Each suite measures:
1. **Cold invocation** — full "first request" cost (component compile + host build + first instance)
2. **Hot invocation** — steady-state single-request latency on a warm host
3. **Throughput** — concurrent RPS with 32 workers × 256 requests per sample

## CI

`cargo bench --no-run` on ubuntu catches compile regressions without measuring. GitHub runners are too noisy for stable numbers. I'm interested in adding our own dedicated infrastructure here, but out of scope for this change.

Run locally:
`cargo bench -p wash-runtime --features wasip3`

## Test plan

- [x] `cargo check -p wash-runtime --features wasip3 --benches` compiles clean
- [x] `cargo bench -p wash-runtime --features wasip3` runs locally and produces reports
- [x] Warmup assertions pass (correctness check before timing)
- [x] CI `cargo bench --no-run` step passes

By no means as scientific as I'd like (on my local mac), so please don't use this to inform metrics in production.
But this is enough to qualify the bug fix and motivate instance re-use:

Cold invocation (first request, includes compilation)
```shell
┌───────────────────┬──────────┬──────────┐
│       Bench       │    P2    │    P3    │
├───────────────────┼──────────┼──────────┤
│ wash-runtime      │ 189.6 ms │ 202.6 ms │
├───────────────────┼──────────┼──────────┤
│ wasmtime baseline │ 186.0 ms │ 203.6 ms │
├───────────────────┼──────────┼──────────┤
│ wasmtime serve    │ 185.3 ms │ 203.6 ms │
└───────────────────┴──────────┴──────────┘
```
Hot invocation (single request, warm host)

```shell
┌───────────────────┬──────────┬──────────┐
│       Bench       │    P2    │    P3    │
├───────────────────┼──────────┼──────────┤
│ wash-runtime      │ 110.8 us │ 110.9 us │
├───────────────────┼──────────┼──────────┤
│ wasmtime baseline │ 96.7 us  │ 101.1 us │
├───────────────────┼──────────┼──────────┤
│ wasmtime serve    │ 106.8 us │ 65.8 us  │
└───────────────────┴──────────┴──────────┘
```
Throughput (32 concurrent workers, 256 req/sample)
```shell
┌───────────────────┬───────────┬───────────┐
│       Bench       │    P2     │    P3     │
├───────────────────┼───────────┼───────────┤
│ wash-runtime      │ 16.5K RPS │ 16.3K RPS │
├───────────────────┼───────────┼───────────┤
│ wasmtime baseline │ 20.8K RPS │ 20.4K RPS │
├───────────────────┼───────────┼───────────┤
│ wasmtime serve    │ 20.5K RPS │ 86.6K RPS │
└───────────────────┴───────────┴───────────┘
```
Key takeaways:

- Cold start: ~3.5 ms overhead from wash-runtime wrappers (P2), negligible for P3. Dominated by compilation in all cases.
- Hot latency: wash-runtime adds ~14 us over raw wasmtime (P2). P3 instance reuse via ProxyHandler cuts latency to 65.8 us — 41% faster than per-request instantiation.
- Throughput: The big story is P3 with instance reuse — 86.6K RPS vs 16.3K for wash-runtime, a 5.3x gap. wash-runtime's per-request instantiation leaves ~20% on the table vs raw wasmtime baseline (16.3K vs 20.4K), but the instance reuse strategy is where the 5x lives.
