### PR TITLE
fix(runtime-gateway): strip port from Host header during workload lookup

### DIFF
--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -217,8 +217,8 @@ impl Router for DynamicRouter {
                 .and_then(|h| h.to_str().ok())
                 .or_else(|| req.uri().authority().map(|a| a.as_str()))
                 .context("no Host header or :authority in request")?;
-            let Some(workload_set) = lock.get(workload_host) else {
-                anyhow::bail!("no workload bound to host header: {}", workload_host);
+            let Some(workload_set) = lookup_workload_set(&lock, workload_host) else {
+                anyhow::bail!("no workload bound to host header: {workload_host}");
             };
 
             let workload_id = workload_set
@@ -229,6 +229,44 @@ impl Router for DynamicRouter {
             Ok(workload_id.clone())
         })
     }
+}
+
+/// Resolve a Host header (which may include a port per RFC 7230 §5.4) against
+/// the workload registration map. Tries the exact header first to honour any
+/// `host:port` registration, then falls back to the host-only portion. This
+/// mirrors the behaviour of nginx/traefik/envoy and the Go runtime-gateway.
+///
+/// Handles bracketed IPv6 literals correctly, e.g. `[::1]:8080` strips to `[::1]`.
+fn lookup_workload_set<'a>(
+    map: &'a HashMap<String, HashSet<String>>,
+    workload_host: &str,
+) -> Option<&'a HashSet<String>> {
+    if let Some(set) = map.get(workload_host) {
+        return Some(set);
+    }
+    strip_port(workload_host).and_then(|host_only| map.get(host_only))
+}
+
+/// Strip a port suffix from a host header value, handling bracketed IPv6.
+/// Returns `None` if there is no port to strip, or if the input is an
+/// unbracketed IPv6 literal (which would be ambiguous to split).
+fn strip_port(host: &str) -> Option<&str> {
+    if let Some(rest) = host.strip_prefix('[') {
+        // IPv6 literal: "[::1]:8080" → keep "[::1]"; "[::1]" alone → no port.
+        let close = rest.find(']')?;
+        let after_bracket = &host[close + 2..];
+        if after_bracket.is_empty() {
+            return None;
+        }
+        return Some(&host[..close + 2]);
+    }
+    // Plain host or IPv4: only treat as host:port if there's exactly one ':'.
+    // More than one ':' indicates an unbracketed IPv6 — refuse to truncate.
+    let first = host.find(':')?;
+    if host[first + 1..].contains(':') {
+        return None;
+    }
+    Some(&host[..first])
 }
 
 /// Development router that routes all requests to the last resolved workload
@@ -1186,5 +1224,83 @@ mod tests {
     fn error_response_returns_correct_status() {
         assert_eq!(error_response(404).status(), 404);
         assert_eq!(error_response(500).status(), 500);
+    }
+
+    // --- DynamicRouter host-header port-stripping tests ---
+
+    fn make_set(id: &str) -> HashSet<String> {
+        let mut s = HashSet::new();
+        s.insert(id.to_string());
+        s
+    }
+
+    /// RFC 7230 §5.4: clients MUST include the port when it differs from the
+    /// default for the scheme. A workload registered as "localhost" must still
+    /// be reachable when the client sends "Host: localhost:8080".
+    #[test]
+    fn lookup_workload_set_strips_port_from_host_header() {
+        let mut map = HashMap::new();
+        map.insert("localhost".to_string(), make_set("workload-1"));
+
+        let result = lookup_workload_set(&map, "localhost:8080");
+        assert!(
+            result.is_some_and(|s| s.contains("workload-1")),
+            "port-stripped lookup should find the workload"
+        );
+    }
+
+    /// An exact host:port registration must take precedence over the bare-host fallback.
+    #[test]
+    fn lookup_workload_set_exact_match_takes_precedence() {
+        let mut map = HashMap::new();
+        map.insert("example.com".to_string(), make_set("workload-bare"));
+        map.insert("example.com:8443".to_string(), make_set("workload-exact"));
+
+        let result = lookup_workload_set(&map, "example.com:8443");
+        assert!(
+            result.is_some_and(|s| s.contains("workload-exact")),
+            "exact match should win over bare-host fallback"
+        );
+    }
+
+    /// An unknown host (even after port stripping) must not resolve.
+    #[test]
+    fn lookup_workload_set_unknown_host_returns_none() {
+        let mut map = HashMap::new();
+        map.insert("localhost".to_string(), make_set("workload-1"));
+
+        assert!(lookup_workload_set(&map, "unknown.example:9000").is_none());
+        assert!(lookup_workload_set(&map, "unknown.example").is_none());
+    }
+
+    /// Bracketed IPv6 literals must strip the port without mangling the address.
+    #[test]
+    fn lookup_workload_set_handles_ipv6_brackets() {
+        let mut map = HashMap::new();
+        map.insert("[::1]".to_string(), make_set("workload-v6"));
+
+        let result = lookup_workload_set(&map, "[::1]:8080");
+        assert!(
+            result.is_some_and(|s| s.contains("workload-v6")),
+            "IPv6 bracketed lookup should strip only the port"
+        );
+    }
+
+    /// Unbracketed IPv6 (technically invalid in a Host header) must not be
+    /// truncated at the last colon — that would corrupt the address.
+    #[test]
+    fn strip_port_does_not_mangle_unbracketed_ipv6() {
+        assert_eq!(strip_port("::1"), None);
+        assert_eq!(strip_port("fe80::1"), None);
+    }
+
+    #[test]
+    fn strip_port_basic_cases() {
+        assert_eq!(strip_port("localhost"), None);
+        assert_eq!(strip_port("localhost:8080"), Some("localhost"));
+        assert_eq!(strip_port("example.com:443"), Some("example.com"));
+        assert_eq!(strip_port("[::1]"), None);
+        assert_eq!(strip_port("[::1]:8080"), Some("[::1]"));
+        assert_eq!(strip_port("[2001:db8::1]:443"), Some("[2001:db8::1]"));
     }
 }

--- a/runtime-gateway/tracker.go
+++ b/runtime-gateway/tracker.go
@@ -67,7 +67,20 @@ func (ht *HostTracker) Resolve(ctx context.Context, req *http.Request) LookupRes
 	ht.lock.RLock()
 	defer ht.lock.RUnlock()
 
+	// Per RFC 7230, the Host header may include a port (e.g.
+	// "localhost:8000"). Workload hostnames are registered as bare
+	// hostnames because the upstream WorkloadDeployment CRD validates
+	// them as RFC 1123 names (no port allowed). Look up the exact
+	// header first to preserve any existing host:port registrations,
+	// then fall back to the host portion without the port. This makes
+	// the gateway behave like nginx/traefik/envoy, which all match on
+	// hostname regardless of the port the client appended.
 	workloads, ok := ht.hostnames[req.Host]
+	if !ok {
+		if hostOnly, _, splitErr := net.SplitHostPort(req.Host); splitErr == nil {
+			workloads, ok = ht.hostnames[hostOnly]
+		}
+	}
 	if !ok {
 		scheme, endpoint := ht.Fallback.InvalidHostname(req.Host)
 		return LookupResult{

--- a/runtime-gateway/tracker_test.go
+++ b/runtime-gateway/tracker_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// noopFallback records the host that triggered the fallback so tests can
+// assert that resolution missed (or hit) the registered hostnames.
+type noopFallback struct {
+	invalidHost string
+	noWorkHost  string
+}
+
+func (n *noopFallback) InvalidHostname(hostname string) (string, string) {
+	n.invalidHost = hostname
+	return "http", "fallback-invalid"
+}
+
+func (n *noopFallback) NoWorkloads(hostname string) (string, string) {
+	n.noWorkHost = hostname
+	return "http", "fallback-noworkloads"
+}
+
+func newTracker(t *testing.T) (*HostTracker, *noopFallback) {
+	t.Helper()
+	fb := &noopFallback{}
+	ht := &HostTracker{
+		Fallback:  fb,
+		hosts:     make(map[string]string),
+		hostnames: make(map[string]sets.Set[string]),
+		workloads: make(map[string]string),
+	}
+	return ht, fb
+}
+
+// TestResolveStripsPortFromHostHeader covers the case where a browser sends
+// "Host: localhost:8000" (non-standard port appended) but the workload was
+// registered with the bare hostname "localhost". The CRD validates host
+// values as RFC 1123 names so the registered value can never carry a port;
+// the gateway must therefore match on the hostname portion of the header.
+func TestResolveStripsPortFromHostHeader(t *testing.T) {
+	ht, fb := newTracker(t)
+
+	if err := ht.RegisterHost(context.Background(), "host-1", "10.0.0.1", 8080); err != nil {
+		t.Fatalf("RegisterHost: %v", err)
+	}
+	if err := ht.RegisterWorkload(context.Background(), "host-1", "wl-1", "localhost"); err != nil {
+		t.Fatalf("RegisterWorkload: %v", err)
+	}
+
+	req := &http.Request{Host: "localhost:8000"}
+	res := ht.Resolve(context.Background(), req)
+
+	if res.WorkloadID != "wl-1" {
+		t.Fatalf("expected workload wl-1, got %q (fallback host=%q)", res.WorkloadID, fb.invalidHost)
+	}
+	if res.Hostname != "10.0.0.1:8080" {
+		t.Fatalf("unexpected upstream hostname: %q", res.Hostname)
+	}
+}
+
+// TestResolveExactMatchTakesPrecedence ensures we still honour an exact
+// host:port registration (if one is ever introduced via a different code
+// path) before falling back to the port-stripped lookup.
+func TestResolveExactMatchTakesPrecedence(t *testing.T) {
+	ht, _ := newTracker(t)
+
+	if err := ht.RegisterHost(context.Background(), "host-a", "10.0.0.1", 8080); err != nil {
+		t.Fatalf("RegisterHost a: %v", err)
+	}
+	if err := ht.RegisterHost(context.Background(), "host-b", "10.0.0.2", 8080); err != nil {
+		t.Fatalf("RegisterHost b: %v", err)
+	}
+	if err := ht.RegisterWorkload(context.Background(), "host-a", "wl-bare", "example.com"); err != nil {
+		t.Fatalf("RegisterWorkload bare: %v", err)
+	}
+	if err := ht.RegisterWorkload(context.Background(), "host-b", "wl-exact", "example.com:8443"); err != nil {
+		t.Fatalf("RegisterWorkload exact: %v", err)
+	}
+
+	req := &http.Request{Host: "example.com:8443"}
+	res := ht.Resolve(context.Background(), req)
+	if res.WorkloadID != "wl-exact" {
+		t.Fatalf("expected exact-match workload wl-exact, got %q", res.WorkloadID)
+	}
+}
+
+// TestResolveUnknownHostFallsBack confirms that unknown hosts still hit the
+// InvalidHostname fallback even after the port-stripping retry.
+func TestResolveUnknownHostFallsBack(t *testing.T) {
+	ht, fb := newTracker(t)
+
+	if err := ht.RegisterHost(context.Background(), "host-1", "10.0.0.1", 8080); err != nil {
+		t.Fatalf("RegisterHost: %v", err)
+	}
+	if err := ht.RegisterWorkload(context.Background(), "host-1", "wl-1", "localhost"); err != nil {
+		t.Fatalf("RegisterWorkload: %v", err)
+	}
+
+	req := &http.Request{Host: "unknown.example:9000"}
+	res := ht.Resolve(context.Background(), req)
+	if res.WorkloadID != "" {
+		t.Fatalf("expected fallback (no workload), got workload %q", res.WorkloadID)
+	}
+	if fb.invalidHost != "unknown.example:9000" {
+		t.Fatalf("expected fallback to record original host header, got %q", fb.invalidHost)
+	}
+	if res.Hostname != "fallback-invalid" {
+		t.Fatalf("expected fallback hostname, got %q", res.Hostname)
+	}
+}


### PR DESCRIPTION
## Problem

Per RFC 7230 §5.4, HTTP/1.1 clients must include the port in the `Host` header
when it is non-standard (e.g. `Host: localhost:8080`). Workload hostnames are
registered as bare RFC 1123 names (no port allowed by the CRD validator), so
the exact map lookup always missed, returning **503 Service Unavailable** for
every browser or standard `curl` request.

The bug exists in **two places**:
1. The `runtime-gateway` (Go) — the user-facing symptom most operators hit first.
2. The `wash-runtime` host (Rust) — the same logic, hidden behind the gateway
   until users migrate to direct `EndpointSlice`-based routing.

**Workaround (before this fix):**
```
curl -H 'Host: localhost' http://localhost:8080/   # 200 OK
curl              http://localhost:8080/            # 503
```

## Fix

### `runtime-gateway/tracker.go` (Go)

After an exact-match miss, retry the lookup with the port stripped using
`net.SplitHostPort`. Exact-match registrations still take precedence.
`net.SplitHostPort` handles bracketed IPv6 (`[::1]:8080`) correctly.

### `crates/wash-runtime/src/host/http.rs` (Rust)

Same logic in `DynamicRouter::route_incoming_request`. Extracted into a
testable `lookup_workload_set` helper with a small `strip_port` utility that:
- handles bracketed IPv6 (`[::1]:8080` → `[::1]`)
- refuses to truncate unbracketed IPv6 (e.g. `fe80::1`) where the split
  would be ambiguous

The `Host` header is **not** rewritten before forwarding to the backend —
components see exactly what the client sent, matching nginx/traefik/envoy
default behaviour. (An earlier draft also rewrote `Host` in `proxy.go`; that
was reverted as redundant once the host-side lookup became port-tolerant.)

## Tests

**Go (`runtime-gateway/tracker_test.go`)** — 3 cases:
- Port-stripped lookup resolves correctly
- Exact `host:port` registration takes precedence over stripped fallback
- Unknown host still hits `InvalidHostname` fallback with the original header

**Rust (`crates/wash-runtime/src/host/http.rs`)** — 6 cases against the
extracted helpers:
- Port-stripped lookup
- Exact-match precedence
- Unknown host returns `None`
- Bracketed IPv6 lookup
- Unbracketed IPv6 is not mangled
- `strip_port` table-driven cases (IPv4/IPv6/no-port)
