### PR TITLE
ci(dependabot): semver fields not supported for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,9 +63,6 @@ updates:
     target-branch: "main"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
     groups:
       all-github-actions:
         patterns:
@@ -82,9 +79,6 @@ updates:
     target-branch: "main"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
     groups:
       all-docker:
         patterns:


### PR DESCRIPTION
Annoying matrix where you can't specify the semver fields for a handful of types:
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference\#configuration-of-cooldown
