### PR TITLE
ci: hardening with zizmor

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-go
       - name: Render
         run: make helm-render
@@ -34,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/helm-publish
         with:
           chart-name: runtime-operator
@@ -53,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/helm-publish
         with:
           chart-name: runtime-operator

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -70,6 +70,8 @@ jobs:
       artifact_prefix: ${{ steps.meta.outputs.artifact_prefix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Login to ghcr.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -79,9 +81,11 @@ jobs:
 
       - name: Meta
         id: meta
+        env:
+          INPUTS_IMAGE: ${{ inputs.image }}
         run: |
           # Create a prefix for the artifact name by taking the image name, removing any registry and replacing / and : with _
-          ARTIFACT_PREFIX=$(echo "${{ inputs.image }}" | sed 's/.*\///; s/[\/:]/_/g')
+          ARTIFACT_PREFIX=$(echo "${INPUTS_IMAGE}" | sed 's/.*\///; s/[\/:]/_/g')
           echo "artifact_prefix=${ARTIFACT_PREFIX}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up QEMU
@@ -108,10 +112,12 @@ jobs:
 
       - name: Export digest
         id: export
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          DIGESTS_DIR: ${{ runner.temp }}/digests
         run: | #shell
-          mkdir -p "${{ runner.temp }}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p "${DIGESTS_DIR}"
+          touch "${DIGESTS_DIR}/${BUILD_DIGEST#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -131,6 +137,8 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -160,8 +168,13 @@ jobs:
         run: |
           # shellcheck disable=SC2046
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ inputs.image }}@sha256:%s ' *)
+            $(printf "${INPUTS_IMAGE}@sha256:%s " *)
+        env:
+          INPUTS_IMAGE: ${{ inputs.image }}
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ inputs.image }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "${INPUTS_IMAGE}:${STEPS_META_OUTPUTS_VERSION}"
+        env:
+          INPUTS_IMAGE: ${{ inputs.image }}
+          STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -27,6 +27,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
           setup_only: false
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
           setup_only: true

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -36,7 +36,13 @@ name: release-tag
 #   - If the git tag already exists on origin, the tag step is a no-op.
 #   - Re-running this workflow is safe: each step is idempotent.
 
-on:
+on:  # zizmor: ignore[dangerous-triggers]
+  # workflow_run is required: this workflow must fire after release-train
+  # finishes merging the release PR. The job's `if:` requires
+  # `workflow_run.conclusion == 'success'`, the verify-head step refuses
+  # to proceed unless HEAD's commit subject matches `release: vX.Y.Z`,
+  # and every downstream step is idempotent against pre-existing tags
+  # and image manifests.
   workflow_run:
     workflows: [release-train]
     types: [completed]
@@ -320,7 +326,13 @@ jobs:
         # Pre-releases (tag contains "-", e.g. v2.1.0-rc.1) are marked as
         # prerelease so `gh release list` and the GitHub UI don't surface
         # them as the "latest" release.
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        #
+        # zizmor flags this as `superfluous-actions` (could use `gh release
+        # create` directly). Keeping the action: it's SHA-pinned, and a
+        # shell equivalent has to re-implement idempotent re-run handling,
+        # release-notes generation, glob fail-on-empty, and prerelease
+        # detection — ~25 lines of bash on a release-critical step.
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0  # zizmor: ignore[superfluous-actions]
         with:
           name: ${{ steps.ver.outputs.tag }}
           tag_name: ${{ steps.ver.outputs.tag }}

--- a/.github/workflows/runtime-gateway.yml
+++ b/.github/workflows/runtime-gateway.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-go
       - uses: ./.github/actions/lint-go
         with:
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-go
       - name: Build
         working-directory: runtime-gateway
@@ -50,7 +54,6 @@ jobs:
       contents: write
       packages: write
     uses: ./.github/workflows/docker-build-push.yml
-    secrets: inherit
     with:
       working-directory: runtime-gateway
       file: runtime-gateway/Dockerfile

--- a/.github/workflows/runtime-operator.yml
+++ b/.github/workflows/runtime-operator.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-go
       - uses: ./.github/actions/lint-go
         with:
@@ -40,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-go
       - name: Build
         working-directory: runtime-operator
@@ -53,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Build operator image
         working-directory: runtime-operator
         run: make docker-build IMG=localhost/runtime-operator:e2e
@@ -70,6 +76,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-go
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -117,7 +125,6 @@ jobs:
       contents: write
       packages: write
     uses: ./.github/workflows/docker-build-push.yml
-    secrets: inherit
     with:
       working-directory: runtime-operator
       file: runtime-operator/Dockerfile

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -29,10 +29,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -60,10 +64,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "22"
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -104,6 +104,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -143,8 +145,12 @@ jobs:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-go
       - name: Build wash runtime image
         run: docker build -t localhost/wasmcloud-wash:e2e .
@@ -202,7 +208,6 @@ jobs:
       contents: write
       packages: write
     uses: ./.github/workflows/docker-build-push.yml
-    secrets: inherit
     with:
       push: false
       image: ghcr.io/wasmcloud/wash
@@ -224,6 +229,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -254,7 +261,9 @@ jobs:
             $(printf 'ghcr.io/wasmcloud/wash@sha256:%s ' *)
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ghcr.io/wasmcloud/wash:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "ghcr.io/wasmcloud/wash:${STEPS_META_OUTPUTS_VERSION}"
+        env:
+          STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
 
   # Canary matrix binary build. Runs on every release commit on main (i.e.
   # what release-train just merged) so release-tag.yml can promote the


### PR DESCRIPTION
- actions/checkout without persist-credentials: false. The default-persisted token can leak via uploaded artifacts
- Remove secrets: inherit
- template-injection fixes
- excessive-permissions
