### PR TITLE
release: v2.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7265,7 +7265,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 authors = ["The wasmCloud Team"]
 edition = "2024"
 rust-version = "1.91.0"
-version = "2.0.4"
+version = "2.0.5"
 
 [workspace.lints.rust]
 warnings = 'deny' # Treat all warnings as errors

--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.4"
+appVersion: "2.0.5"


### PR DESCRIPTION
Bump to release v2.0.5. Primarily this is to begin publishing glibc binaries for #5072 