### PR TITLE
fix(install): install.sh error message improvements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -243,17 +243,35 @@ install_wash() {
     
     if [ -z "$asset_id" ]; then
         log_error "No matching binary found for platform ${platform}"
-        log_error "Available assets:"
-        
+        log_error "Available assets for ${version}:"
+
         # Use same pattern as elsewhere for optional GitHub token
         local list_curl_args=("-s")
         if [ -n "${GITHUB_TOKEN:-}" ]; then
             list_curl_args+=(" -H" "Authorization: token ${GITHUB_TOKEN:-}")
         fi
-        
-        curl "${list_curl_args[@]}" \
-            "https://api.github.com/repos/${REPO}/releases/latest" | \
-            grep '"name"' | sed 's/.*"name": *"\([^"]*\)".*/  - \1/' >&2
+
+        # Query the release the user actually asked for, not /latest — the
+        # latest release's asset list is misleading when the failure is
+        # specifically that an older release lacks the target's binary.
+        local list_response
+        list_response=$(curl "${list_curl_args[@]}" \
+            "https://api.github.com/repos/${REPO}/releases/tags/${version}" 2>/dev/null) || true
+
+        # jq is preferred so we only list real asset names. A bare grep on
+        # "name" also matches the release object's top-level .name (e.g.,
+        # "v2.1.0"), which then appears alongside actual asset filenames
+        # and confuses the diagnostic.
+        if command -v jq >/dev/null 2>&1; then
+            echo "$list_response" | jq -r '.assets[]?.name | "  - \(.)"' 2>/dev/null >&2
+        else
+            # Fallback without jq: rely on the wash- naming convention so
+            # we skip the release-level .name field. Covers the binary
+            # assets (wash-<target>) and the signature bundle (wash.sigstore.json).
+            echo "$list_response" \
+                | grep -oE '"name": *"wash[^"]*"' \
+                | sed 's/.*"name": *"\([^"]*\)".*/  - \1/' >&2
+        fi
         exit 1
     fi
     


### PR DESCRIPTION
install.sh's "no matching binary" error path fetched /releases/latest
and listed every "name" field it found via grep+sed. Two bugs followed:

1. /latest is the wrong release. If a user requested a specific version
    (e.g., v2.0.1) and that version lacks the target's binary, the error
    message listed /latest's assets, which often include binaries that
    v2.0.1 simply never shipped — making the failure look like a runner
    problem when it's really a "this version was built for fewer targets"
    problem.

2. grep '"name"' matched the release object's top-level .name (e.g.,
    "v2.1.0") in addition to asset filenames. The release name then
    appeared in the "Available assets" listing as if it were a binary,
    confusing readers and prompting unfounded suspicion of the release
    workflow.

Fixes by querying /releases/tags/${version} and parsing with jq (the
script's preferred JSON tool, already required for asset lookup), with
a grep fallback that anchors on the wash- asset naming convention to
exclude the release-level .name field.

Bumped into this with gnu not being an available artifact in:
https://github.com/wasmCloud/wasmCloud/actions/runs/25700381328/job/75459017845\#step:3:491
