### PR TITLE
ci: automated release train

### DIFF
--- a/.github/actions/no-diff/action.yaml
+++ b/.github/actions/no-diff/action.yaml
@@ -69,7 +69,7 @@ runs:
         git diff HEAD > diff.patch
     - name: Upload patch
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: diff
         path: diff.patch

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -80,14 +80,14 @@ jobs:
           echo "artifact_prefix=${ARTIFACT_PREFIX}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: ${{ inputs.file }}
           context: ${{ inputs.working-directory }}
@@ -141,11 +141,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ inputs.image }}
           tags: ${{ inputs.tags }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,372 @@
+name: release-tag
+
+# Once the release-train PR has merged AND the canary builds on the merge
+# commit have succeeded, this workflow:
+#   1. Promotes (build-once) each canary container image: retags
+#      `ghcr.io/wasmcloud/<image>:sha-<merge-sha>` as `vX.Y.Z`. Same
+#      manifest digest, no rebuild — the bytes that passed canary CI are
+#      the bytes users pull at the release tag.
+#   2. Re-attests the promoted manifest digest so SLSA provenance covers
+#      the release tag (and not just the sha-prefixed canary).
+#   3. Downloads the canary-binaries artifacts produced by wash.yml on the
+#      merge commit, attests them, and creates the GitHub Release directly
+#      with those exact bytes attached (no rebuild on tag).
+#   4. Pushes the immutable annotated `vX.Y.Z` git tag at the merge commit.
+#      That tag triggers the remaining tag-listening workflows (charts
+#      release, runtime-operator go-module-tag, wash-runtime crates.io
+#      publish, wash homebrew + winget updates).
+#
+# Why workflow_run on release-train:
+#   - Avoids running on every closed PR repo-wide.
+#   - release-train.yml waits for the PR to actually merge before exiting,
+#     so by the time this workflow fires the merge commit is on main.
+#
+# Idempotency:
+#   - If a vX.Y.Z OCI tag already exists at GHCR, the retag step skips it
+#     (immutability — never overwrite a published release).
+#   - If the git tag already exists on origin, the tag step is a no-op.
+#   - Re-running this workflow is safe: each step is idempotent.
+
+on:
+  workflow_run:
+    workflows: [release-train]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-tag-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: write
+      packages: write
+      # For re-attesting the promoted release manifest digest.
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          # PAT so the tag push triggers the downstream tag-listening workflows.
+          token: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "wasmcloud-bot"
+          git config user.email "wasmcloud-bot@users.noreply.github.com"
+
+      - name: Verify HEAD is a release commit and read version
+        id: ver
+        run: |
+          set -euo pipefail
+          echo "STAGE=verify-head" >> "${GITHUB_ENV}"
+          SUBJECT=$(git log -1 --pretty=%s)
+          MERGE_SHA=$(git rev-parse HEAD)
+          # release-train uses rebase-merge so the subject is exactly
+          # "release: vX.Y.Z" or "release: vX.Y.Z-rc.N", with no PR ref
+          # appended. The optional "(#NNN)" group is defensive in case
+          # someone manually squash-merges in the offline-train path (the
+          # runbook still says to rebase-merge, but humans).
+          if [[ ! "${SUBJECT}" =~ ^release:\ v([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?)([[:space:]]\(#[0-9]+\))?$ ]]; then
+            echo "HEAD subject is not a release commit: ${SUBJECT}" >&2
+            echo "abort — release-tag will not tag a non-release HEAD" >&2
+            exit 1
+          fi
+          VERSION="${BASH_REMATCH[1]}"
+          WS_VERSION=$(awk -F'"' '
+            /^\[workspace\.package\]/ { in_pkg = 1; next }
+            /^\[/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
+            in_pkg && /^version = "/ { print $2; exit }
+          ' Cargo.toml)
+          if [[ "${VERSION}" != "${WS_VERSION}" ]]; then
+            echo "commit subject says v${VERSION} but Cargo.toml says ${WS_VERSION}" >&2
+            exit 1
+          fi
+          {
+            echo "version=${VERSION}"
+            echo "tag=v${VERSION}"
+            echo "sha=${MERGE_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Wait for canary builds on the merge commit
+        env:
+          GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          MERGE_SHA: ${{ steps.ver.outputs.sha }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=wait-for-canary" >> "${GITHUB_ENV}"
+          # Each of these workflows publishes a sha-prefixed canary image
+          # (wash, runtime-gateway, runtime-operator) or a chart canary that
+          # we'll repackage on tag (charts).
+          REQUIRED=("wash" "runtime-operator" "runtime-gateway" "charts")
+          # Global deadline across all required workflows. wash.yml's matrix
+          # check is the long pole at ~45 min/runner; canary-publish runs
+          # after it. 90 min gives headroom for queue + retries.
+          DEADLINE=$(( SECONDS + 5400 ))
+          for WF in "${REQUIRED[@]}"; do
+            echo "waiting for ${WF} on ${MERGE_SHA}..."
+            while (( SECONDS < DEADLINE )); do
+              # List ALL runs of this workflow on this commit (a re-run
+              # could have created multiple). Pick the newest *completed*
+              # run; if any completed run for this commit is `success`,
+              # we're done. If the only completed runs are failures, fail
+              # loudly. If none are completed yet, keep polling.
+              RUNS=$(gh run list \
+                --workflow "${WF}.yml" \
+                --commit "${MERGE_SHA}" \
+                --limit 20 \
+                --json databaseId,status,conclusion)
+              SUCCESS=$(echo "${RUNS}" | jq -r '[.[] | select(.status == "completed" and .conclusion == "success")] | length')
+              if [[ "${SUCCESS}" -gt 0 ]]; then
+                echo "${WF}: success"
+                break
+              fi
+              # All runs completed and none succeeded → failed.
+              ANY_INCOMPLETE=$(echo "${RUNS}" | jq -r '[.[] | select(.status != "completed")] | length')
+              ANY_RUN=$(echo "${RUNS}" | jq -r 'length')
+              if (( ANY_RUN > 0 && ANY_INCOMPLETE == 0 )); then
+                FAIL_CONCLUSIONS=$(echo "${RUNS}" | jq -r '[.[].conclusion] | join(",")')
+                echo "${WF}: all runs completed, none succeeded (conclusions: ${FAIL_CONCLUSIONS}) — refusing to tag" >&2
+                exit 1
+              fi
+              sleep 20
+            done
+            if (( SECONDS >= DEADLINE )); then
+              echo "timed out waiting for ${WF} on ${MERGE_SHA}" >&2
+              exit 1
+            fi
+          done
+          echo "all canary builds green on ${MERGE_SHA} — safe to promote"
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Promote canary container images to release tag
+        id: promote
+        env:
+          MERGE_SHA: ${{ steps.ver.outputs.sha }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=promote-images" >> "${GITHUB_ENV}"
+          # Build-once-promote: each image was pushed by its canary workflow
+          # as `sha-<full-sha>` and validated by the corresponding canary
+          # tests. Retagging via `imagetools create` against the sha-pinned
+          # source preserves the multi-arch manifest.
+          declare -A IMAGES=(
+            [wash]="ghcr.io/wasmcloud/wash"
+            [gateway]="ghcr.io/wasmcloud/runtime-gateway"
+            [operator]="ghcr.io/wasmcloud/runtime-operator"
+          )
+          for KEY in wash gateway operator; do
+            IMG="${IMAGES[${KEY}]}"
+            if docker buildx imagetools inspect "${IMG}:${TAG}" >/dev/null 2>&1; then
+              echo "${IMG}:${TAG} already exists — skipping (immutable)"
+              DST=$(docker buildx imagetools inspect "${IMG}:${TAG}" --format '{{json .Manifest}}' | jq -r .digest)
+            else
+              SRC="${IMG}:sha-${MERGE_SHA}"
+              echo "promoting ${SRC} -> ${IMG}:${TAG}"
+              SRC_DIGEST=$(docker buildx imagetools inspect "${SRC}" --format '{{json .Manifest}}' | jq -r .digest)
+              docker buildx imagetools create --tag "${IMG}:${TAG}" "${IMG}@${SRC_DIGEST}"
+              DST=$(docker buildx imagetools inspect "${IMG}:${TAG}" --format '{{json .Manifest}}' | jq -r .digest)
+              if [[ "${DST}" != "${SRC_DIGEST}" ]]; then
+                echo "WARN: retag digest (${DST}) differs from canary source (${SRC_DIGEST}) — same content, different manifest envelope. Attestation below covers ${DST}." >&2
+              fi
+            fi
+            echo "${KEY}_digest=${DST}" >> "${GITHUB_OUTPUT}"
+          done
+
+      # actions/attest-build-provenance takes a single subject per invocation,
+      # so unroll one step per image. Each attestation links the released
+      # manifest digest to this workflow run (Sigstore-signed via Fulcio,
+      # verifiable with `gh attestation verify oci://<image>:<tag>`).
+      - name: Attest wash release manifest
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/wasmcloud/wash
+          subject-digest: ${{ steps.promote.outputs.wash_digest }}
+          push-to-registry: true
+
+      - name: Attest runtime-gateway release manifest
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/wasmcloud/runtime-gateway
+          subject-digest: ${{ steps.promote.outputs.gateway_digest }}
+          push-to-registry: true
+
+      - name: Attest runtime-operator release manifest
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/wasmcloud/runtime-operator
+          subject-digest: ${{ steps.promote.outputs.operator_digest }}
+          push-to-registry: true
+
+      - name: Download canary-binaries artifacts from wash.yml run
+        id: bins
+        env:
+          GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          MERGE_SHA: ${{ steps.ver.outputs.sha }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=download-binaries" >> "${GITHUB_ENV}"
+          # The wash.yml canary-binaries matrix produced one artifact per
+          # target on the merge commit's run. Pick the newest *successful*
+          # completed run — re-runs or stuck runs would otherwise let us
+          # download from the wrong workflow run.
+          RUN_ID=$(gh run list \
+            --workflow wash.yml \
+            --commit "${MERGE_SHA}" \
+            --limit 20 \
+            --json databaseId,status,conclusion \
+            --jq 'map(select(.status == "completed" and .conclusion == "success")) | .[0].databaseId // empty')
+          if [[ -z "${RUN_ID}" ]]; then
+            echo "no successful wash.yml run found for ${MERGE_SHA}" >&2
+            exit 1
+          fi
+          mkdir -p ./artifacts
+          gh run download "${RUN_ID}" --dir ./artifacts --pattern 'wash-*'
+          echo "run_id=${RUN_ID}" >> "${GITHUB_OUTPUT}"
+          echo "--- downloaded ---"
+          find ./artifacts -type f | sort
+
+      - name: Attest binary build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: "./artifacts/*/wash*"
+
+      - name: Push immutable release tag
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+          MERGE_SHA: ${{ steps.ver.outputs.sha }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=push-tag" >> "${GITHUB_ENV}"
+          # Idempotent: skip if the tag already exists on origin.
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "tag ${TAG} already exists on origin — leaving it (immutable)"
+            exit 0
+          fi
+          # Annotated tag pinned to the validated merge commit. Never
+          # force-push.
+          git tag -a "${TAG}" "${MERGE_SHA}" -m "Release ${TAG}"
+          git push origin "${TAG}"
+
+      - name: Push runtime-operator Go module tag
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+          MERGE_SHA: ${{ steps.ver.outputs.sha }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=go-module-tag" >> "${GITHUB_ENV}"
+          # Go module consumers fetch `runtime-operator/vX.Y.Z`. Sequenced
+          # after the main vX.Y.Z tag (and after canary validation) so
+          # consumers never see a Go module tag whose corresponding image
+          # promotion is incomplete.
+          GO_TAG="runtime-operator/${TAG}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${GO_TAG}" >/dev/null 2>&1; then
+            echo "tag ${GO_TAG} already exists on origin — leaving it (immutable)"
+            exit 0
+          fi
+          git tag -a "${GO_TAG}" "${MERGE_SHA}" -m "Release ${GO_TAG}"
+          git push origin "${GO_TAG}"
+
+      - name: Set stage — create-release
+        run: echo "STAGE=create-release" >> "${GITHUB_ENV}"
+
+      - name: Create GitHub Release with promoted binaries
+        # The tag now exists on origin (pushed above). action-gh-release
+        # finds the existing tag and attaches the canary-built binaries.
+        # Pre-releases (tag contains "-", e.g. v2.1.0-rc.1) are marked as
+        # prerelease so `gh release list` and the GitHub UI don't surface
+        # them as the "latest" release.
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          name: ${{ steps.ver.outputs.tag }}
+          tag_name: ${{ steps.ver.outputs.tag }}
+          target_commitish: ${{ steps.ver.outputs.sha }}
+          files: |
+            ./artifacts/*/*
+          token: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          prerelease: ${{ contains(steps.ver.outputs.tag, '-') }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+
+      - name: Dispatch Homebrew tap update
+        # Run after the GitHub Release exists so the formula update can
+        # fetch the binaries and their attestations. Skipped for pre-
+        # releases — the homebrew tap formula tracks stable releases only.
+        if: ${{ !contains(steps.ver.outputs.tag, '-') }}
+        env:
+          GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          echo "STAGE=homebrew" >> "${GITHUB_ENV}"
+          gh api repos/wasmCloud/homebrew-wasmcloud/dispatches \
+            -f event_type=brew-formula-update \
+            -f "client_payload[tag_version]=${VERSION}"
+
+      - name: Set stage — winget
+        if: ${{ !contains(steps.ver.outputs.tag, '-') }}
+        run: echo "STAGE=winget" >> "${GITHUB_ENV}"
+
+      - name: Update winget package
+        # Skip pre-releases (e.g. -rc.1). action reads the GH Release for
+        # the .zip installers, so it must run after the Release exists.
+        if: ${{ !contains(steps.ver.outputs.tag, '-') }}
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: wasmCloud.wash
+          version: ${{ steps.ver.outputs.version }}
+          installers-regex: '\.zip$'
+          release-tag: ${{ steps.ver.outputs.tag }}
+          token: ${{ secrets.WASMCLOUD_BOT_PAT }}
+
+      - name: Notify Slack — release published
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+            echo "SLACK_RELEASE_WEBHOOK_URL not set — skipping notification"
+            exit 0
+          fi
+          TEXT=":rocket: release ${TAG} promoted from canary digest and tagged: ${REPO_URL}/releases/tag/${TAG}"
+          curl -sSf -X POST -H 'Content-Type: application/json' \
+            --data "$(jq -nc --arg text "${TEXT}" '{text: $text}')" \
+            "${SLACK_WEBHOOK_URL}"
+
+      - name: Notify Slack — release-tag failed
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          STAGE: ${{ env.STAGE }}
+        run: |
+          if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+            echo "SLACK_RELEASE_WEBHOOK_URL not set — skipping notification"
+            exit 0
+          fi
+          TEXT=":x: release-tag failed for ${TAG:-?} at stage \`${STAGE:-unknown}\` — Run: ${RUN_URL}"
+          curl -sSf -X POST -H 'Content-Type: application/json' \
+            --data "$(jq -nc --arg text "${TEXT}" '{text: $text}')" \
+            "${SLACK_WEBHOOK_URL}"

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1,0 +1,363 @@
+name: release-train
+
+# Train release model: every two weeks on Tuesday at 16:00 UTC, the train
+# opens a release/vX.Y.Z PR that bumps the workspace version, refreshes
+# Cargo.lock, and updates the Helm chart appVersion. CI runs against the
+# PR; once required checks pass and a maintainer approves, auto-merge fires.
+# This workflow then waits for the PR to merge and exits successfully —
+# release-tag.yml fires via workflow_run on this workflow's success and
+# pushes the vX.Y.Z tag from main, which the existing tag-triggered
+# workflows pick up.
+#
+# The cron runs every Tuesday — the every-two-weeks cadence is enforced by
+# the ISO-week-parity gate in the `gate` job. workflow_dispatch bypasses
+# the gate for manual runs (off-cycle patches, minor/major bumps).
+#
+# See RELEASE_RUNBOOK.md for the human-facing description.
+
+on:
+  schedule:
+    - cron: "0 16 * * 2"
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump"
+        required: false
+        type: choice
+        default: "patch"
+        options:
+          - patch
+          - minor
+          - major
+          # rc: from "X.Y.Z" → "X.(Y+1).0-rc.1"; from RC → increment counter.
+          # To finalize an RC into a GA, use the `version` override.
+          - rc
+      version:
+        description: "Explicit X.Y.Z[-rc.N] (overrides bump)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-train
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - name: ISO-week parity gate
+        id: gate
+        # Train runs on odd ISO weeks, anchored to 2026-W19 (Tue 2026-05-05).
+        # To re-anchor (e.g. to dodge a holiday), flip TRAIN_PARITY below.
+        # workflow_dispatch always proceeds.
+        run: |
+          set -euo pipefail
+          TRAIN_PARITY=1 # 1 = odd ISO weeks; 0 = even ISO weeks
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "manual dispatch — bypassing every-two-weeks gate"
+            echo "run=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          WEEK=$(date -u +%V)
+          if (( WEEK % 2 == TRAIN_PARITY )); then
+            echo "ISO week ${WEEK} matches parity ${TRAIN_PARITY} — train runs"
+            echo "run=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "ISO week ${WEEK} does not match parity ${TRAIN_PARITY} — skipping (every-two-weeks cadence)"
+            echo "run=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+  release:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # PAT (not GITHUB_TOKEN) so the resulting PR triggers required CI.
+          token: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "wasmcloud-bot"
+          git config user.email "wasmcloud-bot@users.noreply.github.com"
+
+      - name: Compute next version
+        id: bump
+        env:
+          BUMP: ${{ inputs.bump || 'patch' }}
+          OVERRIDE: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=compute-version" >> "${GITHUB_ENV}"
+          # Read the workspace.package.version, anchored to the section header
+          # so we can't accidentally pick up a dependency line.
+          CURRENT=$(awk -F'"' '
+            /^\[workspace\.package\]/ { in_pkg = 1; next }
+            /^\[/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
+            in_pkg && /^version = "/ { print $2; exit }
+          ' Cargo.toml)
+          if [[ -z "${CURRENT}" ]]; then
+            echo "could not read [workspace.package] version from Cargo.toml" >&2
+            exit 1
+          fi
+          if [[ -n "${OVERRIDE}" ]]; then
+            NEW="${OVERRIDE}"
+          else
+            # Detect RC base. If CURRENT is "X.Y.Z-rc.N", capture X.Y.Z and N.
+            BASE="${CURRENT%-rc.*}"
+            RC_COUNTER=""
+            if [[ "${CURRENT}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.([0-9]+)$ ]]; then
+              RC_COUNTER="${BASH_REMATCH[1]}"
+            fi
+            IFS=. read -r MAJOR MINOR PATCH <<< "${BASE}"
+            case "${BUMP}" in
+              major|minor|patch)
+                # Plain bumps require a GA base — refuse if current is RC,
+                # so an in-flight RC cycle isn't quietly buried under a
+                # patch. Finalize the RC by dispatching with the explicit
+                # `version` override (e.g. `version=2.1.0`).
+                if [[ -n "${RC_COUNTER}" ]]; then
+                  echo "current version ${CURRENT} is a release candidate" >&2
+                  echo "finalize it by dispatching with version=${BASE}, or cut another RC with bump=rc" >&2
+                  exit 1
+                fi
+                case "${BUMP}" in
+                  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+                  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+                  patch) PATCH=$((PATCH + 1)) ;;
+                esac
+                NEW="${MAJOR}.${MINOR}.${PATCH}"
+                ;;
+              rc)
+                if [[ -n "${RC_COUNTER}" ]]; then
+                  # Increment the existing RC counter.
+                  NEW="${BASE}-rc.$((RC_COUNTER + 1))"
+                else
+                  # Start a fresh minor-RC cycle from GA.
+                  NEW="${MAJOR}.$((MINOR + 1)).0-rc.1"
+                fi
+                ;;
+              *) echo "unknown bump: ${BUMP}" >&2; exit 1 ;;
+            esac
+          fi
+          # Accept plain semver or semver pre-release (X.Y.Z[-prerelease]).
+          # Build metadata (+...) is not supported by the train.
+          if ! [[ "${NEW}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$ ]]; then
+            echo "invalid version: ${NEW}" >&2; exit 1
+          fi
+          BRANCH="release/v${NEW}"
+          {
+            echo "current=${CURRENT}"
+            echo "version=${NEW}"
+            echo "branch=${BRANCH}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "bumping ${CURRENT} -> ${NEW} on ${BRANCH}"
+
+      - name: Abort if release branch or tag already exists
+        env:
+          BRANCH: ${{ steps.bump.outputs.branch }}
+          NEW: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=preflight" >> "${GITHUB_ENV}"
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            echo "branch ${BRANCH} already exists on origin — close/delete it before re-running" >&2
+            exit 1
+          fi
+          # Tags are immutable: refuse to start the train for a version that
+          # has already shipped, even if the branch was deleted.
+          if git ls-remote --exit-code --tags origin "refs/tags/v${NEW}" >/dev/null 2>&1; then
+            echo "tag v${NEW} already exists on origin — versions are immutable; pick a new version" >&2
+            exit 1
+          fi
+
+      - name: Setup Rust
+        # Only needs cargo for `cargo update --workspace`; no compilation here.
+        uses: ./.github/actions/setup-rust
+
+      - name: Bump versions
+        env:
+          NEW: ${{ steps.bump.outputs.version }}
+          CURRENT: ${{ steps.bump.outputs.current }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=bump-versions" >> "${GITHUB_ENV}"
+          # Workspace version (single source of truth for wash, wash-runtime,
+          # runtime-gateway, runtime-operator). GNU sed on ubuntu-latest; the
+          # `0,/.../` form restricts the substitution to the first match so we
+          # only touch the top-level [workspace.package] version, not any inline
+          # dep version. The pattern accepts a pre-release suffix so this works
+          # whether the current version is GA (X.Y.Z) or an RC (X.Y.Z-rc.N).
+          sed -i -E "0,/^version = \"[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?\"$/{s//version = \"${NEW}\"/}" Cargo.toml
+          if ! grep -qE "^version = \"${NEW}\"$" Cargo.toml; then
+            echo "failed to bump workspace version in Cargo.toml" >&2
+            exit 1
+          fi
+          # Helm chart appVersion tracks the workspace version.
+          sed -i -E "s/^appVersion: \".*\"$/appVersion: \"${NEW}\"/" charts/runtime-operator/Chart.yaml
+          if ! grep -qE "^appVersion: \"${NEW}\"$" charts/runtime-operator/Chart.yaml; then
+            echo "failed to bump appVersion in Chart.yaml" >&2
+            exit 1
+          fi
+          # Refresh Cargo.lock — `--workspace` only updates workspace member
+          # entries (verified empirically: 1 package locked, 79 deps unchanged).
+          cargo update --workspace
+          # Defensive sanity check: confirm only workspace member entries
+          # changed in Cargo.lock. If cargo ever expands this flag's scope,
+          # we want to fail loudly rather than smuggle in transitive bumps.
+          CHANGED_PKGS=$(git diff --unified=0 -- Cargo.lock \
+            | grep -E '^[+-]name = "' \
+            | sed -E 's/^[+-]name = "(.+)"$/\1/' \
+            | sort -u)
+          # Workspace members in this repo: wash, wash-runtime.
+          UNEXPECTED=$(echo "${CHANGED_PKGS}" | grep -vE '^(wash|wash-runtime)?$' || true)
+          if [[ -n "${UNEXPECTED}" ]]; then
+            echo "cargo update --workspace touched non-workspace packages:" >&2
+            echo "${UNEXPECTED}" >&2
+            echo "investigate before continuing — the train should not bump transitive deps" >&2
+            exit 1
+          fi
+          echo "--- diff ---"
+          git --no-pager diff --stat -- Cargo.toml Cargo.lock charts/runtime-operator/Chart.yaml
+
+      - name: Create release branch and commit
+        env:
+          BRANCH: ${{ steps.bump.outputs.branch }}
+          NEW: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=create-branch" >> "${GITHUB_ENV}"
+          git checkout -b "${BRANCH}"
+          git add Cargo.toml Cargo.lock charts/runtime-operator/Chart.yaml
+          if git diff --cached --quiet; then
+            echo "no changes staged — version may already be ${NEW}" >&2
+            exit 1
+          fi
+          git commit -m "release: v${NEW}"
+          git push origin "${BRANCH}"
+
+      - name: Open release PR and enable auto-merge
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
+          NEW: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=open-pr" >> "${GITHUB_ENV}"
+          BODY_FILE="$(mktemp)"
+          # Backticks in a single-quoted printf format are literal — shellcheck's
+          # "expressions don't expand in single quotes" warning is the point here.
+          # shellcheck disable=SC2016
+          {
+            printf 'Automated release-train PR for **v%s**.\n\n' "${NEW}"
+            printf '**Action required:** a maintainer needs to approve this PR. Once required checks pass and approval is recorded, auto-merge fires. After merge, `release-tag.yml` waits for canary builds on `main` to pass and then pushes the immutable `v%s` tag, which the existing tag-triggered workflows pick up.\n\n' "${NEW}"
+            printf 'If CI fails: fix forward and push to this branch, or close this PR. The train does not skip — patch releases out-of-cycle can be triggered via `workflow_dispatch` on `release-train.yml`.\n'
+          } > "${BODY_FILE}"
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "release: v${NEW}" \
+            --label "release-train" \
+            --body-file "${BODY_FILE}")
+          echo "pr_url=${PR_URL}" >> "${GITHUB_OUTPUT}"
+          # Rebase (not squash) so the merge commit on main keeps the exact
+          # `release: vX.Y.Z` subject without GitHub appending the `(#NNN)`
+          # PR ref. release-tag.yml's subject check and wash.yml's
+          # canary-binaries trigger both depend on that subject prefix.
+          gh pr merge "${PR_URL}" --auto --rebase
+
+      - name: Notify Slack — train started
+        if: steps.pr.outputs.pr_url != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+          NEW: ${{ steps.bump.outputs.version }}
+        run: |
+          if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+            echo "SLACK_RELEASE_WEBHOOK_URL not set — skipping notification"
+            exit 0
+          fi
+          curl -sSf -X POST -H 'Content-Type: application/json' \
+            --data "$(jq -nc --arg text ":train2: release train started for v${NEW}: ${PR_URL}" '{text: $text}')" \
+            "${SLACK_WEBHOOK_URL}"
+
+      - name: Wait for required checks on release PR
+        if: steps.pr.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=wait-for-checks" >> "${GITHUB_ENV}"
+          # --watch blocks until all required checks complete and exits non-zero
+          # on failure, which we want — the failure step below pages Slack.
+          # NOTE: this only waits for *required* status checks. Configure
+          # branch protection on `main` with the relevant CI as required, or
+          # this step will return immediately and we'll happily merge red CI.
+          gh pr checks "${PR_URL}" --watch --fail-fast --interval 30 --required
+
+      - name: Wait for PR auto-merge to complete
+        if: steps.pr.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+          echo "STAGE=wait-for-merge" >> "${GITHUB_ENV}"
+          # `gh pr checks --required --watch` returned green, but auto-merge
+          # also waits on required reviews. Poll until the PR actually merges
+          # (or is closed) so that release-tag.yml — triggered via workflow_run
+          # on this workflow's success — sees the merge commit on main.
+          DEADLINE=$(( SECONDS + 7200 ))  # 2h
+          while (( SECONDS < DEADLINE )); do
+            STATE=$(gh pr view "${PR_URL}" --json state --jq .state)
+            case "${STATE}" in
+              MERGED)
+                echo "PR merged"
+                exit 0
+                ;;
+              CLOSED)
+                echo "PR was closed without merging" >&2
+                exit 1
+                ;;
+            esac
+            sleep 30
+          done
+          echo "timed out waiting for PR auto-merge — likely awaiting review approval" >&2
+          exit 1
+
+      - name: Notify Slack — train failed
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+          NEW: ${{ steps.bump.outputs.version }}
+          STAGE: ${{ env.STAGE }}
+        run: |
+          if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+            echo "SLACK_RELEASE_WEBHOOK_URL not set — skipping notification"
+            exit 0
+          fi
+          TEXT=":x: release train failed for v${NEW:-?} at stage \`${STAGE:-unknown}\` — human intervention needed."
+          if [[ -n "${PR_URL}" ]]; then
+            TEXT="${TEXT} PR: ${PR_URL}"
+          fi
+          TEXT="${TEXT} Run: ${RUN_URL}"
+          curl -sSf -X POST -H 'Content-Type: application/json' \
+            --data "$(jq -nc --arg text "${TEXT}" '{text: $text}')" \
+            "${SLACK_WEBHOOK_URL}"

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -185,7 +185,6 @@ jobs:
           fi
 
       - name: Setup Rust
-        # Only needs cargo for `cargo update --workspace`; no compilation here.
         uses: ./.github/actions/setup-rust
 
       - name: Bump versions
@@ -232,6 +231,24 @@ jobs:
           fi
           echo "--- diff ---"
           git --no-pager diff --stat -- Cargo.toml Cargo.lock charts/runtime-operator/Chart.yaml
+
+      - name: Validate wash-runtime publish manifest (dry-run)
+        # wash-runtime.yml publishes to crates.io on the v* tag push, *after*
+        # release-tag.yml has already promoted containers and cut the GitHub
+        # Release. A publish failure at that point leaves crates.io stranded
+        # behind the rest of the release. Catch the publish-only failure
+        # modes here — missing files in `include`, missing license/README,
+        # path-only deps without versions, build.rs failures during the
+        # `cargo package` verification — before we open the PR. Uses
+        # --allow-dirty because the Bump versions step left uncommitted
+        # changes (Cargo.toml, Cargo.lock, Chart.yaml) we haven't committed
+        # to the release branch yet. --dry-run does not contact the registry
+        # for the package itself, so this works whether or not the bumped
+        # version is already on crates.io.
+        run: |
+          set -euo pipefail
+          echo "STAGE=wash-runtime-dryrun" >> "${GITHUB_ENV}"
+          cargo publish --dry-run --allow-dirty -p wash-runtime
 
       - name: Create release branch and commit
         env:

--- a/.github/workflows/runtime-gateway.yml
+++ b/.github/workflows/runtime-gateway.yml
@@ -40,6 +40,9 @@ jobs:
         working-directory: runtime-gateway
         run: go build -v ./
 
+  # The `sha-<full-sha>` tag is what release-tag.yml pins to when promoting
+  # this canary digest as the immutable vX.Y.Z release tag. `canary` itself
+  # moves on every subsequent main push.
   canary:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'canary')
     needs: [lint, test]
@@ -55,19 +58,5 @@ jobs:
       push: true
       tags: |
         type=raw,value=canary
+        type=sha,format=long,prefix=sha-
 
-  release:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [lint, test]
-    permissions:
-      contents: write
-      packages: write
-    uses: ./.github/workflows/docker-build-push.yml
-    secrets: inherit
-    with:
-      working-directory: runtime-gateway
-      file: runtime-gateway/Dockerfile
-      image: ghcr.io/wasmcloud/runtime-gateway
-      push: true
-      tags: |
-        type=semver,pattern={{version}},value=${{ github.ref_name }}

--- a/.github/workflows/runtime-operator.yml
+++ b/.github/workflows/runtime-operator.yml
@@ -107,6 +107,9 @@ jobs:
           kubectl get workloaddeployments.runtime.wasmcloud.dev -A -o yaml || true
           kubectl get workloads.runtime.wasmcloud.dev -A -o yaml || true
 
+  # The `sha-<full-sha>` tag is what release-tag.yml pins to when promoting
+  # this canary digest as the immutable vX.Y.Z release tag. `canary` itself
+  # moves on every subsequent main push.
   canary:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'canary')
     needs: [lint, test, test-e2e]
@@ -122,37 +125,4 @@ jobs:
       push: true
       tags: |
         type=raw,value=canary
-
-  release:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [lint, test, test-e2e]
-    permissions:
-      contents: write
-      packages: write
-    uses: ./.github/workflows/docker-build-push.yml
-    secrets: inherit
-    with:
-      working-directory: runtime-operator
-      file: runtime-operator/Dockerfile
-      image: ghcr.io/wasmcloud/runtime-operator
-      push: true
-      tags: |
-        type=semver,pattern={{version}},value=${{ github.ref_name }}
-
-  go-module-tag:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [release]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Create Go module tag
-        run: |
-          TAG="runtime-operator/${GITHUB_REF_NAME}"
-          if git ls-remote --tags origin "${TAG}" | grep -q "${TAG}"; then
-            echo "Tag ${TAG} already exists, skipping"
-          else
-            git tag "${TAG}"
-            git push origin "${TAG}"
-          fi
+        type=sha,format=long,prefix=sha-

--- a/.github/workflows/wash-runtime.yml
+++ b/.github/workflows/wash-runtime.yml
@@ -1,9 +1,15 @@
 name: wash-runtime
 
+# Publishes the wash-runtime library crate to crates.io. wash-runtime is
+# co-versioned with the workspace (see crates/wash-runtime/Cargo.toml,
+# version.workspace = true), so the same vX.Y.Z tag that releases wash,
+# runtime-gateway, runtime-operator, and the Helm chart also publishes the
+# crate.
+
 on:
   push:
     tags:
-      - "wash-runtime-v*"
+      - "v*"
 
 defaults:
   run:
@@ -15,6 +21,9 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      # Required for crates.io trusted publishing (OIDC). Replaces the
+      # long-lived CRATES_PUBLISH_TOKEN secret.
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -26,7 +35,7 @@ jobs:
 
       - name: Verify version matches tag
         run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/wash-runtime-v}"
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "wash-runtime") | .version')
 
           if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
@@ -36,7 +45,29 @@ jobs:
 
           echo "Version check passed: $TAG_VERSION"
 
+      - name: Authenticate with crates.io (OIDC)
+        # Mints a short-lived crates.io token from this run's OIDC identity.
+        # Requires a one-time "Trusted Publisher" configuration on
+        # crates.io — see RELEASE_RUNBOOK.md (crates.io trusted publishing).
+        id: auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+
       - name: Publish to crates.io
+        # Idempotent: a re-run of release-tag.yml that re-pushes the v* tag
+        # (or a manual re-trigger) lands here. crates.io rejects a duplicate
+        # publish; treat that as success so retries don't page noisily.
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
+          set -euo pipefail
           cd crates/wash-runtime
-          cargo publish --token "${{ secrets.CRATES_PUBLISH_TOKEN }}"
+          PUBLISH_LOG=$(mktemp)
+          if cargo publish 2>&1 | tee "${PUBLISH_LOG}"; then
+            exit 0
+          fi
+          if grep -qE "(already (exists|uploaded)|crate version .* is already)" "${PUBLISH_LOG}"; then
+            echo "wash-runtime version already on crates.io — idempotent skip"
+            exit 0
+          fi
+          echo "cargo publish failed for a non-idempotent reason" >&2
+          exit 1

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -203,7 +203,10 @@ jobs:
 
   # Tag promotion: only move `canary-v2` once check, lint, and the
   # runtime-operator e2e have all passed against this commit. Reads the
-  # digests uploaded by canary-build and assembles the manifest list.
+  # digests uploaded by canary-build and assembles the manifest list. The
+  # `sha-<full-sha>` tag is what release-tag.yml pins to when it promotes
+  # this canary digest as the immutable vX.Y.Z release tag — `canary-v2`
+  # itself moves on every subsequent main push, so we cannot rely on it.
   canary-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [check, lint, runtime-operator-e2e, canary-build]
@@ -226,15 +229,16 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/wasmcloud/wash
           tags: |
             type=raw,value=canary-v2
-      - name: Create manifest list and push canary-v2 tag
+            type=sha,format=long,prefix=sha-
+      - name: Create manifest list and push tags
         working-directory: ${{ runner.temp }}/digests
         run: |
           # shellcheck disable=SC2046
@@ -244,25 +248,19 @@ jobs:
         run: |
           docker buildx imagetools inspect ghcr.io/wasmcloud/wash:${{ steps.meta.outputs.version }}
 
-  docker-release:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      contents: write
-      packages: write
-    uses: ./.github/workflows/docker-build-push.yml
-    secrets: inherit
-    with:
-      push: true
-      image: ghcr.io/wasmcloud/wash
-      tags: |
-        type=semver,pattern={{version}},value=${{ github.ref_name }}
-
-  release:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  # Canary matrix binary build. Runs on every release commit on main (i.e.
+  # what release-train just merged) so release-tag.yml can promote the
+  # exact bytes that the canary CI tested instead of rebuilding on tag.
+  # Skipped for non-release main pushes to avoid burning ~7 runners on
+  # every commit. Manual fallback (train offline): push a `release: vX.Y.Z`
+  # commit by hand and this job fires.
+  canary-binaries:
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'release: v')"
+    needs: [check, lint, runtime-operator-e2e]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:
-      contents: write
+      contents: read
     strategy:
       matrix:
         include:
@@ -327,6 +325,15 @@ jobs:
           version: "29.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set SOURCE_DATE_EPOCH from commit timestamp
+        # Pin embedded timestamps in the binary to the merge commit's author
+        # date so the same commit produces the same bytes on every rebuild.
+        # cargo and rustc honor SOURCE_DATE_EPOCH for build metadata; this
+        # is a prerequisite for any future move toward bit-reproducible
+        # SLSA L4 builds. See https://reproducible-builds.org/docs/source-date-epoch/
+        run: |
+          echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "${GITHUB_ENV}"
+
       - name: Build binary (${{ matrix.target }})
         run: |
           ${{ matrix.buildCommand }} --release --target ${{ matrix.buildTarget || matrix.target }}
@@ -352,80 +359,3 @@ jobs:
           name: ${{ matrix.artifact }}.zip
           path: ${{ matrix.artifact }}.zip
           if-no-files-found: error
-
-  upload-release-assets:
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: ./artifacts
-          pattern: wash-*
-
-      - name: Generate build provenance attestations
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: "./artifacts/*/wash*"
-
-      - name: Create GitHub Release and upload binaries
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          name: ${{ github.ref_name }}
-          tag_name: ${{ github.ref_name }}
-          files: |
-            ./artifacts/*/*
-          token: ${{ github.token }}
-          prerelease: false
-          generate_release_notes: true
-
-  update-homebrew:
-    needs: upload-release-assets
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Dispatch Homebrew tap update
-        env:
-          GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
-        run: |
-          gh api repos/wasmCloud/homebrew-wasmcloud/dispatches \
-            -f event_type=brew-formula-update \
-            -f 'client_payload[tag_version]=${{ steps.version.outputs.version }}'
-
-  update-winget:
-    needs: upload-release-assets
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Update winget package
-        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
-        with:
-          identifier: wasmCloud.wash
-          version: ${{ steps.version.outputs.version }}
-          installers-regex: '\.zip$'
-          release-tag: ${{ github.ref_name }}
-          token: ${{ secrets.WASMCLOUD_BOT_PAT }}

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -186,7 +186,7 @@ jobs:
   # avoid serializing the slow cargo build behind the slow tests. With
   # `push: false`, the multi-arch digests are still pushed to ghcr (the
   # workflow always does that for caching), but the human-visible
-  # `canary-v2` tag is *not* created here — that happens in
+  # `canary` tag is *not* created here — that happens in
   # `canary-publish` below, gated on every test job passing.
   canary-build:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -199,13 +199,13 @@ jobs:
       push: false
       image: ghcr.io/wasmcloud/wash
       tags: |
-        type=raw,value=canary-v2
+        type=raw,value=canary
 
-  # Tag promotion: only move `canary-v2` once check, lint, and the
+  # Tag promotion: only move `canary` once check, lint, and the
   # runtime-operator e2e have all passed against this commit. Reads the
   # digests uploaded by canary-build and assembles the manifest list. The
   # `sha-<full-sha>` tag is what release-tag.yml pins to when it promotes
-  # this canary digest as the immutable vX.Y.Z release tag — `canary-v2`
+  # this canary digest as the immutable vX.Y.Z release tag — `canary`
   # itself moves on every subsequent main push, so we cannot rely on it.
   canary-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -236,7 +236,7 @@ jobs:
         with:
           images: ghcr.io/wasmcloud/wash
           tags: |
-            type=raw,value=canary-v2
+            type=raw,value=canary
             type=sha,format=long,prefix=sha-
       - name: Create manifest list and push tags
         working-directory: ${{ runner.temp }}/digests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,12 @@ Types:
 
 All submissions require review. We use GitHub pull requests for this process.
 
+### When does my change ship?
+
+Releases ship every two weeks: each Tuesday at 16:00 UTC on the train's cycle, the next
+`vX.Y.Z` is cut from `main` automatically. Anything merged before the train leaves ships in
+that release. See [RELEASE_RUNBOOK.md](./RELEASE_RUNBOOK.md#release-cadence) for details.
+
 ## Testing
 
 - Write unit tests for new functionality

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "wash-runtime"
-version = "0.2.0"
+version = "2.0.5"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/RELEASE_RUNBOOK.md
+++ b/RELEASE_RUNBOOK.md
@@ -153,13 +153,13 @@ All five ship from a single `vX.Y.Z` tag and are co-versioned.
 
 On every merge to `main` (no tag required):
 
-- `ghcr.io/wasmcloud/wash:canary-v2` and `ghcr.io/wasmcloud/wash:sha-<full-sha>`
+- `ghcr.io/wasmcloud/wash:canary` and `ghcr.io/wasmcloud/wash:sha-<full-sha>`
 - `ghcr.io/wasmcloud/runtime-gateway:canary` and `:sha-<full-sha>`
 - `ghcr.io/wasmcloud/runtime-operator:canary` and `:sha-<full-sha>`
 - Helm chart `runtime-operator:v2-canary`
 
-The `sha-<full-sha>` tags are the stable handles `release-tag.yml` pins to — `canary-v2` and
-`canary` move on every subsequent main push and would race the train.
+The `sha-<full-sha>` tags are the stable handles `release-tag.yml` pins to — the `canary`
+tag moves on every subsequent main push and would race the train.
 
 The `canary-binaries` matrix job in `wash.yml` runs only on merge commits whose subject starts
 with `release: v` (i.e. release-train PR merges). It produces the cross-platform `wash`

--- a/RELEASE_RUNBOOK.md
+++ b/RELEASE_RUNBOOK.md
@@ -2,77 +2,245 @@
 
 This guide is a runbook for maintainers preparing to release components of this monorepo.
 
-wasmCloud v2 uses **tag-triggered automation** for all releases. There is no manual workflow
-dispatch or smart-release tooling. Pushing a correctly formatted tag to `main` kicks off the
-appropriate CI pipeline automatically.
+wasmCloud v2 uses **tag-triggered automation** for all releases. Pushing a correctly formatted
+tag to `main` kicks off the appropriate CI pipeline automatically. The tag itself is normally
+pushed by the [release train](#release-cadence); manual tag pushes are reserved for the rare
+case the train is offline (see [If the train is offline](#if-the-train-is-offline)).
+
+## Release cadence
+
+wasmCloud follows a **train release model**: a release is cut every two weeks on **Tuesday at
+16:00 UTC**. Tuesday avoids the Monday catch-up window and the Friday/pre-weekend cliff, leaving
+Wed–Thu as a buffer for any same-week follow-up patch.
+
+- **No skip conditions.** The train leaves on schedule, holidays and US weekends included. If
+  something is broken, we revert and re-cut, not skip. Predictability is the whole point.
+- **Patch releases out-of-cycle are allowed at any time** for critical fixes. The cadence is a
+  floor, not a ceiling. Trigger an out-of-cycle release via `workflow_dispatch` on
+  [`release-train.yml`](.github/workflows/release-train.yml).
+- **Single co-versioned release.** `wash`, `wash-runtime`, `runtime-gateway`, `runtime-operator`,
+  and the `runtime-operator` Helm chart all ship under a single `vX.Y.Z` tag.
+- **Mostly-push-button automation.** The train opens the PR, runs CI, waits for canary builds on
+  the merge commit to pass, then pushes the immutable tag. Today, a maintainer still needs to
+  approve the release PR before auto-merge fires (see [Approval expectation](#approval-expectation)).
+
+### How the train works
+
+1. [`release-train.yml`](.github/workflows/release-train.yml) runs on a weekly Tuesday cron with
+   an ISO-week-parity gate that enforces the every-two-weeks cadence. `workflow_dispatch`
+   bypasses the gate for off-cycle runs and accepts `bump` (patch/minor/major) or an explicit
+   `version` input.
+2. The job opens a `release/vX.Y.Z` branch with a patch-bump (default). It edits the workspace
+   `Cargo.toml`, refreshes `Cargo.lock` via `cargo update --workspace` (with a sanity check that
+   only workspace member entries change), and bumps `appVersion` in
+   `charts/runtime-operator/Chart.yaml`.
+3. A PR labeled `release-train` is opened; the job enables **rebase auto-merge** (not squash —
+   see [Why rebase merge](#why-rebase-merge)) and watches the PR's required checks. If checks
+   fail, the job fails loudly with a stage-tagged Slack message to `#release-bot` so a human
+   can fix forward the same day.
+4. The job then waits for the PR to actually merge. Once merged, the merge commit's subject is
+   exactly `release: vX.Y.Z` (rebase preserves the branch's commit subject; no `(#NNN)`
+   PR ref is appended). That subject is what `wash.yml`'s `canary-binaries` job keys off to run
+   the matrix release build, and what `release-tag.yml` matches to identify a release commit.
+5. After the PR merges, [`release-tag.yml`](.github/workflows/release-tag.yml) fires via
+   `workflow_run` and performs the **build-once-promote** flow:
+   - Verifies HEAD on `main` is a release commit and the workspace version matches.
+   - Waits for the canary workflows (`wash`, `runtime-operator`, `runtime-gateway`, `charts`) on
+     the merge commit to all conclude `success` — the artifact pipeline has built and tested
+     this exact commit.
+   - **Promotes** each canary container image: retags
+     `ghcr.io/wasmcloud/{wash,runtime-gateway,runtime-operator}:sha-<merge-sha>` as `vX.Y.Z`.
+     Same manifest digest, no rebuild — the bytes that passed canary CI are the bytes users pull.
+   - **Re-attests** each promoted manifest digest (Sigstore-signed via Fulcio).
+   - **Downloads** the canary-binaries artifacts from the wash.yml run that built them, attests
+     them, and (after pushing the tag) creates the GitHub Release with those exact binaries.
+   - Pushes the annotated `vX.Y.Z` git tag at the validated merge commit. **The tag is
+     immutable**: the workflow never force-pushes, and a re-run that finds the tag already on
+     origin is a no-op.
+6. After pushing `vX.Y.Z`, `release-tag.yml` also pushes the
+   `runtime-operator/vX.Y.Z` Go module tag (so module consumers never see it before the
+   matching OCI release exists), then creates the GitHub Release with the promoted binaries,
+   then dispatches Homebrew and runs winget update inline. All sequenced after canary
+   validation.
+7. The tag push triggers the remaining tag-listening workflows: `wash-runtime` publishes the
+   library crate to crates.io (idempotent on re-run — already-published versions exit 0);
+   `charts.yml`'s release job repackages the chart at `vX.Y.Z` (charts are templated and
+   deterministic, so rebuild is acceptable here).
+
+### Why rebase merge
+
+The release-train PR uses `gh pr merge --auto --rebase`, not `--squash`. With squash-merge,
+GitHub appends ` (#NNN)` to the commit subject (e.g. `release: v2.0.6 (#1234)`), which
+breaks the strict subject contract that `release-tag.yml` and `canary-binaries` rely on. With
+rebase-merge, the branch's commit message is preserved verbatim — `release: v2.0.6` —
+which is what those workflows match.
+
+This requires "Allow rebase merging" enabled in repo settings (alongside "Allow auto-merge").
+
+### Approval expectation
+
+Today, branch protection on `main` requires a maintainer review on every PR, including
+release-train PRs. The train will:
+
+- Open the PR (auto)
+- Wait for required CI to go green (auto)
+- **Wait indefinitely (up to 2h timeout) for a maintainer's approval** — at which point
+  auto-merge fires (auto from there)
+
+Maintainers should treat release-train PRs as a normal review item: read the diff (only
+`Cargo.toml`, `Cargo.lock`, and `Chart.yaml` should change), confirm the version bump matches
+expectations, approve. If the PR sits unapproved past the 2h timeout, the train fails with a
+Slack page; resolve and re-dispatch.
+
+### Bumping minor or major
+
+Patch is the default. To cut a minor or major release on the train, dispatch
+`release-train.yml` manually with the `bump` input set to `minor` or `major`. Majo and minor bumps
+should be coordinated with maintainers ahead of time (see [Versioning policy](#versioning-policy)).
+
+### If the train is offline
+
+If `release-train.yml` is broken or the bot can't push, do by hand what the train does. The
+**commit subject must be exactly `release: vX.Y.Z`** — that is what triggers the
+matrix binary build and is what `release-tag.yml` looks for to identify a release commit.
+
+1. Bump the workspace version in `Cargo.toml` to `X.Y.Z` and `appVersion` in
+   `charts/runtime-operator/Chart.yaml` to the same value. Run `cargo update --workspace`.
+2. Commit with subject `release: vX.Y.Z`. Open a PR, get it reviewed, **rebase-merge**
+   to `main` (rebase preserves the subject verbatim; squash-merge would append ` (#NNN)` and
+   break `release-tag.yml`'s subject match).
+3. Wait for canary builds on the merge commit to all succeed (`wash`, `runtime-operator`,
+   `runtime-gateway`, `charts`, plus `canary-binaries` in `wash.yml`).
+4. Re-run `release-tag.yml` from the Actions tab (**Re-run failed jobs** on the failed
+   workflow_run instance) so it picks up the now-green canaries, or perform its work by hand:
+   - Promote the canary OCI images:
+     ```bash
+     for img in ghcr.io/wasmcloud/{wash,runtime-gateway,runtime-operator}; do
+       docker buildx imagetools create --tag "${img}:vX.Y.Z" "${img}:sha-<MERGE_SHA>"
+     done
+     ```
+   - Push the immutable annotated tag and the Go module tag:
+     ```bash
+     git tag -a vX.Y.Z <MERGE_SHA> -m "Release vX.Y.Z"
+     git tag -a runtime-operator/vX.Y.Z <MERGE_SHA> -m "Release runtime-operator/vX.Y.Z"
+     git push origin vX.Y.Z runtime-operator/vX.Y.Z
+     ```
+   - Download the canary-binaries from the merge commit's `wash.yml` run and create the
+     GitHub Release with them attached
+     (`gh run download <RUN_ID> --pattern 'wash-*' --dir artifacts/`, then `gh release
+     create vX.Y.Z artifacts/*/* --target <MERGE_SHA> --generate-notes`).
+   - Dispatch the Homebrew tap update and run winget-releaser as documented in
+     `release-tag.yml`.
+5. The `wash-runtime` workflow fires on the `vX.Y.Z` tag push and publishes the crate
+   (idempotent if already published); `charts.yml` repackages and pushes the chart.
+
+Do not bypass step 3 — promoting a digest that hasn't had the canary suite pass defeats the
+"tested what we're publishing" guarantee.
 
 ## Release artifacts at a glance
 
-| Component | Tag format | What gets published |
-|-----------|-----------|---------------------|
-| `wash` + `runtime-gateway` + `runtime-operator` + Helm charts | `vX.Y.Z` | Binaries, Docker images, Helm chart, GitHub Release |
-| `wash-runtime` (library crate) | `wash-runtime-vX.Y.Z` | crates.io |
+| Component | What gets published on `vX.Y.Z` |
+|-----------|---------------------------------|
+| `wash` (CLI) | Cross-platform binaries with SLSA provenance, GitHub Release, `ghcr.io/wasmcloud/wash:vX.Y.Z`, Homebrew tap update, winget |
+| `wash-runtime` (library crate) | crates.io |
+| `runtime-gateway` | `ghcr.io/wasmcloud/runtime-gateway:vX.Y.Z` |
+| `runtime-operator` | `ghcr.io/wasmcloud/runtime-operator:vX.Y.Z`, Go module tag `runtime-operator/vX.Y.Z` |
+| Helm chart | `ghcr.io/wasmcloud/charts/runtime-operator:vX.Y.Z` |
 
-> **Note:** A single `vX.Y.Z` tag simultaneously triggers releases for `wash`, `runtime-gateway`,
-> `runtime-operator`, and the Helm chart. These components are co-versioned.
+All five ship from a single `vX.Y.Z` tag and are co-versioned.
 
 ## Canary builds
 
 On every merge to `main` (no tag required):
 
-- `ghcr.io/wasmcloud/wash:canary-v2`
-- `ghcr.io/wasmcloud/runtime-gateway:canary`
-- `ghcr.io/wasmcloud/runtime-operator:canary`
+- `ghcr.io/wasmcloud/wash:canary-v2` and `ghcr.io/wasmcloud/wash:sha-<full-sha>`
+- `ghcr.io/wasmcloud/runtime-gateway:canary` and `:sha-<full-sha>`
+- `ghcr.io/wasmcloud/runtime-operator:canary` and `:sha-<full-sha>`
 - Helm chart `runtime-operator:v2-canary`
 
-## Releasing `wash` / `runtime-gateway` / `runtime-operator` / Helm charts
+The `sha-<full-sha>` tags are the stable handles `release-tag.yml` pins to — `canary-v2` and
+`canary` move on every subsequent main push and would race the train.
 
-These four components share a version tag and are released together.
+The `canary-binaries` matrix job in `wash.yml` runs only on merge commits whose subject starts
+with `release: v` (i.e. release-train PR merges). It produces the cross-platform `wash`
+binaries as workflow artifacts that `release-tag.yml` later attests and attaches to the
+GitHub Release. Skipped on every other main push to avoid burning ~7 runners on every merge.
 
-1. Update the version in `Cargo.toml` (root workspace) to `X.Y.Z`:
-   ```
-   version = "X.Y.Z"
-   ```
-2. Open a pull request with only this version bump, get it reviewed, and merge to `main`.
-3. Create and push the release tag from `main`:
-   ```bash
-   git tag vX.Y.Z
-   git push origin vX.Y.Z
-   ```
-4. The `wash` workflow will:
-   - Build cross-platform binaries (Linux x86\_64/aarch64 musl, macOS x86\_64/aarch64, Windows x86\_64)
-   - Generate SLSA build provenance attestations
-   - Create a GitHub Release with binaries attached and auto-generated release notes
-   - Push `ghcr.io/wasmcloud/wash:vX.Y.Z`
-   - Automatically dispatch a Homebrew tap update
-5. The `runtime-gateway` workflow will push `ghcr.io/wasmcloud/runtime-gateway:vX.Y.Z`.
-6. The `runtime-operator` workflow will:
-   - Push `ghcr.io/wasmcloud/runtime-operator:vX.Y.Z`
-   - Create a Go module tag `runtime-operator/vX.Y.Z`
-7. The `charts` workflow will publish the `runtime-operator` Helm chart to
-   `ghcr.io/wasmcloud/charts/runtime-operator:vX.Y.Z`.
+## Build-once-promote and tested artifacts
 
-Monitor the [Actions tab](https://github.com/wasmCloud/wasmCloud/actions) to confirm all workflows
-complete successfully.
+The release flow is designed so that **the bytes users pull are the bytes that passed CI**:
 
-### Pre-release (e.g., release candidate)
+- **Container images.** Canary builds publish multi-arch manifests pinned by `sha-<full-sha>`.
+  `release-tag.yml` retags those exact digests as `vX.Y.Z` via `docker buildx imagetools
+  create`. No rebuild — same manifest, same content. The release tag is then re-attested.
+- **wash binaries.** `canary-binaries` builds the matrix on the release commit (validated by
+  `check`/`lint`/`runtime-operator-e2e`). `release-tag.yml` downloads those artifacts and
+  attaches them to the GitHub Release directly, with a fresh SLSA attestation.
+- **wash-runtime crate.** Published from source at the tag (`wash-runtime.yml`), with the
+  Cargo.toml version verify gate — the version on the tag must match the version in source.
+  Since the workspace version is bumped by the train and validated by canary CI before the
+  tag is pushed, the published crate matches what was tested.
+- **Helm chart.** Repackaged from source at the tag (`charts.yml`'s `release` job). Charts are
+  deterministic templates; rebuild risk is low. (If we want bit-identical charts we'd add an
+  ORAS-based retag step here, but it's not strictly necessary for safety.)
 
-Tag with a pre-release suffix, e.g., `v2.1.0-rc.1`.
+### Image attestations
 
-## Releasing `wash-runtime` (library crate)
+**Attestation is release-only.** Canary container pushes intentionally skip attestation —
+users only ever pull tagged releases, so attesting every main commit's canary would just be
+noise (and a pointless mint of Sigstore certificates). When `release-tag.yml` retags the
+canary digest as `vX.Y.Z`, it mints a fresh SLSA provenance attestation against the promoted
+manifest digest, signed via Fulcio, linking that digest to the workflow run, source commit,
+and runner.
 
-`wash-runtime` is a library crate published independently to crates.io.
+Verify any released image with:
+```bash
+gh attestation verify --repo wasmCloud/wasmCloud oci://ghcr.io/wasmcloud/wash:vX.Y.Z
+gh attestation verify --repo wasmCloud/wasmCloud oci://ghcr.io/wasmcloud/runtime-gateway:vX.Y.Z
+gh attestation verify --repo wasmCloud/wasmCloud oci://ghcr.io/wasmcloud/runtime-operator:vX.Y.Z
+```
 
-1. Update the version in `crates/wash-runtime/Cargo.toml` to `X.Y.Z`.
-2. Open a pull request with the version bump, get it reviewed, and merge to `main`.
-3. Create and push the release tag from `main`:
-   ```bash
-   git tag wash-runtime-vX.Y.Z
-   git push origin wash-runtime-vX.Y.Z
-   ```
-4. The `wash-runtime` workflow will:
-   - Verify the tag version matches the version in `Cargo.toml` (fails fast if mismatched)
-   - Publish the crate to crates.io using the `CRATES_PUBLISH_TOKEN` secret
+Binaries on the GitHub Release have equivalent attestations (verifiable by digest):
+```bash
+gh attestation verify --repo wasmCloud/wasmCloud ./wash
+```
+
+### When canary fails post-merge
+
+`canary-binaries` and the canary docker jobs only fire on push-to-main, not on the release-PR
+itself (the matrix build is too expensive to run on every PR, and only release-train PRs need
+it). That means a release commit can land on `main` and *then* fail the matrix build. When
+this happens:
+
+- `release-tag.yml` will fail at `Wait for canary builds on the merge commit` (stage
+  `wait-for-canary`) and Slack-page `#release-bot`.
+- The release commit is already on `main`, so `Cargo.toml`/`Cargo.lock`/`Chart.yaml` already
+  show the bumped version.
+- **Recovery: fix forward, do not revert.** Open a PR fixing the build issue with subject
+  `release: vX.Y.Z` (same version — the bump is already in main). Rebase-merge it.
+  The new merge commit on main will trigger a fresh canary; once it goes green, re-run
+  `release-tag.yml` (workflow_dispatch, or just wait — `workflow_run` doesn't retrigger
+  automatically, so manual re-dispatch is required).
+- If the fix is large enough that you want a different version on the failed attempt, revert
+  the release commit and run the train again with `bump=patch`. The `vX.Y.Z` git tag has not
+  been pushed (release-tag never got past `wait-for-canary`), so versions are still available.
+
+The train's "no skip" policy applies here too: don't try to dodge the failed canary by
+pushing the tag manually. The promote-don't-rebuild guarantee depends on a green canary on
+the exact merge commit.
+
+### Tag immutability
+
+- **Git tags** (`vX.Y.Z`) are protected by the [tag ruleset](#ruleset-release-tags): no force
+  push, no update, no delete. `release-tag.yml` checks `git ls-remote` before pushing and is a
+  no-op if the tag exists.
+- **OCI tags** are not registry-immutable on GHCR, but the workflow contract makes them so:
+  only `release-tag.yml` writes `vX.Y.Z`, and the promote step skips if the OCI tag already
+  exists. Hand-pushes to those tags should be blocked by package-level admin permissions —
+  see [Repo prerequisites](#repo-prerequisites).
+- **GitHub Release** is created at the tag with a fresh attestation for the binaries; if the
+  release already exists, the workflow logs an error and the maintainer chooses whether to
+  republish.
 
 ## Versioning policy
 
@@ -91,19 +259,71 @@ Conventional commit prefixes used to categorize changes in release notes:
 | `feat!:` / `BREAKING CHANGE:` | Breaking change |
 | `chore:`, `docs:`, `test:`, `refactor:` | Non-functional (no version bump implied) |
 
-## Checklist before tagging
+## Release candidates
 
-- [ ] All CI checks pass on `main`
-- [ ] `Cargo.toml` (or crate-specific `Cargo.toml`) version is updated and merged
-- [ ] CHANGELOG or release notes are accurate (auto-generated from conventional commits)
-- [ ] No open regressions targeting this release
-- [ ] For major releases: migration guide is documented
+The train cuts RCs the same way it cuts GA releases — same PR shape, same canary gating, same
+build-once-promote, same immutable tag. The only differences are:
 
-## Checklist after tagging
+- Tag is `vX.Y.Z-rc.N` instead of `vX.Y.Z`.
+- The GitHub Release is marked `prerelease: true` (so `gh release list` and the GitHub UI
+  don't surface it as the project's "latest" release).
+- `homebrew` and `winget` updates are skipped (those distros are for stable users).
+- Everything else publishes: OCI images at `vX.Y.Z-rc.N` (with SLSA attestation), the Helm
+  chart at `vX.Y.Z-rc.N`, the Go module tag `runtime-operator/vX.Y.Z-rc.N`, and the
+  `wash-runtime` crate at `X.Y.Z-rc.N` on crates.io.
+
+### Cutting an RC
+
+RCs are always cut via `workflow_dispatch` on `release-train.yml`. The biweekly cron only
+cuts patches off GA — it never produces RCs.
+
+| Want | Dispatch input |
+|---|---|
+| First RC of a new minor (e.g. `2.0.5` → `2.1.0-rc.1`) | `bump=rc` |
+| Next RC iteration (e.g. `2.1.0-rc.1` → `2.1.0-rc.2`) | `bump=rc` |
+| Finalize current RC (e.g. `2.1.0-rc.3` → `2.1.0`) | `version=2.1.0` |
+| Major-version RC, or any non-standard version | `version=X.Y.Z-rc.N` |
+
+The train auto-detects whether the current workspace version is GA or RC and picks the
+right transition for `bump=rc`. Plain `bump=patch/minor/major` refuses to run when the
+current version is an RC — finalize first by dispatching with the explicit `version`
+override (the version is already in `Cargo.toml` on main, so the cut stays unambiguous).
+
+### Typical RC cycle
+
+```
+2.0.5 (GA)
+  └─ workflow_dispatch bump=rc        → 2.1.0-rc.1
+  └─ canary CI green, soak 24h
+  └─ workflow_dispatch bump=rc        → 2.1.0-rc.2  (after a fix)
+  └─ canary CI green, soak 24h
+  └─ workflow_dispatch version=2.1.0  → 2.1.0      (finalize; promote with no rebuild)
+2.1.0 (GA)
+  └─ next cron Tuesday: bump=patch    → 2.1.1
+```
+
+Each RC goes through the full canary-validate-then-promote pipeline, so an RC tag
+(`v2.1.0-rc.1`) carries the same SLSA-attested bytes that the eventual GA tag will carry
+if no fixes land in between. If a fix lands between the last RC and the finalize, that fix
+gets its own canary cycle as part of the GA cut.
+
+### What the cron does during an RC cycle
+
+If a release commit on main is currently an RC (e.g. `2.1.0-rc.1`) when the Tuesday cron
+fires, `bump=patch` will refuse with a Slack page: "current version is a release candidate;
+finalize it by dispatching with version=X.Y.Z, or cut another RC with bump=rc." This is
+intentional — the train won't bury an in-flight RC under a quiet patch. Maintainers should
+respond by either:
+
+- Dispatching `version=X.Y.Z` to finalize the in-flight RC into a GA, OR
+- Dispatching `bump=rc` for the next RC iteration, OR
+- Dispatching `version=X.Y.Z` for a different version if the RC was abandoned.
+
+## Checklist after release
 
 - [ ] All release workflows completed successfully in GitHub Actions
 - [ ] GitHub Release is visible with correct binaries attached
 - [ ] Docker images are available on GHCR
 - [ ] Homebrew tap updated (check [homebrew-wasmcloud](https://github.com/wasmCloud/homebrew-wasmcloud))
-- [ ] For `wash-runtime`: crate is visible on [crates.io](https://crates.io/crates/wash-runtime)
+- [ ] `wash-runtime` crate is visible on [crates.io](https://crates.io/crates/wash-runtime)
 - [ ] Announce the release in [Slack](https://slack.wasmcloud.com) `#announcements`

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -7,6 +7,21 @@ license = "Apache-2.0"
 repository = "https://github.com/wasmCloud/wasmCloud"
 authors = ["The wasmCloud Team"]
 categories = ["wasm"]
+readme = "README.md"
+# Allowlist what ships to crates.io. Cargo always includes Cargo.toml,
+# Cargo.lock, Cargo.toml.orig, and .cargo_vcs_info.json regardless. Anything
+# else in the crate directory (notably tests/ with hundreds of MB of
+# gitignored-but-still-cargo-visible fixtures, and any future scratch
+# directory a contributor commits) stays out of the published crate unless
+# explicitly added here.
+include = [
+    "src/**/*",
+    "wit/**/*",
+    "build.rs",
+    "wkg.lock",
+    "README.md",
+    "LICENSE",
+]
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash-runtime"
-version = "0.2.0"
+version.workspace = true
 description = "Opinionated wasmtime wrapper that provides a runtime and workload API for executing Wasm components"
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/wash-runtime/LICENSE
+++ b/crates/wash-runtime/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 wasmCloud Maintainers
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/deploy/k3s/docker-compose.yml
+++ b/deploy/k3s/docker-compose.yml
@@ -81,7 +81,9 @@ services:
       - 80:8000
 
   wash-host:
-    image: ghcr.io/wasmcloud/wash:canary
+    # Pinned to canary-v2 until wash.yml's first post-cutover canary-publish
+    # run on main produces the new `:canary` tag. Flip after that lands.
+    image: ghcr.io/wasmcloud/wash:canary-v2
     restart: always
     command: host --scheduler-nats-url nats://nats:4222 --data-nats-url nats://nats:4222 --http-addr 0.0.0.0:8080 --host-group default --host-name wash-host
     depends_on:

--- a/deploy/k3s/docker-compose.yml
+++ b/deploy/k3s/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - 80:8000
 
   wash-host:
-    image: ghcr.io/wasmcloud/wash:canary-v2
+    image: ghcr.io/wasmcloud/wash:canary
     restart: always
     command: host --scheduler-nats-url nats://nats:4222 --data-nats-url nats://nats:4222 --http-addr 0.0.0.0:8080 --host-group default --host-name wash-host
     depends_on:

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -71,7 +71,10 @@ var (
 	// helmChartPath points to the runtime-operator Helm chart relative to the project dir (runtime-operator/)
 	helmChartPath = "../charts/runtime-operator"
 
-	runtimeImageTag = "canary"
+	// Pinned to `canary-v2` until wash.yml's first post-cutover canary-publish
+	// run on main produces the new `:canary` tag. Flip to "canary" in a
+	// follow-up PR (or the scheduled cleanup agent) after that lands.
+	runtimeImageTag = "canary-v2"
 	// runtimeSupportsHostAliases indicates whether the runtime supports HostAliases,
 	// which is required for testing with EndpointSlices.
 	runtimeSupportsHostAliases = false

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -71,7 +71,7 @@ var (
 	// helmChartPath points to the runtime-operator Helm chart relative to the project dir (runtime-operator/)
 	helmChartPath = "../charts/runtime-operator"
 
-	runtimeImageTag = "canary-v2"
+	runtimeImageTag = "canary"
 	// runtimeSupportsHostAliases indicates whether the runtime supports HostAliases,
 	// which is required for testing with EndpointSlices.
 	runtimeSupportsHostAliases = false


### PR DESCRIPTION
Closes #5071. Biweekly Tuesday cron opens a version-bump PR; release-tag.yml
promotes the canary OCI digest as vX.Y.Z (build-once, no rebuild), attests
artifacts with SLSA provenance, and pushes the immutable tag. wash-runtime
co-versioned and published via crates.io OIDC trusted publishing.

RC support via bump=rc.
