### PR TITLE
ci: fix scorecard publish and harden workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,94 @@
+name: codeql
+
+# CodeQL static analysis for Rust (workspace) and Go (runtime-gateway,
+# runtime-operator). Findings are uploaded to the Security tab as code
+# scanning alerts. Complements audit.yml (cargo-audit on dependency
+# advisories) by analysing first-party code paths for vulnerable patterns.
+
+on:
+  schedule:
+    # Weekly Mondays at 09:00 UTC. Spaced apart from scorecard (Wed) and
+    # audit (daily) so a single bad runner image doesn't take all three out.
+    # CodeQL on Rust + Go matrix is ~60 min total, so we run it weekly
+    # rather than per-PR; audit.yml + cargo's own checks cover the
+    # per-commit fast-feedback layer.
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analyze-rust:
+    name: CodeQL (Rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          languages: rust
+          # security-and-quality includes the security suite plus quality
+          # checks; security-extended is the security-only superset of the
+          # default suite. Use security-extended to keep noise down on a
+          # repo this size.
+          queries: security-extended
+
+      - name: Build
+        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          category: "/language:rust"
+
+  analyze-go:
+    name: CodeQL (Go - ${{ matrix.module }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [runtime-gateway, runtime-operator]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: ${{ matrix.module }}/go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          languages: go
+          source-root: ${{ matrix.module }}
+          queries: security-extended
+
+      - name: Build
+        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          working-directory: ${{ matrix.module }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          category: "/language:go-${{ matrix.module }}"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -46,6 +46,8 @@ on:
         description: "Image digest of the container that was built without the sha256: prefix"
         value: ${{ jobs.build.outputs.artifact_prefix }}
 
+permissions: read-all
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -271,9 +271,32 @@ jobs:
           find ./artifacts -type f | sort
 
       - name: Attest binary build provenance
+        id: attest_bins
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: "./artifacts/*/wash*"
+
+      # Stage the Sigstore bundle alongside the binaries so it is also
+      # uploaded as a GitHub Release asset. Duplicate of the Attestations
+      # API / Rekor / registry publication above. The asset form lets
+      # users without `gh` CLI verify with cosign and surfaces signing to
+      # tools that scan release assets (e.g. OpenSSF Scorecard's
+      # Signed-Releases check).
+      #
+      # Verify with:
+      #   cosign verify-blob-attestation \
+      #     --bundle wash.sigstore.json \
+      #     --certificate-identity-regexp 'https://github\.com/wasmCloud/wasmCloud/' \
+      #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      #     wash-x86_64-unknown-linux-gnu
+      - name: Stage attestation bundle for release upload
+        env:
+          BUNDLE_PATH: ${{ steps.attest_bins.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          mkdir -p ./artifacts/attestations
+          cp "${BUNDLE_PATH}" ./artifacts/attestations/wash.sigstore.json
+          ls -la ./artifacts/attestations/
 
       - name: Push immutable release tag
         env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -51,6 +51,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to Security tab
-        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -20,6 +20,8 @@ on:
       - 'install.ps1'
       - '.github/workflows/test-install-scripts.yml'
 
+permissions: read-all
+
 jobs:
   test-bash-install:
     name: Test Bash Install Script
@@ -30,277 +32,132 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Test curl installation method (Real User Experience)
+      # Run the script from the checked-out tree rather than `curl | bash` from
+      # raw.githubusercontent.com. End-to-end coverage of the real flow is
+      # identical (the script content is what users will fetch once merged) and
+      # the script is now anchored to this workflow's git ref instead of an
+      # unverified network fetch.
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Test bash install script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "🌐 Testing real user experience - no repository checkout"
-          echo "This tests the exact command users will run"
-
-          # Create test directory
           mkdir -p /tmp/wash-test
-          cd /tmp/wash-test
-
-          # Test the actual curl installation that users will run
-          echo "Running: curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | bash"
-          curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | INSTALL_DIR=/tmp/wash-test bash
-
-          # Verify installation
-          if [ -f "/tmp/wash-test/wash" ]; then
-            echo "✅ Bash installation works!"
-            chmod +x /tmp/wash-test/wash
-            /tmp/wash-test/wash --help
-          else
-            echo "❌ Bash installation failed"
-            echo "📁 Directory contents:"
+          INSTALL_DIR=/tmp/wash-test bash ./install.sh
+          if [ ! -f "/tmp/wash-test/wash" ]; then
+            echo "Bash installation failed" >&2
             ls -la /tmp/wash-test/
             exit 1
           fi
+          chmod +x /tmp/wash-test/wash
+          /tmp/wash-test/wash --help
 
-      - name: Test with signature verification
+      - name: Test bash install with signature verification
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "🔐 Testing signature verification with -v flag"
-          echo "This requires GitHub CLI to be installed"
-
-          # Create separate test directory for verification test
-          mkdir -p /tmp/wash-verify-test
-          cd /tmp/wash-verify-test
-
-          # Verify gh CLI is available
-          if command -v gh &> /dev/null; then
-            echo "✅ GitHub CLI is available"
-
-            # Test help flag first
-            echo "Testing help flag..."
-            curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | bash -s -- --help
-
-            # Test installation with verification flag
-            echo "Running: curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | bash -s -- -v"
-            if curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | INSTALL_DIR=/tmp/wash-verify-test bash -s -- -v; then
-              echo "✅ Installation with verification succeeded!"
-
-              # Verify the binary was installed
-              if [ -f "/tmp/wash-verify-test/wash" ]; then
-                echo "✅ Binary was installed and verified!"
-                chmod +x /tmp/wash-verify-test/wash
-                /tmp/wash-verify-test/wash --version
-              else
-                echo "❌ Binary not found after verification"
-                exit 1
-              fi
-            else
-              echo "❌ Installation with verification failed!"
-              echo "Possible causes:"
-              echo "- The release does not have attestations (all releases must have attestations)"
-              echo "- GitHub CLI authentication is required"
-              echo "- Network connectivity issues"
-              exit 1
-            fi
-          else
-            echo "❌ Could not install GitHub CLI - skipping verification test"
+          if ! command -v gh &> /dev/null; then
+            echo "GitHub CLI not available - skipping verification test"
+            exit 0
           fi
+          mkdir -p /tmp/wash-verify-test
+          bash ./install.sh --help
+          if ! INSTALL_DIR=/tmp/wash-verify-test bash ./install.sh -v; then
+            echo "Installation with verification failed - is the latest release attested?" >&2
+            exit 1
+          fi
+          if [ ! -f "/tmp/wash-verify-test/wash" ]; then
+            echo "Binary not found after verification" >&2
+            exit 1
+          fi
+          chmod +x /tmp/wash-verify-test/wash
+          /tmp/wash-verify-test/wash --version
 
-      - name: Test with specific version
+      - name: Test bash install with specific version
         if: ${{ inputs.test_version != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "📦 Testing with specific version: ${{ inputs.test_version }}"
-
-          # Create test directory for version-specific test
           mkdir -p /tmp/wash-version-test
-          cd /tmp/wash-version-test
-
-          # Test installation with specific version
-          echo "Running: curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | bash -s -- --version ${{ inputs.test_version }}"
-          if curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | INSTALL_DIR=/tmp/wash-version-test bash -s -- --version "${{ inputs.test_version }}"; then
-            echo "✅ Version-specific installation succeeded!"
-
-            # Verify the binary was installed
-            if [ -f "/tmp/wash-version-test/wash" ]; then
-              echo "✅ Binary was installed!"
-              chmod +x /tmp/wash-version-test/wash
-              /tmp/wash-version-test/wash --version
-            else
-              echo "❌ Binary not found after installation"
-              exit 1
-            fi
-          else
-            echo "❌ Version-specific installation failed"
+          INSTALL_DIR=/tmp/wash-version-test bash ./install.sh --version "${{ inputs.test_version }}"
+          if [ ! -f "/tmp/wash-version-test/wash" ]; then
+            echo "Binary not found after version-pinned install" >&2
             exit 1
           fi
+          chmod +x /tmp/wash-version-test/wash
+          /tmp/wash-version-test/wash --version
 
   test-powershell-install:
     name: Test PowerShell Install Script
     runs-on: windows-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: Test PowerShell with PATH addition
+      - name: Test PowerShell install (default PATH modification)
         shell: powershell
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Test adding to PATH
           $testDir = "C:\temp\wash-path-test"
           New-Item -ItemType Directory -Path $testDir -Force
-
-          $env:INSTALL_DIR = $testDir
-          $env:ADD_TO_PATH = "true"
-
-          iwr -useb https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.ps1 | iex
-
+          & .\install.ps1 -InstallDir $testDir -Force
           $washPath = Join-Path $testDir "wash.exe"
-          if (Test-Path $washPath) {
-            Write-Host "PowerShell PATH installation successful"
-          } else {
-            Write-Host "PowerShell PATH installation failed"
+          if (-not (Test-Path $washPath)) {
+            Write-Host "PowerShell installation failed"
             exit 1
           }
+          Write-Host "PowerShell installation successful"
 
-      - name: Test PowerShell with signature verification
+      - name: Test PowerShell install with signature verification
         shell: powershell
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          Write-Host "Testing signature verification with -Verify flag"
-          Write-Host "This requires GitHub CLI to be installed"
-
-          # Create separate test directory for verification test
+          $ghPath = Get-Command gh -ErrorAction SilentlyContinue
+          if (-not $ghPath) {
+            Write-Host "GitHub CLI not available - skipping verification test"
+            exit 0
+          }
           $testDir = "C:\temp\wash-verify-test"
           New-Item -ItemType Directory -Path $testDir -Force
-
-          # Check if gh CLI is available
-          $ghPath = Get-Command gh -ErrorAction SilentlyContinue
-          if ($ghPath) {
-            Write-Host "GitHub CLI is available"
-
-            # Download script to a file
-            try {
-              $scriptPath = Join-Path $env:TEMP "install-verify.ps1"
-              Invoke-WebRequest -Uri "https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.ps1" -OutFile $scriptPath
-
-              # Execute script with verification
-              & $scriptPath -InstallDir $testDir -Verify -Force
-
-              $washPath = Join-Path $testDir "wash.exe"
-              if (Test-Path $washPath) {
-                Write-Host "Binary was installed and verified!"
-                & $washPath --version
-              } else {
-                Write-Host "Binary not found after verification"
-                exit 1
-              }
-            } catch {
-              Write-Host "Installation with verification failed!"
-              Write-Host "Error: $($_.Exception.Message)"
-              Write-Host "Possible causes:"
-              Write-Host "- The release does not have attestations (all releases must have attestations)"
-              Write-Host "- GitHub CLI authentication is required"
-              Write-Host "- Network connectivity issues"
-              exit 1
-            }
-          } else {
-            Write-Host "GitHub CLI not available - skipping verification test"
+          try {
+            & .\install.ps1 -InstallDir $testDir -Verify -Force
+          } catch {
+            Write-Host "Installation with verification failed - is the latest release attested? $($_.Exception.Message)"
+            exit 1
           }
+          $washPath = Join-Path $testDir "wash.exe"
+          if (-not (Test-Path $washPath)) {
+            Write-Host "Binary not found after verification"
+            exit 1
+          }
+          & $washPath --version
 
-      - name: Test PowerShell with specific version
+      - name: Test PowerShell install with specific version
         if: ${{ inputs.test_version != '' }}
         shell: powershell
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          Write-Host "Testing with specific version: ${{ inputs.test_version }}"
-
-          # Create test directory for version-specific test
           $testDir = "C:\temp\wash-version-test"
           New-Item -ItemType Directory -Path $testDir -Force
-
-          # Download script to a file
           try {
-            $scriptPath = Join-Path $env:TEMP "install-version.ps1"
-            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.ps1" -OutFile $scriptPath
-
-            # Execute script with specific version
-            & $scriptPath -InstallDir $testDir -Version "${{ inputs.test_version }}" -Force
-
-            $washPath = Join-Path $testDir "wash.exe"
-            if (Test-Path $washPath) {
-              Write-Host "Version-specific installation succeeded!"
-              & $washPath --version
-            } else {
-              Write-Host "Binary not found after installation"
-              exit 1
-            }
+            & .\install.ps1 -InstallDir $testDir -Version "${{ inputs.test_version }}" -Force
           } catch {
-            Write-Host "Version-specific installation failed"
-            Write-Host "Error: $($_.Exception.Message)"
+            Write-Host "Version-specific installation failed: $($_.Exception.Message)"
             exit 1
           }
-
-  summarize-results:
-    name: Summarize Test Results
-    runs-on: ubuntu-latest
-    needs: [test-bash-install, test-powershell-install]
-    if: always()
-
-    steps:
-      - name: Summary
-        run: |
-          echo "## Installation Script Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Test Configuration" >> $GITHUB_STEP_SUMMARY
-          echo "- Test Version: ${{ inputs.test_version || 'latest' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Repository: wasmcloud/wasmCloud (public)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          echo "### Results" >> $GITHUB_STEP_SUMMARY
-          echo "- Bash Install (Unix): ${NEEDS_TEST_BASH_INSTALL_RESULT}" >> $GITHUB_STEP_SUMMARY
-          echo "- PowerShell Install (Windows): ${NEEDS_TEST_POWERSHELL_INSTALL_RESULT}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          if [ "${NEEDS_TEST_BASH_INSTALL_RESULT}" = "success" ] && \
-             [ "${NEEDS_TEST_POWERSHELL_INSTALL_RESULT}" = "success" ]; then
-            echo "✅ All installation script tests passed!" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ Some installation script tests failed. Check the job details above." >> $GITHUB_STEP_SUMMARY
-          fi
-
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Usage Instructions" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Linux/macOS:**" >> $GITHUB_STEP_SUMMARY
-          echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo '# Standard installation (latest version)' >> $GITHUB_STEP_SUMMARY
-          echo 'curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | bash' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '# With signature verification (requires GitHub CLI)' >> $GITHUB_STEP_SUMMARY
-          echo 'curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | bash -s -- -v' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '# Install a specific version' >> $GITHUB_STEP_SUMMARY
-          echo 'curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | bash -s -- --version 1.0.0-beta.10' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '# Install a specific version with verification' >> $GITHUB_STEP_SUMMARY
-          echo 'curl -sSL https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.sh | bash -s -- --version 1.0.0-beta.10 -v' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Windows (PowerShell):**" >> $GITHUB_STEP_SUMMARY
-          echo '```powershell' >> $GITHUB_STEP_SUMMARY
-          echo '# Standard installation (latest version)' >> $GITHUB_STEP_SUMMARY
-          echo 'iwr -useb https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.ps1 | iex' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '# With signature verification (requires GitHub CLI)' >> $GITHUB_STEP_SUMMARY
-          echo 'Invoke-WebRequest -Uri "https://raw.githubusercontent.com/wasmcloud/wasmCloud/main/install.ps1" -UseBasicParsing | Invoke-Expression; Install-Wash -Verify' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '# Install a specific version' >> $GITHUB_STEP_SUMMARY
-          echo './install.ps1 -Version "1.0.0-beta.10"' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '# Install a specific version with verification' >> $GITHUB_STEP_SUMMARY
-          echo './install.ps1 -Version "1.0.0-beta.10" -Verify' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-        env:
-          NEEDS_TEST_BASH_INSTALL_RESULT: ${{ needs.test-bash-install.result }}
-          NEEDS_TEST_POWERSHELL_INSTALL_RESULT: ${{ needs.test-powershell-install.result }}
+          $washPath = Join-Path $testDir "wash.exe"
+          if (-not (Test-Path $washPath)) {
+            Write-Host "Binary not found after installation"
+            exit 1
+          }
+          & $washPath --version

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -29,6 +29,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   check:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Most of these identified after running the OpenSSF scorecard. 

- scorecard.yml: codeql-action was pinned to its annotated tag SHA
  rather than the underlying commit, which the scorecard verifier
  rejects as an "imposter commit" and bubbles up as a publish failure
- docker-build-push.yml, test-install-scripts.yml, wash.yml: top-level
  read-all permissions (Token-Permissions)
- test-install-scripts.yml: run install.sh / install.ps1 from the
  checked-out tree instead of curl|bash from raw.githubusercontent.com
  so the script content is anchored to the workflow's git ref
  (Pinned-Dependencies); drop the summarize-results doc-emitting job
- release-tag.yml: also upload the Sigstore bundle as a release asset
  alongside the existing Attestations API + Rekor + registry
  publication, so cosign can verify without gh and Signed-Releases can
  see the signature next to the binaries
- codeql.yml: weekly CodeQL SAST for Rust + Go (SAST)
