### PR TITLE
fix(dev): friendly url

### DIFF
--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -235,7 +235,9 @@ impl CliCommand for DevCommand {
         // Running workload ID for reloads
         let workload_id = reload_component(host.clone(), &workload, None).await?;
 
-        info!(address = %format!("{}://{}", protocol, http_addr), "listening for HTTP requests");
+        // Display 127.0.0.1 instead of 0.0.0.0 for user-friendly clickable URL
+        let display_addr = http_addr.replace("0.0.0.0", "127.0.0.1");
+        info!(address = %format!("{}://{}", protocol, display_addr), "listening for HTTP requests");
 
         select! {
             // Process a stop


### PR DESCRIPTION
Make it easy for devs when we print the local url to console to right-click.



While 0.0.0.0 tells a service (like a web server) to listen to all incoming network paths, it doesn't represent "this computer" in the same way 127.0.0.1 does. When you right-click or type 0.0.0.0 into a browser, the OS doesn't know where to send it, as it is technically an invalid or unassigned destination address.

