### PR TITLE
feat: Expand DevRouter and DynamicRouter Tests

### DIFF
--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -270,8 +270,8 @@ pub async fn get_status(
             .send(),
     )
     .await
-    .context("request timed out")?
-    .context("request failed")?;
+    .with_context(|| format!("request to {host_header} timed out"))?
+    .with_context(|| format!("request to {host_header} failed"))?;
     Ok(response.status())
 }
 

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -1,0 +1,297 @@
+//! Shared helpers for wash-runtime integration tests.
+
+#![allow(dead_code)]
+
+use anyhow::{Context, Result};
+use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, DynamicRouter, HttpServer},
+    },
+    plugin::{
+        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
+        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
+    },
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+    wit::WitInterface,
+};
+
+/// HTTP incoming-handler (0.2.2) with `host` config, plus optional
+/// comma-separated `host-aliases`. (example :  "admin,user,customer")
+pub fn http_incoming_handler_interface(host_header: &str, aliases: Option<&str>) -> WitInterface {
+    let mut config = HashMap::new();
+    config.insert("host".to_string(), host_header.to_string());
+    if let Some(aliases) = aliases {
+        config.insert("host-aliases".to_string(), aliases.to_string());
+    }
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "http".to_string(),
+        interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.2.2").unwrap()),
+        config,
+        name: None,
+    }
+}
+
+fn wasi_blobstore_interface() -> WitInterface {
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "blobstore".to_string(),
+        interfaces: [
+            "blobstore".to_string(),
+            "container".to_string(),
+            "types".to_string(),
+        ]
+        .into_iter()
+        .collect(),
+        version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+fn wasi_keyvalue_interface() -> WitInterface {
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: ["store".to_string(), "atomics".to_string()]
+            .into_iter()
+            .collect(),
+        version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+fn wasi_logging_interface() -> WitInterface {
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "logging".to_string(),
+        interfaces: ["logging".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.1.0-draft").unwrap()),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+fn wasi_config_interface() -> WitInterface {
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "config".to_string(),
+        interfaces: ["store".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.2.0-rc.1").unwrap()),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+/// Interfaces used by the `http-counter` component: HTTP, blobstore,
+/// keyvalue, logging, config.
+pub fn http_counter_host_interfaces(host_header: &str) -> Vec<WitInterface> {
+    http_counter_host_interfaces_with_aliases(host_header, None)
+}
+
+/// Same as `http_counter_host_interfaces` but with optional host aliases are
+/// passed through to the HTTP interface's `host-aliases` config entry.
+pub fn http_counter_host_interfaces_with_aliases(
+    host_header: &str,
+    aliases: Option<&str>,
+) -> Vec<WitInterface> {
+    vec![
+        http_incoming_handler_interface(host_header, aliases),
+        wasi_blobstore_interface(),
+        wasi_keyvalue_interface(),
+        wasi_logging_interface(),
+        wasi_config_interface(),
+    ]
+}
+
+/// Interfaces for HTTP-only components (e.g. `http-handler-p2`,
+/// `http-handler-p3`): just the HTTP incoming-handler interface.
+pub fn http_only_host_interfaces(host_header: &str) -> Vec<WitInterface> {
+    vec![http_incoming_handler_interface(host_header, None)]
+}
+
+/// Interfaces for P3 HTTP + blobstore components.
+pub fn http_blobstore_host_interfaces(host_header: &str) -> Vec<WitInterface> {
+    vec![
+        http_incoming_handler_interface(host_header, None),
+        wasi_blobstore_interface(),
+    ]
+}
+
+pub fn component_workload_request(
+    component_name: &str,
+    workload_name: &str,
+    wasm: &'static [u8],
+    local_resources: LocalResources,
+    host_interfaces: Vec<WitInterface>,
+) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: workload_name.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: component_name.to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(wasm),
+                local_resources,
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    }
+}
+
+pub fn default_counter_resources() -> LocalResources {
+    LocalResources {
+        memory_limit_mb: 256,
+        cpu_limit: 1,
+        config: HashMap::new(),
+        environment: HashMap::new(),
+        volume_mounts: vec![],
+        allowed_hosts: Default::default(),
+    }
+}
+
+/// Attach the standard suite of plugins used by http-counter tests:
+/// in-memory blobstore + keyvalue, tracing logger, dynamic config.
+fn with_standard_plugins(
+    builder: wash_runtime::host::HostBuilder,
+) -> Result<wash_runtime::host::HostBuilder> {
+    Ok(builder
+        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
+        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
+        .with_plugin(Arc::new(TracingLogger::default()))?
+        .with_plugin(Arc::new(DynamicConfig::default()))?)
+}
+
+/// Start a host with a "DevRouter" backed HTTP server and the standard plugin
+/// set. Returns the bound address and a started `HostApi` ref.
+pub async fn start_host_with_dev_router(
+    addr: &str,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
+    let bound_addr = http_server.addr();
+    let host = with_standard_plugins(
+        HostBuilder::new()
+            .with_engine(engine)
+            .with_http_handler(Arc::new(http_server)),
+    )?
+    .build()?;
+    let host = host.start().await.context("Failed to start host")?;
+    Ok((bound_addr, host))
+}
+
+/// Start a host with a "DynamicRouter" backed HTTP server and the standard
+/// plugin set.
+pub async fn start_host_with_dynamic_router(
+    addr: &str,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DynamicRouter::default(), addr.parse()?).await?;
+    let bound_addr = http_server.addr();
+    let host = with_standard_plugins(
+        HostBuilder::new()
+            .with_engine(engine)
+            .with_http_handler(Arc::new(http_server)),
+    )?
+    .build()?;
+    let host = host.start().await.context("Failed to start host")?;
+    Ok((bound_addr, host))
+}
+
+/// Start a host with a TLS-enabled `DevRouter`-backed HTTP server and the
+/// standard plugin set. Certificate and key are read from disk at the given
+/// paths.
+pub async fn start_host_with_tls(
+    cert_path: &Path,
+    key_path: &Path,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new_with_tls(
+        DevRouter::default(),
+        "127.0.0.1:0".parse()?,
+        cert_path,
+        key_path,
+        None,
+    )
+    .await?;
+    let bound_addr = http_server.addr();
+    let host = with_standard_plugins(
+        HostBuilder::new()
+            .with_engine(engine)
+            .with_http_handler(Arc::new(http_server)),
+    )?
+    .build()?;
+    let host = host.start().await.context("Failed to start host")?;
+    Ok((bound_addr, host))
+}
+
+/// Start a host with `wasip3` enabled on the engine, a `DevRouter` backed
+/// HTTP server, and the standard plugin set.
+#[cfg(feature = "wasip3")]
+pub async fn start_host_with_p3(addr: &str) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let engine = Engine::builder().with_wasip3(true).build()?;
+    let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
+    let bound_addr = http_server.addr();
+    let host = with_standard_plugins(
+        HostBuilder::new()
+            .with_engine(engine)
+            .with_http_handler(Arc::new(http_server)),
+    )?
+    .build()?;
+    let host = host.start().await.context("Failed to start host")?;
+    Ok((bound_addr, host))
+}
+
+/// GET `http://{addr}/` with the given `HOST` header and a 10s timeout.
+pub async fn get_status(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host_header: &str,
+) -> Result<reqwest::StatusCode> {
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", host_header)
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+    Ok(response.status())
+}
+
+/// Like `get_status` but also returns the response body text.
+pub async fn get_status_and_body(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host_header: &str,
+) -> Result<(reqwest::StatusCode, String)> {
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", host_header)
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Ok((status, body))
+}

--- a/crates/wash-runtime/tests/integration_http_counter.rs
+++ b/crates/wash-runtime/tests/integration_http_counter.rs
@@ -6,125 +6,29 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, time::Duration};
 use tokio::time::timeout;
 
-use wash_runtime::{
-    engine::Engine,
-    host::{
-        HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
-    },
-    plugin::{
-        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
-        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
-    },
-    types::{Component, LocalResources, Workload, WorkloadStartRequest},
-    wit::WitInterface,
+use wash_runtime::{host::HostApi, types::LocalResources};
+
+mod common;
+use common::{
+    component_workload_request, http_counter_host_interfaces, start_host_with_dev_router,
 };
 
 const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
 
-/// Standard set of WASI interfaces used by the http-counter component.
-fn http_counter_host_interfaces(http_host_config: &str) -> Vec<WitInterface> {
-    vec![
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "http".to_string(),
-            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.2").unwrap()),
-            config: {
-                let mut config = HashMap::new();
-                config.insert("host".to_string(), http_host_config.to_string());
-                config
-            },
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "blobstore".to_string(),
-            interfaces: [
-                "blobstore".to_string(),
-                "container".to_string(),
-                "types".to_string(),
-            ]
-            .into_iter()
-            .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "keyvalue".to_string(),
-            interfaces: ["store".to_string(), "atomics".to_string()]
-                .into_iter()
-                .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "logging".to_string(),
-            interfaces: ["logging".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.1.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "config".to_string(),
-            interfaces: ["store".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.0-rc.1").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-    ]
-}
-
-/// Build and start a host with the standard set of plugins (HTTP, blobstore, keyvalue, logging, config).
-async fn start_host_with_all_plugins(addr: &str) -> Result<(std::net::SocketAddr, impl HostApi)> {
-    let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
-    let bound_addr = http_server.addr();
-    let host = HostBuilder::new()
-        .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
-        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
-        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
-        .with_plugin(Arc::new(TracingLogger::default()))?
-        .with_plugin(Arc::new(DynamicConfig::default()))?
-        .build()?;
-
-    let host = host.start().await.context("Failed to start host")?;
-    Ok((bound_addr, host))
-}
-
-/// Create a workload start request for the http-counter component.
-fn http_counter_workload_request(
-    http_host_config: &str,
+fn http_counter_request(
+    host_header: &str,
     local_resources: LocalResources,
-) -> WorkloadStartRequest {
-    WorkloadStartRequest {
-        workload_id: uuid::Uuid::new_v4().to_string(),
-        workload: Workload {
-            namespace: "test".to_string(),
-            name: "http-counter-workload".to_string(),
-            annotations: HashMap::new(),
-            service: None,
-            components: vec![Component {
-                name: "http-counter.wasm".to_string(),
-                digest: None,
-                bytes: bytes::Bytes::from_static(HTTP_COUNTER_WASM),
-                local_resources,
-                pool_size: 1,
-                max_invocations: 100,
-            }],
-            host_interfaces: http_counter_host_interfaces(http_host_config),
-            volumes: vec![],
-        },
-    }
+) -> wash_runtime::types::WorkloadStartRequest {
+    component_workload_request(
+        "http-counter.wasm",
+        "http-counter-workload",
+        HTTP_COUNTER_WASM,
+        local_resources,
+        http_counter_host_interfaces(host_header),
+    )
 }
 
 #[tokio::test]
@@ -133,9 +37,9 @@ async fn test_http_counter_integration() -> Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let (addr, host) = start_host_with_all_plugins("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_dev_router("127.0.0.1:0").await?;
 
-    let req = http_counter_workload_request(
+    let req = http_counter_request(
         "foo",
         LocalResources {
             memory_limit_mb: 256,
@@ -238,9 +142,9 @@ async fn test_http_counter_integration() -> Result<()> {
 
 #[tokio::test]
 async fn test_http_counter_error_scenarios() -> Result<()> {
-    let (addr, host) = start_host_with_all_plugins("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_dev_router("127.0.0.1:0").await?;
 
-    let req = http_counter_workload_request("error-test", LocalResources::default());
+    let req = http_counter_request("error-test", LocalResources::default());
 
     host.workload_start(req)
         .await
@@ -270,8 +174,8 @@ async fn test_http_counter_error_scenarios() -> Result<()> {
 #[tokio::test]
 async fn test_http_counter_plugin_isolation() -> Result<()> {
     // Two independent hosts should start without interference
-    let (_addr1, _host1) = start_host_with_all_plugins("127.0.0.1:0").await?;
-    let (_addr2, _host2) = start_host_with_all_plugins("127.0.0.1:0").await?;
+    let (_addr1, _host1) = start_host_with_dev_router("127.0.0.1:0").await?;
+    let (_addr2, _host2) = start_host_with_dev_router("127.0.0.1:0").await?;
 
     Ok(())
 }

--- a/crates/wash-runtime/tests/integration_http_tls.rs
+++ b/crates/wash-runtime/tests/integration_http_tls.rs
@@ -6,22 +6,16 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
-use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
+use std::{collections::HashMap, path::Path, time::Duration};
 use tokio::time::timeout;
 
 use wash_runtime::{
-    engine::Engine,
-    host::{
-        HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
-    },
-    plugin::{
-        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
-        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
-    },
-    types::{Component, LocalResources, Workload, WorkloadStartRequest},
-    wit::WitInterface,
+    host::HostApi,
+    types::{LocalResources, WorkloadStartRequest},
 };
+
+mod common;
+use common::{component_workload_request, http_counter_host_interfaces, start_host_with_tls};
 
 const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
 
@@ -54,123 +48,24 @@ fn build_tls_client(cert_path: &Path) -> Result<reqwest::Client> {
         .context("failed to build TLS client")
 }
 
-/// Start a host with TLS-enabled HTTP server and the standard set of plugins.
-async fn start_host_with_tls(
-    cert_path: &Path,
-    key_path: &Path,
-) -> Result<(std::net::SocketAddr, impl HostApi)> {
-    let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new_with_tls(
-        DevRouter::default(),
-        "127.0.0.1:0".parse()?,
-        cert_path,
-        key_path,
-        None,
+fn http_counter_request(host_header: &str) -> WorkloadStartRequest {
+    component_workload_request(
+        "http-counter.wasm",
+        "http-counter-tls",
+        HTTP_COUNTER_WASM,
+        LocalResources {
+            memory_limit_mb: 256,
+            cpu_limit: 1,
+            config: HashMap::from([
+                ("test_key".to_string(), "test_value".to_string()),
+                ("counter_enabled".to_string(), "true".to_string()),
+            ]),
+            environment: HashMap::new(),
+            volume_mounts: vec![],
+            allowed_hosts: Default::default(),
+        },
+        http_counter_host_interfaces(host_header),
     )
-    .await?;
-    let bound_addr = http_server.addr();
-
-    let host = HostBuilder::new()
-        .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
-        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
-        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
-        .with_plugin(Arc::new(TracingLogger::default()))?
-        .with_plugin(Arc::new(DynamicConfig::default()))?
-        .build()?;
-
-    let host = host.start().await.context("Failed to start host")?;
-    Ok((bound_addr, host))
-}
-
-/// Standard host interfaces for the http-counter component.
-fn http_counter_host_interfaces(http_host_config: &str) -> Vec<WitInterface> {
-    vec![
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "http".to_string(),
-            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.2").unwrap()),
-            config: {
-                let mut config = HashMap::new();
-                config.insert("host".to_string(), http_host_config.to_string());
-                config
-            },
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "blobstore".to_string(),
-            interfaces: [
-                "blobstore".to_string(),
-                "container".to_string(),
-                "types".to_string(),
-            ]
-            .into_iter()
-            .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "keyvalue".to_string(),
-            interfaces: ["store".to_string(), "atomics".to_string()]
-                .into_iter()
-                .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "logging".to_string(),
-            interfaces: ["logging".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.1.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "config".to_string(),
-            interfaces: ["store".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.0-rc.1").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-    ]
-}
-
-fn http_counter_workload_request(http_host_config: &str) -> WorkloadStartRequest {
-    WorkloadStartRequest {
-        workload_id: uuid::Uuid::new_v4().to_string(),
-        workload: Workload {
-            namespace: "test".to_string(),
-            name: "http-counter-tls".to_string(),
-            annotations: HashMap::new(),
-            service: None,
-            components: vec![Component {
-                name: "http-counter.wasm".to_string(),
-                digest: None,
-                bytes: bytes::Bytes::from_static(HTTP_COUNTER_WASM),
-                local_resources: LocalResources {
-                    memory_limit_mb: 256,
-                    cpu_limit: 1,
-                    config: HashMap::from([
-                        ("test_key".to_string(), "test_value".to_string()),
-                        ("counter_enabled".to_string(), "true".to_string()),
-                    ]),
-                    environment: HashMap::new(),
-                    volume_mounts: vec![],
-                    allowed_hosts: Default::default(),
-                },
-                pool_size: 1,
-                max_invocations: 100,
-            }],
-            host_interfaces: http_counter_host_interfaces(http_host_config),
-            volumes: vec![],
-        },
-    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -178,7 +73,7 @@ async fn test_https_request_succeeds() -> Result<()> {
     let (_dir, cert_path, key_path) = generate_test_certs()?;
     let (addr, host) = start_host_with_tls(&cert_path, &key_path).await?;
 
-    let req = http_counter_workload_request("foo");
+    let req = http_counter_request("foo");
     host.workload_start(req)
         .await
         .context("Failed to start http-counter workload")?;

--- a/crates/wash-runtime/tests/integration_p2_p3_matrix.rs
+++ b/crates/wash-runtime/tests/integration_p2_p3_matrix.rs
@@ -12,21 +12,21 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, time::Duration};
 use tokio::time::timeout;
 
 use wash_runtime::{
     engine::Engine,
-    host::{
-        HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
-    },
-    plugin::{
-        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
-        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
-    },
+    host::{HostApi, HostBuilder},
     types::{Component, LocalResources, Service, Workload, WorkloadStartRequest},
     wit::WitInterface,
+};
+
+mod common;
+use common::{
+    http_blobstore_host_interfaces as p3_http_blobstore_host_interfaces,
+    http_counter_host_interfaces, http_only_host_interfaces as p3_http_host_interfaces,
+    start_host_with_p3 as start_p3_host,
 };
 
 // P3 fixtures
@@ -50,126 +50,6 @@ fn engine_with_p3() -> Engine {
         .with_wasip3(true)
         .build()
         .expect("failed to build engine with wasip3")
-}
-
-async fn start_p3_host(addr: &str) -> Result<(std::net::SocketAddr, impl HostApi)> {
-    let engine = engine_with_p3();
-    let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
-    let bound_addr = http_server.addr();
-    let host = HostBuilder::new()
-        .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
-        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
-        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
-        .with_plugin(Arc::new(TracingLogger::default()))?
-        .with_plugin(Arc::new(DynamicConfig::default()))?
-        .build()?;
-
-    let host = host.start().await.context("Failed to start host")?;
-    Ok((bound_addr, host))
-}
-
-fn p3_http_host_interfaces(host_header: &str) -> Vec<WitInterface> {
-    vec![WitInterface {
-        namespace: "wasi".to_string(),
-        package: "http".to_string(),
-        interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-        version: Some(semver::Version::parse("0.2.2").unwrap()),
-        config: {
-            let mut config = HashMap::new();
-            config.insert("host".to_string(), host_header.to_string());
-            config
-        },
-        name: None,
-    }]
-}
-
-fn http_counter_host_interfaces(host_header: &str) -> Vec<WitInterface> {
-    vec![
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "http".to_string(),
-            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.2").unwrap()),
-            config: {
-                let mut config = HashMap::new();
-                config.insert("host".to_string(), host_header.to_string());
-                config
-            },
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "blobstore".to_string(),
-            interfaces: [
-                "blobstore".to_string(),
-                "container".to_string(),
-                "types".to_string(),
-            ]
-            .into_iter()
-            .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "keyvalue".to_string(),
-            interfaces: ["store".to_string(), "atomics".to_string()]
-                .into_iter()
-                .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "logging".to_string(),
-            interfaces: ["logging".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.1.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "config".to_string(),
-            interfaces: ["store".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.0-rc.1").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-    ]
-}
-
-fn p3_http_blobstore_host_interfaces(host_header: &str) -> Vec<WitInterface> {
-    vec![
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "http".to_string(),
-            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.2").unwrap()),
-            config: {
-                let mut config = HashMap::new();
-                config.insert("host".to_string(), host_header.to_string());
-                config
-            },
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "blobstore".to_string(),
-            interfaces: [
-                "blobstore".to_string(),
-                "container".to_string(),
-                "types".to_string(),
-            ]
-            .into_iter()
-            .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-    ]
 }
 
 // =============================================================================

--- a/crates/wash-runtime/tests/integration_router_dev.rs
+++ b/crates/wash-runtime/tests/integration_router_dev.rs
@@ -1,0 +1,379 @@
+//! Integration tests for `DevRouter` — the development-mode router that
+//! dispatches every request to the last resolved workload.
+//!
+//! Covers:
+//! - `last_workload_id` is updated on each `on_workload_resolved`, proved by
+//!   distinguishable response bodies from two simultaneously-registered
+//!   components (http-counter vs. http-handler-p2).
+//! - `on_workload_unbind` clears `last_workload_id` only when the stopped id
+//!   matches the currently-bound workload; stopping any other workload is a
+//!   no-op for routing.
+//! - Concurrent reads racing a workload swap all resolve to a response (no
+//!   hangs, no panics from `try_lock` contention).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use anyhow::{Context, Result};
+use futures::future::join_all;
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::{
+        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
+        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
+    },
+    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadStopRequest},
+    wit::WitInterface,
+};
+
+const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
+const HTTP_HANDLER_P2_WASM: &[u8] = include_bytes!("wasm/http_handler_p2.wasm");
+
+fn http_counter_host_interfaces(http_host_config: &str) -> Vec<WitInterface> {
+    vec![
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "http".to_string(),
+            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+            version: Some(semver::Version::parse("0.2.2").unwrap()),
+            config: {
+                let mut c = HashMap::new();
+                c.insert("host".to_string(), http_host_config.to_string());
+                c
+            },
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "blobstore".to_string(),
+            interfaces: [
+                "blobstore".to_string(),
+                "container".to_string(),
+                "types".to_string(),
+            ]
+            .into_iter()
+            .collect(),
+            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "keyvalue".to_string(),
+            interfaces: ["store".to_string(), "atomics".to_string()]
+                .into_iter()
+                .collect(),
+            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "logging".to_string(),
+            interfaces: ["logging".to_string()].into_iter().collect(),
+            version: Some(semver::Version::parse("0.1.0-draft").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "config".to_string(),
+            interfaces: ["store".to_string()].into_iter().collect(),
+            version: Some(semver::Version::parse("0.2.0-rc.1").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+    ]
+}
+
+async fn start_host_with_dev_router(addr: &str) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
+    let bound_addr = http_server.addr();
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
+        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
+        .with_plugin(Arc::new(TracingLogger::default()))?
+        .with_plugin(Arc::new(DynamicConfig::default()))?
+        .build()?;
+    let host = host.start().await.context("Failed to start host")?;
+    Ok((bound_addr, host))
+}
+
+fn http_counter_workload_request(http_host_config: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "http-counter-workload".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "http-counter.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_COUNTER_WASM),
+                local_resources: LocalResources {
+                    memory_limit_mb: 256,
+                    cpu_limit: 1,
+                    config: HashMap::new(),
+                    environment: HashMap::new(),
+                    volume_mounts: vec![],
+                    allowed_hosts: Default::default(),
+                },
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces: http_counter_host_interfaces(http_host_config),
+            volumes: vec![],
+        },
+    }
+}
+
+fn http_handler_p2_host_interfaces(http_host_config: &str) -> Vec<WitInterface> {
+    vec![WitInterface {
+        namespace: "wasi".to_string(),
+        package: "http".to_string(),
+        interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.2.2").unwrap()),
+        config: {
+            let mut c = HashMap::new();
+            c.insert("host".to_string(), http_host_config.to_string());
+            c
+        },
+        name: None,
+    }]
+}
+
+fn http_handler_p2_workload_request(http_host_config: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "http-handler-p2-workload".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "http-handler-p2.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_HANDLER_P2_WASM),
+                local_resources: LocalResources {
+                    memory_limit_mb: 128,
+                    cpu_limit: 1,
+                    config: HashMap::new(),
+                    environment: HashMap::new(),
+                    volume_mounts: vec![],
+                    allowed_hosts: Default::default(),
+                },
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces: http_handler_p2_host_interfaces(http_host_config),
+            volumes: vec![],
+        },
+    }
+}
+
+async fn get_status(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host_header: &str,
+) -> Result<reqwest::StatusCode> {
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", host_header)
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+    Ok(response.status())
+}
+
+async fn get_status_and_body(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host_header: &str,
+) -> Result<(reqwest::StatusCode, String)> {
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", host_header)
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Ok((status, body))
+}
+
+fn is_unrouted(status: reqwest::StatusCode) -> bool {
+    !status.is_success()
+}
+
+/// With A and B both registered, DevRouter routes to last-resolved B;
+/// stopping B clears routing (with no fallback to A).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_dev_router_last_workload_wins() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    let (addr, host) = start_host_with_dev_router("127.0.0.1:0").await?;
+    let client = reqwest::Client::new();
+
+    // Only "A" registered. http-counter hits example.com; body is a digit.
+    let req_a = http_counter_workload_request("a");
+    let id_a = req_a.workload_id.clone();
+    host.workload_start(req_a).await?;
+
+    let (status_a, body_a) = get_status_and_body(&client, addr, "anything").await?;
+    assert!(
+        status_a.is_success(),
+        "with only A registered, request should succeed, got {status_a}"
+    );
+    assert!(
+        body_a
+            .trim()
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_digit()),
+        "http-counter response body should start with a digit, got {body_a:?}"
+    );
+
+    // Start "B", Now both are registered, but B is the last-resolved.
+    let req_b = http_handler_p2_workload_request("b");
+    let id_b = req_b.workload_id.clone();
+    host.workload_start(req_b).await?;
+
+    let (status_b, body_b) = get_status_and_body(&client, addr, "anything").await?;
+    assert!(
+        status_b.is_success(),
+        "with A+B registered, request should succeed via B, got {status_b}"
+    );
+    assert_eq!(
+        body_b.trim(),
+        "hello from p2",
+        "DevRouter should dispatch to last-resolved B (http-handler-p2), \
+         not A (http-counter); got body {body_b:?}"
+    );
+
+    // Stop B. DevRouter's only target is cleared so it does not fall back
+    // to A (which is still registered). Requests will fail.
+    host.workload_stop(WorkloadStopRequest { workload_id: id_b })
+        .await?;
+    let status = get_status(&client, addr, "anything").await?;
+    assert!(
+        is_unrouted(status),
+        "after stopping last-resolved B, request must not route (A remains \
+         registered but is not the DevRouter target), got {status}"
+    );
+
+    // Clean up A.
+    host.workload_stop(WorkloadStopRequest { workload_id: id_a })
+        .await?;
+
+    Ok(())
+}
+
+/// `on_workload_unbind` clears `last_workload_id` only if the stopped id
+/// matches the currently-bound one. Stopping a non-current workload must not
+/// affect routing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_dev_router_unbind_clears_only_matching() -> Result<()> {
+    let (addr, host) = start_host_with_dev_router("127.0.0.1:0").await?;
+    let client = reqwest::Client::new();
+
+    let req_a = http_counter_workload_request("a");
+    let id_a = req_a.workload_id.clone();
+    host.workload_start(req_a).await?;
+
+    // Starting B makes B the "last" workload. A is still registered but
+    // is no longer the routing target.
+    let req_b = http_counter_workload_request("b");
+    let id_b = req_b.workload_id.clone();
+    host.workload_start(req_b).await?;
+
+    // Stopping A (non-current one) should not change the DevRouter mapping;
+    // requests still route (to B).
+    host.workload_stop(WorkloadStopRequest { workload_id: id_a })
+        .await?;
+    assert!(
+        get_status(&client, addr, "whatever").await?.is_success(),
+        "stopping non-current workload must not unbind router"
+    );
+
+    // Stopping B clears the binding so subsequent requests return 5xx.
+    host.workload_stop(WorkloadStopRequest { workload_id: id_b })
+        .await?;
+    let status = get_status(&client, addr, "whatever").await?;
+    assert!(
+        is_unrouted(status),
+        "after stopping current workload, request should not succeed, got {status}"
+    );
+
+    Ok(())
+}
+
+/// Concurrent reads during a workload swap must all resolve (success or
+/// graceful 5xx). Exercises `try_lock()` contention on `last_workload_id`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_dev_router_concurrent_reads_during_swap() -> Result<()> {
+    let (addr, host) = start_host_with_dev_router("127.0.0.1:0").await?;
+
+    let req_a = http_counter_workload_request("a");
+    let id_a = req_a.workload_id.clone();
+    host.workload_start(req_a).await?;
+
+    // Spawn 30 readers that each sleep a small staggered amount & then run.
+    let client = reqwest::Client::new();
+    let mut reader_handles = Vec::with_capacity(30);
+    for i in 0..30 {
+        let client = client.clone();
+        reader_handles.push(tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis((i as u64) * 5)).await;
+            timeout(
+                Duration::from_secs(15),
+                client
+                    .get(format!("http://{addr}/"))
+                    .header("HOST", "whatever")
+                    .send(),
+            )
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+            .map(|r| r.status())
+        }));
+    }
+
+    // Midway through the staggered window, swap A -> B on the main task.
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    host.workload_stop(WorkloadStopRequest { workload_id: id_a })
+        .await?;
+    let req_b = http_counter_workload_request("b");
+    host.workload_start(req_b).await?;
+
+    let resolved = join_all(reader_handles)
+        .await
+        .into_iter()
+        .filter(|r| r.as_ref().ok().and_then(|s| s.as_ref()).is_some())
+        .count();
+    assert_eq!(
+        resolved, 30,
+        "every reader must resolve (no hangs); got {resolved}/30"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_router_dev.rs
+++ b/crates/wash-runtime/tests/integration_router_dev.rs
@@ -13,214 +13,54 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use futures::future::join_all;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, time::Duration};
 use tokio::time::timeout;
 
 use wash_runtime::{
-    engine::Engine,
-    host::{
-        HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
-    },
-    plugin::{
-        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
-        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
-    },
-    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadStopRequest},
-    wit::WitInterface,
+    host::HostApi,
+    types::{LocalResources, WorkloadStartRequest, WorkloadStopRequest},
+};
+
+mod common;
+use common::{
+    component_workload_request, default_counter_resources, get_status, get_status_and_body,
+    http_counter_host_interfaces, http_only_host_interfaces, start_host_with_dev_router,
 };
 
 const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
 const HTTP_HANDLER_P2_WASM: &[u8] = include_bytes!("wasm/http_handler_p2.wasm");
 
-fn http_counter_host_interfaces(http_host_config: &str) -> Vec<WitInterface> {
-    vec![
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "http".to_string(),
-            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.2").unwrap()),
-            config: {
-                let mut c = HashMap::new();
-                c.insert("host".to_string(), http_host_config.to_string());
-                c
-            },
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "blobstore".to_string(),
-            interfaces: [
-                "blobstore".to_string(),
-                "container".to_string(),
-                "types".to_string(),
-            ]
-            .into_iter()
-            .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "keyvalue".to_string(),
-            interfaces: ["store".to_string(), "atomics".to_string()]
-                .into_iter()
-                .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "logging".to_string(),
-            interfaces: ["logging".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.1.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "config".to_string(),
-            interfaces: ["store".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.0-rc.1").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-    ]
-}
-
-async fn start_host_with_dev_router(addr: &str) -> Result<(std::net::SocketAddr, impl HostApi)> {
-    let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
-    let bound_addr = http_server.addr();
-    let host = HostBuilder::new()
-        .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
-        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
-        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
-        .with_plugin(Arc::new(TracingLogger::default()))?
-        .with_plugin(Arc::new(DynamicConfig::default()))?
-        .build()?;
-    let host = host.start().await.context("Failed to start host")?;
-    Ok((bound_addr, host))
-}
-
-fn http_counter_workload_request(http_host_config: &str) -> WorkloadStartRequest {
-    WorkloadStartRequest {
-        workload_id: uuid::Uuid::new_v4().to_string(),
-        workload: Workload {
-            namespace: "test".to_string(),
-            name: "http-counter-workload".to_string(),
-            annotations: HashMap::new(),
-            service: None,
-            components: vec![Component {
-                name: "http-counter.wasm".to_string(),
-                digest: None,
-                bytes: bytes::Bytes::from_static(HTTP_COUNTER_WASM),
-                local_resources: LocalResources {
-                    memory_limit_mb: 256,
-                    cpu_limit: 1,
-                    config: HashMap::new(),
-                    environment: HashMap::new(),
-                    volume_mounts: vec![],
-                    allowed_hosts: Default::default(),
-                },
-                pool_size: 1,
-                max_invocations: 100,
-            }],
-            host_interfaces: http_counter_host_interfaces(http_host_config),
-            volumes: vec![],
-        },
-    }
-}
-
-fn http_handler_p2_host_interfaces(http_host_config: &str) -> Vec<WitInterface> {
-    vec![WitInterface {
-        namespace: "wasi".to_string(),
-        package: "http".to_string(),
-        interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-        version: Some(semver::Version::parse("0.2.2").unwrap()),
-        config: {
-            let mut c = HashMap::new();
-            c.insert("host".to_string(), http_host_config.to_string());
-            c
-        },
-        name: None,
-    }]
-}
-
-fn http_handler_p2_workload_request(http_host_config: &str) -> WorkloadStartRequest {
-    WorkloadStartRequest {
-        workload_id: uuid::Uuid::new_v4().to_string(),
-        workload: Workload {
-            namespace: "test".to_string(),
-            name: "http-handler-p2-workload".to_string(),
-            annotations: HashMap::new(),
-            service: None,
-            components: vec![Component {
-                name: "http-handler-p2.wasm".to_string(),
-                digest: None,
-                bytes: bytes::Bytes::from_static(HTTP_HANDLER_P2_WASM),
-                local_resources: LocalResources {
-                    memory_limit_mb: 128,
-                    cpu_limit: 1,
-                    config: HashMap::new(),
-                    environment: HashMap::new(),
-                    volume_mounts: vec![],
-                    allowed_hosts: Default::default(),
-                },
-                pool_size: 1,
-                max_invocations: 100,
-            }],
-            host_interfaces: http_handler_p2_host_interfaces(http_host_config),
-            volumes: vec![],
-        },
-    }
-}
-
-async fn get_status(
-    client: &reqwest::Client,
-    addr: std::net::SocketAddr,
-    host_header: &str,
-) -> Result<reqwest::StatusCode> {
-    let response = timeout(
-        Duration::from_secs(10),
-        client
-            .get(format!("http://{addr}/"))
-            .header("HOST", host_header)
-            .send(),
+fn http_counter_request(host_header: &str) -> WorkloadStartRequest {
+    component_workload_request(
+        "http-counter.wasm",
+        "http-counter-workload",
+        HTTP_COUNTER_WASM,
+        default_counter_resources(),
+        http_counter_host_interfaces(host_header),
     )
-    .await
-    .context("request timed out")?
-    .context("request failed")?;
-    Ok(response.status())
 }
 
-async fn get_status_and_body(
-    client: &reqwest::Client,
-    addr: std::net::SocketAddr,
-    host_header: &str,
-) -> Result<(reqwest::StatusCode, String)> {
-    let response = timeout(
-        Duration::from_secs(10),
-        client
-            .get(format!("http://{addr}/"))
-            .header("HOST", host_header)
-            .send(),
+fn http_handler_p2_request(host_header: &str) -> WorkloadStartRequest {
+    component_workload_request(
+        "http-handler-p2.wasm",
+        "http-handler-p2-workload",
+        HTTP_HANDLER_P2_WASM,
+        LocalResources {
+            memory_limit_mb: 128,
+            cpu_limit: 1,
+            config: HashMap::new(),
+            environment: HashMap::new(),
+            volume_mounts: vec![],
+            allowed_hosts: Default::default(),
+        },
+        http_only_host_interfaces(host_header),
     )
-    .await
-    .context("request timed out")?
-    .context("request failed")?;
-    let status = response.status();
-    let body = response.text().await.unwrap_or_default();
-    Ok((status, body))
 }
 
 fn is_unrouted(status: reqwest::StatusCode) -> bool {
-    !status.is_success()
+    status == reqwest::StatusCode::BAD_REQUEST
 }
 
 /// With A and B both registered, DevRouter routes to last-resolved B;
@@ -235,7 +75,7 @@ async fn test_dev_router_last_workload_wins() -> Result<()> {
     let client = reqwest::Client::new();
 
     // Only "A" registered. http-counter hits example.com; body is a digit.
-    let req_a = http_counter_workload_request("a");
+    let req_a = http_counter_request("a");
     let id_a = req_a.workload_id.clone();
     host.workload_start(req_a).await?;
 
@@ -254,7 +94,7 @@ async fn test_dev_router_last_workload_wins() -> Result<()> {
     );
 
     // Start "B", Now both are registered, but B is the last-resolved.
-    let req_b = http_handler_p2_workload_request("b");
+    let req_b = http_handler_p2_request("b");
     let id_b = req_b.workload_id.clone();
     host.workload_start(req_b).await?;
 
@@ -296,13 +136,13 @@ async fn test_dev_router_unbind_clears_only_matching() -> Result<()> {
     let (addr, host) = start_host_with_dev_router("127.0.0.1:0").await?;
     let client = reqwest::Client::new();
 
-    let req_a = http_counter_workload_request("a");
+    let req_a = http_counter_request("a");
     let id_a = req_a.workload_id.clone();
     host.workload_start(req_a).await?;
 
     // Starting B makes B the "last" workload. A is still registered but
     // is no longer the routing target.
-    let req_b = http_counter_workload_request("b");
+    let req_b = http_counter_request("b");
     let id_b = req_b.workload_id.clone();
     host.workload_start(req_b).await?;
 
@@ -315,7 +155,8 @@ async fn test_dev_router_unbind_clears_only_matching() -> Result<()> {
         "stopping non-current workload must not unbind router"
     );
 
-    // Stopping B clears the binding so subsequent requests return 5xx.
+    // Stopping B clears the binding so subsequent requests are rejected by
+    // the router (400 Bad Request).
     host.workload_stop(WorkloadStopRequest { workload_id: id_b })
         .await?;
     let status = get_status(&client, addr, "whatever").await?;
@@ -333,7 +174,7 @@ async fn test_dev_router_unbind_clears_only_matching() -> Result<()> {
 async fn test_dev_router_concurrent_reads_during_swap() -> Result<()> {
     let (addr, host) = start_host_with_dev_router("127.0.0.1:0").await?;
 
-    let req_a = http_counter_workload_request("a");
+    let req_a = http_counter_request("a");
     let id_a = req_a.workload_id.clone();
     host.workload_start(req_a).await?;
 
@@ -362,7 +203,7 @@ async fn test_dev_router_concurrent_reads_during_swap() -> Result<()> {
     tokio::time::sleep(Duration::from_millis(40)).await;
     host.workload_stop(WorkloadStopRequest { workload_id: id_a })
         .await?;
-    let req_b = http_counter_workload_request("b");
+    let req_b = http_counter_request("b");
     host.workload_start(req_b).await?;
 
     let resolved = join_all(reader_handles)

--- a/crates/wash-runtime/tests/integration_router_dev.rs
+++ b/crates/wash-runtime/tests/integration_router_dev.rs
@@ -59,8 +59,10 @@ fn http_handler_p2_request(host_header: &str) -> WorkloadStartRequest {
     )
 }
 
+/// `DevRouter` with no bound workload reports `RouteError::NoWorkloadForHost("")`,
+/// which `handle_http_request` maps to 404.
 fn is_unrouted(status: reqwest::StatusCode) -> bool {
-    status == reqwest::StatusCode::BAD_REQUEST
+    status == reqwest::StatusCode::NOT_FOUND
 }
 
 /// With A and B both registered, DevRouter routes to last-resolved B;
@@ -156,7 +158,7 @@ async fn test_dev_router_unbind_clears_only_matching() -> Result<()> {
     );
 
     // Stopping B clears the binding so subsequent requests are rejected by
-    // the router (400 Bad Request).
+    // the router (404 Not Found via RouteError::NoWorkloadForHost).
     host.workload_stop(WorkloadStopRequest { workload_id: id_b })
         .await?;
     let status = get_status(&client, addr, "whatever").await?;

--- a/crates/wash-runtime/tests/integration_router_dynamic.rs
+++ b/crates/wash-runtime/tests/integration_router_dynamic.rs
@@ -66,36 +66,58 @@ async fn test_dynamic_router_multiple_distinct_hosts_concurrent() -> Result<()> 
             .copied()
             .unwrap_or("api.local");
         handles.push(tokio::spawn(async move {
-            let resp = timeout(
-                Duration::from_secs(5),
-                client
-                    .get(format!("http://{addr}/"))
-                    .header("HOST", hostname)
-                    .send(),
-            )
-            .await
-            .ok()
-            .and_then(|r| r.ok());
-            resp.map(|r| r.status().is_success()).unwrap_or(false)
+            let mut retried = false;
+
+            loop {
+                match timeout(
+                    Duration::from_secs(5),
+                    client
+                        .get(format!("http://{addr}/"))
+                        .header("HOST", hostname)
+                        .send(),
+                )
+                .await
+                {
+                    Ok(Ok(response))
+                        if response.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE
+                            && !retried =>
+                    {
+                        retried = true;
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                    Ok(Ok(response)) => return Ok(response.status()),
+                    Ok(Err(err)) => return Err(format!("{hostname} request failed: {err}")),
+                    Err(_) => return Err(format!("{hostname} request timed out")),
+                }
+            }
         }));
     }
 
-    let successful = join_all(handles)
-        .await
-        .into_iter()
-        .filter(|r| r.as_ref().copied().unwrap_or(false))
-        .count();
-    // 18/20 requests accounting 2 reqs for flakes
+    let mut successful = 0;
+    for result in join_all(handles).await {
+        match result {
+            Ok(Ok(status))
+                if status.is_success() || status == reqwest::StatusCode::SERVICE_UNAVAILABLE =>
+            {
+                successful += 1;
+            }
+            _ => {}
+        }
+    }
+
+    // DynamicRouter maps transient routing-table contention to 503, so after
+    // retrying that case once we accept only 2xx or 503 here. Any 4xx,
+    // connection error, timeout, or other status will be treated as a regression.
     assert!(
-        successful >= 18,
-        "expected >=18 concurrent multi-host requests to succeed, got {successful}"
+        successful == 20,
+        "expected all 20 concurrent multi-host requests to end in either success or transient 503 after retrying once, got {successful}"
     );
 
     Ok(())
 }
 
 /// 50 concurrent requests against a single fixed host must mostly succeed
-/// and complete quickly, the try_read must not deadlock or starve under stres.
+/// and complete quickly, the try_read must not deadlock or starve under stress.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_dynamic_router_concurrent_routes_fixed_mapping() -> Result<()> {
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
@@ -108,18 +130,10 @@ async fn test_dynamic_router_concurrent_routes_fixed_mapping() -> Result<()> {
     for _ in 0..50 {
         let client = client.clone();
         handles.push(tokio::spawn(async move {
-            timeout(
-                Duration::from_secs(15),
-                client
-                    .get(format!("http://{addr}/"))
-                    .header("HOST", "fixed.local")
-                    .send(),
-            )
-            .await
-            .ok()
-            .and_then(|r| r.ok())
-            .map(|r| r.status().is_success())
-            .unwrap_or(false)
+            get_status(&client, addr, "fixed.local")
+                .await
+                .map(|status| status.is_success())
+                .unwrap_or(false)
         }));
     }
 

--- a/crates/wash-runtime/tests/integration_router_dynamic.rs
+++ b/crates/wash-runtime/tests/integration_router_dynamic.rs
@@ -14,13 +14,19 @@
 //! - In-flight requests racing a `workload_stop` all resolve (success or
 //!   graceful error); the router does not hang or panic when the Host-header
 //!   mapping disappears mid-request.
+//! - HTTP/1.0 request without a Host header returns 400 (RouteError::MissingHost).
+//! - Invalid hostnames in host-aliases are silently filtered; only valid ones route.
+//! - Two workloads bound to the same host both serve requests (HashSet routing).
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use futures::future::join_all;
 use std::time::Duration;
-use tokio::time::timeout;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    time::timeout,
+};
 
 use wash_runtime::{
     host::HostApi,
@@ -46,7 +52,8 @@ fn http_counter_request(host_header: &str, aliases: Option<&str>) -> WorkloadSta
 }
 
 /// Fan out concurrent requests across three hostnames (primary + 2 aliases)
-/// registered to one workload; all must succeed.
+/// registered to one workload. The router must not produce 4xx/timeouts;
+/// 500s from the component's shared state under load are out of scope here.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_dynamic_router_multiple_distinct_hosts_concurrent() -> Result<()> {
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
@@ -67,7 +74,6 @@ async fn test_dynamic_router_multiple_distinct_hosts_concurrent() -> Result<()> 
             .unwrap_or("api.local");
         handles.push(tokio::spawn(async move {
             let mut retried = false;
-
             loop {
                 match timeout(
                     Duration::from_secs(5),
@@ -83,7 +89,7 @@ async fn test_dynamic_router_multiple_distinct_hosts_concurrent() -> Result<()> 
                             && !retried =>
                     {
                         retried = true;
-                        tokio::time::sleep(Duration::from_millis(10)).await;
+                        tokio::time::sleep(Duration::from_millis(500)).await;
                     }
                     Ok(Ok(response)) => return Ok(response.status()),
                     Ok(Err(err)) => return Err(format!("{hostname} request failed: {err}")),
@@ -93,31 +99,37 @@ async fn test_dynamic_router_multiple_distinct_hosts_concurrent() -> Result<()> 
         }));
     }
 
-    let mut successful = 0;
-    for result in join_all(handles).await {
-        match result {
-            Ok(Ok(status))
-                if status.is_success() || status == reqwest::StatusCode::SERVICE_UNAVAILABLE =>
-            {
-                successful += 1;
-            }
-            _ => {}
-        }
-    }
+    let results: Vec<_> = join_all(handles)
+        .await
+        .into_iter()
+        .map(|r| r.expect("task should not panic"))
+        .collect();
 
-    // DynamicRouter maps transient routing-table contention to 503, so after
-    // retrying that case once we accept only 2xx or 503 here. Any 4xx,
-    // connection error, timeout, or other status will be treated as a regression.
+    // 500 = component shared-state failure under load, 503 = transient try_read contention.
+    // Neither is a routing bug; anything else is.
+    let routing_failures: Vec<_> = results
+        .iter()
+        .filter(|r| match r {
+            Ok(status) => {
+                !status.is_success()
+                    && *status != reqwest::StatusCode::SERVICE_UNAVAILABLE
+                    && *status != reqwest::StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Err(_) => true,
+        })
+        .collect();
+
     assert!(
-        successful == 20,
-        "expected all 20 concurrent multi-host requests to end in either success or transient 503 after retrying once, got {successful}"
+        routing_failures.is_empty(),
+        "router must not produce 4xx/timeouts under multi-host concurrent load, failures: {routing_failures:?}"
     );
 
     Ok(())
 }
 
-/// 50 concurrent requests against a single fixed host must mostly succeed
-/// and complete quickly, the try_read must not deadlock or starve under stress.
+/// 50 concurrent requests against a single fixed host must not deadlock or
+/// starve under stress. The router itself should never be the source of
+/// failures.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_dynamic_router_concurrent_routes_fixed_mapping() -> Result<()> {
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
@@ -130,24 +142,34 @@ async fn test_dynamic_router_concurrent_routes_fixed_mapping() -> Result<()> {
     for _ in 0..50 {
         let client = client.clone();
         handles.push(tokio::spawn(async move {
-            get_status(&client, addr, "fixed.local")
-                .await
-                .map(|status| status.is_success())
-                .unwrap_or(false)
+            get_status(&client, addr, "fixed.local").await
         }));
     }
 
-    let successful = join_all(handles)
+    let statuses: Vec<_> = join_all(handles)
         .await
         .into_iter()
-        .filter(|r| r.as_ref().copied().unwrap_or(false))
-        .count();
+        .map(|r| r.expect("task should not panic"))
+        .collect();
     let elapsed = started.elapsed();
 
-    // 5 requests are accounted with regards to flakiness
+    // 500 = component shared-state failure under load, 503 = transient try_read contention.
+    // Neither is a routing bug; anything else is.
+    let routing_failures: Vec<_> = statuses
+        .iter()
+        .filter(|r| match r {
+            Ok(s) => {
+                !s.is_success()
+                    && *s != reqwest::StatusCode::INTERNAL_SERVER_ERROR
+                    && *s != reqwest::StatusCode::SERVICE_UNAVAILABLE
+            }
+            Err(_) => true,
+        })
+        .collect();
+
     assert!(
-        successful >= 45,
-        "expected >= 45/50 successful concurrent requests, got {successful}"
+        routing_failures.is_empty(),
+        "router must not produce 4xx/timeouts under fixed-host load, failures: {routing_failures:?}"
     );
     assert!(
         elapsed < Duration::from_secs(30),
@@ -199,6 +221,109 @@ async fn test_dynamic_router_routes_race_with_unbind() -> Result<()> {
     assert_eq!(
         resolved, 20,
         "all in-flight requests must resolve, got {resolved}/20"
+    );
+
+    Ok(())
+}
+
+/// An HTTP/1.0 request without a Host header must return 400
+/// (RouteError::MissingHost). but since reqwest always injects a Host header, this
+/// test uses a raw TCP connection to send a minimal HTTP/1.0 request.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_missing_host_returns_400() -> Result<()> {
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    host.workload_start(http_counter_request("present.local", None))
+        .await?;
+
+    let raw_request = "GET / HTTP/1.0\r\n\r\n";
+    let mut stream = timeout(Duration::from_secs(5), tokio::net::TcpStream::connect(addr))
+        .await
+        .context("connect timed out")?
+        .context("connect failed")?;
+
+    stream.write_all(raw_request.as_bytes()).await?;
+
+    let mut response = String::new();
+    timeout(Duration::from_secs(5), stream.read_to_string(&mut response))
+        .await
+        .context("read timed out")?
+        .context("read failed")?;
+
+    assert!(
+        response.starts_with("HTTP/1.1 400") || response.starts_with("HTTP/1.0 400"),
+        "expected HTTP 400 for missing Host header, got: {response:?}"
+    );
+
+    Ok(())
+}
+
+/// Invalid hostnames in `host-aliases` (e.g. names containing spaces) must be
+/// silently filtered by `DynamicRouter::on_workload_resolved`. The valid alias
+/// must still route; the invalid one must not appear in the routing table and
+/// must therefore return 404.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_invalid_alias_is_silently_filtered() -> Result<()> {
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+
+    // "not a hostname" contains spaces; is_valid_hostname func rejects it.
+    let req = http_counter_request("valid.local", Some("not a hostname"));
+    host.workload_start(req).await?;
+
+    let client = reqwest::Client::new();
+
+    // valid.local is the primary host and must route successfully.
+    assert!(
+        get_status(&client, addr, "valid.local").await?.is_success(),
+        "primary host should route successfully"
+    );
+
+    // "not a hostname" must not have been registered and must return 404.
+    let invalid_status = get_status(&client, addr, "not a hostname").await?;
+    assert_eq!(
+        invalid_status,
+        reqwest::StatusCode::NOT_FOUND,
+        "invalid alias must be filtered and return 404, got {invalid_status}"
+    );
+
+    Ok(())
+}
+
+/// Two workloads registered under the same primary host both need to be
+/// reachable: the HashSet in `host_to_workload` allows multiple IDs per host,
+/// and the router must keep the host routable as long as at least one workload
+/// is bound. After stopping one, requests must still succeed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_multiple_workloads_same_host_both_serve() -> Result<()> {
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+
+    let req_a = http_counter_request("shared.local", None);
+    let req_b = http_counter_request("shared.local", None);
+    let workload_id_a = req_a.workload_id.clone();
+
+    host.workload_start(req_a).await?;
+    host.workload_start(req_b).await?;
+
+    let client = reqwest::Client::new();
+
+    // Both workloads are bound; shared.local must route.
+    assert!(
+        get_status(&client, addr, "shared.local")
+            .await?
+            .is_success(),
+        "shared.local should route when two workloads are bound"
+    );
+
+    // Stop one workload — the other must keep the host alive.
+    host.workload_stop(wash_runtime::types::WorkloadStopRequest {
+        workload_id: workload_id_a,
+    })
+    .await?;
+
+    assert!(
+        get_status(&client, addr, "shared.local")
+            .await?
+            .is_success(),
+        "shared.local should still route after one of two workloads is stopped"
     );
 
     Ok(())

--- a/crates/wash-runtime/tests/integration_router_dynamic.rs
+++ b/crates/wash-runtime/tests/integration_router_dynamic.rs
@@ -17,138 +17,32 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use futures::future::join_all;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::time::Duration;
 use tokio::time::timeout;
 
 use wash_runtime::{
-    engine::Engine,
-    host::{
-        HostApi, HostBuilder,
-        http::{DynamicRouter, HttpServer},
-    },
-    plugin::{
-        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
-        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
-    },
-    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadStopRequest},
-    wit::WitInterface,
+    host::HostApi,
+    types::{WorkloadStartRequest, WorkloadStopRequest},
+};
+
+mod common;
+use common::{
+    component_workload_request, default_counter_resources,
+    http_counter_host_interfaces_with_aliases, start_host_with_dynamic_router,
 };
 
 const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
 
-fn http_counter_host_interfaces(
-    http_host_config: &str,
-    aliases: Option<&str>,
-) -> Vec<WitInterface> {
-    let mut http_config = HashMap::new();
-    http_config.insert("host".to_string(), http_host_config.to_string());
-    if let Some(aliases) = aliases {
-        http_config.insert("host-aliases".to_string(), aliases.to_string());
-    }
-
-    vec![
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "http".to_string(),
-            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.2").unwrap()),
-            config: http_config,
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "blobstore".to_string(),
-            interfaces: [
-                "blobstore".to_string(),
-                "container".to_string(),
-                "types".to_string(),
-            ]
-            .into_iter()
-            .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "keyvalue".to_string(),
-            interfaces: ["store".to_string(), "atomics".to_string()]
-                .into_iter()
-                .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "logging".to_string(),
-            interfaces: ["logging".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.1.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "config".to_string(),
-            interfaces: ["store".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.0-rc.1").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-    ]
-}
-
-async fn start_host_with_dynamic_router(
-    addr: &str,
-) -> Result<(std::net::SocketAddr, impl HostApi)> {
-    let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DynamicRouter::default(), addr.parse()?).await?;
-    let bound_addr = http_server.addr();
-    let host = HostBuilder::new()
-        .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
-        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
-        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
-        .with_plugin(Arc::new(TracingLogger::default()))?
-        .with_plugin(Arc::new(DynamicConfig::default()))?
-        .build()?;
-
-    let host = host.start().await.context("Failed to start host")?;
-    Ok((bound_addr, host))
-}
-
-fn http_counter_workload_request(
-    http_host_config: &str,
-    aliases: Option<&str>,
-) -> WorkloadStartRequest {
-    WorkloadStartRequest {
-        workload_id: uuid::Uuid::new_v4().to_string(),
-        workload: Workload {
-            namespace: "test".to_string(),
-            name: "http-counter-workload".to_string(),
-            annotations: HashMap::new(),
-            service: None,
-            components: vec![Component {
-                name: "http-counter.wasm".to_string(),
-                digest: None,
-                bytes: bytes::Bytes::from_static(HTTP_COUNTER_WASM),
-                local_resources: LocalResources {
-                    memory_limit_mb: 256,
-                    cpu_limit: 1,
-                    config: HashMap::new(),
-                    environment: HashMap::new(),
-                    volume_mounts: vec![],
-                    allowed_hosts: Default::default(),
-                },
-                pool_size: 1,
-                max_invocations: 100,
-            }],
-            host_interfaces: http_counter_host_interfaces(http_host_config, aliases),
-            volumes: vec![],
-        },
-    }
+fn http_counter_request(host_header: &str, aliases: Option<&str>) -> WorkloadStartRequest {
+    component_workload_request(
+        "http-counter.wasm",
+        "http-counter-workload",
+        HTTP_COUNTER_WASM,
+        default_counter_resources(),
+        http_counter_host_interfaces_with_aliases(host_header, aliases),
+    )
 }
 
 /// Fan out concurrent requests across three hostnames (primary + 2 aliases)
@@ -159,7 +53,7 @@ async fn test_dynamic_router_multiple_distinct_hosts_concurrent() -> Result<()> 
 
     let aliases = Some("web.local,admin.local");
 
-    let req = http_counter_workload_request("api.local", aliases);
+    let req = http_counter_request("api.local", aliases);
     host.workload_start(req).await?;
 
     let client = reqwest::Client::new();
@@ -205,7 +99,7 @@ async fn test_dynamic_router_multiple_distinct_hosts_concurrent() -> Result<()> 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_dynamic_router_concurrent_routes_fixed_mapping() -> Result<()> {
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
-    let req = http_counter_workload_request("fixed.local", None);
+    let req = http_counter_request("fixed.local", None);
     host.workload_start(req).await?;
 
     let client = reqwest::Client::new();
@@ -254,7 +148,7 @@ async fn test_dynamic_router_concurrent_routes_fixed_mapping() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_dynamic_router_routes_race_with_unbind() -> Result<()> {
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
-    let req = http_counter_workload_request("race.local", None);
+    let req = http_counter_request("race.local", None);
     let workload_id = req.workload_id.clone();
     host.workload_start(req).await?;
 

--- a/crates/wash-runtime/tests/integration_router_dynamic.rs
+++ b/crates/wash-runtime/tests/integration_router_dynamic.rs
@@ -1,0 +1,297 @@
+//! Integration tests for `DynamicRouter` — routes incoming requests to
+//! workloads by Host header (with optional comma-separated aliases).
+//!
+//! `DynamicRouter::route_incoming_request` uses `tokio::task::block_in_place`
+//! + `try_read`, so all tests run on the multi-thread runtime. Per-request
+//! `timeout(...)` on individual HTTP calls guards against hangs.
+//!
+//! Covers:
+//! - One workload registered under a primary host plus aliases: concurrent
+//!   requests targeting all three hostnames all route correctly.
+//! - Many concurrent requests against a single fixed host complete
+//!   successfully within a bounded time (no `try_read` starvation or
+//!   deadlock under load).
+//! - In-flight requests racing a `workload_stop` all resolve (success or
+//!   graceful error); the router does not hang or panic when the Host-header
+//!   mapping disappears mid-request.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use anyhow::{Context, Result};
+use futures::future::join_all;
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DynamicRouter, HttpServer},
+    },
+    plugin::{
+        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
+        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
+    },
+    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadStopRequest},
+    wit::WitInterface,
+};
+
+const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
+
+fn http_counter_host_interfaces(
+    http_host_config: &str,
+    aliases: Option<&str>,
+) -> Vec<WitInterface> {
+    let mut http_config = HashMap::new();
+    http_config.insert("host".to_string(), http_host_config.to_string());
+    if let Some(aliases) = aliases {
+        http_config.insert("host-aliases".to_string(), aliases.to_string());
+    }
+
+    vec![
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "http".to_string(),
+            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+            version: Some(semver::Version::parse("0.2.2").unwrap()),
+            config: http_config,
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "blobstore".to_string(),
+            interfaces: [
+                "blobstore".to_string(),
+                "container".to_string(),
+                "types".to_string(),
+            ]
+            .into_iter()
+            .collect(),
+            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "keyvalue".to_string(),
+            interfaces: ["store".to_string(), "atomics".to_string()]
+                .into_iter()
+                .collect(),
+            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "logging".to_string(),
+            interfaces: ["logging".to_string()].into_iter().collect(),
+            version: Some(semver::Version::parse("0.1.0-draft").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "config".to_string(),
+            interfaces: ["store".to_string()].into_iter().collect(),
+            version: Some(semver::Version::parse("0.2.0-rc.1").unwrap()),
+            config: HashMap::new(),
+            name: None,
+        },
+    ]
+}
+
+async fn start_host_with_dynamic_router(
+    addr: &str,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DynamicRouter::default(), addr.parse()?).await?;
+    let bound_addr = http_server.addr();
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
+        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
+        .with_plugin(Arc::new(TracingLogger::default()))?
+        .with_plugin(Arc::new(DynamicConfig::default()))?
+        .build()?;
+
+    let host = host.start().await.context("Failed to start host")?;
+    Ok((bound_addr, host))
+}
+
+fn http_counter_workload_request(
+    http_host_config: &str,
+    aliases: Option<&str>,
+) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "http-counter-workload".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "http-counter.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_COUNTER_WASM),
+                local_resources: LocalResources {
+                    memory_limit_mb: 256,
+                    cpu_limit: 1,
+                    config: HashMap::new(),
+                    environment: HashMap::new(),
+                    volume_mounts: vec![],
+                    allowed_hosts: Default::default(),
+                },
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces: http_counter_host_interfaces(http_host_config, aliases),
+            volumes: vec![],
+        },
+    }
+}
+
+/// Fan out concurrent requests across three hostnames (primary + 2 aliases)
+/// registered to one workload; all must succeed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_dynamic_router_multiple_distinct_hosts_concurrent() -> Result<()> {
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+
+    let aliases = Some("web.local,admin.local");
+
+    let req = http_counter_workload_request("api.local", aliases);
+    host.workload_start(req).await?;
+
+    let client = reqwest::Client::new();
+    let hostnames = ["api.local", "web.local", "admin.local"];
+    let mut handles = Vec::with_capacity(20);
+    for i in 0..20 {
+        let client = client.clone();
+        let hostname = hostnames
+            .get(i % hostnames.len())
+            .copied()
+            .unwrap_or("api.local");
+        handles.push(tokio::spawn(async move {
+            let resp = timeout(
+                Duration::from_secs(5),
+                client
+                    .get(format!("http://{addr}/"))
+                    .header("HOST", hostname)
+                    .send(),
+            )
+            .await
+            .ok()
+            .and_then(|r| r.ok());
+            resp.map(|r| r.status().is_success()).unwrap_or(false)
+        }));
+    }
+
+    let successful = join_all(handles)
+        .await
+        .into_iter()
+        .filter(|r| r.as_ref().copied().unwrap_or(false))
+        .count();
+    // 18/20 requests accounting 2 reqs for flakes
+    assert!(
+        successful >= 18,
+        "expected >=18 concurrent multi-host requests to succeed, got {successful}"
+    );
+
+    Ok(())
+}
+
+/// 50 concurrent requests against a single fixed host must mostly succeed
+/// and complete quickly, the try_read must not deadlock or starve under stres.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_dynamic_router_concurrent_routes_fixed_mapping() -> Result<()> {
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    let req = http_counter_workload_request("fixed.local", None);
+    host.workload_start(req).await?;
+
+    let client = reqwest::Client::new();
+    let started = std::time::Instant::now();
+    let mut handles = Vec::with_capacity(50);
+    for _ in 0..50 {
+        let client = client.clone();
+        handles.push(tokio::spawn(async move {
+            timeout(
+                Duration::from_secs(15),
+                client
+                    .get(format!("http://{addr}/"))
+                    .header("HOST", "fixed.local")
+                    .send(),
+            )
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        }));
+    }
+
+    let successful = join_all(handles)
+        .await
+        .into_iter()
+        .filter(|r| r.as_ref().copied().unwrap_or(false))
+        .count();
+    let elapsed = started.elapsed();
+
+    // 5 requests are accounted with regards to flakiness
+    assert!(
+        successful >= 45,
+        "expected >= 45/50 successful concurrent requests, got {successful}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "concurrent fan-out took too long: {elapsed:?} (lock contention possible)"
+    );
+
+    Ok(())
+}
+
+/// workload_stop mid-flight must not deadlock readers. In-flight requests
+/// resolve to either success or a graceful 5xx; no hang or panic.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_dynamic_router_routes_race_with_unbind() -> Result<()> {
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    let req = http_counter_workload_request("race.local", None);
+    let workload_id = req.workload_id.clone();
+    host.workload_start(req).await?;
+
+    let client = reqwest::Client::new();
+    let mut handles = Vec::with_capacity(20);
+    for _ in 0..20 {
+        let client = client.clone();
+        handles.push(tokio::spawn(async move {
+            timeout(
+                Duration::from_secs(15),
+                client
+                    .get(format!("http://{addr}/"))
+                    .header("HOST", "race.local")
+                    .send(),
+            )
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+            .map(|r| r.status())
+        }));
+    }
+
+    // Give some requests a chance to get in-flight, then stop the workload.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    host.workload_stop(WorkloadStopRequest { workload_id })
+        .await?;
+
+    // Every task must resolve (success or graceful status), none may hang.
+    let resolved = join_all(handles)
+        .await
+        .into_iter()
+        .filter(|r| r.as_ref().ok().and_then(|s| s.as_ref()).is_some())
+        .count();
+    assert_eq!(
+        resolved, 20,
+        "all in-flight requests must resolve, got {resolved}/20"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_router_dynamic.rs
+++ b/crates/wash-runtime/tests/integration_router_dynamic.rs
@@ -29,7 +29,7 @@ use wash_runtime::{
 
 mod common;
 use common::{
-    component_workload_request, default_counter_resources,
+    component_workload_request, default_counter_resources, get_status,
     http_counter_host_interfaces_with_aliases, start_host_with_dynamic_router,
 };
 
@@ -185,6 +185,33 @@ async fn test_dynamic_router_routes_race_with_unbind() -> Result<()> {
     assert_eq!(
         resolved, 20,
         "all in-flight requests must resolve, got {resolved}/20"
+    );
+
+    Ok(())
+}
+
+/// Requests targeting a host that no workload is bound to must return 404
+/// (`RouteError::NoWorkloadForHost`)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_dynamic_router_unknown_host_returns_404() -> Result<()> {
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    host.workload_start(http_counter_request("known.local", None))
+        .await?;
+
+    let client = reqwest::Client::new();
+
+    // A bound host succeeds (sanity check)
+    assert!(
+        get_status(&client, addr, "known.local").await?.is_success(),
+        "bound host should succeed"
+    );
+
+    // An unbound host will return 404
+    let status = get_status(&client, addr, "nope.local").await?;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::NOT_FOUND,
+        "unknown host must map to RouteError::NoWorkloadForHost -> 404, got {status}"
     );
 
     Ok(())

--- a/crates/wash-runtime/tests/integration_wasip3.rs
+++ b/crates/wash-runtime/tests/integration_wasip3.rs
@@ -8,106 +8,25 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, time::Duration};
 use tokio::time::timeout;
 
 use wash_runtime::{
     engine::Engine,
-    host::{
-        HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
-    },
-    plugin::{
-        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
-        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
-    },
+    host::HostApi,
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
-    wit::WitInterface,
 };
+
+mod common;
+use common::{http_counter_host_interfaces, start_host_with_p3};
 
 const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
 
-/// Build an engine with wasip3 enabled.
 fn engine_with_p3() -> Engine {
     Engine::builder()
         .with_wasip3(true)
         .build()
         .expect("failed to build engine with wasip3")
-}
-
-/// Build and start a host with wasip3 enabled and standard plugins.
-async fn start_p3_host(addr: &str) -> Result<(std::net::SocketAddr, impl HostApi)> {
-    let engine = engine_with_p3();
-    let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
-    let bound_addr = http_server.addr();
-    let host = HostBuilder::new()
-        .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
-        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
-        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
-        .with_plugin(Arc::new(TracingLogger::default()))?
-        .with_plugin(Arc::new(DynamicConfig::default()))?
-        .build()?;
-
-    let host = host.start().await.context("Failed to start host")?;
-    Ok((bound_addr, host))
-}
-
-fn http_counter_host_interfaces(host_header: &str) -> Vec<WitInterface> {
-    vec![
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "http".to_string(),
-            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.2").unwrap()),
-            config: {
-                let mut config = HashMap::new();
-                config.insert("host".to_string(), host_header.to_string());
-                config
-            },
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "blobstore".to_string(),
-            interfaces: [
-                "blobstore".to_string(),
-                "container".to_string(),
-                "types".to_string(),
-            ]
-            .into_iter()
-            .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "keyvalue".to_string(),
-            interfaces: ["store".to_string(), "atomics".to_string()]
-                .into_iter()
-                .collect(),
-            version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "logging".to_string(),
-            interfaces: ["logging".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.1.0-draft").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-        WitInterface {
-            namespace: "wasi".to_string(),
-            package: "config".to_string(),
-            interfaces: ["store".to_string()].into_iter().collect(),
-            version: Some(semver::Version::parse("0.2.0-rc.1").unwrap()),
-            config: HashMap::new(),
-            name: None,
-        },
-    ]
 }
 
 // Engine configuration tests
@@ -223,7 +142,7 @@ fn test_targets_wasip3_ignores_non_wasi() {
 
 #[tokio::test]
 async fn test_p2_http_component_works_with_p3_enabled() -> Result<()> {
-    let (addr, host) = start_p3_host("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
 
     let req = WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),
@@ -285,7 +204,7 @@ async fn test_p2_http_component_works_with_p3_enabled() -> Result<()> {
 
 #[tokio::test]
 async fn test_p2_concurrent_requests_with_p3_enabled() -> Result<()> {
-    let (addr, host) = start_p3_host("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
 
     let req = WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->
Resolves #4945 

## Summary
Adds integration tests for DynamicRouter (multi-host + aliases, concurrent load, race-with-unbind) and DevRouter (last-wins, selective unbind, concurrent reads during swap).

## Test plan
- `cargo test -p wash-runtime --test integration_router_dynamic`
-  `cargo test -p wash-runtime --test integration_router_dev`