### PR TITLE
bench infra

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,14 @@
 /.dockerignore          @wasmCloud/ci-maintainers
 /RELEASE_RUNBOOK.md     @wasmCloud/ci-maintainers
 
+# Benchmarking pipeline: host provisioning, bench scripts, the bench
+# crate's benches/, and the bench-tools data-processing binary are owned
+# jointly so wash maintainers retain context on the bench code itself
+# while ci maintainers gate the runner + pipeline.
+/scripts/bench/                         @wasmCloud/ci-maintainers
+/crates/bench-tools/                    @wasmCloud/ci-maintainers @wasmCloud/wash-maintainers
+/crates/wash-runtime/benches/           @wasmCloud/ci-maintainers @wasmCloud/wash-maintainers
+
 # Examples and project templates
 /examples/              @wasmCloud/examples-maintainers
 /templates/             @wasmCloud/examples-maintainers

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# Custom self-hosted runner labels used in this repo's workflows.
+# Without this config, actionlint flags these as unknown.
+self-hosted-runner:
+  labels:
+    - bench
+    - hetzner

--- a/.github/scripts/bench-check-runner-version.mjs
+++ b/.github/scripts/bench-check-runner-version.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// Monthly check: is the actions/runner version pinned in
+// scripts/bench/install-runner.sh behind the latest upstream release?
+//
+// If so, opens (or updates) a single tracking issue with the release
+// notes inline, so a maintainer can scan the changelog without
+// clicking through to the GitHub release page and decide whether the
+// bump needs care (e.g. arg/format changes to config.sh, new system
+// dependencies). Idempotent: re-runs on the existing issue rather than
+// spawning duplicates.
+//
+// Auto-close behavior: when the pinned version catches up to the
+// latest upstream, the tracking issue is closed with a one-liner
+// comment. Maintainers can also close via `Closes #N` in the bumping
+// PR; either path works.
+//
+// Invoked by .github/workflows/bench-host-checks.yml on a monthly cron.
+//
+// Reads:
+//   GITHUB_TOKEN      — required; needs issues:write
+//   GITHUB_REPOSITORY — owner/repo (set automatically by GH Actions)
+//
+// Exits 0 on every code path that isn't a hard error (network,
+// malformed install-runner.sh) — the workflow should not fail just
+// because there's a pending bump.
+
+import { readFileSync } from 'node:fs';
+
+const INSTALL_RUNNER = 'scripts/bench/install-runner.sh';
+const ISSUE_MARKER = '[bench-host] actions/runner update available';
+
+const token = required('GITHUB_TOKEN');
+const repo = required('GITHUB_REPOSITORY');
+
+const apiHeaders = {
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': 'wasmcloud-bench-host-version-check',
+};
+
+// ── 1. Pinned version from install-runner.sh ────────────────────────────
+const installSh = readFileSync(INSTALL_RUNNER, 'utf8');
+const pinnedMatch = installSh.match(/^RUNNER_VERSION="([^"]+)"/m);
+if (!pinnedMatch) {
+  console.error(`could not parse RUNNER_VERSION from ${INSTALL_RUNNER}`);
+  process.exit(1);
+}
+const pinned = pinnedMatch[1];
+
+// ── 2. Latest upstream release ──────────────────────────────────────────
+const releaseRes = await fetch(
+  'https://api.github.com/repos/actions/runner/releases/latest',
+  { headers: apiHeaders },
+);
+if (!releaseRes.ok) {
+  console.error(`fetching latest release: ${releaseRes.status} ${await releaseRes.text()}`);
+  process.exit(1);
+}
+const release = await releaseRes.json();
+const latest = release.tag_name.replace(/^v/, '');
+const releaseUrl = release.html_url;
+const releaseBody = release.body || '_(no release notes)_';
+const releaseDate = release.published_at;
+
+console.log(`pinned: v${pinned}; latest: v${latest}`);
+
+// ── 3. Find existing tracking issue (open or recently closed) ──────────
+const existing = await findExistingIssue();
+
+// ── 4. Branch on whether we're behind ───────────────────────────────────
+if (pinned === latest) {
+  if (existing && existing.state === 'open') {
+    await closeIssue(
+      existing.number,
+      `Pinned version is now \`v${pinned}\`, matching latest upstream. Auto-closing.`,
+    );
+    console.log(`closed #${existing.number} — pinned now matches latest`);
+  } else {
+    console.log('up to date — nothing to do');
+  }
+  process.exit(0);
+}
+
+// Behind upstream: open or update.
+const body = composeBody({ pinned, latest, releaseUrl, releaseDate, releaseBody });
+
+if (!existing || existing.state === 'closed') {
+  const created = await createIssue(`${ISSUE_MARKER}: v${latest}`, body);
+  console.log(`opened #${created.number} for v${latest}`);
+  process.exit(0);
+}
+
+// Existing open issue. If it already tracks this exact latest version,
+// nothing to add. Otherwise, comment with the newer info and retitle.
+const trackedMatch = existing.title.match(/v([\d.]+)$/);
+const tracked = trackedMatch?.[1];
+if (tracked === latest) {
+  console.log(`#${existing.number} already tracks v${latest}`);
+  process.exit(0);
+}
+
+await commentOnIssue(
+  existing.number,
+  `Bumped tracked latest from \`v${tracked ?? '?'}\` → \`v${latest}\` on the monthly check.\n\n${body}`,
+);
+await patchIssueTitle(existing.number, `${ISSUE_MARKER}: v${latest}`);
+console.log(`updated #${existing.number}: now tracking v${latest}`);
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+function required(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`${name} is required`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function findExistingIssue() {
+  // We look at both open and closed states in case a previous bump's
+  // tracking issue was just closed — we'd rather reopen the same issue
+  // than spawn a new one for an immediate follow-up release.
+  const q = `repo:${repo} is:issue in:title "${ISSUE_MARKER}"`;
+  const url = `https://api.github.com/search/issues?q=${encodeURIComponent(q)}&sort=updated&order=desc&per_page=1`;
+  const res = await fetch(url, { headers: apiHeaders });
+  if (!res.ok) {
+    console.error(`searching issues: ${res.status} ${await res.text()}`);
+    process.exit(1);
+  }
+  const json = await res.json();
+  return json.items[0];
+}
+
+async function createIssue(title, body) {
+  const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+    method: 'POST',
+    headers: { ...apiHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, body }),
+  });
+  if (!res.ok) {
+    console.error(`creating issue: ${res.status} ${await res.text()}`);
+    process.exit(1);
+  }
+  return res.json();
+}
+
+async function commentOnIssue(number, body) {
+  const res = await fetch(`https://api.github.com/repos/${repo}/issues/${number}/comments`, {
+    method: 'POST',
+    headers: { ...apiHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body }),
+  });
+  if (!res.ok) {
+    console.error(`commenting on #${number}: ${res.status} ${await res.text()}`);
+    process.exit(1);
+  }
+}
+
+async function patchIssueTitle(number, title) {
+  const res = await fetch(`https://api.github.com/repos/${repo}/issues/${number}`, {
+    method: 'PATCH',
+    headers: { ...apiHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  });
+  if (!res.ok) {
+    console.error(`updating title on #${number}: ${res.status} ${await res.text()}`);
+    process.exit(1);
+  }
+}
+
+async function closeIssue(number, comment) {
+  await commentOnIssue(number, comment);
+  const res = await fetch(`https://api.github.com/repos/${repo}/issues/${number}`, {
+    method: 'PATCH',
+    headers: { ...apiHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ state: 'closed', state_reason: 'completed' }),
+  });
+  if (!res.ok) {
+    console.error(`closing #${number}: ${res.status} ${await res.text()}`);
+    process.exit(1);
+  }
+}
+
+function composeBody({ pinned, latest, releaseUrl, releaseDate, releaseBody }) {
+  return [
+    `**Pinned** (in [\`${INSTALL_RUNNER}\`](../blob/main/${INSTALL_RUNNER})): \`v${pinned}\``,
+    `**Latest upstream:** \`v${latest}\` — released ${releaseDate}`,
+    `**Release notes:** ${releaseUrl}`,
+    '',
+    '<details><summary>upstream release body</summary>',
+    '',
+    releaseBody,
+    '',
+    '</details>',
+    '',
+    '---',
+    '',
+    '### To accept the bump',
+    '',
+    '1. Bump `RUNNER_VERSION` and `RUNNER_SHA256` in `scripts/bench/install-runner.sh`. The SHA-256 is on the release page under "Assets" — use the `actions-runner-linux-x64-<version>.tar.gz` checksum.',
+    '2. On the bench host: stop the systemd service, deregister with a fresh removal token, `rm -rf /opt/actions-runner`, then re-run `install-runner.sh` with a fresh registration token. See [scripts/bench/README.md §6](../blob/main/scripts/bench/README.md#6-self-hosted-github-actions-runner).',
+    '3. Reference this issue in the PR (`Closes #N`) so it auto-closes — or just leave it: the next monthly check auto-closes this issue once `RUNNER_VERSION` matches upstream.',
+    '',
+    '### To defer',
+    '',
+    'Leave this issue open. The next monthly check will update it in place if upstream ships another release before the bump lands; it will not spawn a duplicate.',
+    '',
+    '_Filed by [`bench-check-runner-version.mjs`](../blob/main/.github/scripts/bench-check-runner-version.mjs)._',
+  ].join('\n');
+}

--- a/.github/scripts/bench-preflight.mjs
+++ b/.github/scripts/bench-preflight.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// Pre-flight checks for the wasmCloud bench host. Refuses to start a
+// bench if the host has drifted from the baseline established by
+// stage-hetzner.sh + scripts/bench/ansible/provision.yml. A drifted
+// host produces meaningless numbers; better to fail fast than to
+// publish them.
+//
+// Invoked from .github/workflows/bench{,-compare}.yml. Reads:
+//
+//   WASMCLOUD_BENCH_HOSTNAME       expected hostname (workflow: vars.WASMCLOUD_BENCH_HOSTNAME)
+//   WASMCLOUD_BENCH_ISOLATED_CPU   override for the isolated-CPU index (default: "5")
+//   CARGO_TARGET_DIR               persistent target dir (default: /var/lib/bench/target)
+//
+// Each invariant prints one line on success ("pre-flight: …") or a
+// GitHub Actions error annotation on failure and exits non-zero.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, statfsSync } from 'node:fs';
+import { hostname } from 'node:os';
+
+const EXPECTED_NPROC = 6;
+const EXPECTED_GOVERNOR = 'performance';
+const MIN_FREE_BYTES = 5 * 1024 ** 3; // 5 GiB
+const MAX_LOAD1 = 1.0;
+
+const isolatedCpu = process.env.WASMCLOUD_BENCH_ISOLATED_CPU ?? '5';
+const targetDir = process.env.CARGO_TARGET_DIR ?? '/var/lib/bench/target';
+
+function fail(msg) {
+  console.error(`::error::pre-flight: ${msg}`);
+  process.exit(1);
+}
+
+function ok(msg) {
+  console.log(`pre-flight: ${msg}`);
+}
+
+function readTrim(path) {
+  return readFileSync(path, 'utf8').trim();
+}
+
+function runStdout(cmd, args = []) {
+  return execFileSync(cmd, args, { encoding: 'utf8' }).trim();
+}
+
+// 1. WASMCLOUD_BENCH_HOSTNAME must be exported, and we must be on that host.
+const expectedHostname = process.env.WASMCLOUD_BENCH_HOSTNAME;
+if (!expectedHostname) {
+  fail(
+    'WASMCLOUD_BENCH_HOSTNAME not set ' +
+      '(workflow: vars.WASMCLOUD_BENCH_HOSTNAME; local: export from 1Password)',
+  );
+}
+const actualHostname = hostname();
+if (actualHostname !== expectedHostname) {
+  fail(`wrong host: ${actualHostname} (expected ${expectedHostname})`);
+}
+ok(`host: ${expectedHostname}`);
+
+// 2. nproc == 6 (nosmt active).
+const nprocOut = parseInt(runStdout('nproc'), 10);
+if (nprocOut !== EXPECTED_NPROC) {
+  fail(`expected ${EXPECTED_NPROC} online CPUs (nosmt); got ${nprocOut}`);
+}
+ok(`nproc: ${nprocOut}  (nosmt active)`);
+
+// 3. cpufreq governor == "performance" on every CPU.
+const governors = runStdout('sh', [
+  '-c',
+  'cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor',
+]).split('\n');
+for (const g of governors) {
+  if (g !== EXPECTED_GOVERNOR) {
+    fail(`scaling_governor = ${g} (expected ${EXPECTED_GOVERNOR})`);
+  }
+}
+ok(`governor: ${EXPECTED_GOVERNOR} on every CPU`);
+
+// 4. /sys/devices/system/cpu/isolated matches the expected isolated CPU.
+//    Override via WASMCLOUD_BENCH_ISOLATED_CPU for hosts staged differently.
+if (!existsSync('/sys/devices/system/cpu/isolated')) {
+  fail('/sys/devices/system/cpu/isolated not readable (kernel too old?)');
+}
+const isolated = readTrim('/sys/devices/system/cpu/isolated');
+if (isolated !== isolatedCpu) {
+  fail(`isolated CPU mismatch: kernel reports '${isolated}', expected '${isolatedCpu}'`);
+}
+ok(`isolcpus: CPU ${isolatedCpu} reserved`);
+
+// 5. mdraid must not be resyncing — resync I/O would skew bench numbers.
+let mdstat = '';
+try {
+  mdstat = readFileSync('/proc/mdstat', 'utf8');
+} catch {
+  // No mdraid configured; nothing to check.
+}
+if (mdstat.includes('resync')) {
+  fail('mdraid resync in progress; refusing to bench');
+}
+ok('mdraid: clean (no resync)');
+
+// 6. 1-min loadavg < 1.0. The runner agent itself is the only thing on
+//    this box; anything higher means something else is eating CPU.
+const load1 = parseFloat(readTrim('/proc/loadavg').split(/\s+/)[0]);
+if (load1 > MAX_LOAD1) {
+  fail(`1-min loadavg=${load1} (something else is busy)`);
+}
+ok(`loadavg(1m): ${load1}`);
+
+// 7. $CARGO_TARGET_DIR exists and is writable.
+mkdirSync(targetDir, { recursive: true });
+// Posix W_OK = 2. Use access via spawnSync('test -w …') to avoid pulling
+// in fs.constants just to import a value we'd have to JSON-stringify.
+const access = spawnSync('test', ['-w', targetDir]);
+if (access.status !== 0) {
+  fail(`${targetDir} not writable`);
+}
+ok(`cargo target dir: ${targetDir}`);
+
+// 8. At least 5 GiB free on the target dir's mount.
+const fs = statfsSync(targetDir);
+const freeBytes = Number(fs.bavail) * Number(fs.bsize);
+if (freeBytes < MIN_FREE_BYTES) {
+  fail(`less than 5 GiB free at ${targetDir}`);
+}
+ok(`free space: ${Math.floor(freeBytes / 1024 ** 3)} GiB`);
+
+// 9. rustup-managed cargo must be available — the bench pipeline sources
+//    $HOME/.cargo/env in run-bench.sh; here we just confirm the binary
+//    exists. (Earlier versions of provision.yml installed rustup with
+//    `--default-toolchain none`, which would surface as `cargo` exiting
+//    non-zero when called without a project nearby. We accept that path —
+//    run-bench.sh enters the workspace where rust-toolchain.toml applies.)
+const cargoBin = `${process.env.HOME}/.cargo/bin/cargo`;
+if (!existsSync(cargoBin)) {
+  fail(`cargo not found at ${cargoBin}`);
+}
+ok(`cargo: ${runStdout(cargoBin, ['--version'])}`);
+
+ok('all checks passed');

--- a/.github/scripts/bench-push-results.mjs
+++ b/.github/scripts/bench-push-results.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// Upload one bench run's artifacts to S3, then update the public
+// history.json aggregate and invalidate CloudFront.
+//
+// Heavy JSON construction + history.json read-merge-write live here in
+// JS where they're cleaner than jq-in-bash; the actual S3/CloudFront
+// calls shell out to the `aws` CLI (already on the bench host's PATH).
+//
+// Per-run layout (private; only the bench role can read):
+//   s3://${WASMCLOUD_BENCH_S3_BUCKET}/runs/<date>/<short-sha>/<run-id>/<bench>/
+//     ├─ criterion.tar.zst   raw criterion data
+//     ├─ iai.tar.zst         raw iai-callgrind data (when applicable)
+//     ├─ results.jsonl       one JSON row per (group, param, metric)
+//     ├─ metadata.json       run-level facts
+//     └─ run.log             cargo bench stdout/stderr
+//
+// Aggregate (publicly readable through CloudFront):
+//   s3://${WASMCLOUD_BENCH_S3_BUCKET}/history.json
+//     - JSON array of every (group, param, metric) row from every run,
+//       deduped on (sha, bench, group, param, run_attempt, metric),
+//       sorted by timestamp.
+//     - Cache-Control: max-age=60.
+//     - CloudFront invalidation issued after each push.
+//
+// Reads (required):
+//   WASMCLOUD_BENCH_NAME                 bench whose output we're uploading
+//   WASMCLOUD_BENCH_S3_BUCKET            target bucket
+//   WASMCLOUD_BENCH_CF_DISTRIBUTION_ID   CloudFront distribution to invalidate
+//
+// Reads (optional):
+//   CARGO_TARGET_DIR        default /var/lib/bench/target
+//   GITHUB_RUN_ID           default "local"
+//   GITHUB_RUN_ATTEMPT      default "1"
+//   GITHUB_REF_NAME         default `git rev-parse --abbrev-ref HEAD`
+//   GITHUB_ACTOR/_EVENT_NAME/_WORKFLOW/_SERVER_URL/_REPOSITORY  — for metadata.json
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { hostname, tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+// rustup is in $HOME/.cargo/bin (not on the global PATH unless the user
+// shell sources $HOME/.cargo/env). Prepend it here so the `cargo run -p
+// bench-tools` call below resolves without us having to wrap it in `sh
+// -c '. ~/.cargo/env && …'`.
+process.env.PATH = `${process.env.HOME}/.cargo/bin:${process.env.PATH ?? ''}`;
+
+const bench = required('WASMCLOUD_BENCH_NAME');
+const bucket = required('WASMCLOUD_BENCH_S3_BUCKET');
+const distId = required('WASMCLOUD_BENCH_CF_DISTRIBUTION_ID');
+
+const targetDir = process.env.CARGO_TARGET_DIR ?? '/var/lib/bench/target';
+const critDir = join(targetDir, 'criterion');
+const iaiDir = join(targetDir, 'iai');
+
+const runId = process.env.GITHUB_RUN_ID ?? 'local';
+const sha = run('git', ['rev-parse', 'HEAD']);
+const shortSha = run('git', ['rev-parse', '--short=12', 'HEAD']);
+const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+const prefix = `runs/${date}/${shortSha}/${runId}/${bench}`;
+
+const work = mkdtempSync(join(tmpdir(), 'push-bench-'));
+process.on('exit', () => {
+  try {
+    rmSync(work, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+// 1. Tar+zstd the bench-specific output dirs. `tar -I "zstd -19 -T0"`
+//    pipes the archive through external zstd at level 19, matching what
+//    the bash version did via `tar | zstd`. tar's bundled `--zstd` flag
+//    uses level 3 — meaningful compression-ratio difference on criterion
+//    output, so we pin to -19 explicitly.
+let archived = 0;
+if (existsSync(critDir)) {
+  run('tar', ['-cf', join(work, 'criterion.tar.zst'), '-I', 'zstd -19 -T0', '-C', critDir, '.']);
+  archived++;
+}
+if (existsSync(iaiDir)) {
+  run('tar', ['-cf', join(work, 'iai.tar.zst'), '-I', 'zstd -19 -T0', '-C', iaiDir, '.']);
+  archived++;
+}
+if (archived === 0) {
+  console.log(`::warning::no criterion or iai output at ${targetDir}; uploading metadata only`);
+}
+
+// 2. Per-(group, param) JSONL rows for trend ingestion. bench-tools jsonl
+//    emits an empty stream for benches whose layout doesn't feed
+//    history.json today, which keeps the branch in one place (the Rust
+//    binary) instead of being repeated here.
+const jsonl = run('cargo', ['run', '-p', 'bench-tools', '--quiet', '--', 'jsonl', '--bench', bench]);
+writeFileSync(join(work, 'results.jsonl'), jsonl ? `${jsonl}\n` : '');
+
+// 3. Run-level metadata.
+const cpuModel = readFirstModelName('/proc/cpuinfo');
+const metadata = {
+  bench,
+  run_id: runId,
+  run_attempt: process.env.GITHUB_RUN_ATTEMPT ?? '1',
+  workflow: process.env.GITHUB_WORKFLOW ?? 'bench',
+  event: process.env.GITHUB_EVENT_NAME ?? '',
+  actor: process.env.GITHUB_ACTOR ?? '',
+  ref: process.env.GITHUB_REF_NAME || run('git', ['rev-parse', '--abbrev-ref', 'HEAD']),
+  sha,
+  short_sha: shortSha,
+  timestamp: rfc3339Now(),
+  run_url:
+    `${process.env.GITHUB_SERVER_URL ?? 'https://github.com'}/${process.env.GITHUB_REPOSITORY ?? ''}` +
+    `/actions/runs/${runId}`,
+  host: hostname(),
+  kernel: run('uname', ['-r']),
+  cpu: cpuModel,
+  cpus_online: parseInt(run('nproc'), 10),
+};
+writeFileSync(join(work, 'metadata.json'), `${JSON.stringify(metadata, null, 2)}\n`);
+
+// 4. Pick up the run log written by run-bench.sh, if present.
+const logSrc = join(targetDir, `run-${bench}-${runId}.log`);
+if (existsSync(logSrc)) {
+  run('cp', [logSrc, join(work, 'run.log')]);
+}
+
+// 5. Upload per-run artifacts.
+console.log(`uploading per-run artifacts to s3://${bucket}/${prefix}/`);
+for (const file of [
+  'criterion.tar.zst',
+  'iai.tar.zst',
+  'results.jsonl',
+  'metadata.json',
+  'run.log',
+]) {
+  const path = join(work, file);
+  if (!existsSync(path)) continue;
+  run('aws', ['s3', 'cp', '--no-progress', path, `s3://${bucket}/${prefix}/${basename(path)}`]);
+}
+
+// 6. Drop the source log now that it's archived in S3.
+if (existsSync(logSrc)) {
+  unlinkSync(logSrc);
+}
+
+// 7. Read-modify-write the public history.json aggregate. Safe without
+//    locking because the workflow is `concurrency: bench-host` — there's
+//    only ever one writer.
+console.log(`updating s3://${bucket}/history.json`);
+let existing = [];
+const head = spawnSync('aws', ['s3api', 'head-object', '--bucket', bucket, '--key', 'history.json'], {
+  stdio: 'ignore',
+});
+if (head.status === 0) {
+  const histPath = join(work, 'history-existing.json');
+  run('aws', ['s3', 'cp', '--no-progress', `s3://${bucket}/history.json`, histPath]);
+  existing = JSON.parse(readFileSync(histPath, 'utf8'));
+}
+
+const newRows = jsonl
+  .split('\n')
+  .filter((line) => line.length > 0)
+  .map((line) => JSON.parse(line));
+
+// Dedup key matches what build-history.sh uses: (sha, bench, group,
+// param, run_attempt, metric). Rows from before the metric-field schema
+// bump lack `.metric`; those compare as `null` and still unique correctly
+// within the criterion subset.
+const dedupKey = (r) =>
+  JSON.stringify([r.sha, r.bench, r.group, r.param, r.run_attempt, r.metric ?? null]);
+const merged = new Map();
+for (const row of existing) merged.set(dedupKey(row), row);
+for (const row of newRows) merged.set(dedupKey(row), row); // new rows win on collision
+const final = [...merged.values()].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+const histOut = join(work, 'history.json');
+writeFileSync(histOut, JSON.stringify(final));
+
+run('aws', [
+  's3',
+  'cp',
+  '--no-progress',
+  '--content-type',
+  'application/json',
+  '--cache-control',
+  'public, max-age=60',
+  histOut,
+  `s3://${bucket}/history.json`,
+]);
+
+// 8. Invalidate CloudFront so the next request hits a fresh edge cache.
+console.log('invalidating CloudFront /history.json');
+const invalidationId = run('aws', [
+  'cloudfront',
+  'create-invalidation',
+  '--distribution-id',
+  distId,
+  '--paths',
+  '/history.json',
+  '--query',
+  'Invalidation.Id',
+  '--output',
+  'text',
+]);
+console.log(`invalidation: ${invalidationId}`);
+
+console.log(
+  `::notice title=bench results::s3://${bucket}/${prefix}/  (history now ${final.length} rows)`,
+);
+
+// ─── helpers ────────────────────────────────────────────────────────────
+
+function required(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`${name} not set`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function run(cmd, args = []) {
+  return execFileSync(cmd, args, { encoding: 'utf8' }).trim();
+}
+
+function readFirstModelName(path) {
+  // /proc/cpuinfo has "model name : <name>" on Intel/AMD. Match the awk
+  // pipeline the bash version used: first occurrence, leading-space-stripped.
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const m = line.match(/^model name\s*:\s*(.+)$/);
+    if (m) return m[1].trim();
+  }
+  return '';
+}
+
+function rfc3339Now() {
+  // 2026-05-13T12:34:56Z — matches `date -u +%FT%TZ` and what
+  // bench-tools::Meta::capture() emits, so all timestamp fields agree.
+  return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+}

--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -1,0 +1,104 @@
+name: bench-compare
+
+# Pair-bench the same bench against two refs back-to-back on the bench
+# host and post the delta to the run's step summary.
+#
+# Trigger: workflow_dispatch only.
+#
+# Earlier drafts of this workflow also had a `pull_request_target /
+# labeled` entry point (apply `bench:run` to a PR → auto-compare base vs
+# head, post the delta as a PR comment). We deliberately do NOT do that:
+#
+#   - `pull_request_target` runs the workflow file from the base ref but
+#     gives the job access to base-repo secrets and a self-hosted runner.
+#     The bench job has to `git checkout` the PR head to run the bench,
+#     at which point any helper script on disk (run-bench.sh, the bench
+#     fixtures, build.rs in dependencies, etc.) comes from the PR head.
+#     That's untrusted code touching a long-lived bench host with cargo
+#     caches and rustup state.
+#   - Even gated on `author_association` ∈ {OWNER,MEMBER,COLLABORATOR},
+#     the model trusts every member's PR equally with merged code, which
+#     is a higher bar than we want for a single workflow's plumbing.
+#   - Maintainers who want a PR comparison can run this workflow manually
+#     with `ref_a = main`, `ref_b = <PR head sha>` — same delta, no new
+#     attack surface.
+#
+# Comparison runs do NOT push to S3 or update history.json. They are
+# ephemeral by design — for "did this PR move the numbers?" only.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bench:
+        description: which bench to compare
+        type: choice
+        default: iai_callgrind
+        options:
+          - http_invoke
+          - iai_callgrind
+          - wasmtime_baseline
+          - wasmtime_serve
+      ref_a:
+        description: baseline ref (branch, tag, or sha)
+        type: string
+        default: main
+      ref_b:
+        description: candidate ref (branch, tag, or sha) — required
+        type: string
+        required: true
+
+# Comparison runs share the bench-host concurrency group with the main bench
+# workflow so we never have two cargo bench processes on the host at once.
+concurrency:
+  group: bench-host
+  cancel-in-progress: false
+
+# Workflow-level permissions are the floor; the job below stays at this
+# floor — comparison runs don't write to S3, don't post comments, and
+# don't need the GITHUB_TOKEN for anything beyond the checkout.
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    name: ${{ inputs.bench }}
+    runs-on: [self-hosted, bench, hetzner]
+    timeout-minutes: 120
+    env:
+      CARGO_TARGET_DIR: /var/lib/bench/target
+      CARGO_INCREMENTAL: "0"
+      WASMCLOUD_BENCH_NAME: ${{ inputs.bench }}
+      WASMCLOUD_BENCH_REF_A: ${{ inputs.ref_a }}
+      WASMCLOUD_BENCH_REF_B: ${{ inputs.ref_b }}
+      WASMCLOUD_BENCH_COMPARE_DIR: /tmp/bench-compare-${{ github.run_id }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # Don't leave the GITHUB_TOKEN in .git/config; the host runs
+          # cargo bench (which builds + runs build-script and proc-macro
+          # code from the comparison refs) and we don't want it to read
+          # or use the token.
+          persist-credentials: false
+
+      - name: pre-flight host checks
+        env:
+          WASMCLOUD_BENCH_HOSTNAME: ${{ vars.WASMCLOUD_BENCH_HOSTNAME }}
+        run: node .github/scripts/bench-preflight.mjs
+
+      - name: compare-bench
+        run: ./scripts/bench/compare-bench.sh "${WASMCLOUD_BENCH_NAME}" "${WASMCLOUD_BENCH_REF_A}" "${WASMCLOUD_BENCH_REF_B}"
+
+      - name: append delta to step summary
+        if: always()
+        run: |
+          if [ -f "${WASMCLOUD_BENCH_COMPARE_DIR}/delta.md" ]; then
+            cat "${WASMCLOUD_BENCH_COMPARE_DIR}/delta.md" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "_no delta.md produced — see job logs_" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: clean compare working dir
+        if: always()
+        run: rm -rf "${WASMCLOUD_BENCH_COMPARE_DIR}"

--- a/.github/workflows/bench-host-checks.yml
+++ b/.github/workflows/bench-host-checks.yml
@@ -1,0 +1,45 @@
+name: bench-host-checks
+
+# Monthly upstream-version checks for the wasmCloud bench host. Today
+# this only covers the GitHub Actions self-hosted runner; new checks
+# (e.g. valgrind, iai-callgrind-runner, Node LTS) can be added as
+# additional jobs alongside `runner-version`.
+#
+# Jobs run on hosted ubuntu-latest — they do NOT touch the bench host
+# itself. The output of each job is a tracking issue (opened, updated,
+# or auto-closed) that a maintainer follows up on at the next
+# bench-host maintenance window. See scripts/bench/README.md §15 for
+# the recommended cadence.
+
+on:
+  schedule:
+    # 09:00 UTC on the 1st of each month. Time is intentionally office-
+    # hours-friendly across NA + EU; the day is the 1st so the new
+    # tracking issue lands at the same time as other start-of-month
+    # housekeeping.
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  runner-version:
+    name: actions/runner version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      # The script opens / updates / closes a single tracking issue.
+      issues: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: check pinned vs upstream
+        env:
+          # github.token inherits the job's permissions block — narrowest
+          # path to issues:write, no PAT or GH App needed.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node .github/scripts/bench-check-runner-version.mjs

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,161 @@
+name: bench
+
+on:
+  workflow_dispatch:
+    inputs:
+      bench:
+        description: which bench to run
+        type: choice
+        default: http_invoke
+        options:
+          - http_invoke
+          - iai_callgrind
+          - wasmtime_baseline
+          - wasmtime_serve
+      ref:
+        description: git ref to bench (branch, tag, or sha; default = the workflow ref)
+        type: string
+        default: ""
+  # Auto-populate the releases timeline: when a tag is published, run the
+  # subset of benches that actually track wash-runtime regressions against
+  # that exact tag. The site filters rows by `ref` to render the
+  # semver-ordered releases view.
+  #
+  # The release subset is intentionally narrower than the `inputs.bench`
+  # choice list — see RELEASE_BENCHES below.
+  release:
+    types: [published]
+
+defaults:
+  run:
+    shell: bash
+
+# Only one bench workflow can run on the host at a time. Queue rather than
+# cancel so an in-flight bench is never interrupted partway through criterion
+# sampling. Matrix jobs within a single run also serialize naturally because
+# the host has exactly one self-hosted runner.
+concurrency:
+  group: bench-host
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  # Compute the matrix shape from the trigger:
+  #   - workflow_dispatch: a one-element matrix (just inputs.bench)
+  #   - release:           a matrix of $RELEASE_BENCHES (the reference
+  #                        subset we track on the releases timeline)
+  # The dispatch path keeps the one-bench UX so a maintainer can compare
+  # an arbitrary bench (incl. wasmtime_*) against a ref; the release path
+  # restricts to benches that actually move with wash-runtime changes so
+  # a published tag doesn't tie up the bench host for ~4h.
+  matrix:
+    name: build matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      benches: ${{ steps.set.outputs.benches }}
+      ref: ${{ steps.set.outputs.ref }}
+    env:
+      # Subset of inputs.bench.options to run automatically on `release:
+      # published`. wasmtime_* are reference baselines for wasmtime itself
+      # and don't shift with our changes — run them on demand via
+      # workflow_dispatch when wasmtime is upgraded.
+      RELEASE_BENCHES: '["http_invoke","iai_callgrind"]'
+    steps:
+      - id: set
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_BENCH: ${{ inputs.bench }}
+          INPUT_REF: ${{ inputs.ref }}
+          DEFAULT_REF: ${{ github.ref }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "release" ]; then
+            echo "benches=${RELEASE_BENCHES}" >> "$GITHUB_OUTPUT"
+            echo "ref=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "benches=[\"${INPUT_BENCH}\"]" >> "$GITHUB_OUTPUT"
+            ref="${INPUT_REF:-${DEFAULT_REF}}"
+            echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+          fi
+
+  bench:
+    needs: matrix
+    name: ${{ matrix.bench }}
+    runs-on: [self-hosted, bench, hetzner]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write   # OIDC token for AWS role assumption
+    strategy:
+      fail-fast: false
+      # Redundant with the single-runner serialization, but documents intent.
+      max-parallel: 1
+      matrix:
+        bench: ${{ fromJSON(needs.matrix.outputs.benches) }}
+    env:
+      WASMCLOUD_BENCH_NAME: ${{ matrix.bench }}
+      # Persist the cargo build cache outside $GITHUB_WORKSPACE so
+      # actions/checkout's clean step doesn't blow it away every run.
+      CARGO_TARGET_DIR: /var/lib/bench/target
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.matrix.outputs.ref }}
+          fetch-depth: 0
+          # Don't leave the GITHUB_TOKEN in .git/config; the bench host
+          # then runs untrusted user code (the bench under test) and we
+          # don't want it to be able to read or use the token.
+          persist-credentials: false
+
+      - name: pre-flight host checks
+        env:
+          # Expected hostname of the dedicated bench host. Set as a repo
+          # variable (Settings → Secrets and variables → Actions → Variables).
+          # Kept out of the repo so the box's identity isn't broadcast.
+          WASMCLOUD_BENCH_HOSTNAME: ${{ vars.WASMCLOUD_BENCH_HOSTNAME }}
+        run: node .github/scripts/bench-preflight.mjs
+
+      - name: run cargo bench
+        id: run
+        run: ./scripts/bench/run-bench.sh "${WASMCLOUD_BENCH_NAME}"
+
+      # Subsequent steps inherit the implicit `if: success()` — they only
+      # run when every preceding step succeeded.
+      - name: render markdown summary
+        run: |
+          # Each `run:` step gets a fresh shell — PATH from previous steps
+          # doesn't persist — so re-source rustup's env shim before cargo.
+          # shellcheck disable=SC1091
+          . "$HOME/.cargo/env"
+          cargo run -p bench-tools --quiet -- summary --bench "${WASMCLOUD_BENCH_NAME}" \
+            >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: upload bench artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bench-${{ matrix.bench }}-${{ github.run_id }}
+          # criterion benches write to target/criterion/, iai-callgrind benches
+          # (iai_callgrind) write to target/iai/. A genuinely-empty run is a
+          # bug worth flagging loudly — fail rather than warn.
+          path: |
+            ${{ env.CARGO_TARGET_DIR }}/criterion/
+            ${{ env.CARGO_TARGET_DIR }}/iai/
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          role-to-assume: ${{ secrets.WASMCLOUD_BENCH_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.WASMCLOUD_BENCH_S3_REGION }}
+
+      - name: push results to s3 + invalidate CloudFront
+        env:
+          WASMCLOUD_BENCH_S3_BUCKET: ${{ secrets.WASMCLOUD_BENCH_S3_BUCKET }}
+          WASMCLOUD_BENCH_CF_DISTRIBUTION_ID: ${{ secrets.WASMCLOUD_BENCH_CF_DISTRIBUTION_ID }}
+        run: node .github/scripts/bench-push-results.mjs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bench-tools"
+version = "2.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "time",
+ "walkdir",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +605,15 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1771,6 +1792,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2900,6 +2942,42 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "iai-callgrind"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
+dependencies = [
+ "bincode",
+ "derive_more",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5438,6 +5516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7315,6 +7402,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "iai-callgrind",
  "io-lifetimes",
  "moka",
  "names",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 default-members = ["crates/wash"]
 members = [
+    "crates/bench-tools",
     "crates/wash-runtime",
     "crates/wash",
 ]

--- a/crates/bench-tools/Cargo.toml
+++ b/crates/bench-tools/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bench-tools"
+description = "Internal CLI for processing wasmCloud bench output (criterion + iai-callgrind)."
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+authors.workspace = true
+publish = false
+
+[[bin]]
+name = "bench-tools"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true, default-features = true }
+clap = { workspace = true, default-features = true }
+serde = { workspace = true, default-features = true, features = ["derive"] }
+serde_json = { workspace = true, default-features = true }
+# `macros` so the RFC 3339 format description is validated at compile time;
+# `formatting` + `std` (default) for OffsetDateTime::now_utc() + .format().
+time = { version = "0.3", default-features = false, features = ["formatting", "macros", "std"] }
+walkdir = "2.5"

--- a/crates/bench-tools/src/callgrind.rs
+++ b/crates/bench-tools/src/callgrind.rs
@@ -1,0 +1,149 @@
+//! Parser for valgrind's `callgrind.out` output — pulls instruction counts
+//! out of the trailing `events:` / `summary:` lines.
+//!
+//! iai-callgrind invokes valgrind with `--tool=callgrind`, which writes per
+//! bench a tree under `target/iai/`:
+//!
+//! ```text
+//! target/iai/
+//!   <package>/<bench_target>/<function>.<id>/
+//!     callgrind.out
+//!     summary.json     (we don't use this — schema changes across versions)
+//!     callgrind.out.old (baseline if any)
+//! ```
+//!
+//! callgrind.out itself ends with two lines whose format is set by valgrind
+//! and very stable:
+//!
+//! ```text
+//! events: Ir Dr Dw I1mr D1mr ILmr DLmr
+//! summary: 12345 6789 1234 ...
+//! ```
+//!
+//! We read those two lines, look up the column index of `Ir`, and pull the
+//! corresponding number out of `summary:`. That's the metric we report —
+//! instruction reads, i.e. total instructions executed.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use walkdir::WalkDir;
+
+#[derive(Debug)]
+pub struct Row {
+    /// `<bench_target>` — the `library_benchmark_group!` name.
+    pub group: String,
+    /// `<function>.<id>` — the per-bench identity.
+    pub param: String,
+    /// Instruction count (`Ir`).
+    pub ir: u64,
+}
+
+/// Walk `iai_dir`, returning one [`Row`] per `callgrind.out` found.
+///
+/// Every accepted file is logged to stderr in the form
+/// `bench-tools callgrind: <path> → (<group>, <param>) Ir=<ir>` so an
+/// operator can audit exactly which files contributed to the output —
+/// because we derive `(group, param)` from path components, a stray
+/// callgrind.out in the tree (e.g. leftover from manual debugging) would
+/// otherwise silently appear as a real bench row.
+pub fn walk(iai_dir: &Path) -> Result<Vec<Row>> {
+    if !iai_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut rows = Vec::new();
+    for entry in WalkDir::new(iai_dir).sort_by_file_name() {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.file_name() != "callgrind.out" {
+            continue;
+        }
+        let Some(row) = parse_one(iai_dir, entry.path())? else {
+            continue;
+        };
+        eprintln!(
+            "bench-tools callgrind: {} → ({}, {}) Ir={}",
+            entry.path().display(),
+            row.group,
+            row.param,
+            row.ir,
+        );
+        rows.push(row);
+    }
+    Ok(rows)
+}
+
+fn parse_one(iai_dir: &Path, path: &Path) -> Result<Option<Row>> {
+    let rel = path
+        .strip_prefix(iai_dir)
+        .with_context(|| format!("strip_prefix({})", iai_dir.display()))?;
+
+    // `<package>/<group>/<param>/callgrind.out`
+    // We pick the last two non-file components as (group, param). This is
+    // robust against iai-callgrind nesting one or more extra levels above
+    // <group>, which it has done in some versions (e.g. <package>/<binary>/…).
+    let components: Vec<_> = rel
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => s.to_str(),
+            _ => None,
+        })
+        .collect();
+    if components.len() < 3 {
+        return Ok(None);
+    }
+    let len = components.len();
+    let Some(group) = components.get(len - 3) else {
+        return Ok(None);
+    };
+    let Some(param) = components.get(len - 2) else {
+        return Ok(None);
+    };
+
+    let ir = match read_ir(path)? {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+    Ok(Some(Row {
+        group: (*group).to_string(),
+        param: (*param).to_string(),
+        ir,
+    }))
+}
+
+/// Return the `Ir` column of the `summary:` line, looked up by index in
+/// the `events:` line. `None` if either line is missing or `Ir` isn't
+/// among the events (callgrind was invoked with a different event set).
+pub fn read_ir(path: &Path) -> Result<Option<u64>> {
+    use std::io::{BufRead, BufReader};
+
+    let f = std::fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut events: Option<Vec<String>> = None;
+    let mut summary: Option<Vec<String>> = None;
+    for line in BufReader::new(f).lines() {
+        let line = line.with_context(|| format!("read {}", path.display()))?;
+        if let Some(rest) = line.strip_prefix("events: ") {
+            events = Some(rest.split_whitespace().map(String::from).collect());
+        } else if let Some(rest) = line.strip_prefix("summary: ") {
+            summary = Some(rest.split_whitespace().map(String::from).collect());
+        }
+    }
+    let (Some(events), Some(summary)) = (events, summary) else {
+        return Ok(None);
+    };
+    let Some(idx) = events.iter().position(|e| e == "Ir") else {
+        return Ok(None);
+    };
+    let Some(s) = summary.get(idx) else {
+        return Ok(None);
+    };
+    Ok(Some(s.parse().with_context(|| {
+        format!("summary[{idx}] = {s:?} in {}", path.display())
+    })?))
+}
+
+pub fn dir_from_target(target_dir: &Path) -> PathBuf {
+    target_dir.join("iai")
+}

--- a/crates/bench-tools/src/commands/delta.rs
+++ b/crates/bench-tools/src/commands/delta.rs
@@ -1,0 +1,285 @@
+//! `bench-tools delta` — render a markdown delta table from two snapshotted
+//! runs produced by `compare-bench.sh`.
+//!
+//! Expects the snapshot layout that `compare-bench.sh` writes:
+//!
+//! ```text
+//! $WASMCLOUD_BENCH_COMPARE_DIR/
+//!   a/iter-1/criterion/ …
+//!   a/iter-1/iai/       …
+//!   a/iter-2/…          (when criterion benches run 3× interleaved)
+//!   b/iter-1/criterion/ …
+//!   b/iter-1/iai/       …
+//! ```
+//!
+//! For each side we collect one numeric value per `(group, param)` per
+//! iteration (criterion → `mean_ns`; iai → `Ir`), take the median across
+//! iterations, then compute `Δ = (B − A) / A · 100`. Output is markdown
+//! plus a sibling `$WASMCLOUD_BENCH_COMPARE_DIR/delta.md` file that the
+//! bench-compare workflow appends to `$GITHUB_STEP_SUMMARY`.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::callgrind;
+use crate::criterion;
+use crate::meta::Meta;
+
+#[derive(Debug, clap::Args)]
+pub struct Args {
+    #[arg(long, env = "WASMCLOUD_BENCH_COMPARE_DIR")]
+    pub compare_dir: PathBuf,
+    #[arg(long, env = "WASMCLOUD_BENCH_NAME")]
+    pub bench: String,
+    #[arg(long, env = "WASMCLOUD_BENCH_REF_A")]
+    pub ref_a: String,
+    #[arg(long, env = "WASMCLOUD_BENCH_REF_B")]
+    pub ref_b: String,
+    #[arg(long, env = "WASMCLOUD_BENCH_SHORT_A")]
+    pub short_a: String,
+    #[arg(long, env = "WASMCLOUD_BENCH_SHORT_B")]
+    pub short_b: String,
+    #[arg(long, env = "WASMCLOUD_BENCH_ITERS")]
+    pub iters: u32,
+}
+
+/// `(group, param) → [values across iterations]`
+type Series = BTreeMap<(String, String), Vec<f64>>;
+
+pub fn run(args: Args) -> Result<()> {
+    let kind = Kind::for_bench(&args.bench);
+
+    // One capture for the whole render — host/kernel/timestamp are constant
+    // across the run, and Meta::capture() forks ~5 subprocesses we don't
+    // want to repeat per call site.
+    let meta = Meta::capture()?;
+
+    let a = collect_side(&args.compare_dir.join("a"), kind)?;
+    let b = collect_side(&args.compare_dir.join("b"), kind)?;
+
+    let body = render(&args, kind, &meta, &a, &b);
+
+    let out_path = args.compare_dir.join("delta.md");
+    std::fs::write(&out_path, &body).with_context(|| format!("write {}", out_path.display()))?;
+
+    print!("{body}");
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Kind {
+    /// criterion mean_ns; "lower is better".
+    Time,
+    /// iai-callgrind Ir; "lower is better".
+    Instructions,
+}
+
+impl Kind {
+    fn for_bench(bench: &str) -> Self {
+        match bench {
+            "iai_callgrind" => Kind::Instructions,
+            _ => Kind::Time,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Kind::Time => "mean time",
+            Kind::Instructions => "Ir (instructions)",
+        }
+    }
+
+    fn unit(self) -> &'static str {
+        match self {
+            Kind::Time => "ns",
+            Kind::Instructions => "instr",
+        }
+    }
+}
+
+fn collect_side(side_dir: &Path, kind: Kind) -> Result<Series> {
+    let mut series: Series = BTreeMap::new();
+    if !side_dir.exists() {
+        return Ok(series);
+    }
+    for entry in
+        std::fs::read_dir(side_dir).with_context(|| format!("read_dir {}", side_dir.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let iter_dir = entry.path();
+        let name = entry.file_name();
+        // Only look at `iter-*` children.
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with("iter-") {
+            continue;
+        }
+        match kind {
+            Kind::Time => collect_criterion(&iter_dir, &mut series)?,
+            Kind::Instructions => collect_iai(&iter_dir, &mut series)?,
+        }
+    }
+    Ok(series)
+}
+
+fn collect_criterion(iter_dir: &Path, series: &mut Series) -> Result<()> {
+    let crit_dir = iter_dir.join("criterion");
+    // No marker filter when reading snapshots — they're already isolated per
+    // iteration on disk.
+    let rows = criterion::walk(&crit_dir, None)?;
+    for row in rows {
+        series
+            .entry((row.group, row.param))
+            .or_default()
+            .push(row.estimates.mean.point_estimate);
+    }
+    Ok(())
+}
+
+fn collect_iai(iter_dir: &Path, series: &mut Series) -> Result<()> {
+    let iai_dir = iter_dir.join("iai");
+    let rows = callgrind::walk(&iai_dir)?;
+    for row in rows {
+        series
+            .entry((row.group, row.param))
+            .or_default()
+            .push(row.ir as f64);
+    }
+    Ok(())
+}
+
+fn median(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted: Vec<f64> = values.to_vec();
+    sorted.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = sorted.len() / 2;
+    // Matches the jq implementation we replaced: pick the upper-middle for
+    // even-length series. Single-iteration runs (iai) hit the mid=0 path.
+    sorted.get(mid).copied()
+}
+
+fn render(args: &Args, kind: Kind, meta: &Meta, a: &Series, b: &Series) -> String {
+    use std::collections::BTreeSet;
+    use std::fmt::Write;
+
+    let mut keys: BTreeSet<&(String, String)> = BTreeSet::new();
+    keys.extend(a.keys());
+    keys.extend(b.keys());
+
+    let mut out = String::new();
+    let _ = writeln!(out, "## bench-compare: `{}`", args.bench);
+    let _ = writeln!(out);
+    let _ = writeln!(out, "| | |");
+    let _ = writeln!(out, "|---|---|");
+    let _ = writeln!(
+        out,
+        "| **A (baseline)** | `{}` @ `{}` |",
+        args.ref_a, args.short_a
+    );
+    let _ = writeln!(
+        out,
+        "| **B (candidate)** | `{}` @ `{}` |",
+        args.ref_b, args.short_b
+    );
+    let _ = writeln!(out, "| **iters per side** | {} (median used) |", args.iters);
+    let _ = writeln!(
+        out,
+        "| **metric** | {} ({}) — lower is better |",
+        kind.label(),
+        kind.unit()
+    );
+    let _ = writeln!(
+        out,
+        "| **host** | `{}` · {} cpu · isolated cpu: `{}` |",
+        meta.host, meta.cpus_online, meta.isolated_cpu,
+    );
+    let _ = writeln!(out, "| **timestamp** | {} |", meta.timestamp);
+    let _ = writeln!(out);
+
+    if keys.is_empty() {
+        let _ = writeln!(
+            out,
+            "_no measurement output found at `{}` — was the bench run successfully?_",
+            args.compare_dir.display()
+        );
+        return out;
+    }
+
+    let _ = writeln!(out, "| group | param | A | B | Δ |");
+    let _ = writeln!(out, "|---|---|---:|---:|---:|");
+    for key in keys {
+        let am = a.get(key).and_then(|v| median(v));
+        let bm = b.get(key).and_then(|v| median(v));
+        let delta = match (am, bm) {
+            (Some(av), Some(bv)) if av != 0.0 => Some((bv - av) / av * 100.0),
+            _ => None,
+        };
+        let _ = writeln!(
+            out,
+            "| {} | {} | {} | {} | {} |",
+            key.0,
+            key.1,
+            fmt_value(am, kind),
+            fmt_value(bm, kind),
+            fmt_delta(delta),
+        );
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "_Δ is `(B − A) / A · 100` of the median across {} iteration(s). \
+         Single-iteration comparisons (`iai_callgrind`) are deterministic; \
+         multi-iteration comparisons use the median to dampen run-to-run noise._",
+        args.iters
+    );
+    out
+}
+
+fn fmt_value(v: Option<f64>, kind: Kind) -> String {
+    match (v, kind) {
+        (Some(v), Kind::Time) => format!("{v:.0}"),
+        (Some(v), Kind::Instructions) => format!("{}", v as u64),
+        (None, _) => "—".to_string(),
+    }
+}
+
+fn fmt_delta(v: Option<f64>) -> String {
+    match v {
+        Some(pct) => format!("{:.2}%", pct),
+        None => "—".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn median_single() {
+        assert_eq!(median(&[100.0]), Some(100.0));
+    }
+
+    #[test]
+    fn median_odd() {
+        assert_eq!(median(&[99.0, 101.0, 100.0]), Some(100.0));
+    }
+
+    #[test]
+    fn median_even_picks_upper_mid() {
+        // `length / 2 | floor` semantics — for [1,2,3,4] the median is
+        // the 3rd element. Documented so a future refactor doesn't
+        // "fix" this into the arithmetic mean of the two middle values.
+        assert_eq!(median(&[1.0, 2.0, 3.0, 4.0]), Some(3.0));
+    }
+
+    #[test]
+    fn median_empty() {
+        assert_eq!(median(&[]), None);
+    }
+}

--- a/crates/bench-tools/src/commands/jsonl.rs
+++ b/crates/bench-tools/src/commands/jsonl.rs
@@ -1,0 +1,160 @@
+//! `bench-tools jsonl` emit one JSON row per `(group, param, metric)`
+//!
+//! Schema (additive, existing consumers keep working):
+//!
+//! - Every row has `metric` (`"mean_ns"` or `"Ir"`) and `value: f64`.
+//! - Criterion rows additionally carry the original sibling fields
+//!   (`mean_ns`, `median_ns`, `std_dev_ns`, `ci_low_ns`, `ci_high_ns`,
+//!   `throughput`) so the existing `arewefastyet` reader doesn't break
+//!   on the schema bump.
+//! - iai rows carry only `metric` + `value` (Ir instruction counts).
+//!
+//! The dedup key in `push-s3.sh` is widened to include `.metric`, which
+//! lets `(bench, group, param)` map to multiple rows, one per metric,
+//! without each colliding with the others.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::callgrind;
+use crate::criterion::{self, Throughput};
+use crate::meta::Meta;
+
+#[derive(Debug, clap::Args)]
+pub struct Args {
+    /// Bench name (e.g. `http_invoke`); annotates every emitted row.
+    #[arg(long)]
+    pub bench: String,
+
+    /// `$CARGO_TARGET_DIR`. Defaults to env var, then `target/`.
+    #[arg(long, env = "CARGO_TARGET_DIR")]
+    pub target_dir: Option<PathBuf>,
+
+    /// Marker file written by run-bench.sh at the start of the current
+    /// run. Used only for criterion: prevents stale rows from prior runs
+    /// of other benches leaking out. Defaults to
+    /// `$CARGO_TARGET_DIR/.bench-start-<bench>`.
+    #[arg(long)]
+    pub marker: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+struct CriterionRow<'a> {
+    bench: &'a str,
+    group: String,
+    param: String,
+    #[serde(flatten)]
+    meta: &'a Meta,
+    metric: &'static str,
+    value: f64,
+    throughput: Option<Throughput>,
+    mean_ns: f64,
+    median_ns: f64,
+    std_dev_ns: f64,
+    ci_low_ns: f64,
+    ci_high_ns: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct IaiRow<'a> {
+    bench: &'a str,
+    group: String,
+    param: String,
+    #[serde(flatten)]
+    meta: &'a Meta,
+    metric: &'static str,
+    value: f64,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    // Pull non-Copy fields out of `args` first so subsequent `&args.bench`
+    // borrows don't conflict with the partial move from `args.target_dir`.
+    let target_dir: PathBuf = args
+        .target_dir
+        .as_deref()
+        .unwrap_or(Path::new("target"))
+        .to_path_buf();
+    let marker_override = args.marker.clone();
+    let meta = Meta::capture()?;
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    if args.bench == "iai_callgrind" {
+        return emit_iai(&mut out, &args.bench, &meta, &target_dir);
+    }
+
+    emit_criterion(
+        &mut out,
+        &args.bench,
+        marker_override.as_deref(),
+        &meta,
+        &target_dir,
+    )
+}
+
+fn emit_criterion<W: Write>(
+    out: &mut W,
+    bench: &str,
+    marker_override: Option<&Path>,
+    meta: &Meta,
+    target_dir: &Path,
+) -> Result<()> {
+    let crit_dir = criterion::dir_from_target(target_dir);
+    let marker_owned: PathBuf;
+    let marker: &Path = match marker_override {
+        Some(p) => p,
+        None => {
+            marker_owned = target_dir.join(format!(".bench-start-{bench}"));
+            &marker_owned
+        }
+    };
+
+    let rows = criterion::walk(&crit_dir, Some(marker))?;
+    for row in rows {
+        let est = &row.estimates;
+        let serialized = CriterionRow {
+            bench,
+            group: row.group,
+            param: row.param,
+            meta,
+            metric: "mean_ns",
+            value: est.mean.point_estimate,
+            throughput: row.throughput,
+            mean_ns: est.mean.point_estimate,
+            median_ns: est.median.point_estimate,
+            std_dev_ns: est.std_dev.point_estimate,
+            ci_low_ns: est.mean.confidence_interval.lower_bound,
+            ci_high_ns: est.mean.confidence_interval.upper_bound,
+        };
+        serde_json::to_writer(&mut *out, &serialized)?;
+        out.write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+fn emit_iai<W: Write>(
+    out: &mut W,
+    bench: &str,
+    meta: &Meta,
+    target_dir: &std::path::Path,
+) -> Result<()> {
+    let iai_dir = callgrind::dir_from_target(target_dir);
+    let rows = callgrind::walk(&iai_dir)?;
+    for row in rows {
+        let serialized = IaiRow {
+            bench,
+            group: row.group,
+            param: row.param,
+            meta,
+            metric: "Ir",
+            value: row.ir as f64,
+        };
+        serde_json::to_writer(&mut *out, &serialized)?;
+        out.write_all(b"\n")?;
+    }
+    Ok(())
+}

--- a/crates/bench-tools/src/commands/mod.rs
+++ b/crates/bench-tools/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod delta;
+pub mod jsonl;
+pub mod summary;

--- a/crates/bench-tools/src/commands/summary.rs
+++ b/crates/bench-tools/src/commands/summary.rs
@@ -1,0 +1,149 @@
+//! `bench-tools summary` renders a markdown table for `$GITHUB_STEP_SUMMARY`
+//!
+//! Per-row metric is RPS for batch throughput, B/s for byte throughput,
+//! and time otherwise. For `iai_callgrind` we render a separate
+//! instruction-count table from the iai output with different schema and unit,
+//! but same rough shape so the step summary stays consistent.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use crate::callgrind;
+use crate::criterion;
+use crate::markdown;
+use crate::meta::Meta;
+
+#[derive(Debug, clap::Args)]
+pub struct Args {
+    #[arg(long)]
+    pub bench: String,
+
+    #[arg(long, env = "CARGO_TARGET_DIR")]
+    pub target_dir: Option<PathBuf>,
+
+    /// GitHub Actions run id (`$GITHUB_RUN_ID`). Used in the
+    /// download-artifact pointer.
+    #[arg(long, env = "GITHUB_RUN_ID")]
+    pub run_id: Option<String>,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let target_dir = args.target_dir.unwrap_or_else(|| PathBuf::from("target"));
+    let meta = Meta::capture()?;
+    let run_id = args.run_id.unwrap_or_else(|| "local".to_string());
+
+    // Single locked handle for the whole render — fewer syscalls and no
+    // interleaving if anything else writes to stdout.
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    if args.bench == "iai_callgrind" {
+        return render_iai_stub(&mut out, &args.bench, &meta, &target_dir, &run_id);
+    }
+
+    let crit_dir = criterion::dir_from_target(&target_dir);
+    let marker = target_dir.join(format!(".bench-start-{}", args.bench));
+    let rows = criterion::walk(&crit_dir, Some(&marker))?;
+    if rows.is_empty() {
+        writeln!(
+            out,
+            "## bench: `{}`\n\n_no criterion output at `{}`_",
+            args.bench,
+            crit_dir.display()
+        )?;
+        return Ok(());
+    }
+
+    render_criterion(&mut out, &args.bench, &meta, rows, &run_id)
+}
+
+fn render_criterion<W: Write>(
+    out: &mut W,
+    bench: &str,
+    meta: &Meta,
+    rows: Vec<criterion::Row>,
+    run_id: &str,
+) -> Result<()> {
+    writeln!(out, "## bench: `{bench}`")?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "_commit_ `{}` &middot; _ref_ `{}` &middot; _host_ `{}` &middot; _cpus_ {}",
+        meta.short_sha, meta.ref_name, meta.host, meta.cpus_online,
+    )?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "| group | param | metric | mean | median | std-dev | 95 % CI |"
+    )?;
+    writeln!(out, "|---|---|---|---:|---:|---:|---:|")?;
+    for row in &rows {
+        let (unit, vals) = markdown::metric(row);
+        writeln!(
+            out,
+            "| {} | {} | {} | {} | {} | {} | {}–{} |",
+            row.group,
+            row.param,
+            unit.label(),
+            markdown::fmt(vals.mean, unit),
+            markdown::fmt(vals.median, unit),
+            markdown::fmt(vals.std_dev, unit),
+            markdown::fmt(vals.ci_low, unit),
+            markdown::fmt(vals.ci_high, unit),
+        )?;
+    }
+    writeln!(out)?;
+    writeln!(out, "<details><summary>raw criterion output</summary>")?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "Download the workflow artifact `bench-{bench}-{run_id}` or fetch \
+         from S3 (see scripts/bench/README.md).",
+    )?;
+    writeln!(out)?;
+    writeln!(out, "</details>")?;
+    Ok(())
+}
+
+fn render_iai_stub<W: Write>(
+    out: &mut W,
+    bench: &str,
+    meta: &Meta,
+    target_dir: &std::path::Path,
+    run_id: &str,
+) -> Result<()> {
+    writeln!(out, "## bench: `{bench}` (iai-callgrind)")?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "_commit_ `{}` &middot; _ref_ `{}` &middot; _host_ `{}` &middot; _cpus_ {}",
+        meta.short_sha, meta.ref_name, meta.host, meta.cpus_online,
+    )?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "Instruction-count bench (cachegrind via iai-callgrind). Raw counts \
+         and callgrind output are archived under the workflow artifact \
+         `bench-{bench}-{run_id}` and in S3 (see scripts/bench/README.md).",
+    )?;
+    writeln!(out)?;
+
+    let iai_dir = callgrind::dir_from_target(target_dir);
+    let rows = callgrind::walk(&iai_dir)?;
+    if !rows.is_empty() {
+        writeln!(out, "| group | param | Ir (instructions) |")?;
+        writeln!(out, "|---|---|---:|")?;
+        for row in rows {
+            writeln!(
+                out,
+                "| {} | {} | {} |",
+                row.group,
+                row.param,
+                markdown::fmt_thousands(row.ir),
+            )?;
+        }
+    }
+    Ok(())
+}

--- a/crates/bench-tools/src/criterion.rs
+++ b/crates/bench-tools/src/criterion.rs
@@ -1,0 +1,214 @@
+//! Parsers + directory walkers for criterion's per-bench output layout.
+//!
+//! Criterion writes one tree per `(group, param)` under `target/criterion/`:
+//!
+//! ```text
+//! target/criterion/
+//!   <group>/
+//!     <param>/
+//!       new/                      ← this run
+//!         estimates.json          ← point estimates + CI for mean/median/…
+//!         benchmark.json          ← config: function_id, value_str, throughput
+//!       base/                     ← previous run (we ignore)
+//!   report/                       ← rendered HTML (we ignore)
+//! ```
+//!
+//! We only consume `new/estimates.json` + `new/benchmark.json`. The trend
+//! pipeline (jsonl subcommand) attributes every row it finds to the current
+//! bench name; to keep stale data from prior runs of *other* benches out of
+//! the output, callers pass a marker file written by run-bench.sh at the
+//! start of the current run and we filter by mtime > marker.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use walkdir::WalkDir;
+
+/// One `<group>/<param>/new/estimates.json` + its sibling `benchmark.json`.
+#[derive(Debug)]
+pub struct Row {
+    pub group: String,
+    pub param: String,
+    pub estimates: Estimates,
+    pub throughput: Option<Throughput>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Estimates {
+    pub mean: Estimate,
+    pub median: Estimate,
+    pub std_dev: Estimate,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Estimate {
+    pub point_estimate: f64,
+    pub confidence_interval: ConfidenceInterval,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConfidenceInterval {
+    pub lower_bound: f64,
+    pub upper_bound: f64,
+}
+
+/// Criterion's `Throughput` enum — kept untagged so JSON looks like
+/// `{"Elements": 256}` / `{"Bytes": 1024}` / `null`, matching the trend
+/// schema downstream consumers already parse.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum Throughput {
+    Bytes(u64),
+    BytesDecimal(u64),
+    Elements(u64),
+}
+
+#[derive(Debug, Deserialize)]
+struct BenchmarkJson {
+    #[serde(default)]
+    throughput: Option<Throughput>,
+}
+
+/// Walk `criterion_dir`, returning one [`Row`] per `(group, param)` tuple.
+///
+/// If `marker` is `Some`, only `estimates.json` files modified after the
+/// marker's mtime are returned — see module doc-comment for why. If
+/// `marker` is `Some` but the marker file is missing, returns an empty
+/// vec (defensive: don't risk publishing stale rows).
+pub fn walk(criterion_dir: &Path, marker: Option<&Path>) -> Result<Vec<Row>> {
+    if !criterion_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let marker_mtime = match marker {
+        Some(m) if m.exists() => Some(
+            std::fs::metadata(m)
+                .with_context(|| format!("stat {}", m.display()))?
+                .modified()
+                .with_context(|| format!("mtime {}", m.display()))?,
+        ),
+        Some(m) => {
+            eprintln!(
+                "bench-tools: no marker at {}; emitting nothing",
+                m.display()
+            );
+            return Ok(Vec::new());
+        }
+        None => None,
+    };
+
+    let mut rows = Vec::new();
+
+    // depth 4 from criterion_dir: <group>/<param>/new/estimates.json
+    for entry in WalkDir::new(criterion_dir)
+        .min_depth(4)
+        .max_depth(4)
+        .sort_by_file_name()
+    {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.file_name() != "estimates.json" {
+            continue;
+        }
+        let path = entry.path();
+        // Filter to */new/* — base/ is criterion's previous-run baseline.
+        let Some(parent) = path.parent() else {
+            continue;
+        };
+        if parent.file_name() != Some(std::ffi::OsStr::new("new")) {
+            continue;
+        }
+
+        if let Some(want_after) = marker_mtime {
+            let mtime = entry
+                .metadata()
+                .with_context(|| format!("metadata for {}", path.display()))?
+                .modified()
+                .with_context(|| format!("mtime for {}", path.display()))?;
+            if mtime <= want_after {
+                continue;
+            }
+        }
+
+        let (group, param) = derive_group_param(criterion_dir, path)?;
+        // Skip criterion's own report dir aggregations (group == "report").
+        if group == "report" {
+            continue;
+        }
+
+        let estimates = parse_estimates(path)?;
+        let throughput = parse_benchmark_throughput(parent.join("benchmark.json").as_path())?;
+
+        rows.push(Row {
+            group,
+            param,
+            estimates,
+            throughput,
+        });
+    }
+
+    // Loud warning: criterion dir exists but produced no rows. Silent
+    // emptiness is the worst failure mode for trend ingestion — a future
+    // criterion layout change (e.g. renaming `new/`) would otherwise
+    // surface as "history.json stopped growing" weeks later.
+    if rows.is_empty() {
+        eprintln!(
+            "bench-tools criterion: walked {} but found no <group>/<param>/new/estimates.json entries — \
+             criterion layout may have changed, or the marker filter excluded everything",
+            criterion_dir.display(),
+        );
+    }
+
+    Ok(rows)
+}
+
+/// Pull `(group, param)` out of a path of shape
+/// `<crit>/<group>/<param>/new/estimates.json`.
+fn derive_group_param(crit: &Path, estimates_path: &Path) -> Result<(String, String)> {
+    let rel = estimates_path
+        .strip_prefix(crit)
+        .with_context(|| format!("strip_prefix({})", crit.display()))?;
+    let components: Vec<_> = rel
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => s.to_str(),
+            _ => None,
+        })
+        .collect();
+    if components.len() < 2 {
+        anyhow::bail!("unexpected path shape under criterion/: {}", rel.display());
+    }
+    let group = components
+        .first()
+        .copied()
+        .ok_or_else(|| anyhow::anyhow!("missing group in {}", rel.display()))?
+        .to_string();
+    let param = components
+        .get(1)
+        .copied()
+        .ok_or_else(|| anyhow::anyhow!("missing param in {}", rel.display()))?
+        .to_string();
+    Ok((group, param))
+}
+
+fn parse_estimates(path: &Path) -> Result<Estimates> {
+    let f = std::fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    serde_json::from_reader(f).with_context(|| format!("parse {}", path.display()))
+}
+
+fn parse_benchmark_throughput(path: &Path) -> Result<Option<Throughput>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let f = std::fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let parsed: BenchmarkJson =
+        serde_json::from_reader(f).with_context(|| format!("parse {}", path.display()))?;
+    Ok(parsed.throughput)
+}
+
+/// Convenience: build `criterion_dir` from `$CARGO_TARGET_DIR`.
+pub fn dir_from_target(target_dir: &Path) -> PathBuf {
+    target_dir.join("criterion")
+}

--- a/crates/bench-tools/src/main.rs
+++ b/crates/bench-tools/src/main.rs
@@ -1,0 +1,46 @@
+//! Internal CLI for processing wasmCloud bench output (criterion + iai-callgrind).
+//!
+//! Run via `cargo run -p bench-tools -- <subcommand>` from CI or from any
+//! script in `scripts/bench/`. The output schemas match what the trend
+//! site (`wasmCloud/arewefastyet`) ingests from `history.json`.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+mod callgrind;
+mod commands;
+mod criterion;
+mod markdown;
+mod meta;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "bench-tools",
+    version,
+    about = "wasmCloud bench data processing (criterion + iai-callgrind)"
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Debug, Subcommand)]
+enum Cmd {
+    /// Emit one JSONL row per (group, param) for trend ingestion.
+    Jsonl(commands::jsonl::Args),
+
+    /// Render a markdown table for $GITHUB_STEP_SUMMARY.
+    Summary(commands::summary::Args),
+
+    /// Render a markdown comparison delta from compare-bench.sh snapshots.
+    Delta(commands::delta::Args),
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.cmd {
+        Cmd::Jsonl(args) => commands::jsonl::run(args),
+        Cmd::Summary(args) => commands::summary::run(args),
+        Cmd::Delta(args) => commands::delta::run(args),
+    }
+}

--- a/crates/bench-tools/src/markdown.rs
+++ b/crates/bench-tools/src/markdown.rs
@@ -1,0 +1,184 @@
+//! Shared formatting helpers for markdown tables.
+//!
+//! Per-row metric semantics mirror the trend site (`arewefastyet`): use
+//! req/s for batch throughput (`Throughput::Elements > 1`), bytes/sec for
+//! byte throughput, and time otherwise. Keep this in sync if the site's
+//! display rules change.
+
+use crate::criterion::{Row, Throughput};
+
+#[derive(Debug, Clone, Copy)]
+pub enum Unit {
+    Time,
+    Rps,
+    Bps,
+}
+
+impl Unit {
+    pub fn label(self) -> &'static str {
+        match self {
+            Unit::Time => "time",
+            Unit::Rps => "req/s",
+            Unit::Bps => "B/s",
+        }
+    }
+}
+
+/// Decide the natural display unit for a row and translate the criterion
+/// time-based estimates (in ns) into that unit. Returns the unit plus the
+/// converted (mean, median, std_dev, ci_low, ci_high) tuple.
+pub fn metric(row: &Row) -> (Unit, MetricValues) {
+    let mean_ns = row.estimates.mean.point_estimate;
+    let median_ns = row.estimates.median.point_estimate;
+    let std_dev_ns = row.estimates.std_dev.point_estimate;
+    let ci_low_ns = row.estimates.mean.confidence_interval.lower_bound;
+    let ci_high_ns = row.estimates.mean.confidence_interval.upper_bound;
+
+    match row.throughput {
+        Some(Throughput::Elements(n)) if n > 1 => {
+            let k = (n as f64) * 1e9;
+            (
+                Unit::Rps,
+                MetricValues {
+                    // rate = k / time; lower time ↔ higher rate, so CI inverts.
+                    mean: k / mean_ns,
+                    median: k / median_ns,
+                    // Approximate std-dev in rate units by linearising around mean.
+                    std_dev: (k / mean_ns) - (k / (mean_ns + std_dev_ns)),
+                    ci_low: k / ci_high_ns,
+                    ci_high: k / ci_low_ns,
+                },
+            )
+        }
+        Some(Throughput::Bytes(n) | Throughput::BytesDecimal(n)) if n > 0 => {
+            let k = (n as f64) * 1e9;
+            (
+                Unit::Bps,
+                MetricValues {
+                    mean: k / mean_ns,
+                    median: k / median_ns,
+                    std_dev: (k / mean_ns) - (k / (mean_ns + std_dev_ns)),
+                    ci_low: k / ci_high_ns,
+                    ci_high: k / ci_low_ns,
+                },
+            )
+        }
+        _ => (
+            Unit::Time,
+            MetricValues {
+                mean: mean_ns,
+                median: median_ns,
+                std_dev: std_dev_ns,
+                ci_low: ci_low_ns,
+                ci_high: ci_high_ns,
+            },
+        ),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MetricValues {
+    pub mean: f64,
+    pub median: f64,
+    pub std_dev: f64,
+    pub ci_low: f64,
+    pub ci_high: f64,
+}
+
+/// Format a value into the given unit at human-friendly scale.
+/// Mirrors the unit scaling used on the `arewefastyet` trend site so
+/// values rendered into `$GITHUB_STEP_SUMMARY` match what the dashboard
+/// displays for the same row.
+pub fn fmt(v: f64, unit: Unit) -> String {
+    match unit {
+        Unit::Time => fmt_time(v),
+        Unit::Rps => fmt_rps(v),
+        Unit::Bps => fmt_bps(v),
+    }
+}
+
+fn fmt_time(ns: f64) -> String {
+    if ns < 1_000.0 {
+        format!("{} ns", ns.floor() as i64)
+    } else if ns < 1_000_000.0 {
+        format!("{:.2} µs", ns / 1_000.0)
+    } else if ns < 1_000_000_000.0 {
+        format!("{:.2} ms", ns / 1_000_000.0)
+    } else {
+        format!("{:.2} s", ns / 1_000_000_000.0)
+    }
+}
+
+fn fmt_rps(rps: f64) -> String {
+    if rps >= 1_000_000.0 {
+        format!("{:.2} Mreq/s", rps / 1_000_000.0)
+    } else if rps >= 1_000.0 {
+        format!("{:.2} Kreq/s", rps / 1_000.0)
+    } else {
+        format!("{} req/s", rps.floor() as i64)
+    }
+}
+
+fn fmt_bps(bps: f64) -> String {
+    if bps >= 1_000_000_000.0 {
+        format!("{:.2} GB/s", bps / 1_000_000_000.0)
+    } else if bps >= 1_000_000.0 {
+        format!("{:.2} MB/s", bps / 1_000_000.0)
+    } else if bps >= 1_000.0 {
+        format!("{:.2} KB/s", bps / 1_000.0)
+    } else {
+        format!("{} B/s", bps.floor() as i64)
+    }
+}
+
+/// `1_234_567` → `"1,234,567"`. Used by callers that want a human-readable
+/// integer count (e.g. instruction totals in the iai summary).
+pub fn fmt_thousands(n: u64) -> String {
+    let s = n.to_string();
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, b) in bytes.iter().enumerate() {
+        if i > 0 && (bytes.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(*b as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn time_scales() {
+        assert_eq!(fmt_time(500.0), "500 ns");
+        assert_eq!(fmt_time(1_500.0), "1.50 µs");
+        assert_eq!(fmt_time(1_500_000.0), "1.50 ms");
+        assert_eq!(fmt_time(1_500_000_000.0), "1.50 s");
+    }
+
+    #[test]
+    fn rps_scales() {
+        assert_eq!(fmt_rps(800.0), "800 req/s");
+        assert_eq!(fmt_rps(1_500.0), "1.50 Kreq/s");
+        assert_eq!(fmt_rps(1_500_000.0), "1.50 Mreq/s");
+    }
+
+    #[test]
+    fn bps_scales() {
+        assert_eq!(fmt_bps(800.0), "800 B/s");
+        assert_eq!(fmt_bps(1_500.0), "1.50 KB/s");
+        assert_eq!(fmt_bps(1_500_000.0), "1.50 MB/s");
+        assert_eq!(fmt_bps(1_500_000_000.0), "1.50 GB/s");
+    }
+
+    #[test]
+    fn thousands_formatter() {
+        assert_eq!(fmt_thousands(0), "0");
+        assert_eq!(fmt_thousands(999), "999");
+        assert_eq!(fmt_thousands(1_000), "1,000");
+        assert_eq!(fmt_thousands(1_234_567), "1,234,567");
+        assert_eq!(fmt_thousands(12_345_678_901), "12,345,678,901");
+    }
+}

--- a/crates/bench-tools/src/meta.rs
+++ b/crates/bench-tools/src/meta.rs
@@ -1,0 +1,134 @@
+//! Run-level metadata harvested from git, the GitHub Actions environment,
+//! and the bench host's sysfs.
+//!
+//! Centralized so every subcommand that emits structured output (jsonl,
+//! summary, delta) produces consistent provenance fields without each one
+//! re-deriving them.
+
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow};
+use serde::Serialize;
+use time::OffsetDateTime;
+use time::format_description::FormatItem;
+use time::macros::format_description;
+
+/// `2026-05-13T12:34:56Z` — matches `date -u +%FT%TZ`, so history.json rows
+/// from before this rewrite stay format-compatible.
+const TIMESTAMP_FMT: &[FormatItem<'_>] =
+    format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]Z");
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Meta {
+    pub sha: String,
+    pub short_sha: String,
+    #[serde(rename = "ref")]
+    pub ref_name: String,
+    pub run_id: String,
+    pub run_attempt: String,
+    pub timestamp: String,
+    pub host: String,
+    pub kernel: String,
+    pub cpus_online: u32,
+    /// Contents of `/sys/devices/system/cpu/isolated`, or `"?"` if the file
+    /// is unreadable or empty (e.g., running this off the bench host).
+    pub isolated_cpu: String,
+}
+
+impl Meta {
+    /// Snapshot the current run's identity from git + env + uname + sysfs.
+    pub fn capture() -> Result<Self> {
+        let sha = git(&["rev-parse", "HEAD"])?;
+        let short_sha = git(&["rev-parse", "--short=12", "HEAD"])?;
+
+        // GITHUB_REF_NAME is set in CI; fall back to the local branch name
+        // for manual runs so the output is still useful for debugging.
+        let ref_name = std::env::var("GITHUB_REF_NAME")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(Ok)
+            .unwrap_or_else(|| git(&["rev-parse", "--abbrev-ref", "HEAD"]))?;
+
+        let run_id = env_or("GITHUB_RUN_ID", "local");
+        let run_attempt = env_or("GITHUB_RUN_ATTEMPT", "1");
+        let timestamp = OffsetDateTime::now_utc()
+            .format(TIMESTAMP_FMT)
+            .context("format current UTC timestamp")?;
+        let host = hostname()?;
+        let kernel = run(&["uname", "-r"])?;
+        let cpus_online = num_cpus_online()?;
+        let isolated_cpu = read_isolated_cpu();
+
+        Ok(Self {
+            sha,
+            short_sha,
+            ref_name,
+            run_id,
+            run_attempt,
+            timestamp,
+            host,
+            kernel,
+            cpus_online,
+            isolated_cpu,
+        })
+    }
+}
+
+fn git(args: &[&str]) -> Result<String> {
+    run(std::iter::once("git")
+        .chain(args.iter().copied())
+        .collect::<Vec<_>>()
+        .as_slice())
+}
+
+fn run(argv: &[&str]) -> Result<String> {
+    let (cmd, rest) = argv.split_first().ok_or_else(|| anyhow!("empty argv"))?;
+    let out = Command::new(cmd)
+        .args(rest)
+        .output()
+        .with_context(|| format!("spawning {}", argv.join(" ")))?;
+    if !out.status.success() {
+        return Err(anyhow!(
+            "{} exited {}: {}",
+            argv.join(" "),
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8(out.stdout)
+        .with_context(|| format!("{} produced non-utf8", argv.join(" ")))?
+        .trim()
+        .to_string())
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn hostname() -> Result<String> {
+    // Avoid pulling in a dep for one syscall; libc hostname() reads
+    // /proc/sys/kernel/hostname through the kernel on Linux. /etc/hostname
+    // is the persistent value and matches what `hostname` (the command)
+    // prints in our environment.
+    run(&["hostname"])
+}
+
+fn num_cpus_online() -> Result<u32> {
+    let s = run(&["nproc"])?;
+    s.parse()
+        .with_context(|| format!("nproc output not a number: {s:?}"))
+}
+
+/// Read the kernel's reported isolated CPU set. Soft-fail to `"?"` so the
+/// renderers can still emit a meaningful row when running off-host (e.g.
+/// rendering an old snapshot on a developer laptop).
+fn read_isolated_cpu() -> String {
+    std::fs::read_to_string("/sys/devices/system/cpu/isolated")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "?".to_string())
+}

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -154,9 +154,19 @@ gag = "1.0"
 rcgen = { version = "0.14.7", default-features = false, features = ["crypto", "aws_lc_rs", "pem"] }
 testcontainers = { workspace = true }
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
+# Pinned to match the iai-callgrind-runner version the bench host's
+# Ansible playbook installs (scripts/bench/ansible/provision.yml).
+# iai-callgrind enforces equality between this crate version and the
+# runner binary at run time.
+iai-callgrind = "0.16.1"
 
 [[bench]]
 name = "http_invoke"
+harness = false
+required-features = ["wasip3"]
+
+[[bench]]
+name = "iai_callgrind"
 harness = false
 required-features = ["wasip3"]
 

--- a/crates/wash-runtime/benches/iai_callgrind.rs
+++ b/crates/wash-runtime/benches/iai_callgrind.rs
@@ -1,0 +1,192 @@
+//! Valgrind/cachegrind-based instruction-count benchmarks for wash-runtime.
+//!
+//! Uses `iai-callgrind` to count CPU instructions deterministically — which
+//! makes this suite suitable for CI regression detection where wall-clock
+//! timing on shared runners is too noisy. See `http_invoke` for the
+//! wall-clock counterpart.
+//!
+//! Measures the same hot-invocation path as `http_invoke`: a single HTTP
+//! request through the full wash-runtime stack (hyper → router →
+//! component). A cold-path measurement is included to track startup-cost
+//! drift (component compile + host build + first request).
+//!
+//! Requires the `iai-callgrind-runner` binary on `PATH` and `valgrind`
+//! installed:
+//! ```text
+//! cargo install iai-callgrind-runner --version 0.16.1
+//! cargo bench -p wash-runtime --features wasip3 --bench iai_callgrind
+//! ```
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::{collections::HashMap, hint::black_box, sync::Arc};
+
+use common::Flavor;
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use tokio::runtime::Runtime;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+    wit::WitInterface,
+};
+
+fn flavor_host_header(flavor: Flavor) -> &'static str {
+    match flavor {
+        Flavor::P2 => "bench-p2",
+        Flavor::P3 => "bench-p3",
+    }
+}
+
+fn engine() -> Engine {
+    Engine::builder()
+        .with_wasip3(true)
+        .build()
+        .expect("failed to build engine with wasip3")
+}
+
+fn http_host_interfaces(host: &str) -> Vec<WitInterface> {
+    let mut config = HashMap::new();
+    config.insert("host".to_string(), host.to_string());
+    vec![WitInterface {
+        namespace: "wasi".to_string(),
+        package: "http".to_string(),
+        interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.2.2").unwrap()),
+        config,
+        name: None,
+    }]
+}
+
+/// Warm host bundled with the runtime that owns it. The host's drop impl
+/// must run inside its tokio runtime, so the two have to die together.
+struct Warm {
+    rt: Runtime,
+    _host: Box<dyn std::any::Any + Send + Sync>,
+    addr: std::net::SocketAddr,
+    client: reqwest::Client,
+    host_header: &'static str,
+}
+
+fn setup_warm(flavor: Flavor) -> Warm {
+    let rt = Runtime::new().expect("tokio runtime");
+    let (host, addr, client) = rt.block_on(async {
+        let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse().unwrap())
+            .await
+            .unwrap();
+        let addr = http_server.addr();
+
+        let host = HostBuilder::new()
+            .with_engine(engine())
+            .with_http_handler(Arc::new(http_server))
+            .build()
+            .unwrap();
+        let host = host.start().await.unwrap();
+
+        let req = WorkloadStartRequest {
+            workload_id: uuid::Uuid::new_v4().to_string(),
+            workload: Workload {
+                namespace: "bench".to_string(),
+                name: format!("bench-{}", flavor.name()),
+                annotations: HashMap::new(),
+                service: None,
+                components: vec![Component {
+                    name: format!("hello-{}.wasm", flavor.name()),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(flavor.wasm()),
+                    local_resources: LocalResources::default(),
+                    pool_size: 0,
+                    max_invocations: 0,
+                }],
+                host_interfaces: http_host_interfaces(flavor_host_header(flavor)),
+                volumes: vec![],
+            },
+        };
+        host.workload_start(req).await.unwrap();
+
+        let client = reqwest::Client::builder()
+            .pool_max_idle_per_host(64)
+            .tcp_nodelay(true)
+            .build()
+            .unwrap();
+
+        // Warmup primes any one-time lazy state and validates the fixture.
+        let warmup = client
+            .get(format!("http://{addr}/"))
+            .header("HOST", flavor_host_header(flavor))
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            warmup.status().is_success(),
+            "warmup request failed for {flavor:?}: {}",
+            warmup.status()
+        );
+        let body = warmup.text().await.unwrap();
+        assert_eq!(body, flavor.expected_body(), "unexpected warmup body");
+
+        (
+            Box::new(host) as Box<dyn std::any::Any + Send + Sync>,
+            addr,
+            client,
+        )
+    });
+
+    Warm {
+        rt,
+        _host: host,
+        addr,
+        client,
+        host_header: flavor_host_header(flavor),
+    }
+}
+
+fn drop_warm(warm: Warm) {
+    // Move drop out of the measurement window — the host shutdown path is
+    // not what this bench is measuring.
+    drop(warm);
+}
+
+// Hot path: one HTTP request against an already-warm host. Setup builds
+// the host and is excluded from instruction counts; teardown drops it.
+#[library_benchmark]
+#[bench::p2(args = (Flavor::P2), setup = setup_warm, teardown = drop_warm)]
+#[bench::p3(args = (Flavor::P3), setup = setup_warm, teardown = drop_warm)]
+fn iai_hot_invocation(warm: Warm) -> Warm {
+    warm.rt.block_on(async {
+        let resp = warm
+            .client
+            .get(format!("http://{}/", warm.addr))
+            .header("HOST", warm.host_header)
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success(), "non-2xx: {}", resp.status());
+        let _ = black_box(resp.bytes().await.unwrap());
+    });
+    warm
+}
+
+// Cold path: full host build + workload start + first request, all
+// counted. Useful for tracking scale-from-zero drift. Teardown drops the
+// host outside the measurement window — without this, the shutdown path
+// (which we are *not* trying to measure) gets counted alongside startup.
+#[library_benchmark]
+#[bench::p2(args = (Flavor::P2), teardown = drop_warm)]
+#[bench::p3(args = (Flavor::P3), teardown = drop_warm)]
+fn iai_cold_invocation(flavor: Flavor) -> Warm {
+    setup_warm(flavor)
+}
+
+library_benchmark_group!(
+    name = http;
+    benchmarks = iai_hot_invocation, iai_cold_invocation
+);
+
+main!(library_benchmark_groups = http);

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,0 +1,1004 @@
+# wasmCloud bench runner
+
+Operator's runbook for the dedicated `wash-runtime` benchmark host
+(`<WASMCLOUD_BENCH_HOSTNAME>`) and the GitHub-driven pipeline that runs against
+it. Read top-to-bottom for a fresh setup; jump to a section for an
+existing host.
+
+> **TL;DR.** A single Hetzner box, locked-down kernel/cpufreq settings
+> for reproducibility, a self-hosted GitHub Actions runner that fires
+> on `workflow_dispatch`, S3 for artifacts, CloudFront in front for
+> public reads, and [https://wasmcloud.github.io/arewefastyet](https://https://wasmcloud.github.io/arewefastyet)
+> as the trend dashboard (separate repo:
+> [`wasmCloud/arewefastyet`](https://github.com/wasmCloud/arewefastyet)).
+
+## Contents
+
+1. [Hardware](#1-hardware)
+2. [SSH access](#2-ssh-access)
+3. [OS install (Hetzner rescue → Ubuntu)](#3-os-install-hetzner-rescue--ubuntu)
+4. [Bench-time kernel/cpufreq tweaks](#4-bench-time-kernelcpufreq-tweaks)
+5. [Toolchain + dependencies](#5-toolchain--dependencies)
+6. [Self-hosted GitHub Actions runner](#6-self-hosted-github-actions-runner)
+7. [Pipeline architecture](#7-pipeline-architecture)
+8. [AWS bootstrap (S3 + CloudFront + IAM)](#8-aws-bootstrap-s3--cloudfront--iam)
+9. [Running a bench](#9-running-a-bench)
+10. [Pre-flight assertions](#10-pre-flight-assertions)
+11. [What gets stored where](#11-what-gets-stored-where)
+12. [Re-staging from scratch](#12-re-staging-from-scratch)
+13. [Troubleshooting](#13-troubleshooting)
+14. [Files in this directory](#14-files-in-this-directory)
+15. [Dependency cadence](#15-dependency-cadence)
+16. [Out of scope](#16-out-of-scope)
+
+---
+
+## 1. Hardware
+
+Single dedicated Hetzner host. Live detail on the box via `lscpu`, `lsblk`,
+`free -h`, `uname -srm`; summary:
+
+|                      |                                                                                    |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| **Provider**         | Hetzner                                                                            |
+| **CPU**              | AMD Ryzen 5 3600 (6 cores / 12 threads, Zen 2, AVX2 + AES-NI + SHA-NI; no AVX-512) |
+| **Base / max clock** | ~3.6 GHz / 4.208 GHz                                                               |
+| **RAM**              | 62 GiB DDR4, no swap                                                               |
+| **Storage**          | 2× Samsung MZVL2512HCJQ NVMe, 476.94 GiB each (RAID1 via mdadm)                    |
+| **NIC**              | 1× 1 GbE                                                                           |
+| **Boot mode**        | Legacy BIOS                                                                        |
+| **OS**               | Ubuntu 24.04 LTS (Noble) amd64                                                     |
+| **Hostname**         | `<WASMCLOUD_BENCH_HOSTNAME>` (operator runbook — 1Password)                        |
+| **IPv4**             | `<WASMCLOUD_BENCH_HOST_IP>` (operator runbook — 1Password)                         |
+| **IPv6**             | `<WASMCLOUD_BENCH_HOST_IPV6>` (operator runbook — 1Password)                       |
+
+The box is dedicated to benchmarking — nothing else runs on it. Don't
+co-locate workloads if numbers are to mean anything across runs.
+
+## 2. SSH access
+
+The deploy keypair is `~/.ssh/hetzner_bench` (operator's laptop).
+
+```sh
+ssh -i ~/.ssh/hetzner_bench root@<WASMCLOUD_BENCH_HOST_IP>
+```
+
+Optional `~/.ssh/config` entry for convenience:
+
+```text
+Host wasmcloud-bench
+    HostName <WASMCLOUD_BENCH_HOST_IP>
+    User root
+    IdentityFile ~/.ssh/hetzner_bench
+    IdentitiesOnly yes
+```
+
+**Authentication policy:**
+
+- Key-only. `PasswordAuthentication no`, `PermitRootLogin prohibit-password`,
+  set via the drop-in `/etc/ssh/sshd_config.d/00-bench-host-hardening.conf`.
+- The deploy public key is carried into the installed OS automatically
+  (`installimage`'s `-t yes` "take over rescue keys" path).
+- Host key fingerprints are pinned in `~/.ssh/known_hosts` after install.
+  When re-staging, refresh them; `installimage` regenerates host keys.
+
+## 3. OS install (Hetzner rescue → Ubuntu)
+
+Hetzner ships every dedicated server with a Rescue System (PXE-booted
+Debian) that exposes the raw disks. Our OS install runs from there.
+
+The local script [`stage-hetzner.sh`](./stage-hetzner.sh) orchestrates:
+
+```sh
+./scripts/bench/stage-hetzner.sh
+```
+
+It:
+
+1. Asserts `hostname == rescue` over SSH.
+2. Copies [`hetzner-autosetup.cfg`](./hetzner-autosetup.cfg) and
+   [`hetzner-postinstall.sh`](./hetzner-postinstall.sh) to the rescue.
+3. Prompts for the literal string `WIPE` (the install destroys both disks).
+4. Runs Hetzner's `installimage` in batch mode:
+   ```sh
+   /root/.oldroot/nfs/install/installimage -a -c /autosetup -x /tmp/postinstall.sh
+   ```
+5. Reboots into the freshly-installed system.
+
+**Autosetup config** ([`hetzner-autosetup.cfg`](./hetzner-autosetup.cfg)):
+
+```text
+DRIVE1     /dev/nvme0n1
+DRIVE2     /dev/nvme1n1
+SWRAID     1
+SWRAIDLEVEL 1
+BOOTLOADER grub
+HOSTNAME   <WASMCLOUD_BENCH_HOSTNAME>
+PART       /boot ext4 1024M
+PART       /     ext4 all
+IMAGE      /root/.oldroot/nfs/install/../images/Ubuntu-2404-noble-amd64-base.tar.gz
+```
+
+Layout deliberately:
+
+- **mdraid RAID1** mirrors both NVMes — disk loss should not lose bench
+  data while a run is in flight (every result also lands in S3).
+- **No swap** — eliminates a known source of runtime jitter.
+
+After install, host-key fingerprints change (`installimage` regenerates
+them). Refresh:
+
+```bash
+ssh-keygen -R <WASMCLOUD_BENCH_HOST_IP>
+ssh-keyscan -t rsa,ecdsa,ed25519 <WASMCLOUD_BENCH_HOST_IP> >> ~/.ssh/known_hosts
+```
+
+## 4. Bench-time kernel/cpufreq tweaks
+
+Applied in the install chroot by [`hetzner-postinstall.sh`](./hetzner-postinstall.sh)
+so they survive every reboot. Three tweaks, with the rationale:
+
+### 4.1 `nosmt` on the kernel cmdline
+
+Disables hyper-threading. The host comes online with **6 physical
+cores** instead of 12 logical CPUs.
+
+**Why:** SMT-pair scheduling jitter is one of the largest sources of
+variance in latency benches. Two threads sharing a core's L1/μop cache
+will see each other's cache pressure depending on what else the kernel
+schedules on the sibling, which drives p99 spikes. With SMT off,
+each criterion iteration runs on a fully-owned core and per-iteration
+variance drops markedly (we observed std-dev for `hot_invocation` go
+from ~14 µs to ~500 ns after this single change).
+
+**How it's wired:** Hetzner's `/etc/default/grub.d/hetzner.cfg`
+unconditionally rewrites `GRUB_CMDLINE_LINUX_DEFAULT="consoleblank=0"`,
+which would clobber a direct edit to `/etc/default/grub`. So we drop a
+`zz-bench.cfg` that sorts after Hetzner's file and *appends* `nosmt`:
+
+```sh
+GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT} nosmt"
+```
+
+Verify with `nproc` (expect `6`) and `grep nosmt /proc/cmdline`.
+
+### 4.2 `isolcpus=5 nohz_full=5 rcu_nocbs=5` on the kernel cmdline
+
+Reserves CPU 5 from the general scheduler. Pair with `taskset -c 5` to
+pin a bench process to it.
+
+**Why:** even with `nosmt` and the performance governor, the kernel can
+still preempt a bench thread for IRQ handling, RCU callbacks, or the
+periodic scheduler tick. For `iai_callgrind` (deterministic instruction
+counts via valgrind/cachegrind) preemption doesn't affect the *result*,
+but it bloats runtime by ~2–3×. For wall-clock benches that we may pin
+later, scheduler interference is a direct source of p99 variance.
+
+The three flags together give us:
+
+- `isolcpus=5` removes CPU 5 from the general SMP load-balancer. Nothing
+  is scheduled there unless explicitly asked.
+- `nohz_full=5` stops the periodic scheduler tick on CPU 5 when only
+  one runnable task is on it. Kills timer-driven jitter.
+- `rcu_nocbs=5` offloads RCU callbacks off CPU 5 to a kthread on the
+  housekeeping cores.
+
+CPU index `5` is the last with `nosmt` (CPUs 0..5). Reserving the
+trailing CPU leaves 5 cores for the runner agent + system, which is
+plenty.
+
+**How it's used:** [`run-bench.sh`](./run-bench.sh) wraps `iai_callgrind`
+(and only `iai_callgrind` — the criterion benches are multi-threaded and
+would lose throughput) in `taskset -c 5`. The criterion benches run
+unpinned across CPUs 0–4. Override the CPU index via `WASMCLOUD_BENCH_ISOLATED_CPU=`
+if the host was staged with a different reservation.
+
+**How it's wired:** the same `zz-bench.cfg` GRUB drop-in that appends
+`nosmt` also appends the three isolation flags.
+
+Verify:
+
+```sh
+cat /sys/devices/system/cpu/isolated      # → 5
+cat /proc/cmdline | tr ' ' '\n' | grep -E '^(isolcpus|nohz_full|rcu_nocbs)='
+```
+
+**Rollout to an already-staged host:** if `hetzner-postinstall.sh` was
+updated after the box was last staged, the drop-in isn't there yet. Run
+the Ansible playbook with the `kernel` tag to apply just the GRUB
+drop-in idempotently:
+
+```sh
+cd scripts/bench/ansible
+ansible-playbook provision.yml --tags kernel
+ssh -i ~/.ssh/hetzner_bench root@"$WASMCLOUD_BENCH_HOST_IP" reboot
+```
+
+The playbook writes the same content `hetzner-postinstall.sh` would
+have produced at install time, so the live-patched box and a
+fresh-installed box converge on identical state.
+
+### 4.3 cpufreq governor pinned to `performance`
+
+Pins every online CPU's `scaling_governor` to `performance` on boot,
+disabling Intel/AMD pstate's "ondemand"-style frequency scaling.
+
+**Why:** `ondemand` ramps clocks based on load, which means a bench
+warm-up doesn't actually run at the steady-state frequency the
+measured iterations will. Worse, AMD's CPB (Core Performance Boost)
+dynamically changes which cores can boost based on thermal headroom,
+so different cores hit different peak frequencies. Pinning to
+`performance` parks every core at its rated max so warm-up and
+measurement are at the same clock.
+
+**How it's wired:** a oneshot systemd unit
+`/etc/systemd/system/cpu-performance.service` that runs at boot and
+echoes `performance` into every `scaling_governor` sysfs node.
+
+Verify with:
+```sh
+cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor    # → performance
+systemctl is-active cpu-performance.service                  # → active
+```
+
+### 4.4 No swap
+
+Set in the partition layout (no `PART swap …` line). Avoids OOM-driven
+swap-in stalls during bench runs. 62 GiB RAM is plenty for criterion
+to run without ever pressuring memory.
+
+### 4.5 What we explicitly do **not** tune
+
+- **NUMA pinning** — single-socket Ryzen, irrelevant.
+- **Transparent huge pages, swappiness, dirty ratios** — left at
+  Ubuntu defaults. Add deliberately if bench numbers ever justify.
+- **CPU C-states** — left at hardware defaults; the `performance`
+  governor already pins clocks. Disabling C-states improves p99 at a
+  big idle-power cost; not warranted yet.
+
+Document any future tweak in this section AND bake it into the
+post-install script (chroot, fresh install) plus the Ansible playbook
+(running host) so the next re-stage *and* the next live patch get it
+for free.
+
+## 5. Toolchain + dependencies
+
+Run after the OS is up, from your laptop. Provisioning lives in an
+Ansible playbook at [`scripts/bench/ansible/`](./ansible/). It's
+idempotent — re-run any time to apply drift (new apt deps, a pinned
+version bump, a kernel-cmdline change, etc.).
+
+**Prereqs on the laptop:**
+
+```sh
+brew install ansible                  # or `pipx install ansible`, your call
+brew install --cask 1password-cli     # for the env-helper below
+
+# Populate the env vars from 1Password (item: WASMCLOUD_BENCH_BOX).
+# Source, don't execute — the script exports into your current shell.
+source scripts/bench/op-env.sh
+
+# SSH_KEY defaults to ~/.ssh/hetzner_bench; override if it lives elsewhere.
+```
+
+The helper expects an item called `WASMCLOUD_BENCH_BOX` with fields
+`WASMCLOUD_BENCH_HOST_IP`, `WASMCLOUD_BENCH_HOSTNAME`, and (optionally) `WASMCLOUD_BENCH_HOST_IPV6`.
+Override the item name with `WASMCLOUD_BENCH_OP_ITEM=<name>` if yours
+lives under a different label.
+
+**Run the playbook:**
+
+```sh
+cd scripts/bench/ansible
+ansible-playbook provision.yml                  # everything
+ansible-playbook provision.yml --tags toolchain # apt + rustup + iai only
+ansible-playbook provision.yml --tags kernel    # just GRUB drop-in
+ansible-playbook provision.yml --check          # dry-run; no changes
+```
+
+The playbook installs (as `root` on the bench host):
+
+- **apt:** `build-essential pkg-config libssl-dev clang cmake git curl jq
+  ca-certificates protobuf-compiler libprotobuf-dev valgrind`
+  - `protobuf-compiler` (the `protoc` binary) is needed by
+    `crates/wash-runtime/build.rs` for proto-generated bindings.
+  - `libprotobuf-dev` provides `/usr/include/google/protobuf/*.proto`
+    (the well-known types like `timestamp.proto`); without it,
+    `protoc` finds the binary but fails to import.
+  - `valgrind` is the measurement engine for the `iai_callgrind`
+    instruction-count bench (see §9 and the `iai-callgrind-runner`
+    bullet below).
+- **rustup** as `root`, with `stable` as the default toolchain. Inside
+  the wasmCloud workspace the repo's `rust-toolchain.toml` takes
+  precedence (also `stable`, with the `wasm32-unknown-unknown`,
+  `wasm32-wasip1`, and `wasm32-wasip2` targets). The default is set so
+  out-of-tree `cargo install` invocations (notably
+  `iai-callgrind-runner` below) have something to pick.
+- **`iai-callgrind-runner`** via `cargo install --version 0.16.1`
+  (pinned). iai-callgrind enforces equality between the runner binary
+  and the `iai-callgrind` crate version pinned in
+  `crates/wash-runtime/Cargo.toml`; bump them together.
+- **Node.js (current LTS)** from NodeSource's apt repo. The CI
+  workflow runs `.github/scripts/*.mjs` via `run: node …`, which
+  needs an OS-level `node` on `PATH` (self-hosted runners do not
+  expose the actions-runner agent's bundled Node to `run:` steps).
+  The Ubuntu apt `nodejs` package is on Node 18, which is past EOL,
+  so we install via NodeSource and pin the major version in
+  `provision.yml` (`node_lts_major`).
+- **Repo clone** at `/opt/wasmcloud` (used for ad-hoc/manual benches;
+  the CI runner uses its own workspace, see §6).
+- A **smoke build**:
+  ```sh
+  cargo bench -p wash-runtime --features wasip3 --bench http_invoke --no-run
+  ```
+  to verify the bench binary compiles end-to-end. ~3 minutes cold.
+
+Verify after the script:
+
+```sh
+nproc                              # 6
+uname -r                           # 6.8.0-* (Ubuntu Noble)
+cargo --version                    # rustup-pinned stable
+protoc --version                   # libprotoc 3.21.x or newer
+valgrind --version                 # valgrind-3.22.x or newer
+iai-callgrind-runner --version     # 0.16.1
+node --version                     # the node_lts_major pinned in provision.yml
+cat /etc/wasmcloud-bench-stage     # post-install marker
+```
+
+## 6. Self-hosted GitHub Actions runner
+
+The CI pipeline runs on a self-hosted runner registered to
+`wasmCloud/wasmCloud` with the labels `self-hosted, bench, hetzner`.
+
+Setup is a one-shot. The 1-hour expiry only governs the window between
+"obtain a registration token" and "`config.sh` consumes it". Once
+`config.sh` finishes, GitHub exchanges that token for long-lived,
+auto-rotating runner credentials in `/opt/actions-runner/.credentials`,
+and the runner never needs a registration token again unless it's
+deregistered or the host is re-staged. See §6.1.
+
+1. Generate a registration token. Either:
+
+   - **GitHub UI:** Settings → Actions → Runners → New self-hosted runner.
+   - **gh CLI** (operator-side; see §6.1 below).
+
+2. From your laptop, push it to the host (token via env, not CLI flag,
+   so it never lands in `/proc/<pid>/cmdline`):
+
+   ```sh
+   ssh -i ~/.ssh/hetzner_bench root@<WASMCLOUD_BENCH_HOST_IP> \
+     'cd /opt/wasmcloud && \
+      sudo WASMCLOUD_BENCH_RUNNER_TOKEN=<TOKEN> bash scripts/bench/install-runner.sh'
+   ```
+
+[`install-runner.sh`](./install-runner.sh) is idempotent (bails if
+`/opt/actions-runner` already exists; remove it manually to re-register
+with a fresh token). It:
+
+- Creates a non-root **`bench`** user (no shell login). The runner
+  process runs as `bench` via systemd.
+- Installs **AWS CLI v2** (from the official zip — apt's `awscli`
+  package is v1) and `zstd`.
+- Installs **rustup as the `bench` user** so `cargo` is available in
+  the workflow's PATH. The actual toolchain is auto-installed on
+  first build via `rust-toolchain.toml`.
+- Downloads `actions-runner-linux-x64-2.334.0.tar.gz`, **verifies the
+  SHA256** (constant in the script — bump version + sha together
+  when upgrading), extracts to `/opt/actions-runner`.
+- Registers the runner with labels `self-hosted, bench, hetzner` and
+  name `<WASMCLOUD_BENCH_HOSTNAME>`.
+- Installs the runner as a systemd service (`./svc.sh install bench`)
+  that starts on boot.
+
+**Persistent paths (owned by `bench`):**
+
+| Path                    | Purpose                                                                                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/var/lib/bench`        | `bench` user's home (where rustup installs cargo)                                                                                                        |
+| `/var/lib/bench/work`   | `_work` dir GitHub uses for workflow runs                                                                                                                |
+| `/var/lib/bench/target` | `$CARGO_TARGET_DIR` set in the workflow — kept outside the workspace so `actions/checkout`'s `clean` step doesn't blow away the cargo cache between runs |
+| `/opt/actions-runner`   | runner binary + config                                                                                                                                   |
+
+**Runner upgrade procedure:**
+
+1. Bump `RUNNER_VERSION` and `RUNNER_SHA256` in
+   [`install-runner.sh`](./install-runner.sh) (SHA256 from the runner
+   release page).
+2. On the host, stop the service, run `./config.sh remove --token …`
+   (use a fresh removal token from GitHub), `rm -rf /opt/actions-runner`.
+3. Re-run `install-runner.sh` with a fresh registration token.
+
+### 6.1 Token generation via gh CLI (operator-triggered)
+
+Instead of clicking through the GitHub UI, an operator with admin on
+`wasmCloud/wasmCloud` can mint a fresh registration token from a local
+shell. This is a write API call (it creates a credential), so it's an
+**operator-side, manually-invoked** action — Claude/automation does not
+run this.
+
+```sh
+TOKEN=$(gh api -X POST \
+  /repos/wasmCloud/wasmCloud/actions/runners/registration-token \
+  --jq '.token')
+
+ssh -i ~/.ssh/hetzner_bench root@<WASMCLOUD_BENCH_HOST_IP> \
+  "WASMCLOUD_BENCH_RUNNER_TOKEN=$TOKEN bash -s" \
+  < scripts/bench/install-runner.sh
+```
+
+Requirements on the operator's laptop:
+
+- `gh` authenticated as a user with admin on the repo, **or** a
+  fine-grained PAT / GitHub App credential with `Administration: write`.
+- `WASMCLOUD_BENCH_HOSTNAME` and `<WASMCLOUD_BENCH_HOST_IP>` exported from 1Password
+  (item: *wasmCloud Bench Host (Hetzner)*).
+
+The token is single-use and short-lived (~1 hour). It flows: gh API →
+local shell variable → SSH env → `config.sh` on the host. It never
+touches the repo, a CI log, or `/proc/<pid>/cmdline` (env-only).
+
+## 7. Pipeline architecture
+
+```text
+┌──────────────────────┐               ┌────────────────────────────────────┐
+│  GitHub Actions      │               │   <WASMCLOUD_BENCH_HOSTNAME>       │
+│  workflow_dispatch ──┼──────────────▶│   self-hosted runner (user: bench) │
+│  inputs: bench, ref  │               │   labels: self-hosted,bench,hetzner│
+└──────────────────────┘               │                                    │
+        ▲                              │   1. checkout + preflight checks   │
+        │ artifact + step              │   2. cargo bench                   │
+        │ summary                      │   3. summarize → step summary      │
+        │                              │   4. upload criterion artifact     │
+        ▼                              │   5. push S3 + invalidate CF       │
+┌──────────────────────────────┐       └────────────────────────────────────┘
+│ S3 (private)                 │                                  │
+│   runs/<date>/<sha>/<run>/…  │◀─────────────────────────────────┘
+│   history.json               │ ◄── public via CloudFront ───────────────┐
+└──────────────────────────────┘                                          │
+                                                                          ▼
+                                             ┌──────────────────────────────────┐
+                                             │  arewefastyet                    │
+                                             │ (separate repo, GitHub Pages)    │
+                                             │ fetches history.json             │
+                                             └──────────────────────────────────┘
+```
+
+**Workflow:** [`.github/workflows/bench.yml`](../../.github/workflows/bench.yml)
+
+- Trigger: `workflow_dispatch` only. Inputs: `bench` (choice of
+  `http_invoke` / `wasmtime_baseline` / `wasmtime_serve`) and `ref`
+  (any branch/tag/sha; defaults to the workflow's ref).
+- `runs-on: [self-hosted, bench, hetzner]`
+- `concurrency: bench-host`, `cancel-in-progress: false` — queues
+  rather than cancelling, so an in-flight bench is never interrupted.
+- `permissions:` minimal; the bench job adds `contents: read` and
+  `id-token: write` (OIDC for AWS).
+- `CARGO_TARGET_DIR=/var/lib/bench/target` so the cache survives
+  `actions/checkout`'s clean.
+- `persist-credentials: false` on checkout — the runner runs untrusted
+  user code (the bench under test) and we don't want it to read the
+  GITHUB_TOKEN.
+
+**Steps, in order:**
+
+1. **Pre-flight** ([`bench-preflight.mjs`](../../.github/scripts/bench-preflight.mjs)) — see §10.
+2. **Run bench** ([`run-bench.sh`](./run-bench.sh)) — sources cargo,
+   runs `cargo bench -p wash-runtime --features wasip3 --bench <name>`,
+   tees output to a per-run log under `$CARGO_TARGET_DIR`.
+3. **Summary** (`cargo run -p bench-tools -- summary --bench <name>`) —
+   emits a markdown table to `$GITHUB_STEP_SUMMARY` with one row per
+   `(group, param)`. Unit semantics live in
+   [`crates/bench-tools/src/markdown.rs`](../../crates/bench-tools/src/markdown.rs):
+   RPS for batch-throughput benches, B/s for byte throughput, time
+   otherwise. For `iai_callgrind` the same subcommand emits an
+   instruction-count table from the iai output instead.
+4. **Upload artifact** — the criterion and/or iai output dirs as
+   `bench-<bench>-<run-id>` with 90-day retention.
+5. **Configure AWS** — `aws-actions/configure-aws-credentials@v6.1.1`
+   assumes the `WASMCLOUD_BENCH_AWS_ROLE_ARN` role via OIDC.
+6. **Push S3 + invalidate CloudFront**
+   ([`bench-push-results.mjs`](../../.github/scripts/bench-push-results.mjs)) —
+   uploads per-run artifacts under `runs/…`, then read-modify-writes
+   `s3://<bucket>/history.json` (the public aggregate), then issues
+   `cloudfront create-invalidation /history.json`.
+
+**Triggers:** `workflow_dispatch` plus `release: published` (the latter
+auto-populates the releases timeline; see §9.3). Both require repo
+write to fire, which keeps untrusted fork code off the self-hosted
+bench host. The `release` matrix is intentionally narrower than the
+dispatch choice list — see §9.3.
+
+**Why no `pull_request_target` trigger:** see §9.4. Self-hosted runners
+on a public repo are a foot-gun if exposed to fork PRs (a fork can
+ship a malicious workflow file or build script to your bench host).
+Comparison runs use `workflow_dispatch` only.
+
+## 8. AWS bootstrap (S3 + CloudFront + IAM)
+
+One-shot from a workstation authenticated to the AWS account that
+should own the bench bucket:
+
+```sh
+./scripts/bench/aws/setup-aws.sh \
+  --bucket <bucket> \
+  --region <region>
+```
+
+[`aws/setup-aws.sh`](./aws/setup-aws.sh) is idempotent. It provisions:
+
+| Resource                                   | Detail                                                                                                                                                                                                   |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **S3 bucket**                              | versioning + AES-256 encryption + public access **fully blocked** + CORS allowing `GET *`                                                                                                                |
+| **GitHub OIDC provider**                   | `token.actions.githubusercontent.com` with audience `sts.amazonaws.com`                                                                                                                                  |
+| **CloudFront Origin Access Control (OAC)** | sigv4, S3 origin type — replaces the legacy "Origin Access Identity" pattern                                                                                                                             |
+| **CloudFront distribution**                | comment `"arewefastyet bench data"`; managed cache policy `CachingOptimized` (respects origin `Cache-Control`); `PriceClass_100` (NA + EU); HTTP/2 + HTTP/3; default `*.cloudfront.net` cert             |
+| **Bucket policy**                          | scopes `s3:GetObject` on `history.json` to the **specific** distribution principal via `AWS:SourceArn` — the bucket itself is never reachable directly                                                   |
+| **IAM WRITE role**                         | trust pinned to `repo:wasmCloud/wasmCloud:*`; perms: `s3:PutObject` on `runs/*`, `s3:GetObject` + `s3:PutObject` on `history.json`, `s3:ListBucket`, `cloudfront:CreateInvalidation` on the distribution |
+
+The script prints the values to set as repo secrets/vars at the end:
+
+| Repo                              | Setting                                                                                      | Type         |
+| --------------------------------- | -------------------------------------------------------------------------------------------- | ------------ |
+| `wasmCloud/wasmCloud` (this repo) | `WASMCLOUD_BENCH_AWS_ROLE_ARN`                                                               | secret       |
+|                                   | `WASMCLOUD_BENCH_S3_BUCKET`                                                                  | secret       |
+|                                   | `WASMCLOUD_BENCH_S3_REGION`                                                                  | secret       |
+|                                   | `WASMCLOUD_BENCH_CF_DISTRIBUTION_ID`                                                         | secret       |
+|                                   | `WASMCLOUD_BENCH_HOSTNAME` (expected bench host hostname; consumed by `bench-preflight.mjs`) | repo **var** |
+| `wasmCloud/arewefastyet` (site)   | `DATA_URL` (e.g. `https://dXXXX.cloudfront.net/history.json`)                                | repo **var** |
+
+`WASMCLOUD_BENCH_HOSTNAME` is set as a **variable** (not a secret) because it's not
+strictly sensitive; keeping it out of the repo source is a
+defense-in-depth measure rather than a confidentiality requirement.
+
+CloudFront's permanent **Always Free tier** (1 TB egress + 10 M requests
+per month) makes data-transfer cost a non-issue for any plausible
+dashboard traffic. Storage is ~$0.0001/month for our object sizes.
+
+The site (`wasmCloud/arewefastyet`) reads anonymously through
+CloudFront; it has no AWS auth, no IAM role, no AWS secrets.
+
+## 9. Running a bench
+
+### 9.1 Via GitHub (the normal path)
+
+GitHub → **Actions** → **bench** → **Run workflow**:
+
+| Input   | Description                                                                                | Default          |
+| ------- | ------------------------------------------------------------------------------------------ | ---------------- |
+| `bench` | which bench to run (`http_invoke`, `iai_callgrind`, `wasmtime_baseline`, `wasmtime_serve`) | `http_invoke`    |
+| `ref`   | git ref to bench (branch, tag, or sha)                                                     | the workflow ref |
+
+**Bench types:**
+
+| Bench               | Harness       | Measures                           | Notes                                                                                                                                                          |
+| ------------------- | ------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `http_invoke`       | criterion     | wall-clock (ns / req/s)            | wash-runtime HTTP path; cold + hot invocations                                                                                                                 |
+| `iai_callgrind`     | iai-callgrind | CPU instruction count (cachegrind) | deterministic regression detection; not subject to shared-runner timing noise; output schema differs from criterion and does **not** feed `history.json` today |
+| `wasmtime_baseline` | criterion     | wall-clock                         | wasmtime-only baseline for context                                                                                                                             |
+| `wasmtime_serve`    | criterion     | wall-clock                         | wasmtime serve subcommand baseline                                                                                                                             |
+
+Anyone with repo-write can dispatch. The job queues on the
+`bench-host` concurrency group, so two dispatched runs serialize.
+
+### 9.2 Via SSH (manual / debugging)
+
+Useful for "I just want to see what cargo says without rounding through
+GitHub":
+
+```sh
+ssh -i ~/.ssh/hetzner_bench root@<WASMCLOUD_BENCH_HOST_IP> \
+  '. $HOME/.cargo/env && cd /opt/wasmcloud && \
+   cargo bench -p wash-runtime --features wasip3 --bench http_invoke'
+```
+
+Manual runs do **not** touch S3 or arewefastyet — only the GitHub
+pipeline writes there. The `/opt/wasmcloud` checkout is cloned by the
+Ansible playbook and used for these one-offs (it's separate from the
+runner's `_work/` workspace).
+
+To pull manual results back to your laptop:
+
+```sh
+rsync -e 'ssh -i ~/.ssh/hetzner_bench' -avz \
+  root@<WASMCLOUD_BENCH_HOST_IP>:/opt/wasmcloud/target/criterion/ \
+  ./bench-results/$(date -u +%Y-%m-%dT%H%M%SZ)/
+```
+
+### 9.3 Adding a release to the trends timeline
+
+To populate the **releases** view on arewefastyet, dispatch with
+`ref: vX.Y.Z`. The bench workflow checks out that exact tag, and the
+resulting JSONL row carries `ref="vX.Y.Z"`, which the site filters and
+renders semver-ordered. No special tooling — just dispatch with the
+tag.
+
+Tags also auto-bench on `release: published`: every published release
+triggers a matrix run across all four benches against the release tag,
+so the timeline self-populates without manual dispatch.
+
+### 9.4 Comparison runs (did this PR move the numbers?)
+
+Separate workflow:
+[`.github/workflows/bench-compare.yml`](../../.github/workflows/bench-compare.yml).
+Pairs the same bench against two refs back-to-back on the bench host
+and produces a delta.
+
+**One entry point:** `workflow_dispatch`. Actions → bench-compare → Run
+workflow; supply:
+
+- `bench` — which bench to compare (default `iai_callgrind`).
+- `ref_a` — baseline ref (default `main`).
+- `ref_b` — candidate ref. To compare a PR, paste the PR's head sha
+  here (the PR page shows it; `gh pr view <N> --json headRefOid` also
+  works).
+
+**Variance handling:**
+
+- `iai_callgrind`: **1×** per ref. Instruction counts via valgrind are
+  deterministic, so repeats don't reduce noise.
+- Criterion benches (`http_invoke`, `wasmtime_*`): **3× interleaved**
+  (a₁ b₁ a₂ b₂ a₃ b₃); the median of the three is what the delta is
+  computed from. ~30 min per bench.
+
+Output: a markdown delta table on the run's step summary. Comparison
+runs do **not** push to S3 or update `history.json`, and they do
+**not** post a comment back to any PR — they are ephemeral by design.
+
+**Why no PR-label trigger (auto-bench a PR on `bench:run`):**
+
+The bench host is a self-hosted runner. `pull_request_target` gives
+the workflow access to base-repo secrets and the self-hosted runner
+even when the PR is from a fork; the bench host then has to
+`git checkout` the PR head to run the bench, at which point
+`run-bench.sh`, fixtures, build scripts, and dependency proc-macros
+all come from the PR. Even gated on `author_association`, that's a
+higher trust bar than we want — every member's PR ends up running
+arbitrary code on the bench host with the same trust as merged code.
+
+`workflow_dispatch` requires the dispatcher to read the diff first
+and explicitly opt in, which is the trust model we want for this
+particular runner. The bench job has no AWS permissions and no
+`pull-requests: write` permission, so a malicious comparison ref
+cannot exfiltrate the WRITE role or comment on PRs.
+
+## 10. Pre-flight assertions
+
+[`bench-preflight.mjs`](../../.github/scripts/bench-preflight.mjs) runs first in every CI bench job.
+It refuses to proceed if the host has drifted from the baseline,
+because measurements on a drifted host are useless and shouldn't end
+up on the dashboard.
+
+The script requires the env var `WASMCLOUD_BENCH_HOSTNAME` (the expected hostname
+of the dedicated bench host). The workflow sources it from the repo
+variable `vars.WASMCLOUD_BENCH_HOSTNAME`; local runs export it from 1Password.
+Keeping the value out of the script avoids broadcasting the box's
+identity in the public repo.
+
+Hard-checked invariants:
+
+| Check                                | Expected                                               |
+| ------------------------------------ | ------------------------------------------------------ |
+| `hostname`                           | `${WASMCLOUD_BENCH_HOSTNAME}` (env-injected)           |
+| `nproc`                              | `6`  *(SMT off via `nosmt`)*                           |
+| `scaling_governor` on every CPU      | `performance`                                          |
+| `/sys/devices/system/cpu/isolated`   | `5` *(or `${WASMCLOUD_BENCH_ISOLATED_CPU}`; see §4.2)* |
+| `/proc/mdstat` resync                | not in progress                                        |
+| 1-min loadavg                        | < 1.0  *(box should be idle)*                          |
+| `$CARGO_TARGET_DIR`                  | exists, writable                                       |
+| Free space on the target dir's mount | ≥ 5 GiB                                                |
+| `cargo` binary                       | `$HOME/.cargo/bin/cargo` exists                        |
+
+If any check fails, the job aborts with a `::error::` annotation
+explaining which invariant is violated. Fix the host (or fix the
+script if the invariant should be relaxed) and re-dispatch.
+
+## 11. What gets stored where
+
+Per-run uploads (private; only the WRITE role can read):
+
+```text
+s3://<bucket>/runs/<YYYY-MM-DD>/<short-sha>/<run-id>/<bench>/
+  ├─ criterion.tar.zst   raw criterion data (samples, estimates, SVG reports)
+                         only present for criterion-based benches
+  ├─ iai.tar.zst         raw iai-callgrind output (summary.json, callgrind.out, …)
+                         only present for iai-callgrind benches (iai_callgrind)
+  ├─ results.jsonl       one JSON row per (group, param, metric) for trend tools
+  ├─ metadata.json       run-level facts (git, host, kernel, timestamps, run URL)
+  └─ run.log             cargo bench stdout/stderr
+```
+
+Aggregate (publicly readable through CloudFront only — S3 itself is
+not reachable):
+
+```text
+s3://<bucket>/history.json
+  - JSON array of every (group, param, metric) row from every run.
+  - Deduped by (sha, bench, group, param, run_attempt, metric), sorted by timestamp.
+  - Cache-Control: max-age=60.
+  - CloudFront invalidation issued after each push.
+  - Capped to last 365 days by HISTORY_MAX_AGE_DAYS.
+```
+
+`bench-push-results.mjs` does the read-modify-write on `history.json`
+after each run. This is safe without locking because the workflow is
+`concurrency: bench-host` — there's only ever one writer.
+
+**Row schema.** Every row carries `metric` (the measurement name) and
+`value` (the measurement). Criterion rows additionally carry the
+original sibling statistics so older renderers keep working through
+the schema bump; iai rows carry only `metric`/`value` because the
+callgrind summary line doesn't produce per-iteration CIs.
+
+Criterion row (`metric: "mean_ns"`):
+
+```json
+{
+  "bench": "http_invoke",
+  "group": "cold_invocation",
+  "param": "p2",
+  "sha": "...", "short_sha": "...", "ref": "main",
+  "run_id": "...", "run_attempt": "1",
+  "timestamp": "2026-05-08T17:21:20Z",
+  "host": "<WASMCLOUD_BENCH_HOSTNAME>",
+  "kernel": "6.8.0-100-generic",
+  "cpus_online": 6,
+  "metric": "mean_ns",
+  "value": 78667741.74,
+  "throughput": {"Elements": 256},
+  "mean_ns": 78667741.74,
+  "median_ns": 77841173.62,
+  "std_dev_ns": 1770558.62,
+  "ci_low_ns": 77764094.17,
+  "ci_high_ns": 79841655.92
+}
+```
+
+iai row (`metric: "Ir"`):
+
+```json
+{
+  "bench": "iai_callgrind",
+  "group": "http",
+  "param": "iaps_hot_invocation.p2",
+  "sha": "...", "short_sha": "...", "ref": "main",
+  "run_id": "...", "run_attempt": "1",
+  "timestamp": "2026-05-08T17:21:20Z",
+  "host": "<WASMCLOUD_BENCH_HOSTNAME>",
+  "kernel": "6.8.0-100-generic",
+  "cpus_online": 6,
+  "metric": "Ir",
+  "value": 12345678
+}
+```
+
+The `throughput` field on criterion rows is captured from criterion's
+`benchmark.json` and tells the renderer whether to display this row as
+time (latency-style) or as ops/sec (throughput-style). iai rows have no
+throughput field — instruction counts are unit-less in that sense.
+
+## 12. Re-staging from scratch
+
+If the host is hosed (kernel panic, disk corruption, want to bump the
+base OS, want to relocate to a different box):
+
+1. **Re-arm Hetzner Rescue** in Hetzner Robot, reboot.
+2. **Refresh local host keys** — rescue's keys differ from the installed system's:
+   ```sh
+   ssh-keygen -R <WASMCLOUD_BENCH_HOST_IP>
+   ssh-keyscan -t rsa,ecdsa,ed25519 <WASMCLOUD_BENCH_HOST_IP> >> ~/.ssh/known_hosts
+   ```
+   (Verify fingerprints against the rescue's MOTD.)
+3. **Stage:** `./scripts/bench/stage-hetzner.sh`. After reboot, refresh
+   host keys *again* — `installimage` regenerated them.
+4. **Provision:** `cd scripts/bench/ansible && ansible-playbook provision.yml` (see §5).
+5. **Re-register the runner:** generate a fresh registration token,
+   then `sudo WASMCLOUD_BENCH_RUNNER_TOKEN=<X> bash scripts/bench/install-runner.sh`.
+6. **GitHub side:** in repo Settings → Actions → Runners, remove the
+   old offline runner entry.
+
+No state worth preserving lives on the box — bench results are already
+in S3.
+
+## 13. Troubleshooting
+
+### Runner is stuck "offline" in GitHub
+
+```sh
+ssh -i ~/.ssh/hetzner_bench root@<WASMCLOUD_BENCH_HOST_IP> \
+  'systemctl status actions.runner.* | head -30'
+```
+
+If the service crashed: `journalctl -u actions.runner.* -n 100`.
+Common cause is GitHub revoked the registration; re-register with a
+fresh token.
+
+### `cargo bench` is missing `protoc` or proto includes
+
+Re-run the Ansible playbook (`cd scripts/bench/ansible && ansible-playbook
+provision.yml --tags toolchain,apt`); it installs `protobuf-compiler` +
+`libprotobuf-dev`. The build needs both — the binary alone fails when
+`.proto` files import `google/protobuf/timestamp.proto`.
+
+### `nproc` returns 12 instead of 6
+
+`nosmt` didn't apply. Check:
+
+```sh
+cat /proc/cmdline                           # should contain "nosmt"
+ls /etc/default/grub.d/zz-bench.cfg         # should exist
+update-grub && reboot
+```
+Hetzner's `/etc/default/grub.d/hetzner.cfg` resets `GRUB_CMDLINE_LINUX_DEFAULT`,
+which is why we ship our setting in a `zz-`-prefixed drop-in that sorts
+*after* it (see §4.1).
+
+### Governor isn't `performance`
+
+```sh
+systemctl status cpu-performance.service
+for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do cat "$f"; done
+```
+If the service is enabled but not active, `systemctl start cpu-performance.service`.
+If sysfs writes fail, the CPU's cpufreq driver isn't the expected one
+(verify `cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_driver`).
+
+### mdraid is resyncing
+
+```sh
+cat /proc/mdstat
+```
+Resync runs after every fresh install (~30 min on these disks). Wait
+it out before benching — the I/O contention will skew numbers. The
+preflight script already refuses to run during a resync.
+
+### `bench-push-results.mjs` fails with `AccessDenied`
+
+The most common cause is the WRITE role policy missing one of the
+permissions added later (e.g., `cloudfront:CreateInvalidation`).
+Re-run `./scripts/bench/aws/setup-aws.sh --bucket … --region …` —
+it's idempotent and will reconcile the inline policy.
+
+### Site shows stale data
+
+Two-minute lag is normal (`Cache-Control: max-age=60` + browser
+cache). For longer staleness:
+1. Verify the bench job's `push to s3 + invalidate CloudFront` step
+   logged the invalidation ID.
+2. Check the distribution: `aws cloudfront list-invalidations --distribution-id <id>`.
+3. As a last resort, force-refresh: `aws s3 cp s3://<bucket>/history.json /dev/null`
+   then `aws cloudfront create-invalidation --paths "/history.json"`.
+
+## 14. Files in this directory
+
+| File                                                                                                           | Purpose                                                                                                                                                                                                                   |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`README.md`](./README.md)                                                                                     | This runbook                                                                                                                                                                                                              |
+| [`hetzner-autosetup.cfg.tmpl`](./hetzner-autosetup.cfg.tmpl)                                                   | `installimage` config template — `__BENCH_HOSTNAME__` substituted by stage-hetzner.sh at upload time                                                                                                                      |
+| [`hetzner-postinstall.sh`](./hetzner-postinstall.sh)                                                           | Chroot hook: `nosmt` + perf governor                                                                                                                                                                                      |
+| [`op-env.sh`](./op-env.sh)                                                                                     | `source`-only helper: pulls `WASMCLOUD_BENCH_HOST_IP` / `WASMCLOUD_BENCH_HOSTNAME` / `WASMCLOUD_BENCH_HOST_IPV6` from the 1Password item `WASMCLOUD_BENCH_BOX` into the current shell                                     |
+| [`stage-hetzner.sh`](./stage-hetzner.sh)                                                                       | Phase 1 from your laptop: rescue → installed OS                                                                                                                                                                           |
+| [`ansible/`](./ansible/)                                                                                       | Phase 2 from your laptop: deps + Rust + valgrind + iai-callgrind-runner + repo + kernel cmdline + perf governor. Idempotent; re-run to apply drift or as the "patch a live box without re-staging" path (`--tags kernel`) |
+| [`install-runner.sh`](./install-runner.sh)                                                                     | Phase 3 on the host: GH Actions runner under `bench` user; also installs iai-callgrind-runner. Kept as bash because runner registration takes a one-shot token whose lifecycle is awkward to model declaratively.         |
+| [`../../.github/scripts/bench-preflight.mjs`](../../.github/scripts/bench-preflight.mjs)                       | CI step: refuses to bench on a drifted host (env: `WASMCLOUD_BENCH_HOSTNAME`). GHA-only — runs via `node` from the workflow.                                                                                              |
+| [`run-bench.sh`](./run-bench.sh)                                                                               | CI step + local: invokes `cargo bench`, writes a run log. Stays bash because compare-bench.sh invokes it on the host for local operator runs.                                                                             |
+| [`../../.github/scripts/bench-push-results.mjs`](../../.github/scripts/bench-push-results.mjs)                 | CI step: per-run upload + history.json aggregate + CloudFront invalidate; archives `target/criterion/` and/or `target/iai/`. GHA-only.                                                                                    |
+| [`compare-bench.sh`](./compare-bench.sh)                                                                       | Pair-bench script: runs one bench against two refs (interleaved for criterion, 1× for iai) and snapshots per-iteration data                                                                                               |
+| [`../../crates/bench-tools/`](../../crates/bench-tools/)                                                       | Rust binary that parses criterion + iai-callgrind output and renders the JSONL trend rows, the step-summary markdown, and comparison deltas — see "Data processing" below                                                |
+| [`build-history.sh`](./build-history.sh)                                                                       | Maintenance: rebuild `history.json` from scratch by scanning all per-run JSONL in S3                                                                                                                                      |
+| [`aws/setup-aws.sh`](./aws/setup-aws.sh)                                                                       | One-shot: bucket + OAC + CloudFront + WRITE role                                                                                                                                                                          |
+| [`../../.github/workflows/bench.yml`](../../.github/workflows/bench.yml)                                       | Trends pipeline (workflow_dispatch + release auto-trigger)                                                                                                                                                                |
+| [`../../.github/workflows/bench-compare.yml`](../../.github/workflows/bench-compare.yml)                       | Comparison pipeline (workflow_dispatch only — see §9.4 for the rationale against a PR-label trigger)                                                                                                                      |
+| [`../../.github/workflows/bench-host-checks.yml`](../../.github/workflows/bench-host-checks.yml)               | Monthly upstream-version checks (no bench-host involvement; opens / updates / auto-closes a tracking issue per check — see §15)                                                                                           |
+| [`../../.github/scripts/bench-check-runner-version.mjs`](../../.github/scripts/bench-check-runner-version.mjs) | Compares `RUNNER_VERSION` in `install-runner.sh` to the latest actions/runner release; runs from bench-host-checks.yml                                                                                                    |
+
+Sensitive values (the bench host's IP, IPv6, and hostname) are kept in
+1Password rather than in the repo. See §1 and §6.
+
+### Data processing: `crates/bench-tools`
+
+[`crates/bench-tools`](../../crates/bench-tools/) is the Rust binary
+that does the structured-data side of the pipeline. Three subcommands:
+
+| Subcommand                                                     | Used by                                                       |
+| -------------------------------------------------------------- | ------------------------------------------------------------- |
+| `bench-tools jsonl --bench <name>`                             | `bench-push-results.mjs` (writes `results.jsonl`)             |
+| `bench-tools summary --bench <name>`                           | `.github/workflows/bench.yml` (writes `$GITHUB_STEP_SUMMARY`) |
+| `bench-tools delta` (reads env vars set by `compare-bench.sh`) | `compare-bench.sh` (writes `delta.md` + stdout)               |
+
+Design boundary: **structured-data parsing + rendering lives in Rust;
+process orchestration lives in bash (or `.mjs` for GHA-only steps)**.
+`bench-tools` parses criterion's `estimates.json` + `benchmark.json`
+and valgrind's `callgrind.out` events/summary lines into typed
+`serde` structs, then renders markdown or JSONL out the other side.
+The shell/JS callers drive the pipeline (SSH, git checkouts,
+`cargo bench`, `aws s3 cp`) — those operations are shell-shaped and
+spawning subprocesses stays the right tool.
+
+Build is implicit: each invocation site uses `cargo run -p bench-tools
+--quiet -- <subcommand>`. Cargo's incremental build keeps the cost
+near zero after the first invocation per run. `compare-bench.sh`
+explicitly `cargo build`s the binary *before* it starts switching the
+worktree across refs, so the renderer stays constant across the two
+sides of a comparison.
+
+## 15. Dependency cadence
+
+Bench hosts have an unusual constraint: most ops advice ("patch aggressively")
+trades off against measurement stability. The pinned dependency stack splits
+into layers, each with its own cadence.
+
+| Layer                                  | Cadence                                           | Pin location                                                                                       | Notes                                                                                                                                                                                                                  |
+| -------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Ubuntu security patches                | continuous (auto)                                 | `unattended-upgrades` (default-on in Noble)                                                        | Only the `-security` pocket. sshd / openssl / glibc fixes go in continuously; kernel held back.                                                                                                                        |
+| Kernel                                 | quarterly, deliberate                             | apt — held back implicitly because we don't run blanket `apt upgrade`                              | Scheduler / cgroup / cpufreq behavior is the measurement substrate. A kernel jump can shift `iai_callgrind` Ir counts and criterion p99 in ways that look like regressions. Annotate the dashboard with the bump date. |
+| glibc / libstdc++                      | with the kernel                                   | apt                                                                                                | Same reason.                                                                                                                                                                                                           |
+| valgrind                               | yearly, or when iai-callgrind asks for it         | apt                                                                                                | Major valgrind bumps have historically renamed cachegrind event columns; our `Ir` parser is robust to that, but verify.                                                                                                |
+| Rust toolchain                         | rolls with `rust-toolchain.toml` (monthly stable) | repo file                                                                                          | No bench-host-specific pin.                                                                                                                                                                                            |
+| `iai-callgrind` crate + runner         | when the bench fails to start, or yearly          | `crates/wash-runtime/Cargo.toml` + `provision.yml` (`iai_callgrind_version`) + `install-runner.sh` | All three sites must match — iai-callgrind enforces crate-vs-runner equality at run time.                                                                                                                              |
+| Node.js                                | quarterly (with the kernel bump)                  | `provision.yml` (`node_lts_major`)                                                                 | Bump to the current active LTS line. Built-ins-only scripts; Node version changes are usually low-risk.                                                                                                                |
+| GitHub Actions runner agent            | monthly check, bump on changelog review           | `install-runner.sh` (`RUNNER_VERSION` + `RUNNER_SHA256`)                                           | Auto-tracked via [`bench-host-checks.yml`](../../.github/workflows/bench-host-checks.yml); see below.                                                                                                                  |
+| Action SHA pins (`actions/checkout@…`) | weekly via Dependabot                             | `.github/workflows/*.yml`                                                                          | Low risk — these execute on hosted runners, not the bench host.                                                                                                                                                        |
+| AWS CLI v2                             | yearly                                            | `install-runner.sh` (curl from official zip)                                                       | Unpinned; we just pull whatever's current at install time.                                                                                                                                                             |
+
+### Monthly: the actions/runner version check
+
+[`bench-host-checks.yml`](../../.github/workflows/bench-host-checks.yml) runs on
+the 1st of each month and on `workflow_dispatch`. Today it has one job —
+`runner-version` — which compares the `RUNNER_VERSION` pinned in
+[`install-runner.sh`](./install-runner.sh) against the latest release of
+[actions/runner](https://github.com/actions/runner/releases). If they differ it
+opens a tracking issue with the upstream release notes inline so you can scan
+whether the bump needs care (new `config.sh` flags, system-dep changes,
+deprecations). Re-runs of the workflow update the same issue in place; the
+issue auto-closes once `RUNNER_VERSION` catches up to upstream.
+
+To accept a bump:
+
+1. Note the SHA-256 from the release page's assets — `actions-runner-linux-x64-<version>.tar.gz`.
+2. Bump `RUNNER_VERSION` and `RUNNER_SHA256` in `install-runner.sh` together.
+3. On the bench host: stop the service, deregister with a fresh removal token, `rm -rf /opt/actions-runner`, re-run `install-runner.sh`. See §6 for the full re-registration flow.
+
+### Quarterly: bench-host maintenance window
+
+Once a quarter (~1 hour), do the bench-host-specific bumps together so the
+dashboard shows one annotated step instead of N small ones:
+
+1. Re-source `op-env.sh`.
+2. Bump apt: `apt update && apt upgrade` on the bench host. This is where
+   kernel + glibc + valgrind move forward.
+3. Re-run `ansible-playbook provision.yml` — picks up the `node_lts_major`,
+   `iai_callgrind_version` bumps you've staged in the repo.
+4. If the kernel cmdline drop-in changed: reboot the host.
+5. Verify with `cat /etc/wasmcloud-bench-stage` + the `nproc`/`isolcpus` checks
+   from §4.
+6. Trigger one of each bench against `main` before and after via
+   `workflow_dispatch`; annotate the dashboard with the bump date so the
+   inevitable step-change is documented.
+
+## 16. Out of scope
+
+Deliberately not built; document the "why not yet" so the next person
+doesn't reinvent or reattempt without context.
+
+- **Auto-trigger on `release: published`** — would let new tags
+  populate the `releases` view automatically. Easy add when we want
+  it; out for v1 because we're still tuning what to bench per release.
+- **Comment-driven dispatch** (e.g. `@rust-timer queue` style) —
+  needs a fine-grained PAT or GH App. Worth doing once we want PR
+  authors to dispatch their own benches.
+- **Lifecycle expiry** on `runs/*/criterion.tar.zst` — to cap
+  long-term storage. Add a 180-day rule to the bucket lifecycle when
+  storage cost ever shows up on the bill (currently ≪ $0.01/mo).
+- **Multi-host fan-out** — bench numbers across architectures
+  (aarch64, Apple silicon) or multiple x86_64 baselines. Requires
+  rethinking the `concurrency: bench-host` group and the per-row
+  schema.
+- **Auto-regression alerting** — Slack/issue post when a bench
+  regresses by N % with non-overlapping CI vs. baseline. The data
+  is in S3 already; the consumer is missing.
+- **CPU isolation / RT scheduling** — see §4.4. Add only if numbers
+  start showing variance we can't explain.
+- **Custom CloudFront domain** (`data.https://wasmcloud.github.io/arewefastyet`) —
+  optional polish; would need an ACM cert in `us-east-1` validated
+  via Cloudflare DNS, then attached to the distribution.

--- a/scripts/bench/ansible/ansible.cfg
+++ b/scripts/bench/ansible/ansible.cfg
@@ -1,0 +1,29 @@
+[defaults]
+# Run from this directory by default — keeps the operator's invocation short:
+#   cd scripts/bench/ansible && ansible-playbook provision.yml
+inventory = ./inventory.yml
+
+# Strict host-key checking; pin host keys in ~/.ssh/known_hosts the same way
+# stage-hetzner.sh does after the initial install.
+host_key_checking = True
+
+# Render task results as YAML rather than JSON so changes are diff-readable
+# from the terminal.
+stdout_callback = ansible.builtin.default
+result_format = yaml
+
+# Don't spam retry files into the working tree.
+retry_files_enabled = False
+
+# Use the same Python the bench host ships with. Ubuntu 24.04 has python3 at
+# this path; explicit setting silences Ansible's interpreter-discovery
+# warning on first connect.
+interpreter_python = /usr/bin/python3
+
+[ssh_connection]
+# Match the patterns the shell scripts use: batch mode (no password prompts)
+# and a short connect timeout. ControlMaster+Persist makes multi-task plays
+# reuse a single SSH connection, which on this host cuts a 30-task run from
+# ~60s to ~15s.
+ssh_args = -o BatchMode=yes -o ConnectTimeout=15 -o ControlMaster=auto -o ControlPersist=60s
+pipelining = True

--- a/scripts/bench/ansible/inventory.yml
+++ b/scripts/bench/ansible/inventory.yml
@@ -1,0 +1,26 @@
+# Inventory for the wasmCloud bench host.
+#
+# Values come from the operator's environment, not from the repo, so the
+# host's identity stays out of git. Export from 1Password (item:
+# "wasmCloud Bench Host (Hetzner)") before running:
+#
+#   export WASMCLOUD_BENCH_HOST_IP=<ip>
+#   export WASMCLOUD_BENCH_HOSTNAME=<hostname>            # used by playbook assertions
+#   # SSH_KEY defaults to ~/.ssh/hetzner_bench; override if your keypair
+#   # lives elsewhere.
+#
+# Then:
+#   cd scripts/bench/ansible
+#   ansible-playbook provision.yml
+#
+# A single host is enumerated here. If we ever add a second machine, group
+# them under `bench:` and parameterise the playbook to act per-host.
+
+all:
+  children:
+    bench:
+      hosts:
+        bench-host:
+          ansible_host: "{{ lookup('env', 'WASMCLOUD_BENCH_HOST_IP') }}"
+          ansible_user: root
+          ansible_ssh_private_key_file: "{{ lookup('env', 'SSH_KEY') | default(lookup('env', 'HOME') + '/.ssh/hetzner_bench', true) }}"

--- a/scripts/bench/ansible/provision.yml
+++ b/scripts/bench/ansible/provision.yml
@@ -1,0 +1,290 @@
+---
+# Provision the wasmCloud bench host AFTER Ubuntu is installed.
+#
+# The chroot phase (kernel cmdline + RAID + partitioning) lives in
+# stage-hetzner.sh + hetzner-postinstall.sh because Ansible needs a
+# running system with SSH, which we don't have during installimage.
+#
+# Idempotent. Re-running applies any drift: a new iai-callgrind-runner
+# version pinned below, a new apt dep, a kernel-cmdline change, etc.
+#
+# Run from scripts/bench/ansible/ with the env vars from inventory.yml's
+# header exported. Useful invocations:
+#
+#   ansible-playbook provision.yml                  # everything
+#   ansible-playbook provision.yml --tags kernel    # just the GRUB drop-in
+#   ansible-playbook provision.yml --tags toolchain # apt + rustup + iai
+#   ansible-playbook provision.yml --check          # dry-run
+#
+# After --tags kernel changes, a reboot is required for the new cmdline
+# to take effect; the playbook prints a notice but does NOT reboot for
+# you (rebooting the bench host mid-CI-run would be bad).
+
+- name: Provision wasmCloud bench host
+  hosts: bench
+  gather_facts: true
+
+  vars:
+    expected_hostname: "{{ lookup('env', 'WASMCLOUD_BENCH_HOSTNAME') }}"
+    repo_url: "https://github.com/wasmCloud/wasmCloud.git"
+    repo_dir: /opt/wasmcloud
+    # iai-callgrind enforces equality between the runner binary version and
+    # the iai-callgrind crate version pinned in
+    # crates/wash-runtime/Cargo.toml. Bump both together.
+    iai_callgrind_version: "0.16.1"
+    # CPU index reserved by isolcpus / nohz_full / rcu_nocbs. Must match
+    # WASMCLOUD_BENCH_ISOLATED_CPU in scripts/bench/run-bench.sh.
+    isolated_cpu: 5
+    # Node major version installed from NodeSource. Bump to the current
+    # active LTS line (https://nodejs.org/en/about/previous-releases) at
+    # each quarterly bench-host maintenance window. Ubuntu 24.04 ships
+    # Node 18 in `main`, which is past EOL; NodeSource gives us a current
+    # LTS without competing with the OS package.
+    node_lts_major: 22
+
+  pre_tasks:
+    - name: Refuse to run if WASMCLOUD_BENCH_HOSTNAME isn't exported
+      ansible.builtin.assert:
+        that: expected_hostname | length > 0
+        fail_msg: |
+          WASMCLOUD_BENCH_HOSTNAME not set. Export from 1Password
+          (item: "wasmCloud Bench Host (Hetzner)") before running.
+      tags: always
+
+    - name: Refuse to run on Hetzner rescue
+      ansible.builtin.assert:
+        that: ansible_facts['hostname'] != 'rescue'
+        fail_msg: |
+          Host is in Hetzner rescue. Run scripts/bench/stage-hetzner.sh from
+          rescue first to install Ubuntu, then re-run this playbook.
+      tags: always
+
+    - name: Refuse to run on the wrong host
+      ansible.builtin.assert:
+        that: ansible_facts['hostname'] == expected_hostname
+        fail_msg: |
+          Host hostname is {{ ansible_facts['hostname'] }}, expected {{ expected_hostname }}.
+          Either the bench host got renamed or the inventory points at the
+          wrong machine.
+      tags: always
+
+  tasks:
+    # ── Toolchain + deps ──────────────────────────────────────────────────
+    - name: Apt — bench build deps
+      ansible.builtin.apt:
+        name:
+          # Rust + C toolchain for the bench compile.
+          - build-essential
+          - pkg-config
+          - libssl-dev
+          - clang
+          - cmake
+          # Utilities run by the bench pipeline.
+          - git
+          - curl
+          - jq
+          - ca-certificates
+          # `protobuf-compiler` is the protoc binary, needed by
+          # wash-runtime/build.rs. `libprotobuf-dev` provides the
+          # well-known .proto includes (timestamp.proto etc.) — without
+          # it, protoc finds the binary but fails to import.
+          - protobuf-compiler
+          - libprotobuf-dev
+          # Valgrind is the measurement engine for iai_callgrind.
+          - valgrind
+          # zstd for criterion.tar.zst archiving; AWS CLI installed
+          # separately by install-runner.sh (apt's awscli is v1).
+          - zstd
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+      tags: [toolchain, apt]
+
+    - name: Install rustup (root user)
+      ansible.builtin.shell: |
+        set -euo pipefail
+        curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
+          | sh -s -- -y --default-toolchain stable --no-modify-path
+      args:
+        # `creates:` makes this a no-op once rustup is in place. We install
+        # `stable` as the default toolchain so out-of-tree `cargo install`
+        # invocations (e.g. iai-callgrind-runner below) have something to
+        # pick. Inside the wasmCloud workspace the repo's
+        # rust-toolchain.toml still wins — it also pins `stable` today, so
+        # there's no drift between the default and the workspace toolchain.
+        creates: /root/.cargo/bin/rustup
+        executable: /bin/bash
+      tags: [toolchain, rustup]
+
+    # Defense in depth: if the host was previously provisioned with rustup
+    # but no default toolchain (earlier versions of this playbook used
+    # `--default-toolchain none`), the `creates:` guard above will skip the
+    # install task and rustup will still have no default — making any later
+    # `cargo install` fail. `rustup default stable` is idempotent: a no-op
+    # when stable is already the default, downloads + sets stable when it
+    # isn't. Hence `changed_when: false` — we don't care whether it
+    # actually had to act, only that the post-condition holds.
+    - name: Ensure rustup default toolchain is stable
+      ansible.builtin.command: /root/.cargo/bin/rustup default stable
+      changed_when: false
+      tags: [toolchain, rustup]
+
+    # ── Node.js (for .github/scripts/*.mjs in CI) ──────────────────────────
+    # Self-hosted runners do NOT put their bundled Node on the PATH for
+    # `run:` steps — the actions-runner agent uses its own Node only to
+    # execute actions, not user shell commands. Our CI workflow does
+    # `run: node .github/scripts/bench-*.mjs`, which needs an OS-level
+    # `node`. Install the current LTS from NodeSource (the Ubuntu apt
+    # `nodejs` package is on Node 18, which is EOL).
+    - name: NodeSource — apt keyring dir
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: "0755"
+      tags: [toolchain, nodejs]
+
+    - name: NodeSource — install signing key
+      ansible.builtin.get_url:
+        url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+        dest: /etc/apt/keyrings/nodesource.asc
+        mode: "0644"
+      tags: [toolchain, nodejs]
+
+    - name: NodeSource — apt source for Node {{ node_lts_major }}.x
+      ansible.builtin.apt_repository:
+        # `nodistro` is NodeSource's intentional placeholder; their apt
+        # tree is keyed on Node major version, not Ubuntu release.
+        repo: "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesource.com/node_{{ node_lts_major }}.x nodistro main"
+        state: present
+        filename: nodesource
+        update_cache: true
+      tags: [toolchain, nodejs]
+
+    - name: Apt — install nodejs (from NodeSource)
+      ansible.builtin.apt:
+        name: nodejs
+        state: present
+      tags: [toolchain, nodejs]
+
+    - name: List cargo-installed binaries (root)
+      ansible.builtin.command: /root/.cargo/bin/cargo install --list
+      register: cargo_installed
+      changed_when: false
+      tags: [toolchain, iai]
+
+    - name: Install or upgrade iai-callgrind-runner
+      ansible.builtin.shell: |
+        set -euo pipefail
+        . "$HOME/.cargo/env"
+        cargo install iai-callgrind-runner --version {{ iai_callgrind_version }}
+      args:
+        executable: /bin/bash
+      # `cargo install --list` is the canonical way to query installed
+      # binaries. Each crate's entry has the shape `<name> v<version>:`
+      # on its own line — the trailing colon disambiguates `0.16.1` from
+      # `0.16.10` etc., so a plain substring check is safe here (no
+      # regex, no split/last on a possibly-empty value).
+      when: ('iai-callgrind-runner v' ~ iai_callgrind_version ~ ':') not in cargo_installed.stdout
+      tags: [toolchain, iai]
+
+    # ── Repo clone for ad-hoc / manual benches ────────────────────────────
+    - name: Clone wasmCloud repo to {{ repo_dir }}
+      ansible.builtin.git:
+        repo: "{{ repo_url }}"
+        dest: "{{ repo_dir }}"
+        depth: 1
+        version: main
+        force: true
+        # Refuses to overwrite changes in the working tree, which is
+        # what we want for a CI-style host — manual edits there shouldn't
+        # block provisioning.
+      tags: [repo]
+
+    # ── Kernel tweaks (require reboot to take effect) ─────────────────────
+    - name: GRUB drop-in for nosmt + CPU isolation
+      ansible.builtin.copy:
+        dest: /etc/default/grub.d/zz-bench.cfg
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          # wasmCloud bench host: append the bench-time kernel tweaks.
+          #   nosmt         - disable SMT/hyperthreading entirely.
+          #   isolcpus      - remove CPU from general scheduler load-balancing.
+          #   nohz_full     - stop the periodic scheduler tick on that CPU when
+          #                   only one runnable task is on it (kills timer-driven
+          #                   measurement jitter).
+          #   rcu_nocbs     - offload RCU callbacks off that CPU to a kthread.
+          GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT} nosmt isolcpus={{ isolated_cpu }} nohz_full={{ isolated_cpu }} rcu_nocbs={{ isolated_cpu }}"
+      notify: regenerate grub config
+      tags: [kernel]
+
+    # ── cpu-performance governor (no reboot needed) ───────────────────────
+    - name: Install cpu-performance systemd unit
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/cpu-performance.service
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Pin all CPUs to the performance scaling_governor (bench host)
+          After=multi-user.target
+          ConditionPathExists=/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/bin/sh -c 'for g in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do echo performance > "$g"; done'
+
+          [Install]
+          WantedBy=multi-user.target
+      notify:
+        - reload systemd
+        - enable cpu-performance
+      tags: [governor]
+
+    # ── Provisioning marker ───────────────────────────────────────────────
+    - name: Stamp /etc/wasmcloud-bench-stage
+      ansible.builtin.copy:
+        dest: /etc/wasmcloud-bench-stage
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          wasmcloud-bench provisioned (ansible)
+          stamp: {{ ansible_facts['date_time']['iso8601'] }}
+          kernel-tweak: nosmt isolcpus={{ isolated_cpu }} nohz_full={{ isolated_cpu }} rcu_nocbs={{ isolated_cpu }}
+          cpufreq-governor: performance
+          isolated-cpu: {{ isolated_cpu }}
+          iai-callgrind-runner: {{ iai_callgrind_version }}
+          node-lts-major: {{ node_lts_major }}
+      tags: [marker]
+
+  handlers:
+    - name: regenerate grub config
+      ansible.builtin.command: update-grub
+      listen: regenerate grub config
+
+    - name: reload systemd
+      ansible.builtin.systemd:
+        daemon_reload: true
+      listen: reload systemd
+
+    - name: enable cpu-performance
+      ansible.builtin.systemd:
+        name: cpu-performance.service
+        enabled: true
+      listen: enable cpu-performance
+
+  post_tasks:
+    - name: Note pending reboot if cmdline changed
+      ansible.builtin.debug:
+        msg: |
+          GRUB cmdline changed. Reboot the bench host to pick it up:
+            ssh -i ~/.ssh/hetzner_bench root@$WASMCLOUD_BENCH_HOST_IP reboot
+          Verify after reboot with:
+            cat /sys/devices/system/cpu/isolated   # expect: {{ isolated_cpu }}
+      when: >
+        ansible_run_tags is defined
+        and ('kernel' in ansible_run_tags or 'all' in ansible_run_tags)

--- a/scripts/bench/aws/setup-aws.sh
+++ b/scripts/bench/aws/setup-aws.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# One-time AWS provisioning for the bench pipeline.
+#
+#   ./scripts/bench/aws/setup-aws.sh \
+#     --bucket <bucket> \
+#     --region <region> \
+#     [--bench-repo  wasmCloud/wasmCloud]
+#
+# Idempotent. Provisions:
+#   1. S3 bucket  -  versioning + AES256 encryption + public access *blocked*
+#                    (CloudFront is the only thing that can read it)
+#   2. OpenID Connect provider for token.actions.githubusercontent.com
+#   3. CloudFront Origin Access Control (OAC) + Distribution serving
+#      history.json (cached at the edge, free 1 TB/mo)
+#   4. S3 bucket policy: CloudFront-OAC-only read on history.json
+#   5. S3 CORS: GET allowed from any origin (data is public via CloudFront)
+#   6. WRITE IAM role: trusted by <bench-repo>, may
+#      - PutObject to runs/* and history.json
+#      - GetObject on history.json (to merge new rows)
+#      - CreateInvalidation on the distribution
+#
+# The site (arewefastyet) reads anonymously through CloudFront, so we no
+# longer need a READ role or any AWS auth in the site repo.
+#
+# Prints the values to set as secrets/vars at the end.
+#
+# Requires: aws CLI v2, jq.
+
+set -euo pipefail
+
+BUCKET=""
+REGION=""
+WASMCLOUD_BENCH_REPO="wasmCloud/wasmCloud"
+WRITE_ROLE_NAME="wasmcloud-bench-github-oidc-write"
+OAC_NAME="wasmcloud-bench-oac"
+DIST_COMMENT="arewefastyet bench data"
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --bucket)          BUCKET="$2"; shift 2 ;;
+    --region)          REGION="$2"; shift 2 ;;
+    --bench-repo)      WASMCLOUD_BENCH_REPO="$2"; shift 2 ;;
+    --write-role-name) WRITE_ROLE_NAME="$2"; shift 2 ;;
+    -h|--help)         usage 0 ;;
+    *)                 echo "unknown arg: $1" >&2; usage 2 ;;
+  esac
+done
+
+[ -n "$BUCKET" ] || { echo "--bucket required"; exit 1; }
+[ -n "$REGION" ] || { echo "--region required"; exit 1; }
+
+step() { printf '\n=== %s ===\n' "$*"; }
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+OIDC_ARN="arn:aws:iam::${ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com"
+
+# 1. Bucket -------------------------------------------------------------------
+step "S3 bucket: ${BUCKET} (region ${REGION})"
+if aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+  echo "exists"
+else
+  if [ "$REGION" = "us-east-1" ]; then
+    aws s3api create-bucket --bucket "$BUCKET" --region "$REGION"
+  else
+    aws s3api create-bucket --bucket "$BUCKET" --region "$REGION" \
+      --create-bucket-configuration "LocationConstraint=$REGION"
+  fi
+  echo "created"
+fi
+
+aws s3api put-bucket-versioning --bucket "$BUCKET" \
+  --versioning-configuration Status=Enabled
+
+aws s3api put-bucket-encryption --bucket "$BUCKET" \
+  --server-side-encryption-configuration '{
+    "Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"},"BucketKeyEnabled":true}]
+  }'
+
+# Block public access fully — CloudFront uses OAC, never anonymous S3 reads.
+aws s3api put-public-access-block --bucket "$BUCKET" \
+  --public-access-block-configuration \
+    BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+
+# CORS: harmless because the bucket isn't reachable directly, but lets the
+# CloudFront-cached response carry Access-Control-Allow-Origin: * for the site.
+aws s3api put-bucket-cors --bucket "$BUCKET" --cors-configuration '{
+  "CORSRules":[{"AllowedMethods":["GET"],"AllowedOrigins":["*"],"AllowedHeaders":["*"],"MaxAgeSeconds":3600}]
+}'
+
+# 2. OIDC provider ------------------------------------------------------------
+step "OIDC provider for github.com"
+if aws iam get-open-id-connect-provider --open-id-connect-provider-arn "$OIDC_ARN" >/dev/null 2>&1; then
+  echo "exists"
+else
+  aws iam create-open-id-connect-provider \
+    --url https://token.actions.githubusercontent.com \
+    --client-id-list sts.amazonaws.com >/dev/null
+  echo "created"
+fi
+
+# 3. Origin Access Control (OAC) ---------------------------------------------
+step "CloudFront Origin Access Control: ${OAC_NAME}"
+OAC_ID=$(aws cloudfront list-origin-access-controls \
+  --query "OriginAccessControlList.Items[?Name=='${OAC_NAME}'].Id | [0]" \
+  --output text)
+if [ -z "$OAC_ID" ] || [ "$OAC_ID" = "None" ]; then
+  OAC_ID=$(aws cloudfront create-origin-access-control \
+    --origin-access-control-config "{
+      \"Name\":\"${OAC_NAME}\",
+      \"Description\":\"OAC for ${BUCKET} bench data\",
+      \"SigningProtocol\":\"sigv4\",
+      \"SigningBehavior\":\"always\",
+      \"OriginAccessControlOriginType\":\"s3\"
+    }" \
+    --query 'OriginAccessControl.Id' --output text)
+  echo "created: ${OAC_ID}"
+else
+  echo "exists: ${OAC_ID}"
+fi
+
+# 4. CloudFront distribution --------------------------------------------------
+# Note on ViewerCertificate.MinimumProtocolVersion below: `TLSv1` looks lax
+# but is required when CloudFrontDefaultCertificate is true (we're serving
+# from *.cloudfront.net rather than a custom domain). AWS rejects stronger
+# minimums in that mode. Bump to TLSv1.2_2021 (or whatever the current
+# recommendation is) only after attaching an ACM cert via a custom domain.
+step "CloudFront distribution"
+DIST_ID=$(aws cloudfront list-distributions \
+  --query "DistributionList.Items[?Comment=='${DIST_COMMENT}'].Id | [0]" \
+  --output text)
+if [ -z "$DIST_ID" ] || [ "$DIST_ID" = "None" ]; then
+  # AWS managed cache policy "CachingOptimized" — respects the origin's
+  # Cache-Control header, so Cache-Control: max-age=60 on history.json
+  # propagates straight through.
+  CACHING_OPTIMIZED="658327ea-f89d-4fab-a63d-7e88639e58f6"
+
+  origin_dn="${BUCKET}.s3.${REGION}.amazonaws.com"
+  dist_config=$(jq -n \
+    --arg origin_dn "$origin_dn" \
+    --arg oac "$OAC_ID" \
+    --arg ref "bench-$(date -u +%s)" \
+    --arg comment "$DIST_COMMENT" \
+    --arg cache_policy "$CACHING_OPTIMIZED" \
+    '{
+      CallerReference: $ref,
+      Comment: $comment,
+      Enabled: true,
+      PriceClass: "PriceClass_100",
+      HttpVersion: "http2and3",
+      IsIPV6Enabled: true,
+      Origins: {
+        Quantity: 1,
+        Items: [{
+          Id: "s3-origin",
+          DomainName: $origin_dn,
+          OriginPath: "",
+          CustomHeaders: {Quantity: 0},
+          S3OriginConfig: {OriginAccessIdentity: ""},
+          OriginAccessControlId: $oac,
+          ConnectionAttempts: 3,
+          ConnectionTimeout: 10
+        }]
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "s3-origin",
+        ViewerProtocolPolicy: "redirect-to-https",
+        AllowedMethods: {
+          Quantity: 2, Items: ["GET", "HEAD"],
+          CachedMethods: {Quantity: 2, Items: ["GET", "HEAD"]}
+        },
+        Compress: true,
+        CachePolicyId: $cache_policy,
+        SmoothStreaming: false,
+        FieldLevelEncryptionId: ""
+      },
+      ViewerCertificate: {
+        CloudFrontDefaultCertificate: true,
+        MinimumProtocolVersion: "TLSv1",
+        SSLSupportMethod: "vip"
+      },
+      Restrictions: {GeoRestriction: {RestrictionType: "none", Quantity: 0}},
+      DefaultRootObject: "",
+      WebACLId: ""
+    }')
+
+  DIST_ID=$(aws cloudfront create-distribution \
+    --distribution-config "$dist_config" \
+    --query 'Distribution.Id' --output text)
+  echo "created: ${DIST_ID} (still propagating; takes 5-15 min before first hit)"
+else
+  echo "exists: ${DIST_ID}"
+fi
+
+DIST_DOMAIN=$(aws cloudfront get-distribution \
+  --id "$DIST_ID" --query 'Distribution.DomainName' --output text)
+DIST_ARN="arn:aws:cloudfront::${ACCOUNT_ID}:distribution/${DIST_ID}"
+
+# 5. Bucket policy: only this distribution can GetObject history.json --------
+step "S3 bucket policy: CloudFront-OAC only on history.json"
+bucket_policy=$(jq -n \
+  --arg b "$BUCKET" \
+  --arg dist "$DIST_ARN" \
+  '{
+    Version: "2012-10-17",
+    Statement: [{
+      Sid: "AllowCloudFrontServicePrincipalReadHistory",
+      Effect: "Allow",
+      Principal: {Service: "cloudfront.amazonaws.com"},
+      Action: "s3:GetObject",
+      Resource: "arn:aws:s3:::\($b)/history.json",
+      Condition: {StringEquals: {"AWS:SourceArn": $dist}}
+    }]
+  }')
+aws s3api put-bucket-policy --bucket "$BUCKET" --policy "$bucket_policy"
+
+# Helper: create or reconcile a role with the given trust + inline policy.
+upsert_role() {
+  local role_name="$1"
+  local trust="$2"
+  local policy="$3"
+  local policy_name="${role_name}-policy"
+
+  if aws iam get-role --role-name "$role_name" >/dev/null 2>&1; then
+    aws iam update-assume-role-policy --role-name "$role_name" --policy-document "$trust"
+    echo "  trust policy updated"
+  else
+    aws iam create-role --role-name "$role_name" --assume-role-policy-document "$trust" >/dev/null
+    echo "  created"
+  fi
+  aws iam put-role-policy --role-name "$role_name" \
+    --policy-name "$policy_name" --policy-document "$policy"
+}
+
+# 6. WRITE role: bench pipeline ----------------------------------------------
+step "WRITE role: ${WRITE_ROLE_NAME}  (trusted by ${WASMCLOUD_BENCH_REPO})"
+write_trust=$(jq -n \
+  --arg arn "$OIDC_ARN" \
+  --arg sub "repo:${WASMCLOUD_BENCH_REPO}:*" \
+  '{
+    Version: "2012-10-17",
+    Statement: [{
+      Effect: "Allow",
+      Principal: {Federated: $arn},
+      Action: "sts:AssumeRoleWithWebIdentity",
+      Condition: {
+        StringEquals: {"token.actions.githubusercontent.com:aud": "sts.amazonaws.com"},
+        StringLike:   {"token.actions.githubusercontent.com:sub": $sub}
+      }
+    }]
+  }')
+write_policy=$(jq -n --arg b "$BUCKET" --arg dist "$DIST_ARN" '{
+  Version: "2012-10-17",
+  Statement: [
+    { Sid: "WriteRunArtifacts",
+      Effect: "Allow",
+      Action: ["s3:PutObject","s3:PutObjectAcl","s3:AbortMultipartUpload"],
+      Resource: "arn:aws:s3:::\($b)/runs/*" },
+    { Sid: "ReadWriteHistoryAggregate",
+      Effect: "Allow",
+      Action: ["s3:GetObject","s3:PutObject"],
+      Resource: "arn:aws:s3:::\($b)/history.json" },
+    { Sid: "ListBucketForPrefixDiscovery",
+      Effect: "Allow",
+      Action: ["s3:ListBucket"],
+      Resource: "arn:aws:s3:::\($b)" },
+    { Sid: "InvalidateCloudFrontHistory",
+      Effect: "Allow",
+      Action: ["cloudfront:CreateInvalidation"],
+      Resource: $dist }
+  ]
+}')
+upsert_role "$WRITE_ROLE_NAME" "$write_trust" "$write_policy"
+WRITE_ARN=$(aws iam get-role --role-name "$WRITE_ROLE_NAME" --query 'Role.Arn' --output text)
+
+# 7. Print configuration ------------------------------------------------------
+DATA_URL="https://${DIST_DOMAIN}/history.json"
+cat <<EOM
+
+=== done ===
+
+Set the following on each repo:
+
+  ${WASMCLOUD_BENCH_REPO}    (bench pipeline — writes to S3, invalidates CloudFront)
+    secret  WASMCLOUD_BENCH_AWS_ROLE_ARN          = ${WRITE_ARN}
+    secret  WASMCLOUD_BENCH_S3_BUCKET             = ${BUCKET}
+    secret  WASMCLOUD_BENCH_S3_REGION             = ${REGION}
+    secret  WASMCLOUD_BENCH_CF_DISTRIBUTION_ID    = ${DIST_ID}
+
+  wasmCloud/arewefastyet    (trend site — anonymous reads via CloudFront)
+    var     DATA_URL                    = ${DATA_URL}
+
+Distribution domain:
+  ${DIST_DOMAIN}    (use this URL until/unless you attach a custom domain)
+
+If the distribution was just created, it takes ~5-15 minutes for the
+edge configuration to propagate. After that, push a bench run; the
+site should pick it up within \`max-age=60\`.
+EOM

--- a/scripts/bench/build-history.sh
+++ b/scripts/bench/build-history.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Pull every per-run results.jsonl from s3://${WASMCLOUD_BENCH_S3_BUCKET}/runs/, dedupe,
+# sort, and emit history.json — a rebuild-from-scratch path for the public
+# aggregate that .github/scripts/bench-push-results.mjs maintains
+# incrementally. Use this when the
+# incremental file gets out of sync, after schema changes, or to seed a
+# fresh deployment of the trend site (wasmCloud/arewefastyet).
+#
+# Usage:
+#   WASMCLOUD_BENCH_S3_BUCKET=<bucket> ./scripts/bench/build-history.sh
+#
+# Optional:
+#   WASMCLOUD_BENCH_HISTORY_OUT  - output path (default ./history.json)
+#   WASMCLOUD_BENCH_HISTORY_MAX_AGE_DAYS  - drop rows older than this (default 365)
+
+set -euo pipefail
+
+: "${WASMCLOUD_BENCH_S3_BUCKET:?WASMCLOUD_BENCH_S3_BUCKET not set}"
+
+out="${WASMCLOUD_BENCH_HISTORY_OUT:-./history.json}"
+max_age_days="${WASMCLOUD_BENCH_HISTORY_MAX_AGE_DAYS:-365}"
+
+mkdir -p "$(dirname "$out")"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+echo "syncing results.jsonl from s3://${WASMCLOUD_BENCH_S3_BUCKET}/runs/ → ${work}"
+aws s3 sync --no-progress \
+  --exclude '*' --include '*results.jsonl' \
+  "s3://${WASMCLOUD_BENCH_S3_BUCKET}/runs/" "${work}/"
+
+# Concatenate and JSON-encode. unique_by(.sha + .group + .param + .run_attempt)
+# in case the same row was uploaded twice; sort_by(.timestamp) so the frontend
+# can iterate in chronological order.
+#
+# We deliberately let `cat` fail loudly if any per-run results.jsonl is
+# unreadable — this is a recovery tool, you'd reach for it precisely
+# *because* state is wrong, and silently dropping rows would defeat the
+# point. Fix the unreadable file and re-run.
+{
+  find "$work" -type f -name results.jsonl -print0 \
+    | xargs -0 cat
+} \
+  | jq -c --argjson max_age "$max_age_days" '
+      select(. != null) |
+      select(.timestamp != null) |
+      select(((now - (.timestamp | fromdate)) / 86400) <= $max_age)
+    ' \
+  | jq -s 'unique_by([.sha, .bench, .group, .param, .run_attempt, (.metric // null)]) | sort_by(.timestamp)' \
+  > "$out"
+
+count=$(jq 'length' < "$out")
+benches=$(jq -r '[.[] | .bench] | unique | join(", ")' < "$out")
+echo "wrote ${count} rows to ${out}"
+echo "  benches: ${benches:-<none>}"
+echo "  bytes:   $(wc -c < "$out")"

--- a/scripts/bench/compare-bench.sh
+++ b/scripts/bench/compare-bench.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Run a single bench against two refs back-to-back on the same host and emit
+# a delta table. Used by .github/workflows/bench-compare.yml.
+#
+#   ./scripts/bench/compare-bench.sh <bench> <ref_a> <ref_b>
+#
+# Variance handling (per the design call — see scripts/bench/README.md §9.4):
+#   - iai_callgrind: 1 run per ref (instruction counts are deterministic).
+#   - criterion benches: 3 interleaved runs per ref (a₁ b₁ a₂ b₂ a₃ b₃);
+#     median of the three is what the delta is computed from.
+#
+# Side effects:
+#   - Switches the working tree (git checkout). Saves and restores the
+#     original HEAD on exit (including failure) so a hung run doesn't
+#     leave the repo in a detached state.
+#   - Writes per-run snapshots to ${WASMCLOUD_BENCH_COMPARE_DIR:-/tmp/bench-compare}/{a,b}/.
+#   - `bench-tools delta` (invoked at the end) writes the rendered
+#     markdown delta to both stdout and ${WASMCLOUD_BENCH_COMPARE_DIR}/delta.md.
+#     The workflow `cat`s delta.md into ${GITHUB_STEP_SUMMARY}.
+#
+# Does NOT push to S3 or update history.json — comparison runs are
+# ephemeral and don't feed the trends timeline.
+
+set -euo pipefail
+
+bench="${1:?bench name required}"
+ref_a="${2:?ref_a required (the baseline, typically 'main')}"
+ref_b="${3:?ref_b required (the candidate)}"
+
+: "${CARGO_TARGET_DIR:=/var/lib/bench/target}"
+compare_dir="${WASMCLOUD_BENCH_COMPARE_DIR:-/tmp/bench-compare-${GITHUB_RUN_ID:-local}}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Variance regime: instruction-count benches don't benefit from repeats;
+# wall-clock benches do. Override via WASMCLOUD_BENCH_COMPARE_ITERS=N for testing.
+if [ -n "${WASMCLOUD_BENCH_COMPARE_ITERS:-}" ]; then
+  iters="$WASMCLOUD_BENCH_COMPARE_ITERS"
+elif [ "$bench" = "iai_callgrind" ]; then
+  iters=1
+else
+  iters=3
+fi
+
+# Resolve refs to full SHAs once so the rest of the script logs an unambiguous
+# identifier even if a branch tip moves underneath us mid-run.
+sha_a=$(git rev-parse "$ref_a")
+sha_b=$(git rev-parse "$ref_b")
+short_a=$(git rev-parse --short=12 "$sha_a")
+short_b=$(git rev-parse --short=12 "$sha_b")
+saved_head=$(git rev-parse HEAD)
+
+mkdir -p "${compare_dir}/a" "${compare_dir}/b"
+
+# Build bench-tools BEFORE switching the worktree, then invoke the binary
+# at the absolute path cargo reports. If we relied on `cargo run` after
+# each checkout we'd pick up whatever version of bench-tools lives at
+# that ref — including the no-such-crate case for any ref older than
+# this commit. The pinned path keeps the renderer constant across the
+# two refs we're comparing.
+#
+# Discover the path via --message-format=json rather than hardcoding
+# ${CARGO_TARGET_DIR}/debug/bench-tools, which is wrong under any of:
+# build.target in .cargo/config.toml, custom profile, or a host-triple
+# subdir injected by cross-compile toolchains.
+#
+# Debug build is deliberate. bench-tools does ~zero CPU work (parse a
+# few JSON files, render markdown), so the release-mode perf delta is
+# invisible next to the ~30 min comparison runs themselves. Debug
+# builds ~3× faster than release on this host.
+echo "building bench-tools…"
+# shellcheck disable=SC1091
+. "$HOME/.cargo/env" 2>/dev/null || true
+bench_tools=$(
+  cargo build -p bench-tools --message-format=json-render-diagnostics \
+    | jq -r 'select(.reason == "compiler-artifact"
+                    and .target.name == "bench-tools"
+                    and (.target.kind | index("bin")))
+             | .executable' \
+    | grep -v '^null$' \
+    | tail -n1
+)
+if [ -z "$bench_tools" ] || [ ! -x "$bench_tools" ]; then
+  echo "bench-tools binary not found after cargo build (got: '$bench_tools')" >&2
+  exit 1
+fi
+
+# Always return the worktree to where it started — caller (the workflow or
+# operator) shouldn't be surprised by detached HEAD on failure. If the
+# restore itself fails, log it loudly: the operator needs to know the
+# worktree is in an unexpected state, otherwise the next local run picks
+# up half-applied state from the comparison.
+cleanup() {
+  rc=$?
+  if ! git checkout --quiet "$saved_head" 2>/dev/null; then
+    echo "::warning::failed to restore worktree to ${saved_head:0:12}; worktree may be on a comparison ref" >&2
+  fi
+  exit $rc
+}
+trap cleanup EXIT
+
+step() { printf '\n=== %s ===\n' "$*"; }
+
+# Snapshot the bench output dirs that exist (criterion and/or iai) into a
+# numbered iteration dir under ${compare_dir}/{a,b}/. Wipes the live dirs
+# afterwards so the next iteration starts clean (run-bench.sh also wipes,
+# but doing it here guarantees no inter-iteration leak even if run-bench.sh
+# changes later).
+snapshot() {
+  local side="$1" iter="$2"
+  local dest="${compare_dir}/${side}/iter-${iter}"
+  mkdir -p "$dest"
+  for d in criterion iai; do
+    if [ -d "${CARGO_TARGET_DIR}/${d}" ]; then
+      cp -a "${CARGO_TARGET_DIR}/${d}" "${dest}/${d}"
+    fi
+  done
+}
+
+run_one() {
+  local side="$1" sha="$2" iter="$3"
+  step "[${side} iter ${iter}] checkout ${sha:0:12} and run ${bench}"
+  git checkout --quiet --detach "$sha"
+  "${script_dir}/run-bench.sh" "$bench"
+  snapshot "$side" "$iter"
+}
+
+# Interleave so any thermal / cache drift over the run window splits between
+# the two refs rather than landing entirely on one of them.
+for i in $(seq 1 "$iters"); do
+  run_one a "$sha_a" "$i"
+  run_one b "$sha_b" "$i"
+done
+
+step "compute delta"
+WASMCLOUD_BENCH_COMPARE_DIR="$compare_dir" \
+WASMCLOUD_BENCH_SHORT_A="$short_a" WASMCLOUD_BENCH_REF_A="$ref_a" \
+WASMCLOUD_BENCH_SHORT_B="$short_b" WASMCLOUD_BENCH_REF_B="$ref_b" \
+WASMCLOUD_BENCH_NAME="$bench" WASMCLOUD_BENCH_ITERS="$iters" \
+  "$bench_tools" delta

--- a/scripts/bench/hetzner-autosetup.cfg.tmpl
+++ b/scripts/bench/hetzner-autosetup.cfg.tmpl
@@ -1,0 +1,30 @@
+# Hetzner installimage autosetup TEMPLATE for the wasmCloud bench server.
+#
+# Rendered by stage-hetzner.sh: the literal string __BENCH_HOSTNAME__ is
+# substituted with the operator's $BENCH_HOSTNAME at upload time. The actual
+# IP and hostname are kept out of the repo — see scripts/bench/README.md §1
+# and 1Password ("wasmCloud Bench Host (Hetzner)").
+#
+# Hardware target (reproducible via `lscpu`, `lsblk`, `free -h` on the box):
+#   CPU:  AMD Ryzen 5 3600 (6c/12t)
+#   RAM:  62 GiB, no swap
+#   Disk: 2x NVMe (~480 GiB each)
+#   Boot: legacy BIOS
+#
+# Layout: software RAID1 across both NVMes, ext4 root, no swap (bench host).
+# OS:     Ubuntu 24.04 LTS (Noble) amd64 base.
+
+DRIVE1 /dev/nvme0n1
+DRIVE2 /dev/nvme1n1
+
+SWRAID 1
+SWRAIDLEVEL 1
+
+BOOTLOADER grub
+
+HOSTNAME __BENCH_HOSTNAME__
+
+PART /boot ext4 1024M
+PART /     ext4 all
+
+IMAGE /root/.oldroot/nfs/install/../images/Ubuntu-2404-noble-amd64-base.tar.gz

--- a/scripts/bench/hetzner-postinstall.sh
+++ b/scripts/bench/hetzner-postinstall.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Runs inside the chroot of the freshly-installed Ubuntu before first boot.
+# Bake bench-host kernel/cpufreq tweaks into the installed system so they
+# survive reboots and don't have to be reapplied between bench runs.
+#
+# Tweaks (matches user choice during staging):
+#   1. nosmt           - kernel disables hyperthreading, leaving 6 physical
+#                        cores. Cleaner numbers, less variance.
+#   2. isolcpus=5      - reserve CPU 5 from the general scheduler. Plus
+#                        nohz_full=5 + rcu_nocbs=5 to also stop the
+#                        scheduler tick and offload RCU callbacks off
+#                        that core. Bench processes that want a quiet
+#                        core taskset themselves onto CPU 5 (currently
+#                        only iai_callgrind; criterion benches are
+#                        multi-threaded and don't pin).
+#   3. governor=perf   - systemd unit pins every CPU's scaling_governor to
+#                        `performance` on boot, eliminating freq scaling
+#                        jitter during runs.
+
+set -euo pipefail
+
+# CPU index to isolate. With nosmt active, the box has CPUs 0..5; reserving
+# the last one leaves 5 cores for the runner + system, which is plenty.
+# Keep in sync with WASMCLOUD_BENCH_ISOLATED_CPU in scripts/bench/run-bench.sh.
+ISOLATED_CPU=5
+
+# --- 1. nosmt + isolcpus via GRUB cmdline ------------------------------------
+# Hetzner ships /etc/default/grub.d/hetzner.cfg which *resets*
+# GRUB_CMDLINE_LINUX_DEFAULT="consoleblank=0" after /etc/default/grub is
+# sourced. Editing /etc/default/grub directly is therefore clobbered. Use
+# our own drop-in that sorts after the Hetzner one (zz-*) and appends.
+mkdir -p /etc/default/grub.d
+cat > /etc/default/grub.d/zz-bench.cfg <<GRUB
+# wasmCloud bench host: append the bench-time kernel tweaks.
+#   nosmt         - disable SMT/hyperthreading entirely.
+#   isolcpus      - remove CPU from general scheduler load-balancing.
+#   nohz_full     - stop the periodic scheduler tick on that CPU when
+#                   only one runnable task is on it (kills timer-driven
+#                   measurement jitter).
+#   rcu_nocbs     - offload RCU callbacks off that CPU to a kthread.
+GRUB_CMDLINE_LINUX_DEFAULT="\${GRUB_CMDLINE_LINUX_DEFAULT} nosmt isolcpus=${ISOLATED_CPU} nohz_full=${ISOLATED_CPU} rcu_nocbs=${ISOLATED_CPU}"
+GRUB
+update-grub
+
+# --- 2. governor=performance via systemd unit --------------------------------
+cat > /etc/systemd/system/cpu-performance.service <<'UNIT'
+[Unit]
+Description=Pin all CPUs to the performance scaling_governor (bench host)
+After=multi-user.target
+ConditionPathExists=/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c 'for g in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do echo performance > "$g"; done'
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl enable cpu-performance.service
+
+# --- 3. Marker so we can prove post-install ran on the box -------------------
+{
+  echo "wasmcloud-bench post-install"
+  echo "stamp: $(date -u +%FT%TZ)"
+  echo "kernel-tweak: nosmt isolcpus=${ISOLATED_CPU} nohz_full=${ISOLATED_CPU} rcu_nocbs=${ISOLATED_CPU}"
+  echo "cpufreq-governor: performance"
+  echo "isolated-cpu: ${ISOLATED_CPU}"
+} > /etc/wasmcloud-bench-stage

--- a/scripts/bench/install-runner.sh
+++ b/scripts/bench/install-runner.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Install a GitHub Actions self-hosted runner on the wasmCloud bench host.
+# Run once on the bench host as root.
+#
+#   sudo WASMCLOUD_BENCH_RUNNER_TOKEN=<TOKEN> bash scripts/bench/install-runner.sh \
+#     [--repo  wasmCloud/wasmCloud] \
+#     [--version 2.334.0]
+#
+# The registration token is one-shot. Get one from:
+#   GitHub Repo > Settings > Actions > Runners > New self-hosted runner
+# (tokens expire after ~1 hour and are consumed by config.sh).
+#
+# Pass via env (not CLI flag) so the value never appears in /proc/<pid>/cmdline.
+#
+# Effects:
+#   - creates a non-root `bench` user (no shell login by default; runner runs
+#     as bench via systemd)
+#   - installs AWS CLI v2 + zstd (needed by .github/scripts/bench-push-results.mjs)
+#   - installs rustup for the bench user (toolchain auto-installs on first
+#     build via the repo's rust-toolchain.toml)
+#   - downloads + verifies + extracts actions-runner to /opt/actions-runner
+#   - configures the runner with labels: self-hosted,bench,hetzner
+#   - registers a systemd service `actions.runner.<owner>-<repo>.bench-host`
+#     that starts on boot
+#   - creates /var/lib/bench/target with bench: ownership for $CARGO_TARGET_DIR
+#
+# Idempotency: if the runner directory already exists, the script bails and
+# tells you to remove it first. Re-registration requires a fresh token.
+
+set -euo pipefail
+
+REPO="wasmCloud/wasmCloud"
+RUNNER_VERSION="2.334.0"
+# Default to the actual hostname of the box (set by installimage). Override with
+# --name if needed. No hardcoded value here — the box's identity isn't in the repo.
+RUNNER_NAME="$(hostname)"
+LABELS="self-hosted,bench,hetzner"
+RUNNER_DIR="/opt/actions-runner"
+WORK_DIR="/var/lib/bench/work"
+TARGET_DIR="/var/lib/bench/target"
+
+# SHA256 of actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz, copied from
+# https://github.com/actions/runner/releases/tag/v${RUNNER_VERSION}. Bump
+# both `RUNNER_VERSION` and this constant together.
+RUNNER_SHA256="048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271"
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)    REPO="$2"; shift 2 ;;
+    --version) RUNNER_VERSION="$2"; shift 2 ;;
+    --name)    RUNNER_NAME="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *)         echo "unknown arg: $1" >&2; usage 2 ;;
+  esac
+done
+
+[ "$(id -u)" -eq 0 ]                     || { echo "must run as root"; exit 1; }
+[ -n "${WASMCLOUD_BENCH_RUNNER_TOKEN:-}" ]         || { echo "WASMCLOUD_BENCH_RUNNER_TOKEN env var required"; exit 1; }
+[ ! -d "$RUNNER_DIR" ]                   || { echo "$RUNNER_DIR already exists; remove + re-run with a fresh token"; exit 1; }
+
+step() { printf '\n=== %s ===\n' "$*"; }
+
+step "create bench user"
+if ! id bench >/dev/null 2>&1; then
+  useradd --system --create-home --home-dir /var/lib/bench --shell /usr/sbin/nologin bench
+fi
+mkdir -p "$WORK_DIR" "$TARGET_DIR"
+chown -R bench:bench /var/lib/bench
+
+step "install AWS CLI v2 + zstd"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y --no-install-recommends unzip zstd ca-certificates curl
+if ! command -v aws >/dev/null 2>&1 || ! aws --version 2>&1 | grep -q '^aws-cli/2'; then
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  arch=$(uname -m)   # x86_64 → x86_64; aarch64 → aarch64
+  curl -fL "https://awscli.amazonaws.com/awscli-exe-linux-${arch}.zip" -o "$tmp/awscliv2.zip"
+  unzip -q "$tmp/awscliv2.zip" -d "$tmp"
+  "$tmp/aws/install" --update >/dev/null
+  trap - EXIT; rm -rf "$tmp"
+fi
+aws --version
+
+step "install rustup for the bench user"
+# The runner runs as `bench`, so it needs its own cargo. Default to `stable`
+# so out-of-tree `cargo install` invocations (e.g. iai-callgrind-runner
+# below) have something to pick. Inside the wasmCloud workspace the
+# repo's rust-toolchain.toml still wins — it also pins `stable` today,
+# so there's no drift between the default and the workspace toolchain.
+if [ ! -x /var/lib/bench/.cargo/bin/cargo ]; then
+  sudo -u bench -H bash -c '
+    curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain stable --no-modify-path
+  '
+fi
+# Idempotent post-condition for the "rustup is installed but had no
+# default toolchain" case (earlier versions of this script installed
+# with `--default-toolchain none`). `rustup default stable` is a no-op
+# when stable is already the default; downloads + sets it otherwise.
+sudo -u bench -H bash -c '. $HOME/.cargo/env && rustup default stable && rustup --version'
+
+step "install iai-callgrind-runner for the bench user"
+# Required by the iai_callgrind bench. Version must equal the iai-callgrind
+# crate version pinned in crates/wash-runtime/Cargo.toml — iai-callgrind
+# enforces equality at run time.
+sudo -u bench -H bash -c '
+  . $HOME/.cargo/env
+  if ! command -v iai-callgrind-runner >/dev/null 2>&1 \
+       || [ "$(iai-callgrind-runner --version 2>/dev/null | awk "{print \$2}")" != "0.16.1" ]; then
+    cargo install iai-callgrind-runner --version 0.16.1
+  fi
+  iai-callgrind-runner --version
+'
+
+step "download + verify + extract actions-runner v${RUNNER_VERSION}"
+mkdir -p "$RUNNER_DIR"
+chown bench:bench "$RUNNER_DIR"
+tarball="$RUNNER_DIR/runner.tgz"
+url="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+sudo -u bench bash -c "curl -fL -o '$tarball' '$url'"
+echo "${RUNNER_SHA256}  ${tarball}" | sha256sum -c -
+sudo -u bench bash -c "cd '$RUNNER_DIR' && tar xzf runner.tgz && rm runner.tgz"
+
+step "configure runner (registers with GitHub)"
+# Token via env so it never lands in /proc/<pid>/cmdline. The values are
+# already exported in this shell — `sudo --preserve-env=VAR1,VAR2,...`
+# carries them through into the target user's environment regardless of
+# how the host's sudoers is configured (the `sudo VAR=value cmd` form
+# only works when the `setenv` Defaults flag is set, which is true on
+# stock Ubuntu but not guaranteed on hardened images).
+export WASMCLOUD_BENCH_RUNNER_TOKEN WASMCLOUD_BENCH_REPO="$REPO" \
+       WASMCLOUD_BENCH_NAME="$RUNNER_NAME" \
+       WASMCLOUD_BENCH_LABELS="$LABELS" \
+       WASMCLOUD_BENCH_WORK="$WORK_DIR"
+sudo --preserve-env=WASMCLOUD_BENCH_RUNNER_TOKEN,WASMCLOUD_BENCH_REPO,WASMCLOUD_BENCH_NAME,WASMCLOUD_BENCH_LABELS,WASMCLOUD_BENCH_WORK \
+     -u bench bash -c '
+  cd /opt/actions-runner && ./config.sh \
+    --unattended \
+    --replace \
+    --url "https://github.com/${WASMCLOUD_BENCH_REPO}" \
+    --token "${WASMCLOUD_BENCH_RUNNER_TOKEN}" \
+    --name "${WASMCLOUD_BENCH_NAME}" \
+    --labels "${WASMCLOUD_BENCH_LABELS}" \
+    --work "${WASMCLOUD_BENCH_WORK}"
+'
+
+step "install + start systemd service"
+cd "$RUNNER_DIR"
+./svc.sh install bench
+./svc.sh start
+./svc.sh status | head -20
+
+cat <<EOM
+
+Runner registered:
+  repo:    ${REPO}
+  name:    ${RUNNER_NAME}
+  labels:  ${LABELS}
+  workdir: ${WORK_DIR}
+  target:  ${TARGET_DIR}
+
+Confirm in GitHub: Settings > Actions > Runners (the new runner should
+appear as Idle within a few seconds).
+
+Trigger a run from: Actions > bench > Run workflow.
+EOM

--- a/scripts/bench/op-env.sh
+++ b/scripts/bench/op-env.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Fetch the wasmCloud bench-host values from 1Password and export them into
+# the current shell. Source me, don't execute me:
+#
+#   source scripts/bench/op-env.sh
+#
+# After sourcing, these are exported:
+#
+#   WASMCLOUD_BENCH_HOST_IP    public IPv4 — consumed by the Ansible inventory and
+#                    every shell script in this directory
+#   WASMCLOUD_BENCH_HOSTNAME   the box's hostname (matches bench-preflight.mjs's assertion)
+#   WASMCLOUD_BENCH_HOST_IPV6  (optional) public IPv6, if stored on the item
+#
+# 1Password item name defaults to `WASMCLOUD_BENCH_BOX`. Override with:
+#
+#   WASMCLOUD_BENCH_OP_ITEM=<other-item-name> source scripts/bench/op-env.sh
+#
+# Vault is auto-detected (default vault). Pass `--vault <name>` via
+# WASMCLOUD_BENCH_OP_ARGS if you need a specific one:
+#
+#   WASMCLOUD_BENCH_OP_ARGS="--vault Personal" source scripts/bench/op-env.sh
+#
+# Requirements:
+#   - 1Password CLI v2+ (`brew install --cask 1password-cli`)
+#   - Signed in: either `eval $(op signin)` or biometric integration enabled
+#     in the desktop app under Settings → Developer
+#
+# The 1Password item must carry at least these fields (case-sensitive):
+#   WASMCLOUD_BENCH_HOST_IP, WASMCLOUD_BENCH_HOSTNAME, WASMCLOUD_BENCH_HOST_IPV6 (optional)
+
+# Detect that we're being sourced, not executed — we use `return` not `exit`
+# so a failure doesn't kill the caller's shell. `return` only works inside
+# a sourced script or a function.
+if ! (return 0 2>/dev/null); then
+  echo "op-env.sh: source me, don't execute me." >&2
+  echo "  source scripts/bench/op-env.sh" >&2
+  exit 1
+fi
+
+_op_env_item="${WASMCLOUD_BENCH_OP_ITEM:-WASMCLOUD_BENCH_BOX}"
+# shellcheck disable=SC2206  # intentional word-split for op CLI args
+_op_env_args=( ${WASMCLOUD_BENCH_OP_ARGS:-} )
+
+if ! command -v op >/dev/null 2>&1; then
+  echo "op-env.sh: 1Password CLI (op) not installed." >&2
+  echo "  brew install --cask 1password-cli" >&2
+  unset _op_env_item _op_env_args
+  return 1
+fi
+
+# `op whoami` exits non-zero if there's no active session. The check is
+# cheap and gives a clearer error than letting `op item get` blow up later.
+if ! op whoami >/dev/null 2>&1; then
+  echo "op-env.sh: not signed in to 1Password CLI." >&2
+  echo "  - GUI integration: 1Password app → Settings → Developer →" >&2
+  echo "                     'Integrate with 1Password CLI' (biometric)" >&2
+  echo "  - Or shell signin: eval \$(op signin)" >&2
+  unset _op_env_item _op_env_args
+  return 1
+fi
+
+# --reveal forces op to print the field's actual value rather than the
+# masked placeholder it shows in interactive output. Required for use as
+# an env var.
+_op_env_get() {
+  op item get "$_op_env_item" "${_op_env_args[@]}" --field "$1" --reveal 2>/dev/null
+}
+
+_ip=$(_op_env_get WASMCLOUD_BENCH_HOST_IP) || true
+_hostname=$(_op_env_get WASMCLOUD_BENCH_HOSTNAME) || true
+_ipv6=$(_op_env_get WASMCLOUD_BENCH_HOST_IPV6) || true
+
+if [ -z "$_ip" ] || [ -z "$_hostname" ]; then
+  echo "op-env.sh: required fields missing from 1Password item '$_op_env_item'." >&2
+  [ -z "$_ip" ]       && echo "  - WASMCLOUD_BENCH_HOST_IP    (missing or empty)" >&2
+  [ -z "$_hostname" ] && echo "  - WASMCLOUD_BENCH_HOSTNAME   (missing or empty)" >&2
+  echo >&2
+  echo "Edit the item in 1Password to add them, or override the item name with:" >&2
+  echo "  WASMCLOUD_BENCH_OP_ITEM=<name> source scripts/bench/op-env.sh" >&2
+  unset _op_env_item _op_env_args _op_env_get _ip _hostname _ipv6
+  return 1
+fi
+
+export WASMCLOUD_BENCH_HOST_IP="$_ip"
+export WASMCLOUD_BENCH_HOSTNAME="$_hostname"
+if [ -n "$_ipv6" ]; then
+  export WASMCLOUD_BENCH_HOST_IPV6="$_ipv6"
+fi
+
+echo "op-env.sh: exported WASMCLOUD_BENCH_HOST_IP=${_ip}, WASMCLOUD_BENCH_HOSTNAME=${_hostname}${_ipv6:+, WASMCLOUD_BENCH_HOST_IPV6=${_ipv6}}" >&2
+echo "           (source: 1Password item '$_op_env_item')" >&2
+
+unset _op_env_item _op_env_args _op_env_get _ip _hostname _ipv6

--- a/scripts/bench/run-bench.sh
+++ b/scripts/bench/run-bench.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Run a single bench from crates/wash-runtime/benches/. Captures the full
+# bench output to a log file under $CARGO_TARGET_DIR so bench-push-results.mjs can
+# archive it next to the bench data.
+#
+# Two harness types share this script:
+#   - criterion benches (http_invoke, wasmtime_baseline, wasmtime_serve)
+#     write to $CARGO_TARGET_DIR/criterion/.
+#   - iai-callgrind benches (iai_callgrind) write to $CARGO_TARGET_DIR/iai/
+#     and are pinned to the isolated CPU (set by hetzner-postinstall.sh
+#     via isolcpus=) so that scheduler interference doesn't leak into
+#     instruction counts. valgrind serializes threads, so single-core
+#     pinning doesn't hurt throughput.
+#
+# Side effects:
+#   - Creates $CARGO_TARGET_DIR/.bench-start-${bench} (mtime marker).
+#     `bench-tools jsonl` filters by `-newer` against this marker so
+#     stale data from previous runs of *other* benches isn't emitted as
+#     the current bench (otherwise the persistent target dir leaks across
+#     bench types).
+
+set -euo pipefail
+
+# Bench name validation lives in the workflow_dispatch `choice` input
+# (see .github/workflows/bench.yml). cargo bench will surface a clear
+# "no bench target named X" error if anything else is passed, so we
+# avoid maintaining the bench list in two places.
+bench="${1:?bench name required}"
+
+# shellcheck disable=SC1091
+. "$HOME/.cargo/env"
+
+: "${CARGO_TARGET_DIR:=/var/lib/bench/target}"
+mkdir -p "$CARGO_TARGET_DIR"
+
+# CPU index reserved by isolcpus= in hetzner-postinstall.sh. Must match.
+# Override with WASMCLOUD_BENCH_ISOLATED_CPU= for hosts staged differently.
+isolated_cpu="${WASMCLOUD_BENCH_ISOLATED_CPU:-5}"
+
+# Marker for this run; `bench-tools jsonl` uses it as the `find -newer`
+# reference so stale data from prior runs of other benches isn't picked up.
+marker="${CARGO_TARGET_DIR}/.bench-start-${bench}"
+
+log="${CARGO_TARGET_DIR}/run-${bench}-${GITHUB_RUN_ID:-local}.log"
+{
+  echo "=== run-bench: ${bench} ==="
+  echo "host:   $(hostname)"
+  echo "kernel: $(uname -srm)"
+  echo "cpu:    $(awk -F: '/^model name/{print $2; exit}' /proc/cpuinfo | sed 's/^ //')"
+  echo "online: $(nproc) cpu(s)"
+  echo "git:    $(git rev-parse HEAD)"
+  echo "ref:    ${GITHUB_REF_NAME:-?}"
+  echo "ts:     $(date -u +%FT%TZ)"
+  echo
+} | tee "$log"
+
+# Wipe per-bench measurement dirs before the run. Stale data here would
+# otherwise leak across benches because the dir at $CARGO_TARGET_DIR is
+# persistent (kept for the *build* cache, not the measurement output).
+# The build cache lives elsewhere in $CARGO_TARGET_DIR and is preserved.
+# Both criterion and iai keep "previous run" baseline data we don't use.
+rm -rf "${CARGO_TARGET_DIR}/criterion" "${CARGO_TARGET_DIR}/iai"
+
+# Touch the run marker right before invoking cargo so `find -newer "$marker"`
+# in `bench-tools jsonl` picks up exactly the files this run produced.
+# Belt-and-suspenders with the wipe above: if the wipe is skipped (e.g.,
+# manual partial run), the marker still bounds what gets emitted.
+touch "$marker"
+
+# iai_callgrind: pin to the isolated CPU. The criterion-style benches are
+# multi-threaded (tokio + hyper) and would lose throughput under taskset,
+# so they run unpinned across the non-isolated cores.
+prefix=()
+if [ "$bench" = "iai_callgrind" ]; then
+  if [ -x "$(command -v taskset)" ]; then
+    prefix=(taskset -c "$isolated_cpu")
+    echo "pinning $bench to CPU $isolated_cpu via taskset" | tee -a "$log"
+  else
+    echo "::warning::taskset not installed; running $bench unpinned" | tee -a "$log"
+  fi
+fi
+
+"${prefix[@]}" cargo bench -p wash-runtime --features wasip3 --bench "$bench" 2>&1 \
+  | tee -a "$log"
+
+echo "WASMCLOUD_BENCH_LOG=${log}" >> "${GITHUB_OUTPUT:-/dev/null}"
+echo "WASMCLOUD_BENCH_MARKER=${marker}" >> "${GITHUB_OUTPUT:-/dev/null}"
+echo "log: $log"

--- a/scripts/bench/stage-hetzner.sh
+++ b/scripts/bench/stage-hetzner.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Stage the wasmCloud bench server: install Ubuntu 24.04 onto the raw NVMes
+# via Hetzner installimage, then reboot.
+#
+# Prereqs:
+#   - Server booted into Hetzner rescue and reachable as root
+#   - ~/.ssh/hetzner_bench keypair exists and is authorized in rescue
+#   - Host keys pinned in ~/.ssh/known_hosts
+#
+# This script is destructive: installimage WIPES both /dev/nvme0n1 and
+# /dev/nvme1n1. There is a final confirmation prompt.
+#
+# After reboot:
+#   - Hetzner regenerates SSH host keys, so the rescue fingerprints in
+#     ~/.ssh/known_hosts will not match. Refresh them, then run the
+#     Ansible playbook (scripts/bench/ansible/provision.yml).
+
+set -euo pipefail
+
+# WASMCLOUD_BENCH_HOST_IP and WASMCLOUD_BENCH_HOSTNAME are read from the operator's environment
+# — they are kept out of the repo. Populate from 1Password via:
+#   source scripts/bench/op-env.sh    (item: WASMCLOUD_BENCH_BOX)
+: "${WASMCLOUD_BENCH_HOST_IP:?WASMCLOUD_BENCH_HOST_IP not set — source scripts/bench/op-env.sh first}"
+: "${WASMCLOUD_BENCH_HOSTNAME:?WASMCLOUD_BENCH_HOSTNAME not set — source scripts/bench/op-env.sh first}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/hetzner_bench}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ssh_opts=(-i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=15)
+ssh_cmd() { ssh "${ssh_opts[@]}" "root@${WASMCLOUD_BENCH_HOST_IP}" "$@"; }
+scp_cmd() { scp "${ssh_opts[@]}" "$@"; }
+
+step() { printf '\n=== %s ===\n' "$*"; }
+
+step "Sanity: server must be in Hetzner rescue"
+hn=$(ssh_cmd 'hostname')
+if [ "$hn" != "rescue" ]; then
+  echo "hostname is '$hn', expected 'rescue'." >&2
+  echo "Re-arm rescue mode in Hetzner Robot, reboot, then re-run." >&2
+  exit 1
+fi
+
+step "Copy autosetup + post-install hook to rescue"
+# Render hetzner-autosetup.cfg.tmpl with the operator-provided hostname;
+# the .tmpl file is committed, the rendered config is generated on demand
+# and lives only on the rescue system. This keeps the actual hostname out
+# of the repo (defense-in-depth — see scripts/bench/README.md §1).
+tmpcfg=$(mktemp)
+trap 'rm -f "$tmpcfg"' EXIT
+sed "s/__BENCH_HOSTNAME__/${WASMCLOUD_BENCH_HOSTNAME}/g" \
+    "${SCRIPT_DIR}/hetzner-autosetup.cfg.tmpl" > "$tmpcfg"
+scp_cmd "$tmpcfg" "root@${WASMCLOUD_BENCH_HOST_IP}:/autosetup"
+scp_cmd "${SCRIPT_DIR}/hetzner-postinstall.sh" "root@${WASMCLOUD_BENCH_HOST_IP}:/tmp/postinstall.sh"
+ssh_cmd 'chmod +x /tmp/postinstall.sh'
+
+step "About to run installimage — this will WIPE both NVMes"
+ssh_cmd 'lsblk -o NAME,SIZE,TYPE,FSTYPE | grep -E "^nvme"'
+read -rp "Type WIPE to proceed: " ans
+[ "$ans" = "WIPE" ] || { echo "Aborted."; exit 1; }
+
+step "Running installimage"
+# -a   auto / batch
+# -c   config
+# -x   post-install hook (runs in chroot)
+ssh_cmd '/root/.oldroot/nfs/install/installimage -a -c /autosetup -x /tmp/postinstall.sh'
+
+step "Reboot into installed OS"
+# `reboot` will close the SSH connection; ignore the resulting error.
+ssh_cmd 'reboot' || true
+
+cat <<EOM
+
+Box is rebooting. Once it's back (~2-3 minutes):
+
+  1. Refresh host keys (installimage regenerated them):
+       ssh-keygen -R ${WASMCLOUD_BENCH_HOST_IP}
+       ssh-keyscan -t rsa,ecdsa,ed25519 ${WASMCLOUD_BENCH_HOST_IP} >> ~/.ssh/known_hosts
+
+  2. Confirm key auth still works (your authorized_keys was carried over):
+       ssh -i ${SSH_KEY} root@${WASMCLOUD_BENCH_HOST_IP} 'hostname; uname -srm'
+
+  3. Run provisioning (from this checkout):
+       cd ${SCRIPT_DIR}/ansible && ansible-playbook provision.yml
+EOM


### PR DESCRIPTION
## Summary

Stand up the wash-runtime benchmarking pipeline end-to-end: a dedicated Hetzner bench host, deterministic instruction-count benches in addition to the existing wall-clock ones, and a GitHub-driven workflow that publishes a self-updating trend timeline for wasmCloud/arewefastyet.

Three commits on top of `main`:

- `feat: add iai-callgrind bench and bench-tools crate`: adds the deterministic CPU-instruction bench (less immune to runner noise) plus an internal Rust CLI that parses criterion + iai output into the pipeline's JSONL / step-summary / comparison-delta formats
- `feat: bench host provisioning scripts`: operator-side automation from Hetzner rescue → ready-to-register runner. Two phases (installimage chroot + Ansible playbook), an idempotent runner installer, AWS bootstrap one-shot, and a 1Password env helper
- `ci: bench pipeline and trend-tracking workflows`: the three workflows (trends pipeline, pair-bench compare, monthly upstream version check), three plain-ESM `.mjs` scripts in `.github/scripts/`, the runbook at `scripts/bench/README.md`, CODEOWNERS, and the actionlint config for the self-hosted runner labels

Sensitive host identity (IP / IPv6 / hostname) stays in 1Password and is templated everywhere in the repo as `<WASMCLOUD_BENCH_*>`. AWS identifiers flow through repo secrets / OIDC; no credentials touch the bench host.

## Test plan

- [x] `cargo test -p bench-tools` passes locally
- [x] `cargo bench -p wash-runtime --features wasip3 --bench iai_callgrind --no-run` compiles
- [x] `ansible-playbook scripts/bench/ansible/provision.yml --check` is clean (or only shows kernel-cmdline drift)
- [ ] After merge: dispatch `bench` for `http_invoke` against `main` — verify step summary renders, S3 artifacts upload, `history.json` updates, CloudFront invalidation fires
- [ ] Dispatch `bench` for `iai_callgrind` — verify the iai instruction-count row lands in `history.json` alongside the criterion row (same `(bench, group, param)`, different `metric`)
- [ ] Dispatch `bench-compare` with `ref_a=main`, `ref_b=<this PR's head sha>` for `iai_callgrind` — verify delta table renders in the step summary
- [ ] First scheduled `bench-host-checks` run (or `workflow_dispatch`) — verify a tracking issue opens if pinned `RUNNER_VERSION` is behind upstream, and auto-closes after the bump
