### PR TITLE
chore: rm passing wash prefix to brew

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -301,6 +301,7 @@ jobs:
         run: |
           gh api repos/wasmCloud/homebrew-wasmcloud/dispatches \
             -f event_type=brew-formula-update \
+            -f 'client_payload[tag_prefix]=wash' \
             -f 'client_payload[tag_version]=${{ steps.version.outputs.version }}'
 
   update-winget:

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -301,7 +301,6 @@ jobs:
         run: |
           gh api repos/wasmCloud/homebrew-wasmcloud/dispatches \
             -f event_type=brew-formula-update \
-            -f 'client_payload[tag_prefix]=wash' \
             -f 'client_payload[tag_version]=${{ steps.version.outputs.version }}'
 
   update-winget:


### PR DESCRIPTION
Small chg: don't pass in wash- as a prefix (legacy holdover from v1 wasmCloud)