### PR TITLE
[bugfix] Add port name to hello-world

### DIFF
--- a/examples/http-hello-world/manifests/workloaddeployment.yaml
+++ b/examples/http-hello-world/manifests/workloaddeployment.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - port: 80
+    - name: http
+      port: 80
       protocol: TCP
       nodePort: 30950
 ---


### PR DESCRIPTION
With moving to Kubernetes Services+EndpointSlices, the port names must match between the Kubernetes `Service` and the respective `EndpointSlice`. The runtime-operator when reconciling with the `Endpointslice` for the deployed workload, will add a port name of `http`. Example:

```yaml
addressType: IPv4
apiVersion: discovery.k8s.io/v1
kind: EndpointSlice
ports:
- name: http <<<-- This here
  port: 80
  protocol: TCP
endpoints:
- addresses:
  - 10.244.0.6
  conditions:
    ready: true
    serving: true
```

Since the Service deployed doesn't have a name for the port, it can't lookup the endpoints correctly. Simply adding `name: http` to the Service does allow for the lookup to happen:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: hello-world
spec:
  type: NodePort
  ports:
    - name: http. <<--added this
      port: 80
      protocol: TCP
      nodePort: 30950
``` 

Tested with a local kind cluster, and doing a `curl localhost -i`, and received the `Hello from wasmCloud!` message

Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
