### PR TITLE
CI for CodeQL, fix protoc install

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -30,13 +30,6 @@ inputs:
     description: "Install Zig and cargo-zigbuild for cross-compilation"
     required: false
     default: "false"
-  install-protoc:
-    description: >
-      Install protoc (protobuf-compiler) for crates whose build.rs calls
-      prost-build / tonic-build (e.g. wash-runtime). Linux and macOS only;
-      Windows callers should install protoc separately.
-    required: false
-    default: "false"
 
 runs:
   using: "composite"
@@ -88,23 +81,3 @@ runs:
     - name: Install wash CLI
       if: ${{ inputs.install-wash == 'true' }}
       uses: wasmcloud/setup-wash-action@47756fa211cc82f392c57e39504f43ef46fc0b3e # v2.1.0
-
-    - name: Install protoc
-      if: ${{ inputs.install-protoc == 'true' }}
-      shell: bash
-      run: |
-        set -euo pipefail
-        case "${RUNNER_OS}" in
-          Linux)
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends protobuf-compiler
-            ;;
-          macOS)
-            brew install protobuf
-            ;;
-          *)
-            echo "install-protoc is only supported on Linux and macOS runners (got ${RUNNER_OS:-unknown})" >&2
-            exit 1
-            ;;
-        esac
-        protoc --version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,13 @@ on:
     # per-commit fast-feedback layer.
     - cron: "0 9 * * 1"
   workflow_dispatch:
+  # Validate the analysis on PRs that touch the workflow itself or the
+  # setup-rust composite action it depends on — otherwise a breakage only
+  # surfaces on the weekly cron and we lose a week of coverage.
+  pull_request:
+    paths:
+      - ".github/workflows/codeql.yml"
+      - ".github/actions/setup-rust/**"
 
 permissions: read-all
 
@@ -26,20 +33,23 @@ jobs:
       security-events: write
       contents: read
       actions: read
-    env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/target
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
+      - name: Setup protoc
+        # wash-runtime's build.rs invokes prost-build / tonic-build, which
+        # needs protoc plus the well-known .proto includes on PATH. Matches
+        # the version pinned by wash.yml and examples.yml.
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "29.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
-        with:
-          # wash-runtime's build.rs invokes prost-build, so the workspace
-          # build below needs protoc on PATH.
-          install-protoc: "true"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
@@ -54,11 +64,16 @@ jobs:
           # default suite. Use security-extended to keep noise down on a
           # repo this size.
           queries: security-extended
-          # Reuse the same CARGO_TARGET_DIR for the extractor's internal cargo
-          # invocation so it picks up the proc-macro artifacts built below;
-          # without warm proc-macros, rust-analyzer fails to expand
-          # tracing::*, anyhow::*, and std macros like vec!/format!, which
-          # tanks the "calls with resolved target" quality metric.
+          # Point the extractor at cargo's default target dir (workspace
+          # root = ${{ github.workspace }}) so it picks up the proc-macro
+          # artifacts built below; without warm proc-macros, rust-analyzer
+          # fails to expand tracing::*, anyhow::*, and std macros like
+          # vec!/format!, which tanks the "calls with resolved target"
+          # quality metric. We deliberately do NOT set CARGO_TARGET_DIR as
+          # a job env: that env var propagates into any child `cargo build`
+          # invoked from a build script (e.g. wash-runtime's fixture
+          # builds), redirecting their outputs and breaking their
+          # post-build artifact lookups.
           config: |
             extraction:
               rust:


### PR DESCRIPTION
Basically reverting what I did in #5165 with an action that installs well-known .proto includes (google/protobuf/empty.proto, timestamp.proto, …). Just installing protoc is not enough TIL. We could install these via apt-get, but at this point I think it's worth the setup-action.

The Rust workspace build fails under CodeQL because wash-runtime's build.rs drives prost-build / tonic-build, which needs protoc on PATH and we depend on timestamp and empty protos.

Add a Setup protoc step using arduino/setup-protoc pinned to v29.x, matching wash.yml and examples.yml so all three workflows codegen with the same compiler. I wanted to see if we could avoid the setup-protoc step to reduce deps (also pulling from arduino for this surprised me).

Also add a pull_request paths filter so the analysis runs on PRs that touch the workflow or setup-rust.

Now that changes to this workflow actually trigger the workflow to run (sorry I thought it was already configured that way!) we bumped into another issue. ~~Converting to draft while I work through the rough edges in building our test fixtures.~~

