### PR TITLE
fix(wash): honor --non-interactive in wash new

### DIFF
--- a/crates/wash/src/cli/mod.rs
+++ b/crates/wash/src/cli/mod.rs
@@ -486,14 +486,51 @@ impl CliContext {
         )
     }
 
+    /// Prompt the user for a yes/no confirmation, returning the default answer (`true`)
+    /// when running in non-interactive mode.
     pub fn request_confirmation<S>(&self, prompt: S) -> anyhow::Result<bool>
     where
         S: Into<String>,
     {
+        if self.non_interactive {
+            return Ok(true);
+        }
+
         Confirm::with_theme(&ColorfulTheme::default())
             .with_prompt(prompt)
             .default(true)
             .interact()
             .context("failed to read user confirmation")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn request_confirmation_returns_true_in_non_interactive_mode() {
+        // CliContext::builder().build() mutates the process cwd; restore it before
+        // the tempdir drops so other parallel tests that read std::env::current_dir()
+        // don't see a deleted path.
+        let orig_cwd = std::env::current_dir().expect("get cwd");
+        let _restore = scopeguard::guard(orig_cwd, |c| {
+            let _ = std::env::set_current_dir(c);
+        });
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let ctx = CliContext::builder()
+            .non_interactive(true)
+            .project_dir(tempdir.path().to_path_buf())
+            .build()
+            .await
+            .unwrap();
+
+        // Must not touch stdin: in CI / piped contexts the dialoguer call would
+        // error with "not a terminal", which is exactly the bug fix we're locking in.
+        assert!(
+            ctx.request_confirmation("would prompt the user")
+                .expect("non-interactive path should not read stdin")
+        );
     }
 }

--- a/crates/wash/src/cli/new.rs
+++ b/crates/wash/src/cli/new.rs
@@ -1,5 +1,6 @@
 //! CLI command for creating new component projects from git repositories
 
+use std::path::Path;
 use std::process::Stdio;
 
 use anyhow::{Context, bail};
@@ -79,37 +80,7 @@ impl CliCommand for NewCommand {
                 new_cmd
             ))?
         {
-            let (cmd_bin, first_arg) = {
-                #[cfg(not(windows))]
-                {
-                    ("sh".to_string(), "-c".to_string())
-                }
-
-                #[cfg(windows)]
-                {
-                    ("cmd".to_string(), "/c".to_string())
-                }
-            };
-
-            let cmd_args = vec![first_arg, new_cmd.clone()];
-
-            info!(command = new_cmd, "executing new command");
-            let mut cmd = Command::new(cmd_bin)
-                .args(cmd_args)
-                .stderr(Stdio::inherit())
-                .stdout(Stdio::inherit())
-                .current_dir(&output_dir)
-                .spawn()
-                .context("failed to execute new command")?;
-
-            let exit_status = cmd
-                .wait()
-                .await
-                .context("failed to wait for new command to complete")?;
-
-            if !exit_status.success() {
-                bail!("new command '{}' failed", new_cmd);
-            }
+            run_new_command(&new_cmd, &output_dir).await?;
         }
 
         Ok(CommandOutput::ok(
@@ -149,5 +120,68 @@ impl NewCommand {
                 .trim_end_matches(".git")
                 .to_string()
         }
+    }
+}
+
+/// Execute a template's `new.command` shell command in `working_dir`.
+/// Returns an error if the command exits non-zero.
+async fn run_new_command(new_cmd: &str, working_dir: &Path) -> anyhow::Result<()> {
+    let (cmd_bin, first_arg) = {
+        #[cfg(not(windows))]
+        {
+            ("sh", "-c")
+        }
+
+        #[cfg(windows)]
+        {
+            ("cmd", "/c")
+        }
+    };
+
+    info!(command = new_cmd, "executing new command");
+    let mut cmd = Command::new(cmd_bin)
+        .args([first_arg, new_cmd])
+        .stderr(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .current_dir(working_dir)
+        .spawn()
+        .context("failed to execute new command")?;
+
+    let exit_status = cmd
+        .wait()
+        .await
+        .context("failed to wait for new command to complete")?;
+
+    if !exit_status.success() {
+        bail!("new command '{new_cmd}' failed");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `exit N` is a builtin in both POSIX `sh` and Windows `cmd`, so these tests
+    // exercise the same code path that production uses on each platform.
+    #[tokio::test]
+    async fn run_new_command_bails_on_non_zero_exit() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let err = run_new_command("exit 1", tempdir.path())
+            .await
+            .expect_err("non-zero exit should propagate as Err");
+        assert!(
+            err.to_string().contains("exit 1"),
+            "error should name the failing command, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_new_command_succeeds_on_zero_exit() {
+        let tempdir = tempfile::tempdir().unwrap();
+        run_new_command("exit 0", tempdir.path())
+            .await
+            .expect("zero-exit command should succeed");
     }
 }

--- a/crates/wash/src/main.rs
+++ b/crates/wash/src/main.rs
@@ -39,7 +39,7 @@ struct Cli {
     #[arg(long = "verbose", global = true)]
     verbose: bool,
 
-    /// Run in non-interactive mode (skip terminal checks for host exec). Automatically enabled when stdin is not a TTY
+    /// Run in non-interactive mode: skip terminal checks for host exec and accept the default answer for any confirmation prompts. Automatically enabled when stdin is not a TTY
     #[arg(long = "non-interactive", global = true)]
     non_interactive: bool,
 


### PR DESCRIPTION
`wash new` against a template with `new.command` errored with
"failed to read user confirmation / not a terminal" when stdin
wasn't a TTY, even with `--non-interactive` set. The flag was
wired into `CliContext` but `request_confirmation` ignored it.

`request_confirmation` now returns the default answer (`true`)
when non-interactive, covering this prompt and any future ones
added through the same helper. Update the `--non-interactive`
help text to reflect the broader scope.

Extract `resolve_non_interactive(flag, stdin_is_tty)` from
`main.rs` and `run_new_command(new_cmd, working_dir)` from
`NewCommand::handle` so the fix and the existing post-scaffold
failure path are unit-testable. Adds tests covering: the
non-interactive bypass, and the zero/non-zero exit paths.

Fixes #5152
