### PR TITLE
ci: disable 1.9 dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,16 +10,6 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    target-branch: "release-1.9.x"
-    groups:
-      all-cargo-release-1-9:
-        patterns:
-          - "*"
-
   # Go modules - one PR for runtime-gateway + runtime-operator
   - package-ecosystem: "gomod"
     directories:


### PR DESCRIPTION
Since we haven't re-enabled/rebuilt the old CI for 1.9, I think it's better to leave the branch as-is rather than roll the deps forward for now.
