### PR TITLE
ci: reuse wash runtime image build

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -29,6 +29,11 @@ on:
         description: "Build and Push Image. Default=false"
         required: false
         default: false
+      push-by-digest:
+        type: boolean
+        description: "Push image by digest to the registry (required for manifest assembly). Set false to build locally without pushing, e.g. on pull-request runs where the token lacks org-package write access. Default=true"
+        required: false
+        default: true
       build-contexts:
         type: string
         required: false
@@ -102,7 +107,7 @@ jobs:
           context: ${{ inputs.working-directory }}
           tags: ${{ inputs.image }}
           build-contexts: ${{ inputs.build-contexts }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,push-by-digest=${{ inputs.push-by-digest }},name-canonical=true,push=${{ inputs.push-by-digest }}
           build-args: ${{ inputs.build-args }}
           cache-from: |
             type=gha,scope=buildx-${{ steps.meta.outputs.artifact_prefix }}-${{ matrix.arch }}-${{ github.ref_name }}
@@ -112,6 +117,7 @@ jobs:
 
       - name: Export digest
         id: export
+        if: ${{ inputs.push-by-digest }}
         env:
           BUILD_DIGEST: ${{ steps.build.outputs.digest }}
           DIGESTS_DIR: ${{ runner.temp }}/digests
@@ -120,6 +126,7 @@ jobs:
           touch "${DIGESTS_DIR}/${BUILD_DIGEST#sha256:}"
 
       - name: Upload digest
+        if: ${{ inputs.push-by-digest }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ steps.meta.outputs.artifact_prefix }}-${{ github.run_id }}-linux-${{ matrix.arch }}

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -135,13 +135,9 @@ jobs:
         run: |
           cargo machete
 
-  # Integration gate: build the wash image from this commit, install it
-  # alongside the runtime-operator chart in a kind cluster, and run the
-  # operator's e2e suite (including the messaging round-trip from #5074)
-  # against it. The canary tag only moves if this passes. Also runs on
-  # PRs that touch wash, the chart, or the e2e suite, so regressions are
-  # caught before merge rather than after.
-  runtime-operator-e2e:
+  # Build the wash runtime image once and pass it to both the operator e2e
+  # gate and the canary publisher.
+  wash-image:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -151,9 +147,37 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-go
       - name: Build wash runtime image
         run: docker build -t localhost/wasmcloud-wash:e2e .
+      - name: Save wash runtime image
+        run: docker save localhost/wasmcloud-wash:e2e -o /tmp/wash-image.tar
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wash-image
+          path: /tmp/wash-image.tar
+          if-no-files-found: error
+          retention-days: 1
+
+  # Integration gate: install the shared wash image alongside the
+  # runtime-operator chart in a kind cluster, and run the operator's e2e
+  # suite (including the messaging round-trip from #5074) against it. The
+  # canary tag only moves if this passes. Also runs on PRs that touch wash,
+  # the chart, or the e2e suite, so regressions are caught before merge
+  # rather than after.
+  runtime-operator-e2e:
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    needs: [wash-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-go
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: wash-image
+          path: /tmp
+      - name: Load wash runtime image
+        run: docker load -i /tmp/wash-image.tar
       - name: Build runtime-operator image
         working-directory: runtime-operator
         run: make docker-build IMG=localhost/runtime-operator:e2e
@@ -192,37 +216,15 @@ jobs:
           kubectl get workloaddeployments.runtime.wasmcloud.dev -A -o yaml || true
           kubectl get workloads.runtime.wasmcloud.dev -A -o yaml || true
 
-  # The canary docker image is built in parallel with check/lint/e2e to
-  # avoid serializing the slow cargo build behind the slow tests. With
-  # `push: false`, the multi-arch digests are still pushed to ghcr (the
-  # workflow always does that for caching), but the human-visible
-  # `canary` tag is *not* created here — that happens in
-  # `canary-publish` below, gated on every test job passing.
-  canary-build:
-    # Runs on every main push, and on PRs labeled `canary` so that changes to
-    # this workflow or to docker-build-push.yml can be validated end-to-end
-    # (including the reusable-workflow permission handshake) before merge.
-    # `push: false` below means no canary tag moves on PR runs.
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || contains(github.event.pull_request.labels.*.name, 'canary')
-    permissions:
-      contents: write
-      packages: write
-    uses: ./.github/workflows/docker-build-push.yml
-    with:
-      push: false
-      image: ghcr.io/wasmcloud/wash
-      tags: |
-        type=raw,value=canary
-
-  # Tag promotion: only move `canary` once check, lint, and the
-  # runtime-operator e2e have all passed against this commit. Reads the
-  # digests uploaded by canary-build and assembles the manifest list. The
+  # Tag promotion: only push `canary` once check, lint, and the
+  # runtime-operator e2e have all passed against this commit. Reuses the
+  # shared single-arch wash image that the e2e gate exercised. The
   # `sha-<full-sha>` tag is what release-tag.yml pins to when it promotes
   # this canary digest as the immutable vX.Y.Z release tag — `canary`
   # itself moves on every subsequent main push, so we cannot rely on it.
   canary-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [check, lint, runtime-operator-e2e, canary-build]
+    needs: [check, lint, runtime-operator-e2e, wash-image]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -231,12 +233,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-${{ needs.canary-build.outputs.artifact_prefix }}-${{ github.run_id }}-*
-          merge-multiple: true
+          name: wash-image
+          path: /tmp
+      - name: Load wash runtime image
+        run: docker load -i /tmp/wash-image.tar
       - name: Login to ghcr.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -253,12 +255,23 @@ jobs:
           tags: |
             type=raw,value=canary
             type=sha,format=long,prefix=sha-
-      - name: Create manifest list and push tags
-        working-directory: ${{ runner.temp }}/digests
+      - name: Push canary tags
         run: |
-          # shellcheck disable=SC2046
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf 'ghcr.io/wasmcloud/wash@sha256:%s ' *)
+          set -euo pipefail
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          canary_tag=""
+          for tag in "${tags[@]}"; do
+            if [[ "$tag" == *":canary" ]]; then
+              canary_tag="$tag"
+              continue
+            fi
+            docker tag localhost/wasmcloud-wash:e2e "$tag"
+            docker push "$tag"
+          done
+          if [[ -n "$canary_tag" ]]; then
+            docker tag localhost/wasmcloud-wash:e2e "$canary_tag"
+            docker push "$canary_tag"
+          fi
       - name: Inspect image
         run: |
           docker buildx imagetools inspect "ghcr.io/wasmcloud/wash:${STEPS_META_OUTPUTS_VERSION}"

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -169,6 +169,27 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Prepare build outputs
+        id: prep
+        # PRs lack org-package write access; only push by digest on main so
+        # canary-publish can assemble the manifest after all gates pass.
+        # Use $GITHUB_EVENT_NAME (built-in env var) to avoid template
+        # expansion inside a shell script (zizmor).
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            {
+              echo 'outputs<<EOF'
+              echo 'type=docker,dest=/tmp/wash-image.tar,name=localhost/wasmcloud-wash:e2e'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'outputs<<EOF'
+              echo 'type=image,name=ghcr.io/wasmcloud/wash,push-by-digest=true,name-canonical=true,push=true'
+              echo 'type=docker,dest=/tmp/wash-image.tar,name=localhost/wasmcloud-wash:e2e'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Build wash runtime image
         id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
@@ -178,9 +199,7 @@ jobs:
           # staging tags, and also emit a local docker tarball so the
           # operator e2e gate (and any future arch-specific gate)
           # exercises the exact bytes that get published.
-          outputs: |
-            type=image,name=ghcr.io/wasmcloud/wash,push-by-digest=true,name-canonical=true,push=true
-            type=docker,dest=/tmp/wash-image.tar,name=localhost/wasmcloud-wash:e2e
+          outputs: ${{ steps.prep.outputs.outputs }}
           # head_ref on PRs (the source branch, shared across re-pushes
           # and across PRs from the same branch); falls back to ref_name
           # on main pushes ("main"). Always falls back to the main scope
@@ -190,6 +209,7 @@ jobs:
             type=gha,scope=wash-${{ matrix.arch }}-main
           cache-to: type=gha,scope=wash-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }},mode=max
       - name: Export digest
+        if: github.event_name != 'pull_request'
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
@@ -201,6 +221,7 @@ jobs:
           fi
           touch "/tmp/digests/${DIGEST#sha256:}"
       - name: Upload digest
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wash-image-digest-${{ matrix.arch }}

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -135,25 +135,81 @@ jobs:
         run: |
           cargo machete
 
-  # Build the wash runtime image once and pass it to both the operator e2e
-  # gate and the canary publisher.
+  # Build the wash runtime image per-arch with the buildx GHA cache, push
+  # each arch by digest, and export a docker tarball per arch. The operator
+  # e2e gate loads the amd64 tarball, so the bytes exercised in e2e are the
+  # same bytes canary-publish later assembles into the multi-arch manifest
+  # list (`canary`, `sha-<full-sha>`, and via release-tag.yml the released
+  # `vX.Y.Z`). arm64 builds on every PR too so Dockerfile regressions are
+  # caught before merge.
   wash-image:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
     permissions:
       contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Build wash runtime image
-        run: docker build -t localhost/wasmcloud-wash:e2e .
-      - name: Save wash runtime image
-        run: docker save localhost/wasmcloud-wash:e2e -o /tmp/wash-image.tar
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Login to ghcr.io
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          name: wash-image
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build wash runtime image
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          # Push by digest so the registry doesn't accumulate per-commit
+          # staging tags, and also emit a local docker tarball so the
+          # operator e2e gate (and any future arch-specific gate)
+          # exercises the exact bytes that get published.
+          outputs: |
+            type=image,name=ghcr.io/wasmcloud/wash,push-by-digest=true,name-canonical=true,push=true
+            type=docker,dest=/tmp/wash-image.tar,name=localhost/wasmcloud-wash:e2e
+          # head_ref on PRs (the source branch, shared across re-pushes
+          # and across PRs from the same branch); falls back to ref_name
+          # on main pushes ("main"). Always falls back to the main scope
+          # for cold-cache reads on first push.
+          cache-from: |
+            type=gha,scope=wash-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+            type=gha,scope=wash-${{ matrix.arch }}-main
+          cache-to: type=gha,scope=wash-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }},mode=max
+      - name: Export digest
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          if [[ -z "$digest" ]]; then
+            echo "no digest on build step output" >&2
+            exit 1
+          fi
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wash-image-digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+      - name: Upload image tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wash-image-tarball-${{ matrix.arch }}
           path: /tmp/wash-image.tar
           if-no-files-found: error
           retention-days: 1
@@ -165,16 +221,19 @@ jobs:
   # the chart, or the e2e suite, so regressions are caught before merge
   # rather than after.
   runtime-operator-e2e:
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [wash-image]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-go
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: wash-image
+          name: wash-image-tarball-amd64
           path: /tmp
       - name: Load wash runtime image
         run: docker load -i /tmp/wash-image.tar
@@ -217,11 +276,13 @@ jobs:
           kubectl get workloads.runtime.wasmcloud.dev -A -o yaml || true
 
   # Tag promotion: only push `canary` once check, lint, and the
-  # runtime-operator e2e have all passed against this commit. Reuses the
-  # shared single-arch wash image that the e2e gate exercised. The
-  # `sha-<full-sha>` tag is what release-tag.yml pins to when it promotes
-  # this canary digest as the immutable vX.Y.Z release tag — `canary`
-  # itself moves on every subsequent main push, so we cannot rely on it.
+  # runtime-operator e2e have all passed against this commit. Assembles
+  # the multi-arch manifest list from the per-arch digests that
+  # wash-image already pushed (amd64 was also exercised by the e2e gate).
+  # The `sha-<full-sha>` tag is what release-tag.yml pins to when it
+  # promotes this canary digest as the immutable vX.Y.Z release tag —
+  # `canary` itself moves on every subsequent main push, so we cannot
+  # rely on it.
   canary-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [check, lint, runtime-operator-e2e, wash-image]
@@ -233,12 +294,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: wash-image
-          path: /tmp
-      - name: Load wash runtime image
-        run: docker load -i /tmp/wash-image.tar
+          path: /tmp/digests
+          pattern: wash-image-digest-*
+          merge-multiple: true
       - name: Login to ghcr.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -255,23 +316,30 @@ jobs:
           tags: |
             type=raw,value=canary
             type=sha,format=long,prefix=sha-
-      - name: Push canary tags
+      - name: Create manifest list and push tags
+        working-directory: /tmp/digests
         run: |
           set -euo pipefail
           mapfile -t tags < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          canary_tag=""
-          for tag in "${tags[@]}"; do
-            if [[ "$tag" == *":canary" ]]; then
-              canary_tag="$tag"
-              continue
-            fi
-            docker tag localhost/wasmcloud-wash:e2e "$tag"
-            docker push "$tag"
-          done
-          if [[ -n "$canary_tag" ]]; then
-            docker tag localhost/wasmcloud-wash:e2e "$canary_tag"
-            docker push "$canary_tag"
+          if (( ${#tags[@]} == 0 )); then
+            echo "No tags from docker meta. Refusing to push" >&2
+            exit 1
           fi
+          shopt -s nullglob
+          digests=( * )
+          shopt -u nullglob
+          if (( ${#digests[@]} == 0 )); then
+            echo "No digests downloaded. Refusing to push" >&2
+            exit 1
+          fi
+          args=()
+          for tag in "${tags[@]}"; do
+            args+=(-t "$tag")
+          done
+          for d in "${digests[@]}"; do
+            args+=("ghcr.io/wasmcloud/wash@sha256:$d")
+          done
+          docker buildx imagetools create "${args[@]}"
       - name: Inspect image
         run: |
           docker buildx imagetools inspect "ghcr.io/wasmcloud/wash:${STEPS_META_OUTPUTS_VERSION}"

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -190,15 +190,16 @@ jobs:
             type=gha,scope=wash-${{ matrix.arch }}-main
           cache-to: type=gha,scope=wash-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }},mode=max
       - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          if [[ -z "$digest" ]]; then
+          if [[ -z "$DIGEST" ]]; then
             echo "no digest on build step output" >&2
             exit 1
           fi
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
﻿Refs #5116.

## Summary
- add a shared `wash-image` job that builds `localhost/wasmcloud-wash:e2e`, saves it, and uploads it once
- update `runtime-operator-e2e` to download/load that artifact before the existing kind/e2e path loads it into the cluster
- replace the `docker-build-push.yml` canary image path with a gated publish from the same saved image after check/lint/e2e pass

## Maintainer note
This follows the issue's single-arch artifact direction. One contract to confirm: `wash:sha-<full-sha>` and `wash:canary` now come from the same single-arch image exercised by e2e, instead of the previous multi-arch digest artifacts assembled by `docker-build-push.yml`. If the release path must keep a multi-arch wash image, I can revise this to preserve the arm64 digest path while still reusing the amd64 artifact for e2e.

## Validation
- `actionlint .github/workflows/wash.yml`
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/wash.yml', encoding='utf-8'))"`
- `git diff --check`

<!-- source: github-outbound-wasmcloud-wasmcloud-5116-2026-05-05 -->
