### PR TITLE
ci: add status gate pattern to all path-filtered workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -69,7 +69,6 @@ jobs:
       - cargo-audit
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Require all jobs to pass or be skipped
         env:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      - ".github/workflows/audit.yml"
   push:
     branches:
       - main
@@ -24,13 +20,38 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - '.github/workflows/audit.yml'
+
   cargo-audit:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -42,3 +63,18 @@ jobs:
           tool: cargo-audit
       - name: Run cargo audit
         run: cargo audit
+
+  gate:
+    needs:
+      - cargo-audit
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require all jobs to pass or be skipped
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            exit 1
+          fi

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -6,9 +6,6 @@ on:
     tags:
       - "v*"
   pull_request:
-    paths:
-      - "charts/**"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -17,7 +14,29 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'charts/**'
+
   test:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,9 +46,25 @@ jobs:
       - name: Render
         run: make helm-render
 
+  gate:
+    needs:
+      - test
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require all jobs to pass or be skipped
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            exit 1
+          fi
+
   canary:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'canary')
-    needs: [test]
+    needs:
+      - test
     permissions:
       contents: write
       packages: write
@@ -50,7 +85,8 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test]
+    needs:
+      - test
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -10,8 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   changes:
@@ -38,6 +37,8 @@ jobs:
       - changes
     if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -51,7 +52,6 @@ jobs:
       - test
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Require all jobs to pass or be skipped
         env:

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -84,7 +84,6 @@ jobs:
       - zizmor
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Require all jobs to pass or be skipped
         env:

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -3,9 +3,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
   push:
     branches:
       - main
@@ -16,7 +13,30 @@ on:
 permissions: {}
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+
   actionlint:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     name: actionlint
     runs-on: ubuntu-latest
     permissions:
@@ -34,6 +54,9 @@ jobs:
         run: actionlint -color
 
   zizmor:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     name: zizmor
     runs-on: ubuntu-latest
     permissions:
@@ -54,3 +77,19 @@ jobs:
           # Used by zizmor for online audits (e.g. checking whether a
           # referenced action's tag still resolves to its pinned SHA).
           GH_TOKEN: ${{ github.token }}
+
+  gate:
+    needs:
+      - actionlint
+      - zizmor
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require all jobs to pass or be skipped
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            exit 1
+          fi

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -8,9 +8,6 @@ on:
       - "v*"
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths:
-      - "proto/**"
-      - ".github/workflows/proto.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -20,7 +17,34 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'proto/**'
+              - 'buf.yaml'
+              - 'buf.gen.yaml'
+              - 'runtime-operator/buf.yaml'
+              - 'runtime-operator/buf.gen.yaml'
+              - '.github/workflows/proto.yml'
+
   lint:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -34,6 +58,9 @@ jobs:
           setup_only: false
 
   check-generated:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,3 +76,19 @@ jobs:
         uses: ./.github/actions/no-diff
         with:
           fixup-command: "buf generate"
+
+  gate:
+    needs:
+      - lint
+      - check-generated
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require all jobs to pass or be skipped
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            exit 1
+          fi

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -13,8 +13,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   changes:
@@ -62,6 +61,8 @@ jobs:
       - changes
     if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -83,7 +84,6 @@ jobs:
       - check-generated
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Require all jobs to pass or be skipped
         env:

--- a/.github/workflows/runtime-gateway.yml
+++ b/.github/workflows/runtime-gateway.yml
@@ -6,11 +6,6 @@ on:
     tags:
       - "v*"
   pull_request:
-    paths:
-      - "runtime-gateway/**"
-      - "runtime-operator/**"
-      - "go.work"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -19,7 +14,31 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'runtime-gateway/**'
+              - 'runtime-operator/**'
+              - 'go.work'
+
   lint:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     permissions:
       # Required: allow read access to the content for analysis.
       contents: read
@@ -34,6 +53,9 @@ jobs:
           working-directory: runtime-gateway
 
   test:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,12 +66,30 @@ jobs:
         working-directory: runtime-gateway
         run: go build -v ./
 
+  gate:
+    needs:
+      - lint
+      - test
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require all jobs to pass or be skipped
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            exit 1
+          fi
+
   # The `sha-<full-sha>` tag is what release-tag.yml pins to when promoting
   # this canary digest as the immutable vX.Y.Z release tag. `canary` itself
   # moves on every subsequent main push.
   canary:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'canary')
-    needs: [lint, test]
+    needs:
+      - lint
+      - test
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-gateway.yml
+++ b/.github/workflows/runtime-gateway.yml
@@ -10,8 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   changes:
@@ -57,6 +56,8 @@ jobs:
       - changes
     if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -72,7 +73,6 @@ jobs:
       - test
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Require all jobs to pass or be skipped
         env:

--- a/.github/workflows/runtime-operator.yml
+++ b/.github/workflows/runtime-operator.yml
@@ -6,13 +6,6 @@ on:
     tags:
       - "v*"
   pull_request:
-    paths:
-      - ".github/workflows/runtime-operator.yml"
-      - "runtime-operator/**"
-      - "proto/**"
-      - "charts/runtime-operator/**"
-      - "deploy/kind/kind-config.yaml"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -24,7 +17,33 @@ env:
   GOWORK: "off"
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - '.github/workflows/runtime-operator.yml'
+              - 'runtime-operator/**'
+              - 'proto/**'
+              - 'charts/runtime-operator/**'
+              - 'deploy/kind/kind-config.yaml'
+
   lint:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true' || contains(github.event.pull_request.labels.*.name, 'canary'))
     permissions:
       # Required: allow read access to the content for analysis.
       contents: read
@@ -39,6 +58,9 @@ jobs:
           working-directory: runtime-operator
 
   test:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true' || contains(github.event.pull_request.labels.*.name, 'canary'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -53,7 +75,9 @@ jobs:
         run: make test
 
   build:
-    needs: [lint, test]
+    needs:
+      - lint
+      - test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -71,7 +95,8 @@ jobs:
           retention-days: 1
 
   test-e2e:
-    needs: [build]
+    needs:
+      - build
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -115,12 +140,33 @@ jobs:
           kubectl get workloaddeployments.runtime.wasmcloud.dev -A -o yaml || true
           kubectl get workloads.runtime.wasmcloud.dev -A -o yaml || true
 
+  gate:
+    needs:
+      - lint
+      - test
+      - build
+      - test-e2e
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require all jobs to pass or be skipped
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            exit 1
+          fi
+
   # The `sha-<full-sha>` tag is what release-tag.yml pins to when promoting
   # this canary digest as the immutable vX.Y.Z release tag. `canary` itself
   # moves on every subsequent main push.
   canary:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'canary')
-    needs: [lint, test, test-e2e]
+    needs:
+      - lint
+      - test
+      - test-e2e
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-operator.yml
+++ b/.github/workflows/runtime-operator.yml
@@ -10,8 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   GOWORK: "off"
@@ -62,6 +61,8 @@ jobs:
       - changes
     if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true' || contains(github.event.pull_request.labels.*.name, 'canary'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -79,6 +80,8 @@ jobs:
       - lint
       - test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -99,6 +102,8 @@ jobs:
       - build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -148,7 +153,6 @@ jobs:
       - test-e2e
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Require all jobs to pass or be skipped
         env:

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -19,8 +19,7 @@ on:
 # Minimum needed: checkout + reading attestations from the public repo via
 # `gh attestation verify` (which the install scripts call when -v/-Verify is
 # set). Public-repo attestations are readable with the default token.
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   changes:
@@ -50,6 +49,8 @@ jobs:
     if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     name: Test Bash Install Script
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -125,6 +126,8 @@ jobs:
     if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     name: Test PowerShell Install Script
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -203,7 +206,6 @@ jobs:
       - test-powershell-install
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Require all jobs to pass or be skipped
         env:

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -8,10 +8,6 @@ on:
         required: false
         default: ""
   pull_request:
-    paths:
-      - 'install.sh'
-      - 'install.ps1'
-      - '.github/workflows/test-install-scripts.yml'
   push:
     branches:
       - main
@@ -27,7 +23,31 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'install.sh'
+              - 'install.ps1'
+              - '.github/workflows/test-install-scripts.yml'
+
   test-bash-install:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     name: Test Bash Install Script
     runs-on: ${{ matrix.os }}
     strategy:
@@ -100,6 +120,9 @@ jobs:
           /tmp/wash-version-test/wash --version
 
   test-powershell-install:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     name: Test PowerShell Install Script
     runs-on: windows-latest
 
@@ -173,3 +196,19 @@ jobs:
             exit 1
           }
           & $washPath --version
+
+  gate:
+    needs:
+      - test-bash-install
+      - test-powershell-install
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require all jobs to pass or be skipped
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            exit 1
+          fi

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -4,17 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".github/workflows/wash.yml"
-      - "crates/**"
-      - "src/**"
-      - "tests/**"
-      - "Cargo.*"
-      - "rust-toolchain.toml"
-      - "rustfmt.toml"
-      - "runtime-operator/test/e2e/**"
-      - "charts/runtime-operator/**"
-      - "deploy/kind/kind-config.yaml"
   push:
     branches:
       - main
@@ -32,7 +21,39 @@ concurrency:
 permissions: {}
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - '.github/workflows/wash.yml'
+              - 'crates/**'
+              - 'src/**'
+              - 'tests/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'rustfmt.toml'
+              - 'runtime-operator/test/e2e/**'
+              - 'charts/runtime-operator/**'
+              - 'deploy/kind/kind-config.yaml'
+
   check:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     permissions:
@@ -102,6 +123,9 @@ jobs:
           cargo bench -p wash-runtime --features wasip3 --no-run
 
   lint:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -143,7 +167,9 @@ jobs:
   # `vX.Y.Z`). arm64 builds on every PR too so Dockerfile regressions are
   # caught before merge.
   wash-image:
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true') && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
     permissions:
       contents: read
       packages: write
@@ -243,7 +269,8 @@ jobs:
   # the chart, or the e2e suite, so regressions are caught before merge
   # rather than after.
   runtime-operator-e2e:
-    needs: [wash-image]
+    needs:
+      - wash-image
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -297,6 +324,24 @@ jobs:
           kubectl get workloaddeployments.runtime.wasmcloud.dev -A -o yaml || true
           kubectl get workloads.runtime.wasmcloud.dev -A -o yaml || true
 
+  gate:
+    needs:
+      - check
+      - lint
+      - wash-image
+      - runtime-operator-e2e
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require all jobs to pass or be skipped
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            exit 1
+          fi
+
   # Tag promotion: only push `canary` once check, lint, and the
   # runtime-operator e2e have all passed against this commit. Assembles
   # the multi-arch manifest list from the per-arch digests that
@@ -307,7 +352,11 @@ jobs:
   # rely on it.
   canary-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [check, lint, runtime-operator-e2e, wash-image]
+    needs:
+      - check
+      - lint
+      - runtime-operator-e2e
+      - wash-image
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -376,7 +425,10 @@ jobs:
   # commit by hand and this job fires.
   canary-binaries:
     if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'release: v')"
-    needs: [check, lint, runtime-operator-e2e]
+    needs:
+      - check
+      - lint
+      - runtime-operator-e2e
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -332,7 +332,6 @@ jobs:
       - runtime-operator-e2e
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Require all jobs to pass or be skipped
         env:


### PR DESCRIPTION
## Summary

Required status checks that use trigger-level paths: filters stay Pending (never fire) when a PR touches unrelated files, forcing maintainers to use bypass. This PR implements the status gate pattern across all 8 CI workflows to fix that.

## What changed

Every workflow that had a paths: filter on its pull_request trigger now uses:

1. changes job (if: github.event_name == 'pull_request'): runs dorny/paths-filter via the GitHub API to detect whether relevant files changed. Skipped entirely on push/tag/dispatch events.
2. Work jobs (if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')): run unconditionally on push/tag/dispatch; on PRs, run only when changes reports relevant files touched.
3. gate job (if: always()): the single required check. Always reports a definitive pass or fail, never stays Pending.

### Why dorny/paths-filter instead of git diff

I started with a custom bash approach which required fetch-depth: 0 to reliably find the merge base for three-dot diffs. dorny/paths-filter uses the GitHub Checks API directly for PRsso it has a cleaner glob syntax matching the original paths: format, and battle-tested across thousands of repos.

### References

- dorny/paths-filter: https://github.com/dorny/paths-filter
- GitHub docs — skipped vs. pending required checks:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
