### PR TITLE
fix(chart): disable gateway in values.local.yaml and route hello-world via Service

### DIFF
--- a/charts/runtime-operator/values.local.yaml
+++ b/charts/runtime-operator/values.local.yaml
@@ -1,8 +1,24 @@
+# The Runtime Gateway is deprecated as of wasmCloud 2.0.3. HTTP traffic to
+# workloads is now routed by the operator via EndpointSlices tied to standard
+# Kubernetes Services (see a WorkloadDeployment's
+# spec.template.spec.kubernetes.service.name field).
+#
+# The gateway is disabled here so its NodePort Service does not collide with
+# workload Services on port 30950. To re-enable it (e.g. for backwards
+# compatibility with 2.0.2 manifests), set `gateway.enabled: true` and add a
+# service block such as:
+#
+#   gateway:
+#     enabled: true
+#     service:
+#       type: NodePort
+#       nodePorts:
+#         http: 30950
+#
+# See https://wasmcloud.com/docs/kubernetes-operator/operator-manual/helm-values
+# for the full gateway configuration reference.
 gateway:
-  enabled: true
-  service:
-    type: NodePort
-    nodePort: 30950
+  enabled: false
 
 runtime:
   hostGroups:

--- a/examples/http-hello-world/manifests/workloaddeployment.yaml
+++ b/examples/http-hello-world/manifests/workloaddeployment.yaml
@@ -1,3 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      protocol: TCP
+      nodePort: 30950
+---
 apiVersion: runtime.wasmcloud.dev/v1alpha1
 kind: WorkloadDeployment
 metadata:
@@ -8,6 +19,9 @@ spec:
     spec:
       hostSelector:
         hostgroup: default
+      kubernetes:
+        service:
+          name: hello-world
       components:
         - name: hello-world
           image: ghcr.io/wasmcloud/components/hello-world:0.1.0


### PR DESCRIPTION
The Runtime Gateway is deprecated in 2.0.3, and HTTP traffic is now routed to workloads by the operator via EndpointSlices tied to standard Kubernetes Services. This PR brings the local-dev overlay and the `http-hello-world` example in line with that pattern, so users can follow the quickstart without needing `--set gateway.enabled=false` on every install.

- `charts/runtime-operator/values.local.yaml`: set `gateway.enabled: false` and drop the gateway Service block. The host HTTP listener on port 80 is still preserved.
- `examples/http-hello-world/manifests/workloaddeployment.yaml`: add a `NodePort` Service named `hello-world` (nodePort 30950) and reference it from the WorkloadDeployment via `spec.template.spec.kubernetes.service.name`. Traffic on host port 80 (mapped by `deploy/kind/kind-config.yaml` to container 30950) now reaches the component via the operator-managed EndpointSlice.