### PR TITLE
fix: preserve wash dev postgres config

### DIFF
--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -18,7 +18,7 @@ use wash_runtime::{
 
 use crate::{
     cli::{CliCommand, CliContext, CommandOutput, component_build::build_dev_component},
-    config::{Config, load_config},
+    config::{Config, DevConfig, load_config},
     wit::WitConfig,
 };
 
@@ -40,6 +40,7 @@ impl CliCommand for DevCommand {
             &ctx.user_config_path(),
             Some(project_dir),
             Some(Config {
+                version: None,
                 dev: None,
                 wit: Some(WitConfig {
                     skip_fetch: true,
@@ -50,7 +51,8 @@ impl CliCommand for DevCommand {
         )
         .context("failed to load config for development")?;
 
-        let dev_config = config.dev();
+        let mut dev_config = config.dev();
+        apply_dev_env_overrides(&mut dev_config);
         let http_addr = dev_config
             .address
             .clone()
@@ -404,6 +406,14 @@ async fn create_workload(host: &Host, config: &Config, bytes: Bytes) -> anyhow::
         service,
         volumes,
     })
+}
+
+fn apply_dev_env_overrides(dev_config: &mut DevConfig) {
+    if let Ok(postgres_url) = std::env::var("WASH_POSTGRES_URL")
+        && !postgres_url.is_empty()
+    {
+        dev_config.postgres_url = Some(postgres_url);
+    }
 }
 
 /// Reload the component in the host, stopping the previous workload if needed

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -349,3 +349,62 @@ pub async fn generate_default_config(path: &Path, force: bool) -> Result<()> {
     info!(config_path = %path.display(), "Generated default configuration");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn load_config_preserves_local_dev_config_when_cli_override_disables_wit_fetch() -> Result<()> {
+        let project_dir = tempfile::tempdir()?;
+        let wash_dir = project_dir.path().join(CONFIG_DIR_NAME);
+        fs::create_dir_all(&wash_dir)?;
+        fs::write(
+            wash_dir.join(CONFIG_FILE_NAME),
+            r#"
+dev:
+  address: 127.0.0.1:8090
+  postgres_url: postgres://user:pass@localhost:5432
+  host_interfaces:
+    - namespace: wasmcloud
+      package: postgres
+      interfaces: [query, types]
+      version: 0.1.1-draft
+      config:
+        database: mydb
+"#,
+        )?;
+
+        let config = load_config(
+            &project_dir.path().join("missing-global-config.yaml"),
+            Some(project_dir.path()),
+            Some(Config {
+                version: None,
+                dev: None,
+                wit: Some(WitConfig {
+                    skip_fetch: true,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        )?;
+
+        let dev = config.dev();
+        assert_eq!(dev.address.as_deref(), Some("127.0.0.1:8090"));
+        assert_eq!(
+            dev.postgres_url.as_deref(),
+            Some("postgres://user:pass@localhost:5432")
+        );
+        assert_eq!(dev.host_interfaces.len(), 1);
+        assert!(
+            config
+                .wit
+                .as_ref()
+                .is_some_and(|wit_config| wit_config.skip_fetch)
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Fixes #4935

## Summary
- keep the `wash dev` WIT skip-fetch overlay from carrying unrelated config defaults
- preserve project `dev.postgres_url` and related dev config while applying that overlay
- allow `WASH_POSTGRES_URL` to override the dev postgres URL, matching the host command environment variable

## Testing
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p wash load_config_preserves_local_dev_config_when_cli_override_disables_wit_fetch`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo clippy -p wash --features wasip3`