### PR TITLE
chore: update CODEOWNERS and reconcile MAINTAINERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,26 @@
-# CODEOWNERS for wash
-# 
-# This file defines the code owners for the wash repository.
-# Code owners are automatically requested for review when someone opens a pull request
-# that modifies code that they own.
+# CODEOWNERS for the wasmCloud monorepo
 #
-# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Code owners are automatically requested for review when someone opens a pull
+# request that modifies code they own. Teams referenced here are defined in
+# MAINTAINERS.md at the repository root.
 
-# Default owners for everything in the repo
-* @wasmCloud/wash-maintainers
+# Default owner: org maintainers catch anything not matched below
+*                       @wasmCloud/org-maintainers
+
+# wash CLI and runtime
+/crates/wash/           @wasmCloud/wash-maintainers
+/crates/wash-runtime/   @wasmCloud/wash-maintainers
+
+# Go-based runtime components
+/runtime-gateway/       @wasmCloud/go-maintainers
+/runtime-operator/      @wasmCloud/go-maintainers
+/proto/                 @wasmCloud/go-maintainers
+
+# CI, release automation, charts, and deploy assets
+/.github/               @wasmCloud/ci-maintainers
+/charts/                @wasmCloud/ci-maintainers
+/deploy/                @wasmCloud/ci-maintainers
+
+# Examples and project templates
+/examples/              @wasmCloud/examples-maintainers
+/templates/             @wasmCloud/examples-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,164 +4,209 @@ The following individuals are responsible for reviewing code, managing issues, a
 overall quality of the project. This document is organized by the GitHub team that can be used to
 mention _all_ maintainers of a particular aspect of the project.
 
-Maintainers of projects that are not in this monorepo can be found in their respective repositories;
-including [wadm](https://github.com/wasmCloud/wadm/blob/main/MAINTAINERS.md),
-[wasmcloud-operator](https://github.com/wasmCloud/wasmcloud-operator/blob/main/MAINTAINERS.md), and
-[wasmcloud.com](https://github.com/wasmCloud/wasmcloud.com/blob/main/MAINTAINERS.md) at the time of
-writing this.
+Maintainers of projects that are not in this monorepo can be found in their respective repositories,
+including:
+
+- [wadm](https://github.com/wasmCloud/wadm/blob/main/MAINTAINERS.md)
+- [wasmcloud-operator](https://github.com/wasmCloud/wasmcloud-operator/blob/main/MAINTAINERS.md)
+- [wasmcloud.com](https://github.com/wasmCloud/wasmcloud.com/blob/main/MAINTAINERS.md)
+- [typescript](https://github.com/wasmCloud/typescript) — TypeScript SDKs,
+  owned by [`@wasmCloud/typescript-maintainers`](https://github.com/orgs/wasmCloud/teams/typescript-maintainers)
+- [go](https://github.com/wasmCloud/go) — Go SDK and tooling outside this
+  monorepo, owned by [`@wasmCloud/go-maintainers`](https://github.com/orgs/wasmCloud/teams/go-maintainers)
 
 ## @wasmCloud/org-maintainers
 
-Name: Bailey Hayes  
-GitHub: @ricochet  
+Name: Bailey Hayes
+GitHub: @ricochet
 Organization: Cosmonic
 
-Name: Jeremy Tanner <!-- TODO: confirm GitHub handle -->  
-GitHub: @[jeremy-handle]  
+Name: Brooks Townsend
+GitHub: @brooksmtownsend
+Organization: Capital One
+
+Name: Colin Murphy
+GitHub: @cdmurph32
+Organization: Adobe
+
+Name: Jordan Rash
+GitHub: @jordan-rash
+Organization: Synadia
+
+Name: Liam Randall
+GitHub: @LiamRandall
 Organization: Cosmonic
 
-## @wasmCloud/runtime-maintainers
+Name: Aditya Salunkhe
+GitHub: @Aditya1404Sal
+Organization: Betty Blocks
 
-_Covers the wasmCloud host runtime, capability provider SDK, observability, and related crates._
-
-Name: Bailey Hayes  
-GitHub: @ricochet  
-Organization: Cosmonic
-
-Name: Brooks Townsend  
-GitHub: @brooksmtownsend  
-Organization: Cosmonic
-
-Name: Roman Volosatovs  
-GitHub: @rvolosatovs  
-Organization: Cosmonic
-
-Name: Victor Adossi  
-GitHub: @vados-cosmonic  
+Name: Victor Adossi
+GitHub: @vados-cosmonic
 Organization: Cosmonic
 
 ## @wasmCloud/wash-maintainers
 
 _Covers the `wash` CLI and `wash-runtime` crates._
 
-Name: Bailey Hayes  
-GitHub: @ricochet  
+Name: Bailey Hayes
+GitHub: @ricochet
 Organization: Cosmonic
 
-Name: Brooks Townsend  
-GitHub: @brooksmtownsend  
+Name: Brooks Townsend
+GitHub: @brooksmtownsend
+Organization: Capital One
+
+Name: Victor Adossi
+GitHub: @vados-cosmonic
 Organization: Cosmonic
 
-Name: Victor Adossi  
-GitHub: @vados-cosmonic  
-Organization: Cosmonic
-
-Name: Colin Murphy  
-GitHub: @cdmurph32  
+Name: Colin Murphy
+GitHub: @cdmurph32
 Organization: Adobe
 
-Name: ifOne <!-- TODO: confirm full name and GitHub handle -->  
-GitHub: @[ifOne-handle]  
-Organization: [Organization or "Independent"]
+Name: Aditya Salunkhe
+GitHub: @Aditya1404Sal
+Organization: Betty Blocks
 
 ## @wasmCloud/go-maintainers
 
-_Covers Go SDK and Go-based tooling._
+_Covers Go SDK and Go-based tooling, including the runtime gateway, runtime operator, and proto
+definitions._
 
-Name: Bailey Hayes  
-GitHub: @ricochet  
+Name: Bailey Hayes
+GitHub: @ricochet
 Organization: Cosmonic
 
-Name: Brooks Townsend  
-GitHub: @brooksmtownsend  
-Organization: Cosmonic
+Name: Brooks Townsend
+GitHub: @brooksmtownsend
+Organization: Capital One
 
-Name: Roman Volosatovs  
-GitHub: @rvolosatovs  
-Organization: Cosmonic
+Name: Roman Volosatovs
+GitHub: @rvolosatovs
+Organization: Helmet Security
 
-Name: Jordan Rash  
-GitHub: @jordan-rash  
+Name: Jordan Rash
+GitHub: @jordan-rash
 Organization: Synadia
 
-Name: Lucas Fontes  
-GitHub: @lxfontes  
+Name: Lucas Fontes
+GitHub: @lxfontes
+Organization: Independent
+
+Name: Eric Gregory
+GitHub: @ericgregory
+Organization: Cosmonic
+
+Name: Jeremy Fleitz
+GitHub: @jfleitz
 Organization: Cosmonic
 
 ## @wasmCloud/ci-maintainers
 
-_Covers GitHub Actions workflows, release automation, and CI infrastructure._
+_Covers GitHub Actions workflows, release automation, CI infrastructure, Helm charts, and deploy
+assets._
 
-Name: Bailey Hayes  
-GitHub: @ricochet  
+Name: Bailey Hayes
+GitHub: @ricochet
 Organization: Cosmonic
 
-Name: Brooks Townsend  
-GitHub: @brooksmtownsend  
+Name: Brooks Townsend
+GitHub: @brooksmtownsend
+Organization: Capital One
+
+Name: Roman Volosatovs
+GitHub: @rvolosatovs
+Organization: Helmet Security
+
+Name: Victor Adossi
+GitHub: @vados-cosmonic
 Organization: Cosmonic
 
-Name: Roman Volosatovs  
-GitHub: @rvolosatovs  
+Name: Lachlan Heywood
+GitHub: @lachieh
+Organization: Tambo
+
+## @wasmCloud/examples-maintainers
+
+_Covers examples and project templates._
+
+Name: Bailey Hayes
+GitHub: @ricochet
 Organization: Cosmonic
 
-Name: Victor Adossi  
-GitHub: @vados-cosmonic  
+Name: Brooks Townsend
+GitHub: @brooksmtownsend
+Organization: Capital One
+
+Name: Roman Volosatovs
+GitHub: @rvolosatovs
+Organization: Helmet Security
+
+Name: Victor Adossi
+GitHub: @vados-cosmonic
 Organization: Cosmonic
 
-Name: Lachlan Heywood  
-GitHub: @lachieh  
-Organization: Cosmonic
+Name: Lucas Fontes
+GitHub: @lxfontes
+Organization: Independent
 
 ## @wasmCloud/triage-maintainers
 
 _Contributors with triage privileges — can label, assign, and close issues and PRs._
 
-Name: Aditya Salunkhe  
-GitHub: @Aditya1404Sal  
-Organization: Independent
+Name: Bailey Hayes
+GitHub: @ricochet
+Organization: Cosmonic
 
-Name: Márk Kővári  
-GitHub: @markkovari  
+Name: Jiaxiao Zhou
+GitHub: @Mossaka
+Organization: Microsoft
+
+Name: Aditya Salunkhe
+GitHub: @Aditya1404Sal
+Organization: Betty Blocks
+
+Name: Márk Kővári
+GitHub: @markkovari
 Organization: commercetools
 
-Name: Luke Jones  
-GitHub: @LUK3ARK  
+Name: Luke Jones
+GitHub: @LUK3ARK
 Organization: Lattica
+
+Name: Masoud Baharlouie
+GitHub: @ossfellow
+Organization: Operatik Inc.
 
 ## Emeritus Maintainers
 
 These individuals have contributed significantly to the project but are no longer actively
 maintaining it.
 
-Name: Kevin Hoffman  
+Name: Kevin Hoffman
 GitHub: @autodidaddict
 
-Name: Steve Schoettler  
+Name: Steve Schoettler
 GitHub: @stevelr
 
-Name: Connor Smith  
+Name: Connor Smith
 GitHub: @connorsmith256
 
-Name: Kaushik Shanadi  
+Name: Kaushik Shanadi
 GitHub: @ks2211
 
-Name: Taylor Thomas  
+Name: Taylor Thomas
 GitHub: @thomastaylor312
 
-Name: Liam Randall  
-GitHub: @LiamRandall
-
-Name: Joonas Bergius  
+Name: Joonas Bergius
 GitHub: @joonas
 
-Name: Dan Norris  
+Name: Dan Norris
 GitHub: @protochron
 
-Name: Jiaxiao Zhou  
-GitHub: @Mossaka
-
-Name: Matt Wilkinson  
+Name: Matt Wilkinson
 GitHub: @mattwilkinsonn
 
-Name: Masoud Baharlouie  
-GitHub: @ossfellow
+Name: Ashe Rillan
+GitHub: @asherillan


### PR DESCRIPTION
Replace the legacy wash-only CODEOWNERS with per-area ownership for the
wasmCloud v2 monorepo. Reconcile MAINTAINERS.md with the current GitHub
team memberships per the governance requirement that MAINTAINERS.md be
the authoritative record.

Rosters cross-checked against live GitHub team membership for every team
referenced in the file.

CODEOWNERS changes:
- Default: @wasmCloud/org-maintainers
- /crates/wash/, /crates/wash-runtime/: @wasmCloud/wash-maintainers
- /runtime-gateway/, /runtime-operator/, /proto/: @wasmCloud/go-maintainers
- /.github/, /charts/, /deploy/: @wasmCloud/ci-maintainers
- /examples/, /templates/: @wasmCloud/examples-maintainers

MAINTAINERS.md changes:
- Add wasmCloud/typescript and wasmCloud/go to external-repo list
- Add @wasmCloud/examples-maintainers section
- Remove @wasmCloud/runtime-maintainers section (team does not exist)
- org-maintainers: drop Jeremy Tanner (accident from pr earlier today)
- Emeritus: remove Liam, Masoud, Jiaxiao (still active); add Ashe Rillan
- Refresh organization affiliations across sections