### PR TITLE
ci(security): harden composite actions, add cooldown

### DIFF
--- a/.github/actions/helm-publish/action.yaml
+++ b/.github/actions/helm-publish/action.yaml
@@ -62,8 +62,10 @@ runs:
         shell: bash
         env:
           CHART_PATH: ${{ format('charts/{0}', inputs.chart-name)}}
+          CHART_APP_VERSION: ${{ inputs.chart-app-version }}
+          CHART_VERSION: ${{ inputs.chart-version }}
         run: |
-          helm package --app-version "${{ inputs.chart-app-version }}" --version "${{ inputs.chart-version }}" ${{ env.CHART_PATH }} -d .helm-charts
+          helm package --app-version "${CHART_APP_VERSION}" --version "${CHART_VERSION}" "${CHART_PATH}" -d .helm-charts
 
       - name: Use Git version
         if: inputs.chart-app-version == '' && inputs.chart-version == ''
@@ -73,7 +75,7 @@ runs:
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo "VERSION=${VERSION}"
-          helm package --app-version "$VERSION" --version "$VERSION" ${{ env.CHART_PATH }} -d .helm-charts
+          helm package --app-version "$VERSION" --version "$VERSION" "${CHART_PATH}" -d .helm-charts
 
       - name: Publish
         shell: bash
@@ -84,5 +86,5 @@ runs:
             if [ -z "${chart:-}" ]; then
               break
             fi
-            helm push "${chart}" "${{ env.CHART_REMOTE }}"
+            helm push "${chart}" "${CHART_REMOTE}"
           done

--- a/.github/actions/lint-go/action.yaml
+++ b/.github/actions/lint-go/action.yaml
@@ -20,7 +20,7 @@ runs:
       working-directory: "${{ inputs.working-directory }}"
       run: "go mod tidy"
     - name: "Verify Go Mod Tidy"
-      uses: "wasmCloud/wasmCloud/.github/actions/no-diff@main"
+      uses: ./.github/actions/no-diff
       with:
         fixup-command: "go mod tidy"
     - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/actions/no-diff/action.yaml
+++ b/.github/actions/no-diff/action.yaml
@@ -21,9 +21,13 @@ runs:
   steps:
     - name: Verify No Diffs
       shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        FIXUP_COMMAND: ${{ inputs.fixup-command }}
+        REPO: ${{ github.repository }}
       run: |
         set -e
-        pushd "${GITHUB_WORKSPACE}/${{ inputs.path }}" || exit 1
+        pushd "${GITHUB_WORKSPACE}/${INPUT_PATH}" || exit 1
 
         # From: https://backreference.org/2009/12/23/how-to-match-newlines-in-sed/
         # This is to leverage this workaround:
@@ -46,21 +50,21 @@ runs:
         # Untracked (new) files
         if [[ $(git ls-files --others --exclude-standard) ]]; then
             for x in $(git ls-files --others --exclude-standard); do
-              echo "::error file=$x::Please run ${{ inputs.fixup-command }}.%0A$x"
+              echo "::error file=$x::Please run ${FIXUP_COMMAND}.%0A$x"
             done
-            echo "${{ github.repository }} has untracked files. Please run ${{ inputs.fixup-command }}."
+            echo "${REPO} has untracked files. Please run ${FIXUP_COMMAND}."
             exit 1
         fi
 
         # Modified files
         if [[ $(git diff-index --name-only HEAD --) ]]; then
             for x in $(git diff-index --name-only HEAD --); do
-              echo "::error file=$x::Please run ${{ inputs.fixup-command }}.%0A$(git diff $x | urlencode)"
+              echo "::error file=$x::Please run ${FIXUP_COMMAND}.%0A$(git diff "$x" | urlencode)"
             done
-            echo "${{ github.repository }} is incorrectly formatted. Please run ${{ inputs.fixup-command }}."
+            echo "${REPO} is incorrectly formatted. Please run ${FIXUP_COMMAND}."
             exit 1
         fi
-        echo "${{ github.repository }} is formatted correctly."
+        echo "${REPO} is formatted correctly."
         popd
     - name: Generate patch
       if: failure()

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,11 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       all-cargo:
         patterns:
@@ -33,6 +38,11 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       all-go:
         patterns:
@@ -51,6 +61,11 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       all-github-actions:
         patterns:
@@ -65,6 +80,11 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       all-docker:
         patterns:


### PR DESCRIPTION
Address the zizmor findings reported by code-scanning:

- no-diff, helm-publish: move inputs and github context out of inline
  expressions and into per-step env: blocks, then dereference as shell
  vars. Closes the template-injection alerts where a malicious caller
  input could be rendered as shell code rather than a string argument.
- dependabot.yml: add a cooldown block (default 7d, major 14d, minor 7d,
  patch 3d) to all four ecosystem entries to avoid landing freshly
  published releases. Security advisories bypass cooldown.
- lint-go: switch the in-tree no-diff invocation from
  wasmCloud/wasmCloud/.github/actions/no-diff@main to ./.github/actions/no-diff,
  matching the convention used elsewhere in the repo. Removes the
  unpinned-uses warning and ensures lint-go always runs against the
  in-tree action.
