### PR TITLE
fix: remove canary-v2 now that canary exists

### DIFF
--- a/deploy/k3s/docker-compose.yml
+++ b/deploy/k3s/docker-compose.yml
@@ -81,9 +81,7 @@ services:
       - 80:8000
 
   wash-host:
-    # Pinned to canary-v2 until wash.yml's first post-cutover canary-publish
-    # run on main produces the new `:canary` tag. Flip after that lands.
-    image: ghcr.io/wasmcloud/wash:canary-v2
+    image: ghcr.io/wasmcloud/wash:canary
     restart: always
     command: host --scheduler-nats-url nats://nats:4222 --data-nats-url nats://nats:4222 --http-addr 0.0.0.0:8080 --host-group default --host-name wash-host
     depends_on:

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -71,10 +71,8 @@ var (
 	// helmChartPath points to the runtime-operator Helm chart relative to the project dir (runtime-operator/)
 	helmChartPath = "../charts/runtime-operator"
 
-	// Pinned to `canary-v2` until wash.yml's first post-cutover canary-publish
-	// run on main produces the new `:canary` tag. Flip to "canary" in a
-	// follow-up PR (or the scheduled cleanup agent) after that lands.
-	runtimeImageTag = "canary-v2"
+	// canary is published on every merge to main
+	runtimeImageTag = "canary"
 	// runtimeSupportsHostAliases indicates whether the runtime supports HostAliases,
 	// which is required for testing with EndpointSlices.
 	runtimeSupportsHostAliases = false


### PR DESCRIPTION
Ok this should wrap up our canary-v2 to canary migration. 