### PR TITLE
feat(wash): workload env/config/secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7252,6 +7277,7 @@ version = "2.2.0"
 dependencies = [
  "anyhow",
  "async-nats",
+ "bon",
  "bytes",
  "chrono",
  "clap",
@@ -7266,6 +7292,8 @@ dependencies = [
  "http-body-util",
  "humansize",
  "humantime",
+ "hyper",
+ "libc",
  "pbjson-build 0.8.0",
  "rcgen",
  "reqwest",
@@ -7300,6 +7328,7 @@ dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
  "bit-vec 0.6.3",
+ "bon",
  "bytes",
  "cap-net-ext",
  "cap-std",
@@ -7312,6 +7341,7 @@ dependencies = [
  "gag",
  "geo-types",
  "hostname",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ base64 = { version = "0.22", default-features = false, features = ["std"] }
 clap = { version = "4.5.40", default-features = false, features = ["derive", "env", "help", "color", "suggestions", "wrap_help", "cargo", "string"] }
 clap_complete = { version = "4.5.40", default-features = false }
 async-trait = { version = "0.1", default-features = false}
+bon = { version = "3.9", default-features = false }
 bytes = { version = "1", default-features = false }
 chrono = { version = "0.4.42", default-features = false, features = ["clock", "alloc"] }
 clap-markdown = { version = "0.1.5", default-features = false }
@@ -58,6 +59,7 @@ etcetera = { version = "0.10.0", default-features = false }
 figment = { version = "0.10.19", default-features = false }
 futures = { version = "0.3", default-features = false }
 flate2 = { version = "1.0", default-features = false }
+http = { version = "1", default-features = false }
 humansize = { version = "2.1", default-features = false }
 hyper = { version = "1.6.0", default-features = false }
 hyper-util = { version = "0.1.18", default-features = false }

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -64,10 +64,12 @@ wasi-tls = ["dep:wasmtime-wasi-tls", "wasip3"]
 anyhow = { workspace = true }
 async-nats = { workspace = true, features = ["aws-lc-rs"] }
 async-trait = { workspace = true }
+bon = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 hostname = { workspace = true }
+http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["server", "http1", "http2"] }
 hyper-util = { workspace = true, features = ["client-legacy", "http1", "http2", "tokio", "server-auto"] }

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -18,6 +18,7 @@ use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpHooks, WasiHttpView};
 #[cfg(feature = "wasi-tls")]
 use wasmtime_wasi_tls::{WasiTlsCtx, WasiTlsCtxBuilder, WasiTlsCtxView, WasiTlsView};
 
+use crate::host::allowed_hosts::AllowedHost;
 use crate::plugin::HostPlugin;
 
 /// A shareable, cloneable `wasi:tls` provider. Wraps an `Arc<dyn TlsProvider>`
@@ -238,7 +239,7 @@ impl wasmtime_wasi_http::p3::WasiHttpView for SharedCtx {
 struct CtxHttpHooks {
     http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
     workload_id: Arc<str>,
-    allowed_hosts: Arc<[String]>,
+    allowed_hosts: Arc<[AllowedHost]>,
 }
 
 impl WasiHttpHooks for CtxHttpHooks {
@@ -267,7 +268,7 @@ impl WasiHttpHooks for CtxHttpHooks {
 struct CtxHttpHooksP3 {
     http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
     workload_id: Arc<str>,
-    allowed_hosts: Arc<[String]>,
+    allowed_hosts: Arc<[AllowedHost]>,
 }
 
 #[cfg(feature = "wasip3")]
@@ -339,7 +340,7 @@ pub struct CtxBuilder {
     sockets: Option<crate::sockets::WasiSocketsCtx>,
     plugins: HashMap<&'static str, Arc<dyn HostPlugin + Send + Sync>>,
     http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
-    allowed_hosts: Arc<[String]>,
+    allowed_hosts: Arc<[AllowedHost]>,
     /// TLS provider override for `wasi:tls` client connections.
     #[cfg(feature = "wasi-tls")]
     tls_provider: Option<SharedTlsProvider>,
@@ -399,7 +400,7 @@ impl CtxBuilder {
         self
     }
 
-    pub fn with_allowed_hosts(mut self, allowed_hosts: Arc<[String]>) -> Self {
+    pub fn with_allowed_hosts(mut self, allowed_hosts: Arc<[AllowedHost]>) -> Self {
         self.allowed_hosts = allowed_hosts;
         self
     }

--- a/crates/wash-runtime/src/host/allowed_hosts.rs
+++ b/crates/wash-runtime/src/host/allowed_hosts.rs
@@ -1,0 +1,756 @@
+//! Outbound host allowlist for HTTP/TCP egress from workloads.
+//!
+//! Each entry parses into one of four shapes and is checked at request time
+//! by [`AllowedHost::matches`]. Wire format is a plain string. Both the
+//! wash YAML config and the Kubernetes `WorkloadDeployment` CRD carry
+//! `allowedHosts: [String]`; parsing into [`AllowedHost`] happens once,
+//! either at deserialize-time (wash) or at proto → in-memory conversion
+//! (operator path), so request-path matching is allocation-free.
+//!
+//! # Accepted forms
+//!
+//! | Form                                 | Variant                         |
+//! | ------------------------------------ | ------------------------------- |
+//! | `*`                                  | [`AllowedHost::Any`]            |
+//! | `*.example.com[:port]`               | [`AllowedHost::SuffixWildcard`] |
+//! | `scheme://*.example.com[:port][/]`   | [`AllowedHost::SuffixWildcard`] |
+//! | `scheme://host[:port][/]`            | [`AllowedHost::Url`]            |
+//! | `host[:port]`                        | [`AllowedHost::Authority`]      |
+//!
+//! The wildcard must always be `*.<rest>` (leading-dot subdomain match).
+//! A bare `*foo` is rejected — `*com` matching every `.com` was never the
+//! intent and is a footgun.
+//!
+//! This is a host policy, not a URL policy. Entries are rejected at parse
+//! time if they include any path beyond a bare trailing `/`, a query
+//! string, or a fragment.
+//!
+//! # Empty list = deny all
+//!
+//! At the runtime check ([`crate::host::http::check_allowed_hosts`]) an
+//! empty list of [`AllowedHost`] entries denies every outgoing request
+//! (fail-closed). Callers that want unrestricted egress must pass an
+//! explicit `[AllowedHost::Any]`. The wash config layer substitutes
+//! `[Any]` when `allowedHosts` is omitted from YAML, so `wash dev`
+//! workloads land at the runtime with a populated policy.
+//!
+//! # Matching semantics
+//!
+//! - Hostname comparison is ASCII-case-insensitive.
+//! - `Authority` and `SuffixWildcard` with no explicit port match any
+//!   request port. With an explicit port they match exact.
+//! - `SuffixWildcard` with no explicit scheme matches any scheme. With an
+//!   explicit scheme it matches exact (case-insensitive).
+//! - `Url` matches scheme + host + port exactly. Paths on policy entries
+//!   aren't allowed (see above) and request paths/queries are not
+//!   inspected by the matcher.
+//!
+//! # Examples
+//!
+//! ```
+//! use wash_runtime::host::allowed_hosts::AllowedHost;
+//!
+//! let policy: AllowedHost = "*.example.com".parse().unwrap();
+//! let req: http::Uri = "http://api.example.com/v1/users".parse().unwrap();
+//! assert!(policy.matches(&req));
+//!
+//! let denied: http::Uri = "http://evil.com".parse().unwrap();
+//! assert!(!policy.matches(&denied));
+//! ```
+
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::{Context, anyhow};
+use http::Uri;
+use http::uri::{Authority, Scheme};
+use serde::{Deserialize, Serialize, de, ser};
+use url::Url;
+
+/// A parsed entry from the `allowedHosts` allowlist.
+///
+/// See the [module-level docs](self) for accepted string forms and
+/// matching semantics. Parsed via [`FromStr`]; rendered back to its wire
+/// representation via [`Display`](fmt::Display); the [`Serialize`] /
+/// [`Deserialize`] impls round-trip through that same string form, so
+/// YAML / JSON callers see plain strings. Use [`AllowedHost::matches`]
+/// to evaluate a request URI against an entry.
+///
+/// # Errors
+///
+/// Parsing via [`FromStr`] returns an error when the input:
+///
+/// - is empty (after trimming),
+/// - is a wildcard not of the form `*.<rest>` (e.g. bare `*foo` is rejected),
+/// - has an invalid URL scheme, host, or port,
+/// - is a URL form with a path beyond bare `/`, a query string, or a
+///   fragment — this is a hosts policy, not a URL policy.
+///
+/// # Examples
+///
+/// ```
+/// use wash_runtime::host::allowed_hosts::AllowedHost;
+///
+/// // The five accepted forms all parse:
+/// let _: AllowedHost = "*".parse().unwrap();
+/// let _: AllowedHost = "example.com".parse().unwrap();
+/// let _: AllowedHost = "example.com:8443".parse().unwrap();
+/// let _: AllowedHost = "https://api.example.com".parse().unwrap();
+/// let _: AllowedHost = "*.example.com".parse().unwrap();
+///
+/// // Paths on URL entries are rejected — this is a hosts policy.
+/// assert!("https://api.example.com/v1".parse::<AllowedHost>().is_err());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AllowedHost {
+    /// `*` — match every outbound host.
+    Any,
+    /// `host[:port]` — exact host match, optional port pin.
+    Authority(Authority),
+    /// `scheme://host[:port][/]` — exact scheme + host (+ optional port)
+    /// match. A bare trailing `/` is accepted for ergonomics (matches what
+    /// `url::Url` normalizes to); any other path, query, or fragment is
+    /// rejected at parse time because this is a host policy, not a URL
+    /// policy.
+    Url(Url),
+    /// `[scheme://]*.suffix[:port]` — subdomain wildcard.
+    ///
+    /// `suffix` stores the canonical lowercased suffix *including* the
+    /// leading dot, e.g. `".example.com"`. Matching requires the request
+    /// host to end with `suffix` AND have at least one character before
+    /// it, so `example.com` does NOT satisfy `*.example.com`.
+    SuffixWildcard {
+        suffix: String,
+        scheme: Option<Scheme>,
+        port: Option<u16>,
+    },
+}
+
+impl AllowedHost {
+    /// Returns `true` if `request` satisfies this allowlist entry.
+    ///
+    /// Inspects the URI's host, scheme, and explicit port. Path, query,
+    /// and fragment are not consulted — this is a host policy, not a URL
+    /// policy. A URI without a host (e.g. a relative `/path-only`) never
+    /// matches; the caller is expected to have already validated request
+    /// shape.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wash_runtime::host::allowed_hosts::AllowedHost;
+    ///
+    /// let policy: AllowedHost = "https://api.example.com".parse().unwrap();
+    /// let allowed: http::Uri = "https://api.example.com/v1".parse().unwrap();
+    /// let wrong_scheme: http::Uri = "http://api.example.com".parse().unwrap();
+    ///
+    /// assert!(policy.matches(&allowed));     // scheme + host match; path ignored
+    /// assert!(!policy.matches(&wrong_scheme));
+    /// ```
+    pub fn matches(&self, request: &Uri) -> bool {
+        let Some(request_host) = request.host() else {
+            return false;
+        };
+        let request_scheme = request.scheme_str();
+        let request_port = request.port_u16();
+
+        match self {
+            AllowedHost::Any => true,
+
+            AllowedHost::Authority(authority) => {
+                if !authority.host().eq_ignore_ascii_case(request_host) {
+                    return false;
+                }
+                // Unspecified port on the policy matches any request port.
+                match authority.port_u16() {
+                    Some(p) => Some(p) == request_port,
+                    None => true,
+                }
+            }
+
+            AllowedHost::Url(url) => {
+                let Some(policy_host) = url.host_str() else {
+                    return false;
+                };
+                if !policy_host.eq_ignore_ascii_case(request_host) {
+                    return false;
+                }
+                if let Some(req_scheme) = request_scheme
+                    && !url.scheme().eq_ignore_ascii_case(req_scheme)
+                {
+                    return false;
+                }
+                match url.port() {
+                    Some(p) => Some(p) == request_port,
+                    None => true,
+                }
+            }
+
+            AllowedHost::SuffixWildcard {
+                suffix,
+                scheme,
+                port,
+            } => {
+                // Require `host` to end with `.suffix-without-dot` AND have
+                // at least one char before the dot. `suffix` already has
+                // the leading dot baked in.
+                let host_lower = request_host.to_ascii_lowercase();
+                let Some(prefix) = host_lower.strip_suffix(suffix.as_str()) else {
+                    return false;
+                };
+                if prefix.is_empty() {
+                    return false;
+                }
+                if let (Some(pol_scheme), Some(req_scheme)) = (scheme.as_ref(), request_scheme)
+                    && !pol_scheme.as_str().eq_ignore_ascii_case(req_scheme)
+                {
+                    return false;
+                }
+                match port {
+                    Some(p) => Some(*p) == request_port,
+                    None => true,
+                }
+            }
+        }
+    }
+}
+
+impl FromStr for AllowedHost {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(anyhow!("allowed-host entry is empty"));
+        }
+
+        // 1. `*` (no scheme, no port).
+        if trimmed == "*" {
+            return Ok(AllowedHost::Any);
+        }
+
+        // 2. `scheme://…`. Sub-cases: wildcard (`scheme://*.foo`) vs. exact
+        //    (`scheme://host[:port]`). Match the wildcard form by hand since
+        //    `url::Url` won't parse `*.foo` as a host. Paths beyond bare `/`
+        //    are rejected for both sub-cases — this is a host policy, not a
+        //    URL policy, and silently stripping a path would teach the wrong
+        //    mental model (`https://api/v1` does NOT restrict to `/v1`).
+        if let Some((scheme_part, rest)) = trimmed.split_once("://") {
+            let scheme = Scheme::from_str(scheme_part)
+                .with_context(|| format!("invalid scheme '{scheme_part}'"))?;
+
+            if let Some(wildcard_rest) = rest.strip_prefix("*.") {
+                // `scheme://*.foo.com[:port][/]`
+                let (host_port, path) = wildcard_rest
+                    .split_once('/')
+                    .map_or((wildcard_rest, ""), |(h, p)| (h, p));
+                reject_non_root_path(path)?;
+                let (suffix_no_dot, port) = split_host_port(host_port)
+                    .with_context(|| format!("invalid wildcard host '{wildcard_rest}'"))?;
+                return Ok(AllowedHost::SuffixWildcard {
+                    suffix: format!(".{}", suffix_no_dot.to_ascii_lowercase()),
+                    scheme: Some(scheme),
+                    port,
+                });
+            }
+
+            // Plain URL form. Let `url::Url` do the heavy lifting, then
+            // reject anything beyond scheme + host + port + bare `/`.
+            // Error messages here don't repeat the entry text — callers
+            // (e.g. `TryFrom<v2::LocalResources>` in washlet) already wrap
+            // each error with `'<entry>':`, so duplicating it produces
+            // unreadable nested quoting.
+            let url = Url::parse(trimmed).context("not a valid URL")?;
+            if url.host_str().is_none() {
+                return Err(anyhow!("URL has no host"));
+            }
+            if url.path() != "" && url.path() != "/" {
+                return Err(anyhow!("must not include a path; got '{}'", url.path()));
+            }
+            if url.query().is_some() {
+                return Err(anyhow!("must not include a query string"));
+            }
+            if url.fragment().is_some() {
+                return Err(anyhow!("must not include a fragment"));
+            }
+            return Ok(AllowedHost::Url(url));
+        }
+
+        // 3. Scheme-less wildcard: `*.foo.com[:port]`.
+        if let Some(wildcard_rest) = trimmed.strip_prefix("*.") {
+            let (suffix_no_dot, port) = split_host_port(wildcard_rest)
+                .with_context(|| format!("invalid wildcard host '{wildcard_rest}'"))?;
+            return Ok(AllowedHost::SuffixWildcard {
+                suffix: format!(".{}", suffix_no_dot.to_ascii_lowercase()),
+                scheme: None,
+                port,
+            });
+        }
+
+        // 4. Reject ambiguous wildcards that don't follow `*.<rest>`. A
+        //    bare `*foo` would historically match `barfoo`, which is a
+        //    foot-gun (`*com` matches every .com). Make it a parse error.
+        if trimmed.starts_with('*') {
+            return Err(anyhow!(
+                "wildcard must be of the form `*.<rest>` (leading dot required)"
+            ));
+        }
+
+        // 5. Bare authority — `host[:port]`. Let `http::Authority` validate
+        //    the syntax; additionally reject `host:port` where `port` isn't
+        //    a valid u16. `Authority::port_u16()` returns `None` both when
+        //    no port is present and when the port string fails to parse, so
+        //    detect the "port suffix is present" case explicitly. IPv6 hosts
+        //    are bracket-wrapped so their host portion contains `:` itself;
+        //    the port (if any) follows `]:`, not the first `:`.
+        let authority = Authority::from_str(trimmed).context("invalid host[:port]")?;
+        let s = authority.as_str();
+        let has_port_suffix = if s.starts_with('[') {
+            s.contains("]:")
+        } else {
+            s.contains(':')
+        };
+        if has_port_suffix && authority.port_u16().is_none() {
+            return Err(anyhow!("invalid port"));
+        }
+        Ok(AllowedHost::Authority(authority))
+    }
+}
+
+impl fmt::Display for AllowedHost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AllowedHost::Any => f.write_str("*"),
+            AllowedHost::Authority(authority) => write!(f, "{authority}"),
+            AllowedHost::Url(url) => write!(f, "{url}"),
+            AllowedHost::SuffixWildcard {
+                suffix,
+                scheme,
+                port,
+            } => {
+                // `suffix` already has the leading dot; render the three
+                // optional pieces directly to the formatter to avoid
+                // intermediate `String` allocations.
+                if let Some(scheme) = scheme {
+                    write!(f, "{scheme}://")?;
+                }
+                write!(f, "*{suffix}")?;
+                if let Some(port) = port {
+                    write!(f, ":{port}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Serialize for AllowedHost {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for AllowedHost {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
+        s.parse().map_err(de::Error::custom)
+    }
+}
+
+/// Rejects any path component beyond the empty string.
+///
+/// Used for the wildcard arms where we hand-parse
+/// `scheme://*.foo[:port][/]` and need to refuse `scheme://*.foo/v1`
+/// while still accepting a bare trailing slash (`scheme://*.foo/`).
+fn reject_non_root_path(path: &str) -> anyhow::Result<()> {
+    if !path.is_empty() {
+        return Err(anyhow!("must not include a path; got '/{path}'"));
+    }
+    Ok(())
+}
+
+/// Parses `host` or `host:port` into `(host_no_port, Option<port>)`.
+///
+/// Rejects empty host and out-of-range / non-numeric ports.
+fn split_host_port(s: &str) -> anyhow::Result<(&str, Option<u16>)> {
+    match s.rsplit_once(':') {
+        Some((host, port_s)) => {
+            if host.is_empty() {
+                return Err(anyhow!("empty host before ':'"));
+            }
+            let port: u16 = port_s
+                .parse()
+                .with_context(|| format!("invalid port '{port_s}'"))?;
+            Ok((host, Some(port)))
+        }
+        None => {
+            if s.is_empty() {
+                return Err(anyhow!("empty host"));
+            }
+            Ok((s, None))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> AllowedHost {
+        s.parse()
+            .unwrap_or_else(|e| panic!("parse '{s}' failed: {e:#}"))
+    }
+
+    // ---- parsing ----
+
+    #[test]
+    fn parses_any() {
+        assert_eq!(parse("*"), AllowedHost::Any);
+    }
+
+    #[test]
+    fn parses_authority() {
+        match parse("example.com") {
+            AllowedHost::Authority(a) => {
+                assert_eq!(a.host(), "example.com");
+                assert_eq!(a.port_u16(), None);
+            }
+            other => panic!("expected Authority, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_authority_with_port() {
+        match parse("example.com:8080") {
+            AllowedHost::Authority(a) => {
+                assert_eq!(a.host(), "example.com");
+                assert_eq!(a.port_u16(), Some(8080));
+            }
+            other => panic!("expected Authority, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_url() {
+        // Bare scheme + host + port (no path) — the canonical URL form for
+        // a hosts policy. The path-rejection tests below cover the
+        // anything-beyond-`/` failure modes.
+        match parse("https://api.example.com:8443") {
+            AllowedHost::Url(u) => {
+                assert_eq!(u.scheme(), "https");
+                assert_eq!(u.host_str(), Some("api.example.com"));
+                assert_eq!(u.port(), Some(8443));
+            }
+            other => panic!("expected Url, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_suffix_wildcard_no_scheme() {
+        match parse("*.example.com") {
+            AllowedHost::SuffixWildcard {
+                suffix,
+                scheme,
+                port,
+            } => {
+                assert_eq!(suffix, ".example.com");
+                assert!(scheme.is_none());
+                assert!(port.is_none());
+            }
+            other => panic!("expected SuffixWildcard, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_suffix_wildcard_lowercases_suffix() {
+        match parse("*.Example.COM") {
+            AllowedHost::SuffixWildcard { suffix, .. } => assert_eq!(suffix, ".example.com"),
+            other => panic!("expected SuffixWildcard, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_suffix_wildcard_with_scheme_and_port() {
+        match parse("https://*.example.com:8443") {
+            AllowedHost::SuffixWildcard {
+                suffix,
+                scheme,
+                port,
+            } => {
+                assert_eq!(suffix, ".example.com");
+                assert_eq!(scheme.as_ref().map(Scheme::as_str), Some("https"));
+                assert_eq!(port, Some(8443));
+            }
+            other => panic!("expected SuffixWildcard, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_bare_star_prefix() {
+        let err = "*example.com".parse::<AllowedHost>().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("leading dot required"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_string() {
+        let err = "".parse::<AllowedHost>().unwrap_err();
+        assert!(format!("{err:#}").contains("empty"));
+    }
+
+    #[test]
+    fn rejects_invalid_port() {
+        let err = "example.com:notaport".parse::<AllowedHost>().unwrap_err();
+        // http::Authority reports its own error; just check parsing failed.
+        assert!(format!("{err:#}").contains("invalid"));
+    }
+
+    // ---- path/query/fragment rejection on URL form ----
+    //
+    // `allowed_hosts` is a hosts policy. Silently dropping `/v1` would teach
+    // users that `https://api/v1` restricts to that path, when it doesn't.
+    // Bare trailing `/` is fine because that's what `url::Url` normalizes to.
+
+    #[test]
+    fn url_accepts_bare_trailing_slash() {
+        let h: AllowedHost = "https://api.example.com/".parse().unwrap();
+        assert!(matches!(h, AllowedHost::Url(_)));
+    }
+
+    #[test]
+    fn url_accepts_no_path() {
+        // url::Url::parse normalizes this to add the trailing /, but the
+        // input form without it should also parse cleanly.
+        let h: AllowedHost = "https://api.example.com".parse().unwrap();
+        assert!(matches!(h, AllowedHost::Url(_)));
+    }
+
+    #[test]
+    fn url_rejects_non_root_path() {
+        let err = "https://api.example.com/v1"
+            .parse::<AllowedHost>()
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("must not include a path"), "{msg}");
+        assert!(msg.contains("/v1"), "{msg}");
+    }
+
+    #[test]
+    fn url_rejects_query() {
+        let err = "https://api.example.com/?q=1"
+            .parse::<AllowedHost>()
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("query"));
+    }
+
+    #[test]
+    fn url_rejects_fragment() {
+        let err = "https://api.example.com/#frag"
+            .parse::<AllowedHost>()
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("fragment"));
+    }
+
+    #[test]
+    fn wildcard_scheme_accepts_bare_trailing_slash() {
+        let h: AllowedHost = "https://*.example.com/".parse().unwrap();
+        assert!(matches!(h, AllowedHost::SuffixWildcard { .. }));
+    }
+
+    #[test]
+    fn wildcard_scheme_rejects_non_root_path() {
+        let err = "https://*.example.com/v1"
+            .parse::<AllowedHost>()
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("must not include a path"), "{msg}");
+        assert!(msg.contains("/v1"), "{msg}");
+    }
+
+    // ---- display round-trip ----
+
+    #[test]
+    fn display_round_trips() {
+        for s in [
+            "*",
+            "example.com",
+            "example.com:8080",
+            "https://api.example.com/",
+            "*.example.com",
+            "https://*.example.com:8443",
+        ] {
+            let parsed: AllowedHost = s.parse().unwrap();
+            let re_parsed: AllowedHost = parsed.to_string().parse().unwrap();
+            assert_eq!(parsed, re_parsed, "round-trip failed for {s}");
+        }
+    }
+
+    // ---- matching ----
+
+    fn uri(s: &str) -> Uri {
+        s.parse()
+            .unwrap_or_else(|e| panic!("URI '{s}' invalid: {e}"))
+    }
+
+    #[test]
+    fn any_matches_everything() {
+        let h = AllowedHost::Any;
+        assert!(h.matches(&uri("http://foo.example.com:8080/x")));
+        assert!(h.matches(&uri("https://bar")));
+    }
+
+    #[test]
+    fn any_does_not_match_request_with_no_host() {
+        // Relative URIs (path-only) have no host; nothing can match them.
+        let h = AllowedHost::Any;
+        assert!(!h.matches(&uri("/relative/path")));
+    }
+
+    #[test]
+    fn authority_matches_exact_case_insensitive() {
+        let h: AllowedHost = "Example.COM".parse().unwrap();
+        assert!(h.matches(&uri("https://example.com:443")));
+        assert!(h.matches(&uri("http://EXAMPLE.com")));
+        assert!(!h.matches(&uri("http://api.example.com")));
+    }
+
+    #[test]
+    fn authority_no_port_matches_any_request_port() {
+        let h: AllowedHost = "example.com".parse().unwrap();
+        assert!(h.matches(&uri("http://example.com")));
+        assert!(h.matches(&uri("http://example.com:80")));
+        assert!(h.matches(&uri("https://example.com:8443")));
+    }
+
+    #[test]
+    fn authority_with_port_pins_port() {
+        let h: AllowedHost = "example.com:8443".parse().unwrap();
+        assert!(h.matches(&uri("https://example.com:8443")));
+        assert!(!h.matches(&uri("https://example.com:443")));
+        assert!(!h.matches(&uri("https://example.com")));
+    }
+
+    #[test]
+    fn url_matches_scheme_host() {
+        let h: AllowedHost = "https://api.example.com".parse().unwrap();
+        assert!(h.matches(&uri("https://api.example.com")));
+        assert!(!h.matches(&uri("http://api.example.com")));
+        assert!(!h.matches(&uri("https://other.example.com")));
+    }
+
+    #[test]
+    fn url_ignores_request_path_and_query() {
+        // Locking the documented "path/query not consulted at match time"
+        // semantic — request path/query shouldn't affect whether the policy
+        // allows the request, only host/scheme/port do.
+        let h: AllowedHost = "https://api.example.com".parse().unwrap();
+        assert!(h.matches(&uri("https://api.example.com/v1/users?id=5")));
+        assert!(h.matches(&uri("https://api.example.com/admin")));
+    }
+
+    #[test]
+    fn suffix_wildcard_matches_subdomain_not_bare() {
+        let h: AllowedHost = "*.example.com".parse().unwrap();
+        assert!(h.matches(&uri("http://api.example.com")));
+        assert!(h.matches(&uri("http://a.b.example.com")));
+        assert!(!h.matches(&uri("http://example.com")));
+        assert!(!h.matches(&uri("http://evil.com")));
+    }
+
+    #[test]
+    fn suffix_wildcard_is_case_insensitive() {
+        let h: AllowedHost = "*.Example.COM".parse().unwrap();
+        assert!(h.matches(&uri("http://Sub.EXAMPLE.com")));
+    }
+
+    #[test]
+    fn suffix_wildcard_scheme_and_port_pin() {
+        let h: AllowedHost = "https://*.example.com:8443".parse().unwrap();
+        assert!(h.matches(&uri("https://api.example.com:8443")));
+        assert!(!h.matches(&uri("http://api.example.com:8443")));
+        assert!(!h.matches(&uri("https://api.example.com:443")));
+    }
+
+    #[test]
+    fn suffix_wildcard_with_port_pin_rejects_request_without_port() {
+        // Policy explicitly pins port 8443; a request omitting the port
+        // entirely (most defaults) does NOT match. This is intentional —
+        // matches "unspecified port on the request" to "explicit port on
+        // the policy" would be ambiguous and weaken the pin.
+        let h: AllowedHost = "*.example.com:8443".parse().unwrap();
+        assert!(h.matches(&uri("http://api.example.com:8443")));
+        assert!(!h.matches(&uri("http://api.example.com")));
+    }
+
+    #[test]
+    fn ipv6_authority_matches() {
+        // Authority::from_str accepts bracketed IPv6 with port; the matcher
+        // should compare host strings as the http crate exposes them (no
+        // brackets in Uri::host()).
+        let h: AllowedHost = "[::1]:8080".parse().unwrap();
+        assert!(h.matches(&uri("http://[::1]:8080")));
+        assert!(!h.matches(&uri("http://[::1]:9090")));
+    }
+
+    #[test]
+    fn ipv6_authority_without_port_parses_and_matches_any_port() {
+        // IPv6 hosts contain colons inside the brackets, which previously
+        // tripped the naive `as_str().contains(':')` port-suffix detector
+        // and made `[::1]` (no port) fail to parse. Lock the correct
+        // behavior: bracketed IPv6 with no port is a valid Authority and
+        // matches any request port.
+        let h: AllowedHost = "[::1]".parse().unwrap();
+        assert!(matches!(h, AllowedHost::Authority(_)));
+        assert!(h.matches(&uri("http://[::1]")));
+        assert!(h.matches(&uri("http://[::1]:8080")));
+        assert!(h.matches(&uri("https://[::1]:443")));
+    }
+
+    #[test]
+    fn ipv6_authority_with_invalid_port_is_rejected() {
+        // Lock the other side: a port suffix that doesn't parse as u16
+        // must still error for bracketed IPv6, not be silently accepted
+        // as "no port".
+        let err = "[::1]:notaport".parse::<AllowedHost>().unwrap_err();
+        assert!(format!("{err:#}").contains("invalid"), "{err:#}");
+    }
+
+    #[test]
+    fn localhost_authority_matches() {
+        // Single-label host — most common dev policy. Tests that the
+        // RFC-1123 single-label form survives the K8s-regex / parser
+        // round-trip even though the regex's per-label rule is the loosest
+        // place this could regress.
+        let h: AllowedHost = "localhost:8080".parse().unwrap();
+        assert!(h.matches(&uri("http://localhost:8080")));
+        assert!(!h.matches(&uri("http://localhost:9090")));
+    }
+
+    // ---- serde ----
+
+    #[test]
+    fn deserialize_from_json_list() {
+        let json = r#"["*", "example.com", "example.com:8443", "https://api.example.com", "*.example.com"]"#;
+        let parsed: Vec<AllowedHost> = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.len(), 5);
+        assert!(matches!(parsed[0], AllowedHost::Any));
+        assert!(matches!(parsed[4], AllowedHost::SuffixWildcard { .. }));
+    }
+
+    #[test]
+    fn deserialize_rejects_invalid_entry() {
+        let json = r#"["*com"]"#;
+        let err = serde_json::from_str::<Vec<AllowedHost>>(json).unwrap_err();
+        assert!(format!("{err}").contains("leading dot"), "{err}");
+    }
+
+    #[test]
+    fn serialize_round_trips_string() {
+        let h: AllowedHost = "https://*.example.com:8443".parse().unwrap();
+        let json = serde_json::to_string(&h).unwrap();
+        assert_eq!(json, "\"https://*.example.com:8443\"");
+    }
+}

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -26,6 +26,7 @@ use std::{
     time::Duration,
 };
 
+use crate::host::allowed_hosts::AllowedHost;
 use crate::wit::WitInterface;
 use crate::{engine::ctx::SharedCtx, observability::Meters};
 use crate::{engine::workload::ResolvedWorkload, observability::FuelConsumptionMeter};
@@ -76,8 +77,8 @@ fn is_valid_hostname(host: &str) -> bool {
 /// Why a request could not be routed to a workload.
 #[derive(Debug)]
 pub enum RouteError {
-    /// Request had no `Host` header a
-    /// genuinely malformed client request. Maps to 400.
+    /// Request had no `Host` header which is a genuinely malformed client
+    /// request. Maps to 400.
     MissingHost,
     /// No workload is currently bound to the host.
     /// `DynamicRouter` passes the offending host header; `DevRouter` is
@@ -139,7 +140,7 @@ pub trait Router: Send + Sync + 'static {
         workload_id: &str,
         request: &hyper::Request<wasmtime_wasi_http::p2::body::HyperOutgoingBody>,
         config: &wasmtime_wasi_http::p2::types::OutgoingRequestConfig,
-        _allowed_hosts: &[String],
+        _allowed_hosts: &[AllowedHost],
     ) -> anyhow::Result<()>;
 
     /// Determine if a P3 outgoing request is allowed.
@@ -149,7 +150,7 @@ pub trait Router: Send + Sync + 'static {
         _workload_id: &str,
         request: &hyper::Request<crate::host::http_p3::P3Body>,
         _options: Option<wasmtime_wasi_http::p3::RequestOptions>,
-        allowed_hosts: &[String],
+        allowed_hosts: &[AllowedHost],
     ) -> anyhow::Result<()> {
         check_allowed_hosts(request, allowed_hosts)
     }
@@ -258,7 +259,7 @@ impl Router for DynamicRouter {
         _workload_id: &str,
         request: &hyper::Request<wasmtime_wasi_http::p2::body::HyperOutgoingBody>,
         _config: &wasmtime_wasi_http::p2::types::OutgoingRequestConfig,
-        allowed_hosts: &[String],
+        allowed_hosts: &[AllowedHost],
     ) -> anyhow::Result<()> {
         check_allowed_hosts(request, allowed_hosts)
     }
@@ -396,23 +397,15 @@ impl Router for DevRouter {
     fn allow_outgoing_request(
         &self,
         _workload_id: &str,
-        _request: &hyper::Request<wasmtime_wasi_http::p2::body::HyperOutgoingBody>,
+        request: &hyper::Request<wasmtime_wasi_http::p2::body::HyperOutgoingBody>,
         _config: &wasmtime_wasi_http::p2::types::OutgoingRequestConfig,
-        _allowed_hosts: &[String],
+        allowed_hosts: &[AllowedHost],
     ) -> anyhow::Result<()> {
-        Ok(())
+        check_allowed_hosts(request, allowed_hosts)
     }
 
-    #[cfg(feature = "wasip3")]
-    fn allow_outgoing_request_p3(
-        &self,
-        _workload_id: &str,
-        _request: &hyper::Request<crate::host::http_p3::P3Body>,
-        _options: Option<wasmtime_wasi_http::p3::RequestOptions>,
-        _allowed_hosts: &[String],
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
+    // `allow_outgoing_request_p3` deliberately not overridden — the trait
+    // default calls `check_allowed_hosts`, matching the P2 behavior above.
 
     /// Pick a workload ID based on the incoming request
     fn route_incoming_request(
@@ -461,7 +454,7 @@ pub trait HostHandler: Send + Sync + 'static {
         workload_id: &str,
         request: hyper::Request<wasmtime_wasi_http::p2::body::HyperOutgoingBody>,
         config: wasmtime_wasi_http::p2::types::OutgoingRequestConfig,
-        allowed_hosts: &[String],
+        allowed_hosts: &[AllowedHost],
     ) -> wasmtime_wasi_http::p2::HttpResult<wasmtime_wasi_http::p2::types::HostFutureIncomingResponse>;
 
     /// Handle a P3 outgoing request, enforcing `allowed_hosts` policy and
@@ -479,7 +472,7 @@ pub trait HostHandler: Send + Sync + 'static {
         // Response-side body-error sink: unused here because hyper's response
         // body already reports body errors through its `Stream` impl.
         _fut: crate::host::http_p3::P3RequestErrorFuture,
-        allowed_hosts: &[String],
+        allowed_hosts: &[AllowedHost],
     ) -> crate::host::http_p3::P3SendFuture {
         if let Err(e) = check_allowed_hosts(&request, allowed_hosts) {
             use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
@@ -538,7 +531,7 @@ impl HostHandler for NullServer {
         _workload_id: &str,
         _request: hyper::Request<wasmtime_wasi_http::p2::body::HyperOutgoingBody>,
         _config: wasmtime_wasi_http::p2::types::OutgoingRequestConfig,
-        _allowed_hosts: &[String],
+        _allowed_hosts: &[AllowedHost],
     ) -> wasmtime_wasi_http::p2::HttpResult<wasmtime_wasi_http::p2::types::HostFutureIncomingResponse>
     {
         Err(wasmtime_wasi_http::p2::HttpError::trap(
@@ -553,7 +546,7 @@ impl HostHandler for NullServer {
         _request: hyper::Request<crate::host::http_p3::P3Body>,
         _options: Option<wasmtime_wasi_http::p3::RequestOptions>,
         _fut: crate::host::http_p3::P3RequestErrorFuture,
-        _allowed_hosts: &[String],
+        _allowed_hosts: &[AllowedHost],
     ) -> crate::host::http_p3::P3SendFuture {
         use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
         Box::new(async {
@@ -836,7 +829,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
         workload_id: &str,
         request: hyper::Request<wasmtime_wasi_http::p2::body::HyperOutgoingBody>,
         config: wasmtime_wasi_http::p2::types::OutgoingRequestConfig,
-        allowed_hosts: &[String],
+        allowed_hosts: &[AllowedHost],
     ) -> wasmtime_wasi_http::p2::HttpResult<wasmtime_wasi_http::p2::types::HostFutureIncomingResponse>
     {
         if let Err(e) =
@@ -862,7 +855,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
         request: hyper::Request<crate::host::http_p3::P3Body>,
         options: Option<wasmtime_wasi_http::p3::RequestOptions>,
         fut: crate::host::http_p3::P3RequestErrorFuture,
-        allowed_hosts: &[String],
+        allowed_hosts: &[AllowedHost],
     ) -> crate::host::http_p3::P3SendFuture {
         if let Err(e) =
             self.router
@@ -1235,36 +1228,40 @@ async fn load_tls_config(
     Ok(config)
 }
 
-/// Check if an outgoing request's host is permitted by the allowed_hosts list.
+/// Checks whether an outgoing request is permitted by the `allowed_hosts`
+/// policy.
 ///
-/// If `allowed_hosts` is empty, all requests are allowed.
-/// Supports wildcard patterns like `*.example.com` which match any subdomain.
+/// **Empty list = deny all.** A workload with no entries cannot
+/// reach any outbound host. Callers that want unrestricted egress must pass
+/// an explicit `[AllowedHost::Any]`. The wash config layer enforces this by
+/// substituting `[Any]` when `allowedHosts` is omitted from the YAML
+/// (see `wash::workload::resolve_workload`), so runtime callers that come
+/// through wash never see an empty list.
+///
+/// Otherwise the request's host (and, when the policy entry specifies them,
+/// scheme and port) must satisfy at least one [`AllowedHost`] entry. See
+/// [`AllowedHost::matches`] for per-variant semantics.
+///
+/// # Errors
+///
+/// Returns an error when the request has no host, when `allowed_hosts` is
+/// empty, or when no policy entry matches.
 pub fn check_allowed_hosts<B>(
     request: &hyper::Request<B>,
-    allowed_hosts: &[String],
+    allowed_hosts: &[AllowedHost],
 ) -> anyhow::Result<()> {
+    let uri = request.uri();
+    let request_host = uri.host().context("outgoing request has no host")?;
+
     if allowed_hosts.is_empty() {
-        return Ok(());
+        anyhow::bail!(
+            "outgoing request to host '{}' denied: allowed_hosts policy is empty (deny-all)",
+            request_host
+        );
     }
 
-    let request_host = request
-        .uri()
-        .host()
-        .context("outgoing request has no host")?;
-
-    let request_host_lower = request_host.to_ascii_lowercase();
-    for pattern in allowed_hosts {
-        if let Some(suffix) = pattern.strip_prefix('*') {
-            // Wildcard: *.example.com matches foo.example.com but not example.com
-            let suffix_lower = suffix.to_ascii_lowercase();
-            if let Some(prefix) = request_host_lower.strip_suffix(suffix_lower.as_str())
-                && !prefix.is_empty()
-            {
-                return Ok(());
-            }
-        } else if request_host.eq_ignore_ascii_case(pattern) {
-            return Ok(());
-        }
+    if allowed_hosts.iter().any(|entry| entry.matches(uri)) {
+        return Ok(());
     }
 
     anyhow::bail!(
@@ -1600,61 +1597,79 @@ mod tests {
 
     // --- check_allowed_hosts tests ---
 
+    fn hosts(entries: &[&str]) -> Vec<AllowedHost> {
+        entries.iter().map(|s| s.parse().unwrap()).collect()
+    }
+
     #[test]
-    fn empty_allowed_hosts_permits_any() {
+    fn empty_allowed_hosts_denies_all() {
+        // An empty policy means no egress. To opt into allow-all
+        // the caller must pass an explicit `[AllowedHost::Any]`.
         let req = build_request("http://anything.example.com/path");
-        assert!(check_allowed_hosts(&req, &[]).is_ok());
+        let err = check_allowed_hosts(&req, &[]).unwrap_err();
+        assert!(err.to_string().contains("deny-all"), "{}", err.to_string());
+    }
+
+    #[test]
+    fn explicit_any_permits_anything() {
+        let req = build_request("http://anything.example.com/path");
+        assert!(check_allowed_hosts(&req, &hosts(&["*"])).is_ok());
     }
 
     #[test]
     fn exact_match_works() {
         let req = build_request("http://example.com/path");
-        let hosts = vec!["example.com".to_string()];
-        assert!(check_allowed_hosts(&req, &hosts).is_ok());
+        assert!(check_allowed_hosts(&req, &hosts(&["example.com"])).is_ok());
     }
 
     #[test]
     fn exact_match_is_case_insensitive() {
         let req = build_request("http://example.com/path");
-        let hosts = vec!["Example.COM".to_string()];
-        assert!(check_allowed_hosts(&req, &hosts).is_ok());
+        assert!(check_allowed_hosts(&req, &hosts(&["Example.COM"])).is_ok());
     }
 
     #[test]
     fn wildcard_matches_subdomain() {
         let req = build_request("http://sub.example.com/path");
-        let hosts = vec!["*.example.com".to_string()];
-        assert!(check_allowed_hosts(&req, &hosts).is_ok());
+        assert!(check_allowed_hosts(&req, &hosts(&["*.example.com"])).is_ok());
     }
 
     #[test]
     fn wildcard_does_not_match_bare_domain() {
         let req = build_request("http://example.com/path");
-        let hosts = vec!["*.example.com".to_string()];
-        assert!(check_allowed_hosts(&req, &hosts).is_err());
+        assert!(check_allowed_hosts(&req, &hosts(&["*.example.com"])).is_err());
     }
 
     #[test]
     fn wildcard_is_case_insensitive() {
         let req = build_request("http://sub.example.com/path");
-        let hosts = vec!["*.Example.COM".to_string()];
-        assert!(check_allowed_hosts(&req, &hosts).is_ok());
+        assert!(check_allowed_hosts(&req, &hosts(&["*.Example.COM"])).is_ok());
     }
 
     #[test]
     fn non_matching_host_is_rejected() {
         let req = build_request("http://evil.com/path");
-        let hosts = vec!["example.com".to_string()];
-        let err = check_allowed_hosts(&req, &hosts).unwrap_err();
+        let err = check_allowed_hosts(&req, &hosts(&["example.com"])).unwrap_err();
         assert!(err.to_string().contains("not allowed"));
     }
 
     #[test]
     fn request_with_no_host_returns_error() {
         let req = build_request("/path-only");
-        let hosts = vec!["example.com".to_string()];
-        let err = check_allowed_hosts(&req, &hosts).unwrap_err();
+        let err = check_allowed_hosts(&req, &hosts(&["example.com"])).unwrap_err();
         assert!(err.to_string().contains("no host"));
+    }
+
+    #[test]
+    fn star_any_matches_everything() {
+        let req = build_request("http://anything.example.com/path");
+        assert!(check_allowed_hosts(&req, &hosts(&["*"])).is_ok());
+    }
+
+    #[test]
+    fn url_policy_pins_scheme() {
+        let req = build_request("http://api.example.com/path");
+        assert!(check_allowed_hosts(&req, &hosts(&["https://api.example.com"])).is_err());
     }
 
     // --- error_response tests ---
@@ -1718,7 +1733,10 @@ mod tests {
             .await
             .unwrap();
         let request = build_request("http://example.com/");
-        let _ = server.outgoing_request("test-workload", request, dummy_config(), &[]);
+        // Explicit `[Any]` policy so the deny-all-on-empty default doesn't
+        // short-circuit before reaching the spy.
+        let allow_any = [AllowedHost::Any];
+        let _ = server.outgoing_request("test-workload", request, dummy_config(), &allow_any);
         assert!(called.load(std::sync::atomic::Ordering::SeqCst));
     }
 
@@ -1739,7 +1757,11 @@ mod tests {
             .header(hyper::header::CONTENT_TYPE, "application/grpc")
             .body(HyperOutgoingBody::default())
             .unwrap();
-        let _ = server.outgoing_request("test-workload", request, dummy_config(), &[]);
+        // `[Any]` lets the policy check pass so the test actually verifies
+        // the gRPC dispatch path. With `&[]` (deny-all), the spy would
+        // appear "not called" because policy denied — for the wrong reason.
+        let allow_any = [AllowedHost::Any];
+        let _ = server.outgoing_request("test-workload", request, dummy_config(), &allow_any);
         assert!(!called.load(std::sync::atomic::Ordering::SeqCst));
     }
 

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -62,6 +62,7 @@ use crate::wit::{WitInterface, WitWorld};
 mod sysinfo;
 use sysinfo::SystemMonitor;
 
+pub mod allowed_hosts;
 pub mod http;
 #[cfg(feature = "wasip3")]
 pub mod http_p3;

--- a/crates/wash-runtime/src/plugin/wasi_config/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_config/mod.rs
@@ -49,20 +49,29 @@ type ConfigMap = HashMap<Arc<str>, HashMap<String, String>>;
 /// This plugin implements the WASI config interface, allowing components to
 /// retrieve configuration values and environment variables at runtime. Each
 /// component gets isolated access to its own configuration scope.
-#[derive(Clone, Default)]
+///
+/// Construct via [`DynamicConfig::builder`] (or [`Default::default`]) so new
+/// optional knobs land without breaking callers.
+///
+/// # Examples
+///
+/// ```
+/// use wash_runtime::plugin::wasi_config::DynamicConfig;
+///
+/// let _plugin = DynamicConfig::builder().copy_environment(true).build();
+/// ```
+#[derive(Clone, Default, bon::Builder)]
 pub struct DynamicConfig {
+    /// When `true`, the component's `LocalResources.environment` is merged
+    /// into the per-component `wasi:config/store` view at bind time,
+    /// surfacing workload env vars to components as both env vars and
+    /// config entries without further plumbing.
+    #[builder(default)]
     copy_environment: bool,
-    /// A map of configuration from component id to key-value pairs
+    /// Per-component-id key-value store. Always starts empty; not part of
+    /// the builder surface.
+    #[builder(skip)]
     config: Arc<RwLock<ConfigMap>>,
-}
-
-impl DynamicConfig {
-    pub fn new(copy_environment: bool) -> Self {
-        Self {
-            copy_environment,
-            ..Default::default()
-        }
-    }
 }
 
 impl<'a> bindings::wasi::config::store::Host for ActiveCtx<'a> {

--- a/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
@@ -32,6 +32,12 @@ use crate::wit::{WitInterface, WitWorld};
 
 const WASI_OTEL_ID: &str = "wasi-otel";
 
+/// OTel gRPC default per the OTLP/gRPC spec. Matches what
+/// `opentelemetry_otlp::SpanExporter::builder().with_tonic()` falls back to
+/// when no `OTEL_EXPORTER_OTLP_*_ENDPOINT` is set; duplicated here only so
+/// the log line at plugin start reflects what the exporter actually used.
+const DEFAULT_OTLP_GRPC_ENDPOINT: &str = "http://localhost:4317";
+
 mod bindings {
     wasmtime::component::bindgen!({
         world: "otel",
@@ -41,17 +47,33 @@ mod bindings {
 
 use bindings::wasi::otel::tracing::{SpanContext as WitSpanContext, TraceFlags as WitTraceFlags};
 
-/// Plugin configuration
-#[derive(Clone, Debug)]
+/// Configuration for the [`WasiOtel`] plugin.
+///
+/// Construct via [`WasiOtelConfig::builder`] (or [`Default::default`]) to
+/// stay forward-compatible with new fields.
+///
+/// # Examples
+///
+/// ```
+/// use wash_runtime::plugin::wasi_otel::WasiOtelConfig;
+///
+/// let cfg = WasiOtelConfig::builder()
+///     .service_name("my-service")
+///     .build();
+/// assert_eq!(cfg.service_name, "my-service");
+/// ```
+#[derive(Clone, Debug, bon::Builder)]
+#[non_exhaustive]
 pub struct WasiOtelConfig {
+    /// `service.name` resource attribute attached to all exported spans,
+    /// metrics, and logs. Defaults to the plugin id (`wasi-otel`).
+    #[builder(default = WASI_OTEL_ID.to_string(), into)]
     pub service_name: String,
 }
 
 impl Default for WasiOtelConfig {
     fn default() -> Self {
-        Self {
-            service_name: "wasi-otel".to_string(),
-        }
+        Self::builder().build()
     }
 }
 
@@ -104,11 +126,12 @@ impl HostPlugin for WasiOtel {
     async fn start(&self) -> anyhow::Result<()> {
         // The exporter resolves its endpoint from `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`,
         // then `OTEL_EXPORTER_OTLP_ENDPOINT`, falling back to the OTel gRPC default
-        // (`http://localhost:4317`). Protocol is fixed to gRPC because we use
-        // `with_tonic()` below.
+        // ([`DEFAULT_OTLP_GRPC_ENDPOINT`]). Protocol is fixed to gRPC because we use
+        // `with_tonic()` below; tracking richer per-target endpoint configuration as a
+        // follow-up to this PR (see TODO below).
         let endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
             .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT"))
-            .unwrap_or_else(|_| "http://localhost:4317".to_string());
+            .unwrap_or_else(|_| DEFAULT_OTLP_GRPC_ENDPOINT.to_string());
         tracing::info!(
             endpoint = %endpoint,
             protocol = "grpc",

--- a/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
@@ -44,21 +44,13 @@ use bindings::wasi::otel::tracing::{SpanContext as WitSpanContext, TraceFlags as
 /// Plugin configuration
 #[derive(Clone, Debug)]
 pub struct WasiOtelConfig {
-    pub endpoint: String,
-    pub protocol: String,
     pub service_name: String,
-    pub propagate_context: bool,
-    pub batch_timeout_ms: u64,
 }
 
 impl Default for WasiOtelConfig {
     fn default() -> Self {
         Self {
-            endpoint: String::new(),
-            protocol: String::new(),
             service_name: "wasi-otel".to_string(),
-            propagate_context: true,
-            batch_timeout_ms: 5000,
         }
     }
 }
@@ -110,14 +102,21 @@ impl HostPlugin for WasiOtel {
     }
 
     async fn start(&self) -> anyhow::Result<()> {
+        // The exporter resolves its endpoint from `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`,
+        // then `OTEL_EXPORTER_OTLP_ENDPOINT`, falling back to the OTel gRPC default
+        // (`http://localhost:4317`). Protocol is fixed to gRPC because we use
+        // `with_tonic()` below.
+        let endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+            .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT"))
+            .unwrap_or_else(|_| "http://localhost:4317".to_string());
         tracing::info!(
-            endpoint = %self.config.endpoint,
-            protocol = %self.config.protocol,
+            endpoint = %endpoint,
+            protocol = "grpc",
             "Starting WASI OTel plugin"
         );
 
-        // TODO: Add configurable endpoints/protocols to use. This would be beneficial for when you want to have Host otel go to Platform engineering teams,
-        // And Workload otel go to a different backend for application monitoring.
+        // TODO: thread per-target endpoints (host vs workload) through `WasiOtelConfig`
+        // so platform telemetry and application telemetry can ship to different backends.
 
         // set up the grpc span exporter
         let span_exporter = SpanExporter::builder()

--- a/crates/wash-runtime/src/types.rs
+++ b/crates/wash-runtime/src/types.rs
@@ -17,6 +17,7 @@
 use bytes::Bytes;
 use std::{collections::HashMap, sync::Arc};
 
+use crate::host::allowed_hosts::AllowedHost;
 use crate::wit::WitInterface;
 
 /// Represents a deployable workload containing one or more WebAssembly components.
@@ -78,10 +79,20 @@ pub struct LocalResources {
     /// Allows passing arbitrary configuration values to influence implementation behavior for all component interfaces.
     /// Example: tracing=disable
     pub config: HashMap<String, String>,
-    // wasi:cli/env variables, copied to WasiCtxBuilder
+    /// `wasi:cli/env` variables, copied to `WasiCtxBuilder` at component
+    /// instantiation.
     pub environment: HashMap<String, String>,
     pub volume_mounts: Vec<VolumeMount>,
-    pub allowed_hosts: Arc<[String]>,
+    /// Parsed outbound allowlist.
+    /// **Empty = deny all outgoing requests**. See
+    /// [`crate::host::http::check_allowed_hosts`]). To opt into
+    /// unrestricted egress, pass an explicit `[AllowedHost::Any]`. The
+    /// wash config layer substitutes `[Any]` when `allowedHosts` is
+    /// omitted from YAML, so workloads coming through `wash dev` never
+    /// land here with an unintentionally-empty list. Strings from the
+    /// wire (proto / wash YAML) are parsed at conversion time, so the
+    /// request hot path matches against the typed enum directly.
+    pub allowed_hosts: Arc<[AllowedHost]>,
 }
 
 impl Default for LocalResources {

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use crate::host::{Host, HostApi, HostConfig};
 use crate::oci::{self, OciConfig};
 use crate::plugin::HostPlugin;
-use anyhow::Context as _;
+use anyhow::{Context as _, anyhow};
 use futures::StreamExt as _;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, instrument};
@@ -409,15 +409,29 @@ async fn workload_start(
                     });
                 }
             };
+            let local_resources = match component.local_resources.clone() {
+                Some(lr) => match crate::types::LocalResources::try_from(lr) {
+                    Ok(lr) => lr,
+                    Err(e) => {
+                        return Ok(types::v2::WorkloadStartResponse {
+                            workload_status: Some(types::v2::WorkloadStatus {
+                                workload_id: workload_id.clone(),
+                                workload_state: types::v2::WorkloadState::Error.into(),
+                                message: format!(
+                                    "invalid local_resources for component {}: {e:#}",
+                                    component.name
+                                ),
+                            }),
+                        });
+                    }
+                },
+                None => crate::types::LocalResources::default(),
+            };
             pulled_components.push(crate::types::Component {
                 name: component.name.clone(),
                 bytes: bytes.into(),
                 digest: Some(digest),
-                local_resources: component
-                    .local_resources
-                    .clone()
-                    .map(Into::into)
-                    .unwrap_or_default(),
+                local_resources,
                 pool_size: component.pool_size,
                 max_invocations: component.max_invocations,
             })
@@ -454,14 +468,25 @@ async fn workload_start(
                 });
             }
         };
+        let local_resources = match service.local_resources.clone() {
+            Some(lr) => match crate::types::LocalResources::try_from(lr) {
+                Ok(lr) => lr,
+                Err(e) => {
+                    return Ok(types::v2::WorkloadStartResponse {
+                        workload_status: Some(types::v2::WorkloadStatus {
+                            workload_id: workload_id.clone(),
+                            workload_state: types::v2::WorkloadState::Error.into(),
+                            message: format!("invalid local_resources for service: {e:#}"),
+                        }),
+                    });
+                }
+            },
+            None => crate::types::LocalResources::default(),
+        };
         Some(crate::types::Service {
             bytes: bytes.into(),
             digest: Some(digest),
-            local_resources: service
-                .local_resources
-                .clone()
-                .map(Into::into)
-                .unwrap_or_default(),
+            local_resources,
             max_restarts: service.max_restarts,
         })
     } else {
@@ -569,16 +594,45 @@ impl From<types::v2::Volume> for crate::types::Volume {
     }
 }
 
-impl From<types::v2::LocalResources> for crate::types::LocalResources {
-    fn from(lr: types::v2::LocalResources) -> Self {
-        crate::types::LocalResources {
+impl TryFrom<types::v2::LocalResources> for crate::types::LocalResources {
+    type Error = anyhow::Error;
+
+    fn try_from(lr: types::v2::LocalResources) -> Result<Self, Self::Error> {
+        // Parse `allowed_hosts` eagerly: every entry must be a recognized
+        // form (`*`, `*.foo`, `host[:port]`, or `scheme://…`). A bad entry
+        // fails the conversion so the workload start surfaces a clear error
+        // rather than silently widening egress. All parse failures are
+        // collected and joined into one error so a workload with several
+        // bad entries doesn't make the user fix them one-by-one.
+        let mut parsed: Vec<crate::host::allowed_hosts::AllowedHost> =
+            Vec::with_capacity(lr.allowed_hosts.len());
+        let mut errors: Vec<String> = Vec::new();
+        for s in &lr.allowed_hosts {
+            // Per-entry messages are formatted as `'<entry>': <parse error>`
+            // (no leading "invalid allowed_hosts" — that's the outer
+            // wrapper's job). The final message renders as one heading line
+            // plus a bullet per bad entry so multi-error output is scannable
+            // in a terminal.
+            match s.parse::<crate::host::allowed_hosts::AllowedHost>() {
+                Ok(entry) => parsed.push(entry),
+                Err(e) => errors.push(format!("'{s}': {e:#}")),
+            }
+        }
+        if !errors.is_empty() {
+            return Err(anyhow!(
+                "invalid allowed_hosts:\n  - {}",
+                errors.join("\n  - ")
+            ));
+        }
+        let allowed_hosts: Arc<[_]> = parsed.into();
+        Ok(crate::types::LocalResources {
             memory_limit_mb: lr.memory_limit_mb,
             cpu_limit: lr.cpu_limit,
             config: lr.config,
             volume_mounts: lr.volume_mounts.into_iter().map(Into::into).collect(),
-            allowed_hosts: lr.allowed_hosts.into(),
+            allowed_hosts,
             environment: lr.environment,
-        }
+        })
     }
 }
 
@@ -689,6 +743,85 @@ impl From<types::v2::ImagePullPolicy> for crate::oci::OciPullPolicy {
 mod tests {
 
     use super::*;
+    use crate::host::allowed_hosts::AllowedHost;
+
+    #[test]
+    fn try_from_v2_local_resources_parses_allowed_hosts() {
+        // Strings flowing in from the proto wire are parsed into typed
+        // `AllowedHost` entries. Valid forms should round-trip cleanly.
+        let proto = types::v2::LocalResources {
+            memory_limit_mb: 0,
+            cpu_limit: 0,
+            config: Default::default(),
+            environment: Default::default(),
+            volume_mounts: vec![],
+            allowed_hosts: vec![
+                "*".to_string(),
+                "*.example.com".to_string(),
+                "api.example.com:8443".to_string(),
+                "https://api.example.com".to_string(),
+            ],
+        };
+        let lr = crate::types::LocalResources::try_from(proto).expect("conversion should succeed");
+        assert_eq!(lr.allowed_hosts.len(), 4);
+        assert!(matches!(lr.allowed_hosts[0], AllowedHost::Any));
+        assert!(matches!(
+            lr.allowed_hosts[1],
+            AllowedHost::SuffixWildcard { .. }
+        ));
+        assert!(matches!(lr.allowed_hosts[2], AllowedHost::Authority(_)));
+        assert!(matches!(lr.allowed_hosts[3], AllowedHost::Url(_)));
+    }
+
+    #[test]
+    fn try_from_v2_local_resources_rejects_bad_allowed_hosts_entry() {
+        // An ambiguous wildcard (`*com` matches every .com) must be
+        // rejected — the K8s pattern guards this at admission time, but
+        // workloads constructed by other paths land here and the
+        // workload start should surface a clear error rather than
+        // silently widen egress.
+        let proto = types::v2::LocalResources {
+            memory_limit_mb: 0,
+            cpu_limit: 0,
+            config: Default::default(),
+            environment: Default::default(),
+            volume_mounts: vec![],
+            allowed_hosts: vec!["*com".to_string()],
+        };
+        let err = crate::types::LocalResources::try_from(proto)
+            .expect_err("conversion should reject ambiguous wildcard");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("*com"), "{msg}");
+        assert!(
+            msg.contains("leading dot") || msg.contains("invalid"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn try_from_v2_local_resources_collects_all_allowed_hosts_errors() {
+        // Three bad entries in one workload — the conversion should report
+        // all three in a single error so the user doesn't have to iterate
+        // fix → start → fail → fix → start → ... for each entry.
+        let proto = types::v2::LocalResources {
+            memory_limit_mb: 0,
+            cpu_limit: 0,
+            config: Default::default(),
+            environment: Default::default(),
+            volume_mounts: vec![],
+            allowed_hosts: vec![
+                "*com".to_string(),                       // bare-star wildcard
+                "https://api.example.com/v1".to_string(), // has path
+                "example.com:notaport".to_string(),       // bad port
+            ],
+        };
+        let err = crate::types::LocalResources::try_from(proto)
+            .expect_err("conversion should reject all bad entries");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("*com"), "{msg}");
+        assert!(msg.contains("/v1"), "{msg}");
+        assert!(msg.contains("notaport"), "{msg}");
+    }
 
     #[tokio::test]
     async fn test_image_pull_secret_to_oci_config_none() {

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -157,13 +157,16 @@ pub fn component_workload_request(
 }
 
 pub fn default_counter_resources() -> LocalResources {
+    // http-counter calls example.com — encode that exact host in the
+    // policy so the deny-all default doesn't block it AND the test
+    // documents which upstream the fixture talks to.
     LocalResources {
         memory_limit_mb: 256,
         cpu_limit: 1,
         config: HashMap::new(),
         environment: HashMap::new(),
         volume_mounts: vec![],
-        allowed_hosts: Default::default(),
+        allowed_hosts: vec!["example.com".parse().unwrap()].into(),
     }
 }
 

--- a/crates/wash-runtime/tests/fixtures/http-allowed-hosts/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/http-allowed-hosts/src/lib.rs
@@ -1,48 +1,48 @@
+use wstd::http::error::ErrorCode;
 use wstd::http::{Body, Client, Request, Response, StatusCode};
+
+// The fixture reports the host-side allowed_hosts policy decision via its
+// own status code, not the upstream's:
+//
+// - 200 OK          — request reached upstream (which may return any status)
+// - 403 Forbidden   — denied by the wasmCloud host's allowed_hosts policy
+// - 502 Bad Gateway — any other client error (DNS, network, TLS, timeout)
+//
+// Reporting upstream status as-is would conflate "the host rejected this on
+// policy grounds" with "the upstream returned a 4xx/5xx," so tests couldn't
+// tell the two apart.
 
 #[wstd::http_server]
 async fn main(req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
     match req.uri().path_and_query().unwrap().as_str() {
-        "/example" => fetch_example().await,
-        "/wiki" => fetch_wiki().await,
+        "/example" => fetch("http://example.com").await,
+        "/org" => fetch("http://example.org").await,
+        "/www" => fetch("http://www.example.com").await,
         _ => not_found().await,
     }
 }
 
-async fn fetch_example() -> Result<Response<Body>, wstd::http::Error> {
+async fn fetch(url: &str) -> Result<Response<Body>, wstd::http::Error> {
     let client = Client::new();
-    let req = Request::get("http://example.com")
-        .body(Body::empty())
-        .unwrap();
-    match client.send(req).await {
-        Ok(resp) => Ok(Response::builder()
-            .status(resp.status())
-            .body(Body::from(format!("example.com: status {}", resp.status())))
-            .unwrap()),
-        Err(e) => Ok(Response::builder()
-            .status(StatusCode::INTERNAL_SERVER_ERROR)
-            .body(Body::from(format!("example.com request failed: {e}")))
-            .unwrap()),
-    }
+    let req = Request::get(url).body(Body::empty()).unwrap();
+    let (status, body) = match client.send(req).await {
+        Ok(resp) => (StatusCode::OK, format!("{url}: upstream {}", resp.status())),
+        Err(e) => (status_for_error(&e), format!("{url} failed: {e}")),
+    };
+    Ok(Response::builder()
+        .status(status)
+        .body(Body::from(body))
+        .unwrap())
 }
 
-async fn fetch_wiki() -> Result<Response<Body>, wstd::http::Error> {
-    let client = Client::new();
-    let req = Request::get("https://en.wikipedia.org")
-        .body(Body::empty())
-        .unwrap();
-    match client.send(req).await {
-        Ok(resp) => Ok(Response::builder()
-            .status(resp.status())
-            .body(Body::from(format!(
-                "en.wikipedia.org: status {}",
-                resp.status()
-            )))
-            .unwrap()),
-        Err(e) => Ok(Response::builder()
-            .status(StatusCode::INTERNAL_SERVER_ERROR)
-            .body(Body::from(format!("en.wikipedia.org request blocked: {e}")))
-            .unwrap()),
+fn status_for_error(e: &wstd::http::Error) -> StatusCode {
+    if matches!(
+        e.downcast_ref::<ErrorCode>(),
+        Some(ErrorCode::HttpRequestDenied)
+    ) {
+        StatusCode::FORBIDDEN
+    } else {
+        StatusCode::BAD_GATEWAY
     }
 }
 

--- a/crates/wash-runtime/tests/integration_http_allowed_hosts.rs
+++ b/crates/wash-runtime/tests/integration_http_allowed_hosts.rs
@@ -2,7 +2,21 @@
 //!
 //! Uses the http-allowed-hosts component which:
 //! - `/example` makes an outgoing request to `example.com`
-//! - `/wiki` makes an outgoing request to `en.wikipedia.org`
+//! - `/org`     makes an outgoing request to `example.org` (unrelated domain)
+//! - `/www`     makes an outgoing request to `www.example.com` (subdomain)
+//!
+//! All three targets are IANA-reserved (RFC 2606), so tests don't depend on
+//! third-party bot-detection or rate limits. Having three lets us cover the
+//! three distinct match outcomes:
+//! - exact host match           (`/example` vs policy `example.com`)
+//! - unrelated host             (`/org`     vs policy `example.com`)
+//! - subdomain of policy host   (`/www`     vs policy `example.com` or `*.example.com`)
+//!
+//! The fixture reports the policy outcome via its own status, not the
+//! upstream's:
+//! - 200 OK          — upstream was reached (whatever upstream returned)
+//! - 403 Forbidden   — denied by the host's allowed_hosts policy
+//! - 502 Bad Gateway — DNS/network/TLS failure (treated as "egress unavailable")
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -82,17 +96,18 @@ fn allowed_hosts_workload(allowed_hosts: Vec<String>) -> WorkloadStartRequest {
     }
 }
 
-/// Only example.com is allowed. `/wiki` (→ en.wikipedia.org) should be blocked,
-/// `/example` (→ example.com) should succeed.
+/// Exact `example.com` allows `/example` but blocks `/org` (unrelated domain)
+/// and `/www` (subdomain). Locks two invariants of the bare-authority
+/// variant: it doesn't permit unrelated hosts, and it doesn't implicitly
+/// expand into a subdomain wildcard.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_allowed_hosts_blocks_denied_host() -> Result<()> {
-    tracing_subscriber::fmt()
+    let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+        .try_init();
 
     let (addr, host) = start_host("127.0.0.1:0").await?;
 
-    // Only allow example.com — en.wikipedia.org should be blocked
     let req = allowed_hosts_workload(vec!["example.com".to_string()]);
     host.workload_start(req)
         .await
@@ -100,23 +115,30 @@ async fn test_allowed_hosts_blocks_denied_host() -> Result<()> {
 
     let client = reqwest::Client::new();
 
-    // /wiki should be blocked by policy
-    let wiki_response = timeout(
-        Duration::from_secs(10),
-        client
-            .get(format!("http://{addr}/wiki"))
-            .header("HOST", "test")
-            .send(),
-    )
-    .await
-    .context("Wiki request timed out")?
-    .context("Failed to make wiki request")?;
+    for (path, why) in [
+        ("/org", "unrelated host (example.org)"),
+        (
+            "/www",
+            "subdomain (www.example.com) — bare authority is exact, not a wildcard",
+        ),
+    ] {
+        let response = timeout(
+            Duration::from_secs(10),
+            client
+                .get(format!("http://{addr}{path}"))
+                .header("HOST", "test")
+                .send(),
+        )
+        .await
+        .context(format!("{path} request timed out"))?
+        .context(format!("Failed to make {path} request"))?;
 
-    assert_eq!(
-        wiki_response.status().as_u16(),
-        500,
-        "Request to en.wikipedia.org should be blocked"
-    );
+        assert_eq!(
+            response.status().as_u16(),
+            403,
+            "{path} should be blocked by policy `[example.com]`: {why}"
+        );
+    }
 
     // /example should succeed (example.com is in allowed_hosts)
     let example_response = timeout(
@@ -131,9 +153,11 @@ async fn test_allowed_hosts_blocks_denied_host() -> Result<()> {
     .context("Failed to make example request")?;
 
     let status = example_response.status();
-    // example.com should be reachable; 502 is acceptable if network is unavailable in CI
+    // example.com is in the allowlist, so 200 (upstream reached) is the
+    // success case. 502 covers CI runs where egress is unavailable — still
+    // a pass since the host didn't reject the request on policy grounds.
     assert!(
-        status.is_success() || status.as_u16() == 502,
+        status.as_u16() == 200 || status.as_u16() == 502,
         "Request to example.com should be allowed (got {})",
         status
     );
@@ -141,56 +165,63 @@ async fn test_allowed_hosts_blocks_denied_host() -> Result<()> {
     Ok(())
 }
 
-/// Wildcard *.wikipedia.org allows en.wikipedia.org but blocks example.com.
+/// Wildcard `*.example.com` allows the `www.example.com` subdomain but blocks
+/// both the bare `example.com` (wildcard requires a non-empty prefix) and
+/// `example.org` (unrelated domain).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_allowed_hosts_wildcard() -> Result<()> {
     let (addr, host) = start_host("127.0.0.1:0").await?;
 
-    // Allow *.wikipedia.org — en.wikipedia.org should pass,
-    // but example.com should be blocked
-    let req = allowed_hosts_workload(vec!["*.wikipedia.org".to_string()]);
+    let req = allowed_hosts_workload(vec!["*.example.com".to_string()]);
     host.workload_start(req)
         .await
         .context("Failed to start workload")?;
 
     let client = reqwest::Client::new();
 
-    // /wiki targets en.wikipedia.org — should be ALLOWED by wildcard
-    let wiki_response = timeout(
+    // /www targets www.example.com — should be ALLOWED by wildcard
+    let www_response = timeout(
         Duration::from_secs(10),
         client
-            .get(format!("http://{addr}/wiki"))
+            .get(format!("http://{addr}/www"))
             .header("HOST", "test")
             .send(),
     )
     .await
-    .context("Wiki request timed out")?
-    .context("Failed to make wiki request")?;
+    .context("www request timed out")?
+    .context("Failed to make www request")?;
 
-    let status = wiki_response.status();
-    assert_ne!(
-        status.as_u16(),
-        500,
-        "Request to en.wikipedia.org should be allowed by *.wikipedia.org wildcard"
+    let status = www_response.status();
+    assert!(
+        status.as_u16() == 200 || status.as_u16() == 502,
+        "Request to www.example.com should be allowed by *.example.com wildcard (got {})",
+        status
     );
 
-    // /example targets example.com — should be BLOCKED (not in *.wikipedia.org)
-    let example_response = timeout(
-        Duration::from_secs(10),
-        client
-            .get(format!("http://{addr}/example"))
-            .header("HOST", "test")
-            .send(),
-    )
-    .await
-    .context("Example request timed out")?
-    .context("Failed to make example request")?;
+    for (path, why) in [
+        (
+            "/example",
+            "bare example.com (wildcard requires a non-empty prefix)",
+        ),
+        ("/org", "example.org (unrelated domain)"),
+    ] {
+        let response = timeout(
+            Duration::from_secs(10),
+            client
+                .get(format!("http://{addr}{path}"))
+                .header("HOST", "test")
+                .send(),
+        )
+        .await
+        .context(format!("{path} request timed out"))?
+        .context(format!("Failed to make {path} request"))?;
 
-    assert_eq!(
-        example_response.status().as_u16(),
-        500,
-        "Request to example.com should be blocked when only *.wikipedia.org is allowed"
-    );
+        assert_eq!(
+            response.status().as_u16(),
+            403,
+            "{path} should be blocked by policy `[*.example.com]`: {why}"
+        );
+    }
 
     Ok(())
 }
@@ -209,7 +240,7 @@ async fn test_star_any_permits_all() -> Result<()> {
         .context("Failed to start workload")?;
 
     let client = reqwest::Client::new();
-    for path in ["/wiki", "/example"] {
+    for path in ["/www", "/example", "/org"] {
         let response = timeout(
             Duration::from_secs(10),
             client
@@ -221,10 +252,11 @@ async fn test_star_any_permits_all() -> Result<()> {
         .context(format!("{path} request timed out"))?
         .context(format!("Failed to make {path} request"))?;
 
-        assert_ne!(
-            response.status().as_u16(),
-            500,
-            "With allowed_hosts=['*'], {path} should not be blocked by policy"
+        let status = response.status();
+        assert!(
+            status.as_u16() == 200 || status.as_u16() == 502,
+            "With allowed_hosts=['*'], {path} should not be blocked by policy (got {})",
+            status
         );
     }
     Ok(())
@@ -256,7 +288,7 @@ async fn test_url_policy_pins_scheme() -> Result<()> {
 
     assert_eq!(
         response.status().as_u16(),
-        500,
+        403,
         "http://example.com should be blocked when policy is https://example.com"
     );
     Ok(())
@@ -279,7 +311,7 @@ async fn test_empty_allowed_hosts_denies_all() -> Result<()> {
     let client = reqwest::Client::new();
 
     // Both routes should be BLOCKED by the empty-list deny-all policy.
-    for path in ["/wiki", "/example"] {
+    for path in ["/www", "/example", "/org"] {
         let response = timeout(
             Duration::from_secs(10),
             client
@@ -293,7 +325,7 @@ async fn test_empty_allowed_hosts_denies_all() -> Result<()> {
 
         assert_eq!(
             response.status().as_u16(),
-            500,
+            403,
             "Empty allowed_hosts should deny all egress; {path} unexpectedly succeeded"
         );
     }

--- a/crates/wash-runtime/tests/integration_http_allowed_hosts.rs
+++ b/crates/wash-runtime/tests/integration_http_allowed_hosts.rs
@@ -39,6 +39,10 @@ async fn start_host(addr: &str) -> Result<(std::net::SocketAddr, impl HostApi)> 
 }
 
 fn allowed_hosts_workload(allowed_hosts: Vec<String>) -> WorkloadStartRequest {
+    let parsed: Vec<wash_runtime::host::allowed_hosts::AllowedHost> = allowed_hosts
+        .iter()
+        .map(|s| s.parse().expect("test gave invalid allowed_hosts entry"))
+        .collect();
     WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),
         workload: Workload {
@@ -56,7 +60,7 @@ fn allowed_hosts_workload(allowed_hosts: Vec<String>) -> WorkloadStartRequest {
                     config: HashMap::new(),
                     environment: HashMap::new(),
                     volume_mounts: vec![],
-                    allowed_hosts: allowed_hosts.into(),
+                    allowed_hosts: parsed.into(),
                 },
                 pool_size: 1,
                 max_invocations: 100,
@@ -191,20 +195,20 @@ async fn test_allowed_hosts_wildcard() -> Result<()> {
     Ok(())
 }
 
-/// When allowed_hosts is empty, all outgoing requests should be permitted.
+/// Literal `*` (AllowedHost::Any) lets every host through, same as
+/// an empty list but exercises the explicit `Any` variant rather than
+/// the empty-list shortcut. Important because the wash config layer
+/// resolves missing `allowed_hosts` to `[Any]` rather than an empty list.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_empty_allowed_hosts_permits_all() -> Result<()> {
+async fn test_star_any_permits_all() -> Result<()> {
     let (addr, host) = start_host("127.0.0.1:0").await?;
 
-    // Empty allowed_hosts = no restrictions
-    let req = allowed_hosts_workload(vec![]);
+    let req = allowed_hosts_workload(vec!["*".to_string()]);
     host.workload_start(req)
         .await
         .context("Failed to start workload")?;
 
     let client = reqwest::Client::new();
-
-    // Both routes should be permitted (not blocked by policy)
     for path in ["/wiki", "/example"] {
         let response = timeout(
             Duration::from_secs(10),
@@ -217,11 +221,80 @@ async fn test_empty_allowed_hosts_permits_all() -> Result<()> {
         .context(format!("{path} request timed out"))?
         .context(format!("Failed to make {path} request"))?;
 
-        let status = response.status();
         assert_ne!(
-            status.as_u16(),
+            response.status().as_u16(),
             500,
-            "With empty allowed_hosts, {path} should not be blocked by policy"
+            "With allowed_hosts=['*'], {path} should not be blocked by policy"
+        );
+    }
+    Ok(())
+}
+
+/// URL-form policy pins scheme. `/example` hits `http://example.com`; the
+/// policy below allows `https://example.com` only. The request should be
+/// blocked because the schemes differ — the host alone isn't enough.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_url_policy_pins_scheme() -> Result<()> {
+    let (addr, host) = start_host("127.0.0.1:0").await?;
+
+    let req = allowed_hosts_workload(vec!["https://example.com".to_string()]);
+    host.workload_start(req)
+        .await
+        .context("Failed to start workload")?;
+
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/example"))
+            .header("HOST", "test")
+            .send(),
+    )
+    .await
+    .context("Example request timed out")?
+    .context("Failed to make example request")?;
+
+    assert_eq!(
+        response.status().as_u16(),
+        500,
+        "http://example.com should be blocked when policy is https://example.com"
+    );
+    Ok(())
+}
+
+/// An empty `allowed_hosts` list denies all outgoing requests.
+/// Callers that want unrestricted egress must use the explicit `["*"]` form,
+/// which the wash config layer applies automatically when `allowedHosts` is
+/// omitted from YAML (see [`test_star_any_permits_all`]).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_empty_allowed_hosts_denies_all() -> Result<()> {
+    let (addr, host) = start_host("127.0.0.1:0").await?;
+
+    // Empty allowed_hosts = deny all egress.
+    let req = allowed_hosts_workload(vec![]);
+    host.workload_start(req)
+        .await
+        .context("Failed to start workload")?;
+
+    let client = reqwest::Client::new();
+
+    // Both routes should be BLOCKED by the empty-list deny-all policy.
+    for path in ["/wiki", "/example"] {
+        let response = timeout(
+            Duration::from_secs(10),
+            client
+                .get(format!("http://{addr}{path}"))
+                .header("HOST", "test")
+                .send(),
+        )
+        .await
+        .context(format!("{path} request timed out"))?
+        .context(format!("Failed to make {path} request"))?;
+
+        assert_eq!(
+            response.status().as_u16(),
+            500,
+            "Empty allowed_hosts should deny all egress; {path} unexpectedly succeeded"
         );
     }
 

--- a/crates/wash-runtime/tests/integration_http_counter.rs
+++ b/crates/wash-runtime/tests/integration_http_counter.rs
@@ -50,7 +50,8 @@ async fn test_http_counter_integration() -> Result<()> {
             ]),
             environment: HashMap::new(),
             volume_mounts: vec![],
-            allowed_hosts: Default::default(),
+            // http-counter calls example.com
+            allowed_hosts: vec!["example.com".parse().unwrap()].into(),
         },
     );
 

--- a/crates/wash-runtime/tests/integration_http_tls.rs
+++ b/crates/wash-runtime/tests/integration_http_tls.rs
@@ -62,7 +62,8 @@ fn http_counter_request(host_header: &str) -> WorkloadStartRequest {
             ]),
             environment: HashMap::new(),
             volume_mounts: vec![],
-            allowed_hosts: Default::default(),
+            // http-counter calls example.com
+            allowed_hosts: vec!["example.com".parse().unwrap()].into(),
         },
         http_counter_host_interfaces(host_header),
     )

--- a/crates/wash-runtime/tests/integration_p2_p3_matrix.rs
+++ b/crates/wash-runtime/tests/integration_p2_p3_matrix.rs
@@ -589,7 +589,8 @@ async fn test_p2_regression_with_p3_enabled() -> Result<()> {
                     ]),
                     environment: HashMap::new(),
                     volume_mounts: vec![],
-                    allowed_hosts: Default::default(),
+                    // http-counter calls example.com
+                    allowed_hosts: vec!["example.com".parse().unwrap()].into(),
                 },
                 pool_size: 1,
                 max_invocations: 100,

--- a/crates/wash-runtime/tests/integration_wasip3.rs
+++ b/crates/wash-runtime/tests/integration_wasip3.rs
@@ -164,7 +164,8 @@ async fn test_p2_http_component_works_with_p3_enabled() -> Result<()> {
                     ]),
                     environment: HashMap::new(),
                     volume_mounts: vec![],
-                    allowed_hosts: Default::default(),
+                    // http-counter calls example.com — empty-list default would deny.
+                    allowed_hosts: vec!["example.com".parse().unwrap()].into(),
                 },
                 pool_size: 1,
                 max_invocations: 100,
@@ -217,7 +218,11 @@ async fn test_p2_concurrent_requests_with_p3_enabled() -> Result<()> {
                 name: "http-counter.wasm".to_string(),
                 digest: None,
                 bytes: bytes::Bytes::from_static(HTTP_COUNTER_WASM),
-                local_resources: LocalResources::default(),
+                local_resources: LocalResources {
+                    // http-counter calls example.com.
+                    allowed_hosts: vec!["example.com".parse().unwrap()].into(),
+                    ..Default::default()
+                },
                 pool_size: 1,
                 max_invocations: 100,
             }],

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -31,6 +31,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 anyhow = { workspace = true }
 async-nats = { workspace = true }
+bon = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "help", "color", "suggestions", "wrap_help", "cargo", "string"] }
@@ -66,6 +67,11 @@ wit-component = { workspace = true }
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 wash-runtime = { workspace = true, features = ["wasi-webgpu"] }
 
+# `O_NOFOLLOW` for the secret-file-open hardening in `crate::workload`.
+# Unix-only. Windows has no portable equivalent.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 
 [build-dependencies]
 anyhow = { workspace = true, default-features = true }
@@ -76,6 +82,7 @@ pbjson-build = { workspace = true, default-features = true }
 bytes = { version = "1", default-features = false }
 http = { version = "1.3.1", default-features = false }
 http-body-util = { version = "0.1.3", default-features = false }
+hyper = { workspace = true }
 rcgen = { version = "0.14.7", default-features = false, features = ["crypto", "aws_lc_rs", "pem"] }
 scopeguard = { version = "1.2", default-features = false }
 tempfile = { version = "3.0", default-features = false }

--- a/crates/wash/src/cli/component_build.rs
+++ b/crates/wash/src/cli/component_build.rs
@@ -92,7 +92,23 @@ pub async fn build_dev_component(
             .command
             .ok_or(anyhow!("build.command is required in wash config"))?
     };
-    perform_component_build(ctx, config, &build_command).await
+
+    // `dev.component_path` overrides `build.component_path` so the shared
+    // build path looks for the artifact in the right place. Needed when
+    // `dev.command` produces a different output than `build.command` (e.g.
+    // cargo debug vs release). Build-time env vars stay on `build.env`;
+    // workload-runtime env vars belong on `workload.environment`, not here.
+    let config = if let Some(component_path) = dev_config.component_path {
+        let mut config = config.clone();
+        let mut build = config.build.clone().unwrap_or_default();
+        build.component_path = Some(component_path);
+        config.build = Some(build);
+        config
+    } else {
+        config.clone()
+    };
+
+    perform_component_build(ctx, &config, &build_command).await
 }
 
 /// Build a component at the specified project path
@@ -338,7 +354,7 @@ impl ComponentBuilder {
         Ok(())
     }
 
-    /// Placeholder for post-build hook  
+    /// Placeholder for post-build hook
     async fn run_post_build_hook(&self) -> anyhow::Result<()> {
         trace!("running post-build hook (placeholder)");
         Ok(())

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -81,8 +81,11 @@ impl CliCommand for DevCommand {
         // `wasi:config/store::get`, so values from `workload.environment` are
         // visible to the component as both env vars and wasi:config entries
         // without further plumbing.
-        host_builder =
-            host_builder.with_plugin(Arc::new(plugin::wasi_config::DynamicConfig::new(true)))?;
+        host_builder = host_builder.with_plugin(Arc::new(
+            plugin::wasi_config::DynamicConfig::builder()
+                .copy_environment(true)
+                .build(),
+        ))?;
 
         // Enable wasmcloud:messaging
         host_builder = host_builder.with_plugin(Arc::new(
@@ -616,10 +619,6 @@ mod tests {
         workload.components.iter().find(|c| c.name == name)
     }
 
-    // ---------------------------------------------------------------------
-    // Tests for `build_workload` used by `wash dev`
-    // ---------------------------------------------------------------------
-
     #[test]
     fn build_workload_lands_workload_values_on_dev_component_only() {
         // The dev component (when not running as a service) is the one
@@ -628,7 +627,7 @@ mod tests {
         let resolved = ResolvedWorkload {
             environment: HashMap::from([("LOG".into(), "debug".into())]),
             config: HashMap::from([("flag".into(), "on".into())]),
-            allowed_hosts: vec!["https://api.example.com".into()],
+            allowed_hosts: vec!["https://api.example.com".parse().unwrap()],
         };
         let dev_cfg = DevConfig {
             components: vec![dev_component_named("sidecar-a")],
@@ -654,7 +653,7 @@ mod tests {
         assert_eq!(dev.local_resources.config.get("flag").unwrap(), "on");
         assert_eq!(
             &dev.local_resources.allowed_hosts[..],
-            &["https://api.example.com".to_string()]
+            &["https://api.example.com".parse().unwrap()]
         );
 
         let sidecar = find_component(&workload, "sidecar-a").unwrap();

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -56,6 +56,7 @@ impl CliCommand for DevCommand {
         .context("failed to load config for development")?;
 
         let dev_config = config.dev();
+
         let http_addr = dev_config
             .address
             .clone()

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use anyhow::{Context as _, bail, ensure};
 use bytes::Bytes;
@@ -14,12 +17,14 @@ use wash_runtime::{
         Component, HostPathVolume, LocalResources, Service, Volume, VolumeMount, VolumeType,
         Workload, WorkloadStartRequest, WorkloadState, WorkloadStopRequest,
     },
+    wit::WitInterface,
 };
 
 use crate::{
     cli::{CliCommand, CliContext, CommandOutput, component_build::build_dev_component},
     config::{Config, load_config},
     wit::WitConfig,
+    workload::{ResolvedWorkload, resolve_workload},
 };
 
 /// Start a development server for a Wasm component
@@ -70,9 +75,13 @@ impl CliCommand for DevCommand {
             .with_engine(engine)
             .with_meters(Meters::new(ctx.enable_meters()));
 
-        // Enable wasi config
+        // Enable wasi config. `copy_environment = true` causes the plugin to
+        // surface every entry of `LocalResources.environment` via
+        // `wasi:config/store::get`, so values from `workload.environment` are
+        // visible to the component as both env vars and wasi:config entries
+        // without further plumbing.
         host_builder =
-            host_builder.with_plugin(Arc::new(plugin::wasi_config::DynamicConfig::default()))?;
+            host_builder.with_plugin(Arc::new(plugin::wasi_config::DynamicConfig::new(true)))?;
 
         // Enable wasmcloud:messaging
         host_builder = host_builder.with_plugin(Arc::new(
@@ -233,7 +242,14 @@ impl CliCommand for DevCommand {
         let wasm_bytes = tokio::fs::read(&build_result.component_path)
             .await
             .context("failed to read component file")?;
-        let workload = create_workload(&host, &config, wasm_bytes.into()).await?;
+        // Resolve workload-level env / config / allowed_hosts now (before
+        // running the component) so that bad config or missing secrets fail
+        // before we deploy. Pass project_dir as the repo root for the
+        // gitignored-secret warning.
+        let resolved_workload = resolve_workload(&config, project_dir, Some(project_dir))
+            .context("failed to resolve workload-level configuration")?;
+        let workload =
+            create_workload(&host, &config, wasm_bytes.into(), &resolved_workload).await?;
         // Running workload ID for reloads
         let workload_id = reload_component(host.clone(), &workload, None).await?;
 
@@ -271,124 +287,32 @@ impl CliCommand for DevCommand {
     }
 }
 
-/// Create the [`Workload`] structure for the development component
-///
-/// ## Arguments
-/// - `config`: The overall Wash configuration
-/// - `bytes`: The bytes of the component under development
-async fn create_workload(host: &Host, config: &Config, bytes: Bytes) -> anyhow::Result<Workload> {
+/// Loaded inputs for [`build_workload`]. Bundles a component's raw bytes
+/// with its already-extracted WIT interface set so the pure assembly step
+/// has everything it needs without further I/O or host calls.
+struct LoadedComponent {
+    name: String,
+    bytes: Bytes,
+    interfaces: HashSet<WitInterface>,
+}
+
+/// Thin wrapper around [`build_workload`]: extracts dev-component
+/// interfaces, loads sidecar bytes + interfaces, and (when configured)
+/// loads the service-file bytes. All workload-construction logic lives in
+/// `build_workload`.
+async fn create_workload(
+    host: &Host,
+    config: &Config,
+    bytes: Bytes,
+    resolved_workload: &ResolvedWorkload,
+) -> anyhow::Result<Workload> {
     let dev_config = config.dev();
 
-    let mut volumes = Vec::<Volume>::new();
-    let mut volume_mounts = Vec::<VolumeMount>::new();
+    let dev_interfaces = host
+        .intersect_interfaces(&bytes)
+        .context("failed to extract component interfaces")?;
 
-    dev_config.volumes.iter().for_each(|cfg_volume| {
-        let name = uuid::Uuid::new_v4().to_string();
-        volumes.push(Volume {
-            name: name.clone(),
-            volume_type: VolumeType::HostPath(HostPathVolume {
-                local_path: cfg_volume.host_path.to_string_lossy().to_string(),
-            }),
-        });
-
-        volume_mounts.push(VolumeMount {
-            name,
-            mount_path: cfg_volume.guest_path.to_string_lossy().to_string(),
-            read_only: false,
-        });
-    });
-
-    // Extract both imports and exports from the component
-    // This populates host_interfaces which is checked bidirectionally during plugin binding
-    let mut host_interfaces = dev_config.host_interfaces.clone();
-
-    let mut service: Option<Service> = None;
-    let mut components = Vec::new();
-    if dev_config.service {
-        let service_interfaces = host
-            .intersect_interfaces(&bytes)
-            .context("failed to extract service interfaces")?;
-
-        // Merge service interfaces into host_interfaces
-        for interface in service_interfaces {
-            match host_interfaces
-                .iter()
-                .find(|i| i.namespace == interface.namespace && i.package == interface.package)
-            {
-                Some(_) => {}
-                None => host_interfaces.push(interface),
-            }
-        }
-
-        service = Some(Service {
-            bytes,
-            digest: None,
-            max_restarts: 0,
-            local_resources: LocalResources {
-                volume_mounts: volume_mounts.clone(),
-                ..Default::default()
-            },
-        })
-    } else {
-        let component_interfaces = host
-            .intersect_interfaces(&bytes)
-            .context("failed to extract component interfaces")?;
-
-        // Merge component interfaces into host_interfaces
-        for interface in component_interfaces {
-            match host_interfaces
-                .iter()
-                .find(|i| i.namespace == interface.namespace && i.package == interface.package)
-            {
-                Some(_) => {}
-                None => host_interfaces.push(interface),
-            }
-        }
-
-        components.push(Component {
-            name: "wash-dev-component".to_string(),
-            bytes,
-            digest: None,
-            local_resources: LocalResources {
-                volume_mounts: volume_mounts.clone(),
-                ..Default::default()
-            },
-            pool_size: -1,
-            max_invocations: -1,
-        });
-
-        if let Some(service_path) = &dev_config.service_file {
-            let service_bytes = tokio::fs::read(service_path).await.with_context(|| {
-                format!("failed to read service file at {}", service_path.display())
-            })?;
-
-            let service_interfaces = host
-                .intersect_interfaces(&service_bytes)
-                .context("failed to extract service interfaces")?;
-
-            // Merge component interfaces into host_interfaces
-            for interface in service_interfaces {
-                match host_interfaces
-                    .iter()
-                    .find(|i| i.namespace == interface.namespace && i.package == interface.package)
-                {
-                    Some(_) => {}
-                    None => host_interfaces.push(interface),
-                }
-            }
-
-            service = Some(Service {
-                bytes: Bytes::from(service_bytes),
-                digest: None,
-                max_restarts: 0,
-                local_resources: LocalResources {
-                    volume_mounts: volume_mounts.clone(),
-                    ..Default::default()
-                },
-            });
-        }
-    }
-
+    let mut sidecars = Vec::with_capacity(dev_config.components.len());
     for dev_component in &dev_config.components {
         let comp_bytes = tokio::fs::read(&dev_component.file)
             .await
@@ -398,30 +322,136 @@ async fn create_workload(host: &Host, config: &Config, bytes: Bytes) -> anyhow::
                     dev_component.file.display()
                 )
             })?;
-
-        let comp_interfaces = host
+        let interfaces = host
             .intersect_interfaces(&comp_bytes)
             .context("failed to extract component interfaces")?;
-
-        // Merge component interfaces into host_interfaces
-        for interface in comp_interfaces {
-            match host_interfaces
-                .iter()
-                .find(|i| i.namespace == interface.namespace && i.package == interface.package)
-            {
-                Some(_) => {}
-                None => host_interfaces.push(interface),
-            }
-        }
-
-        components.push(Component {
+        sidecars.push(LoadedComponent {
             name: dev_component.name.clone(),
             bytes: Bytes::from(comp_bytes),
+            interfaces,
+        });
+    }
+
+    let service_file_bytes = if let Some(service_path) = &dev_config.service_file {
+        let raw = tokio::fs::read(service_path).await.with_context(|| {
+            format!("failed to read service file at {}", service_path.display())
+        })?;
+        Some(Bytes::from(raw))
+    } else {
+        None
+    };
+
+    Ok(build_workload(
+        &dev_config,
+        bytes,
+        dev_interfaces,
+        sidecars,
+        service_file_bytes,
+        resolved_workload,
+    ))
+}
+
+/// Pure assembly of a [`Workload`] from already-loaded inputs.
+///
+/// This is the function `wash dev` actually uses to construct the workload
+/// it ships to the host. `create_workload` is just I/O around it. Keeping
+/// it pure lets the unit tests verify the real production codepath:
+/// per-component LocalResources placement, sidecar handling, the service
+/// vs component branch, volume wiring, and the wasi:config injection (via
+/// [`build_workload_host_interfaces`]).
+///
+/// Per-component workload values (`environment`, `config`, `allowed_hosts`)
+/// land on the dev component when `dev.service = false`, or on the service
+/// when `dev.service = true`. Sidecars in `dev.components` and a
+/// `service_file_bytes`-loaded sidecar service get default `LocalResources`.
+/// Workload-level decisions (notably the `wasi:config` interface injection)
+/// consider every component's imports, including sidecars.
+fn build_workload(
+    dev_config: &crate::config::DevConfig,
+    bytes: Bytes,
+    dev_interfaces: HashSet<WitInterface>,
+    sidecars: Vec<LoadedComponent>,
+    service_file_bytes: Option<Bytes>,
+    resolved_workload: &ResolvedWorkload,
+) -> Workload {
+    let mut volumes = Vec::<Volume>::new();
+    let mut volume_mounts = Vec::<VolumeMount>::new();
+
+    for cfg_volume in &dev_config.volumes {
+        let name = uuid::Uuid::new_v4().to_string();
+        volumes.push(Volume {
+            name: name.clone(),
+            volume_type: VolumeType::HostPath(HostPathVolume {
+                local_path: cfg_volume.host_path.to_string_lossy().to_string(),
+            }),
+        });
+        volume_mounts.push(VolumeMount {
+            name,
+            mount_path: cfg_volume.guest_path.to_string_lossy().to_string(),
+            read_only: false,
+        });
+    }
+
+    let mut all_component_interfaces = Vec::with_capacity(1 + sidecars.len());
+    all_component_interfaces.push(dev_interfaces);
+    for s in &sidecars {
+        all_component_interfaces.push(s.interfaces.clone());
+    }
+
+    let host_interfaces = build_workload_host_interfaces(
+        dev_config.host_interfaces.clone(),
+        &all_component_interfaces,
+        &resolved_workload.config,
+    );
+
+    let dev_local_resources = || LocalResources {
+        volume_mounts: volume_mounts.clone(),
+        environment: resolved_workload.environment.clone(),
+        config: resolved_workload.config.clone(),
+        allowed_hosts: resolved_workload.allowed_hosts.clone().into(),
+        ..Default::default()
+    };
+
+    let default_local_resources = || LocalResources {
+        volume_mounts: volume_mounts.clone(),
+        ..Default::default()
+    };
+
+    let mut service: Option<Service> = None;
+    let mut components = Vec::new();
+    if dev_config.service {
+        service = Some(Service {
+            bytes,
             digest: None,
-            local_resources: LocalResources {
-                volume_mounts: volume_mounts.clone(),
-                ..Default::default()
-            },
+            max_restarts: 0,
+            local_resources: dev_local_resources(),
+        })
+    } else {
+        components.push(Component {
+            name: "wash-dev-component".to_string(),
+            bytes,
+            digest: None,
+            local_resources: dev_local_resources(),
+            pool_size: -1,
+            max_invocations: -1,
+        });
+
+        if let Some(service_bytes) = service_file_bytes {
+            service = Some(Service {
+                bytes: service_bytes,
+                digest: None,
+                max_restarts: 0,
+                local_resources: default_local_resources(),
+            });
+        }
+    }
+
+    for sidecar in sidecars {
+        components.push(Component {
+            name: sidecar.name,
+            bytes: sidecar.bytes,
+            digest: None,
+            local_resources: default_local_resources(),
             pool_size: -1,
             max_invocations: -1,
         });
@@ -429,7 +459,7 @@ async fn create_workload(host: &Host, config: &Config, bytes: Bytes) -> anyhow::
 
     debug!("workload host interfaces: {:?}", host_interfaces);
 
-    Ok(Workload {
+    Workload {
         namespace: "default".to_string(),
         name: "dev".to_string(),
         annotations: HashMap::default(),
@@ -437,7 +467,71 @@ async fn create_workload(host: &Host, config: &Config, bytes: Bytes) -> anyhow::
         host_interfaces,
         service,
         volumes,
-    })
+    }
+}
+
+/// Merge per-component WIT interface sets into a workload-level
+/// `host_interfaces` list, optionally injecting `workload.config` values into
+/// the `wasi:config` entry.
+///
+/// The wasi:config entry is workload-scoped (one per workload, not per
+/// component), so injection happens at most once even when multiple
+/// components import wasi:config. They all read from the same map. When NO
+/// component in the workload imports wasi:config the entry is not created at
+/// all, to avoid dead state and to leave room for an explicit declaration in
+/// `dev.host_interfaces`. When the user has already declared a wasi:config
+/// entry in `dev.host_interfaces`, their values win on key conflicts.
+///
+/// `base` is the user's `dev.host_interfaces` (the explicit declarations);
+/// `component_interfaces` is one set per component in the workload, in any
+/// order; `workload_config` is the resolved `workload.config` map.
+fn build_workload_host_interfaces(
+    mut base: Vec<WitInterface>,
+    component_interfaces: &[HashSet<WitInterface>],
+    workload_config: &HashMap<String, String>,
+) -> Vec<WitInterface> {
+    let mut any_imports_wasi_config = false;
+    for set in component_interfaces {
+        for interface in set {
+            if interface.namespace == "wasi" && interface.package == "config" {
+                any_imports_wasi_config = true;
+            }
+            if !base
+                .iter()
+                .any(|i| i.namespace == interface.namespace && i.package == interface.package)
+            {
+                base.push(interface.clone());
+            }
+        }
+    }
+
+    if any_imports_wasi_config && !workload_config.is_empty() {
+        match base
+            .iter_mut()
+            .find(|i| i.namespace == "wasi" && i.package == "config")
+        {
+            Some(existing) => {
+                for (k, v) in workload_config {
+                    existing
+                        .config
+                        .entry(k.clone())
+                        .or_insert_with(|| v.clone());
+                }
+            }
+            None => {
+                base.push(WitInterface {
+                    namespace: "wasi".into(),
+                    package: "config".into(),
+                    interfaces: Default::default(),
+                    version: None,
+                    config: workload_config.clone(),
+                    name: None,
+                });
+            }
+        }
+    }
+
+    base
 }
 
 /// Reload the component in the host, stopping the previous workload if needed
@@ -467,4 +561,457 @@ async fn reload_component(
     }
 
     Ok(response.workload_status.workload_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DevComponent, DevConfig, DevVolume};
+    use std::path::PathBuf;
+
+    fn iface(namespace: &str, package: &str) -> WitInterface {
+        WitInterface {
+            namespace: namespace.into(),
+            package: package.into(),
+            interfaces: HashSet::new(),
+            version: None,
+            config: HashMap::new(),
+            name: None,
+        }
+    }
+
+    fn iface_with_config(namespace: &str, package: &str, kvs: &[(&str, &str)]) -> WitInterface {
+        let mut i = iface(namespace, package);
+        for (k, v) in kvs {
+            i.config.insert((*k).into(), (*v).into());
+        }
+        i
+    }
+
+    fn find_iface<'a>(
+        list: &'a [WitInterface],
+        namespace: &str,
+        package: &str,
+    ) -> Option<&'a WitInterface> {
+        list.iter()
+            .find(|i| i.namespace == namespace && i.package == package)
+    }
+
+    /// Cheap stand-in for "real wasm bytes". `build_workload` never inspects
+    /// the bytes; it just threads them into the Component/Service struct.
+    fn fake_bytes(tag: &str) -> Bytes {
+        Bytes::from(tag.as_bytes().to_vec())
+    }
+
+    fn dev_component_named(name: &str) -> DevComponent {
+        DevComponent {
+            name: name.into(),
+            file: PathBuf::from(format!("/dev/null/{name}.wasm")),
+        }
+    }
+
+    /// Find a component by name in a built Workload.
+    fn find_component<'a>(workload: &'a Workload, name: &str) -> Option<&'a Component> {
+        workload.components.iter().find(|c| c.name == name)
+    }
+
+    // ---------------------------------------------------------------------
+    // Tests for `build_workload` used by `wash dev`
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn build_workload_lands_workload_values_on_dev_component_only() {
+        // The dev component (when not running as a service) is the one
+        // configured with the resolved workload's environment / config /
+        // allowed_hosts. Sidecars get default LocalResources.
+        let resolved = ResolvedWorkload {
+            environment: HashMap::from([("LOG".into(), "debug".into())]),
+            config: HashMap::from([("flag".into(), "on".into())]),
+            allowed_hosts: vec!["https://api.example.com".into()],
+        };
+        let dev_cfg = DevConfig {
+            components: vec![dev_component_named("sidecar-a")],
+            ..Default::default()
+        };
+        let sidecars = vec![LoadedComponent {
+            name: "sidecar-a".into(),
+            bytes: fake_bytes("sidecar-a"),
+            interfaces: HashSet::new(),
+        }];
+
+        let workload = build_workload(
+            &dev_cfg,
+            fake_bytes("dev"),
+            HashSet::new(),
+            sidecars,
+            None,
+            &resolved,
+        );
+
+        let dev = find_component(&workload, "wash-dev-component").unwrap();
+        assert_eq!(dev.local_resources.environment.get("LOG").unwrap(), "debug");
+        assert_eq!(dev.local_resources.config.get("flag").unwrap(), "on");
+        assert_eq!(
+            &dev.local_resources.allowed_hosts[..],
+            &["https://api.example.com".to_string()]
+        );
+
+        let sidecar = find_component(&workload, "sidecar-a").unwrap();
+        assert!(sidecar.local_resources.environment.is_empty());
+        assert!(sidecar.local_resources.config.is_empty());
+        assert!(sidecar.local_resources.allowed_hosts.is_empty());
+    }
+
+    #[test]
+    fn build_workload_service_mode_lands_workload_values_on_service() {
+        // When dev.service = true the dev bytes become the workload's
+        // Service, and the workload values land there instead of on a
+        // component.
+        let resolved = ResolvedWorkload {
+            environment: HashMap::from([("LOG".into(), "trace".into())]),
+            ..Default::default()
+        };
+        let dev_cfg = DevConfig {
+            service: true,
+            ..Default::default()
+        };
+
+        let workload = build_workload(
+            &dev_cfg,
+            fake_bytes("dev"),
+            HashSet::new(),
+            Vec::new(),
+            None,
+            &resolved,
+        );
+
+        let svc = workload
+            .service
+            .as_ref()
+            .expect("service mode should produce a Service");
+        assert_eq!(svc.local_resources.environment.get("LOG").unwrap(), "trace");
+        // No "wash-dev-component" Component when running as service.
+        assert!(find_component(&workload, "wash-dev-component").is_none());
+    }
+
+    #[test]
+    fn build_workload_service_file_sidecar_gets_default_local_resources() {
+        // dev.service = false + dev.service_file = Some(...) loads a sidecar
+        // service alongside the dev component. That service is a sidecar —
+        // it should NOT receive workload values (those went to the dev
+        // component above).
+        let resolved = ResolvedWorkload {
+            environment: HashMap::from([("LOG".into(), "info".into())]),
+            ..Default::default()
+        };
+        let dev_cfg = DevConfig::default();
+
+        let workload = build_workload(
+            &dev_cfg,
+            fake_bytes("dev"),
+            HashSet::new(),
+            Vec::new(),
+            Some(fake_bytes("svc-sidecar")),
+            &resolved,
+        );
+
+        let svc = workload
+            .service
+            .as_ref()
+            .expect("service_file should produce a Service");
+        assert!(
+            svc.local_resources.environment.is_empty(),
+            "service-file sidecar must not receive workload values"
+        );
+        let dev = find_component(&workload, "wash-dev-component").unwrap();
+        assert_eq!(dev.local_resources.environment.get("LOG").unwrap(), "info");
+    }
+
+    #[test]
+    fn build_workload_volumes_mount_into_every_component_and_service() {
+        // dev.volumes get mounted into every Component and the Service, with
+        // matching VolumeMount entries pointing at the workload-level Volume.
+        let dev_cfg = DevConfig {
+            volumes: vec![DevVolume {
+                host_path: PathBuf::from("/host"),
+                guest_path: PathBuf::from("/guest"),
+            }],
+            components: vec![dev_component_named("sidecar")],
+            ..Default::default()
+        };
+        let sidecars = vec![LoadedComponent {
+            name: "sidecar".into(),
+            bytes: fake_bytes("sidecar"),
+            interfaces: HashSet::new(),
+        }];
+
+        let workload = build_workload(
+            &dev_cfg,
+            fake_bytes("dev"),
+            HashSet::new(),
+            sidecars,
+            Some(fake_bytes("svc")),
+            &ResolvedWorkload::default(),
+        );
+
+        assert_eq!(workload.volumes.len(), 1);
+        let volume_name = &workload.volumes[0].name;
+
+        for c in &workload.components {
+            assert_eq!(
+                c.local_resources.volume_mounts.len(),
+                1,
+                "component {} missing mount",
+                c.name
+            );
+            assert_eq!(&c.local_resources.volume_mounts[0].name, volume_name);
+            assert_eq!(c.local_resources.volume_mounts[0].mount_path, "/guest");
+        }
+        let svc = workload.service.unwrap();
+        assert_eq!(svc.local_resources.volume_mounts.len(), 1);
+        assert_eq!(&svc.local_resources.volume_mounts[0].name, volume_name);
+    }
+
+    #[test]
+    fn build_workload_sidecar_only_wasi_config_importer_triggers_injection() {
+        // The dev component imports nothing wasi:config-related; a sidecar
+        // does. End-to-end: the workload's host_interfaces should contain
+        // a wasi:config entry populated with workload.config.
+        let resolved = ResolvedWorkload {
+            config: HashMap::from([("KEY".into(), "value".into())]),
+            ..Default::default()
+        };
+        let dev_cfg = DevConfig {
+            components: vec![dev_component_named("sidecar")],
+            ..Default::default()
+        };
+        let sidecars = vec![LoadedComponent {
+            name: "sidecar".into(),
+            bytes: fake_bytes("sidecar"),
+            interfaces: HashSet::from([iface("wasi", "config")]),
+        }];
+
+        let workload = build_workload(
+            &dev_cfg,
+            fake_bytes("dev"),
+            HashSet::from([iface("wasi", "http")]),
+            sidecars,
+            None,
+            &resolved,
+        );
+
+        let entry = find_iface(&workload.host_interfaces, "wasi", "config")
+            .expect("sidecar import should have triggered wasi:config injection");
+        assert_eq!(entry.config.get("KEY").unwrap(), "value");
+    }
+
+    #[test]
+    fn build_workload_assembles_components_in_dev_then_sidecar_order() {
+        // Sanity: the dev component is component[0]; sidecars follow in
+        // dev_config.components order. Some downstream wiring depends on
+        // the dev component being identifiable as "wash-dev-component" but
+        // it's worth pinning the order too.
+        let dev_cfg = DevConfig {
+            components: vec![
+                dev_component_named("first-sidecar"),
+                dev_component_named("second-sidecar"),
+            ],
+            ..Default::default()
+        };
+        let sidecars = vec![
+            LoadedComponent {
+                name: "first-sidecar".into(),
+                bytes: fake_bytes("a"),
+                interfaces: HashSet::new(),
+            },
+            LoadedComponent {
+                name: "second-sidecar".into(),
+                bytes: fake_bytes("b"),
+                interfaces: HashSet::new(),
+            },
+        ];
+
+        let workload = build_workload(
+            &dev_cfg,
+            fake_bytes("dev"),
+            HashSet::new(),
+            sidecars,
+            None,
+            &ResolvedWorkload::default(),
+        );
+
+        let names: Vec<_> = workload
+            .components
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["wash-dev-component", "first-sidecar", "second-sidecar"]
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Tests for `build_workload_host_interfaces`.
+    // These cover edge cases of the merge/inject logic in isolation; the
+    // build_workload tests above prove the helper is actually invoked.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn multi_component_workload_shares_one_wasi_config_entry() {
+        // Two components both import wasi:config. The workload-level
+        // host_interfaces list should contain exactly one wasi:config entry,
+        // populated from workload.config — both components bind the same map.
+        let comp_a = HashSet::from([iface("wasi", "config"), iface("wasi", "http")]);
+        let comp_b = HashSet::from([iface("wasi", "config"), iface("wasi", "logging")]);
+        let workload_cfg = HashMap::from([
+            ("feature.flags".into(), "v2,beta".into()),
+            ("LOG_LEVEL".into(), "debug".into()),
+        ]);
+
+        let result = build_workload_host_interfaces(Vec::new(), &[comp_a, comp_b], &workload_cfg);
+
+        let wasi_config: Vec<_> = result
+            .iter()
+            .filter(|i| i.namespace == "wasi" && i.package == "config")
+            .collect();
+        assert_eq!(
+            wasi_config.len(),
+            1,
+            "expected a single wasi:config entry shared across both components, got {}",
+            wasi_config.len()
+        );
+        assert_eq!(
+            wasi_config[0].config.get("feature.flags").unwrap(),
+            "v2,beta"
+        );
+        assert_eq!(wasi_config[0].config.get("LOG_LEVEL").unwrap(), "debug");
+
+        // The other interfaces from each component should also appear.
+        assert!(find_iface(&result, "wasi", "http").is_some());
+        assert!(find_iface(&result, "wasi", "logging").is_some());
+    }
+
+    #[test]
+    fn multi_component_workload_only_one_imports_wasi_config() {
+        // Only the second component imports wasi:config. The injection
+        // should still happen — workload.config is workload-scoped, so a
+        // sidecar-only importer is enough to surface it. The non-importing
+        // component is unaffected.
+        let comp_no_config = HashSet::from([iface("wasi", "http"), iface("wasi", "cli")]);
+        let comp_with_config = HashSet::from([iface("wasi", "config"), iface("wasi", "logging")]);
+        let workload_cfg = HashMap::from([("KEY".into(), "value".into())]);
+
+        let result = build_workload_host_interfaces(
+            Vec::new(),
+            &[comp_no_config, comp_with_config],
+            &workload_cfg,
+        );
+
+        let wasi_config = find_iface(&result, "wasi", "config")
+            .expect("wasi:config entry should be present because one component imports it");
+        assert_eq!(wasi_config.config.get("KEY").unwrap(), "value");
+
+        // Non-importer's interfaces are still merged in.
+        assert!(find_iface(&result, "wasi", "http").is_some());
+        assert!(find_iface(&result, "wasi", "cli").is_some());
+    }
+
+    #[test]
+    fn no_component_imports_wasi_config_means_no_injection() {
+        // Even with non-empty workload.config, if no component imports
+        // wasi:config we don't add a dead entry — leaves room for a future
+        // explicit declaration without surprise overrides.
+        let comp = HashSet::from([iface("wasi", "http")]);
+        let workload_cfg = HashMap::from([("KEY".into(), "value".into())]);
+
+        let result = build_workload_host_interfaces(Vec::new(), &[comp], &workload_cfg);
+
+        assert!(find_iface(&result, "wasi", "config").is_none());
+    }
+
+    #[test]
+    fn empty_workload_config_means_no_injection_even_when_imported() {
+        // The component imports wasi:config so the entry gets merged in
+        // either way. The injection contract is that no *workload* values
+        // are added — verify the entry's config map stays empty.
+        let comp = HashSet::from([iface("wasi", "config")]);
+        let result = build_workload_host_interfaces(Vec::new(), &[comp], &HashMap::new());
+        let entry = find_iface(&result, "wasi", "config").unwrap();
+        assert!(
+            entry.config.is_empty(),
+            "no workload.config means no injected values"
+        );
+    }
+
+    #[test]
+    fn explicit_dev_host_interfaces_wasi_config_wins_on_conflicts() {
+        // User declared wasi:config in dev.host_interfaces with their own
+        // values for some keys. Workload.config fills in missing keys but
+        // does not overwrite user-declared ones.
+        let user_declared = iface_with_config(
+            "wasi",
+            "config",
+            &[("LOG_LEVEL", "user_value"), ("USER_ONLY", "yes")],
+        );
+        let comp = HashSet::from([iface("wasi", "config")]);
+        let workload_cfg = HashMap::from([
+            ("LOG_LEVEL".into(), "workload_value".into()),
+            ("WORKLOAD_ONLY".into(), "yes".into()),
+        ]);
+
+        let result = build_workload_host_interfaces(vec![user_declared], &[comp], &workload_cfg);
+
+        let entry = find_iface(&result, "wasi", "config").unwrap();
+        assert_eq!(
+            entry.config.get("LOG_LEVEL").unwrap(),
+            "user_value",
+            "explicit dev.host_interfaces declaration must win on conflict"
+        );
+        assert_eq!(entry.config.get("USER_ONLY").unwrap(), "yes");
+        assert_eq!(
+            entry.config.get("WORKLOAD_ONLY").unwrap(),
+            "yes",
+            "workload.config keys not in user declaration must fill in"
+        );
+    }
+
+    #[test]
+    fn user_declared_wasi_config_untouched_when_no_component_imports_it() {
+        // User declared wasi:config in dev.host_interfaces with their own
+        // values, but nothing in the workload imports wasi:config. The
+        // injection branch is gated on at least one importer, so the user's
+        // entry must pass through unmodified. The workload.config doesn't
+        // sneak values in via a non-importer.
+        let user_declared = iface_with_config("wasi", "config", &[("USER_KEY", "user_value")]);
+        let comp = HashSet::from([iface("wasi", "http")]);
+        let workload_cfg = HashMap::from([("WORKLOAD_KEY".into(), "workload_value".into())]);
+
+        let result = build_workload_host_interfaces(vec![user_declared], &[comp], &workload_cfg);
+
+        let entry = find_iface(&result, "wasi", "config").unwrap();
+        assert_eq!(
+            entry.config.len(),
+            1,
+            "no workload values should have been merged in"
+        );
+        assert_eq!(entry.config.get("USER_KEY").unwrap(), "user_value");
+        assert!(entry.config.get("WORKLOAD_KEY").is_none());
+    }
+
+    #[test]
+    fn merging_does_not_duplicate_interfaces() {
+        // Two components import the same wasi:http; only one entry should
+        // appear. Important when checking shared config as duplicates would
+        // confuse plugin binding.
+        let comp_a = HashSet::from([iface("wasi", "http")]);
+        let comp_b = HashSet::from([iface("wasi", "http"), iface("wasi", "logging")]);
+        let result = build_workload_host_interfaces(Vec::new(), &[comp_a, comp_b], &HashMap::new());
+
+        let http_count = result
+            .iter()
+            .filter(|i| i.namespace == "wasi" && i.package == "http")
+            .count();
+        assert_eq!(http_count, 1);
+    }
 }

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -172,7 +172,11 @@ impl CliCommand for HostCommand {
             .with_host_config(host_config)
             .with_nats_client(Arc::new(scheduler_nats_client))
             .with_host_group(self.host_group.clone())
-            .with_plugin(Arc::new(plugin::wasi_config::DynamicConfig::new(true)))?
+            .with_plugin(Arc::new(
+                plugin::wasi_config::DynamicConfig::builder()
+                    .copy_environment(true)
+                    .build(),
+            ))?
             .with_plugin(Arc::new(plugin::wasi_logging::TracingLogger::default()))?
             .with_plugin(Arc::new(plugin::wasi_blobstore::NatsBlobstore::new(
                 &data_nats_client,

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -3,7 +3,7 @@
 //! with explicit defaults.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -14,6 +14,7 @@ use figment::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::info;
+use wash_runtime::host::allowed_hosts::AllowedHost;
 use wash_runtime::wit::WitInterface;
 
 use crate::{
@@ -51,12 +52,24 @@ pub struct Config {
     pub workload: Option<WorkloadConfig>,
 
     /// Named ConfigMap-equivalent sources referenced by `workload.environment.configFrom`.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub configs: HashMap<String, ConfigSource>,
+    ///
+    /// `BTreeMap` so iteration / serialization order is deterministic.
+    #[serde(
+        default,
+        rename = "configs",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub config_sources: BTreeMap<String, ConfigSource>,
 
     /// Named Secret-equivalent sources referenced by `workload.environment.secretFrom`.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub secrets: HashMap<String, ConfigSource>,
+    ///
+    /// `BTreeMap` so iteration / serialization order is deterministic.
+    #[serde(
+        default,
+        rename = "secrets",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub secret_sources: BTreeMap<String, SecretSource>,
 
     /// WIT dependency management configuration (default: empty/optional)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -73,8 +86,8 @@ impl Default for Config {
             new: None,
             dev: None,
             workload: None,
-            configs: HashMap::new(),
-            secrets: HashMap::new(),
+            config_sources: BTreeMap::new(),
+            secret_sources: BTreeMap::new(),
             wit: None,
         }
     }
@@ -175,11 +188,25 @@ impl BuildConfig {
     }
 }
 
+/// Serde default for [`WorkloadConfig::allowed_hosts`]: a single
+/// [`AllowedHost::Any`] entry (allow-all). Fires only when the YAML
+/// omits `allowedHosts` entirely — an explicit `allowedHosts: []` stays
+/// empty (deny-all in the runtime).
+fn default_allow_all_hosts() -> Vec<AllowedHost> {
+    vec![AllowedHost::Any]
+}
+
 /// Workload-level configuration that mirrors the `localResources` shape of a
-/// `WorkloadDeployment` component. Currently consumed by `wash dev`; the same
-/// shape is intended to round-trip to a Kubernetes `WorkloadDeployment`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+/// `WorkloadDeployment` component.
+///
+/// Currently consumed by `wash dev`; the same shape is intended to round-trip
+/// to a Kubernetes `WorkloadDeployment`.
+///
+/// Use [`WorkloadConfig::builder`] to construct so future fields don't break
+/// callers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, bon::Builder)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct WorkloadConfig {
     /// Environment variables for the component (wasi:cli/env). Combines inline
     /// values with named references to top-level `configs:` and `secrets:`.
@@ -188,18 +215,38 @@ pub struct WorkloadConfig {
     /// Opaque key-value config delivered to the component (e.g. wasi:config/store).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub config: HashMap<String, String>,
-    /// Outbound HTTP allowlist. Empty means unrestricted (matches runtime
-    /// behavior in `crates/wash-runtime/src/host/http.rs`).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub allowed_hosts: Vec<String>,
+    /// Outbound HTTP allowlist. Each entry parses into a typed
+    /// [`AllowedHost`]; YAML/JSON callers continue to write plain strings.
+    ///
+    /// Default resolution distinguishes "field omitted" from "explicit
+    /// empty":
+    ///
+    /// - **Missing from YAML** → serde default fires →
+    ///   `[AllowedHost::Any]` (allow-all). Keeps `wash dev` ergonomic for
+    ///   users who haven't thought about egress.
+    /// - **`allowedHosts: []` in YAML** → empty `Vec` is preserved.
+    ///   `resolve_workload` passes it through unchanged; the runtime
+    ///   (`wash-runtime::host::http::check_allowed_hosts`) treats empty
+    ///   as deny-all. Explicit user intent is respected.
+    /// - **`WorkloadConfig::default()` (Rust API)** → empty `Vec`
+    ///   (derived `Default`), which the runtime treats as deny-all
+    ///   — fail-closed for programmatic construction.
+    ///
+    /// The serialization side does NOT skip empty lists, so a round-trip
+    /// preserves the explicit-empty intent.
+    #[serde(default = "default_allow_all_hosts")]
+    pub allowed_hosts: Vec<AllowedHost>,
 }
 
-/// One layer of environment variables. Inline values are written directly;
-/// `configFrom` / `secretFrom` reference named entries in the top-level
-/// `configs:` / `secrets:` blocks by name. On key conflicts later entries win,
-/// in order: inline → configFrom → secretFrom (matches K8s envFrom semantics).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+/// One layer of environment variables.
+///
+/// Inline values are written directly; `configFrom` / `secretFrom` reference
+/// named entries in the top-level `configs:` / `secrets:` blocks by name. On
+/// key conflicts later entries win, in order: inline → configFrom → secretFrom
+/// (matches K8s `envFrom` semantics).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, bon::Builder)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct EnvironmentLayer {
     /// Inline plain values. Suitable for non-sensitive defaults.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -212,26 +259,62 @@ pub struct EnvironmentLayer {
     pub secret_from: Vec<String>,
 }
 
-/// A source of key-value pairs for a `configs:` or `secrets:` entry. Multiple
-/// fields can be set on a single entry.. They merge last-wins in the order
-/// `inline` → `file` → `fromEnv` (matches K8s ConfigMap merge semantics).
+/// A source of non-sensitive key-value pairs for a `configs:` entry.
 ///
-/// Distinct types are not used for config vs secret because the schema is
-/// identical; the difference is the security posture applied at resolve time
-/// (see [`crate::workload::resolve_workload`]).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+/// Multiple fields can be set on a single entry. They merge last-wins in the
+/// order `inline` → `file` → `fromEnv` (matches K8s ConfigMap merge
+/// semantics). Resolution lives in [`crate::workload`] as
+/// [`ConfigSource::resolve`].
+///
+/// See [`SecretSource`] for the sibling type that carries the stricter
+/// posture (file-mode check, in-repo-tree warning, etc.). The two share
+/// today's wire schema but are deliberately distinct types so secret
+/// handling can never be applied to a config and vice versa.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, bon::Builder)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct ConfigSource {
-    /// Literal key-value entries.
+    /// Literal key-value entries supplied inline.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub inline: HashMap<String, String>,
     /// Path to a `.env`-format file. Relative paths resolve against the
-    /// project directory. For secrets, the file must be 0600/0400 and must
-    /// not escape the project directory via `..` or symlink.
+    /// project directory.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file: Option<PathBuf>,
     /// Names of environment variables to pull from the developer's shell.
-    /// Missing variables are an error unless `optional` is true on the ref.
+    /// Each name is read at resolve time via [`std::env::var`]; a missing
+    /// variable is a hard error.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub from_env: Vec<String>,
+}
+
+/// A source of sensitive key-value pairs for a `secrets:` entry.
+///
+/// Same wire shape as [`ConfigSource`] today, but a distinct Rust type so
+/// the stricter resolve-time posture (Unix file mode `0600`/`0400`,
+/// `O_NOFOLLOW` open + `fstat` perm check, in-repo-tree warning, no value
+/// snippets in error / log output) can only be applied here. Resolution
+/// lives in [`crate::workload`] as [`SecretSource::resolve`].
+///
+/// The two types may diverge in the future (e.g. a future `rotation`
+/// field that only makes sense for secrets) — keeping them separate now
+/// avoids retrofitting the type split later.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, bon::Builder)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SecretSource {
+    /// Literal key-value entries supplied inline. Convenient for dev /
+    /// test; do not commit production secrets this way.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub inline: HashMap<String, String>,
+    /// Path to a `.env`-format file. Relative paths resolve against the
+    /// project directory. The file must be Unix mode `0600` or `0400`
+    /// and must not escape the project directory via `..` or symlink.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<PathBuf>,
+    /// Names of environment variables to pull from the developer's shell.
+    /// Each name is read at resolve time via [`std::env::var`]; a missing
+    /// variable is a hard error.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub from_env: Vec<String>,
 }
@@ -682,8 +765,8 @@ pub fn example_config() -> Config {
             ]),
         }),
         workload: None,
-        configs: HashMap::new(),
-        secrets: HashMap::new(),
+        config_sources: BTreeMap::new(),
+        secret_sources: BTreeMap::new(),
     }
 }
 
@@ -805,7 +888,7 @@ workload:
         assert_eq!(workload.config.get("flag").unwrap(), "on");
         assert_eq!(
             workload.allowed_hosts,
-            vec!["https://api.example.com".to_string()]
+            vec!["https://api.example.com".parse().unwrap()]
         );
     }
 
@@ -1014,12 +1097,15 @@ secrets:
 "#;
         let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
 
-        let app = config.configs.get("app").expect("configs.app should parse");
+        let app = config
+            .config_sources
+            .get("app")
+            .expect("configs.app should parse");
         assert_eq!(app.inline.get("APP_FOO").unwrap(), "app_foo_value");
         assert_eq!(app.file.as_deref(), Some(Path::new("./app.env")));
 
         let creds = config
-            .secrets
+            .secret_sources
             .get("creds")
             .expect("secrets.creds should parse");
         assert_eq!(creds.from_env, vec!["DB_PASSWORD".to_string()]);

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -284,6 +284,14 @@ pub struct DevConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub volumes: Vec<DevVolume>,
 
+    /// Environment variables exported into the `wash dev` process before the
+    /// host is built. Surfaces values to plugins and runtime crates that read
+    /// from `std::env` (e.g. `RUST_LOG`, `OTEL_*`, libpq's `PG*` family).
+    /// Distinct from `workload.environment`, which is delivered to the
+    /// component via `wasi:cli/env`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub environment: HashMap<String, String>,
+
     /// Host interfaces configuration
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub host_interfaces: Vec<WitInterface>,
@@ -544,6 +552,48 @@ pub async fn generate_example_config(path: &Path, force: bool) -> Result<()> {
     generate_config(&example_config(), path, force).await
 }
 
+/// Export `dev.environment` from the loaded wash config into the current
+/// process via `std::env::set_var`. Must be called from `main()` *before*
+/// plugins, so that values like `OTEL_*` and `RUST_LOG`
+/// configured under `dev.environment` are visible to the tracing subscriber
+/// (which reads `OTEL_*` and `RUST_LOG` at init time and never again).
+///
+/// Best-effort: if the global XDG config dir can't be determined or the
+/// project config can't be loaded, returns silently. The tracing
+/// subscriber isn't initialized at this point so we have nowhere to log.
+///
+/// # Safety
+///
+/// `std::env::set_var` is `unsafe` in the 2024 edition because it races
+/// with concurrent `getenv` from other threads. Callers MUST invoke this
+/// once, very early in `main()`, before any worker thread has begun
+/// reading env vars.
+#[allow(unsafe_code)]
+pub fn apply_dev_environment(user_config_override: Option<&Path>, project_dir: &Path) {
+    let global_config_path = match user_config_override {
+        Some(path) => path.to_path_buf(),
+        None => {
+            let Ok(strategy) = etcetera::choose_app_strategy(etcetera::AppStrategyArgs {
+                top_level_domain: "com.wasmcloud".to_string(),
+                author: "wasmCloud Team".to_string(),
+                app_name: "wash".to_string(),
+            }) else {
+                return;
+            };
+            locate_user_config(&etcetera::AppStrategy::config_dir(&strategy))
+        }
+    };
+
+    let Ok(config) = load_config::<Config>(&global_config_path, Some(project_dir), None) else {
+        return;
+    };
+
+    for (key, value) in &config.dev().environment {
+        // SAFETY: see function-level docs.
+        unsafe { std::env::set_var(key, value) };
+    }
+}
+
 async fn generate_config(config: &Config, path: &Path, force: bool) -> Result<()> {
     if path.exists() && !force {
         bail!(
@@ -631,6 +681,9 @@ pub fn example_config() -> Config {
                 ),
             ]),
         }),
+        workload: None,
+        configs: HashMap::new(),
+        secrets: HashMap::new(),
     }
 }
 
@@ -679,6 +732,32 @@ mod tests {
     }
 
     #[test]
+    fn dev_environment_deserializes_from_yaml() {
+        // Locks in the YAML contract surfaced to users:
+        //
+        //   dev:
+        //     environment:
+        //       KEY: value
+        //
+        // A regression here (e.g. someone adding `rename_all = "camelCase"`
+        // to `DevConfig`, or moving the field) would silently drop user-
+        // configured env vars at `wash dev` startup.
+        let yaml = r#"
+dev:
+  environment:
+    RUST_LOG: debug
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4317
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let env = config.dev().environment;
+        assert_eq!(env.get("RUST_LOG").map(String::as_str), Some("debug"));
+        assert_eq!(
+            env.get("OTEL_EXPORTER_OTLP_ENDPOINT").map(String::as_str),
+            Some("http://localhost:4317")
+        );
+    }
+
+    #[test]
     fn build_whitespace_command_is_err() {
         let cfg = BuildConfig {
             command: Some("   ".to_string()),
@@ -689,6 +768,44 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("build.command")
+        );
+    }
+
+    #[test]
+    fn workload_yaml_uses_camel_case_for_renamed_fields() {
+        // `WorkloadConfig`, `EnvironmentLayer`, and `ConfigSource` carry
+        // `rename_all = "camelCase"`. Users write `configFrom` / `secretFrom`
+        // / `allowedHosts` / `fromEnv` in YAML; if a refactor drops one of
+        // those `rename_all` attributes, the camelCase keys get silently
+        // dropped (parses fine, fields stay default). Pin the contract.
+        let yaml = r#"
+workload:
+  environment:
+    config:
+      INLINE_KEY: inline_value
+    configFrom:
+      - app
+    secretFrom:
+      - creds
+  config:
+    flag: "on"
+  allowedHosts:
+    - https://api.example.com
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let workload = config.workload.expect("workload should parse");
+
+        let env = workload
+            .environment
+            .expect("environment layer should parse");
+        assert_eq!(env.config.get("INLINE_KEY").unwrap(), "inline_value");
+        assert_eq!(env.config_from, vec!["app".to_string()]);
+        assert_eq!(env.secret_from, vec!["creds".to_string()]);
+
+        assert_eq!(workload.config.get("flag").unwrap(), "on");
+        assert_eq!(
+            workload.allowed_hosts,
+            vec!["https://api.example.com".to_string()]
         );
     }
 
@@ -874,5 +991,48 @@ mod tests {
             err.contains("wasi_keyvalue_redis_url"),
             "missing redis error"
         );
+    }
+
+    #[test]
+    fn configs_and_secrets_named_map_with_camel_case_source_fields() {
+        // The top-level `configs:` and `secrets:` blocks are name -> ConfigSource
+        // maps, and ConfigSource's `from_env` field is `fromEnv` in YAML.
+        // `secrets:` shares the same struct as `configs:` — pin both so a
+        // future split into separate types doesn't silently lose schema parity.
+        let yaml = r#"
+configs:
+  app:
+    inline:
+      APP_FOO: app_foo_value
+    file: ./app.env
+secrets:
+  creds:
+    fromEnv:
+      - DB_PASSWORD
+    inline:
+      DB_USER: alice
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+
+        let app = config.configs.get("app").expect("configs.app should parse");
+        assert_eq!(app.inline.get("APP_FOO").unwrap(), "app_foo_value");
+        assert_eq!(app.file.as_deref(), Some(Path::new("./app.env")));
+
+        let creds = config
+            .secrets
+            .get("creds")
+            .expect("secrets.creds should parse");
+        assert_eq!(creds.from_env, vec!["DB_PASSWORD".to_string()]);
+        assert_eq!(creds.inline.get("DB_USER").unwrap(), "alice");
+    }
+
+    #[test]
+    fn dev_environment_defaults_to_empty() {
+        // `dev.environment` is optional — a `dev:` block without it must
+        // not fail to parse, and must produce an empty map (not panic on
+        // the `set_var` loop reading a None).
+        let yaml = "dev: {}\n";
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(config.dev().environment.is_empty());
     }
 }

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -44,6 +44,20 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new: Option<NewConfig>,
 
+    /// Workload-level configuration that describes the component being developed
+    /// (env vars, wasi:config values, outbound allowlist). Field shape mirrors
+    /// `WorkloadDeployment.spec.template.spec.components[].localResources`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workload: Option<WorkloadConfig>,
+
+    /// Named ConfigMap-equivalent sources referenced by `workload.environment.configFrom`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub configs: HashMap<String, ConfigSource>,
+
+    /// Named Secret-equivalent sources referenced by `workload.environment.secretFrom`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub secrets: HashMap<String, ConfigSource>,
+
     /// WIT dependency management configuration (default: empty/optional)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wit: Option<WitConfig>,
@@ -58,6 +72,9 @@ impl Default for Config {
             build: None,
             new: None,
             dev: None,
+            workload: None,
+            configs: HashMap::new(),
+            secrets: HashMap::new(),
             wit: None,
         }
     }
@@ -158,6 +175,67 @@ impl BuildConfig {
     }
 }
 
+/// Workload-level configuration that mirrors the `localResources` shape of a
+/// `WorkloadDeployment` component. Currently consumed by `wash dev`; the same
+/// shape is intended to round-trip to a Kubernetes `WorkloadDeployment`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkloadConfig {
+    /// Environment variables for the component (wasi:cli/env). Combines inline
+    /// values with named references to top-level `configs:` and `secrets:`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<EnvironmentLayer>,
+    /// Opaque key-value config delivered to the component (e.g. wasi:config/store).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub config: HashMap<String, String>,
+    /// Outbound HTTP allowlist. Empty means unrestricted (matches runtime
+    /// behavior in `crates/wash-runtime/src/host/http.rs`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_hosts: Vec<String>,
+}
+
+/// One layer of environment variables. Inline values are written directly;
+/// `configFrom` / `secretFrom` reference named entries in the top-level
+/// `configs:` / `secrets:` blocks by name. On key conflicts later entries win,
+/// in order: inline → configFrom → secretFrom (matches K8s envFrom semantics).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvironmentLayer {
+    /// Inline plain values. Suitable for non-sensitive defaults.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub config: HashMap<String, String>,
+    /// Names of entries in the top-level `configs:` block.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub config_from: Vec<String>,
+    /// Names of entries in the top-level `secrets:` block.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_from: Vec<String>,
+}
+
+/// A source of key-value pairs for a `configs:` or `secrets:` entry. Multiple
+/// fields can be set on a single entry.. They merge last-wins in the order
+/// `inline` → `file` → `fromEnv` (matches K8s ConfigMap merge semantics).
+///
+/// Distinct types are not used for config vs secret because the schema is
+/// identical; the difference is the security posture applied at resolve time
+/// (see [`crate::workload::resolve_workload`]).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigSource {
+    /// Literal key-value entries.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub inline: HashMap<String, String>,
+    /// Path to a `.env`-format file. Relative paths resolve against the
+    /// project directory. For secrets, the file must be 0600/0400 and must
+    /// not escape the project directory via `..` or symlink.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<PathBuf>,
+    /// Names of environment variables to pull from the developer's shell.
+    /// Missing variables are an error unless `optional` is true on the ref.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub from_env: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DevVolume {
     /// Host path to mount
@@ -180,6 +258,13 @@ pub struct DevConfig {
     /// If not specified, defaults to 'build.command'.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
+    /// Expected path to the built Wasm component artifact for dev mode.
+    /// Overrides `build.component_path`. Useful when `dev.command` builds a
+    /// different artifact (e.g. cargo debug profile in `target/.../debug/`
+    /// instead of `release/`). Relative paths are resolved against the project
+    /// directory. Exposed to build commands via `WASH_COMPONENT_PATH`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_path: Option<PathBuf>,
     /// Address for the dev server to bind to (default: "0.0.0.0:8000")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<String>,

--- a/crates/wash/src/lib.rs
+++ b/crates/wash/src/lib.rs
@@ -13,3 +13,5 @@ pub mod inspect;
 pub mod new;
 /// Manage WebAssembly Interface Types (WIT) for wash components
 pub(crate) mod wit;
+/// Resolve workload-level env, secrets, and config from project configuration
+pub mod workload;

--- a/crates/wash/src/main.rs
+++ b/crates/wash/src/main.rs
@@ -147,6 +147,18 @@ async fn main() {
 
     let (mut stdout, mut stderr) = (Box::new(std::io::stdout()), Box::new(std::io::stderr()));
 
+    // For `wash dev`, export `dev.environment` from the project config into the
+    // wash process before observability initializes. The tracing subscriber reads
+    // `RUST_LOG` and the OTel exporter checks for `OTEL_*` once during
+    // `initialize_observability`. Neither honors changes made later, so values
+    // set inside `DevCommand::handle()` arrive too late.
+    if matches!(global_args.command, Some(WashCliCommand::Dev(_))) {
+        wash::config::apply_dev_environment(
+            global_args.user_config.as_deref(),
+            &global_args.project_path,
+        );
+    }
+
     // Initialize observability as early as possible, with the specified log level
     let observability_shutdown = wash_runtime::observability::initialize_observability(
         global_args.log_level,

--- a/crates/wash/src/workload.rs
+++ b/crates/wash/src/workload.rs
@@ -1,0 +1,661 @@
+//! Resolves the `workload:` / `configs:` / `secrets:` schema from
+//! [`crate::config::Config`] into a flat key-value map suitable for handing
+//! to a wasmCloud runtime workload.
+//!
+//! Secrets and configs share the same source schema ([`ConfigSource`]) but
+//! differ in security posture at resolve time:
+//!
+//! * **Path containment.** Every `file:` path is canonicalized and rejected
+//!   if it escapes the project directory (defense against the
+//!   `CVE-2025-62725` class, a joining attacker-controlled path strings with
+//!   a working directory without canonicalization).
+//! * **Permission check (secrets only).** A secret `file:` source must be
+//!   mode `0600` or `0400` on Unix. Looser modes are refused, matching the
+//!   Kubernetes Secret volume `defaultMode: 0400` posture.
+//! * **Repo-tree warning (secrets only).** When a resolved secret `file:`
+//!   path sits inside the repo working tree we warn. This is the class of
+//!   mistake behind the `.env` mass-exfiltration campaigns.
+//! * **Logging hygiene.** Errors and traces reference sources and keys by
+//!   name only; resolved values never appear in log output (relevant given
+//!   `wash dev`'s OpenTelemetry hook).
+//! * **Memory only.** Resolved values are returned by value and never
+//!   written back to disk.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context as _, Result, bail};
+use tracing::warn;
+
+use crate::config::{Config, ConfigSource, WorkloadConfig};
+
+/// Resolved workload values ready to be applied to a runtime `LocalResources`.
+#[derive(Debug, Default, Clone)]
+pub struct ResolvedWorkload {
+    /// Environment variables (wasi:cli/env), merged from inline + configFrom + secretFrom.
+    pub environment: HashMap<String, String>,
+    /// Opaque key-value config delivered to the component.
+    pub config: HashMap<String, String>,
+    /// Outbound HTTP allowlist.
+    pub allowed_hosts: Vec<String>,
+}
+
+/// Resolve the workload section of a [`Config`], pulling in named entries
+/// from the top-level `configs:` and `secrets:` blocks.
+///
+/// `project_dir` anchors relative `file:` paths and bounds path containment
+/// checks. `repo_root` (when known) gates the "secret file lives in the repo
+/// tree" warning.
+pub fn resolve_workload(
+    config: &Config,
+    project_dir: &Path,
+    repo_root: Option<&Path>,
+) -> Result<ResolvedWorkload> {
+    let Some(workload) = config.workload.as_ref() else {
+        return Ok(ResolvedWorkload::default());
+    };
+
+    let environment = resolve_environment(
+        workload,
+        &config.configs,
+        &config.secrets,
+        project_dir,
+        repo_root,
+    )?;
+
+    Ok(ResolvedWorkload {
+        environment,
+        config: workload.config.clone(),
+        allowed_hosts: workload.allowed_hosts.clone(),
+    })
+}
+
+fn resolve_environment(
+    workload: &WorkloadConfig,
+    configs: &HashMap<String, ConfigSource>,
+    secrets: &HashMap<String, ConfigSource>,
+    project_dir: &Path,
+    repo_root: Option<&Path>,
+) -> Result<HashMap<String, String>> {
+    let Some(env) = workload.environment.as_ref() else {
+        return Ok(HashMap::new());
+    };
+
+    let mut out: HashMap<String, String> = HashMap::new();
+
+    // Layer order matches K8s envFrom: inline values first, then configFrom,
+    // then secretFrom. Later layers overwrite earlier on key conflicts.
+    out.extend(env.config.clone());
+
+    apply_refs(
+        &env.config_from,
+        configs,
+        project_dir,
+        /* secret */ false,
+        repo_root,
+        &mut out,
+    )
+    .context("failed to resolve workload.environment.configFrom")?;
+    apply_refs(
+        &env.secret_from,
+        secrets,
+        project_dir,
+        /* secret */ true,
+        repo_root,
+        &mut out,
+    )
+    .context("failed to resolve workload.environment.secretFrom")?;
+
+    Ok(out)
+}
+
+fn apply_refs(
+    refs: &[String],
+    catalog: &HashMap<String, ConfigSource>,
+    project_dir: &Path,
+    secret: bool,
+    repo_root: Option<&Path>,
+    out: &mut HashMap<String, String>,
+) -> Result<()> {
+    for name in refs {
+        let Some(source) = catalog.get(name) else {
+            let kind = if secret { "secret" } else { "config" };
+            bail!(
+                "workload references {} '{}' which is not defined in the top-level `{}s:` block",
+                kind,
+                name,
+                kind
+            );
+        };
+
+        let resolved = resolve_source(name, source, project_dir, secret, repo_root)?;
+        out.extend(resolved);
+    }
+    Ok(())
+}
+
+fn resolve_source(
+    name: &str,
+    source: &ConfigSource,
+    project_dir: &Path,
+    secret: bool,
+    repo_root: Option<&Path>,
+) -> Result<HashMap<String, String>> {
+    let mut out: HashMap<String, String> = HashMap::new();
+
+    out.extend(source.inline.clone());
+
+    if let Some(file) = source.file.as_ref() {
+        let resolved_path = resolve_contained_path(file, project_dir)
+            .with_context(|| format!("source '{}' has an unsafe `file:` path", name))?;
+
+        if secret {
+            check_secret_file_perms(&resolved_path).with_context(|| {
+                format!(
+                    "secret source '{}' file permissions are too permissive",
+                    name
+                )
+            })?;
+            warn_if_in_repo(&resolved_path, repo_root, name);
+        }
+
+        let parsed = parse_env_file(&resolved_path).with_context(|| {
+            // Reference by name only; never include resolved value snippets.
+            format!("failed to parse `file:` for source '{}'", name)
+        })?;
+        out.extend(parsed);
+    }
+
+    for var in &source.from_env {
+        match std::env::var(var) {
+            Ok(v) => {
+                out.insert(var.clone(), v);
+            }
+            Err(_) => {
+                bail!(
+                    "source '{}' references environment variable '{}' which is not set",
+                    name,
+                    var
+                );
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Canonicalize `path` (resolving symlinks) and reject anything that escapes
+/// `project_dir`. The CVE-2025-62725 class is "join attacker-controlled
+/// segments to a base dir without checking the result is still under it".
+/// Canonicalizing both sides and comparing prefixes is the standard fix.
+fn resolve_contained_path(path: &Path, project_dir: &Path) -> Result<PathBuf> {
+    // Allow `~` expansion for ergonomics.
+    let expanded = expand_tilde(path);
+
+    let candidate = if expanded.is_absolute() {
+        expanded
+    } else {
+        project_dir.join(expanded)
+    };
+
+    let canonical = candidate
+        .canonicalize()
+        .with_context(|| format!("could not resolve `file:` path: {}", candidate.display()))?;
+
+    let project_canonical = project_dir.canonicalize().with_context(|| {
+        format!(
+            "could not canonicalize project_dir: {}",
+            project_dir.display()
+        )
+    })?;
+
+    // Absolute paths anywhere on disk are allowed (e.g. `~/.config/wash/...`),
+    // BUT relative paths must stay under the project. We detect "was relative"
+    // by checking whether the original path was relative.
+    if !path.is_absolute() && !is_tilde(path) && !canonical.starts_with(&project_canonical) {
+        bail!(
+            "relative `file:` path resolves outside the project directory: {} -> {}",
+            path.display(),
+            canonical.display()
+        );
+    }
+
+    Ok(canonical)
+}
+
+fn expand_tilde(path: &Path) -> PathBuf {
+    let Some(s) = path.to_str() else {
+        return path.to_path_buf();
+    };
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    if let Some(rest) = s.strip_prefix("~/")
+        && let Some(home) = home.as_ref()
+    {
+        return home.join(rest);
+    }
+    if s == "~"
+        && let Some(home) = home
+    {
+        return home;
+    }
+    path.to_path_buf()
+}
+
+fn is_tilde(path: &Path) -> bool {
+    matches!(path.to_str(), Some(s) if s == "~" || s.starts_with("~/"))
+}
+
+#[cfg(unix)]
+fn check_secret_file_perms(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let meta = std::fs::metadata(path)
+        .with_context(|| format!("could not stat secret file: {}", path.display()))?;
+    let mode = meta.permissions().mode() & 0o777;
+    // Allow only owner-read or owner-read-write. Anything group/world readable
+    // is rejected — matches Kubernetes Secret volume defaultMode 0400.
+    if mode != 0o600 && mode != 0o400 {
+        bail!(
+            "secret file {} has mode {:o}; require 0600 or 0400",
+            path.display(),
+            mode
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn check_secret_file_perms(_path: &Path) -> Result<()> {
+    // No portable equivalent on Windows; rely on the user's NTFS ACLs.
+    Ok(())
+}
+
+fn warn_if_in_repo(path: &Path, repo_root: Option<&Path>, name: &str) {
+    let Some(root) = repo_root else { return };
+    let Ok(root_canon) = root.canonicalize() else {
+        return;
+    };
+    if !path.starts_with(&root_canon) {
+        return;
+    }
+    // In-tree but gitignored is the well-known pattern for local dev secret
+    // files (`.env.local`, etc.) — don't be noisy about it. Only warn when
+    // the file is in-tree AND tracked or untracked-but-not-ignored. If git
+    // isn't available we err on the side of warning, matching the
+    // pre-gitignore-aware behavior.
+    if is_gitignored(&root_canon, path).unwrap_or(false) {
+        return;
+    }
+    warn!(
+        secret = name,
+        "secret source `file:` resolves inside the repo working tree and is not gitignored; add it to .gitignore"
+    );
+}
+
+/// Returns `Some(true)` if `git check-ignore` reports `path` as ignored from
+/// `repo_root`, `Some(false)` if it reports it as not ignored, and `None` if
+/// git is unavailable or the directory isn't a git repository. Wraps a
+/// blocking subprocess; only called in the secret-resolve warning path so
+/// the cost is negligible.
+fn is_gitignored(repo_root: &Path, path: &Path) -> Option<bool> {
+    use std::process::{Command, Stdio};
+    // `--quiet` suppresses stdout; exit code carries the answer (per
+    // `git help check-ignore`):
+    //   0 = ignored, 1 = not ignored, 128 = not a git repo or other error.
+    // stderr is piped to /dev/null because the 128 case spits "fatal: not a
+    // git repository" — fine for a fallback path, not fine to leak into the
+    // user's `wash dev` terminal.
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .arg("check-ignore")
+        .arg("--quiet")
+        .arg(path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .ok()?;
+    match status.code() {
+        Some(0) => Some(true),
+        Some(1) => Some(false),
+        _ => None,
+    }
+}
+
+/// Minimal `.env` parser: `KEY=VALUE` per line, `#` line comments, blank lines
+/// ignored. No quoting, escapes, or variable expansion — keep this surface
+/// small and predictable.
+fn parse_env_file(path: &Path) -> Result<HashMap<String, String>> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("could not read file: {}", path.display()))?;
+
+    let mut out = HashMap::new();
+    for (lineno, raw) in contents.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((k, v)) = line.split_once('=') else {
+            bail!("line {} is not KEY=VALUE in {}", lineno + 1, path.display());
+        };
+        let key = k.trim().to_string();
+        if key.is_empty() {
+            bail!("line {} has empty key in {}", lineno + 1, path.display());
+        }
+        out.insert(key, v.trim().to_string());
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::EnvironmentLayer;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn parse_env_file_basic() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("a.env");
+        write(&f, "# comment\nFOO=bar\n\nBAZ=qux\n");
+        let out = parse_env_file(&f).unwrap();
+        assert_eq!(out.get("FOO").unwrap(), "bar");
+        assert_eq!(out.get("BAZ").unwrap(), "qux");
+    }
+
+    #[test]
+    fn relative_path_must_stay_under_project() {
+        let outer = TempDir::new().unwrap();
+        let project = outer.path().join("proj");
+        std::fs::create_dir(&project).unwrap();
+        let outside = outer.path().join("outside.env");
+        write(&outside, "X=1\n");
+
+        let err = resolve_contained_path(Path::new("../outside.env"), &project).unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("outside the project directory"), "{}", msg);
+    }
+
+    #[test]
+    fn relative_path_inside_project_ok() {
+        let project = TempDir::new().unwrap();
+        let inside = project.path().join("a.env");
+        write(&inside, "X=1\n");
+
+        let resolved = resolve_contained_path(Path::new("a.env"), project.path()).unwrap();
+        assert!(resolved.ends_with("a.env"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secret_perms_too_loose_is_rejected() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("s.env");
+        write(&f, "X=1\n");
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let err = check_secret_file_perms(&f).unwrap_err();
+        assert!(format!("{:#}", err).contains("require 0600 or 0400"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secret_perms_0600_ok() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("s.env");
+        write(&f, "X=1\n");
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o600)).unwrap();
+        check_secret_file_perms(&f).unwrap();
+    }
+
+    #[test]
+    fn missing_named_ref_errors() {
+        let mut env = EnvironmentLayer::default();
+        env.config_from.push("missing".into());
+        let workload = WorkloadConfig {
+            environment: Some(env),
+            ..Default::default()
+        };
+        let project = TempDir::new().unwrap();
+        let err = resolve_environment(
+            &workload,
+            &HashMap::new(),
+            &HashMap::new(),
+            project.path(),
+            None,
+        )
+        .unwrap_err();
+        assert!(format!("{:#}", err).contains("missing"));
+    }
+
+    #[test]
+    fn parse_env_file_rejects_missing_equals() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("a.env");
+        write(&f, "FOO=bar\nNOEQUALS\n");
+        let err = parse_env_file(&f).unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("line 2"), "{}", msg);
+        assert!(msg.contains("not KEY=VALUE"), "{}", msg);
+    }
+
+    #[test]
+    fn parse_env_file_rejects_empty_key() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("a.env");
+        write(&f, "=value\n");
+        let err = parse_env_file(&f).unwrap_err();
+        assert!(format!("{:#}", err).contains("empty key"));
+    }
+
+    // SAFETY rationale for `std::env::{set,remove}_var` in tests below:
+    // each test uses a UUID-suffixed variable name, so no other test reads or
+    // writes the same key. `setenv`/`unsetenv` are not thread-safe at the libc
+    // level, but with disjoint keys the only realistic concurrent risk is
+    // pointer corruption inside the env block — accepted for test code, and
+    // the wider codebase has no other env-mutating tests to compound it.
+    #[test]
+    #[allow(unsafe_code)]
+    fn from_env_resolves_set_var_and_errors_on_missing() {
+        let var = format!("WASH_TEST_FROM_ENV_{}", uuid::Uuid::new_v4().simple());
+        unsafe { std::env::set_var(&var, "hello") };
+
+        let project = TempDir::new().unwrap();
+        let source = ConfigSource {
+            from_env: vec![var.clone()],
+            ..Default::default()
+        };
+        let out = resolve_source("c", &source, project.path(), false, None).unwrap();
+        assert_eq!(out.get(&var).unwrap(), "hello");
+
+        unsafe { std::env::remove_var(&var) };
+        let err = resolve_source("c", &source, project.path(), false, None).unwrap_err();
+        assert!(format!("{:#}", err).contains(&var));
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn source_precedence_inline_then_file_then_from_env() {
+        // Within one source: inline → file → fromEnv (later wins). Use the
+        // same key in all three so we can observe overrides.
+        let project = TempDir::new().unwrap();
+        let var = format!("WASH_TEST_PREC_{}", uuid::Uuid::new_v4().simple());
+
+        let f = project.path().join("a.env");
+        write(&f, &format!("{}=from_file\n", var));
+
+        unsafe { std::env::set_var(&var, "from_env") };
+
+        let source = ConfigSource {
+            inline: HashMap::from([(var.clone(), "from_inline".into())]),
+            file: Some(f.clone()),
+            from_env: vec![var.clone()],
+        };
+        let out = resolve_source("c", &source, project.path(), false, None).unwrap();
+        assert_eq!(out.get(&var).unwrap(), "from_env", "fromEnv must win");
+
+        // Drop fromEnv → file should win over inline.
+        unsafe { std::env::remove_var(&var) };
+        let source_no_env = ConfigSource {
+            from_env: vec![],
+            ..source.clone()
+        };
+        let out = resolve_source("c", &source_no_env, project.path(), false, None).unwrap();
+        assert_eq!(
+            out.get(&var).unwrap(),
+            "from_file",
+            "file must win over inline"
+        );
+    }
+
+    #[test]
+    fn env_layer_precedence_inline_then_config_from_then_secret_from() {
+        // Across envFrom layers: inline → configFrom → secretFrom (later wins),
+        // matching K8s envFrom merge semantics. Each layer also writes a
+        // disjoint marker key so a regression that silently drops a layer is
+        // caught even when the conflicting key still gets a winning value.
+        let project = TempDir::new().unwrap();
+        let workload = WorkloadConfig {
+            environment: Some(EnvironmentLayer {
+                config: HashMap::from([
+                    ("KEY".into(), "from_inline".into()),
+                    ("ONLY_INLINE".into(), "1".into()),
+                ]),
+                config_from: vec!["shared_cfg".into()],
+                secret_from: vec!["shared_sec".into()],
+            }),
+            ..Default::default()
+        };
+        let configs = HashMap::from([(
+            "shared_cfg".to_string(),
+            ConfigSource {
+                inline: HashMap::from([
+                    ("KEY".into(), "from_config".into()),
+                    ("ONLY_CONFIG".into(), "1".into()),
+                ]),
+                ..Default::default()
+            },
+        )]);
+        let secrets = HashMap::from([(
+            "shared_sec".to_string(),
+            ConfigSource {
+                inline: HashMap::from([
+                    ("KEY".into(), "from_secret".into()),
+                    ("ONLY_SECRET".into(), "1".into()),
+                ]),
+                ..Default::default()
+            },
+        )]);
+
+        // The secret source has no `file:`, so no perm check fires.
+        let env = resolve_environment(&workload, &configs, &secrets, project.path(), None).unwrap();
+        assert_eq!(
+            env.get("KEY").unwrap(),
+            "from_secret",
+            "secretFrom must win"
+        );
+        // Disjoint markers prove every layer ran.
+        assert_eq!(
+            env.get("ONLY_INLINE").unwrap(),
+            "1",
+            "inline layer was dropped"
+        );
+        assert_eq!(
+            env.get("ONLY_CONFIG").unwrap(),
+            "1",
+            "configFrom layer was dropped"
+        );
+        assert_eq!(
+            env.get("ONLY_SECRET").unwrap(),
+            "1",
+            "secretFrom layer was dropped"
+        );
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn end_to_end_resolve_workload_all_source_types() {
+        let project = TempDir::new().unwrap();
+
+        // configFrom uses a file source (no perm check).
+        let cfg_file = project.path().join("app.env");
+        write(
+            &cfg_file,
+            "APP_FOO=app_foo_value\n# comment\nAPP_BAR=app_bar_value\n",
+        );
+
+        // secretFrom uses an inline + fromEnv source (file would require 0600,
+        // which TempDir defaults don't enforce — keep this test cross-platform).
+        let var = format!("WASH_TEST_E2E_{}", uuid::Uuid::new_v4().simple());
+        unsafe { std::env::set_var(&var, "shell_value") };
+
+        let workload = WorkloadConfig {
+            environment: Some(EnvironmentLayer {
+                config: HashMap::from([("INLINE_KEY".into(), "inline_value".into())]),
+                config_from: vec!["app".into()],
+                secret_from: vec!["creds".into()],
+            }),
+            config: HashMap::from([("WORKLOAD_CFG".into(), "cfg_value".into())]),
+            allowed_hosts: vec!["https://api.example.com".into()],
+        };
+
+        let configs = HashMap::from([(
+            "app".to_string(),
+            ConfigSource {
+                file: Some(cfg_file.clone()),
+                ..Default::default()
+            },
+        )]);
+        let secrets = HashMap::from([(
+            "creds".to_string(),
+            ConfigSource {
+                inline: HashMap::from([("DB_USER".into(), "alice".into())]),
+                from_env: vec![var.clone()],
+                ..Default::default()
+            },
+        )]);
+
+        let config = Config {
+            workload: Some(workload),
+            configs,
+            secrets,
+            ..Default::default()
+        };
+
+        let resolved = resolve_workload(&config, project.path(), Some(project.path())).unwrap();
+
+        unsafe { std::env::remove_var(&var) };
+
+        // environment combines: inline + configFrom file values + secretFrom inline + secretFrom from_env
+        assert_eq!(
+            resolved.environment.get("INLINE_KEY").unwrap(),
+            "inline_value"
+        );
+        assert_eq!(
+            resolved.environment.get("APP_FOO").unwrap(),
+            "app_foo_value"
+        );
+        assert_eq!(
+            resolved.environment.get("APP_BAR").unwrap(),
+            "app_bar_value"
+        );
+        assert_eq!(resolved.environment.get("DB_USER").unwrap(), "alice");
+        assert_eq!(resolved.environment.get(&var).unwrap(), "shell_value");
+
+        // config and allowed_hosts pass through untouched.
+        assert_eq!(resolved.config.get("WORKLOAD_CFG").unwrap(), "cfg_value");
+        assert_eq!(
+            resolved.allowed_hosts,
+            vec!["https://api.example.com".to_string()]
+        );
+    }
+}

--- a/crates/wash/src/workload.rs
+++ b/crates/wash/src/workload.rs
@@ -2,8 +2,9 @@
 //! [`crate::config::Config`] into a flat key-value map suitable for handing
 //! to a wasmCloud runtime workload.
 //!
-//! Secrets and configs share the same source schema ([`ConfigSource`]) but
-//! differ in security posture at resolve time:
+//! Configs and secrets carry distinct types ([`ConfigSource`],
+//! [`SecretSource`]) so the stricter secret-handling posture can only be
+//! applied to secrets:
 //!
 //! * **Path containment.** Every `file:` path is canonicalized and rejected
 //!   if it escapes the project directory (defense against the
@@ -22,14 +23,17 @@
 //!   written back to disk.
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
+    fs::File,
+    io::{BufRead, BufReader},
     path::{Path, PathBuf},
 };
 
 use anyhow::{Context as _, Result, bail};
-use tracing::warn;
+use tracing::{trace, warn};
+use wash_runtime::host::allowed_hosts::AllowedHost;
 
-use crate::config::{Config, ConfigSource, WorkloadConfig};
+use crate::config::{Config, ConfigSource, SecretSource, WorkloadConfig};
 
 /// Resolved workload values ready to be applied to a runtime `LocalResources`.
 #[derive(Debug, Default, Clone)]
@@ -38,16 +42,29 @@ pub struct ResolvedWorkload {
     pub environment: HashMap<String, String>,
     /// Opaque key-value config delivered to the component.
     pub config: HashMap<String, String>,
-    /// Outbound HTTP allowlist.
-    pub allowed_hosts: Vec<String>,
+    /// Outbound HTTP allowlist (typed). When the wash YAML omitted
+    /// `allowedHosts`, this is `[AllowedHost::Any]` (allow-all) — the
+    /// serde default fires at deserialize time. An explicit
+    /// `allowedHosts: []` in YAML stays empty here, and the runtime
+    /// (see [`wash_runtime::host::http::check_allowed_hosts`]) interprets
+    /// empty as deny-all.
+    pub allowed_hosts: Vec<AllowedHost>,
 }
 
-/// Resolve the workload section of a [`Config`], pulling in named entries
+/// Resolves the workload section of a [`Config`], pulling in named entries
 /// from the top-level `configs:` and `secrets:` blocks.
 ///
 /// `project_dir` anchors relative `file:` paths and bounds path containment
 /// checks. `repo_root` (when known) gates the "secret file lives in the repo
 /// tree" warning.
+///
+/// # Errors
+///
+/// Returns an error if any `configFrom` / `secretFrom` reference cannot be
+/// found in the catalogs, if a `file:` source has an unsafe path (escapes
+/// the project directory or has the wrong mode for a secret), if a
+/// `fromEnv` reference points at a missing environment variable, or if a
+/// `.env` file fails to parse.
 pub fn resolve_workload(
     config: &Config,
     project_dir: &Path,
@@ -59,12 +76,17 @@ pub fn resolve_workload(
 
     let environment = resolve_environment(
         workload,
-        &config.configs,
-        &config.secrets,
+        &config.config_sources,
+        &config.secret_sources,
         project_dir,
         repo_root,
     )?;
 
+    // `workload.allowed_hosts` is whatever serde produced: `[Any]` when the
+    // YAML omitted `allowedHosts` (via `default_allow_all_hosts`), or the
+    // user's explicit list (including an explicit empty list, which the
+    // runtime treats as deny-all). Either way, pass through unchanged.
+    //Tthe substitution lives on the serde default, not here.
     Ok(ResolvedWorkload {
         environment,
         config: workload.config.clone(),
@@ -72,10 +94,14 @@ pub fn resolve_workload(
     })
 }
 
+/// Builds the flat env-var map for a workload by walking
+/// `environment.inline`, `environment.configFrom`, and
+/// `environment.secretFrom` in K8s `envFrom` order (inline → configFrom →
+/// secretFrom, later wins on key conflicts).
 fn resolve_environment(
     workload: &WorkloadConfig,
-    configs: &HashMap<String, ConfigSource>,
-    secrets: &HashMap<String, ConfigSource>,
+    configs: &BTreeMap<String, ConfigSource>,
+    secrets: &BTreeMap<String, SecretSource>,
     project_dir: &Path,
     repo_root: Option<&Path>,
 ) -> Result<HashMap<String, String>> {
@@ -89,106 +115,174 @@ fn resolve_environment(
     // then secretFrom. Later layers overwrite earlier on key conflicts.
     out.extend(env.config.clone());
 
-    apply_refs(
-        &env.config_from,
-        configs,
-        project_dir,
-        /* secret */ false,
-        repo_root,
-        &mut out,
-    )
-    .context("failed to resolve workload.environment.configFrom")?;
-    apply_refs(
-        &env.secret_from,
-        secrets,
-        project_dir,
-        /* secret */ true,
-        repo_root,
-        &mut out,
-    )
-    .context("failed to resolve workload.environment.secretFrom")?;
+    apply_config_refs(&env.config_from, configs, project_dir, &mut out)
+        .context("failed to resolve workload.environment.configFrom")?;
+    apply_secret_refs(&env.secret_from, secrets, project_dir, repo_root, &mut out)
+        .context("failed to resolve workload.environment.secretFrom")?;
 
     Ok(out)
 }
 
-fn apply_refs(
+/// Looks up each named reference in `catalog`, resolves its
+/// [`ConfigSource`], and merges the result into `out`. Missing names are
+/// a hard error so typos in `configFrom` fail loudly.
+fn apply_config_refs(
     refs: &[String],
-    catalog: &HashMap<String, ConfigSource>,
+    catalog: &BTreeMap<String, ConfigSource>,
     project_dir: &Path,
-    secret: bool,
-    repo_root: Option<&Path>,
     out: &mut HashMap<String, String>,
 ) -> Result<()> {
     for name in refs {
         let Some(source) = catalog.get(name) else {
-            let kind = if secret { "secret" } else { "config" };
             bail!(
-                "workload references {} '{}' which is not defined in the top-level `{}s:` block",
-                kind,
-                name,
-                kind
+                "workload references config '{name}' which is not defined in the top-level `configs:` block",
             );
         };
-
-        let resolved = resolve_source(name, source, project_dir, secret, repo_root)?;
+        let resolved = source.resolve(name, project_dir)?;
         out.extend(resolved);
     }
     Ok(())
 }
 
-fn resolve_source(
-    name: &str,
-    source: &ConfigSource,
+/// Looks up each named reference in `catalog`, resolves its
+/// [`SecretSource`], and merges the result into `out`. Missing names are
+/// a hard error so typos in `secretFrom` fail loudly.
+fn apply_secret_refs(
+    refs: &[String],
+    catalog: &BTreeMap<String, SecretSource>,
     project_dir: &Path,
-    secret: bool,
     repo_root: Option<&Path>,
-) -> Result<HashMap<String, String>> {
-    let mut out: HashMap<String, String> = HashMap::new();
+    out: &mut HashMap<String, String>,
+) -> Result<()> {
+    for name in refs {
+        let Some(source) = catalog.get(name) else {
+            bail!(
+                "workload references secret '{name}' which is not defined in the top-level `secrets:` block",
+            );
+        };
+        let resolved = source.resolve(name, project_dir, repo_root)?;
+        out.extend(resolved);
+    }
+    Ok(())
+}
 
-    out.extend(source.inline.clone());
+impl ConfigSource {
+    /// Resolves this config source into a flat key-value map.
+    ///
+    /// Layers merge last-wins in the order `inline` → `file` → `fromEnv`
+    /// (matches K8s ConfigMap merge semantics). `name` is used only in
+    /// error / log messages — value snippets never appear in either.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `file:` path is unsafe (escapes the
+    /// project directory) or unreadable, the file fails to parse as
+    /// `.env`, or a `fromEnv` entry is missing from the process
+    /// environment.
+    pub fn resolve(&self, name: &str, project_dir: &Path) -> Result<HashMap<String, String>> {
+        let mut out: HashMap<String, String> = HashMap::new();
+        out.extend(self.inline.clone());
 
-    if let Some(file) = source.file.as_ref() {
-        let resolved_path = resolve_contained_path(file, project_dir)
-            .with_context(|| format!("source '{}' has an unsafe `file:` path", name))?;
-
-        if secret {
-            check_secret_file_perms(&resolved_path).with_context(|| {
-                format!(
-                    "secret source '{}' file permissions are too permissive",
-                    name
-                )
-            })?;
-            warn_if_in_repo(&resolved_path, repo_root, name);
+        if let Some(file) = self.file.as_ref() {
+            let resolved_path = resolve_contained_path(file, project_dir)
+                .with_context(|| format!("config source '{name}' has an unsafe `file:` path"))?;
+            // `O_NOFOLLOW` on the open hardens against a symlink-swap race
+            // between our `canonicalize` and the read — useful even for
+            // non-secret config.
+            let handle = open_file_secure(&resolved_path)
+                .with_context(|| format!("could not open `file:` for config source '{name}'"))?;
+            let parsed = parse_env_file(handle, &resolved_path)
+                .with_context(|| format!("failed to parse `file:` for config source '{name}'"))?;
+            out.extend(parsed);
         }
 
-        let parsed = parse_env_file(&resolved_path).with_context(|| {
-            // Reference by name only; never include resolved value snippets.
-            format!("failed to parse `file:` for source '{}'", name)
-        })?;
-        out.extend(parsed);
+        extend_from_env(&self.from_env, "config source", name, &mut out)?;
+        Ok(out)
     }
+}
 
-    for var in &source.from_env {
+impl SecretSource {
+    /// Resolves this secret source into a flat key-value map under the
+    /// stricter secret-handling posture.
+    ///
+    /// Layer order matches [`ConfigSource::resolve`] (inline → file →
+    /// fromEnv, last-wins). In addition, when a `file:` is set the
+    /// resolved path is:
+    ///
+    /// - opened with `O_NOFOLLOW` so a symlink swap between
+    ///   canonicalize and open is rejected,
+    /// - mode-checked via `fstat` on the open fd (must be `0600` or
+    ///   `0400` on Unix), and
+    /// - warned-about if it sits inside the repo working tree and is not
+    ///   gitignored.
+    ///
+    /// `name` is used only in error / log messages — value snippets
+    /// never appear in either.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any check above fails, if the path is unsafe,
+    /// if the file fails to parse, or if a `fromEnv` entry is missing
+    /// from the process environment.
+    pub fn resolve(
+        &self,
+        name: &str,
+        project_dir: &Path,
+        repo_root: Option<&Path>,
+    ) -> Result<HashMap<String, String>> {
+        let mut out: HashMap<String, String> = HashMap::new();
+        out.extend(self.inline.clone());
+
+        if let Some(file) = self.file.as_ref() {
+            let resolved_path = resolve_contained_path(file, project_dir)
+                .with_context(|| format!("secret source '{name}' has an unsafe `file:` path"))?;
+            // TOCTOU-safe sequence: open once (`O_NOFOLLOW`), `fstat` the
+            // open fd for perms, then read from that same fd. Closes both
+            // the canonicalize↔open race (symlink swap) and the
+            // perm-check↔read race (mode swap).
+            let handle = open_file_secure(&resolved_path)
+                .with_context(|| format!("could not open `file:` for secret source '{name}'"))?;
+            check_secret_file_perms(&handle, &resolved_path).with_context(|| {
+                format!("secret source '{name}' file permissions are too permissive")
+            })?;
+            warn_if_in_repo(&resolved_path, repo_root, name);
+            let parsed = parse_env_file(handle, &resolved_path)
+                .with_context(|| format!("failed to parse `file:` for secret source '{name}'"))?;
+            out.extend(parsed);
+        }
+
+        extend_from_env(&self.from_env, "secret source", name, &mut out)?;
+        Ok(out)
+    }
+}
+
+/// Reads each named env var and inserts it into `out`. `kind` is the
+/// label used in error messages (e.g. `"config source"` /
+/// `"secret source"`).
+fn extend_from_env(
+    vars: &[String],
+    kind: &str,
+    name: &str,
+    out: &mut HashMap<String, String>,
+) -> Result<()> {
+    for var in vars {
         match std::env::var(var) {
             Ok(v) => {
                 out.insert(var.clone(), v);
             }
             Err(_) => {
-                bail!(
-                    "source '{}' references environment variable '{}' which is not set",
-                    name,
-                    var
-                );
+                bail!("{kind} '{name}' references environment variable '{var}' which is not set");
             }
         }
     }
-
-    Ok(out)
+    Ok(())
 }
 
-/// Canonicalize `path` (resolving symlinks) and reject anything that escapes
-/// `project_dir`. The CVE-2025-62725 class is "join attacker-controlled
-/// segments to a base dir without checking the result is still under it".
+/// Canonicalizes `path` (resolving symlinks) and rejects anything that
+/// escapes `project_dir`.
+///
+/// The CVE-2025-62725 class is "join attacker-controlled segments to a
+/// base dir without checking the result is still under it".
 /// Canonicalizing both sides and comparing prefixes is the standard fix.
 fn resolve_contained_path(path: &Path, project_dir: &Path) -> Result<PathBuf> {
     // Allow `~` expansion for ergonomics.
@@ -225,11 +319,19 @@ fn resolve_contained_path(path: &Path, project_dir: &Path) -> Result<PathBuf> {
     Ok(canonical)
 }
 
+/// Expands a leading `~` or `~/` in `path` to the user's home directory.
+///
+/// Returns `path` unchanged when it doesn't start with `~`, when the path
+/// isn't valid UTF-8, or when the home directory can't be determined.
 fn expand_tilde(path: &Path) -> PathBuf {
     let Some(s) = path.to_str() else {
         return path.to_path_buf();
     };
-    let home = std::env::var_os("HOME").map(PathBuf::from);
+    // `etcetera::home_dir` wraps the same `home_dir` crate the rest of wash
+    // uses for XDG resolution. Don't fall back to `$HOME`: an absent home
+    // directory means "no expansion" rather than constructing a path that
+    // can't possibly be right.
+    let home = etcetera::home_dir().ok();
     if let Some(rest) = s.strip_prefix("~/")
         && let Some(home) = home.as_ref()
     {
@@ -243,15 +345,51 @@ fn expand_tilde(path: &Path) -> PathBuf {
     path.to_path_buf()
 }
 
+/// Returns `true` when `path` is exactly `~` or starts with `~/`.
 fn is_tilde(path: &Path) -> bool {
     matches!(path.to_str(), Some(s) if s == "~" || s.starts_with("~/"))
 }
 
+/// Opens `path` read-only with symlink-swap protection.
+///
+/// On Unix, `O_NOFOLLOW` ensures the final path component is not a
+/// symlink: if `path` was swapped to a symlink between our `canonicalize`
+/// check and this open, the call fails (`ELOOP`) instead of following the
+/// new target. The canonicalize step already resolved any earlier
+/// symlinks, so `O_NOFOLLOW` here is the last hop's guarantee.
+///
+/// On non-Unix platforms there's no portable equivalent — falls back to a
+/// plain open and relies on the host's NTFS ACLs (the same posture as
+/// `check_secret_file_perms` for Windows).
 #[cfg(unix)]
-fn check_secret_file_perms(path: &Path) -> Result<()> {
+fn open_file_secure(path: &Path) -> std::io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_file_secure(path: &Path) -> std::io::Result<File> {
+    File::open(path)
+}
+
+/// Rejects a secret file unless its mode is `0600` or `0400`.
+///
+/// Performs the check via `fstat` on the open descriptor (Unix), which is
+/// race-free against symlink / path swaps between this check and the
+/// subsequent read. On Windows there's no portable equivalent and the
+/// check is a no-op — callers fall back to NTFS ACLs.
+#[cfg(unix)]
+fn check_secret_file_perms(file: &File, path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
-    let meta = std::fs::metadata(path)
+    // `File::metadata` is `fstat` on Unix — it operates on the open
+    // descriptor, not the path, so it can't be raced by a symlink swap
+    // between check and read.
+    let meta = file
+        .metadata()
         .with_context(|| format!("could not stat secret file: {}", path.display()))?;
     let mode = meta.permissions().mode() & 0o777;
     // Allow only owner-read or owner-read-write. Anything group/world readable
@@ -267,13 +405,37 @@ fn check_secret_file_perms(path: &Path) -> Result<()> {
 }
 
 #[cfg(not(unix))]
-fn check_secret_file_perms(_path: &Path) -> Result<()> {
-    // No portable equivalent on Windows; rely on the user's NTFS ACLs.
+fn check_secret_file_perms(_file: &File, path: &Path) -> Result<()> {
+    // No portable equivalent on Windows — rely on the user's NTFS ACLs.
+    // Emit a one-shot `warn!` so the developer knows their secrets aren't
+    // mode-checked here; per-call warnings would spam workloads with
+    // several secrets without adding signal.
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if !WARNED.swap(true, Ordering::Relaxed) {
+        warn!(
+            ?path,
+            "secret file permission checks are not enforced on this platform; \
+             relying on the host filesystem ACLs"
+        );
+    }
     Ok(())
 }
 
+/// Emits a `warn!` log when `path` resolves inside the repo working tree
+/// and is not gitignored.
+///
+/// This catches the common `.env`-in-repo footgun before a developer
+/// accidentally commits secrets. Gitignored files are skipped (that's the
+/// well-known `.env.local` dev pattern). If `repo_root` is unknown or git
+/// is unavailable, errs on the side of warning.
 fn warn_if_in_repo(path: &Path, repo_root: Option<&Path>, name: &str) {
-    let Some(root) = repo_root else { return };
+    let Some(root) = repo_root else {
+        // Caller didn't supply a repo root, so we can't decide. Trace-only so
+        // it doesn't drown the dev terminal but is still findable.
+        trace!(secret = name, "skipping in-repo check: repo_root unknown");
+        return;
+    };
     let Ok(root_canon) = root.canonicalize() else {
         return;
     };
@@ -285,7 +447,7 @@ fn warn_if_in_repo(path: &Path, repo_root: Option<&Path>, name: &str) {
     // the file is in-tree AND tracked or untracked-but-not-ignored. If git
     // isn't available we err on the side of warning, matching the
     // pre-gitignore-aware behavior.
-    if is_gitignored(&root_canon, path).unwrap_or(false) {
+    if is_path_gitignored(&root_canon, path) {
         return;
     }
     warn!(
@@ -294,12 +456,12 @@ fn warn_if_in_repo(path: &Path, repo_root: Option<&Path>, name: &str) {
     );
 }
 
-/// Returns `Some(true)` if `git check-ignore` reports `path` as ignored from
-/// `repo_root`, `Some(false)` if it reports it as not ignored, and `None` if
-/// git is unavailable or the directory isn't a git repository. Wraps a
-/// blocking subprocess; only called in the secret-resolve warning path so
-/// the cost is negligible.
-fn is_gitignored(repo_root: &Path, path: &Path) -> Option<bool> {
+/// Returns `true` only when `git check-ignore` confidently reports `path` as
+/// ignored from `repo_root`. Any other outcome — not ignored, git missing,
+/// not a git repo, command failure — returns `false`. The caller treats
+/// "we can't be sure" the same as "definitely not ignored" so a developer
+/// who has e.g. uninstalled git still gets the warning.
+fn is_path_gitignored(repo_root: &Path, path: &Path) -> bool {
     use std::process::{Command, Stdio};
     // `--quiet` suppresses stdout; exit code carries the answer (per
     // `git help check-ignore`):
@@ -307,7 +469,7 @@ fn is_gitignored(repo_root: &Path, path: &Path) -> Option<bool> {
     // stderr is piped to /dev/null because the 128 case spits "fatal: not a
     // git repository" — fine for a fallback path, not fine to leak into the
     // user's `wash dev` terminal.
-    let status = Command::new("git")
+    let Ok(status) = Command::new("git")
         .arg("-C")
         .arg(repo_root)
         .arg("check-ignore")
@@ -316,28 +478,32 @@ fn is_gitignored(repo_root: &Path, path: &Path) -> Option<bool> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .ok()?;
-    match status.code() {
-        Some(0) => Some(true),
-        Some(1) => Some(false),
-        _ => None,
-    }
+    else {
+        return false;
+    };
+    status.code() == Some(0)
 }
 
 /// Minimal `.env` parser: `KEY=VALUE` per line, `#` line comments, blank lines
 /// ignored. No quoting, escapes, or variable expansion — keep this surface
 /// small and predictable.
-fn parse_env_file(path: &Path) -> Result<HashMap<String, String>> {
-    let contents = std::fs::read_to_string(path)
-        .with_context(|| format!("could not read file: {}", path.display()))?;
+///
+/// Takes an already-open [`File`] so the caller can keep one descriptor for
+/// the lifetime of the perm-check-then-read sequence (eliminates the TOCTOU
+/// race between a path-based stat and a path-based open). Streams via
+/// `BufReader` so a large `.env` file never lands in memory whole. `path`
+/// is used only for error messages.
+fn parse_env_file(file: File, path: &Path) -> Result<HashMap<String, String>> {
+    let reader = BufReader::new(file);
 
     let mut out = HashMap::new();
-    for (lineno, raw) in contents.lines().enumerate() {
-        let line = raw.trim();
-        if line.is_empty() || line.starts_with('#') {
+    for (lineno, line) in reader.lines().enumerate() {
+        let raw = line.with_context(|| format!("could not read file: {}", path.display()))?;
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
-        let Some((k, v)) = line.split_once('=') else {
+        let Some((k, v)) = trimmed.split_once('=') else {
             bail!("line {} is not KEY=VALUE in {}", lineno + 1, path.display());
         };
         let key = k.trim().to_string();
@@ -355,16 +521,12 @@ mod tests {
     use crate::config::EnvironmentLayer;
     use tempfile::TempDir;
 
-    fn write(path: &Path, contents: &str) {
-        std::fs::write(path, contents).unwrap();
-    }
-
     #[test]
     fn parse_env_file_basic() {
         let dir = TempDir::new().unwrap();
         let f = dir.path().join("a.env");
-        write(&f, "# comment\nFOO=bar\n\nBAZ=qux\n");
-        let out = parse_env_file(&f).unwrap();
+        std::fs::write(&f, "# comment\nFOO=bar\n\nBAZ=qux\n").unwrap();
+        let out = parse_env_file(open_file_secure(&f).unwrap(), &f).unwrap();
         assert_eq!(out.get("FOO").unwrap(), "bar");
         assert_eq!(out.get("BAZ").unwrap(), "qux");
     }
@@ -375,7 +537,7 @@ mod tests {
         let project = outer.path().join("proj");
         std::fs::create_dir(&project).unwrap();
         let outside = outer.path().join("outside.env");
-        write(&outside, "X=1\n");
+        std::fs::write(&outside, "X=1\n").unwrap();
 
         let err = resolve_contained_path(Path::new("../outside.env"), &project).unwrap_err();
         let msg = format!("{:#}", err);
@@ -386,7 +548,7 @@ mod tests {
     fn relative_path_inside_project_ok() {
         let project = TempDir::new().unwrap();
         let inside = project.path().join("a.env");
-        write(&inside, "X=1\n");
+        std::fs::write(&inside, "X=1\n").unwrap();
 
         let resolved = resolve_contained_path(Path::new("a.env"), project.path()).unwrap();
         assert!(resolved.ends_with("a.env"));
@@ -399,9 +561,10 @@ mod tests {
 
         let dir = TempDir::new().unwrap();
         let f = dir.path().join("s.env");
-        write(&f, "X=1\n");
+        std::fs::write(&f, "X=1\n").unwrap();
         std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o644)).unwrap();
-        let err = check_secret_file_perms(&f).unwrap_err();
+        let handle = open_file_secure(&f).unwrap();
+        let err = check_secret_file_perms(&handle, &f).unwrap_err();
         assert!(format!("{:#}", err).contains("require 0600 or 0400"));
     }
 
@@ -412,9 +575,31 @@ mod tests {
 
         let dir = TempDir::new().unwrap();
         let f = dir.path().join("s.env");
-        write(&f, "X=1\n");
+        std::fs::write(&f, "X=1\n").unwrap();
         std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o600)).unwrap();
-        check_secret_file_perms(&f).unwrap();
+        let handle = open_file_secure(&f).unwrap();
+        check_secret_file_perms(&handle, &f).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_file_secure_rejects_symlink_to_secret() {
+        // `O_NOFOLLOW` is the last-hop guarantee for the canonicalize↔open
+        // race: if the final path component is a symlink, the open fails.
+        // We don't follow symlinks even if the target would have passed
+        // every prior check (mode, in-repo).
+        let dir = TempDir::new().unwrap();
+        let real = dir.path().join("real.env");
+        std::fs::write(&real, "X=1\n").unwrap();
+        let link = dir.path().join("link.env");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let err = open_file_secure(&link).expect_err("symlink open should be rejected");
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ELOOP),
+            "expected ELOOP from O_NOFOLLOW, got {err:?}"
+        );
     }
 
     #[test]
@@ -428,8 +613,8 @@ mod tests {
         let project = TempDir::new().unwrap();
         let err = resolve_environment(
             &workload,
-            &HashMap::new(),
-            &HashMap::new(),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
             project.path(),
             None,
         )
@@ -441,8 +626,8 @@ mod tests {
     fn parse_env_file_rejects_missing_equals() {
         let dir = TempDir::new().unwrap();
         let f = dir.path().join("a.env");
-        write(&f, "FOO=bar\nNOEQUALS\n");
-        let err = parse_env_file(&f).unwrap_err();
+        std::fs::write(&f, "FOO=bar\nNOEQUALS\n").unwrap();
+        let err = parse_env_file(open_file_secure(&f).unwrap(), &f).unwrap_err();
         let msg = format!("{:#}", err);
         assert!(msg.contains("line 2"), "{}", msg);
         assert!(msg.contains("not KEY=VALUE"), "{}", msg);
@@ -452,8 +637,8 @@ mod tests {
     fn parse_env_file_rejects_empty_key() {
         let dir = TempDir::new().unwrap();
         let f = dir.path().join("a.env");
-        write(&f, "=value\n");
-        let err = parse_env_file(&f).unwrap_err();
+        std::fs::write(&f, "=value\n").unwrap();
+        let err = parse_env_file(open_file_secure(&f).unwrap(), &f).unwrap_err();
         assert!(format!("{:#}", err).contains("empty key"));
     }
 
@@ -474,11 +659,11 @@ mod tests {
             from_env: vec![var.clone()],
             ..Default::default()
         };
-        let out = resolve_source("c", &source, project.path(), false, None).unwrap();
+        let out = source.resolve("c", project.path()).unwrap();
         assert_eq!(out.get(&var).unwrap(), "hello");
 
         unsafe { std::env::remove_var(&var) };
-        let err = resolve_source("c", &source, project.path(), false, None).unwrap_err();
+        let err = source.resolve("c", project.path()).unwrap_err();
         assert!(format!("{:#}", err).contains(&var));
     }
 
@@ -491,7 +676,7 @@ mod tests {
         let var = format!("WASH_TEST_PREC_{}", uuid::Uuid::new_v4().simple());
 
         let f = project.path().join("a.env");
-        write(&f, &format!("{}=from_file\n", var));
+        std::fs::write(&f, format!("{}=from_file\n", var)).unwrap();
 
         unsafe { std::env::set_var(&var, "from_env") };
 
@@ -500,7 +685,7 @@ mod tests {
             file: Some(f.clone()),
             from_env: vec![var.clone()],
         };
-        let out = resolve_source("c", &source, project.path(), false, None).unwrap();
+        let out = source.resolve("c", project.path()).unwrap();
         assert_eq!(out.get(&var).unwrap(), "from_env", "fromEnv must win");
 
         // Drop fromEnv → file should win over inline.
@@ -509,7 +694,7 @@ mod tests {
             from_env: vec![],
             ..source.clone()
         };
-        let out = resolve_source("c", &source_no_env, project.path(), false, None).unwrap();
+        let out = source_no_env.resolve("c", project.path()).unwrap();
         assert_eq!(
             out.get(&var).unwrap(),
             "from_file",
@@ -535,7 +720,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let configs = HashMap::from([(
+        let configs = BTreeMap::from([(
             "shared_cfg".to_string(),
             ConfigSource {
                 inline: HashMap::from([
@@ -545,9 +730,9 @@ mod tests {
                 ..Default::default()
             },
         )]);
-        let secrets = HashMap::from([(
+        let secrets = BTreeMap::from([(
             "shared_sec".to_string(),
-            ConfigSource {
+            SecretSource {
                 inline: HashMap::from([
                     ("KEY".into(), "from_secret".into()),
                     ("ONLY_SECRET".into(), "1".into()),
@@ -588,10 +773,11 @@ mod tests {
 
         // configFrom uses a file source (no perm check).
         let cfg_file = project.path().join("app.env");
-        write(
+        std::fs::write(
             &cfg_file,
             "APP_FOO=app_foo_value\n# comment\nAPP_BAR=app_bar_value\n",
-        );
+        )
+        .unwrap();
 
         // secretFrom uses an inline + fromEnv source (file would require 0600,
         // which TempDir defaults don't enforce — keep this test cross-platform).
@@ -605,19 +791,19 @@ mod tests {
                 secret_from: vec!["creds".into()],
             }),
             config: HashMap::from([("WORKLOAD_CFG".into(), "cfg_value".into())]),
-            allowed_hosts: vec!["https://api.example.com".into()],
+            allowed_hosts: vec!["https://api.example.com".parse().unwrap()],
         };
 
-        let configs = HashMap::from([(
+        let configs = BTreeMap::from([(
             "app".to_string(),
             ConfigSource {
                 file: Some(cfg_file.clone()),
                 ..Default::default()
             },
         )]);
-        let secrets = HashMap::from([(
+        let secrets = BTreeMap::from([(
             "creds".to_string(),
-            ConfigSource {
+            SecretSource {
                 inline: HashMap::from([("DB_USER".into(), "alice".into())]),
                 from_env: vec![var.clone()],
                 ..Default::default()
@@ -626,8 +812,8 @@ mod tests {
 
         let config = Config {
             workload: Some(workload),
-            configs,
-            secrets,
+            config_sources: configs,
+            secret_sources: secrets,
             ..Default::default()
         };
 
@@ -655,7 +841,74 @@ mod tests {
         assert_eq!(resolved.config.get("WORKLOAD_CFG").unwrap(), "cfg_value");
         assert_eq!(
             resolved.allowed_hosts,
-            vec!["https://api.example.com".to_string()]
+            vec!["https://api.example.com".parse().unwrap()]
         );
+    }
+
+    #[test]
+    fn workload_config_default_is_empty_allowed_hosts_for_deny_close() {
+        // Programmatic `WorkloadConfig::default()` is fail-closed: empty
+        // `allowed_hosts`. Only the serde deserialize path substitutes
+        // `[Any]` when the YAML omits the field.
+        let cfg = WorkloadConfig::default();
+        assert!(cfg.allowed_hosts.is_empty());
+    }
+
+    #[test]
+    fn allowed_hosts_defaults_to_any_when_yaml_omits_field() {
+        // Serde default fires only on missing field, resolving to [Any].
+        let yaml = r#"
+workload:
+  environment:
+    config:
+      LOG: debug
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let project = TempDir::new().unwrap();
+        let resolved = resolve_workload(&config, project.path(), Some(project.path())).unwrap();
+        assert_eq!(resolved.allowed_hosts, vec![AllowedHost::Any]);
+    }
+
+    #[test]
+    fn allowed_hosts_explicit_empty_in_yaml_stays_empty_for_deny_all() {
+        // Explicit `allowedHosts: []` must NOT trigger the serde default;
+        // it should round-trip through `resolve_workload` as an empty list
+        // so the runtime denies all egress.
+        let yaml = r#"
+workload:
+  allowedHosts: []
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let project = TempDir::new().unwrap();
+        let resolved = resolve_workload(&config, project.path(), Some(project.path())).unwrap();
+        assert!(resolved.allowed_hosts.is_empty());
+    }
+
+    #[test]
+    fn resolve_workload_empty_allowed_hosts_denied_by_runtime_check() {
+        use wash_runtime::host::http::check_allowed_hosts;
+        let yaml = "workload:\n  allowedHosts: []\n";
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let project = TempDir::new().unwrap();
+        let resolved = resolve_workload(&config, project.path(), Some(project.path())).unwrap();
+        let req = hyper::Request::builder()
+            .uri("http://example.com")
+            .body(())
+            .unwrap();
+        assert!(check_allowed_hosts(&req, &resolved.allowed_hosts).is_err());
+    }
+
+    #[test]
+    fn resolve_workload_default_allowed_hosts_allowed_by_runtime_check() {
+        use wash_runtime::host::http::check_allowed_hosts;
+        let yaml = "workload:\n  environment:\n    config:\n      X: \"1\"\n";
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let project = TempDir::new().unwrap();
+        let resolved = resolve_workload(&config, project.path(), Some(project.path())).unwrap();
+        let req = hyper::Request::builder()
+            .uri("http://example.com")
+            .body(())
+            .unwrap();
+        assert!(check_allowed_hosts(&req, &resolved.allowed_hosts).is_ok());
     }
 }

--- a/runtime-operator/api/runtime/v1alpha1/allowed_hosts_pattern_test.go
+++ b/runtime-operator/api/runtime/v1alpha1/allowed_hosts_pattern_test.go
@@ -1,0 +1,104 @@
+package v1alpha1
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestAllowedHostsPattern exercises the kubebuilder Pattern regex annotated
+// on LocalResources.AllowedHosts. The pattern is loaded from the generated
+// CRD YAML so the test follows the source of truth — if someone edits the
+// +kubebuilder:validation:items:Pattern annotation and re-runs
+// `make manifests`, this test re-extracts and re-checks.
+//
+// kube-apiserver evaluates OpenAPI patterns via kube-openapi/pkg/validation,
+// which uses Go's regexp package (RE2). Testing the same regex with the
+// stdlib regexp is faithful to admission-time behavior.
+func TestAllowedHostsPattern(t *testing.T) {
+	pattern := loadAllowedHostsPattern(t)
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		t.Fatalf("CRD pattern failed to compile as a Go regex: %v\npattern: %s", err, pattern)
+	}
+
+	cases := []struct {
+		input string
+		want  bool
+		why   string
+	}{
+		// --- accepted forms ---
+		{"*", true, "literal star = allow all"},
+		{"example.com", true, "bare authority"},
+		{"example.com:8443", true, "authority with port"},
+		{"localhost:8080", true, "single-label host"},
+		{"a.b.c.example.com", true, "deeply nested host"},
+		{"*.example.com", true, "scheme-less wildcard"},
+		{"*.example.com:8443", true, "wildcard with port"},
+		{"https://example.com", true, "URL no path"},
+		{"https://example.com/", true, "URL bare trailing slash"},
+		{"https://example.com:8443", true, "URL with port"},
+		{"https://*.example.com", true, "URL wildcard"},
+		{"https://*.example.com:8443/", true, "URL wildcard + port + slash"},
+
+		// --- rejected forms ---
+		{"", false, "empty"},
+		{"*foo", false, "wildcard without leading dot"},
+		{"*com", false, "the *com footgun"},
+		{"example.com/v1", false, "bare authority + path (no scheme)"},
+		{"example.com:notaport", false, "non-numeric port"},
+		{"https://example.com/v1", false, "URL with non-root path"},
+		{"https://example.com/v1/users", false, "URL with multi-segment path"},
+		{"http://", false, "scheme with no host"},
+		{":8080", false, "port with no host"},
+		{"-example.com", false, "host label starts with hyphen"},
+		{"example-.com", false, "host label ends with hyphen"},
+
+		// Note: ECMA-262 (the OpenAPI spec) and RE2 (Go) agree on every
+		// construct used in this pattern (anchors, character classes,
+		// alternation, quantifiers, simple escapes). No engine-specific
+		// behavior to worry about for our cases.
+	}
+
+	for _, tc := range cases {
+		got := re.MatchString(tc.input)
+		if got != tc.want {
+			t.Errorf("MatchString(%q) = %v, want %v  // %s", tc.input, got, tc.want, tc.why)
+		}
+	}
+}
+
+// loadAllowedHostsPattern reads the generated `workloads` CRD and extracts
+// the Pattern annotation applied to the AllowedHosts items. The kubebuilder
+// generator emits the pattern as a bare YAML scalar on its own line; we
+// match it by anchoring on `^\*$|` which is unique to this regex within
+// the CRD file (other Pattern entries — e.g. HostInterface.Name — start
+// with different alternations).
+func loadAllowedHostsPattern(t *testing.T) string {
+	t.Helper()
+	here, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// runtime-operator/api/runtime/v1alpha1 → runtime-operator/config/crd/bases
+	crdPath := filepath.Join(
+		here, "..", "..", "..",
+		"config", "crd", "bases",
+		"runtime.wasmcloud.dev_workloads.yaml",
+	)
+	data, err := os.ReadFile(crdPath)
+	if err != nil {
+		t.Fatalf("read CRD %q: %v", crdPath, err)
+	}
+	// `pattern: ^\*$|...` — the YAML scalar is unquoted, so backslashes
+	// in the regex are literal. Capture from `^\*$|` to end-of-line.
+	finder := regexp.MustCompile(`pattern: (\^\\\*\$\|[^\n]+)`)
+	m := finder.FindSubmatch(data)
+	if m == nil {
+		t.Fatalf("could not locate allowedHosts pattern in %s\n"+
+			"(did you run `make manifests` after editing workload_types.go?)", crdPath)
+	}
+	return strings.TrimRight(string(m[1]), " \t\r")
+}

--- a/runtime-operator/api/runtime/v1alpha1/workload_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_types.go
@@ -75,7 +75,25 @@ type LocalResources struct {
 	Environment *ConfigLayer `json:"environment,omitempty"`
 	// +kubebuilder:validation:Optional
 	Config map[string]string `json:"config,omitempty"`
+	// AllowedHosts is the outbound egress allowlist for this component.
+	//
+	// Each entry must match one of:
+	//   - "*"                       (allow all)
+	//   - "host[:port]"             e.g. "example.com" or "example.com:8443"
+	//   - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+	//   - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+	//   - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+	//
+	// This is a hosts policy, not a URL policy: entries must not include a
+	// path (beyond bare `/`), query string, or fragment. The wildcard must
+	// be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+	//
+	// Empty or absent allowedHosts denies all outgoing requests
+	// (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+	// ["*"]` explicitly. Final validation runs in the runtime. This regex
+	// is an admission-time guard, not the source of truth.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:items:Pattern=`^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$`
 	AllowedHosts []string `json:"allowedHosts,omitempty"`
 }
 

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloaddeployments.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloaddeployments.yaml
@@ -150,7 +150,26 @@ spec:
                                 will be made available to a workload component.
                               properties:
                                 allowedHosts:
+                                  description: |-
+                                    AllowedHosts is the outbound egress allowlist for this component.
+
+                                    Each entry must match one of:
+                                      - "*"                       (allow all)
+                                      - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                                      - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                                      - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                                      - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                                    This is a hosts policy, not a URL policy: entries must not include a
+                                    path (beyond bare `/`), query string, or fragment. The wildcard must
+                                    be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                                    Empty or absent allowedHosts denies all outgoing requests
+                                    (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                                    ["*"]` explicitly. Final validation runs in the runtime. This regex
+                                    is an admission-time guard, not the source of truth.
                                   items:
+                                    pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                                     type: string
                                   type: array
                                 config:
@@ -400,7 +419,26 @@ spec:
                               be made available to a workload component.
                             properties:
                               allowedHosts:
+                                description: |-
+                                  AllowedHosts is the outbound egress allowlist for this component.
+
+                                  Each entry must match one of:
+                                    - "*"                       (allow all)
+                                    - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                                    - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                                    - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                                    - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                                  This is a hosts policy, not a URL policy: entries must not include a
+                                  path (beyond bare `/`), query string, or fragment. The wildcard must
+                                  be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                                  Empty or absent allowedHosts denies all outgoing requests
+                                  (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                                  ["*"]` explicitly. Final validation runs in the runtime. This regex
+                                  is an admission-time guard, not the source of truth.
                                 items:
+                                  pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                                   type: string
                                 type: array
                               config:

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloadreplicasets.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloadreplicasets.yaml
@@ -99,7 +99,26 @@ spec:
                                 will be made available to a workload component.
                               properties:
                                 allowedHosts:
+                                  description: |-
+                                    AllowedHosts is the outbound egress allowlist for this component.
+
+                                    Each entry must match one of:
+                                      - "*"                       (allow all)
+                                      - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                                      - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                                      - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                                      - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                                    This is a hosts policy, not a URL policy: entries must not include a
+                                    path (beyond bare `/`), query string, or fragment. The wildcard must
+                                    be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                                    Empty or absent allowedHosts denies all outgoing requests
+                                    (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                                    ["*"]` explicitly. Final validation runs in the runtime. This regex
+                                    is an admission-time guard, not the source of truth.
                                   items:
+                                    pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                                     type: string
                                   type: array
                                 config:
@@ -349,7 +368,26 @@ spec:
                               be made available to a workload component.
                             properties:
                               allowedHosts:
+                                description: |-
+                                  AllowedHosts is the outbound egress allowlist for this component.
+
+                                  Each entry must match one of:
+                                    - "*"                       (allow all)
+                                    - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                                    - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                                    - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                                    - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                                  This is a hosts policy, not a URL policy: entries must not include a
+                                  path (beyond bare `/`), query string, or fragment. The wildcard must
+                                  be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                                  Empty or absent allowedHosts denies all outgoing requests
+                                  (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                                  ["*"]` explicitly. Final validation runs in the runtime. This regex
+                                  is an admission-time guard, not the source of truth.
                                 items:
+                                  pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                                   type: string
                                 type: array
                               config:

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloads.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloads.yaml
@@ -91,7 +91,26 @@ spec:
                         made available to a workload component.
                       properties:
                         allowedHosts:
+                          description: |-
+                            AllowedHosts is the outbound egress allowlist for this component.
+
+                            Each entry must match one of:
+                              - "*"                       (allow all)
+                              - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                              - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                              - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                              - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                            This is a hosts policy, not a URL policy: entries must not include a
+                            path (beyond bare `/`), query string, or fragment. The wildcard must
+                            be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                            Empty or absent allowedHosts denies all outgoing requests
+                            (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                            ["*"]` explicitly. Final validation runs in the runtime. This regex
+                            is an admission-time guard, not the source of truth.
                           items:
+                            pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                             type: string
                           type: array
                         config:
@@ -339,7 +358,26 @@ spec:
                       available to a workload component.
                     properties:
                       allowedHosts:
+                        description: |-
+                          AllowedHosts is the outbound egress allowlist for this component.
+
+                          Each entry must match one of:
+                            - "*"                       (allow all)
+                            - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                            - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                            - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                            - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                          This is a hosts policy, not a URL policy: entries must not include a
+                          path (beyond bare `/`), query string, or fragment. The wildcard must
+                          be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                          Empty or absent allowedHosts denies all outgoing requests
+                          (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                          ["*"]` explicitly. Final validation runs in the runtime. This regex
+                          is an admission-time guard, not the source of truth.
                         items:
+                          pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                           type: string
                         type: array
                       config:


### PR DESCRIPTION
Adds a `workload:` section to .wash/config.yaml with `environment`
(inline + configFrom + secretFrom), opaque `config`, and outbound
`allowedHosts`. Top-level `configs:` and `secrets:` carry named
sources of three kinds: `inline`, `file:` (.env format), and
`fromEnv:`. Field shape mirrors WorkloadDeployment.localResources
so the same file can round-trip to a Kubernetes manifest later.

Resolution lives in `crates/wash/src/workload.rs`. Secrets get a
stricter posture: file paths canonicalized and confined to the
project dir (CVE-2025-62725 class), 0600/0400 mode required on
Unix, gitignore-aware warning when a secret file resolves inside
the repo working tree. Errors and traces reference sources by name
only - resolved values never appear in log output.

`wash dev` now resolves the workload before deploy and applies the
result to the dev component's LocalResources. The wasi:config
plugin is constructed with copy_environment=true, so workload env
vars surface via both wasi:cli/env and wasi:config/store::get.
`workload.config` is injected into the wasi:config interface entry
when at least one component in the workload imports it, sidecars
included.

create_workload is split into a thin I/O wrapper plus a pure
build_workload that the unit tests exercise end-to-end. Also fixes
a pre-existing gap by honoring `dev.component_path` (lets the dev
build command produce its artifact in a different folder than the
release build).

Fixes #5088
Fixes #5099
