### PR TITLE
feat(runtime): support wasip3 cross-component streams via dynamic linker

### DIFF
--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -100,51 +100,77 @@ impl SharedCtx {
     }
 }
 
-pub struct AccessorActiveCtxGuard<'a> {
+/// RAII guard that points [`SharedCtx::active_ctx`] at a linked component for
+/// the duration of a cross-component call, restoring the previous component on
+/// drop.
+///
+/// TODO(concurrency): the single `active_ctx` slot with LIFO save/restore is
+/// only correct for *sequential* linked calls. `func_new_concurrent` allows
+/// several in flight on one shared store, and their save/restore interleaves —
+/// A sets B; C (concurrent) saves B, sets D; A restores B; C restores B — so
+/// the original ctx is lost and `active_ctx` is wrong even after both finish
+/// (and mid-flight, across awaits, it need not match the running call). The
+/// single-call fixtures issue one at a time so they don't exercise this; a real
+/// fix needs per-call ctx scoping rather than a shared slot. Tracked follow-up.
+pub(crate) struct AccessorActiveCtxGuard<'a> {
     accessor: &'a Accessor<SharedCtx>,
-    previous: Arc<str>,
+    previous_component_id: Arc<str>,
 }
 
 impl<'a> AccessorActiveCtxGuard<'a> {
-    pub fn new(accessor: &'a Accessor<SharedCtx>, id: &Arc<str>) -> wasmtime::Result<Self> {
-        let previous = accessor.with(|mut access| -> wasmtime::Result<_> {
-            let previous = access.data_mut().active_ctx.component_id.clone();
+    pub(crate) fn new(accessor: &'a Accessor<SharedCtx>, id: &Arc<str>) -> wasmtime::Result<Self> {
+        let previous_component_id = accessor.with(|mut access| -> wasmtime::Result<_> {
+            let previous_component_id = access.data_mut().active_ctx.component_id.clone();
             access.data_mut().set_active_ctx(id)?;
-            Ok(previous)
+            Ok(previous_component_id)
         })?;
 
-        Ok(Self { accessor, previous })
+        Ok(Self {
+            accessor,
+            previous_component_id,
+        })
     }
 }
 
 impl Drop for AccessorActiveCtxGuard<'_> {
     fn drop(&mut self) {
-        let _ = self
-            .accessor
-            .with(|mut access| access.data_mut().set_active_ctx(&self.previous));
+        let _ = self.accessor.with(|mut access| {
+            access
+                .data_mut()
+                .set_active_ctx(&self.previous_component_id)
+        });
     }
 }
 
-pub struct StoreActiveCtxGuard<'a> {
+pub(crate) struct StoreActiveCtxGuard<'a> {
     store: StoreContextMut<'a, SharedCtx>,
-    previous: Arc<str>,
+    previous_component_id: Arc<str>,
 }
 
 impl<'a> StoreActiveCtxGuard<'a> {
-    pub fn new(mut store: StoreContextMut<'a, SharedCtx>, id: &Arc<str>) -> wasmtime::Result<Self> {
-        let previous = store.data().active_ctx.component_id.clone();
+    pub(crate) fn new(
+        mut store: StoreContextMut<'a, SharedCtx>,
+        id: &Arc<str>,
+    ) -> wasmtime::Result<Self> {
+        let previous_component_id = store.data().active_ctx.component_id.clone();
         store.data_mut().set_active_ctx(id)?;
-        Ok(Self { store, previous })
+        Ok(Self {
+            store,
+            previous_component_id,
+        })
     }
 
-    pub fn store_mut(&mut self) -> &mut StoreContextMut<'a, SharedCtx> {
+    pub(crate) fn store_mut(&mut self) -> &mut StoreContextMut<'a, SharedCtx> {
         &mut self.store
     }
 }
 
 impl Drop for StoreActiveCtxGuard<'_> {
     fn drop(&mut self) {
-        let _ = self.store.data_mut().set_active_ctx(&self.previous);
+        let _ = self
+            .store
+            .data_mut()
+            .set_active_ctx(&self.previous_component_id);
     }
 }
 
@@ -192,7 +218,7 @@ pub struct Ctx {
     /// Unique identifier for this component context. This is a [uuid::Uuid::new_v4] string.
     pub id: Arc<str>,
     /// Unique identifier shared by all component contexts in the same store.
-    pub store_id: String,
+    pub store_id: Arc<str>,
     /// The unique identifier for the workload component this instance belongs to
     pub component_id: Arc<str>,
     /// The unique identifier for the workload this component belongs to
@@ -407,7 +433,7 @@ impl wasmtime_wasi_http::p3::WasiHttpHooks for CtxHttpHooksP3 {
 /// Helper struct to build a [`Ctx`] with a builder pattern
 pub struct CtxBuilder {
     id: Arc<str>,
-    store_id: String,
+    store_id: Arc<str>,
     workload_id: Arc<str>,
     component_id: Arc<str>,
     ctx: Option<WasiCtx>,
@@ -424,7 +450,7 @@ impl CtxBuilder {
     pub fn new(workload_id: impl Into<Arc<str>>, component_id: impl Into<Arc<str>>) -> Self {
         Self {
             id: uuid::Uuid::new_v4().to_string().into(),
-            store_id: uuid::Uuid::new_v4().to_string(),
+            store_id: uuid::Uuid::new_v4().to_string().into(),
             component_id: component_id.into(),
             workload_id: workload_id.into(),
             ctx: None,

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -138,6 +138,8 @@ impl<'a> DerefMut for ActiveCtx<'a> {
 pub struct Ctx {
     /// Unique identifier for this component context. This is a [uuid::Uuid::new_v4] string.
     pub id: Arc<str>,
+    /// Unique identifier shared by all component contexts in the same store.
+    pub store_id: String,
     /// The unique identifier for the workload component this instance belongs to
     pub component_id: Arc<str>,
     /// The unique identifier for the workload this component belongs to
@@ -352,6 +354,7 @@ impl wasmtime_wasi_http::p3::WasiHttpHooks for CtxHttpHooksP3 {
 /// Helper struct to build a [`Ctx`] with a builder pattern
 pub struct CtxBuilder {
     id: Arc<str>,
+    store_id: String,
     workload_id: Arc<str>,
     component_id: Arc<str>,
     ctx: Option<WasiCtx>,
@@ -368,6 +371,7 @@ impl CtxBuilder {
     pub fn new(workload_id: impl Into<Arc<str>>, component_id: impl Into<Arc<str>>) -> Self {
         Self {
             id: uuid::Uuid::new_v4().to_string().into(),
+            store_id: uuid::Uuid::new_v4().to_string(),
             component_id: component_id.into(),
             workload_id: workload_id.into(),
             ctx: None,
@@ -444,6 +448,7 @@ impl CtxBuilder {
 
         Ctx {
             id: self.id,
+            store_id: self.store_id,
             ctx: self.ctx.unwrap_or_else(|| {
                 WasiCtxBuilder::new()
                     .args(&["main.wasm"])

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -11,7 +11,8 @@ use std::{
     sync::Arc,
 };
 
-use wasmtime::component::ResourceTable;
+use wasmtime::StoreContextMut;
+use wasmtime::component::{Accessor, Instance, ResourceTable};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wasi_http::WasiHttpCtx;
 use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpHooks, WasiHttpView};
@@ -67,6 +68,15 @@ pub struct SharedCtx {
     pub table: wasmtime::component::ResourceTable,
     /// Contexts for linked components
     pub contexts: HashMap<Arc<str>, Ctx>,
+    /// Pre-instantiated linked-component instances, keyed by component id.
+    ///
+    /// Owned by the store: every store created by the workload's store factory
+    /// is born with its linked components instantiated here, and they are
+    /// reclaimed automatically when the store is dropped (no external cache,
+    /// guards, or completion hooks). The concurrent cross-component call path
+    /// reads from here under `accessor.with`, where it cannot instantiate on
+    /// demand.
+    pub exporter_instances: HashMap<Arc<str>, Instance>,
 }
 
 impl SharedCtx {
@@ -75,6 +85,7 @@ impl SharedCtx {
             active_ctx: context,
             table: ResourceTable::new(),
             contexts: Default::default(),
+            exporter_instances: Default::default(),
         }
     }
 
@@ -92,6 +103,54 @@ impl SharedCtx {
                 "Context for component {id} not found"
             ))
         }
+    }
+}
+
+pub struct AccessorActiveCtxGuard<'a> {
+    accessor: &'a Accessor<SharedCtx>,
+    previous: Arc<str>,
+}
+
+impl<'a> AccessorActiveCtxGuard<'a> {
+    pub fn new(accessor: &'a Accessor<SharedCtx>, id: &Arc<str>) -> wasmtime::Result<Self> {
+        let previous = accessor.with(|mut access| -> wasmtime::Result<_> {
+            let previous = access.data_mut().active_ctx.component_id.clone();
+            access.data_mut().set_active_ctx(id)?;
+            Ok(previous)
+        })?;
+
+        Ok(Self { accessor, previous })
+    }
+}
+
+impl Drop for AccessorActiveCtxGuard<'_> {
+    fn drop(&mut self) {
+        let _ = self
+            .accessor
+            .with(|mut access| access.data_mut().set_active_ctx(&self.previous));
+    }
+}
+
+pub struct StoreActiveCtxGuard<'a> {
+    store: StoreContextMut<'a, SharedCtx>,
+    previous: Arc<str>,
+}
+
+impl<'a> StoreActiveCtxGuard<'a> {
+    pub fn new(mut store: StoreContextMut<'a, SharedCtx>, id: &Arc<str>) -> wasmtime::Result<Self> {
+        let previous = store.data().active_ctx.component_id.clone();
+        store.data_mut().set_active_ctx(id)?;
+        Ok(Self { store, previous })
+    }
+
+    pub fn store_mut(&mut self) -> &mut StoreContextMut<'a, SharedCtx> {
+        &mut self.store
+    }
+}
+
+impl Drop for StoreActiveCtxGuard<'_> {
+    fn drop(&mut self) {
+        let _ = self.store.data_mut().set_active_ctx(&self.previous);
     }
 }
 
@@ -559,5 +618,33 @@ mod tests {
         shared.set_active_ctx(&comp_a).unwrap();
         assert_eq!(shared.active_ctx.component_id.as_ref(), "comp-a");
         assert!(shared.contexts.is_empty());
+    }
+
+    #[test]
+    fn store_active_ctx_guard_restores_on_drop() {
+        setup();
+        use wasmtime::AsContextMut;
+
+        let mut config = wasmtime::Config::new();
+        config.wasm_component_model(true);
+        let engine = wasmtime::Engine::new(&config).unwrap();
+
+        let ctx_a = Ctx::builder("wk", "comp-a").build();
+        let ctx_b = Ctx::builder("wk", "comp-b").build();
+        let comp_b_id: Arc<str> = Arc::from("comp-b");
+
+        let mut shared = SharedCtx::new(ctx_a);
+        shared.contexts.insert(comp_b_id.clone(), ctx_b);
+        let mut store = wasmtime::Store::new(&engine, shared);
+
+        {
+            let mut guard = StoreActiveCtxGuard::new(store.as_context_mut(), &comp_b_id).unwrap();
+            assert_eq!(
+                guard.store_mut().data().active_ctx.component_id.as_ref(),
+                "comp-b"
+            );
+        }
+
+        assert_eq!(store.data().active_ctx.component_id.as_ref(), "comp-a");
     }
 }

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -68,14 +68,8 @@ pub struct SharedCtx {
     pub table: wasmtime::component::ResourceTable,
     /// Contexts for linked components
     pub contexts: HashMap<Arc<str>, Ctx>,
-    /// Pre-instantiated linked-component instances, keyed by component id.
-    ///
-    /// Owned by the store: every store created by the workload's store factory
-    /// is born with its linked components instantiated here, and they are
-    /// reclaimed automatically when the store is dropped (no external cache,
-    /// guards, or completion hooks). The concurrent cross-component call path
-    /// reads from here under `accessor.with`, where it cannot instantiate on
-    /// demand.
+    /// Store-owned linked-component instances, keyed by component id.
+    /// Dropping the store reclaims the instances without external cleanup.
     pub exporter_instances: HashMap<Arc<str>, Instance>,
 }
 

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -1,0 +1,563 @@
+//! Cross-component dynamic-linker call machinery.
+//!
+//! When one component in a workload imports a function that another component
+//! exports, the linker wires the import to one of the `invoke_*` helpers here.
+//! Each call is dispatched, by signature, down one of two paths:
+//!
+//! - the **shared-store path** ([`invoke_shared_store_linked_export`] /
+//!   [`invoke_linked_sync_export`]), where the callee was pre-instantiated into
+//!   the caller's long-lived store and handles can cross the boundary by
+//!   identity, and
+//! - the **ephemeral path** ([`invoke_ephemeral_linked_export`]), where a
+//!   plain-value call runs in a throwaway store built per call.
+//!
+//! Store creation for both paths is also here: [`ComponentCtxTemplate`] is the
+//! cheap recipe for a component's [`Ctx`], [`build_ctx_from_template`] turns one
+//! into a [`Ctx`], and [`new_store_from_templates`] / [`new_ephemeral_store`]
+//! assemble the store (pre-instantiating the linked components). See
+//! [`EphemeralLinkedCall`] for how the ephemeral path is captured at link time.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::RwLock;
+use tokio::time::timeout;
+use tracing::trace;
+use wasmtime::component::{
+    Accessor, ComponentExportIndex, InstancePre, Val,
+    types::{ComponentFunc, Type},
+};
+use wasmtime::error::Context as _;
+use wasmtime::{AsContext, AsContextMut, StoreContextMut};
+use wasmtime_wasi::WasiCtxBuilder;
+
+#[cfg(feature = "wasi-tls")]
+use crate::engine::ctx::SharedTlsProvider;
+use crate::engine::ctx::{AccessorActiveCtxGuard, Ctx, SharedCtx, StoreActiveCtxGuard};
+use crate::engine::value::{carries_cross_store_handle, lift_results, lower_params};
+use crate::engine::volumes::{ResolvedVolumeMount, resolve_component_volume_mounts_in_map};
+use crate::engine::workload::{WorkloadComponent, WorkloadMetadata};
+use crate::plugin::HostPlugin;
+use crate::sockets::{self, SocketAddrUse, loopback};
+
+/// A cheap, cloneable recipe for building a component's [`Ctx`].
+///
+/// Constructing a [`Ctx`] is comparatively expensive (it canonicalizes volume
+/// mounts, builds a fresh `WasiCtx`, sockets ctx, etc.), and a single store may
+/// need a ctx for the active component *and* for each component linked into it.
+/// Rather than re-derive those inputs from [`WorkloadMetadata`] every time, we
+/// snapshot the per-component pieces once into this template via
+/// [`ComponentCtxTemplate::from_metadata`] and hand it to
+/// [`build_ctx_from_template`], which turns it into an actual [`Ctx`] for a
+/// given `store_id`.
+///
+/// Templates drive store creation on both linked-call paths:
+/// [`new_store_from_templates`] builds the long-lived request/service store
+/// (one active template + the linked templates), and the ephemeral path
+/// rebuilds templates per call from metadata inside [`new_ephemeral_store`].
+/// The `tls_provider` field is populated (under `wasi-tls`) at the
+/// [`EphemeralLinkedCall`] construction site so the ephemeral path doesn't drop
+/// TLS support that the request path has.
+#[derive(Clone)]
+pub(crate) struct ComponentCtxTemplate {
+    component_id: Arc<str>,
+    workload_id: Arc<str>,
+    local_resources: crate::types::LocalResources,
+    volume_mounts: Vec<ResolvedVolumeMount>,
+    plugins: Option<HashMap<&'static str, Arc<dyn HostPlugin + Send + Sync>>>,
+    loopback: Arc<std::sync::Mutex<loopback::Network>>,
+    #[cfg(feature = "wasi-tls")]
+    tls_provider: Option<SharedTlsProvider>,
+}
+
+impl ComponentCtxTemplate {
+    fn from_metadata(metadata: &WorkloadMetadata) -> Self {
+        Self {
+            component_id: metadata.id.clone(),
+            workload_id: metadata.workload_id.clone(),
+            local_resources: metadata.local_resources.clone(),
+            volume_mounts: metadata.resolved_volume_mounts.clone(),
+            plugins: metadata.plugins.clone(),
+            loopback: metadata.loopback.clone(),
+            #[cfg(feature = "wasi-tls")]
+            tls_provider: None,
+        }
+    }
+}
+
+#[cfg(not(feature = "wasi-tls"))]
+pub(crate) fn component_ctx_template_from_metadata(
+    metadata: &WorkloadMetadata,
+) -> ComponentCtxTemplate {
+    ComponentCtxTemplate::from_metadata(metadata)
+}
+
+#[cfg(feature = "wasi-tls")]
+pub(crate) fn component_ctx_template_from_metadata_with_tls(
+    metadata: &WorkloadMetadata,
+    tls_provider: Option<SharedTlsProvider>,
+) -> ComponentCtxTemplate {
+    let mut template = ComponentCtxTemplate::from_metadata(metadata);
+    template.tls_provider = tls_provider;
+    template
+}
+
+/// Everything needed to spin up a throwaway store for a single cross-component
+/// linked call.
+///
+/// # Where it fits in a cross-component call
+///
+/// When a component (`active_component_id`) imports a function that another
+/// component in the same workload exports, the dynamic linker routes the call
+/// to one of two paths, chosen at link time by [`func_is_ephemeral_safe`]:
+///
+/// - **Shared-store path** — used when the call's signature carries a handle
+///   that must keep its identity across the boundary (resource/borrow/stream/
+///   future/error-context; see [`carries_cross_store_handle`]). The callee is
+///   instantiated once into the caller's long-lived store and reused
+///   ([`invoke_shared_store_linked_export`]).
+/// - **Ephemeral path** — used when every parameter and result is a *plain
+///   value* (no cross-store handle). The call runs in a brand-new store that is
+///   instantiated, invoked, and dropped per call
+///   ([`invoke_ephemeral_linked_export`]), so its core-instance slots are
+///   reclaimed immediately. Plain values copy cleanly across the store
+///   boundary, so nothing is lost by not sharing a store.
+///
+/// This struct is the captured input for that second path. One
+/// `Arc<EphemeralLinkedCall>` is built per eligible import during
+/// `link_components` and stored on the [`LinkedExportInvocation`]; each call
+/// hands it to [`new_ephemeral_store`], which rebuilds the active + linked
+/// [`ComponentCtxTemplate`]s from current metadata (`components`),
+/// pre-instantiates the linked components into the fresh store, and runs the
+/// export. Wrapped in `Arc` so the per-call clone is a pointer bump rather than
+/// a deep copy of the engine/handler/component map.
+#[derive(Clone)]
+pub(crate) struct EphemeralLinkedCall {
+    pub(crate) engine: wasmtime::Engine,
+    pub(crate) http_handler: Arc<dyn crate::host::http::HostHandler>,
+    pub(crate) components: Arc<RwLock<HashMap<Arc<str>, WorkloadComponent>>>,
+    pub(crate) active_component_id: Arc<str>,
+    pub(crate) linked_component_ids: Vec<Arc<str>>,
+    #[cfg(feature = "wasi-tls")]
+    pub(crate) tls_provider: Option<SharedTlsProvider>,
+}
+
+fn type_is_ephemeral_safe(ty: &Type) -> bool {
+    !carries_cross_store_handle(ty)
+}
+
+pub(crate) fn func_is_ephemeral_safe(func_ty: &ComponentFunc) -> bool {
+    func_ty.params().all(|(_, ty)| type_is_ephemeral_safe(&ty))
+        && func_ty.results().all(|ty| type_is_ephemeral_safe(&ty))
+}
+
+async fn build_ctx_from_template(
+    template: &ComponentCtxTemplate,
+    http_handler: Arc<dyn crate::host::http::HostHandler>,
+    all_volume_mounts: &[ResolvedVolumeMount],
+    store_id: &str,
+    is_service: bool,
+) -> anyhow::Result<Ctx> {
+    let mut wasi_ctx_builder = WasiCtxBuilder::new();
+    wasi_ctx_builder
+        .envs(
+            template
+                .local_resources
+                .environment
+                .iter()
+                .map(|kv| (kv.0.as_str(), kv.1.as_str()))
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
+        .inherit_stdout()
+        .inherit_stderr();
+
+    let sockets_ctx = sockets::WasiSocketsCtx {
+        socket_addr_check: sockets::SocketAddrCheck::new(move |addr, reason| {
+            Box::pin(async move {
+                match reason {
+                    SocketAddrUse::TcpBind if is_service => addr.ip().is_loopback(),
+                    SocketAddrUse::TcpBind => false,
+                    SocketAddrUse::UdpBind => addr.ip().is_loopback() || addr.ip().is_unspecified(),
+                    SocketAddrUse::TcpConnect
+                    | SocketAddrUse::UdpConnect
+                    | SocketAddrUse::UdpOutgoingDatagram => true,
+                }
+            })
+        }),
+        loopback: Arc::clone(&template.loopback),
+        ..Default::default()
+    };
+
+    for mount in all_volume_mounts {
+        wasi_ctx_builder.preopened_dir(
+            &mount.host_path,
+            &mount.mount_path,
+            mount.dir_perms,
+            mount.file_perms,
+        )?;
+    }
+
+    let mut ctx_builder = Ctx::builder(template.workload_id.clone(), template.component_id.clone())
+        .with_http_handler(http_handler)
+        .with_wasi_ctx(wasi_ctx_builder.build())
+        .with_sockets(sockets_ctx)
+        .with_allowed_hosts(template.local_resources.allowed_hosts.clone());
+
+    if let Some(plugins) = &template.plugins {
+        ctx_builder = ctx_builder.with_plugins(plugins.clone());
+    }
+
+    #[cfg(feature = "wasi-tls")]
+    if let Some(provider) = template.tls_provider.clone() {
+        ctx_builder = ctx_builder.with_tls_provider(provider);
+    }
+
+    let mut ctx = ctx_builder.build();
+    ctx.store_id = store_id.to_string().into();
+    Ok(ctx)
+}
+
+pub(crate) async fn new_store_from_templates(
+    engine: &wasmtime::Engine,
+    http_handler: Arc<dyn crate::host::http::HostHandler>,
+    active: &ComponentCtxTemplate,
+    linked: &[ComponentCtxTemplate],
+    linked_instances: &[(Arc<str>, InstancePre<SharedCtx>)],
+    is_service: bool,
+) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
+    let store_id = uuid::Uuid::new_v4().to_string();
+    let all_volume_mounts = std::iter::once(active)
+        .chain(linked.iter())
+        .flat_map(|template| template.volume_mounts.clone())
+        .collect::<Vec<_>>();
+    let active_ctx = build_ctx_from_template(
+        active,
+        http_handler.clone(),
+        &all_volume_mounts,
+        &store_id,
+        is_service,
+    )
+    .await?;
+    let mut shared_ctx = SharedCtx::new(active_ctx);
+
+    for linked in linked {
+        let linked_ctx = build_ctx_from_template(
+            linked,
+            http_handler.clone(),
+            &all_volume_mounts,
+            &store_id,
+            false,
+        )
+        .await?;
+        shared_ctx
+            .contexts
+            .insert(linked.component_id.clone(), linked_ctx);
+    }
+
+    let mut store = wasmtime::Store::new(engine, shared_ctx);
+
+    let active_id = active.component_id.clone();
+    for (linked_id, linked_pre) in linked_instances {
+        store.data_mut().set_active_ctx(linked_id)?;
+        let instantiate_result = linked_pre.instantiate_async(&mut store).await;
+        store.data_mut().set_active_ctx(&active_id)?;
+        let instance = instantiate_result.map_err(|e| {
+            anyhow::anyhow!(
+                "failed to instantiate linked component '{linked_id}' in ephemeral store: {e}"
+            )
+        })?;
+        store
+            .data_mut()
+            .exporter_instances
+            .insert(linked_id.clone(), instance);
+    }
+
+    Ok(store)
+}
+
+async fn new_ephemeral_store(
+    call: &EphemeralLinkedCall,
+) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
+    let mut component_ids = call.linked_component_ids.clone();
+    component_ids.push(call.active_component_id.clone());
+    component_ids.sort();
+    component_ids.dedup();
+    resolve_component_volume_mounts_in_map(&call.components, &component_ids).await?;
+
+    let (active_metadata, linked_metadata) = {
+        let components = call.components.read().await;
+        let active = components
+            .get(&call.active_component_id)
+            .with_context(|| {
+                format!(
+                    "ephemeral linked component '{}' not found",
+                    call.active_component_id
+                )
+            })?
+            .metadata
+            .clone();
+        let linked = call
+            .linked_component_ids
+            .iter()
+            .map(|component_id| {
+                components
+                    .get(component_id)
+                    .with_context(|| format!("linked component '{component_id}' not found"))
+                    .map(|component| component.metadata.clone())
+            })
+            .collect::<wasmtime::Result<Vec<_>>>()?;
+        (active, linked)
+    };
+
+    #[cfg(not(feature = "wasi-tls"))]
+    let active = component_ctx_template_from_metadata(&active_metadata);
+    #[cfg(feature = "wasi-tls")]
+    let active =
+        component_ctx_template_from_metadata_with_tls(&active_metadata, call.tls_provider.clone());
+
+    #[cfg(not(feature = "wasi-tls"))]
+    let linked = linked_metadata
+        .iter()
+        .map(component_ctx_template_from_metadata)
+        .collect::<Vec<_>>();
+    #[cfg(feature = "wasi-tls")]
+    let linked = linked_metadata
+        .iter()
+        .map(|metadata| {
+            component_ctx_template_from_metadata_with_tls(metadata, call.tls_provider.clone())
+        })
+        .collect::<Vec<_>>();
+
+    let linked_instances = {
+        let mut components = call.components.write().await;
+        call.linked_component_ids
+            .iter()
+            .map(|component_id| {
+                let component = components.get_mut(component_id).ok_or_else(|| {
+                    wasmtime::format_err!("linked component '{component_id}' not found")
+                })?;
+                component
+                    .pre_instantiate()
+                    .map(|pre| (component_id.clone(), pre))
+            })
+            .collect::<wasmtime::Result<Vec<_>>>()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to pre-instantiate linked components for ephemeral call: {e}"
+                )
+            })?
+    };
+
+    new_store_from_templates(
+        &call.engine,
+        call.http_handler.clone(),
+        &active,
+        &linked,
+        &linked_instances,
+        false,
+    )
+    .await
+}
+
+#[derive(Clone)]
+pub(crate) struct LinkedExportInvocation {
+    pub(crate) import_name: Arc<str>,
+    pub(crate) export_name: Arc<str>,
+    pub(crate) pre: InstancePre<SharedCtx>,
+    pub(crate) plugin_component_id: Arc<str>,
+    pub(crate) func_idx: ComponentExportIndex,
+    pub(crate) param_tys: Arc<std::sync::OnceLock<Arc<[Type]>>>,
+    pub(crate) ephemeral_call: Option<Arc<EphemeralLinkedCall>>,
+}
+
+pub(crate) async fn invoke_linked_async_export(
+    accessor: &Accessor<SharedCtx>,
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+) -> wasmtime::Result<()> {
+    if let Some(ephemeral_call) = &inv.ephemeral_call {
+        invoke_ephemeral_linked_export(params, results, inv, ephemeral_call).await
+    } else {
+        invoke_shared_store_linked_export(accessor, params, results, inv).await
+    }
+}
+
+/// Run a plain-value async linked call in a short-lived store that is dropped
+/// (reclaiming its core-instance slots) as soon as the call returns.
+async fn invoke_ephemeral_linked_export(
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+    ephemeral_call: &EphemeralLinkedCall,
+) -> wasmtime::Result<()> {
+    let mut store = new_ephemeral_store(ephemeral_call)
+        .await
+        .map_err(|e| wasmtime::format_err!("{e:#}"))?;
+
+    let params_buf = params.to_vec();
+    let mut results_buf = vec![Val::Bool(false); results.len()];
+    let call_import_name = inv.import_name.clone();
+    let call_export_name = inv.export_name.clone();
+    let call_pre = inv.pre.clone();
+    let func_idx = inv.func_idx;
+
+    trace!(
+        name = %inv.import_name,
+        fn_name = %inv.export_name,
+        ?params,
+        "invoking ephemeral dynamic export"
+    );
+
+    let call_result = tokio::task::spawn(async move {
+        let instance = call_pre.instantiate_async(&mut store).await?;
+        store
+            .run_concurrent(async move |accessor| {
+                let func = accessor.with(|mut access| -> wasmtime::Result<_> {
+                    instance.get_func(&mut access, func_idx).with_context(|| {
+                        format!(
+                            "function not found for linked import {call_import_name}.{call_export_name}"
+                        )
+                    })
+                })?;
+                const CALL_TIMEOUT: Duration = Duration::from_secs(600);
+                timeout(
+                    CALL_TIMEOUT,
+                    func.call_concurrent(accessor, &params_buf, &mut results_buf),
+                )
+                .await
+                .map_err(|e| {
+                    wasmtime::format_err!("function call timed out after 600 seconds: {e}")
+                })??;
+                Ok::<Vec<Val>, wasmtime::Error>(results_buf)
+            })
+            .await
+            .map_err(|e| wasmtime::format_err!("{e:#}"))?
+    })
+    .await
+    .map_err(|e| wasmtime::format_err!("ephemeral linked call task failed: {e}"));
+    let call_result = call_result??;
+
+    for (i, v) in call_result.into_iter().enumerate() {
+        *results.get_mut(i).context("result index out of bounds")? = v;
+    }
+
+    trace!(
+        name = %inv.import_name,
+        fn_name = %inv.export_name,
+        ?results,
+        "invoked ephemeral dynamic export"
+    );
+
+    Ok(())
+}
+
+async fn invoke_shared_store_linked_export(
+    accessor: &Accessor<SharedCtx>,
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+) -> wasmtime::Result<()> {
+    let _active_ctx = AccessorActiveCtxGuard::new(accessor, &inv.plugin_component_id)?;
+
+    let call: wasmtime::Result<()> = async {
+        let (func, params_buf) = accessor.with(|mut access| -> wasmtime::Result<_> {
+            let instance = access
+                .data_mut()
+                .exporter_instances
+                .get(&inv.plugin_component_id)
+                .copied()
+                .with_context(|| {
+                    format!(
+                        "linked component '{}' was not pre-instantiated in this store",
+                        inv.plugin_component_id
+                    )
+                })?;
+            let func = instance
+                .get_func(&mut access, inv.func_idx)
+                .context("function not found")?;
+            let tys = inv.param_tys.get_or_init(|| {
+                func.ty(access.as_context())
+                    .params()
+                    .map(|(_, ty)| ty)
+                    .collect::<Vec<_>>()
+                    .into()
+            });
+            let params_buf = lower_params(&mut access.as_context_mut(), params, tys)?;
+            Ok((func, params_buf))
+        })?;
+
+        trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoking dynamic export");
+
+        let mut results_buf = vec![Val::Bool(false); results.len()];
+        func.call_concurrent(accessor, &params_buf, &mut results_buf)
+            .await?;
+
+        accessor.with(|mut access| -> wasmtime::Result<_> {
+            lift_results(&mut access.as_context_mut(), results_buf, results)
+        })?;
+
+        Ok(())
+    }
+    .await;
+
+    call?;
+
+    trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoked dynamic export");
+
+    Ok(())
+}
+
+pub(crate) async fn invoke_linked_sync_export(
+    store: StoreContextMut<'_, SharedCtx>,
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+) -> wasmtime::Result<()> {
+    let mut active_ctx = StoreActiveCtxGuard::new(store, &inv.plugin_component_id)?;
+    let mut store = active_ctx.store_mut();
+
+    async {
+        let instance = store
+            .data()
+            .exporter_instances
+            .get(&inv.plugin_component_id)
+            .copied()
+            .with_context(|| {
+                format!(
+                    "linked component '{}' was not pre-instantiated in this store",
+                    inv.plugin_component_id
+                )
+            })?;
+
+        let func = instance
+            .get_func(&mut store, inv.func_idx)
+            .context("function not found")?;
+        let tys = inv.param_tys.get_or_init(|| {
+            func.ty(store.as_context())
+                .params()
+                .map(|(_, ty)| ty)
+                .collect::<Vec<_>>()
+                .into()
+        });
+        let params_buf = lower_params(store, params, tys)?;
+        trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoking dynamic export");
+
+        let mut results_buf = vec![Val::Bool(false); results.len()];
+
+        const CALL_TIMEOUT: Duration = Duration::from_secs(30);
+        timeout(
+            CALL_TIMEOUT,
+            func.call_async(&mut store, &params_buf, &mut results_buf),
+        )
+        .await
+        .map_err(|e| wasmtime::format_err!("function call timed out after 30 seconds: {e}"))??;
+
+        lift_results(store, results_buf, results)?;
+        trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoked dynamic export");
+        Ok(())
+    }
+    .await
+}

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -218,7 +218,9 @@ pub fn targets_wasip3_http(component: &Component) -> bool {
 }
 
 pub mod ctx;
+mod linked_call;
 mod value;
+mod volumes;
 pub mod workload;
 
 /// The core WebAssembly engine for executing components and workloads.

--- a/crates/wash-runtime/src/engine/value.rs
+++ b/crates/wash-runtime/src/engine/value.rs
@@ -2,7 +2,7 @@
 //! instance to another in the context of a single [`wasmtime::Store`].
 
 use tracing::trace;
-use wasmtime::component::Val;
+use wasmtime::component::{ResourceAny, ResourceType, Val, types::Type};
 use wasmtime::error::Context as _;
 use wasmtime::{AsContextMut, StoreContextMut};
 
@@ -133,9 +133,26 @@ pub(crate) fn lower(store: &mut StoreContextMut<SharedCtx>, v: &Val) -> wasmtime
                 }
             }
         }
-        &Val::Future(_) | &Val::Stream(_) | &Val::ErrorContext(_) => {
-            wasmtime::bail!("async not supported")
+        Val::Future(v) => Ok(Val::Future(v.clone())),
+        Val::Stream(v) => Ok(Val::Stream(v.clone())),
+        Val::ErrorContext(v) => Ok(Val::ErrorContext(v.clone())),
+    }
+}
+
+pub(crate) fn lower_with_type(
+    store: &mut StoreContextMut<SharedCtx>,
+    v: &Val,
+    ty: &Type,
+) -> wasmtime::Result<Val> {
+    match (ty, v) {
+        (Type::Own(resource_ty) | Type::Borrow(resource_ty), &Val::Resource(any))
+            if *resource_ty == ResourceType::host::<ResourceAny>()
+                && any.ty() == ResourceType::host::<ResourceAny>() =>
+        {
+            trace!(resource = ?any, "lowering host resource by identity");
+            Ok(Val::Resource(any))
         }
+        _ => lower(store, v),
     }
 }
 
@@ -258,9 +275,9 @@ pub(crate) fn lift(store: &mut StoreContextMut<SharedCtx>, v: Val) -> wasmtime::
                 ))
             }
         }
-        Val::Future(_) | Val::Stream(_) | Val::ErrorContext(_) => {
-            wasmtime::bail!("async not supported")
-        }
+        Val::Future(v) => Ok(Val::Future(v)),
+        Val::Stream(v) => Ok(Val::Stream(v)),
+        Val::ErrorContext(v) => Ok(Val::ErrorContext(v)),
     }
 }
 

--- a/crates/wash-runtime/src/engine/value.rs
+++ b/crates/wash-runtime/src/engine/value.rs
@@ -8,6 +8,48 @@ use wasmtime::{AsContextMut, StoreContextMut};
 
 use crate::engine::ctx::SharedCtx;
 
+pub(crate) fn carries_cross_store_handle(ty: &Type) -> bool {
+    match ty {
+        Type::Bool
+        | Type::S8
+        | Type::U8
+        | Type::S16
+        | Type::U16
+        | Type::S32
+        | Type::U32
+        | Type::S64
+        | Type::U64
+        | Type::Float32
+        | Type::Float64
+        | Type::Char
+        | Type::String
+        | Type::Enum(_)
+        | Type::Flags(_) => false,
+        Type::List(list) => carries_cross_store_handle(&list.ty()),
+        Type::Map(map) => {
+            carries_cross_store_handle(&map.key()) || carries_cross_store_handle(&map.value())
+        }
+        Type::Record(record) => record
+            .fields()
+            .any(|field| carries_cross_store_handle(&field.ty)),
+        Type::Tuple(tuple) => tuple.types().any(|ty| carries_cross_store_handle(&ty)),
+        Type::Variant(variant) => variant
+            .cases()
+            .any(|case| case.ty.as_ref().is_some_and(carries_cross_store_handle)),
+        Type::Option(option) => carries_cross_store_handle(&option.ty()),
+        Type::Result(result) => {
+            result.ok().as_ref().is_some_and(carries_cross_store_handle)
+                || result
+                    .err()
+                    .as_ref()
+                    .is_some_and(carries_cross_store_handle)
+        }
+        Type::Own(_) | Type::Borrow(_) | Type::Future(_) | Type::Stream(_) | Type::ErrorContext => {
+            true
+        }
+    }
+}
+
 pub(crate) fn lower(store: &mut StoreContextMut<SharedCtx>, v: &Val) -> wasmtime::Result<Val> {
     match v {
         &Val::Bool(v) => Ok(Val::Bool(v)),
@@ -144,6 +186,10 @@ pub(crate) fn lower_with_type(
     v: &Val,
     ty: &Type,
 ) -> wasmtime::Result<Val> {
+    if !carries_cross_store_handle(ty) {
+        return lower(store, v);
+    }
+
     match (ty, v) {
         (Type::Own(resource_ty) | Type::Borrow(resource_ty), &Val::Resource(any))
             if *resource_ty == ResourceType::host::<ResourceAny>()

--- a/crates/wash-runtime/src/engine/value.rs
+++ b/crates/wash-runtime/src/engine/value.rs
@@ -181,6 +181,40 @@ pub(crate) fn lower(store: &mut StoreContextMut<SharedCtx>, v: &Val) -> wasmtime
     }
 }
 
+/// Lower dynamic-linker call params, using each param's declared type so host
+/// resource handles cross the linker by identity (see [`lower_with_type`]).
+pub(crate) fn lower_params(
+    store: &mut StoreContextMut<'_, SharedCtx>,
+    params: &[Val],
+    param_tys: &[Type],
+) -> wasmtime::Result<Vec<Val>> {
+    if params.len() != param_tys.len() {
+        return Err(wasmtime::format_err!(
+            "dynamic call arity mismatch: {} args vs {} param types",
+            params.len(),
+            param_tys.len()
+        ));
+    }
+    let mut params_buf = Vec::with_capacity(params.len());
+    for (v, ty) in params.iter().zip(param_tys) {
+        params_buf.push(lower_with_type(store, v, ty)?);
+    }
+    Ok(params_buf)
+}
+
+/// Lift a dynamic-linker call's result values back into the caller's store,
+/// writing each into `results` (see [`lift`]).
+pub(crate) fn lift_results(
+    store: &mut StoreContextMut<'_, SharedCtx>,
+    results_buf: Vec<Val>,
+    results: &mut [Val],
+) -> wasmtime::Result<()> {
+    for (i, v) in results_buf.into_iter().enumerate() {
+        *results.get_mut(i).context("result index out of bounds")? = lift(store, v)?;
+    }
+    Ok(())
+}
+
 pub(crate) fn lower_with_type(
     store: &mut StoreContextMut<SharedCtx>,
     v: &Val,

--- a/crates/wash-runtime/src/engine/volumes.rs
+++ b/crates/wash-runtime/src/engine/volumes.rs
@@ -1,0 +1,120 @@
+//! Volume-mount resolution for workload components.
+//!
+//! Component volume mounts arrive as `(host_path, VolumeMount)` pairs and must
+//! be canonicalized (and turned into wasmtime preopen permissions) before a
+//! store can preopen them. This module holds the resolved-mount value type
+//! ([`ResolvedVolumeMount`]) plus the helpers that canonicalize a component's
+//! mounts once and cache them on its [`WorkloadMetadata`], so request-path
+//! store creation never re-canonicalizes.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use wasmtime::error::Context as _;
+use wasmtime_wasi::{DirPerms, FilePerms};
+
+use crate::engine::workload::WorkloadComponent;
+use crate::types::VolumeMount;
+
+/// A volume mount with its host path canonicalized and its
+/// read-only/read-write flag turned into wasmtime preopen permissions.
+///
+/// Built once per component during workload resolution (see
+/// [`resolve_component_volume_mounts_in_map`]) and reused by the store factory
+/// when preopening directories, so the canonicalization cost stays off the
+/// request path.
+#[derive(Clone)]
+pub(crate) struct ResolvedVolumeMount {
+    pub(crate) host_path: PathBuf,
+    pub(crate) mount_path: String,
+    pub(crate) dir_perms: DirPerms,
+    pub(crate) file_perms: FilePerms,
+}
+
+impl ResolvedVolumeMount {
+    pub(crate) async fn from_mount(
+        host_path: &PathBuf,
+        mount: &VolumeMount,
+    ) -> anyhow::Result<Self> {
+        let host_path = tokio::fs::canonicalize(host_path)
+            .await
+            .with_context(|| format!("failed to canonicalize volume host path {host_path:?}"))?;
+        let (dir_perms, file_perms) = match mount.read_only {
+            true => (DirPerms::READ, FilePerms::READ),
+            false => (DirPerms::all(), FilePerms::all()),
+        };
+
+        Ok(Self {
+            host_path,
+            mount_path: mount.mount_path.clone(),
+            dir_perms,
+            file_perms,
+        })
+    }
+}
+
+/// Canonicalize a list of `(host_path, VolumeMount)` pairs into
+/// [`ResolvedVolumeMount`]s, preserving order.
+pub(crate) async fn resolve_volume_mounts(
+    volume_mounts: &[(PathBuf, VolumeMount)],
+) -> anyhow::Result<Vec<ResolvedVolumeMount>> {
+    let mut resolved = Vec::with_capacity(volume_mounts.len());
+    for (host_path, mount) in volume_mounts {
+        resolved.push(ResolvedVolumeMount::from_mount(host_path, mount).await?);
+    }
+    Ok(resolved)
+}
+
+/// Resolve and cache the volume mounts for the given components in the workload
+/// component map.
+///
+/// For each component that has requested mounts but no resolved mounts yet, the
+/// canonicalization runs without holding the components lock; the resolved
+/// mounts are then written back under a single write lock. Components whose
+/// mounts are already resolved are skipped, so this is cheap to call repeatedly.
+pub(crate) async fn resolve_component_volume_mounts_in_map(
+    components: &Arc<RwLock<HashMap<Arc<str>, WorkloadComponent>>>,
+    component_ids: &[Arc<str>],
+) -> anyhow::Result<()> {
+    let pending = {
+        let components = components.read().await;
+        let mut pending = Vec::new();
+        for component_id in component_ids {
+            let component = components
+                .get(component_id)
+                .with_context(|| format!("component '{component_id}' not found"))?;
+            if component.metadata.resolved_volume_mounts.is_empty()
+                && !component.metadata.volume_mounts.is_empty()
+            {
+                pending.push((
+                    component_id.clone(),
+                    component.metadata.volume_mounts.clone(),
+                ));
+            }
+        }
+        pending
+    };
+
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    let mut resolved = Vec::with_capacity(pending.len());
+    for (component_id, volume_mounts) in pending {
+        resolved.push((component_id, resolve_volume_mounts(&volume_mounts).await?));
+    }
+
+    let mut components = components.write().await;
+    for (component_id, resolved_volume_mounts) in resolved {
+        let component = components
+            .get_mut(&component_id)
+            .with_context(|| format!("component '{component_id}' not found"))?;
+        if component.metadata.resolved_volume_mounts.is_empty() {
+            component.metadata.resolved_volume_mounts = resolved_volume_mounts;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -16,8 +16,9 @@ use anyhow::{Context as _, bail, ensure};
 use tokio::{sync::RwLock, task::JoinHandle, time::timeout};
 use tracing::{Instrument, debug, error, info, instrument, trace, warn};
 use wasmtime::component::{
-    Component, Instance, InstancePre, Linker, ResourceAny, ResourceType, Val,
-    types::{ComponentItem, Type},
+    Accessor, Component, ComponentExportIndex, Instance, InstancePre, Linker, ResourceAny,
+    ResourceType, Val,
+    types::{ComponentFunc, ComponentItem, Type},
 };
 use wasmtime::{AsContext, AsContextMut, StoreContextMut};
 use wasmtime_wasi::p2::bindings::CommandPre;
@@ -89,19 +90,469 @@ fn lift_results(
 /// RAII guard that drops a store's entries from the exporter-instance cache when
 /// dropped — including on task abort/panic, where a trailing statement would be
 /// skipped.
-#[cfg(feature = "wasip3")]
 struct ExporterCacheCleanup {
     exporter_instances: Arc<std::sync::RwLock<HashMap<ExporterInstanceKey, Instance>>>,
     store_id: String,
 }
 
-#[cfg(feature = "wasip3")]
 impl Drop for ExporterCacheCleanup {
     fn drop(&mut self) {
         if let Ok(mut cache) = self.exporter_instances.write() {
             cache.retain(|(_, cached_store_id), _| cached_store_id != &self.store_id);
         }
     }
+}
+
+#[derive(Clone)]
+struct ComponentCtxTemplate {
+    component_id: Arc<str>,
+    workload_id: Arc<str>,
+    local_resources: LocalResources,
+    volume_mounts: Vec<(PathBuf, VolumeMount)>,
+    plugins: Option<HashMap<&'static str, Arc<dyn HostPlugin + Send + Sync>>>,
+    loopback: Arc<std::sync::Mutex<loopback::Network>>,
+}
+
+impl ComponentCtxTemplate {
+    fn from_metadata(metadata: &WorkloadMetadata) -> Self {
+        Self {
+            component_id: metadata.id.clone(),
+            workload_id: metadata.workload_id.clone(),
+            local_resources: metadata.local_resources.clone(),
+            volume_mounts: metadata.volume_mounts.clone(),
+            plugins: metadata.plugins.clone(),
+            loopback: metadata.loopback.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct EphemeralLinkedCall {
+    engine: wasmtime::Engine,
+    http_handler: Arc<dyn crate::host::http::HostHandler>,
+    active: ComponentCtxTemplate,
+    linked: Vec<ComponentCtxTemplate>,
+    linked_instances: Vec<(Arc<str>, InstancePre<SharedCtx>)>,
+}
+
+fn type_is_ephemeral_safe(ty: &Type) -> bool {
+    match ty {
+        Type::Bool
+        | Type::S8
+        | Type::U8
+        | Type::S16
+        | Type::U16
+        | Type::S32
+        | Type::U32
+        | Type::S64
+        | Type::U64
+        | Type::Float32
+        | Type::Float64
+        | Type::Char
+        | Type::String
+        | Type::Enum(_)
+        | Type::Flags(_) => true,
+        Type::List(list) => type_is_ephemeral_safe(&list.ty()),
+        Type::Map(map) => {
+            type_is_ephemeral_safe(&map.key()) && type_is_ephemeral_safe(&map.value())
+        }
+        Type::Record(record) => record
+            .fields()
+            .all(|field| type_is_ephemeral_safe(&field.ty)),
+        Type::Tuple(tuple) => tuple.types().all(|ty| type_is_ephemeral_safe(&ty)),
+        Type::Variant(variant) => variant
+            .cases()
+            .all(|case| case.ty.as_ref().is_none_or(type_is_ephemeral_safe)),
+        Type::Option(option) => type_is_ephemeral_safe(&option.ty()),
+        Type::Result(result) => {
+            result.ok().as_ref().is_none_or(type_is_ephemeral_safe)
+                && result.err().as_ref().is_none_or(type_is_ephemeral_safe)
+        }
+        Type::Own(_) | Type::Borrow(_) | Type::Future(_) | Type::Stream(_) | Type::ErrorContext => {
+            false
+        }
+    }
+}
+
+fn func_is_ephemeral_safe(func_ty: &ComponentFunc) -> bool {
+    func_ty.params().all(|(_, ty)| type_is_ephemeral_safe(&ty))
+        && func_ty.results().all(|ty| type_is_ephemeral_safe(&ty))
+}
+
+async fn build_ctx_from_template(
+    template: &ComponentCtxTemplate,
+    http_handler: Arc<dyn crate::host::http::HostHandler>,
+    all_volume_mounts: &[(PathBuf, VolumeMount)],
+    store_id: &str,
+    is_service: bool,
+) -> anyhow::Result<Ctx> {
+    let mut wasi_ctx_builder = WasiCtxBuilder::new();
+    wasi_ctx_builder
+        .envs(
+            template
+                .local_resources
+                .environment
+                .iter()
+                .map(|kv| (kv.0.as_str(), kv.1.as_str()))
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
+        .inherit_stdout()
+        .inherit_stderr();
+
+    let sockets_ctx = sockets::WasiSocketsCtx {
+        socket_addr_check: sockets::SocketAddrCheck::new(move |addr, reason| {
+            Box::pin(async move {
+                match reason {
+                    SocketAddrUse::TcpBind if is_service => addr.ip().is_loopback(),
+                    SocketAddrUse::TcpBind => false,
+                    SocketAddrUse::UdpBind => addr.ip().is_loopback() || addr.ip().is_unspecified(),
+                    SocketAddrUse::TcpConnect
+                    | SocketAddrUse::UdpConnect
+                    | SocketAddrUse::UdpOutgoingDatagram => true,
+                }
+            })
+        }),
+        loopback: Arc::clone(&template.loopback),
+        ..Default::default()
+    };
+
+    for (host_path, mount) in all_volume_mounts {
+        let dir = tokio::fs::canonicalize(host_path).await?;
+        let (dir_perms, file_perms) = match mount.read_only {
+            true => (DirPerms::READ, FilePerms::READ),
+            false => (DirPerms::all(), FilePerms::all()),
+        };
+        wasi_ctx_builder.preopened_dir(&dir, &mount.mount_path, dir_perms, file_perms)?;
+    }
+
+    let mut ctx_builder = Ctx::builder(template.workload_id.clone(), template.component_id.clone())
+        .with_http_handler(http_handler)
+        .with_wasi_ctx(wasi_ctx_builder.build())
+        .with_sockets(sockets_ctx)
+        .with_allowed_hosts(template.local_resources.allowed_hosts.clone());
+
+    if let Some(plugins) = &template.plugins {
+        ctx_builder = ctx_builder.with_plugins(plugins.clone());
+    }
+
+    let mut ctx = ctx_builder.build();
+    ctx.store_id = store_id.to_string();
+    Ok(ctx)
+}
+
+async fn new_ephemeral_store(
+    call: &EphemeralLinkedCall,
+) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
+    let store_id = uuid::Uuid::new_v4().to_string();
+    let all_volume_mounts = std::iter::once(&call.active)
+        .chain(call.linked.iter())
+        .flat_map(|template| template.volume_mounts.clone())
+        .collect::<Vec<_>>();
+    let active_ctx = build_ctx_from_template(
+        &call.active,
+        call.http_handler.clone(),
+        &all_volume_mounts,
+        &store_id,
+        false,
+    )
+    .await?;
+    let mut shared_ctx = SharedCtx::new(active_ctx);
+
+    for linked in &call.linked {
+        let linked_ctx = build_ctx_from_template(
+            linked,
+            call.http_handler.clone(),
+            &all_volume_mounts,
+            &store_id,
+            false,
+        )
+        .await?;
+        shared_ctx
+            .contexts
+            .insert(linked.component_id.clone(), linked_ctx);
+    }
+
+    Ok(wasmtime::Store::new(&call.engine, shared_ctx))
+}
+
+/// Everything a linker closure needs to invoke one linked component export,
+/// bundled so the invocation logic lives in named helpers instead of a deeply
+/// nested inline `async` block.
+#[derive(Clone)]
+struct LinkedExportInvocation {
+    import_name: Arc<str>,
+    export_name: Arc<str>,
+    pre: InstancePre<SharedCtx>,
+    /// Legacy single-slot instance cache, used only by the synchronous path.
+    instance: Arc<RwLock<Option<(String, Instance)>>>,
+    exporter_instances: Arc<std::sync::RwLock<HashMap<ExporterInstanceKey, Instance>>>,
+    plugin_component_id: Arc<str>,
+    func_idx: ComponentExportIndex,
+    param_tys: Arc<std::sync::OnceLock<Arc<[Type]>>>,
+    ephemeral_call: Option<EphemeralLinkedCall>,
+}
+
+/// Dispatch an async (`func_new_concurrent`) linked export to either the
+/// ephemeral-store path (plain-value signatures) or the shared-store path.
+async fn invoke_linked_async_export(
+    accessor: &Accessor<SharedCtx>,
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+) -> wasmtime::Result<()> {
+    if let Some(ephemeral_call) = &inv.ephemeral_call {
+        invoke_ephemeral_linked_export(params, results, inv, ephemeral_call).await
+    } else {
+        invoke_shared_store_linked_export(accessor, params, results, inv).await
+    }
+}
+
+/// Run a plain-value async linked call in a short-lived store that is dropped
+/// (reclaiming its core-instance slots) as soon as the call returns.
+async fn invoke_ephemeral_linked_export(
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+    ephemeral_call: &EphemeralLinkedCall,
+) -> wasmtime::Result<()> {
+    let mut store = new_ephemeral_store(ephemeral_call)
+        .await
+        .map_err(|e| wasmtime::format_err!("{e:#}"))?;
+    let store_id = store.data().active_ctx.store_id.clone();
+    for (linked_component_id, linked_pre) in &ephemeral_call.linked_instances {
+        let key = (linked_component_id.clone(), store_id.clone());
+        if inv
+            .exporter_instances
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(&key)
+        {
+            continue;
+        }
+
+        let prev_component_id = store.data().active_ctx.component_id.clone();
+        store
+            .data_mut()
+            .set_active_ctx(linked_component_id)
+            .map_err(|e| wasmtime::format_err!("{e:#}"))?;
+        let instantiate_result = linked_pre.instantiate_async(&mut store).await;
+        store
+            .data_mut()
+            .set_active_ctx(&prev_component_id)
+            .map_err(|e| wasmtime::format_err!("{e:#}"))?;
+        let instance = instantiate_result.map_err(|e| {
+            wasmtime::format_err!(
+                "failed to instantiate linked component '{linked_component_id}' in ephemeral store: {e}"
+            )
+        })?;
+        inv.exporter_instances
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(key, instance);
+    }
+
+    let params_buf = params.to_vec();
+    let mut results_buf = vec![Val::Bool(false); results.len()];
+    let call_import_name = inv.import_name.clone();
+    let call_export_name = inv.export_name.clone();
+    let call_pre = inv.pre.clone();
+    let func_idx = inv.func_idx;
+    let cleanup_store_id = store_id.clone();
+    let call_result = tokio::task::spawn(async move {
+        let instance = call_pre.instantiate_async(&mut store).await?;
+        store
+            .run_concurrent(async move |accessor| {
+                let func = accessor.with(|mut access| -> wasmtime::Result<_> {
+                    instance.get_func(&mut access, func_idx).ok_or_else(|| {
+                        wasmtime::format_err!(
+                            "function not found for linked import {call_import_name}.{call_export_name}"
+                        )
+                    })
+                })?;
+                const CALL_TIMEOUT: Duration = Duration::from_secs(600);
+                timeout(
+                    CALL_TIMEOUT,
+                    func.call_concurrent(accessor, &params_buf, &mut results_buf),
+                )
+                .await
+                .map_err(|e| {
+                    wasmtime::format_err!("function call timed out after 600 seconds: {e}")
+                })??;
+                Ok::<Vec<Val>, wasmtime::Error>(results_buf)
+            })
+            .await
+            .map_err(|e| wasmtime::format_err!("{e:#}"))?
+    })
+    .await
+    .map_err(|e| wasmtime::format_err!("ephemeral linked call task failed: {e}"));
+    inv.exporter_instances
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .retain(|(_, cached_store_id), _| cached_store_id != &cleanup_store_id);
+    let call_result = call_result??;
+
+    for (i, v) in call_result.into_iter().enumerate() {
+        *results
+            .get_mut(i)
+            .ok_or_else(|| wasmtime::format_err!("result index out of bounds"))? = v;
+    }
+
+    trace!(
+        name = %inv.import_name,
+        fn_name = %inv.export_name,
+        ?results,
+        "invoked ephemeral dynamic export"
+    );
+
+    Ok(())
+}
+
+/// Run an async linked call on the request's own (long-lived) store, reusing the
+/// exporter instance pre-instantiated for `(component, store)` by the entrypoint.
+async fn invoke_shared_store_linked_export(
+    accessor: &Accessor<SharedCtx>,
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+) -> wasmtime::Result<()> {
+    // Switch active ctx to the linked component, remembering the caller's to restore below.
+    let prev_id = accessor.with(|mut access| -> wasmtime::Result<_> {
+        let prev_id = access.data_mut().active_ctx.component_id.clone();
+        access.data_mut().set_active_ctx(&inv.plugin_component_id)?;
+        Ok(prev_id)
+    })?;
+
+    // Run the call; the caller's active ctx is restored on every return path below.
+    // NOTE: if this future is cancelled (dropped) mid-call the restore does not run.
+    let call: wasmtime::Result<()> = async {
+        let store_id = accessor.with(|mut access| access.data_mut().active_ctx.store_id.clone());
+
+        // Every entrypoint pre-instantiates linked components, so a miss is a bug,
+        // not a lazy path (release-46's `Accessor` has no `instantiate_async`).
+        let cached = inv
+            .exporter_instances
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&(inv.plugin_component_id.clone(), store_id.clone()))
+            .cloned();
+        let instance = match cached {
+            Some(instance) => instance,
+            None => {
+                return Err(wasmtime::format_err!(
+                    "linked component '{}' was not pre-instantiated for store '{store_id}'",
+                    inv.plugin_component_id
+                ));
+            }
+        };
+
+        let (func, params_buf) = accessor.with(|mut access| -> wasmtime::Result<_> {
+            let func = instance
+                .get_func(&mut access, inv.func_idx)
+                .ok_or_else(|| wasmtime::format_err!("function not found"))?;
+            let tys = inv.param_tys.get_or_init(|| {
+                func.ty(access.as_context())
+                    .params()
+                    .map(|(_, ty)| ty)
+                    .collect::<Vec<_>>()
+                    .into()
+            });
+            let params_buf = lower_params(&mut access.as_context_mut(), params, tys)?;
+            Ok((func, params_buf))
+        })?;
+
+        trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoking dynamic export");
+
+        let mut results_buf = vec![Val::Bool(false); results.len()];
+        func.call_concurrent(accessor, &params_buf, &mut results_buf)
+            .await?;
+
+        accessor.with(|mut access| -> wasmtime::Result<_> {
+            lift_results(&mut access.as_context_mut(), results_buf, results)
+        })?;
+
+        Ok(())
+    }
+    .await;
+
+    let restore = accessor
+        .with(|mut access| -> wasmtime::Result<_> { access.data_mut().set_active_ctx(&prev_id) });
+
+    call?;
+    restore?;
+
+    trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoked dynamic export");
+
+    Ok(())
+}
+
+/// Run a synchronous (`func_new_async`) linked call on the caller's store.
+async fn invoke_linked_sync_export(
+    mut store: StoreContextMut<'_, SharedCtx>,
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+) -> wasmtime::Result<()> {
+    // TODO(#103): some kind of store data hashing mechanism to detect a diff store to drop the old one
+    let prev_id = store.data().active_ctx.component_id.clone();
+
+    store.data_mut().set_active_ctx(&inv.plugin_component_id)?;
+
+    let store_id = store.data().active_ctx.store_id.clone();
+    let instance = if let Some(instance) = inv
+        .exporter_instances
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&(inv.plugin_component_id.clone(), store_id.clone()))
+        .cloned()
+    {
+        instance
+    } else {
+        let existing_instance = inv.instance.read().await;
+        if let Some((id, instance)) = existing_instance.clone()
+            && id == store_id
+        {
+            drop(existing_instance);
+            instance
+        } else {
+            // Likely unnecessary, but explicit drop of the read lock
+            let new_instance = inv.pre.instantiate_async(&mut store).await?;
+            drop(existing_instance);
+            *inv.instance.write().await = Some((store_id, new_instance));
+            new_instance
+        }
+    };
+
+    let func = instance
+        .get_func(&mut store, inv.func_idx)
+        .ok_or_else(|| wasmtime::format_err!("function not found"))?;
+    let tys = inv.param_tys.get_or_init(|| {
+        func.ty(store.as_context())
+            .params()
+            .map(|(_, ty)| ty)
+            .collect::<Vec<_>>()
+            .into()
+    });
+    let params_buf = lower_params(&mut store, params, tys)?;
+    trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoking dynamic export");
+
+    let mut results_buf = vec![Val::Bool(false); results.len()];
+
+    // Enforce a timeout on this call to prevent hanging indefinitely
+    const CALL_TIMEOUT: Duration = Duration::from_secs(30);
+    timeout(
+        CALL_TIMEOUT,
+        func.call_async(&mut store, &params_buf, &mut results_buf),
+    )
+    .await
+    .map_err(|e| wasmtime::format_err!("function call timed out after 30 seconds: {e}"))??;
+
+    lift_results(&mut store, results_buf, results)?;
+    trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoked dynamic export");
+
+    store.data_mut().set_active_ctx(&prev_id)?;
+
+    Ok(())
 }
 
 /// Metadata associated with components and services within a workload.
@@ -204,8 +655,8 @@ impl WorkloadMetadata {
             .exports(self.component.engine())
             .map(|(name, item)| (name, item.ty))
             .filter_map(|(name, item)| {
-                if matches!(item.ty, ComponentItem::ComponentInstance(_)) {
-                    Some((name.to_string(), item.ty))
+                if matches!(item, ComponentItem::ComponentInstance(_)) {
+                    Some((name.to_string(), item))
                 } else {
                     None
                 }
@@ -745,11 +1196,10 @@ impl ResolvedWorkload {
             .collect()
     }
 
-    #[cfg(feature = "wasip3")]
     pub(crate) fn clear_exporter_instances_for_store(&self, store_id: &str) {
         self.exporter_instances
             .write()
-            .expect("exporter instance cache poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .retain(|(_, cached_store_id), _| cached_store_id != store_id);
     }
 
@@ -765,7 +1215,7 @@ impl ResolvedWorkload {
             if self
                 .exporter_instances
                 .read()
-                .expect("exporter instance cache poisoned")
+                .unwrap_or_else(|e| e.into_inner())
                 .contains_key(&key)
             {
                 continue;
@@ -784,7 +1234,7 @@ impl ResolvedWorkload {
 
             self.exporter_instances
                 .write()
-                .expect("exporter instance cache poisoned")
+                .unwrap_or_else(|e| e.into_inner())
                 .insert(key, instance);
         }
 
@@ -982,8 +1432,16 @@ impl ResolvedWorkload {
                 ComponentItem::ComponentInstance(import_instance_ty) => {
                     trace!(name = import_name, "processing component instance import");
                     let mut all_components = self.components.write().await;
-                    let (plugin_component, instance_idx) = {
-                        let Some(exporter_component) = interface_map.get(import_name) else {
+                    let (
+                        plugin_component,
+                        instance_idx,
+                        plugin_ctx_template,
+                        linked_ctx_templates,
+                        linked_instances,
+                        plugin_engine,
+                    ) = {
+                        let Some(exporter_component) = interface_map.get(import_name).cloned()
+                        else {
                             // Import not provided by another component in the workload.
                             // This is expected for host-provided interfaces (e.g. wasi:*).
                             // If it's not host-provided, linking will fail later with a
@@ -994,12 +1452,84 @@ impl ResolvedWorkload {
                             );
                             continue;
                         };
-                        let Some(plugin_component) = all_components.get_mut(exporter_component)
+                        let nested_linked_component_ids = {
+                            let Some(exporter_workload_component) =
+                                all_components.get(&exporter_component)
+                            else {
+                                anyhow::bail!(
+                                    "exporting component '{exporter_component}' for import '{import_name}' not found"
+                                );
+                            };
+                            let mut ids = Vec::<Arc<str>>::new();
+                            for (nested_import_name, nested_import_item) in
+                                exporter_workload_component
+                                    .metadata
+                                    .component
+                                    .component_type()
+                                    .imports(
+                                        exporter_workload_component.metadata.component.engine(),
+                                    )
+                            {
+                                if !matches!(
+                                    nested_import_item.ty,
+                                    ComponentItem::ComponentInstance(_)
+                                ) {
+                                    continue;
+                                }
+                                let Some(nested_component_id) =
+                                    interface_map.get(nested_import_name)
+                                else {
+                                    continue;
+                                };
+                                if nested_component_id.as_ref() == exporter_component.as_ref() {
+                                    continue;
+                                }
+                                if ids
+                                    .iter()
+                                    .any(|id| id.as_ref() == nested_component_id.as_ref())
+                                {
+                                    continue;
+                                }
+                                ids.push(nested_component_id.clone());
+                            }
+                            ids
+                        };
+                        let linked_ctx_templates = nested_linked_component_ids
+                            .iter()
+                            .filter_map(|component_id| all_components.get(component_id))
+                            .map(|component| {
+                                ComponentCtxTemplate::from_metadata(&component.metadata)
+                            })
+                            .collect::<Vec<_>>();
+                        let linked_instances = nested_linked_component_ids
+                            .iter()
+                            .map(|component_id| {
+                                let component = all_components.get_mut(component_id).ok_or_else(
+                                    || {
+                                        wasmtime::format_err!(
+                                            "linked component '{component_id}' not found"
+                                        )
+                                    },
+                                )?;
+                                component
+                                    .pre_instantiate()
+                                    .map(|pre| (component_id.clone(), pre))
+                            })
+                            .collect::<wasmtime::Result<Vec<_>>>()
+                            .map_err(|e| {
+                                anyhow::anyhow!(
+                                    "failed to pre-instantiate linked components for ephemeral call: {e}"
+                                )
+                            })?;
+                        let Some(plugin_component) = all_components.get_mut(&exporter_component)
                         else {
                             anyhow::bail!(
                                 "exporting component '{exporter_component}' for import '{import_name}' not found"
                             );
                         };
+                        let plugin_ctx_template =
+                            ComponentCtxTemplate::from_metadata(&plugin_component.metadata);
+                        let plugin_engine = plugin_component.metadata.engine().clone();
                         let Some((ComponentItem::ComponentInstance(_), idx)) = plugin_component
                             .metadata
                             .component
@@ -1008,7 +1538,14 @@ impl ResolvedWorkload {
                             trace!(name = import_name, "skipping non-instance import");
                             continue;
                         };
-                        (plugin_component, idx)
+                        (
+                            plugin_component,
+                            idx,
+                            plugin_ctx_template,
+                            linked_ctx_templates,
+                            linked_instances,
+                            plugin_engine,
+                        )
                     };
                     trace!(name = import_name, index = ?instance_idx, "found import at index");
 
@@ -1054,161 +1591,46 @@ impl ResolvedWorkload {
                                     fn_name = export_name,
                                     "linking function import"
                                 );
-                                let import_name: Arc<str> = import_name.into();
-                                let export_name: Arc<str> = export_name.into();
-                                let pre = pre.clone();
-                                let instance = instance.clone();
-                                let exporter_instances = self.exporter_instances.clone();
-                                let plugin_component_id = plugin_component.id.clone();
                                 let export_is_async = func_ty.async_();
-                                // Cache this export's param types after the first call instead of
-                                // rebuilding them every call. They must come from the *runtime*
-                                // func type — which represents linked resources as host
-                                // `ResourceAny` — not the static component type, or
-                                // `lower_with_type` can't recognise resource handles.
-                                let param_tys: Arc<std::sync::OnceLock<Arc<[Type]>>> =
-                                    Arc::default();
+                                let ephemeral_call =
+                                    if export_is_async && func_is_ephemeral_safe(&func_ty) {
+                                        Some(EphemeralLinkedCall {
+                                            engine: plugin_engine.clone(),
+                                            http_handler: self.http_handler.clone(),
+                                            active: plugin_ctx_template.clone(),
+                                            linked: linked_ctx_templates.clone(),
+                                            linked_instances: linked_instances.clone(),
+                                        })
+                                    } else {
+                                        None
+                                    };
 
-                                linked_components.insert(plugin_component_id.clone());
+                                let inv = LinkedExportInvocation {
+                                    import_name: import_name.into(),
+                                    export_name: export_name.into(),
+                                    pre: pre.clone(),
+                                    instance: instance.clone(),
+                                    exporter_instances: self.exporter_instances.clone(),
+                                    plugin_component_id: plugin_component.id.clone(),
+                                    func_idx,
+                                    param_tys: Arc::default(),
+                                    ephemeral_call,
+                                };
 
+                                linked_components.insert(inv.plugin_component_id.clone());
+
+                                let export_name = inv.export_name.clone();
                                 if export_is_async {
-                                    let param_tys = param_tys.clone();
                                     linker_instance
                                         .func_new_concurrent(
-                                            &export_name.clone(),
+                                            export_name.as_ref(),
                                             move |accessor, _func_ty, params, results| {
-                                                let import_name = import_name.clone();
-                                                let export_name = export_name.clone();
-                                                let exporter_instances = exporter_instances.clone();
-                                                let plugin_component_id = plugin_component_id.clone();
-                                                let param_tys = param_tys.clone();
+                                                let inv = inv.clone();
                                                 Box::pin(async move {
-                                                    // Switch active ctx to the linked component,
-                                                    // remembering the caller's to restore below.
-                                                    let prev_id = accessor.with(
-                                                        |mut access| -> wasmtime::Result<_> {
-                                                            let prev_id = access
-                                                                .data_mut()
-                                                                .active_ctx
-                                                                .component_id
-                                                                .clone();
-                                                            access
-                                                                .data_mut()
-                                                                .set_active_ctx(&plugin_component_id)?;
-                                                            Ok(prev_id)
-                                                        },
-                                                    )?;
-
-                                                    // Run the call; the caller's active ctx is
-                                                    // restored on every return path below. NOTE: if
-                                                    // this future is cancelled (dropped) mid-call the
-                                                    // restore does not run — a drop-safe restore
-                                                    // would need async-Drop, which the concurrent
-                                                    // runtime does not expose.
-                                                    let call: wasmtime::Result<()> = async {
-                                                        let store_id = accessor.with(|mut access| {
-                                                            access
-                                                                .data_mut()
-                                                                .active_ctx
-                                                                .store_id
-                                                                .clone()
-                                                        });
-
-                                                        // Resolve the exporter instance for this
-                                                        // store, instantiating lazily on a miss
-                                                        // (entrypoints other than P3-http/-service
-                                                        // do not pre-instantiate). First writer wins.
-                                                        let cached = exporter_instances
-                                                            .read()
-                                                            .expect("exporter instance cache poisoned")
-                                                            .get(&(
-                                                                plugin_component_id.clone(),
-                                                                store_id.clone(),
-                                                            ))
-                                                            .cloned();
-                                                        let instance = match cached {
-                                                            Some(instance) => instance,
-                                                            // release-46's `Accessor` has no
-                                                            // `instantiate_async`; every entrypoint
-                                                            // pre-instantiates linked components, so a
-                                                            // miss here is a bug, not a lazy path.
-                                                            None => {
-                                                                return Err(wasmtime::format_err!(
-                                                                    "linked component '{plugin_component_id}' was not pre-instantiated for store '{store_id}'"
-                                                                ));
-                                                            }
-                                                        };
-
-                                                        let (func, params_buf) = accessor.with(
-                                                            |mut access| -> wasmtime::Result<_> {
-                                                                let func = instance
-                                                                    .get_func(&mut access, func_idx)
-                                                                    .ok_or_else(|| {
-                                                                        wasmtime::format_err!(
-                                                                            "function not found"
-                                                                        )
-                                                                    })?;
-                                                                let tys = param_tys.get_or_init(|| {
-                                                                    func.ty(access.as_context())
-                                                                        .params()
-                                                                        .map(|(_, ty)| ty)
-                                                                        .collect::<Vec<_>>()
-                                                                        .into()
-                                                                });
-                                                                let params_buf = lower_params(
-                                                                    &mut access.as_context_mut(),
-                                                                    params,
-                                                                    tys,
-                                                                )?;
-                                                                Ok((func, params_buf))
-                                                            },
-                                                        )?;
-
-                                                        trace!(
-                                                            name = %import_name,
-                                                            fn_name = %export_name,
-                                                            "invoking dynamic export"
-                                                        );
-
-                                                        let mut results_buf =
-                                                            vec![Val::Bool(false); results.len()];
-                                                        func.call_concurrent(
-                                                            accessor,
-                                                            &params_buf,
-                                                            &mut results_buf,
-                                                        )
-                                                        .await?;
-
-                                                        accessor.with(
-                                                            |mut access| -> wasmtime::Result<_> {
-                                                                lift_results(
-                                                                    &mut access.as_context_mut(),
-                                                                    results_buf,
-                                                                    results,
-                                                                )
-                                                            },
-                                                        )?;
-
-                                                        Ok(())
-                                                    }
-                                                    .await;
-
-                                                    let restore = accessor.with(
-                                                        |mut access| -> wasmtime::Result<_> {
-                                                            access.data_mut().set_active_ctx(&prev_id)
-                                                        },
-                                                    );
-
-                                                    call?;
-                                                    restore?;
-
-                                                    trace!(
-                                                        name = %import_name,
-                                                        fn_name = %export_name,
-                                                        "invoked dynamic export"
-                                                    );
-
-                                                    Ok(())
+                                                    invoke_linked_async_export(
+                                                        accessor, params, results, &inv,
+                                                    )
+                                                    .await
                                                 })
                                             },
                                         )
@@ -1216,109 +1638,16 @@ impl ResolvedWorkload {
                                             e.context("failed to create concurrent func")
                                         })?;
                                 } else {
-                                    let param_tys = param_tys.clone();
                                     linker_instance
                                         .func_new_async(
-                                            &export_name.clone(),
-                                            move |mut store, _func_ty, params, results| {
-                                                // TODO(#103): some kind of store data hashing mechanism
-                                                // to detect a diff store to drop the old one
-                                                let import_name = import_name.clone();
-                                                let export_name = export_name.clone();
-                                                let pre = pre.clone();
-                                                let plugin_component_id = plugin_component_id.clone();
-                                                let instance = instance.clone();
-                                                let exporter_instances =
-                                                    exporter_instances.clone();
-                                                let param_tys = param_tys.clone();
+                                            export_name.as_ref(),
+                                            move |store, _func_ty, params, results| {
+                                                let inv = inv.clone();
                                                 Box::new(async move {
-                                                    let prev_id =
-                                                        store.data().active_ctx.component_id.clone();
-
-                                                    store
-                                                        .data_mut()
-                                                        .set_active_ctx(&plugin_component_id)?;
-
-                                                    let store_id = store.data().active_ctx.store_id.clone();
-                                                    let instance = if let Some(instance) =
-                                                        exporter_instances
-                                                            .read()
-                                                            .expect("exporter instance cache poisoned")
-                                                            .get(&(
-                                                                plugin_component_id.clone(),
-                                                                store_id.clone(),
-                                                            ))
-                                                            .cloned()
-                                                    {
-                                                        instance
-                                                    } else {
-                                                        let existing_instance = instance.read().await;
-                                                        if let Some((id, instance)) =
-                                                            existing_instance.clone()
-                                                            && id == store_id
-                                                        {
-                                                            drop(existing_instance);
-                                                            instance
-                                                        } else {
-                                                            // Likely unnecessary, but explicit drop of the read lock
-                                                            let new_instance =
-                                                                pre.instantiate_async(&mut store).await?;
-                                                            drop(existing_instance);
-                                                            *instance.write().await =
-                                                                Some((store_id, new_instance));
-                                                            new_instance
-                                                        }
-                                                    };
-
-                                                    let func = instance
-                                                        .get_func(&mut store, func_idx)
-                                                        .ok_or_else(|| {
-                                                            wasmtime::format_err!("function not found")
-                                                        })?;
-                                                    let tys = param_tys.get_or_init(|| {
-                                                        func.ty(store.as_context())
-                                                            .params()
-                                                            .map(|(_, ty)| ty)
-                                                            .collect::<Vec<_>>()
-                                                            .into()
-                                                    });
-                                                    let params_buf =
-                                                        lower_params(&mut store, params, tys)?;
-                                                    trace!(
-                                                        name = %import_name,
-                                                        fn_name = %export_name,
-                                                        "invoking dynamic export"
-                                                    );
-
-                                                    let mut results_buf =
-                                                        vec![Val::Bool(false); results.len()];
-
-                                                    // Enforce a timeout on this call to prevent hanging indefinitely
-                                                    const CALL_TIMEOUT: Duration =
-                                                        Duration::from_secs(30);
-                                                    timeout(
-                                                        CALL_TIMEOUT,
-                                                        func.call_async(
-                                                            &mut store,
-                                                            &params_buf,
-                                                            &mut results_buf,
-                                                        ),
+                                                    invoke_linked_sync_export(
+                                                        store, params, results, &inv,
                                                     )
                                                     .await
-                                                    .map_err(|e| wasmtime::format_err!(
-                                                        "function call timed out after 30 seconds: {e}",
-                                                    ))??;
-
-                                                    lift_results(&mut store, results_buf, results)?;
-                                                    trace!(
-                                                        name = %import_name,
-                                                        fn_name = %export_name,
-                                                        "invoked dynamic export"
-                                                    );
-
-                                                    store.data_mut().set_active_ctx(&prev_id)?;
-
-                                                    Ok(())
                                                 })
                                             },
                                         )

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -16,8 +16,7 @@ use anyhow::{Context as _, bail, ensure};
 use tokio::{sync::RwLock, task::JoinHandle, time::timeout};
 use tracing::{Instrument, debug, error, info, instrument, trace, warn};
 use wasmtime::component::{
-    Accessor, Component, ComponentExportIndex, Instance, InstancePre, Linker, ResourceAny,
-    ResourceType, Val,
+    Accessor, Component, ComponentExportIndex, InstancePre, Linker, ResourceAny, ResourceType, Val,
     types::{ComponentFunc, ComponentItem, Type},
 };
 use wasmtime::{AsContext, AsContextMut, StoreContextMut};
@@ -28,8 +27,8 @@ use wasmtime_wasi::{DirPerms, FilePerms, WasiCtxBuilder};
 use crate::engine::ctx::SharedTlsProvider;
 use crate::{
     engine::{
-        ctx::{Ctx, SharedCtx},
-        value::{lift, lower_with_type},
+        ctx::{AccessorActiveCtxGuard, Ctx, SharedCtx, StoreActiveCtxGuard},
+        value::{carries_cross_store_handle, lift, lower_with_type},
     },
     plugin::HostPlugin,
     types::{LocalResources, VolumeMount},
@@ -43,14 +42,6 @@ type BoundPluginWithInterfaces = (
     HashSet<WitInterface>,
     Vec<String>,
 );
-
-/// Shared slot holding the most recently instantiated component, keyed by the
-/// store id it was built for. Used as a fallback while resolving inter-component
-/// imports (the P2 path, which does not pre-instantiate into
-/// `exporter_instances`).
-type SharedInstanceSlot = Arc<RwLock<Option<(String, Instance)>>>;
-
-type ExporterInstanceKey = (Arc<str>, String);
 
 /// Lower dynamic-linker call params, using each param's declared type so host
 /// resource handles cross the linker by identity (see [`lower_with_type`]).
@@ -87,19 +78,28 @@ fn lift_results(
     Ok(())
 }
 
-/// RAII guard that drops a store's entries from the exporter-instance cache when
-/// dropped — including on task abort/panic, where a trailing statement would be
-/// skipped.
-struct ExporterCacheCleanup {
-    exporter_instances: Arc<std::sync::RwLock<HashMap<ExporterInstanceKey, Instance>>>,
-    store_id: String,
+#[derive(Clone)]
+struct ResolvedVolumeMount {
+    host_path: PathBuf,
+    mount_path: String,
+    dir_perms: DirPerms,
+    file_perms: FilePerms,
 }
 
-impl Drop for ExporterCacheCleanup {
-    fn drop(&mut self) {
-        if let Ok(mut cache) = self.exporter_instances.write() {
-            cache.retain(|(_, cached_store_id), _| cached_store_id != &self.store_id);
-        }
+impl ResolvedVolumeMount {
+    async fn from_mount(host_path: &PathBuf, mount: &VolumeMount) -> anyhow::Result<Self> {
+        let host_path = tokio::fs::canonicalize(host_path).await?;
+        let (dir_perms, file_perms) = match mount.read_only {
+            true => (DirPerms::READ, FilePerms::READ),
+            false => (DirPerms::all(), FilePerms::all()),
+        };
+
+        Ok(Self {
+            host_path,
+            mount_path: mount.mount_path.clone(),
+            dir_perms,
+            file_perms,
+        })
     }
 }
 
@@ -108,9 +108,11 @@ struct ComponentCtxTemplate {
     component_id: Arc<str>,
     workload_id: Arc<str>,
     local_resources: LocalResources,
-    volume_mounts: Vec<(PathBuf, VolumeMount)>,
+    volume_mounts: Vec<ResolvedVolumeMount>,
     plugins: Option<HashMap<&'static str, Arc<dyn HostPlugin + Send + Sync>>>,
     loopback: Arc<std::sync::Mutex<loopback::Network>>,
+    #[cfg(feature = "wasi-tls")]
+    tls_provider: Option<SharedTlsProvider>,
 }
 
 impl ComponentCtxTemplate {
@@ -119,9 +121,11 @@ impl ComponentCtxTemplate {
             component_id: metadata.id.clone(),
             workload_id: metadata.workload_id.clone(),
             local_resources: metadata.local_resources.clone(),
-            volume_mounts: metadata.volume_mounts.clone(),
+            volume_mounts: metadata.resolved_volume_mounts.clone(),
             plugins: metadata.plugins.clone(),
             loopback: metadata.loopback.clone(),
+            #[cfg(feature = "wasi-tls")]
+            tls_provider: None,
         }
     }
 }
@@ -136,42 +140,7 @@ struct EphemeralLinkedCall {
 }
 
 fn type_is_ephemeral_safe(ty: &Type) -> bool {
-    match ty {
-        Type::Bool
-        | Type::S8
-        | Type::U8
-        | Type::S16
-        | Type::U16
-        | Type::S32
-        | Type::U32
-        | Type::S64
-        | Type::U64
-        | Type::Float32
-        | Type::Float64
-        | Type::Char
-        | Type::String
-        | Type::Enum(_)
-        | Type::Flags(_) => true,
-        Type::List(list) => type_is_ephemeral_safe(&list.ty()),
-        Type::Map(map) => {
-            type_is_ephemeral_safe(&map.key()) && type_is_ephemeral_safe(&map.value())
-        }
-        Type::Record(record) => record
-            .fields()
-            .all(|field| type_is_ephemeral_safe(&field.ty)),
-        Type::Tuple(tuple) => tuple.types().all(|ty| type_is_ephemeral_safe(&ty)),
-        Type::Variant(variant) => variant
-            .cases()
-            .all(|case| case.ty.as_ref().is_none_or(type_is_ephemeral_safe)),
-        Type::Option(option) => type_is_ephemeral_safe(&option.ty()),
-        Type::Result(result) => {
-            result.ok().as_ref().is_none_or(type_is_ephemeral_safe)
-                && result.err().as_ref().is_none_or(type_is_ephemeral_safe)
-        }
-        Type::Own(_) | Type::Borrow(_) | Type::Future(_) | Type::Stream(_) | Type::ErrorContext => {
-            false
-        }
-    }
+    !carries_cross_store_handle(ty)
 }
 
 fn func_is_ephemeral_safe(func_ty: &ComponentFunc) -> bool {
@@ -182,7 +151,7 @@ fn func_is_ephemeral_safe(func_ty: &ComponentFunc) -> bool {
 async fn build_ctx_from_template(
     template: &ComponentCtxTemplate,
     http_handler: Arc<dyn crate::host::http::HostHandler>,
-    all_volume_mounts: &[(PathBuf, VolumeMount)],
+    all_volume_mounts: &[ResolvedVolumeMount],
     store_id: &str,
     is_service: bool,
 ) -> anyhow::Result<Ctx> {
@@ -217,13 +186,13 @@ async fn build_ctx_from_template(
         ..Default::default()
     };
 
-    for (host_path, mount) in all_volume_mounts {
-        let dir = tokio::fs::canonicalize(host_path).await?;
-        let (dir_perms, file_perms) = match mount.read_only {
-            true => (DirPerms::READ, FilePerms::READ),
-            false => (DirPerms::all(), FilePerms::all()),
-        };
-        wasi_ctx_builder.preopened_dir(&dir, &mount.mount_path, dir_perms, file_perms)?;
+    for mount in all_volume_mounts {
+        wasi_ctx_builder.preopened_dir(
+            &mount.host_path,
+            &mount.mount_path,
+            mount.dir_perms,
+            mount.file_perms,
+        )?;
     }
 
     let mut ctx_builder = Ctx::builder(template.workload_id.clone(), template.component_id.clone())
@@ -236,33 +205,43 @@ async fn build_ctx_from_template(
         ctx_builder = ctx_builder.with_plugins(plugins.clone());
     }
 
+    #[cfg(feature = "wasi-tls")]
+    if let Some(provider) = template.tls_provider.clone() {
+        ctx_builder = ctx_builder.with_tls_provider(provider);
+    }
+
     let mut ctx = ctx_builder.build();
     ctx.store_id = store_id.to_string();
     Ok(ctx)
 }
 
-async fn new_ephemeral_store(
-    call: &EphemeralLinkedCall,
+async fn new_store_from_templates(
+    engine: &wasmtime::Engine,
+    http_handler: Arc<dyn crate::host::http::HostHandler>,
+    active: &ComponentCtxTemplate,
+    linked: &[ComponentCtxTemplate],
+    linked_instances: &[(Arc<str>, InstancePre<SharedCtx>)],
+    is_service: bool,
 ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
     let store_id = uuid::Uuid::new_v4().to_string();
-    let all_volume_mounts = std::iter::once(&call.active)
-        .chain(call.linked.iter())
+    let all_volume_mounts = std::iter::once(active)
+        .chain(linked.iter())
         .flat_map(|template| template.volume_mounts.clone())
         .collect::<Vec<_>>();
     let active_ctx = build_ctx_from_template(
-        &call.active,
-        call.http_handler.clone(),
+        active,
+        http_handler.clone(),
         &all_volume_mounts,
         &store_id,
-        false,
+        is_service,
     )
     .await?;
     let mut shared_ctx = SharedCtx::new(active_ctx);
 
-    for linked in &call.linked {
+    for linked in linked {
         let linked_ctx = build_ctx_from_template(
             linked,
-            call.http_handler.clone(),
+            http_handler.clone(),
             &all_volume_mounts,
             &store_id,
             false,
@@ -273,7 +252,39 @@ async fn new_ephemeral_store(
             .insert(linked.component_id.clone(), linked_ctx);
     }
 
-    Ok(wasmtime::Store::new(&call.engine, shared_ctx))
+    let mut store = wasmtime::Store::new(engine, shared_ctx);
+
+    let active_id = active.component_id.clone();
+    for (linked_id, linked_pre) in linked_instances {
+        store.data_mut().set_active_ctx(linked_id)?;
+        let instantiate_result = linked_pre.instantiate_async(&mut store).await;
+        store.data_mut().set_active_ctx(&active_id)?;
+        let instance = instantiate_result.map_err(|e| {
+            anyhow::anyhow!(
+                "failed to instantiate linked component '{linked_id}' in ephemeral store: {e}"
+            )
+        })?;
+        store
+            .data_mut()
+            .exporter_instances
+            .insert(linked_id.clone(), instance);
+    }
+
+    Ok(store)
+}
+
+async fn new_ephemeral_store(
+    call: &EphemeralLinkedCall,
+) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
+    new_store_from_templates(
+        &call.engine,
+        call.http_handler.clone(),
+        &call.active,
+        &call.linked,
+        &call.linked_instances,
+        false,
+    )
+    .await
 }
 
 /// Everything a linker closure needs to invoke one linked component export,
@@ -284,13 +295,10 @@ struct LinkedExportInvocation {
     import_name: Arc<str>,
     export_name: Arc<str>,
     pre: InstancePre<SharedCtx>,
-    /// Legacy single-slot instance cache, used only by the synchronous path.
-    instance: Arc<RwLock<Option<(String, Instance)>>>,
-    exporter_instances: Arc<std::sync::RwLock<HashMap<ExporterInstanceKey, Instance>>>,
     plugin_component_id: Arc<str>,
     func_idx: ComponentExportIndex,
     param_tys: Arc<std::sync::OnceLock<Arc<[Type]>>>,
-    ephemeral_call: Option<EphemeralLinkedCall>,
+    ephemeral_call: Option<Arc<EphemeralLinkedCall>>,
 }
 
 /// Dispatch an async (`func_new_concurrent`) linked export to either the
@@ -319,38 +327,6 @@ async fn invoke_ephemeral_linked_export(
     let mut store = new_ephemeral_store(ephemeral_call)
         .await
         .map_err(|e| wasmtime::format_err!("{e:#}"))?;
-    let store_id = store.data().active_ctx.store_id.clone();
-    for (linked_component_id, linked_pre) in &ephemeral_call.linked_instances {
-        let key = (linked_component_id.clone(), store_id.clone());
-        if inv
-            .exporter_instances
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .contains_key(&key)
-        {
-            continue;
-        }
-
-        let prev_component_id = store.data().active_ctx.component_id.clone();
-        store
-            .data_mut()
-            .set_active_ctx(linked_component_id)
-            .map_err(|e| wasmtime::format_err!("{e:#}"))?;
-        let instantiate_result = linked_pre.instantiate_async(&mut store).await;
-        store
-            .data_mut()
-            .set_active_ctx(&prev_component_id)
-            .map_err(|e| wasmtime::format_err!("{e:#}"))?;
-        let instance = instantiate_result.map_err(|e| {
-            wasmtime::format_err!(
-                "failed to instantiate linked component '{linked_component_id}' in ephemeral store: {e}"
-            )
-        })?;
-        inv.exporter_instances
-            .write()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(key, instance);
-    }
 
     let params_buf = params.to_vec();
     let mut results_buf = vec![Val::Bool(false); results.len()];
@@ -358,7 +334,6 @@ async fn invoke_ephemeral_linked_export(
     let call_export_name = inv.export_name.clone();
     let call_pre = inv.pre.clone();
     let func_idx = inv.func_idx;
-    let cleanup_store_id = store_id.clone();
     let call_result = tokio::task::spawn(async move {
         let instance = call_pre.instantiate_async(&mut store).await?;
         store
@@ -386,10 +361,6 @@ async fn invoke_ephemeral_linked_export(
     })
     .await
     .map_err(|e| wasmtime::format_err!("ephemeral linked call task failed: {e}"));
-    inv.exporter_instances
-        .write()
-        .unwrap_or_else(|e| e.into_inner())
-        .retain(|(_, cached_store_id), _| cached_store_id != &cleanup_store_id);
     let call_result = call_result??;
 
     for (i, v) in call_result.into_iter().enumerate() {
@@ -416,37 +387,24 @@ async fn invoke_shared_store_linked_export(
     results: &mut [Val],
     inv: &LinkedExportInvocation,
 ) -> wasmtime::Result<()> {
-    // Switch active ctx to the linked component, remembering the caller's to restore below.
-    let prev_id = accessor.with(|mut access| -> wasmtime::Result<_> {
-        let prev_id = access.data_mut().active_ctx.component_id.clone();
-        access.data_mut().set_active_ctx(&inv.plugin_component_id)?;
-        Ok(prev_id)
-    })?;
+    let _active_ctx = AccessorActiveCtxGuard::new(accessor, &inv.plugin_component_id)?;
 
-    // Run the call; the caller's active ctx is restored on every return path below.
-    // NOTE: if this future is cancelled (dropped) mid-call the restore does not run.
     let call: wasmtime::Result<()> = async {
-        let store_id = accessor.with(|mut access| access.data_mut().active_ctx.store_id.clone());
-
-        // Every entrypoint pre-instantiates linked components, so a miss is a bug,
-        // not a lazy path (release-46's `Accessor` has no `instantiate_async`).
-        let cached = inv
-            .exporter_instances
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .get(&(inv.plugin_component_id.clone(), store_id.clone()))
-            .cloned();
-        let instance = match cached {
-            Some(instance) => instance,
-            None => {
-                return Err(wasmtime::format_err!(
-                    "linked component '{}' was not pre-instantiated for store '{store_id}'",
-                    inv.plugin_component_id
-                ));
-            }
-        };
-
+        // The store factory pre-instantiates every linked component into the
+        // store's own cache, so the instance is always present here — the
+        // concurrent `accessor.with` closure cannot instantiate on demand.
         let (func, params_buf) = accessor.with(|mut access| -> wasmtime::Result<_> {
+            let instance = access
+                .data_mut()
+                .exporter_instances
+                .get(&inv.plugin_component_id)
+                .copied()
+                .ok_or_else(|| {
+                    wasmtime::format_err!(
+                        "linked component '{}' was not pre-instantiated in this store",
+                        inv.plugin_component_id
+                    )
+                })?;
             let func = instance
                 .get_func(&mut access, inv.func_idx)
                 .ok_or_else(|| wasmtime::format_err!("function not found"))?;
@@ -475,11 +433,7 @@ async fn invoke_shared_store_linked_export(
     }
     .await;
 
-    let restore = accessor
-        .with(|mut access| -> wasmtime::Result<_> { access.data_mut().set_active_ctx(&prev_id) });
-
     call?;
-    restore?;
 
     trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoked dynamic export");
 
@@ -488,71 +442,59 @@ async fn invoke_shared_store_linked_export(
 
 /// Run a synchronous (`func_new_async`) linked call on the caller's store.
 async fn invoke_linked_sync_export(
-    mut store: StoreContextMut<'_, SharedCtx>,
+    store: StoreContextMut<'_, SharedCtx>,
     params: &[Val],
     results: &mut [Val],
     inv: &LinkedExportInvocation,
 ) -> wasmtime::Result<()> {
     // TODO(#103): some kind of store data hashing mechanism to detect a diff store to drop the old one
-    let prev_id = store.data().active_ctx.component_id.clone();
+    let mut active_ctx = StoreActiveCtxGuard::new(store, &inv.plugin_component_id)?;
+    let mut store = active_ctx.store_mut();
 
-    store.data_mut().set_active_ctx(&inv.plugin_component_id)?;
+    async {
+        // The store factory pre-instantiates linked components into the store's
+        // own cache, so the instance is always present.
+        let instance = store
+            .data()
+            .exporter_instances
+            .get(&inv.plugin_component_id)
+            .copied()
+            .ok_or_else(|| {
+                wasmtime::format_err!(
+                    "linked component '{}' was not pre-instantiated in this store",
+                    inv.plugin_component_id
+                )
+            })?;
 
-    let store_id = store.data().active_ctx.store_id.clone();
-    let instance = if let Some(instance) = inv
-        .exporter_instances
-        .read()
-        .unwrap_or_else(|e| e.into_inner())
-        .get(&(inv.plugin_component_id.clone(), store_id.clone()))
-        .cloned()
-    {
-        instance
-    } else {
-        let existing_instance = inv.instance.read().await;
-        if let Some((id, instance)) = existing_instance.clone()
-            && id == store_id
-        {
-            drop(existing_instance);
-            instance
-        } else {
-            // Likely unnecessary, but explicit drop of the read lock
-            let new_instance = inv.pre.instantiate_async(&mut store).await?;
-            drop(existing_instance);
-            *inv.instance.write().await = Some((store_id, new_instance));
-            new_instance
-        }
-    };
+        let func = instance
+            .get_func(&mut store, inv.func_idx)
+            .ok_or_else(|| wasmtime::format_err!("function not found"))?;
+        let tys = inv.param_tys.get_or_init(|| {
+            func.ty(store.as_context())
+                .params()
+                .map(|(_, ty)| ty)
+                .collect::<Vec<_>>()
+                .into()
+        });
+        let params_buf = lower_params(store, params, tys)?;
+        trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoking dynamic export");
 
-    let func = instance
-        .get_func(&mut store, inv.func_idx)
-        .ok_or_else(|| wasmtime::format_err!("function not found"))?;
-    let tys = inv.param_tys.get_or_init(|| {
-        func.ty(store.as_context())
-            .params()
-            .map(|(_, ty)| ty)
-            .collect::<Vec<_>>()
-            .into()
-    });
-    let params_buf = lower_params(&mut store, params, tys)?;
-    trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoking dynamic export");
+        let mut results_buf = vec![Val::Bool(false); results.len()];
 
-    let mut results_buf = vec![Val::Bool(false); results.len()];
+        // Enforce a timeout on this call to prevent hanging indefinitely
+        const CALL_TIMEOUT: Duration = Duration::from_secs(30);
+        timeout(
+            CALL_TIMEOUT,
+            func.call_async(&mut store, &params_buf, &mut results_buf),
+        )
+        .await
+        .map_err(|e| wasmtime::format_err!("function call timed out after 30 seconds: {e}"))??;
 
-    // Enforce a timeout on this call to prevent hanging indefinitely
-    const CALL_TIMEOUT: Duration = Duration::from_secs(30);
-    timeout(
-        CALL_TIMEOUT,
-        func.call_async(&mut store, &params_buf, &mut results_buf),
-    )
+        lift_results(store, results_buf, results)?;
+        trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoked dynamic export");
+        Ok(())
+    }
     .await
-    .map_err(|e| wasmtime::format_err!("function call timed out after 30 seconds: {e}"))??;
-
-    lift_results(&mut store, results_buf, results)?;
-    trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoked dynamic export");
-
-    store.data_mut().set_active_ctx(&prev_id)?;
-
-    Ok(())
 }
 
 /// Metadata associated with components and services within a workload.
@@ -572,6 +514,8 @@ pub struct WorkloadMetadata {
     linker: Linker<SharedCtx>,
     /// The volume mounts requested by this component
     volume_mounts: Vec<(PathBuf, VolumeMount)>,
+    /// Canonicalized volume mounts, resolved once during workload resolution.
+    resolved_volume_mounts: Vec<ResolvedVolumeMount>,
     /// The local resources requested by this component
     local_resources: LocalResources,
     /// The plugins available to this component
@@ -583,6 +527,15 @@ pub struct WorkloadMetadata {
 }
 
 impl WorkloadMetadata {
+    async fn resolve_volume_mounts(&mut self) -> anyhow::Result<()> {
+        let mut resolved = Vec::with_capacity(self.volume_mounts.len());
+        for (host_path, mount) in &self.volume_mounts {
+            resolved.push(ResolvedVolumeMount::from_mount(host_path, mount).await?);
+        }
+        self.resolved_volume_mounts = resolved;
+        Ok(())
+    }
+
     /// Returns the unique identifier for this component.
     pub fn id(&self) -> &str {
         &self.id
@@ -788,6 +741,7 @@ impl WorkloadService {
                 component,
                 linker,
                 volume_mounts,
+                resolved_volume_mounts: Vec::new(),
                 local_resources,
                 plugins: None,
                 loopback,
@@ -864,6 +818,7 @@ impl WorkloadComponent {
                 component,
                 linker,
                 volume_mounts,
+                resolved_volume_mounts: Vec::new(),
                 local_resources,
                 plugins: None,
                 loopback,
@@ -1008,9 +963,6 @@ pub struct ResolvedWorkload {
     service: Option<WorkloadService>,
     /// The requested host [`WitInterface`]s to resolve this workload
     host_interfaces: Vec<WitInterface>,
-    /// Per-store cache of exporter instances used by async canonical-ABI
-    /// cross-component calls.
-    exporter_instances: Arc<std::sync::RwLock<HashMap<ExporterInstanceKey, Instance>>>,
     /// TLS provider override for `wasi:tls` client connections in this workload.
     #[cfg(feature = "wasi-tls")]
     tls_provider: Option<SharedTlsProvider>,
@@ -1055,6 +1007,7 @@ impl ResolvedWorkload {
         };
         let pre = service.pre_instantiate()?;
         let mut max_restarts = service.max_restarts;
+        self.resolve_service_volume_mounts().await?;
         // Re-borrow immutably after the mutable borrow for pre_instantiate() is done
         let Some(service) = self.service.as_ref() else {
             bail!("service unexpectedly missing during execution");
@@ -1094,30 +1047,18 @@ impl ResolvedWorkload {
             .map(|s| (s.pre_instantiate_p3(), s.max_restarts));
 
         if let Some((Ok(pre), mut max_restarts)) = service {
+            self.resolve_service_volume_mounts().await?;
             let mut store = if let Some(service) = self.service.as_ref() {
                 self.new_store_from_metadata(&service.metadata, true)
                     .await?
             } else {
                 bail!("service unexpectedly missing during execution");
             };
-            let linked_component_ids = if let Some(service) = self.service.as_ref() {
-                self.component_ids_except(service.metadata.id()).await
-            } else {
-                Vec::new()
-            };
-            self.pre_instantiate_linked_component_ids(&mut store, linked_component_ids)
-                .await?;
-            let store_id = store.data().active_ctx.store_id.clone();
-            // Drops this store's exporter-instance entries when the service task
-            // ends — including on stop_service()'s abort(), where the old
-            // trailing `retain` was skipped.
-            let cache_cleanup = ExporterCacheCleanup {
-                exporter_instances: self.exporter_instances.clone(),
-                store_id,
-            };
+            // `new_store_from_metadata` already pre-instantiated the linked
+            // components into the store-owned cache; they are reclaimed when the
+            // store is dropped (service exit/abort), no external cleanup needed.
 
             let handle = tokio::spawn(async move {
-                let _cache_cleanup = cache_cleanup;
                 loop {
                     let instance = match pre.instantiate_async(&mut store).await {
                         Ok(i) => i,
@@ -1186,77 +1127,60 @@ impl ResolvedWorkload {
         &self.host_interfaces
     }
 
-    async fn component_ids_except(&self, component_id: &str) -> Vec<Arc<str>> {
-        self.components
-            .read()
-            .await
-            .keys()
-            .filter(|id| id.as_ref() != component_id)
-            .cloned()
-            .collect()
-    }
-
-    pub(crate) fn clear_exporter_instances_for_store(&self, store_id: &str) {
-        self.exporter_instances
-            .write()
-            .unwrap_or_else(|e| e.into_inner())
-            .retain(|(_, cached_store_id), _| cached_store_id != store_id);
-    }
-
-    async fn pre_instantiate_linked_component_ids(
+    async fn resolve_component_volume_mounts(
         &self,
-        store: &mut wasmtime::Store<SharedCtx>,
-        linked_component_ids: Vec<Arc<str>>,
+        component_ids: &[Arc<str>],
     ) -> anyhow::Result<()> {
-        let store_id = store.data().active_ctx.store_id.clone();
-
-        for linked_component_id in linked_component_ids {
-            let key = (linked_component_id.clone(), store_id.clone());
-            if self
-                .exporter_instances
-                .read()
-                .unwrap_or_else(|e| e.into_inner())
-                .contains_key(&key)
+        let mut components = self.components.write().await;
+        for component_id in component_ids {
+            let component = components
+                .get_mut(component_id)
+                .with_context(|| format!("component '{component_id}' not found"))?;
+            if component.metadata.resolved_volume_mounts.is_empty()
+                && !component.metadata.volume_mounts.is_empty()
             {
-                continue;
+                component.metadata.resolve_volume_mounts().await?;
             }
-
-            let pre = self.instantiate_pre(linked_component_id.as_ref()).await?;
-            let prev_component_id = store.data().active_ctx.component_id.clone();
-            store.data_mut().set_active_ctx(&linked_component_id)?;
-            let instantiate_result = pre.instantiate_async(&mut *store).await;
-            store.data_mut().set_active_ctx(&prev_component_id)?;
-            let instance = instantiate_result.map_err(|e| {
-                anyhow::anyhow!(
-                    "failed to instantiate linked component '{linked_component_id}': {e}"
-                )
-            })?;
-
-            self.exporter_instances
-                .write()
-                .unwrap_or_else(|e| e.into_inner())
-                .insert(key, instance);
         }
-
         Ok(())
     }
 
-    pub async fn pre_instantiate_linked_components_for_component(
-        &self,
-        store: &mut wasmtime::Store<SharedCtx>,
-        component_id: &str,
-    ) -> anyhow::Result<()> {
+    async fn resolve_service_volume_mounts(&mut self) -> anyhow::Result<()> {
+        let linked_component_ids = self
+            .service
+            .as_ref()
+            .map(|service| {
+                service
+                    .metadata
+                    .linked_components
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        self.resolve_component_volume_mounts(&linked_component_ids)
+            .await?;
+        if let Some(service) = &mut self.service
+            && service.metadata.resolved_volume_mounts.is_empty()
+            && !service.metadata.volume_mounts.is_empty()
         {
-            let components = self.components.read().await;
-            components
-                .get(component_id)
-                .context("component ID not found in workload")?;
+            service.metadata.resolve_volume_mounts().await?;
+        }
+        Ok(())
+    }
+
+    fn component_ctx_template(&self, metadata: &WorkloadMetadata) -> ComponentCtxTemplate {
+        #[cfg(feature = "wasi-tls")]
+        {
+            let mut template = ComponentCtxTemplate::from_metadata(metadata);
+            template.tls_provider = self.tls_provider.clone();
+            template
         }
 
-        let linked_component_ids = self.component_ids_except(component_id).await;
-
-        self.pre_instantiate_linked_component_ids(store, linked_component_ids)
-            .await
+        #[cfg(not(feature = "wasi-tls"))]
+        {
+            ComponentCtxTemplate::from_metadata(metadata)
+        }
     }
 
     #[instrument(name="link_components", skip_all, fields(workload.id = self.id.as_ref(), workload.name = self.name.as_ref(), workload.namespace = self.namespace.as_ref()))]
@@ -1354,6 +1278,8 @@ impl ResolvedWorkload {
             "processing components in topological order"
         );
 
+        let mut resolved_links: HashMap<Arc<str>, HashSet<Arc<str>>> = HashMap::new();
+
         for component_id in sorted_component_ids {
             // In order to have mutable access to both the workload component and components that need
             // to be instantiated as "plugins" during linking, we remove and re-add the component to the list.
@@ -1368,29 +1294,29 @@ impl ResolvedWorkload {
             let component = workload_component.metadata.component.clone();
             let linker = &mut workload_component.metadata.linker;
 
-            // TODO: only triggerable components (e.g. http-handler, messaging handler) should have linked components
-            let linked_components = self.components.read().await.keys().cloned().collect();
-
             let res = match self
                 .resolve_component_imports(&component, linker, interface_map)
                 .await
             {
-                Ok(_) => {
+                Ok(direct_links) => {
+                    let linked_components = expand_link_closure(&direct_links, &resolved_links);
                     workload_component.linked_components = linked_components;
                     Ok(())
                 }
                 Err(err) => Err(err),
             };
 
+            let linked_components = workload_component.linked_components.clone();
+            let workload_component_id = workload_component.metadata.id.clone();
+
             self.components
                 .write()
                 .await
                 .insert(workload_component.metadata.id.clone(), workload_component);
+            resolved_links.insert(workload_component_id, linked_components);
             // Propagate any errors encountered during import resolution
             res?;
         }
-
-        let linked_components = self.components.read().await.keys().cloned().collect();
 
         if let Some(mut service) = self.service.take() {
             let component = service.metadata.component.clone();
@@ -1400,7 +1326,8 @@ impl ResolvedWorkload {
                 .resolve_component_imports(&component, linker, interface_map)
                 .await
             {
-                Ok(_) => {
+                Ok(direct_links) => {
+                    let linked_components = expand_link_closure(&direct_links, &resolved_links);
                     service.metadata.linked_components = linked_components;
                     Ok(())
                 }
@@ -1426,7 +1353,6 @@ impl ResolvedWorkload {
         let ty = component.component_type();
         let imports: Vec<_> = ty.imports(component.engine()).collect();
 
-        let instance: SharedInstanceSlot = Arc::default();
         for (import_name, import_item) in imports.into_iter() {
             match import_item.ty {
                 ComponentItem::ComponentInstance(import_instance_ty) => {
@@ -1460,46 +1386,17 @@ impl ResolvedWorkload {
                                     "exporting component '{exporter_component}' for import '{import_name}' not found"
                                 );
                             };
-                            let mut ids = Vec::<Arc<str>>::new();
-                            for (nested_import_name, nested_import_item) in
-                                exporter_workload_component
-                                    .metadata
-                                    .component
-                                    .component_type()
-                                    .imports(
-                                        exporter_workload_component.metadata.component.engine(),
-                                    )
-                            {
-                                if !matches!(
-                                    nested_import_item.ty,
-                                    ComponentItem::ComponentInstance(_)
-                                ) {
-                                    continue;
-                                }
-                                let Some(nested_component_id) =
-                                    interface_map.get(nested_import_name)
-                                else {
-                                    continue;
-                                };
-                                if nested_component_id.as_ref() == exporter_component.as_ref() {
-                                    continue;
-                                }
-                                if ids
-                                    .iter()
-                                    .any(|id| id.as_ref() == nested_component_id.as_ref())
-                                {
-                                    continue;
-                                }
-                                ids.push(nested_component_id.clone());
-                            }
-                            ids
+                            exporter_workload_component
+                                .metadata
+                                .linked_components
+                                .iter()
+                                .cloned()
+                                .collect::<Vec<_>>()
                         };
                         let linked_ctx_templates = nested_linked_component_ids
                             .iter()
                             .filter_map(|component_id| all_components.get(component_id))
-                            .map(|component| {
-                                ComponentCtxTemplate::from_metadata(&component.metadata)
-                            })
+                            .map(|component| self.component_ctx_template(&component.metadata))
                             .collect::<Vec<_>>();
                         let linked_instances = nested_linked_component_ids
                             .iter()
@@ -1528,7 +1425,7 @@ impl ResolvedWorkload {
                             );
                         };
                         let plugin_ctx_template =
-                            ComponentCtxTemplate::from_metadata(&plugin_component.metadata);
+                            self.component_ctx_template(&plugin_component.metadata);
                         let plugin_engine = plugin_component.metadata.engine().clone();
                         let Some((ComponentItem::ComponentInstance(_), idx)) = plugin_component
                             .metadata
@@ -1594,13 +1491,13 @@ impl ResolvedWorkload {
                                 let export_is_async = func_ty.async_();
                                 let ephemeral_call =
                                     if export_is_async && func_is_ephemeral_safe(&func_ty) {
-                                        Some(EphemeralLinkedCall {
+                                        Some(Arc::new(EphemeralLinkedCall {
                                             engine: plugin_engine.clone(),
                                             http_handler: self.http_handler.clone(),
                                             active: plugin_ctx_template.clone(),
                                             linked: linked_ctx_templates.clone(),
                                             linked_instances: linked_instances.clone(),
-                                        })
+                                        }))
                                     } else {
                                         None
                                     };
@@ -1609,8 +1506,6 @@ impl ResolvedWorkload {
                                     import_name: import_name.into(),
                                     export_name: export_name.into(),
                                     pre: pre.clone(),
-                                    instance: instance.clone(),
-                                    exporter_instances: self.exporter_instances.clone(),
                                     plugin_component_id: plugin_component.id.clone(),
                                     func_idx,
                                     param_tys: Arc::default(),
@@ -1754,103 +1649,43 @@ impl ResolvedWorkload {
         self.components.read().await.len()
     }
 
-    /// Helper to create a new wasmtime Store for a given component in the workload.
-    async fn new_ctx(&self, component_id: &str) -> anyhow::Result<Ctx> {
-        let components = self.components.read().await;
-        let component = components
-            .get(component_id)
-            .context("component ID not found in workload")?;
-        self.new_ctx_from_metadata(&component.metadata, false).await
-    }
-
-    /// Creates a new wasmtime Store from the given workload metadata.
-    async fn new_ctx_from_metadata(
-        &self,
-        metadata: &WorkloadMetadata,
-        is_service: bool,
-    ) -> anyhow::Result<Ctx> {
-        let components = self.components.read().await;
-
-        // TODO: Consider stderr/stdout buffering + logging
-        let mut wasi_ctx_builder = WasiCtxBuilder::new();
-        wasi_ctx_builder
-            .envs(
-                metadata
-                    .local_resources
-                    .environment
-                    .iter()
-                    .map(|kv| (kv.0.as_str(), kv.1.as_str()))
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            )
-            .inherit_stdout()
-            .inherit_stderr();
-
-        // Build our custom sockets context with loopback support
-        let sockets_ctx = sockets::WasiSocketsCtx {
-            socket_addr_check: sockets::SocketAddrCheck::new(move |addr, reason| {
-                Box::pin(async move {
-                    match reason {
-                        SocketAddrUse::TcpBind if is_service => addr.ip().is_loopback(),
-                        SocketAddrUse::TcpBind => false,
-                        SocketAddrUse::UdpBind => {
-                            // NOTE: Outbound UDP requires an explicit bind in `wasi:sockets`
-                            addr.ip().is_loopback() || addr.ip().is_unspecified()
-                        }
-                        SocketAddrUse::TcpConnect
-                        | SocketAddrUse::UdpConnect
-                        | SocketAddrUse::UdpOutgoingDatagram => true,
-                    }
-                })
-            }),
-            loopback: Arc::clone(&metadata.loopback),
-            ..Default::default()
-        };
-
-        // Mount all possible volume mounts in the workload since components share a WasiCtx
-        for (host_path, mount) in &components
-            .values()
-            .flat_map(|workload_component| workload_component.metadata.volume_mounts.clone())
-            .collect::<Vec<_>>()
-        {
-            let dir = tokio::fs::canonicalize(host_path).await?;
-            debug!(host_path = %dir.display(), container_path = %mount.mount_path, "preopening volume mount");
-            let (dir_perms, file_perms) = match mount.read_only {
-                true => (DirPerms::READ, FilePerms::READ),
-                false => (DirPerms::all(), FilePerms::all()),
-            };
-            wasi_ctx_builder.preopened_dir(&dir, &mount.mount_path, dir_perms, file_perms)?;
-        }
-
-        let mut ctx_builder = Ctx::builder(metadata.workload_id(), metadata.id())
-            .with_http_handler(self.http_handler.clone())
-            .with_wasi_ctx(wasi_ctx_builder.build())
-            .with_sockets(sockets_ctx)
-            .with_allowed_hosts(metadata.local_resources.allowed_hosts.clone());
-
-        if let Some(plugins) = &metadata.plugins {
-            ctx_builder = ctx_builder.with_plugins(plugins.clone());
-        }
-
-        #[cfg(feature = "wasi-tls")]
-        if let Some(provider) = self.tls_provider.clone() {
-            ctx_builder = ctx_builder.with_tls_provider(provider);
-        }
-
-        Ok(ctx_builder.build())
-    }
-
     /// Helper to create a new wasmtime Store for multiple components and set active given component in the workload.
     pub async fn new_store(
         &self,
         component_id: &str,
     ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
-        let components = self.components.read().await;
-        let component = components
-            .get(component_id)
-            .context("component ID not found in workload")?;
-        self.new_store_from_metadata(&component.metadata, false)
-            .await
+        let component_id = Arc::<str>::from(component_id);
+        let mut component_ids = {
+            let components = self.components.read().await;
+            let component = components
+                .get(&component_id)
+                .context("component ID not found in workload")?;
+            let mut ids = component
+                .metadata
+                .linked_components
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>();
+            ids.push(component_id.clone());
+            ids
+        };
+        component_ids.sort();
+        component_ids.dedup();
+        self.resolve_component_volume_mounts(&component_ids).await?;
+
+        // Clone the metadata and drop the read lock before building the store:
+        // the store factory pre-instantiates linked components, which takes a
+        // `components` write lock (via `instantiate_pre`) — holding the read
+        // lock across that call would deadlock.
+        let metadata = {
+            let components = self.components.read().await;
+            components
+                .get(&component_id)
+                .context("component ID not found in workload")?
+                .metadata
+                .clone()
+        };
+        self.new_store_from_metadata(&metadata, false).await
     }
 
     /// Creates a new wasmtime Store for multiple components from the given workload metadata.
@@ -1859,24 +1694,47 @@ impl ResolvedWorkload {
         metadata: &WorkloadMetadata,
         is_service: bool,
     ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
-        let store_id = uuid::Uuid::new_v4().to_string();
-        let mut active_ctx = self.new_ctx_from_metadata(metadata, is_service).await?;
-        active_ctx.store_id = store_id.clone();
-        let mut shared_ctx = SharedCtx::new(active_ctx);
-
-        let linked_component_ids = self.component_ids_except(metadata.id()).await;
-
-        for linked_component_id in linked_component_ids {
-            let mut linked_component_ctx = self.new_ctx(linked_component_id.as_ref()).await?;
-            linked_component_ctx.store_id = store_id.clone();
-            shared_ctx
-                .contexts
-                .insert(linked_component_id.clone(), linked_component_ctx);
+        let linked_component_ids = metadata
+            .linked_components
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let linked_metadata = {
+            let components = self.components.read().await;
+            linked_component_ids
+                .iter()
+                .map(|linked_component_id| {
+                    components
+                        .get(linked_component_id)
+                        .map(|component| component.metadata.clone())
+                        .with_context(|| {
+                            format!("linked component '{linked_component_id}' not found")
+                        })
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?
+        };
+        let active_template = self.component_ctx_template(metadata);
+        let linked_templates = linked_metadata
+            .iter()
+            .map(|metadata| self.component_ctx_template(metadata))
+            .collect::<Vec<_>>();
+        let mut linked_instances = Vec::with_capacity(linked_component_ids.len());
+        for linked_component_id in &linked_component_ids {
+            linked_instances.push((
+                linked_component_id.clone(),
+                self.instantiate_pre(linked_component_id.as_ref()).await?,
+            ));
         }
 
-        let store = wasmtime::Store::new(metadata.engine(), shared_ctx);
-
-        Ok(store)
+        new_store_from_templates(
+            metadata.engine(),
+            self.http_handler.clone(),
+            &active_template,
+            &linked_templates,
+            &linked_instances,
+            is_service,
+        )
+        .await
     }
 
     pub async fn instantiate_pre(
@@ -2403,7 +2261,6 @@ impl UnresolvedWorkload {
             service: self.service,
             host_interfaces: self.host_interfaces,
             http_handler: http_handler.clone(),
-            exporter_instances: Arc::default(),
             #[cfg(feature = "wasi-tls")]
             tls_provider: self.tls_provider,
         };
@@ -2611,6 +2468,19 @@ fn topological_sort_components(
     }
 
     Ok(result)
+}
+
+fn expand_link_closure(
+    direct_links: &HashSet<Arc<str>>,
+    resolved_links: &HashMap<Arc<str>, HashSet<Arc<str>>>,
+) -> HashSet<Arc<str>> {
+    let mut linked_components = direct_links.clone();
+    for linked_component_id in direct_links {
+        if let Some(nested_links) = resolved_links.get(linked_component_id) {
+            linked_components.extend(nested_links.iter().cloned());
+        }
+    }
+    linked_components
 }
 
 // Helper enum to differentiate between component and service IDs
@@ -3286,6 +3156,28 @@ mod tests {
         let (map, ambiguous) = build_export_map(&exports);
         assert!(!map.contains_key(&iface));
         assert!(ambiguous.contains(&iface));
+    }
+
+    #[test]
+    fn expand_link_closure_adds_nested_links_only() {
+        let a: Arc<str> = Arc::from("component-a");
+        let b: Arc<str> = Arc::from("component-b");
+        let c: Arc<str> = Arc::from("component-c");
+        let unrelated: Arc<str> = Arc::from("unrelated");
+
+        let direct_links = HashSet::from([a.clone()]);
+        let resolved_links = HashMap::from([
+            (a.clone(), HashSet::from([b.clone(), c.clone()])),
+            (unrelated.clone(), HashSet::from([Arc::from("ignored")])),
+        ]);
+
+        let closure = expand_link_closure(&direct_links, &resolved_links);
+
+        assert_eq!(closure.len(), 3);
+        assert!(closure.contains(&a));
+        assert!(closure.contains(&b));
+        assert!(closure.contains(&c));
+        assert!(!closure.contains(&unrelated));
     }
 
     #[test]

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -5,30 +5,29 @@ use std::{
     ops::{Deref, DerefMut},
     path::PathBuf,
     sync::Arc,
-    time::Duration,
 };
 
-use crate::{
-    plugin::WitInterfaces,
-    sockets::{self, SocketAddrUse, loopback},
-};
-use anyhow::{Context as _, bail, ensure};
-use tokio::{sync::RwLock, task::JoinHandle, time::timeout};
+use crate::{plugin::WitInterfaces, sockets::loopback};
+use anyhow::{bail, ensure};
+use tokio::{sync::RwLock, task::JoinHandle};
 use tracing::{Instrument, debug, error, info, instrument, trace, warn};
 use wasmtime::component::{
-    Accessor, Component, ComponentExportIndex, InstancePre, Linker, ResourceAny, ResourceType, Val,
-    types::{ComponentFunc, ComponentItem, Type},
+    Component, InstancePre, Linker, ResourceAny, ResourceType, types::ComponentItem,
 };
-use wasmtime::{AsContext, AsContextMut, StoreContextMut};
+use wasmtime::error::Context as _;
 use wasmtime_wasi::p2::bindings::CommandPre;
-use wasmtime_wasi::{DirPerms, FilePerms, WasiCtxBuilder};
 
 #[cfg(feature = "wasi-tls")]
 use crate::engine::ctx::SharedTlsProvider;
 use crate::{
     engine::{
-        ctx::{AccessorActiveCtxGuard, Ctx, SharedCtx, StoreActiveCtxGuard},
-        value::{carries_cross_store_handle, lift, lower_with_type},
+        ctx::SharedCtx,
+        linked_call::{
+            ComponentCtxTemplate, EphemeralLinkedCall, LinkedExportInvocation,
+            func_is_ephemeral_safe, invoke_linked_async_export, invoke_linked_sync_export,
+            new_store_from_templates,
+        },
+        volumes::{ResolvedVolumeMount, resolve_component_volume_mounts_in_map},
     },
     plugin::HostPlugin,
     types::{LocalResources, VolumeMount},
@@ -43,593 +42,13 @@ type BoundPluginWithInterfaces = (
     Vec<String>,
 );
 
-/// Lower dynamic-linker call params, using each param's declared type so host
-/// resource handles cross the linker by identity (see [`lower_with_type`]).
-fn lower_params(
-    store: &mut StoreContextMut<'_, SharedCtx>,
-    params: &[Val],
-    param_tys: &[Type],
-) -> wasmtime::Result<Vec<Val>> {
-    if params.len() != param_tys.len() {
-        return Err(wasmtime::format_err!(
-            "dynamic call arity mismatch: {} args vs {} param types",
-            params.len(),
-            param_tys.len()
-        ));
-    }
-    let mut params_buf = Vec::with_capacity(params.len());
-    for (v, ty) in params.iter().zip(param_tys) {
-        params_buf.push(lower_with_type(store, v, ty)?);
-    }
-    Ok(params_buf)
-}
-
-fn lift_results(
-    store: &mut StoreContextMut<'_, SharedCtx>,
-    results_buf: Vec<Val>,
-    results: &mut [Val],
-) -> wasmtime::Result<()> {
-    for (i, v) in results_buf.into_iter().enumerate() {
-        *results
-            .get_mut(i)
-            .ok_or_else(|| wasmtime::format_err!("result index out of bounds"))? = lift(store, v)?;
-    }
-    Ok(())
-}
-
-#[derive(Clone)]
-struct ResolvedVolumeMount {
-    host_path: PathBuf,
-    mount_path: String,
-    dir_perms: DirPerms,
-    file_perms: FilePerms,
-}
-
-impl ResolvedVolumeMount {
-    async fn from_mount(host_path: &PathBuf, mount: &VolumeMount) -> anyhow::Result<Self> {
-        let host_path = tokio::fs::canonicalize(host_path).await?;
-        let (dir_perms, file_perms) = match mount.read_only {
-            true => (DirPerms::READ, FilePerms::READ),
-            false => (DirPerms::all(), FilePerms::all()),
-        };
-
-        Ok(Self {
-            host_path,
-            mount_path: mount.mount_path.clone(),
-            dir_perms,
-            file_perms,
-        })
-    }
-}
-
-async fn resolve_volume_mounts(
-    volume_mounts: &[(PathBuf, VolumeMount)],
-) -> anyhow::Result<Vec<ResolvedVolumeMount>> {
-    let mut resolved = Vec::with_capacity(volume_mounts.len());
-    for (host_path, mount) in volume_mounts {
-        resolved.push(ResolvedVolumeMount::from_mount(host_path, mount).await?);
-    }
-    Ok(resolved)
-}
-
-async fn resolve_component_volume_mounts_in_map(
-    components: &Arc<RwLock<HashMap<Arc<str>, WorkloadComponent>>>,
-    component_ids: &[Arc<str>],
-) -> anyhow::Result<()> {
-    let pending = {
-        let components = components.read().await;
-        let mut pending = Vec::new();
-        for component_id in component_ids {
-            let component = components
-                .get(component_id)
-                .with_context(|| format!("component '{component_id}' not found"))?;
-            if component.metadata.resolved_volume_mounts.is_empty()
-                && !component.metadata.volume_mounts.is_empty()
-            {
-                pending.push((
-                    component_id.clone(),
-                    component.metadata.volume_mounts.clone(),
-                ));
-            }
-        }
-        pending
-    };
-
-    if pending.is_empty() {
-        return Ok(());
-    }
-
-    let mut resolved = Vec::with_capacity(pending.len());
-    for (component_id, volume_mounts) in pending {
-        resolved.push((component_id, resolve_volume_mounts(&volume_mounts).await?));
-    }
-
-    let mut components = components.write().await;
-    for (component_id, resolved_volume_mounts) in resolved {
-        let component = components
-            .get_mut(&component_id)
-            .with_context(|| format!("component '{component_id}' not found"))?;
-        if component.metadata.resolved_volume_mounts.is_empty() {
-            component.metadata.resolved_volume_mounts = resolved_volume_mounts;
-        }
-    }
-
-    Ok(())
-}
-
-#[derive(Clone)]
-struct ComponentCtxTemplate {
-    component_id: Arc<str>,
-    workload_id: Arc<str>,
-    local_resources: LocalResources,
-    volume_mounts: Vec<ResolvedVolumeMount>,
-    plugins: Option<HashMap<&'static str, Arc<dyn HostPlugin + Send + Sync>>>,
-    loopback: Arc<std::sync::Mutex<loopback::Network>>,
-    #[cfg(feature = "wasi-tls")]
-    tls_provider: Option<SharedTlsProvider>,
-}
-
-impl ComponentCtxTemplate {
-    fn from_metadata(metadata: &WorkloadMetadata) -> Self {
-        Self {
-            component_id: metadata.id.clone(),
-            workload_id: metadata.workload_id.clone(),
-            local_resources: metadata.local_resources.clone(),
-            volume_mounts: metadata.resolved_volume_mounts.clone(),
-            plugins: metadata.plugins.clone(),
-            loopback: metadata.loopback.clone(),
-            #[cfg(feature = "wasi-tls")]
-            tls_provider: None,
-        }
-    }
-}
-
-#[cfg(not(feature = "wasi-tls"))]
-fn component_ctx_template_from_metadata(metadata: &WorkloadMetadata) -> ComponentCtxTemplate {
-    ComponentCtxTemplate::from_metadata(metadata)
-}
-
-#[cfg(feature = "wasi-tls")]
-fn component_ctx_template_from_metadata_with_tls(
-    metadata: &WorkloadMetadata,
-    tls_provider: Option<SharedTlsProvider>,
-) -> ComponentCtxTemplate {
-    let mut template = ComponentCtxTemplate::from_metadata(metadata);
-    template.tls_provider = tls_provider;
-    template
-}
-
-#[derive(Clone)]
-struct EphemeralLinkedCall {
-    engine: wasmtime::Engine,
-    http_handler: Arc<dyn crate::host::http::HostHandler>,
-    components: Arc<RwLock<HashMap<Arc<str>, WorkloadComponent>>>,
-    active_component_id: Arc<str>,
-    linked_component_ids: Vec<Arc<str>>,
-    #[cfg(feature = "wasi-tls")]
-    tls_provider: Option<SharedTlsProvider>,
-}
-
-fn type_is_ephemeral_safe(ty: &Type) -> bool {
-    !carries_cross_store_handle(ty)
-}
-
-fn func_is_ephemeral_safe(func_ty: &ComponentFunc) -> bool {
-    func_ty.params().all(|(_, ty)| type_is_ephemeral_safe(&ty))
-        && func_ty.results().all(|ty| type_is_ephemeral_safe(&ty))
-}
-
-async fn build_ctx_from_template(
-    template: &ComponentCtxTemplate,
-    http_handler: Arc<dyn crate::host::http::HostHandler>,
-    all_volume_mounts: &[ResolvedVolumeMount],
-    store_id: &str,
-    is_service: bool,
-) -> anyhow::Result<Ctx> {
-    let mut wasi_ctx_builder = WasiCtxBuilder::new();
-    wasi_ctx_builder
-        .envs(
-            template
-                .local_resources
-                .environment
-                .iter()
-                .map(|kv| (kv.0.as_str(), kv.1.as_str()))
-                .collect::<Vec<_>>()
-                .as_slice(),
-        )
-        .inherit_stdout()
-        .inherit_stderr();
-
-    let sockets_ctx = sockets::WasiSocketsCtx {
-        socket_addr_check: sockets::SocketAddrCheck::new(move |addr, reason| {
-            Box::pin(async move {
-                match reason {
-                    SocketAddrUse::TcpBind if is_service => addr.ip().is_loopback(),
-                    SocketAddrUse::TcpBind => false,
-                    SocketAddrUse::UdpBind => addr.ip().is_loopback() || addr.ip().is_unspecified(),
-                    SocketAddrUse::TcpConnect
-                    | SocketAddrUse::UdpConnect
-                    | SocketAddrUse::UdpOutgoingDatagram => true,
-                }
-            })
-        }),
-        loopback: Arc::clone(&template.loopback),
-        ..Default::default()
-    };
-
-    for mount in all_volume_mounts {
-        wasi_ctx_builder.preopened_dir(
-            &mount.host_path,
-            &mount.mount_path,
-            mount.dir_perms,
-            mount.file_perms,
-        )?;
-    }
-
-    let mut ctx_builder = Ctx::builder(template.workload_id.clone(), template.component_id.clone())
-        .with_http_handler(http_handler)
-        .with_wasi_ctx(wasi_ctx_builder.build())
-        .with_sockets(sockets_ctx)
-        .with_allowed_hosts(template.local_resources.allowed_hosts.clone());
-
-    if let Some(plugins) = &template.plugins {
-        ctx_builder = ctx_builder.with_plugins(plugins.clone());
-    }
-
-    #[cfg(feature = "wasi-tls")]
-    if let Some(provider) = template.tls_provider.clone() {
-        ctx_builder = ctx_builder.with_tls_provider(provider);
-    }
-
-    let mut ctx = ctx_builder.build();
-    ctx.store_id = store_id.to_string();
-    Ok(ctx)
-}
-
-async fn new_store_from_templates(
-    engine: &wasmtime::Engine,
-    http_handler: Arc<dyn crate::host::http::HostHandler>,
-    active: &ComponentCtxTemplate,
-    linked: &[ComponentCtxTemplate],
-    linked_instances: &[(Arc<str>, InstancePre<SharedCtx>)],
-    is_service: bool,
-) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
-    let store_id = uuid::Uuid::new_v4().to_string();
-    let all_volume_mounts = std::iter::once(active)
-        .chain(linked.iter())
-        .flat_map(|template| template.volume_mounts.clone())
-        .collect::<Vec<_>>();
-    let active_ctx = build_ctx_from_template(
-        active,
-        http_handler.clone(),
-        &all_volume_mounts,
-        &store_id,
-        is_service,
-    )
-    .await?;
-    let mut shared_ctx = SharedCtx::new(active_ctx);
-
-    for linked in linked {
-        let linked_ctx = build_ctx_from_template(
-            linked,
-            http_handler.clone(),
-            &all_volume_mounts,
-            &store_id,
-            false,
-        )
-        .await?;
-        shared_ctx
-            .contexts
-            .insert(linked.component_id.clone(), linked_ctx);
-    }
-
-    let mut store = wasmtime::Store::new(engine, shared_ctx);
-
-    let active_id = active.component_id.clone();
-    for (linked_id, linked_pre) in linked_instances {
-        store.data_mut().set_active_ctx(linked_id)?;
-        let instantiate_result = linked_pre.instantiate_async(&mut store).await;
-        store.data_mut().set_active_ctx(&active_id)?;
-        let instance = instantiate_result.map_err(|e| {
-            anyhow::anyhow!(
-                "failed to instantiate linked component '{linked_id}' in ephemeral store: {e}"
-            )
-        })?;
-        store
-            .data_mut()
-            .exporter_instances
-            .insert(linked_id.clone(), instance);
-    }
-
-    Ok(store)
-}
-
-async fn new_ephemeral_store(
-    call: &EphemeralLinkedCall,
-) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
-    let mut component_ids = call.linked_component_ids.clone();
-    component_ids.push(call.active_component_id.clone());
-    component_ids.sort();
-    component_ids.dedup();
-    resolve_component_volume_mounts_in_map(&call.components, &component_ids).await?;
-
-    let (active_metadata, linked_metadata) = {
-        let components = call.components.read().await;
-        let active = components
-            .get(&call.active_component_id)
-            .with_context(|| {
-                format!(
-                    "ephemeral linked component '{}' not found",
-                    call.active_component_id
-                )
-            })?
-            .metadata
-            .clone();
-        let linked = call
-            .linked_component_ids
-            .iter()
-            .map(|component_id| {
-                components
-                    .get(component_id)
-                    .with_context(|| format!("linked component '{component_id}' not found"))
-                    .map(|component| component.metadata.clone())
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-        (active, linked)
-    };
-
-    #[cfg(not(feature = "wasi-tls"))]
-    let active = component_ctx_template_from_metadata(&active_metadata);
-    #[cfg(feature = "wasi-tls")]
-    let active =
-        component_ctx_template_from_metadata_with_tls(&active_metadata, call.tls_provider.clone());
-
-    #[cfg(not(feature = "wasi-tls"))]
-    let linked = linked_metadata
-        .iter()
-        .map(component_ctx_template_from_metadata)
-        .collect::<Vec<_>>();
-    #[cfg(feature = "wasi-tls")]
-    let linked = linked_metadata
-        .iter()
-        .map(|metadata| {
-            component_ctx_template_from_metadata_with_tls(metadata, call.tls_provider.clone())
-        })
-        .collect::<Vec<_>>();
-
-    let linked_instances = {
-        let mut components = call.components.write().await;
-        call.linked_component_ids
-            .iter()
-            .map(|component_id| {
-                let component = components.get_mut(component_id).ok_or_else(|| {
-                    wasmtime::format_err!("linked component '{component_id}' not found")
-                })?;
-                component
-                    .pre_instantiate()
-                    .map(|pre| (component_id.clone(), pre))
-            })
-            .collect::<wasmtime::Result<Vec<_>>>()
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "failed to pre-instantiate linked components for ephemeral call: {e}"
-                )
-            })?
-    };
-
-    new_store_from_templates(
-        &call.engine,
-        call.http_handler.clone(),
-        &active,
-        &linked,
-        &linked_instances,
-        false,
-    )
-    .await
-}
-
-#[derive(Clone)]
-struct LinkedExportInvocation {
-    import_name: Arc<str>,
-    export_name: Arc<str>,
-    pre: InstancePre<SharedCtx>,
-    plugin_component_id: Arc<str>,
-    func_idx: ComponentExportIndex,
-    param_tys: Arc<std::sync::OnceLock<Arc<[Type]>>>,
-    ephemeral_call: Option<Arc<EphemeralLinkedCall>>,
-}
-
-async fn invoke_linked_async_export(
-    accessor: &Accessor<SharedCtx>,
-    params: &[Val],
-    results: &mut [Val],
-    inv: &LinkedExportInvocation,
-) -> wasmtime::Result<()> {
-    if let Some(ephemeral_call) = &inv.ephemeral_call {
-        invoke_ephemeral_linked_export(params, results, inv, ephemeral_call).await
-    } else {
-        invoke_shared_store_linked_export(accessor, params, results, inv).await
-    }
-}
-
-/// Run a plain-value async linked call in a short-lived store that is dropped
-/// (reclaiming its core-instance slots) as soon as the call returns.
-async fn invoke_ephemeral_linked_export(
-    params: &[Val],
-    results: &mut [Val],
-    inv: &LinkedExportInvocation,
-    ephemeral_call: &EphemeralLinkedCall,
-) -> wasmtime::Result<()> {
-    let mut store = new_ephemeral_store(ephemeral_call)
-        .await
-        .map_err(|e| wasmtime::format_err!("{e:#}"))?;
-
-    let params_buf = params.to_vec();
-    let mut results_buf = vec![Val::Bool(false); results.len()];
-    let call_import_name = inv.import_name.clone();
-    let call_export_name = inv.export_name.clone();
-    let call_pre = inv.pre.clone();
-    let func_idx = inv.func_idx;
-    let call_result = tokio::task::spawn(async move {
-        let instance = call_pre.instantiate_async(&mut store).await?;
-        store
-            .run_concurrent(async move |accessor| {
-                let func = accessor.with(|mut access| -> wasmtime::Result<_> {
-                    instance.get_func(&mut access, func_idx).ok_or_else(|| {
-                        wasmtime::format_err!(
-                            "function not found for linked import {call_import_name}.{call_export_name}"
-                        )
-                    })
-                })?;
-                const CALL_TIMEOUT: Duration = Duration::from_secs(600);
-                timeout(
-                    CALL_TIMEOUT,
-                    func.call_concurrent(accessor, &params_buf, &mut results_buf),
-                )
-                .await
-                .map_err(|e| {
-                    wasmtime::format_err!("function call timed out after 600 seconds: {e}")
-                })??;
-                Ok::<Vec<Val>, wasmtime::Error>(results_buf)
-            })
-            .await
-            .map_err(|e| wasmtime::format_err!("{e:#}"))?
-    })
-    .await
-    .map_err(|e| wasmtime::format_err!("ephemeral linked call task failed: {e}"));
-    let call_result = call_result??;
-
-    for (i, v) in call_result.into_iter().enumerate() {
-        *results
-            .get_mut(i)
-            .ok_or_else(|| wasmtime::format_err!("result index out of bounds"))? = v;
-    }
-
-    trace!(
-        name = %inv.import_name,
-        fn_name = %inv.export_name,
-        ?results,
-        "invoked ephemeral dynamic export"
-    );
-
-    Ok(())
-}
-
-async fn invoke_shared_store_linked_export(
-    accessor: &Accessor<SharedCtx>,
-    params: &[Val],
-    results: &mut [Val],
-    inv: &LinkedExportInvocation,
-) -> wasmtime::Result<()> {
-    let _active_ctx = AccessorActiveCtxGuard::new(accessor, &inv.plugin_component_id)?;
-
-    let call: wasmtime::Result<()> = async {
-        let (func, params_buf) = accessor.with(|mut access| -> wasmtime::Result<_> {
-            let instance = access
-                .data_mut()
-                .exporter_instances
-                .get(&inv.plugin_component_id)
-                .copied()
-                .ok_or_else(|| {
-                    wasmtime::format_err!(
-                        "linked component '{}' was not pre-instantiated in this store",
-                        inv.plugin_component_id
-                    )
-                })?;
-            let func = instance
-                .get_func(&mut access, inv.func_idx)
-                .ok_or_else(|| wasmtime::format_err!("function not found"))?;
-            let tys = inv.param_tys.get_or_init(|| {
-                func.ty(access.as_context())
-                    .params()
-                    .map(|(_, ty)| ty)
-                    .collect::<Vec<_>>()
-                    .into()
-            });
-            let params_buf = lower_params(&mut access.as_context_mut(), params, tys)?;
-            Ok((func, params_buf))
-        })?;
-
-        trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoking dynamic export");
-
-        let mut results_buf = vec![Val::Bool(false); results.len()];
-        func.call_concurrent(accessor, &params_buf, &mut results_buf)
-            .await?;
-
-        accessor.with(|mut access| -> wasmtime::Result<_> {
-            lift_results(&mut access.as_context_mut(), results_buf, results)
-        })?;
-
-        Ok(())
-    }
-    .await;
-
-    call?;
-
-    trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoked dynamic export");
-
-    Ok(())
-}
-
-async fn invoke_linked_sync_export(
-    store: StoreContextMut<'_, SharedCtx>,
-    params: &[Val],
-    results: &mut [Val],
-    inv: &LinkedExportInvocation,
-) -> wasmtime::Result<()> {
-    let mut active_ctx = StoreActiveCtxGuard::new(store, &inv.plugin_component_id)?;
-    let mut store = active_ctx.store_mut();
-
-    async {
-        let instance = store
-            .data()
-            .exporter_instances
-            .get(&inv.plugin_component_id)
-            .copied()
-            .ok_or_else(|| {
-                wasmtime::format_err!(
-                    "linked component '{}' was not pre-instantiated in this store",
-                    inv.plugin_component_id
-                )
-            })?;
-
-        let func = instance
-            .get_func(&mut store, inv.func_idx)
-            .ok_or_else(|| wasmtime::format_err!("function not found"))?;
-        let tys = inv.param_tys.get_or_init(|| {
-            func.ty(store.as_context())
-                .params()
-                .map(|(_, ty)| ty)
-                .collect::<Vec<_>>()
-                .into()
-        });
-        let params_buf = lower_params(store, params, tys)?;
-        trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoking dynamic export");
-
-        let mut results_buf = vec![Val::Bool(false); results.len()];
-
-        const CALL_TIMEOUT: Duration = Duration::from_secs(30);
-        timeout(
-            CALL_TIMEOUT,
-            func.call_async(&mut store, &params_buf, &mut results_buf),
-        )
-        .await
-        .map_err(|e| wasmtime::format_err!("function call timed out after 30 seconds: {e}"))??;
-
-        lift_results(store, results_buf, results)?;
-        trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoked dynamic export");
-        Ok(())
-    }
-    .await
-}
-
 /// Metadata associated with components and services within a workload.
 #[derive(Clone)]
 pub struct WorkloadMetadata {
     /// The unique identifier for this component
-    id: Arc<str>,
+    pub(crate) id: Arc<str>,
     /// The unique identifier for the workload this component belongs to
-    workload_id: Arc<str>,
+    pub(crate) workload_id: Arc<str>,
     /// The name of the workload this component belongs to
     workload_name: Arc<str>,
     /// The namespace of the workload this component belongs to
@@ -639,15 +58,15 @@ pub struct WorkloadMetadata {
     /// The wasmtime [`Linker`] used to instantiate the component
     linker: Linker<SharedCtx>,
     /// The volume mounts requested by this component
-    volume_mounts: Vec<(PathBuf, VolumeMount)>,
+    pub(crate) volume_mounts: Vec<(PathBuf, VolumeMount)>,
     /// Canonicalized volume mounts, resolved once during workload resolution.
-    resolved_volume_mounts: Vec<ResolvedVolumeMount>,
+    pub(crate) resolved_volume_mounts: Vec<ResolvedVolumeMount>,
     /// The local resources requested by this component
-    local_resources: LocalResources,
+    pub(crate) local_resources: LocalResources,
     /// The plugins available to this component
-    plugins: Option<HashMap<&'static str, Arc<dyn HostPlugin + Send + Sync>>>,
+    pub(crate) plugins: Option<HashMap<&'static str, Arc<dyn HostPlugin + Send + Sync>>>,
     /// Workload loopback
-    loopback: Arc<std::sync::Mutex<loopback::Network>>,
+    pub(crate) loopback: Arc<std::sync::Mutex<loopback::Network>>,
     /// Linked component ids
     linked_components: HashSet<Arc<str>>,
 }
@@ -913,7 +332,7 @@ pub struct WorkloadComponent {
     /// Component name. Primarily for debugging purposes.
     name: Arc<str>,
     /// The [`WorkloadMetadata`] for this component
-    metadata: WorkloadMetadata,
+    pub(crate) metadata: WorkloadMetadata,
     /// The number of warm instances to keep for this component
     pool_size: usize,
     /// The maximum number of concurrent invocations allowed for this component
@@ -1283,14 +702,14 @@ impl ResolvedWorkload {
     fn component_ctx_template(&self, metadata: &WorkloadMetadata) -> ComponentCtxTemplate {
         #[cfg(feature = "wasi-tls")]
         {
-            let mut template = ComponentCtxTemplate::from_metadata(metadata);
-            template.tls_provider = self.tls_provider.clone();
-            template
+            crate::engine::linked_call::component_ctx_template_from_metadata_with_tls(
+                metadata,
+                self.tls_provider.clone(),
+            )
         }
-
         #[cfg(not(feature = "wasi-tls"))]
         {
-            ComponentCtxTemplate::from_metadata(metadata)
+            crate::engine::linked_call::component_ctx_template_from_metadata(metadata)
         }
     }
 
@@ -1380,7 +799,8 @@ impl ResolvedWorkload {
         // Topologically sort components: components with no dependencies (or dependencies
         // already processed) come first. This ensures that when we process a component
         // that imports from another component, the exporter has already been resolved.
-        let sorted_component_ids = topological_sort_components(&dependencies).context(
+        let sorted_component_ids = anyhow::Context::context(
+            topological_sort_components(&dependencies),
             "failed to determine component processing order - possible circular dependency",
         )?;
 
@@ -1632,7 +1052,9 @@ impl ResolvedWorkload {
                                                 })
                                             },
                                         )
-                                        .map_err(|e| e.context("failed to create async func"))?;
+                                        .map_err(|e| {
+                                            e.context("failed to wrap sync func in async func")
+                                        })?;
                                 }
                             }
                             ComponentItem::Resource(resource_ty) => {
@@ -1740,33 +1162,12 @@ impl ResolvedWorkload {
         &self,
         component_id: &str,
     ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
-        let component_id = Arc::<str>::from(component_id);
-        let mut component_ids = {
-            let components = self.components.read().await;
-            let component = components
-                .get(&component_id)
-                .context("component ID not found in workload")?;
-            let mut ids = component
-                .metadata
-                .linked_components
-                .iter()
-                .cloned()
-                .collect::<Vec<_>>();
-            ids.push(component_id.clone());
-            ids
-        };
-        component_ids.sort();
-        component_ids.dedup();
-        self.resolve_component_volume_mounts(&component_ids).await?;
-
-        // Clone the metadata and drop the read lock before building the store:
-        // the store factory pre-instantiates linked components, which takes a
-        // `components` write lock (via `instantiate_pre`) — holding the read
-        // lock across that call would deadlock.
+        // Clone + drop the lock before building: the store factory write-locks
+        // `components`, so a held read lock would deadlock.
         let metadata = {
             let components = self.components.read().await;
             components
-                .get(&component_id)
+                .get(component_id)
                 .context("component ID not found in workload")?
                 .metadata
                 .clone()
@@ -1797,7 +1198,7 @@ impl ResolvedWorkload {
                             format!("linked component '{linked_component_id}' not found")
                         })
                 })
-                .collect::<anyhow::Result<Vec<_>>>()?
+                .collect::<wasmtime::Result<Vec<_>>>()?
         };
         let active_template = self.component_ctx_template(metadata);
         let linked_templates = linked_metadata
@@ -1889,10 +1290,10 @@ impl ResolvedWorkload {
             }
 
             if component.exports_wasi_http() {
-                self.http_handler
-                    .on_workload_unbind(self.id())
-                    .await
-                    .context("failed to notify HTTP handler of workload")?;
+                anyhow::Context::context(
+                    self.http_handler.on_workload_unbind(self.id()).await,
+                    "failed to notify HTTP handler of workload",
+                )?;
             }
         }
 
@@ -2362,6 +1763,19 @@ impl UnresolvedWorkload {
             bail!(e);
         }
 
+        // Canonicalize component volume mounts up front so bad paths fail at
+        // deploy time, not on first request (the service resolves its own).
+        let all_component_ids: Vec<Arc<str>> = resolved_workload
+            .components
+            .read()
+            .await
+            .keys()
+            .cloned()
+            .collect();
+        resolved_workload
+            .resolve_component_volume_mounts(&all_component_ids)
+            .await?;
+
         // Notify plugins of the resolved workload
         for (plugin, component_ids) in bound_plugins.iter() {
             debug!(
@@ -2429,20 +1843,6 @@ impl UnresolvedWorkload {
     }
 }
 
-/// Performs a topological sort on components based on their inter-component dependencies.
-///
-/// This function uses Kahn's algorithm to produce an ordering where components
-/// that export interfaces are processed before components that import those interfaces.
-/// This ensures that when linking components, the exporting component's linker has
-/// already been fully configured before it needs to be pre-instantiated.
-///
-/// # Arguments
-/// * `dependencies` - A map from component ID to the set of component IDs it depends on
-///   (i.e., components whose exports it imports)
-///
-/// # Returns
-/// A vector of component IDs in topological order (dependencies first), or an error
-/// if a circular dependency is detected.
 /// Builds the export→component map used to wire intra-workload component
 /// imports. An interface exported by exactly one component is registered for
 /// linking; an interface exported by more than one component is "ambiguous" —
@@ -2498,6 +1898,9 @@ fn other_plugin_serves(
     })
 }
 
+/// Topologically sort components (Kahn's algorithm) so exporters come before
+/// importers, a component's linker must be fully configured before anything
+/// that imports from it is pre-instantiated. Errors on a dependency cycle.
 fn topological_sort_components(
     dependencies: &HashMap<Arc<str>, HashSet<Arc<str>>>,
 ) -> anyhow::Result<Vec<Arc<str>>> {
@@ -2556,6 +1959,9 @@ fn topological_sort_components(
     Ok(result)
 }
 
+/// Expand `direct_links` into the full transitive closure. One hop suffices
+/// because components are processed in topological order, so each
+/// `resolved_links[dep]` already holds that dep's complete closure.
 fn expand_link_closure(
     direct_links: &HashSet<Arc<str>>,
     resolved_links: &HashMap<Arc<str>, HashSet<Arc<str>>>,

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -103,6 +103,61 @@ impl ResolvedVolumeMount {
     }
 }
 
+async fn resolve_volume_mounts(
+    volume_mounts: &[(PathBuf, VolumeMount)],
+) -> anyhow::Result<Vec<ResolvedVolumeMount>> {
+    let mut resolved = Vec::with_capacity(volume_mounts.len());
+    for (host_path, mount) in volume_mounts {
+        resolved.push(ResolvedVolumeMount::from_mount(host_path, mount).await?);
+    }
+    Ok(resolved)
+}
+
+async fn resolve_component_volume_mounts_in_map(
+    components: &Arc<RwLock<HashMap<Arc<str>, WorkloadComponent>>>,
+    component_ids: &[Arc<str>],
+) -> anyhow::Result<()> {
+    let pending = {
+        let components = components.read().await;
+        let mut pending = Vec::new();
+        for component_id in component_ids {
+            let component = components
+                .get(component_id)
+                .with_context(|| format!("component '{component_id}' not found"))?;
+            if component.metadata.resolved_volume_mounts.is_empty()
+                && !component.metadata.volume_mounts.is_empty()
+            {
+                pending.push((
+                    component_id.clone(),
+                    component.metadata.volume_mounts.clone(),
+                ));
+            }
+        }
+        pending
+    };
+
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    let mut resolved = Vec::with_capacity(pending.len());
+    for (component_id, volume_mounts) in pending {
+        resolved.push((component_id, resolve_volume_mounts(&volume_mounts).await?));
+    }
+
+    let mut components = components.write().await;
+    for (component_id, resolved_volume_mounts) in resolved {
+        let component = components
+            .get_mut(&component_id)
+            .with_context(|| format!("component '{component_id}' not found"))?;
+        if component.metadata.resolved_volume_mounts.is_empty() {
+            component.metadata.resolved_volume_mounts = resolved_volume_mounts;
+        }
+    }
+
+    Ok(())
+}
+
 #[derive(Clone)]
 struct ComponentCtxTemplate {
     component_id: Arc<str>,
@@ -130,13 +185,30 @@ impl ComponentCtxTemplate {
     }
 }
 
+#[cfg(not(feature = "wasi-tls"))]
+fn component_ctx_template_from_metadata(metadata: &WorkloadMetadata) -> ComponentCtxTemplate {
+    ComponentCtxTemplate::from_metadata(metadata)
+}
+
+#[cfg(feature = "wasi-tls")]
+fn component_ctx_template_from_metadata_with_tls(
+    metadata: &WorkloadMetadata,
+    tls_provider: Option<SharedTlsProvider>,
+) -> ComponentCtxTemplate {
+    let mut template = ComponentCtxTemplate::from_metadata(metadata);
+    template.tls_provider = tls_provider;
+    template
+}
+
 #[derive(Clone)]
 struct EphemeralLinkedCall {
     engine: wasmtime::Engine,
     http_handler: Arc<dyn crate::host::http::HostHandler>,
-    active: ComponentCtxTemplate,
-    linked: Vec<ComponentCtxTemplate>,
-    linked_instances: Vec<(Arc<str>, InstancePre<SharedCtx>)>,
+    components: Arc<RwLock<HashMap<Arc<str>, WorkloadComponent>>>,
+    active_component_id: Arc<str>,
+    linked_component_ids: Vec<Arc<str>>,
+    #[cfg(feature = "wasi-tls")]
+    tls_provider: Option<SharedTlsProvider>,
 }
 
 fn type_is_ephemeral_safe(ty: &Type) -> bool {
@@ -276,12 +348,82 @@ async fn new_store_from_templates(
 async fn new_ephemeral_store(
     call: &EphemeralLinkedCall,
 ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
+    let mut component_ids = call.linked_component_ids.clone();
+    component_ids.push(call.active_component_id.clone());
+    component_ids.sort();
+    component_ids.dedup();
+    resolve_component_volume_mounts_in_map(&call.components, &component_ids).await?;
+
+    let (active_metadata, linked_metadata) = {
+        let components = call.components.read().await;
+        let active = components
+            .get(&call.active_component_id)
+            .with_context(|| {
+                format!(
+                    "ephemeral linked component '{}' not found",
+                    call.active_component_id
+                )
+            })?
+            .metadata
+            .clone();
+        let linked = call
+            .linked_component_ids
+            .iter()
+            .map(|component_id| {
+                components
+                    .get(component_id)
+                    .with_context(|| format!("linked component '{component_id}' not found"))
+                    .map(|component| component.metadata.clone())
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        (active, linked)
+    };
+
+    #[cfg(not(feature = "wasi-tls"))]
+    let active = component_ctx_template_from_metadata(&active_metadata);
+    #[cfg(feature = "wasi-tls")]
+    let active =
+        component_ctx_template_from_metadata_with_tls(&active_metadata, call.tls_provider.clone());
+
+    #[cfg(not(feature = "wasi-tls"))]
+    let linked = linked_metadata
+        .iter()
+        .map(component_ctx_template_from_metadata)
+        .collect::<Vec<_>>();
+    #[cfg(feature = "wasi-tls")]
+    let linked = linked_metadata
+        .iter()
+        .map(|metadata| {
+            component_ctx_template_from_metadata_with_tls(metadata, call.tls_provider.clone())
+        })
+        .collect::<Vec<_>>();
+
+    let linked_instances = {
+        let mut components = call.components.write().await;
+        call.linked_component_ids
+            .iter()
+            .map(|component_id| {
+                let component = components.get_mut(component_id).ok_or_else(|| {
+                    wasmtime::format_err!("linked component '{component_id}' not found")
+                })?;
+                component
+                    .pre_instantiate()
+                    .map(|pre| (component_id.clone(), pre))
+            })
+            .collect::<wasmtime::Result<Vec<_>>>()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to pre-instantiate linked components for ephemeral call: {e}"
+                )
+            })?
+    };
+
     new_store_from_templates(
         &call.engine,
         call.http_handler.clone(),
-        &call.active,
-        &call.linked,
-        &call.linked_instances,
+        &active,
+        &linked,
+        &linked_instances,
         false,
     )
     .await
@@ -1131,18 +1273,7 @@ impl ResolvedWorkload {
         &self,
         component_ids: &[Arc<str>],
     ) -> anyhow::Result<()> {
-        let mut components = self.components.write().await;
-        for component_id in component_ids {
-            let component = components
-                .get_mut(component_id)
-                .with_context(|| format!("component '{component_id}' not found"))?;
-            if component.metadata.resolved_volume_mounts.is_empty()
-                && !component.metadata.volume_mounts.is_empty()
-            {
-                component.metadata.resolve_volume_mounts().await?;
-            }
-        }
-        Ok(())
+        resolve_component_volume_mounts_in_map(&self.components, component_ids).await
     }
 
     async fn resolve_service_volume_mounts(&mut self) -> anyhow::Result<()> {
@@ -1361,9 +1492,8 @@ impl ResolvedWorkload {
                     let (
                         plugin_component,
                         instance_idx,
-                        plugin_ctx_template,
-                        linked_ctx_templates,
-                        linked_instances,
+                        plugin_component_id,
+                        nested_linked_component_ids,
                         plugin_engine,
                     ) = {
                         let Some(exporter_component) = interface_map.get(import_name).cloned()
@@ -1393,39 +1523,13 @@ impl ResolvedWorkload {
                                 .cloned()
                                 .collect::<Vec<_>>()
                         };
-                        let linked_ctx_templates = nested_linked_component_ids
-                            .iter()
-                            .filter_map(|component_id| all_components.get(component_id))
-                            .map(|component| self.component_ctx_template(&component.metadata))
-                            .collect::<Vec<_>>();
-                        let linked_instances = nested_linked_component_ids
-                            .iter()
-                            .map(|component_id| {
-                                let component = all_components.get_mut(component_id).ok_or_else(
-                                    || {
-                                        wasmtime::format_err!(
-                                            "linked component '{component_id}' not found"
-                                        )
-                                    },
-                                )?;
-                                component
-                                    .pre_instantiate()
-                                    .map(|pre| (component_id.clone(), pre))
-                            })
-                            .collect::<wasmtime::Result<Vec<_>>>()
-                            .map_err(|e| {
-                                anyhow::anyhow!(
-                                    "failed to pre-instantiate linked components for ephemeral call: {e}"
-                                )
-                            })?;
                         let Some(plugin_component) = all_components.get_mut(&exporter_component)
                         else {
                             anyhow::bail!(
                                 "exporting component '{exporter_component}' for import '{import_name}' not found"
                             );
                         };
-                        let plugin_ctx_template =
-                            self.component_ctx_template(&plugin_component.metadata);
+                        let plugin_component_id = plugin_component.id.clone();
                         let plugin_engine = plugin_component.metadata.engine().clone();
                         let Some((ComponentItem::ComponentInstance(_), idx)) = plugin_component
                             .metadata
@@ -1438,9 +1542,8 @@ impl ResolvedWorkload {
                         (
                             plugin_component,
                             idx,
-                            plugin_ctx_template,
-                            linked_ctx_templates,
-                            linked_instances,
+                            plugin_component_id,
+                            nested_linked_component_ids,
                             plugin_engine,
                         )
                     };
@@ -1489,18 +1592,21 @@ impl ResolvedWorkload {
                                     "linking function import"
                                 );
                                 let export_is_async = func_ty.async_();
-                                let ephemeral_call =
-                                    if export_is_async && func_is_ephemeral_safe(&func_ty) {
-                                        Some(Arc::new(EphemeralLinkedCall {
-                                            engine: plugin_engine.clone(),
-                                            http_handler: self.http_handler.clone(),
-                                            active: plugin_ctx_template.clone(),
-                                            linked: linked_ctx_templates.clone(),
-                                            linked_instances: linked_instances.clone(),
-                                        }))
-                                    } else {
-                                        None
-                                    };
+                                let ephemeral_call = if export_is_async
+                                    && func_is_ephemeral_safe(&func_ty)
+                                {
+                                    Some(Arc::new(EphemeralLinkedCall {
+                                        engine: plugin_engine.clone(),
+                                        http_handler: self.http_handler.clone(),
+                                        components: self.components.clone(),
+                                        active_component_id: plugin_component_id.clone(),
+                                        linked_component_ids: nested_linked_component_ids.clone(),
+                                        #[cfg(feature = "wasi-tls")]
+                                        tls_provider: self.tls_provider.clone(),
+                                    }))
+                                } else {
+                                    None
+                                };
 
                                 let inv = LinkedExportInvocation {
                                     import_name: import_name.into(),
@@ -1689,7 +1795,7 @@ impl ResolvedWorkload {
     }
 
     /// Creates a new wasmtime Store for multiple components from the given workload metadata.
-    pub async fn new_store_from_metadata(
+    async fn new_store_from_metadata(
         &self,
         metadata: &WorkloadMetadata,
         is_service: bool,

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -64,7 +64,6 @@ fn lower_params(
     Ok(params_buf)
 }
 
-/// Lift dynamic-linker call results back into the caller-provided result slots.
 fn lift_results(
     store: &mut StoreContextMut<'_, SharedCtx>,
     results_buf: Vec<Val>,
@@ -429,9 +428,6 @@ async fn new_ephemeral_store(
     .await
 }
 
-/// Everything a linker closure needs to invoke one linked component export,
-/// bundled so the invocation logic lives in named helpers instead of a deeply
-/// nested inline `async` block.
 #[derive(Clone)]
 struct LinkedExportInvocation {
     import_name: Arc<str>,
@@ -443,8 +439,6 @@ struct LinkedExportInvocation {
     ephemeral_call: Option<Arc<EphemeralLinkedCall>>,
 }
 
-/// Dispatch an async (`func_new_concurrent`) linked export to either the
-/// ephemeral-store path (plain-value signatures) or the shared-store path.
 async fn invoke_linked_async_export(
     accessor: &Accessor<SharedCtx>,
     params: &[Val],
@@ -521,8 +515,6 @@ async fn invoke_ephemeral_linked_export(
     Ok(())
 }
 
-/// Run an async linked call on the request's own (long-lived) store, reusing the
-/// exporter instance pre-instantiated for `(component, store)` by the entrypoint.
 async fn invoke_shared_store_linked_export(
     accessor: &Accessor<SharedCtx>,
     params: &[Val],
@@ -532,9 +524,6 @@ async fn invoke_shared_store_linked_export(
     let _active_ctx = AccessorActiveCtxGuard::new(accessor, &inv.plugin_component_id)?;
 
     let call: wasmtime::Result<()> = async {
-        // The store factory pre-instantiates every linked component into the
-        // store's own cache, so the instance is always present here — the
-        // concurrent `accessor.with` closure cannot instantiate on demand.
         let (func, params_buf) = accessor.with(|mut access| -> wasmtime::Result<_> {
             let instance = access
                 .data_mut()
@@ -582,20 +571,16 @@ async fn invoke_shared_store_linked_export(
     Ok(())
 }
 
-/// Run a synchronous (`func_new_async`) linked call on the caller's store.
 async fn invoke_linked_sync_export(
     store: StoreContextMut<'_, SharedCtx>,
     params: &[Val],
     results: &mut [Val],
     inv: &LinkedExportInvocation,
 ) -> wasmtime::Result<()> {
-    // TODO(#103): some kind of store data hashing mechanism to detect a diff store to drop the old one
     let mut active_ctx = StoreActiveCtxGuard::new(store, &inv.plugin_component_id)?;
     let mut store = active_ctx.store_mut();
 
     async {
-        // The store factory pre-instantiates linked components into the store's
-        // own cache, so the instance is always present.
         let instance = store
             .data()
             .exporter_instances
@@ -623,7 +608,6 @@ async fn invoke_linked_sync_export(
 
         let mut results_buf = vec![Val::Bool(false); results.len()];
 
-        // Enforce a timeout on this call to prevent hanging indefinitely
         const CALL_TIMEOUT: Duration = Duration::from_secs(30);
         timeout(
             CALL_TIMEOUT,
@@ -1196,10 +1180,6 @@ impl ResolvedWorkload {
             } else {
                 bail!("service unexpectedly missing during execution");
             };
-            // `new_store_from_metadata` already pre-instantiated the linked
-            // components into the store-owned cache; they are reclaimed when the
-            // store is dropped (service exit/abort), no external cleanup needed.
-
             let handle = tokio::spawn(async move {
                 loop {
                     let instance = match pre.instantiate_async(&mut store).await {

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -16,8 +16,10 @@ use anyhow::{Context as _, bail, ensure};
 use tokio::{sync::RwLock, task::JoinHandle, time::timeout};
 use tracing::{Instrument, debug, error, info, instrument, trace, warn};
 use wasmtime::component::{
-    Component, Instance, InstancePre, Linker, ResourceAny, ResourceType, Val, types::ComponentItem,
+    Component, Instance, InstancePre, Linker, ResourceAny, ResourceType, Val,
+    types::{ComponentItem, Type},
 };
+use wasmtime::{AsContext, AsContextMut, StoreContextMut};
 use wasmtime_wasi::p2::bindings::CommandPre;
 use wasmtime_wasi::{DirPerms, FilePerms, WasiCtxBuilder};
 
@@ -26,7 +28,7 @@ use crate::engine::ctx::SharedTlsProvider;
 use crate::{
     engine::{
         ctx::{Ctx, SharedCtx},
-        value::{lift, lower},
+        value::{lift, lower_with_type},
     },
     plugin::HostPlugin,
     types::{LocalResources, VolumeMount},
@@ -41,9 +43,66 @@ type BoundPluginWithInterfaces = (
     Vec<String>,
 );
 
-/// Shared slot holding the most recently instantiated component, keyed by its id.
-/// Used while resolving inter-component imports.
-type SharedInstanceSlot = Arc<RwLock<Option<(Arc<str>, Instance)>>>;
+/// Shared slot holding the most recently instantiated component, keyed by the
+/// store id it was built for. Used as a fallback while resolving inter-component
+/// imports (the P2 path, which does not pre-instantiate into
+/// `exporter_instances`).
+type SharedInstanceSlot = Arc<RwLock<Option<(String, Instance)>>>;
+
+type ExporterInstanceKey = (Arc<str>, String);
+
+/// Lower dynamic-linker call params, using each param's declared type so host
+/// resource handles cross the linker by identity (see [`lower_with_type`]).
+fn lower_params(
+    store: &mut StoreContextMut<'_, SharedCtx>,
+    params: &[Val],
+    param_tys: &[Type],
+) -> wasmtime::Result<Vec<Val>> {
+    if params.len() != param_tys.len() {
+        return Err(wasmtime::format_err!(
+            "dynamic call arity mismatch: {} args vs {} param types",
+            params.len(),
+            param_tys.len()
+        ));
+    }
+    let mut params_buf = Vec::with_capacity(params.len());
+    for (v, ty) in params.iter().zip(param_tys) {
+        params_buf.push(lower_with_type(store, v, ty)?);
+    }
+    Ok(params_buf)
+}
+
+/// Lift dynamic-linker call results back into the caller-provided result slots.
+fn lift_results(
+    store: &mut StoreContextMut<'_, SharedCtx>,
+    results_buf: Vec<Val>,
+    results: &mut [Val],
+) -> wasmtime::Result<()> {
+    for (i, v) in results_buf.into_iter().enumerate() {
+        *results
+            .get_mut(i)
+            .ok_or_else(|| wasmtime::format_err!("result index out of bounds"))? = lift(store, v)?;
+    }
+    Ok(())
+}
+
+/// RAII guard that drops a store's entries from the exporter-instance cache when
+/// dropped — including on task abort/panic, where a trailing statement would be
+/// skipped.
+#[cfg(feature = "wasip3")]
+struct ExporterCacheCleanup {
+    exporter_instances: Arc<std::sync::RwLock<HashMap<ExporterInstanceKey, Instance>>>,
+    store_id: String,
+}
+
+#[cfg(feature = "wasip3")]
+impl Drop for ExporterCacheCleanup {
+    fn drop(&mut self) {
+        if let Ok(mut cache) = self.exporter_instances.write() {
+            cache.retain(|(_, cached_store_id), _| cached_store_id != &self.store_id);
+        }
+    }
+}
 
 /// Metadata associated with components and services within a workload.
 #[derive(Clone)]
@@ -145,8 +204,8 @@ impl WorkloadMetadata {
             .exports(self.component.engine())
             .map(|(name, item)| (name, item.ty))
             .filter_map(|(name, item)| {
-                if matches!(item, ComponentItem::ComponentInstance(_)) {
-                    Some((name.to_string(), item))
+                if matches!(item.ty, ComponentItem::ComponentInstance(_)) {
+                    Some((name.to_string(), item.ty))
                 } else {
                     None
                 }
@@ -498,6 +557,9 @@ pub struct ResolvedWorkload {
     service: Option<WorkloadService>,
     /// The requested host [`WitInterface`]s to resolve this workload
     host_interfaces: Vec<WitInterface>,
+    /// Per-store cache of exporter instances used by async canonical-ABI
+    /// cross-component calls.
+    exporter_instances: Arc<std::sync::RwLock<HashMap<ExporterInstanceKey, Instance>>>,
     /// TLS provider override for `wasi:tls` client connections in this workload.
     #[cfg(feature = "wasi-tls")]
     tls_provider: Option<SharedTlsProvider>,
@@ -587,8 +649,24 @@ impl ResolvedWorkload {
             } else {
                 bail!("service unexpectedly missing during execution");
             };
+            let linked_component_ids = if let Some(service) = self.service.as_ref() {
+                self.component_ids_except(service.metadata.id()).await
+            } else {
+                Vec::new()
+            };
+            self.pre_instantiate_linked_component_ids(&mut store, linked_component_ids)
+                .await?;
+            let store_id = store.data().active_ctx.store_id.clone();
+            // Drops this store's exporter-instance entries when the service task
+            // ends — including on stop_service()'s abort(), where the old
+            // trailing `retain` was skipped.
+            let cache_cleanup = ExporterCacheCleanup {
+                exporter_instances: self.exporter_instances.clone(),
+                store_id,
+            };
 
             let handle = tokio::spawn(async move {
+                let _cache_cleanup = cache_cleanup;
                 loop {
                     let instance = match pre.instantiate_async(&mut store).await {
                         Ok(i) => i,
@@ -655,6 +733,80 @@ impl ResolvedWorkload {
 
     pub fn host_interfaces(&self) -> &Vec<WitInterface> {
         &self.host_interfaces
+    }
+
+    async fn component_ids_except(&self, component_id: &str) -> Vec<Arc<str>> {
+        self.components
+            .read()
+            .await
+            .keys()
+            .filter(|id| id.as_ref() != component_id)
+            .cloned()
+            .collect()
+    }
+
+    #[cfg(feature = "wasip3")]
+    pub(crate) fn clear_exporter_instances_for_store(&self, store_id: &str) {
+        self.exporter_instances
+            .write()
+            .expect("exporter instance cache poisoned")
+            .retain(|(_, cached_store_id), _| cached_store_id != store_id);
+    }
+
+    async fn pre_instantiate_linked_component_ids(
+        &self,
+        store: &mut wasmtime::Store<SharedCtx>,
+        linked_component_ids: Vec<Arc<str>>,
+    ) -> anyhow::Result<()> {
+        let store_id = store.data().active_ctx.store_id.clone();
+
+        for linked_component_id in linked_component_ids {
+            let key = (linked_component_id.clone(), store_id.clone());
+            if self
+                .exporter_instances
+                .read()
+                .expect("exporter instance cache poisoned")
+                .contains_key(&key)
+            {
+                continue;
+            }
+
+            let pre = self.instantiate_pre(linked_component_id.as_ref()).await?;
+            let prev_component_id = store.data().active_ctx.component_id.clone();
+            store.data_mut().set_active_ctx(&linked_component_id)?;
+            let instantiate_result = pre.instantiate_async(&mut *store).await;
+            store.data_mut().set_active_ctx(&prev_component_id)?;
+            let instance = instantiate_result.map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to instantiate linked component '{linked_component_id}': {e}"
+                )
+            })?;
+
+            self.exporter_instances
+                .write()
+                .expect("exporter instance cache poisoned")
+                .insert(key, instance);
+        }
+
+        Ok(())
+    }
+
+    pub async fn pre_instantiate_linked_components_for_component(
+        &self,
+        store: &mut wasmtime::Store<SharedCtx>,
+        component_id: &str,
+    ) -> anyhow::Result<()> {
+        {
+            let components = self.components.read().await;
+            components
+                .get(component_id)
+                .context("component ID not found in workload")?;
+        }
+
+        let linked_component_ids = self.component_ids_except(component_id).await;
+
+        self.pre_instantiate_linked_component_ids(store, linked_component_ids)
+            .await
     }
 
     #[instrument(name="link_components", skip_all, fields(workload.id = self.id.as_ref(), workload.name = self.name.as_ref(), workload.namespace = self.namespace.as_ref()))]
@@ -877,7 +1029,7 @@ impl ResolvedWorkload {
                         import_instance_ty.exports(plugin_component.metadata.component.engine())
                     {
                         match export_ty.ty {
-                            ComponentItem::ComponentFunc(_func_ty) => {
+                            ComponentItem::ComponentFunc(func_ty) => {
                                 let (item, func_idx) = match plugin_component
                                     .metadata
                                     .component
@@ -906,116 +1058,272 @@ impl ResolvedWorkload {
                                 let export_name: Arc<str> = export_name.into();
                                 let pre = pre.clone();
                                 let instance = instance.clone();
+                                let exporter_instances = self.exporter_instances.clone();
                                 let plugin_component_id = plugin_component.id.clone();
+                                let export_is_async = func_ty.async_();
+                                // Cache this export's param types after the first call instead of
+                                // rebuilding them every call. They must come from the *runtime*
+                                // func type — which represents linked resources as host
+                                // `ResourceAny` — not the static component type, or
+                                // `lower_with_type` can't recognise resource handles.
+                                let param_tys: Arc<std::sync::OnceLock<Arc<[Type]>>> =
+                                    Arc::default();
 
                                 linked_components.insert(plugin_component_id.clone());
 
-                                linker_instance
-                                    .func_new_async(
-                                        &export_name.clone(),
-                                        move |mut store, _func, params, results| {
-                                            // TODO(#103): some kind of store data hashing mechanism
-                                            // to detect a diff store to drop the old one
-                                            let import_name = import_name.clone();
-                                            let export_name = export_name.clone();
-                                            let pre = pre.clone();
-                                            let plugin_component_id = plugin_component_id.clone();
-                                            let instance = instance.clone();
-                                            Box::new(async move {
-                                                let prev_id =
-                                                    store.data().active_ctx.component_id.clone();
+                                if export_is_async {
+                                    let param_tys = param_tys.clone();
+                                    linker_instance
+                                        .func_new_concurrent(
+                                            &export_name.clone(),
+                                            move |accessor, _func_ty, params, results| {
+                                                let import_name = import_name.clone();
+                                                let export_name = export_name.clone();
+                                                let exporter_instances = exporter_instances.clone();
+                                                let plugin_component_id = plugin_component_id.clone();
+                                                let param_tys = param_tys.clone();
+                                                Box::pin(async move {
+                                                    // Switch active ctx to the linked component,
+                                                    // remembering the caller's to restore below.
+                                                    let prev_id = accessor.with(
+                                                        |mut access| -> wasmtime::Result<_> {
+                                                            let prev_id = access
+                                                                .data_mut()
+                                                                .active_ctx
+                                                                .component_id
+                                                                .clone();
+                                                            access
+                                                                .data_mut()
+                                                                .set_active_ctx(&plugin_component_id)?;
+                                                            Ok(prev_id)
+                                                        },
+                                                    )?;
 
-                                                store
-                                                    .data_mut()
-                                                    .set_active_ctx(&plugin_component_id)?;
+                                                    // Run the call; the caller's active ctx is
+                                                    // restored on every return path below. NOTE: if
+                                                    // this future is cancelled (dropped) mid-call the
+                                                    // restore does not run — a drop-safe restore
+                                                    // would need async-Drop, which the concurrent
+                                                    // runtime does not expose.
+                                                    let call: wasmtime::Result<()> = async {
+                                                        let store_id = accessor.with(|mut access| {
+                                                            access
+                                                                .data_mut()
+                                                                .active_ctx
+                                                                .store_id
+                                                                .clone()
+                                                        });
 
-                                                let existing_instance = instance.read().await;
-                                                let store_id = store.data().active_ctx.id.clone();
-                                                let instance = if let Some((id, instance)) =
-                                                    existing_instance.clone()
-                                                    && id == store_id
-                                                {
-                                                    drop(existing_instance);
-                                                    instance
-                                                } else {
-                                                    // Likely unnecessary, but explicit drop of the read lock
-                                                    let new_instance =
-                                                        pre.instantiate_async(&mut store).await?;
-                                                    drop(existing_instance);
-                                                    *instance.write().await =
-                                                        Some((store_id, new_instance));
-                                                    new_instance
-                                                };
+                                                        // Resolve the exporter instance for this
+                                                        // store, instantiating lazily on a miss
+                                                        // (entrypoints other than P3-http/-service
+                                                        // do not pre-instantiate). First writer wins.
+                                                        let cached = exporter_instances
+                                                            .read()
+                                                            .expect("exporter instance cache poisoned")
+                                                            .get(&(
+                                                                plugin_component_id.clone(),
+                                                                store_id.clone(),
+                                                            ))
+                                                            .cloned();
+                                                        let instance = match cached {
+                                                            Some(instance) => instance,
+                                                            // release-46's `Accessor` has no
+                                                            // `instantiate_async`; every entrypoint
+                                                            // pre-instantiates linked components, so a
+                                                            // miss here is a bug, not a lazy path.
+                                                            None => {
+                                                                return Err(wasmtime::format_err!(
+                                                                    "linked component '{plugin_component_id}' was not pre-instantiated for store '{store_id}'"
+                                                                ));
+                                                            }
+                                                        };
 
-                                                let func = instance
-                                                    .get_func(&mut store, func_idx)
-                                                    .ok_or_else(|| {
-                                                        wasmtime::format_err!("function not found")
-                                                    })?;
-                                                trace!(
-                                                    name = %import_name,
-                                                    fn_name = %export_name,
-                                                    ?params,
-                                                    "lowering params"
-                                                );
-                                                let mut params_buf =
-                                                    Vec::with_capacity(params.len());
-                                                for v in params {
-                                                    params_buf.push(lower(&mut store, v)?);
-                                                }
-                                                trace!(
-                                                    name = %import_name,
-                                                    fn_name = %export_name,
-                                                    ?params_buf,
-                                                    "invoking dynamic export"
-                                                );
+                                                        let (func, params_buf) = accessor.with(
+                                                            |mut access| -> wasmtime::Result<_> {
+                                                                let func = instance
+                                                                    .get_func(&mut access, func_idx)
+                                                                    .ok_or_else(|| {
+                                                                        wasmtime::format_err!(
+                                                                            "function not found"
+                                                                        )
+                                                                    })?;
+                                                                let tys = param_tys.get_or_init(|| {
+                                                                    func.ty(access.as_context())
+                                                                        .params()
+                                                                        .map(|(_, ty)| ty)
+                                                                        .collect::<Vec<_>>()
+                                                                        .into()
+                                                                });
+                                                                let params_buf = lower_params(
+                                                                    &mut access.as_context_mut(),
+                                                                    params,
+                                                                    tys,
+                                                                )?;
+                                                                Ok((func, params_buf))
+                                                            },
+                                                        )?;
 
-                                                let mut results_buf =
-                                                    vec![Val::Bool(false); results.len()];
+                                                        trace!(
+                                                            name = %import_name,
+                                                            fn_name = %export_name,
+                                                            "invoking dynamic export"
+                                                        );
 
-                                                // Enforce a timeout on this call to prevent hanging indefinitely
-                                                const CALL_TIMEOUT: Duration =
-                                                    Duration::from_secs(30);
-                                                timeout(
-                                                    CALL_TIMEOUT,
-                                                    func.call_async(
-                                                        &mut store,
-                                                        &params_buf,
-                                                        &mut results_buf,
-                                                    ),
-                                                )
-                                                .await
-                                                .map_err(|e| wasmtime::format_err!(
-                                                    "function call timed out after 30 seconds: {e}",
-                                                ))??;
-
-                                                trace!(
-                                                    name = %import_name,
-                                                    fn_name = %export_name,
-                                                    ?results_buf,
-                                                    "lifting results"
-                                                );
-                                                for (i, v) in results_buf.into_iter().enumerate() {
-                                                    *results.get_mut(i).ok_or_else(|| {
-                                                        wasmtime::format_err!(
-                                                            "result index out of bounds"
+                                                        let mut results_buf =
+                                                            vec![Val::Bool(false); results.len()];
+                                                        func.call_concurrent(
+                                                            accessor,
+                                                            &params_buf,
+                                                            &mut results_buf,
                                                         )
-                                                    })? = lift(&mut store, v)?;
-                                                }
-                                                trace!(
-                                                    name = %import_name,
-                                                    fn_name = %export_name,
-                                                    ?results,
-                                                    "invoked dynamic export"
-                                                );
+                                                        .await?;
 
-                                                store.data_mut().set_active_ctx(&prev_id)?;
+                                                        accessor.with(
+                                                            |mut access| -> wasmtime::Result<_> {
+                                                                lift_results(
+                                                                    &mut access.as_context_mut(),
+                                                                    results_buf,
+                                                                    results,
+                                                                )
+                                                            },
+                                                        )?;
 
-                                                Ok(())
-                                            })
-                                        },
-                                    )
-                                    .map_err(|e| e.context("failed to create async func"))?;
+                                                        Ok(())
+                                                    }
+                                                    .await;
+
+                                                    let restore = accessor.with(
+                                                        |mut access| -> wasmtime::Result<_> {
+                                                            access.data_mut().set_active_ctx(&prev_id)
+                                                        },
+                                                    );
+
+                                                    call?;
+                                                    restore?;
+
+                                                    trace!(
+                                                        name = %import_name,
+                                                        fn_name = %export_name,
+                                                        "invoked dynamic export"
+                                                    );
+
+                                                    Ok(())
+                                                })
+                                            },
+                                        )
+                                        .map_err(|e| {
+                                            e.context("failed to create concurrent func")
+                                        })?;
+                                } else {
+                                    let param_tys = param_tys.clone();
+                                    linker_instance
+                                        .func_new_async(
+                                            &export_name.clone(),
+                                            move |mut store, _func_ty, params, results| {
+                                                // TODO(#103): some kind of store data hashing mechanism
+                                                // to detect a diff store to drop the old one
+                                                let import_name = import_name.clone();
+                                                let export_name = export_name.clone();
+                                                let pre = pre.clone();
+                                                let plugin_component_id = plugin_component_id.clone();
+                                                let instance = instance.clone();
+                                                let exporter_instances =
+                                                    exporter_instances.clone();
+                                                let param_tys = param_tys.clone();
+                                                Box::new(async move {
+                                                    let prev_id =
+                                                        store.data().active_ctx.component_id.clone();
+
+                                                    store
+                                                        .data_mut()
+                                                        .set_active_ctx(&plugin_component_id)?;
+
+                                                    let store_id = store.data().active_ctx.store_id.clone();
+                                                    let instance = if let Some(instance) =
+                                                        exporter_instances
+                                                            .read()
+                                                            .expect("exporter instance cache poisoned")
+                                                            .get(&(
+                                                                plugin_component_id.clone(),
+                                                                store_id.clone(),
+                                                            ))
+                                                            .cloned()
+                                                    {
+                                                        instance
+                                                    } else {
+                                                        let existing_instance = instance.read().await;
+                                                        if let Some((id, instance)) =
+                                                            existing_instance.clone()
+                                                            && id == store_id
+                                                        {
+                                                            drop(existing_instance);
+                                                            instance
+                                                        } else {
+                                                            // Likely unnecessary, but explicit drop of the read lock
+                                                            let new_instance =
+                                                                pre.instantiate_async(&mut store).await?;
+                                                            drop(existing_instance);
+                                                            *instance.write().await =
+                                                                Some((store_id, new_instance));
+                                                            new_instance
+                                                        }
+                                                    };
+
+                                                    let func = instance
+                                                        .get_func(&mut store, func_idx)
+                                                        .ok_or_else(|| {
+                                                            wasmtime::format_err!("function not found")
+                                                        })?;
+                                                    let tys = param_tys.get_or_init(|| {
+                                                        func.ty(store.as_context())
+                                                            .params()
+                                                            .map(|(_, ty)| ty)
+                                                            .collect::<Vec<_>>()
+                                                            .into()
+                                                    });
+                                                    let params_buf =
+                                                        lower_params(&mut store, params, tys)?;
+                                                    trace!(
+                                                        name = %import_name,
+                                                        fn_name = %export_name,
+                                                        "invoking dynamic export"
+                                                    );
+
+                                                    let mut results_buf =
+                                                        vec![Val::Bool(false); results.len()];
+
+                                                    // Enforce a timeout on this call to prevent hanging indefinitely
+                                                    const CALL_TIMEOUT: Duration =
+                                                        Duration::from_secs(30);
+                                                    timeout(
+                                                        CALL_TIMEOUT,
+                                                        func.call_async(
+                                                            &mut store,
+                                                            &params_buf,
+                                                            &mut results_buf,
+                                                        ),
+                                                    )
+                                                    .await
+                                                    .map_err(|e| wasmtime::format_err!(
+                                                        "function call timed out after 30 seconds: {e}",
+                                                    ))??;
+
+                                                    lift_results(&mut store, results_buf, results)?;
+                                                    trace!(
+                                                        name = %import_name,
+                                                        fn_name = %export_name,
+                                                        "invoked dynamic export"
+                                                    );
+
+                                                    store.data_mut().set_active_ctx(&prev_id)?;
+
+                                                    Ok(())
+                                                })
+                                            },
+                                        )
+                                        .map_err(|e| e.context("failed to create async func"))?;
+                                }
                             }
                             ComponentItem::Resource(resource_ty) => {
                                 let (item, _idx) = match plugin_component
@@ -1222,11 +1530,16 @@ impl ResolvedWorkload {
         metadata: &WorkloadMetadata,
         is_service: bool,
     ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
-        let active_ctx = self.new_ctx_from_metadata(metadata, is_service).await?;
+        let store_id = uuid::Uuid::new_v4().to_string();
+        let mut active_ctx = self.new_ctx_from_metadata(metadata, is_service).await?;
+        active_ctx.store_id = store_id.clone();
         let mut shared_ctx = SharedCtx::new(active_ctx);
 
-        for linked_component_id in metadata.linked_components.iter() {
-            let linked_component_ctx = self.new_ctx(linked_component_id).await?;
+        let linked_component_ids = self.component_ids_except(metadata.id()).await;
+
+        for linked_component_id in linked_component_ids {
+            let mut linked_component_ctx = self.new_ctx(linked_component_id.as_ref()).await?;
+            linked_component_ctx.store_id = store_id.clone();
             shared_ctx
                 .contexts
                 .insert(linked_component_id.clone(), linked_component_ctx);
@@ -1761,6 +2074,7 @@ impl UnresolvedWorkload {
             service: self.service,
             host_interfaces: self.host_interfaces,
             http_handler: http_handler.clone(),
+            exporter_instances: Arc::default(),
             #[cfg(feature = "wasi-tls")]
             tls_provider: self.tls_provider,
         };

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -817,14 +817,18 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
             .await?;
         let instance_pre = resolved_handle.instantiate_pre(component_id).await?;
 
-        self.workload_handles.write().await.insert(
-            resolved_handle.id().to_string(),
-            (
-                resolved_handle.clone(),
-                instance_pre,
-                component_id.to_string(),
-            ),
-        );
+        // Only components that export wasi:http are routable HTTP entrypoints.
+        // Anything else stays unregistered and routes to a 404.
+        if crate::engine::exports_wasi_http(instance_pre.component()) {
+            self.workload_handles.write().await.insert(
+                resolved_handle.id().to_string(),
+                (
+                    resolved_handle.clone(),
+                    instance_pre,
+                    component_id.to_string(),
+                ),
+            );
+        }
 
         Ok(())
     }
@@ -1294,13 +1298,28 @@ async fn invoke_component_handler(
     fuel_meter: FuelConsumptionMeter,
 ) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
     // Create a new store for this request with plugin contexts
-    let store = workload_handle.new_store(component_id).await?;
+    #[allow(unused_mut)]
+    let mut store = workload_handle.new_store(component_id).await?;
 
     // Check if this component targets WASIP3 and dispatch accordingly
     if crate::engine::targets_wasip3_http(instance_pre.component()) {
-        let resp =
-            crate::host::http_p3::handle_component_request_p3(store, instance_pre, req, fuel_meter)
-                .await?;
+        workload_handle
+            .pre_instantiate_linked_components_for_component(&mut store, component_id)
+            .await?;
+        let store_id = store.data().active_ctx.store_id.clone();
+        let cleanup_workload = workload_handle.clone();
+        let cleanup_store_id = store_id.clone();
+        let resp = crate::host::http_p3::handle_component_request_p3(
+            store,
+            instance_pre,
+            req,
+            fuel_meter,
+            Box::new(move || {
+                cleanup_workload.clear_exporter_instances_for_store(&cleanup_store_id);
+            }),
+        )
+        .await;
+        let resp = resp?;
         // Convert P3 response to a compatible HyperOutgoingBody response
         let (parts, body) = resp.into_parts();
         let body = HyperOutgoingBody::new(

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1297,18 +1297,12 @@ async fn invoke_component_handler(
     req: hyper::Request<hyper::body::Incoming>,
     fuel_meter: FuelConsumptionMeter,
 ) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
-    // Create a new store for this request with plugin contexts. The store
-    // factory pre-instantiates linked components into the store-owned exporter
-    // cache, so cross-component calls never instantiate on demand and the
-    // instances are reclaimed when the store is dropped.
     let store = workload_handle.new_store(component_id).await?;
 
-    // Check if this component targets WASIP3 and dispatch accordingly
     if crate::engine::targets_wasip3_http(instance_pre.component()) {
         let resp =
             crate::host::http_p3::handle_component_request_p3(store, instance_pre, req, fuel_meter)
                 .await?;
-        // Convert P3 response to a compatible HyperOutgoingBody response
         let (parts, body) = resp.into_parts();
         let body = HyperOutgoingBody::new(
             body.map_err(|e| {

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1297,29 +1297,17 @@ async fn invoke_component_handler(
     req: hyper::Request<hyper::body::Incoming>,
     fuel_meter: FuelConsumptionMeter,
 ) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
-    // Create a new store for this request with plugin contexts
-    #[allow(unused_mut)]
-    let mut store = workload_handle.new_store(component_id).await?;
+    // Create a new store for this request with plugin contexts. The store
+    // factory pre-instantiates linked components into the store-owned exporter
+    // cache, so cross-component calls never instantiate on demand and the
+    // instances are reclaimed when the store is dropped.
+    let store = workload_handle.new_store(component_id).await?;
 
     // Check if this component targets WASIP3 and dispatch accordingly
     if crate::engine::targets_wasip3_http(instance_pre.component()) {
-        workload_handle
-            .pre_instantiate_linked_components_for_component(&mut store, component_id)
-            .await?;
-        let store_id = store.data().active_ctx.store_id.clone();
-        let cleanup_workload = workload_handle.clone();
-        let cleanup_store_id = store_id.clone();
-        let resp = crate::host::http_p3::handle_component_request_p3(
-            store,
-            instance_pre,
-            req,
-            fuel_meter,
-            Box::new(move || {
-                cleanup_workload.clear_exporter_instances_for_store(&cleanup_store_id);
-            }),
-        )
-        .await;
-        let resp = resp?;
+        let resp =
+            crate::host::http_p3::handle_component_request_p3(store, instance_pre, req, fuel_meter)
+                .await?;
         // Convert P3 response to a compatible HyperOutgoingBody response
         let (parts, body) = resp.into_parts();
         let body = HyperOutgoingBody::new(

--- a/crates/wash-runtime/src/host/http_p3.rs
+++ b/crates/wash-runtime/src/host/http_p3.rs
@@ -35,6 +35,26 @@ pub type P3SendResult = Result<
 /// Future returned by [`crate::host::http::OutgoingHandler::send_request_p3`].
 pub type P3SendFuture = Box<dyn std::future::Future<Output = P3SendResult> + Send>;
 
+/// Called once the P3 component task exits — whether it ran to completion,
+/// returned early, or was aborted because the response body was dropped (client
+/// disconnect). Used to reclaim per-request store state, e.g. the cached
+/// linked-component instances keyed by this request's store id.
+pub type P3CompletionHook = Box<dyn FnOnce() + Send + 'static>;
+
+/// Runs the [`P3CompletionHook`] from `Drop` so it fires on **every** task exit
+/// path. The component runs in a task wrapped in an `AbortOnDropHandle`, so when
+/// the response body is dropped mid-stream the task is cancelled and any
+/// end-of-task cleanup code would never run — a `Drop` guard does.
+struct OnCompleteGuard(Option<P3CompletionHook>);
+
+impl Drop for OnCompleteGuard {
+    fn drop(&mut self) {
+        if let Some(hook) = self.0.take() {
+            hook();
+        }
+    }
+}
+
 /// Response body that yields frames forwarded from the component task over a
 /// bounded channel. End-of-stream is signalled when the sender (held by the
 /// component task) is dropped.
@@ -71,16 +91,28 @@ impl hyper::body::Body for ChannelBody {
 /// guest stays alive until the body has been fully drained, and a slow client
 /// applies backpressure to the guest rather than buffering the whole body in
 /// memory.
+///
+/// `on_complete` runs once the component task exits (completion, early error, or
+/// abort-on-disconnect) to reclaim per-request store state.
 pub async fn handle_component_request_p3(
     mut store: Store<SharedCtx>,
     pre: InstancePre<SharedCtx>,
     req: hyper::Request<hyper::body::Incoming>,
     fuel_meter: FuelConsumptionMeter,
+    on_complete: P3CompletionHook,
 ) -> anyhow::Result<hyper::Response<P3Body>> {
     let _ = &fuel_meter; // fuel metering integration deferred to match P2's observe() pattern
 
-    let service_pre = ServicePre::new(pre)
-        .map_err(|e| anyhow::anyhow!(e).context("failed to create P3 ServicePre"))?;
+    let service_pre = match ServicePre::new(pre)
+        .map_err(|e| anyhow::anyhow!(e).context("failed to create P3 ServicePre"))
+    {
+        Ok(service_pre) => service_pre,
+        Err(e) => {
+            // No task is spawned on this path, so run the hook here.
+            on_complete();
+            return Err(e);
+        }
+    };
 
     // Convert the hyper request body — map error type since hyper::Error doesn't impl Into<ErrorCode>
     let (parts, body) = req.into_parts();
@@ -108,6 +140,10 @@ pub async fn handle_component_request_p3(
     // task is aborted rather than detached to run unbounded.
     let task = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(
         async move {
+            // Reclaim per-request store state on every exit path below
+            // (completion, early return, or abort), via this guard's `Drop`.
+            let _on_complete = OnCompleteGuard(Some(on_complete));
+
             let service = match service_pre.instantiate_async(&mut store).await {
                 Ok(service) => service,
                 Err(e) => {

--- a/crates/wash-runtime/src/host/http_p3.rs
+++ b/crates/wash-runtime/src/host/http_p3.rs
@@ -71,7 +71,6 @@ impl hyper::body::Body for ChannelBody {
 /// guest stays alive until the body has been fully drained, and a slow client
 /// applies backpressure to the guest rather than buffering the whole body in
 /// memory.
-///
 pub async fn handle_component_request_p3(
     mut store: Store<SharedCtx>,
     pre: InstancePre<SharedCtx>,

--- a/crates/wash-runtime/src/host/http_p3.rs
+++ b/crates/wash-runtime/src/host/http_p3.rs
@@ -35,26 +35,6 @@ pub type P3SendResult = Result<
 /// Future returned by [`crate::host::http::OutgoingHandler::send_request_p3`].
 pub type P3SendFuture = Box<dyn std::future::Future<Output = P3SendResult> + Send>;
 
-/// Called once the P3 component task exits — whether it ran to completion,
-/// returned early, or was aborted because the response body was dropped (client
-/// disconnect). Used to reclaim per-request store state, e.g. the cached
-/// linked-component instances keyed by this request's store id.
-pub type P3CompletionHook = Box<dyn FnOnce() + Send + 'static>;
-
-/// Runs the [`P3CompletionHook`] from `Drop` so it fires on **every** task exit
-/// path. The component runs in a task wrapped in an `AbortOnDropHandle`, so when
-/// the response body is dropped mid-stream the task is cancelled and any
-/// end-of-task cleanup code would never run — a `Drop` guard does.
-struct OnCompleteGuard(Option<P3CompletionHook>);
-
-impl Drop for OnCompleteGuard {
-    fn drop(&mut self) {
-        if let Some(hook) = self.0.take() {
-            hook();
-        }
-    }
-}
-
 /// Response body that yields frames forwarded from the component task over a
 /// bounded channel. End-of-stream is signalled when the sender (held by the
 /// component task) is dropped.
@@ -92,27 +72,16 @@ impl hyper::body::Body for ChannelBody {
 /// applies backpressure to the guest rather than buffering the whole body in
 /// memory.
 ///
-/// `on_complete` runs once the component task exits (completion, early error, or
-/// abort-on-disconnect) to reclaim per-request store state.
 pub async fn handle_component_request_p3(
     mut store: Store<SharedCtx>,
     pre: InstancePre<SharedCtx>,
     req: hyper::Request<hyper::body::Incoming>,
     fuel_meter: FuelConsumptionMeter,
-    on_complete: P3CompletionHook,
 ) -> anyhow::Result<hyper::Response<P3Body>> {
     let _ = &fuel_meter; // fuel metering integration deferred to match P2's observe() pattern
 
-    let service_pre = match ServicePre::new(pre)
-        .map_err(|e| anyhow::anyhow!(e).context("failed to create P3 ServicePre"))
-    {
-        Ok(service_pre) => service_pre,
-        Err(e) => {
-            // No task is spawned on this path, so run the hook here.
-            on_complete();
-            return Err(e);
-        }
-    };
+    let service_pre = ServicePre::new(pre)
+        .map_err(|e| anyhow::anyhow!(e).context("failed to create P3 ServicePre"))?;
 
     // Convert the hyper request body — map error type since hyper::Error doesn't impl Into<ErrorCode>
     let (parts, body) = req.into_parts();
@@ -140,10 +109,6 @@ pub async fn handle_component_request_p3(
     // task is aborted rather than detached to run unbounded.
     let task = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(
         async move {
-            // Reclaim per-request store state on every exit path below
-            // (completion, early return, or abort), via this guard's `Drop`.
-            let _on_complete = OnCompleteGuard(Some(on_complete));
-
             let service = match service_pre.instantiate_async(&mut store).await {
                 Ok(service) => service,
                 Err(e) => {

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -238,14 +238,14 @@ dependencies = [
 name = "ephemeral-callee-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "ephemeral-caller-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -1098,21 +1098,21 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 name = "res-caller-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "res-producer-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "res-sink-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -1253,21 +1253,21 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stream-consumer-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "stream-pacer-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "stream-producer-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -235,6 +235,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ephemeral-callee-p3"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.54.0",
+]
+
+[[package]]
+name = "ephemeral-caller-p3"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.54.0",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -1081,6 +1081,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "res-caller-p3"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.54.0",
+]
+
+[[package]]
+name = "res-producer-p3"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.54.0",
+]
+
+[[package]]
+name = "res-sink-p3"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.54.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1234,27 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stream-consumer-p3"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.54.0",
+]
+
+[[package]]
+name = "stream-pacer-p3"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.54.0",
+]
+
+[[package]]
+name = "stream-producer-p3"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.54.0",
+]
 
 [[package]]
 name = "syn"

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -25,6 +25,12 @@ members = [
     "tls-echo-client-p3",
     "inter-component-call-p3-caller",
     "inter-component-call-p3-callee",
+    "stream-producer-p3",
+    "stream-consumer-p3",
+    "stream-pacer-p3",
+    "res-producer-p3",
+    "res-sink-p3",
+    "res-caller-p3",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -31,6 +31,8 @@ members = [
     "res-producer-p3",
     "res-sink-p3",
     "res-caller-p3",
+    "ephemeral-callee-p3",
+    "ephemeral-caller-p3",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ephemeral-callee-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/src/lib.rs
@@ -1,0 +1,26 @@
+//! Minimal P3 fixture: exports a plain-value async `run` function. Paired with
+//! `ephemeral-caller-p3`, which imports this interface through the dynamic
+//! linker. Because the signature is all plain values, the linked call is
+//! dispatched via the ephemeral-store path (`invoke_ephemeral_linked_export`).
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+        async: [
+            "export:wasmcloud:ephemeral-test/compute@0.1.0#run",
+        ],
+    });
+}
+
+use bindings::exports::wasmcloud::ephemeral_test::compute::Guest;
+
+struct Component;
+
+impl Guest for Component {
+    async fn run(n: u32) -> u32 {
+        // Deterministic plain-value transform the caller can assert on.
+        n.wrapping_mul(2).wrapping_add(1)
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/src/lib.rs
@@ -18,7 +18,6 @@ struct Component;
 
 impl Guest for Component {
     async fn run(n: u32) -> u32 {
-        // Deterministic plain-value transform the caller can assert on.
         n.wrapping_mul(2).wrapping_add(1)
     }
 }

--- a/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/wit/world.wit
@@ -1,0 +1,13 @@
+package wasmcloud:ephemeral-test@0.1.0;
+
+interface compute {
+    /// Plain-value async function: both the param and result are plain values
+    /// (no resource/stream/future/borrow handles), so the dynamic linker
+    /// dispatches a call to it through the *ephemeral store* path
+    /// (instantiate-call-drop in a throwaway store).
+    run: async func(n: u32) -> u32;
+}
+
+world ephemeral-callee {
+    export compute;
+}

--- a/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ephemeral-caller-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/src/lib.rs
@@ -32,7 +32,7 @@ impl Handler for Component {
         let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
 
         let body = result.to_string().into_bytes();
-        wit_bindgen::spawn(async move {
+        wit_bindgen::spawn_local(async move {
             tx.write_all(body).await;
             drop(tx);
             let _ = trailers_tx.write(Ok(None)).await;

--- a/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/src/lib.rs
@@ -1,14 +1,15 @@
-//! P3 fixture (HTTP entrypoint): obtains a `token` from `res-producer-p3` and
-//! hands it to `res-sink-p3`, then returns the sink's reply as the HTTP body.
-//! Passing the token to `accept` is what exercises `lower_with_type`'s
-//! resource-identity passthrough across the dynamic linker.
+//! Minimal P3 fixture: an HTTP handler that invokes the plain-value async
+//! `run` export of the linked `ephemeral-callee-p3` component and returns the
+//! result as the response body. Because `run`'s signature is all plain values,
+//! the call is dispatched through the ephemeral-store path
+//! (`invoke_ephemeral_linked_export`): the callee is instantiated in a
+//! short-lived store that is dropped as soon as the call returns.
 
 mod bindings {
     wit_bindgen::generate!({
         generate_all,
         async: [
-            "import:wasmcloud:resource-test/factory@0.1.0#make-token",
-            "import:wasmcloud:resource-test/sink@0.1.0#accept",
+            "import:wasmcloud:ephemeral-test/compute@0.1.0#run",
             "export:wasi:http/handler@0.3.0#handle",
         ],
     });
@@ -16,22 +17,23 @@ mod bindings {
 
 use bindings::exports::wasi::http::handler::Guest as Handler;
 use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
-use bindings::wasmcloud::resource_test::{factory, sink};
+use bindings::wasmcloud::ephemeral_test::compute;
 
 struct Component;
 
 impl Handler for Component {
     async fn handle(_request: Request) -> Result<Response, ErrorCode> {
-        // make_token returns a host-owned handle; passing it to accept lowers
-        // it across the linker into res-sink-p3.
-        let token = factory::make_token("world".to_string()).await;
-        let body = sink::accept(token).await;
+        // Plain-value async cross-component call -> ephemeral-store path.
+        // run(21) = 21 * 2 + 1 = 43.
+        let result = compute::run(21).await;
 
         let headers = Fields::new();
         let (mut tx, rx) = bindings::wit_stream::new::<u8>();
         let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
+
+        let body = result.to_string().into_bytes();
         wit_bindgen::spawn(async move {
-            tx.write_all(body.into_bytes()).await;
+            tx.write_all(body).await;
             drop(tx);
             let _ = trailers_tx.write(Ok(None)).await;
         });

--- a/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/wit/world.wit
@@ -1,0 +1,14 @@
+package wasmcloud:ephemeral-test@0.1.0;
+
+interface compute {
+    /// Mirror of the callee interface. The signature must match the callee
+    /// fixture exactly so the dynamic linker wires the import of
+    /// `wasmcloud:ephemeral-test/compute` to the callee's export.
+    run: async func(n: u32) -> u32;
+}
+
+world ephemeral-caller {
+    import compute;
+    import wasi:http/types@0.3.0;
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/res-caller-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/res-caller-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "res-caller-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/res-caller-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/res-caller-p3/src/lib.rs
@@ -30,7 +30,7 @@ impl Handler for Component {
         let headers = Fields::new();
         let (mut tx, rx) = bindings::wit_stream::new::<u8>();
         let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
-        wit_bindgen::spawn(async move {
+        wit_bindgen::spawn_local(async move {
             tx.write_all(body.into_bytes()).await;
             drop(tx);
             let _ = trailers_tx.write(Ok(None)).await;

--- a/crates/wash-runtime/tests/fixtures/res-caller-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/res-caller-p3/src/lib.rs
@@ -1,0 +1,44 @@
+//! P3 fixture (HTTP entrypoint): obtains a `token` from `res-producer-p3` and
+//! hands it to `res-sink-p3`, then returns the sink's reply as the HTTP body.
+//! Passing the token to `accept` is what exercises `lower_with_type`'s
+//! resource-identity passthrough across the dynamic linker.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+        async: [
+            "import:wasmcloud:resource-test/factory@0.1.0#make-token",
+            "import:wasmcloud:resource-test/sink@0.1.0#accept",
+            "export:wasi:http/handler@0.3.0-rc-2026-03-15#handle",
+        ],
+    });
+}
+
+use bindings::exports::wasi::http::handler::Guest as Handler;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::wasmcloud::resource_test::{factory, sink};
+
+struct Component;
+
+impl Handler for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        // make_token returns a host-owned handle; passing it to accept lowers
+        // it across the linker into res-sink-p3.
+        let token = factory::make_token("world".to_string()).await;
+        let body = sink::accept(token).await;
+
+        let headers = Fields::new();
+        let (mut tx, rx) = bindings::wit_stream::new::<u8>();
+        let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
+        wit_bindgen::spawn(async move {
+            tx.write_all(body.into_bytes()).await;
+            drop(tx);
+            let _ = trailers_tx.write(Ok(None)).await;
+        });
+
+        let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+        Ok(response)
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/res-caller-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/res-caller-p3/wit/world.wit
@@ -1,0 +1,25 @@
+package wasmcloud:resource-test@0.1.0;
+
+interface factory {
+    resource token {
+        greet: func() -> string;
+    }
+
+    make-token: async func(name: string) -> token;
+}
+
+interface sink {
+    use factory.{token};
+
+    accept: async func(t: token) -> string;
+}
+
+world res-caller {
+    import factory;
+    import sink;
+    import wasi:http/types@0.3.0-rc-2026-03-15;
+    import wasi:clocks/types@0.3.0-rc-2026-03-15;
+    import wasi:random/random@0.3.0-rc-2026-03-15;
+
+    export wasi:http/handler@0.3.0-rc-2026-03-15;
+}

--- a/crates/wash-runtime/tests/fixtures/res-caller-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/res-caller-p3/wit/world.wit
@@ -17,9 +17,9 @@ interface sink {
 world res-caller {
     import factory;
     import sink;
-    import wasi:http/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
-    import wasi:random/random@0.3.0-rc-2026-03-15;
+    import wasi:http/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:random/random@0.3.0;
 
-    export wasi:http/handler@0.3.0-rc-2026-03-15;
+    export wasi:http/handler@0.3.0;
 }

--- a/crates/wash-runtime/tests/fixtures/res-producer-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/res-producer-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "res-producer-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/res-producer-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/res-producer-p3/src/lib.rs
@@ -1,0 +1,36 @@
+//! P3 fixture: produces a guest `token` resource. Paired with `res-sink-p3`
+//! and `res-caller-p3` to exercise passing a resource handle across the
+//! dynamic linker (`engine::value::lower_with_type` identity passthrough).
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+        async: [
+            "export:wasmcloud:resource-test/factory@0.1.0#make-token",
+        ],
+    });
+}
+
+use bindings::exports::wasmcloud::resource_test::factory::{Guest, GuestToken, Token};
+
+struct Component;
+
+struct TokenState {
+    name: String,
+}
+
+impl GuestToken for TokenState {
+    fn greet(&self) -> String {
+        format!("hello {}", self.name)
+    }
+}
+
+impl Guest for Component {
+    type Token = TokenState;
+
+    async fn make_token(name: String) -> Token {
+        Token::new(TokenState { name })
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/res-producer-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/res-producer-p3/wit/world.wit
@@ -11,8 +11,8 @@ interface factory {
 }
 
 world res-producer {
-    import wasi:cli/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
+    import wasi:cli/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
 
     export factory;
 }

--- a/crates/wash-runtime/tests/fixtures/res-producer-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/res-producer-p3/wit/world.wit
@@ -1,0 +1,18 @@
+package wasmcloud:resource-test@0.1.0;
+
+interface factory {
+    /// A guest-defined resource. When its handle crosses the dynamic linker,
+    /// the runtime represents it as a host `ResourceAny`.
+    resource token {
+        greet: func() -> string;
+    }
+
+    make-token: async func(name: string) -> token;
+}
+
+world res-producer {
+    import wasi:cli/types@0.3.0-rc-2026-03-15;
+    import wasi:clocks/types@0.3.0-rc-2026-03-15;
+
+    export factory;
+}

--- a/crates/wash-runtime/tests/fixtures/res-sink-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/res-sink-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "res-sink-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/res-sink-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/res-sink-p3/src/lib.rs
@@ -1,0 +1,27 @@
+//! P3 fixture: receives a `token` resource handle as a parameter and calls a
+//! method on it (dispatched back to `res-producer-p3` through the linker).
+//! The inbound handle is lowered across the dynamic linker via
+//! `lower_with_type` — if identity were not preserved, `greet()` below would
+//! fail or read the wrong resource.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+        async: [
+            "export:wasmcloud:resource-test/sink@0.1.0#accept",
+        ],
+    });
+}
+
+use bindings::exports::wasmcloud::resource_test::sink::Guest;
+use bindings::wasmcloud::resource_test::factory::Token;
+
+struct Component;
+
+impl Guest for Component {
+    async fn accept(t: Token) -> String {
+        format!("sink:{}", t.greet())
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/res-sink-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/res-sink-p3/wit/world.wit
@@ -1,0 +1,25 @@
+package wasmcloud:resource-test@0.1.0;
+
+interface factory {
+    resource token {
+        greet: func() -> string;
+    }
+
+    make-token: async func(name: string) -> token;
+}
+
+interface sink {
+    use factory.{token};
+
+    /// Takes ownership of a `token` and reports on it. The handle is lowered
+    /// into this component by the dynamic linker (lower_with_type).
+    accept: async func(t: token) -> string;
+}
+
+world res-sink {
+    import factory;
+    import wasi:cli/types@0.3.0-rc-2026-03-15;
+    import wasi:clocks/types@0.3.0-rc-2026-03-15;
+
+    export sink;
+}

--- a/crates/wash-runtime/tests/fixtures/res-sink-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/res-sink-p3/wit/world.wit
@@ -18,8 +18,8 @@ interface sink {
 
 world res-sink {
     import factory;
-    import wasi:cli/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
+    import wasi:cli/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
 
     export sink;
 }

--- a/crates/wash-runtime/tests/fixtures/stream-consumer-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/stream-consumer-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "stream-consumer-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/stream-consumer-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/stream-consumer-p3/src/lib.rs
@@ -1,0 +1,53 @@
+//! Minimal P3 fixture: an HTTP handler that pulls a `stream<u8>` from the
+//! linked `stream-producer-p3` component and forwards it to the response
+//! body. Exercises the cross-component stream path:
+//!   - the `stream<u8>` handle crosses the dynamic linker boundary
+//!     (`lower_with_type` resource-identity passthrough),
+//!   - the producer is auto-linked into this workload
+//!     (`component_ids_except`),
+//!   - the response body streams through to hyper without being buffered.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+        async: [
+            "import:wasmcloud:stream-test/producer@0.1.0#produce",
+            "export:wasi:http/handler@0.3.0-rc-2026-03-15#handle",
+        ],
+    });
+}
+
+use bindings::exports::wasi::http::handler::Guest as Handler;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::wasmcloud::stream_test::producer;
+
+struct Component;
+
+impl Handler for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        // Pull a byte stream from the linked producer component. This
+        // `stream<u8>` handle is created in the producer and travels across
+        // the dynamic linker into this component.
+        let mut upstream = producer::produce(16).await;
+
+        let headers = Fields::new();
+        let (mut tx, rx) = bindings::wit_stream::new::<u8>();
+        let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
+
+        // Forward producer bytes straight into the HTTP response body, then
+        // close. The runtime streams P3 bodies through to hyper, so these
+        // reach the client without being buffered in full first.
+        wit_bindgen::spawn(async move {
+            while let Some(byte) = upstream.next().await {
+                tx.write_all(vec![byte]).await;
+            }
+            drop(tx);
+            let _ = trailers_tx.write(Ok(None)).await;
+        });
+
+        let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+        Ok(response)
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/stream-consumer-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/stream-consumer-p3/src/lib.rs
@@ -12,7 +12,7 @@ mod bindings {
         generate_all,
         async: [
             "import:wasmcloud:stream-test/producer@0.1.0#produce",
-            "export:wasi:http/handler@0.3.0-rc-2026-03-15#handle",
+            "export:wasi:http/handler@0.3.0#handle",
         ],
     });
 }

--- a/crates/wash-runtime/tests/fixtures/stream-consumer-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/stream-consumer-p3/src/lib.rs
@@ -37,7 +37,7 @@ impl Handler for Component {
         // Forward producer bytes straight into the HTTP response body, then
         // close. The runtime streams P3 bodies through to hyper, so these
         // reach the client without being buffered in full first.
-        wit_bindgen::spawn(async move {
+        wit_bindgen::spawn_local(async move {
             while let Some(byte) = upstream.next().await {
                 tx.write_all(vec![byte]).await;
             }

--- a/crates/wash-runtime/tests/fixtures/stream-consumer-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/stream-consumer-p3/wit/world.wit
@@ -9,9 +9,9 @@ interface producer {
 
 world stream-consumer {
     import producer;
-    import wasi:http/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
-    import wasi:random/random@0.3.0-rc-2026-03-15;
+    import wasi:http/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:random/random@0.3.0;
 
-    export wasi:http/handler@0.3.0-rc-2026-03-15;
+    export wasi:http/handler@0.3.0;
 }

--- a/crates/wash-runtime/tests/fixtures/stream-consumer-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/stream-consumer-p3/wit/world.wit
@@ -1,0 +1,17 @@
+package wasmcloud:stream-test@0.1.0;
+
+interface producer {
+    /// Mirror of the producer interface. The signature must match the
+    /// producer fixture exactly so the dynamic linker wires the import of
+    /// `wasmcloud:stream-test/producer` to the producer's export.
+    produce: async func(n: u32) -> stream<u8>;
+}
+
+world stream-consumer {
+    import producer;
+    import wasi:http/types@0.3.0-rc-2026-03-15;
+    import wasi:clocks/types@0.3.0-rc-2026-03-15;
+    import wasi:random/random@0.3.0-rc-2026-03-15;
+
+    export wasi:http/handler@0.3.0-rc-2026-03-15;
+}

--- a/crates/wash-runtime/tests/fixtures/stream-pacer-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/stream-pacer-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "stream-pacer-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/stream-pacer-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/stream-pacer-p3/src/lib.rs
@@ -38,7 +38,7 @@ impl Handler for Component {
 
         // Emit `chunk-{i}\n` once per tick. The response is returned to the
         // host immediately; this task keeps feeding the body afterwards.
-        wit_bindgen::spawn(async move {
+        wit_bindgen::spawn_local(async move {
             for i in 0..CHUNKS {
                 if i > 0 {
                     monotonic_clock::wait_for(TICK_NS).await;

--- a/crates/wash-runtime/tests/fixtures/stream-pacer-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/stream-pacer-p3/src/lib.rs
@@ -13,8 +13,8 @@ mod bindings {
     wit_bindgen::generate!({
         generate_all,
         async: [
-            "export:wasi:http/handler@0.3.0-rc-2026-03-15#handle",
-            "import:wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#wait-for",
+            "export:wasi:http/handler@0.3.0#handle",
+            "import:wasi:clocks/monotonic-clock@0.3.0#wait-for",
         ],
     });
 }

--- a/crates/wash-runtime/tests/fixtures/stream-pacer-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/stream-pacer-p3/src/lib.rs
@@ -1,0 +1,57 @@
+//! Self-contained P3 HTTP handler that emits its response body as a
+//! sequence of chunks spaced out over time (via monotonic-clock
+//! `wait-for`).
+//!
+//! It exists to prove the runtime *streams* P3 response bodies through to
+//! hyper rather than buffering them. With streaming, a client reading the
+//! body sees `chunk-0` hundreds of milliseconds before `chunk-9`. With the
+//! old collect-then-send path, the handler would not return a response at
+//! all until the whole body was produced, so the first byte and the last
+//! byte arrive at essentially the same time.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+        async: [
+            "export:wasi:http/handler@0.3.0-rc-2026-03-15#handle",
+            "import:wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15#wait-for",
+        ],
+    });
+}
+
+use bindings::exports::wasi::http::handler::Guest as Handler;
+use bindings::wasi::clocks::monotonic_clock;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+
+struct Component;
+
+/// Number of chunks and the gap between them. 10 × 100ms ≈ 0.9s of paced
+/// output, so a streaming client observes chunk 0 well before chunk 9.
+const CHUNKS: u32 = 10;
+const TICK_NS: u64 = 100_000_000; // 100ms
+
+impl Handler for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        let headers = Fields::new();
+        let (mut tx, rx) = bindings::wit_stream::new::<u8>();
+        let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
+
+        // Emit `chunk-{i}\n` once per tick. The response is returned to the
+        // host immediately; this task keeps feeding the body afterwards.
+        wit_bindgen::spawn(async move {
+            for i in 0..CHUNKS {
+                if i > 0 {
+                    monotonic_clock::wait_for(TICK_NS).await;
+                }
+                tx.write_all(format!("chunk-{i}\n").into_bytes()).await;
+            }
+            drop(tx);
+            let _ = trailers_tx.write(Ok(None)).await;
+        });
+
+        let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+        Ok(response)
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/stream-pacer-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/stream-pacer-p3/wit/world.wit
@@ -1,10 +1,10 @@
 package wasmcloud:stream-pacer@0.1.0;
 
 world stream-pacer {
-    import wasi:http/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
-    import wasi:random/random@0.3.0-rc-2026-03-15;
+    import wasi:http/types@0.3.0;
+    import wasi:clocks/monotonic-clock@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:random/random@0.3.0;
 
-    export wasi:http/handler@0.3.0-rc-2026-03-15;
+    export wasi:http/handler@0.3.0;
 }

--- a/crates/wash-runtime/tests/fixtures/stream-pacer-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/stream-pacer-p3/wit/world.wit
@@ -1,0 +1,10 @@
+package wasmcloud:stream-pacer@0.1.0;
+
+world stream-pacer {
+    import wasi:http/types@0.3.0-rc-2026-03-15;
+    import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
+    import wasi:clocks/types@0.3.0-rc-2026-03-15;
+    import wasi:random/random@0.3.0-rc-2026-03-15;
+
+    export wasi:http/handler@0.3.0-rc-2026-03-15;
+}

--- a/crates/wash-runtime/tests/fixtures/stream-producer-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/stream-producer-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "stream-producer-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/stream-producer-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/stream-producer-p3/src/lib.rs
@@ -2,28 +2,45 @@
 //! `stream<u8>`. Paired with `stream-consumer-p3`, which imports this
 //! interface through the dynamic linker and forwards the stream to an
 //! HTTP response body.
+//!
+//! Bytes are emitted one per tick (via monotonic-clock `wait-for`) so a
+//! reader on the far side of the linker observes the stream arriving
+//! incrementally. That's what lets `integration_p3_streams` prove the
+//! cross-component stream stays concurrent rather than being buffered at the
+//! linker boundary.
 
 mod bindings {
     wit_bindgen::generate!({
         generate_all,
         async: [
             "export:wasmcloud:stream-test/producer@0.1.0#produce",
+            "import:wasi:clocks/monotonic-clock@0.3.0#wait-for",
         ],
     });
 }
 
 use bindings::exports::wasmcloud::stream_test::producer::Guest;
+use bindings::wasi::clocks::monotonic_clock;
 use wit_bindgen::StreamReader;
 
 struct Component;
 
+/// Gap between emitted bytes. Paced so a reader across the dynamic linker
+/// sees early bytes well before late ones; 16 bytes at this tick spans
+/// ~0.75s, plenty to distinguish streaming from buffering.
+const TICK_NS: u64 = 50_000_000; // 50ms
+
 impl Guest for Component {
     async fn produce(n: u32) -> StreamReader<u8> {
         let (mut tx, rx) = bindings::wit_stream::new::<u8>();
-        // Emit `n` bytes ('a', 'b', ...) on a background task so the reader
-        // can be returned immediately and drained by the consumer.
+        // Emit `n` bytes ('a', 'b', ...) on a background task, one per tick,
+        // so the reader can be returned immediately and drained incrementally
+        // by the consumer across the linker.
         wit_bindgen::spawn(async move {
             for i in 0..n {
+                if i > 0 {
+                    monotonic_clock::wait_for(TICK_NS).await;
+                }
                 tx.write_all(vec![b'a' + (i % 26) as u8]).await;
             }
             drop(tx);

--- a/crates/wash-runtime/tests/fixtures/stream-producer-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/stream-producer-p3/src/lib.rs
@@ -1,0 +1,35 @@
+//! Minimal P3 fixture: exports `produce`, returning a cross-component
+//! `stream<u8>`. Paired with `stream-consumer-p3`, which imports this
+//! interface through the dynamic linker and forwards the stream to an
+//! HTTP response body.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+        async: [
+            "export:wasmcloud:stream-test/producer@0.1.0#produce",
+        ],
+    });
+}
+
+use bindings::exports::wasmcloud::stream_test::producer::Guest;
+use wit_bindgen::StreamReader;
+
+struct Component;
+
+impl Guest for Component {
+    async fn produce(n: u32) -> StreamReader<u8> {
+        let (mut tx, rx) = bindings::wit_stream::new::<u8>();
+        // Emit `n` bytes ('a', 'b', ...) on a background task so the reader
+        // can be returned immediately and drained by the consumer.
+        wit_bindgen::spawn(async move {
+            for i in 0..n {
+                tx.write_all(vec![b'a' + (i % 26) as u8]).await;
+            }
+            drop(tx);
+        });
+        rx
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/stream-producer-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/stream-producer-p3/src/lib.rs
@@ -36,7 +36,7 @@ impl Guest for Component {
         // Emit `n` bytes ('a', 'b', ...) on a background task, one per tick,
         // so the reader can be returned immediately and drained incrementally
         // by the consumer across the linker.
-        wit_bindgen::spawn(async move {
+        wit_bindgen::spawn_local(async move {
             for i in 0..n {
                 if i > 0 {
                     monotonic_clock::wait_for(TICK_NS).await;

--- a/crates/wash-runtime/tests/fixtures/stream-producer-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/stream-producer-p3/wit/world.wit
@@ -1,0 +1,14 @@
+package wasmcloud:stream-test@0.1.0;
+
+interface producer {
+    /// Produce a stream of `n` bytes. Returned as a `stream<u8>` so the
+    /// handle can be passed to another component through the dynamic linker.
+    produce: async func(n: u32) -> stream<u8>;
+}
+
+world stream-producer {
+    import wasi:cli/types@0.3.0-rc-2026-03-15;
+    import wasi:clocks/types@0.3.0-rc-2026-03-15;
+
+    export producer;
+}

--- a/crates/wash-runtime/tests/fixtures/stream-producer-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/stream-producer-p3/wit/world.wit
@@ -1,14 +1,17 @@
 package wasmcloud:stream-test@0.1.0;
 
 interface producer {
-    /// Produce a stream of `n` bytes. Returned as a `stream<u8>` so the
-    /// handle can be passed to another component through the dynamic linker.
+    /// Produce a stream of `n` bytes, emitted one per tick. Returned as a
+    /// `stream<u8>` so the handle can be passed to another component through
+    /// the dynamic linker; the pacing lets a reader on the far side observe
+    /// the stream arriving incrementally rather than all at once.
     produce: async func(n: u32) -> stream<u8>;
 }
 
 world stream-producer {
-    import wasi:cli/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
+    import wasi:cli/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:clocks/monotonic-clock@0.3.0;
 
     export producer;
 }

--- a/crates/wash-runtime/tests/integration_p3_ephemeral.rs
+++ b/crates/wash-runtime/tests/integration_p3_ephemeral.rs
@@ -16,6 +16,8 @@
 //! A correct round-trip body (`run(21) == 43`) proves the call crossed the
 //! linker into a fresh ephemeral store, executed, and returned its plain value
 //! back to the caller.
+//! Run with `RUST_LOG=wash_runtime::engine::workload=trace` to see the
+//! `invoked ephemeral dynamic export` trace for each request.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -36,11 +38,12 @@ const EPHEMERAL_CALLEE_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_callee_p3
 
 #[tokio::test]
 async fn test_p3_plain_value_async_call_uses_ephemeral_store() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
     let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
 
-    // The caller exports wasi:http/handler and is the workload's incoming
-    // entrypoint; the callee is auto-linked in and supplies the plain-value
-    // async `run` function dispatched via the ephemeral-store path.
     let req = WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),
         workload: Workload {
@@ -93,17 +96,12 @@ async fn test_p3_plain_value_async_call_uses_ephemeral_store() -> Result<()> {
         response.status()
     );
 
-    // run(21) = 21 * 2 + 1 = 43. A correct value proves the plain-value async
-    // call round-tripped through the freshly-created ephemeral store.
     let body = response.text().await?;
     assert_eq!(
         body, "43",
         "ephemeral cross-component call should return run(21) == 43"
     );
 
-    // A second request reuses the same long-lived request stores but creates a
-    // fresh ephemeral store again; it must still succeed (the per-call store is
-    // dropped and its exporter-cache entries evicted after each call).
     let response2 = timeout(
         Duration::from_secs(10),
         client

--- a/crates/wash-runtime/tests/integration_p3_ephemeral.rs
+++ b/crates/wash-runtime/tests/integration_p3_ephemeral.rs
@@ -1,0 +1,121 @@
+//! Integration test for the WASIP3 ephemeral-store linked-call path.
+//!
+//! `ephemeral-caller-p3` (a P3 HTTP handler) imports a plain-value async
+//! function `run(u32) -> u32` from a second P3 component
+//! (`ephemeral-callee-p3`) and returns its result as the response body.
+//!
+//! Because the linked function's signature is *all plain values* (no
+//! resource/stream/future/borrow handles), the dynamic linker dispatches the
+//! call through the ephemeral-store path
+//! (`ResolvedWorkload::resolve_component_imports` →
+//! `invoke_ephemeral_linked_export`): the callee is instantiated in a
+//! short-lived `Store` that is dropped — and its core-instance slots reclaimed —
+//! as soon as the call returns. The streaming/resource fixtures only exercise
+//! the shared-store path, so this is the only coverage of the ephemeral path.
+//!
+//! A correct round-trip body (`run(21) == 43`) proves the call crossed the
+//! linker into a fresh ephemeral store, executed, and returned its plain value
+//! back to the caller.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use anyhow::{Context, Result};
+use std::{collections::HashMap, time::Duration};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    host::HostApi,
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+};
+
+mod common;
+use common::{http_only_host_interfaces, start_host_with_p3};
+
+const EPHEMERAL_CALLER_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_caller_p3.wasm");
+const EPHEMERAL_CALLEE_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_callee_p3.wasm");
+
+#[tokio::test]
+async fn test_p3_plain_value_async_call_uses_ephemeral_store() -> Result<()> {
+    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+
+    // The caller exports wasi:http/handler and is the workload's incoming
+    // entrypoint; the callee is auto-linked in and supplies the plain-value
+    // async `run` function dispatched via the ephemeral-store path.
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "p3-ephemeral".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![
+                Component {
+                    name: "ephemeral-caller".to_string(),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(EPHEMERAL_CALLER_P3_WASM),
+                    local_resources: LocalResources::default(),
+                    pool_size: 1,
+                    max_invocations: 100,
+                },
+                Component {
+                    name: "ephemeral-callee".to_string(),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(EPHEMERAL_CALLEE_P3_WASM),
+                    local_resources: LocalResources::default(),
+                    pool_size: 1,
+                    max_invocations: 100,
+                },
+            ],
+            host_interfaces: http_only_host_interfaces("p3-ephemeral"),
+            volumes: vec![],
+        },
+    };
+
+    host.workload_start(req)
+        .await
+        .context("ephemeral cross-component workload should start")?;
+
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "p3-ephemeral")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+
+    assert!(
+        response.status().is_success(),
+        "ephemeral handler should return 2xx, got {}",
+        response.status()
+    );
+
+    // run(21) = 21 * 2 + 1 = 43. A correct value proves the plain-value async
+    // call round-tripped through the freshly-created ephemeral store.
+    let body = response.text().await?;
+    assert_eq!(
+        body, "43",
+        "ephemeral cross-component call should return run(21) == 43"
+    );
+
+    // A second request reuses the same long-lived request stores but creates a
+    // fresh ephemeral store again; it must still succeed (the per-call store is
+    // dropped and its exporter-cache entries evicted after each call).
+    let response2 = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "p3-ephemeral")
+            .send(),
+    )
+    .await
+    .context("second request timed out")?
+    .context("second request failed")?;
+    assert!(response2.status().is_success());
+    assert_eq!(response2.text().await?, "43");
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_p3_resources.rs
+++ b/crates/wash-runtime/tests/integration_p3_resources.rs
@@ -9,7 +9,6 @@
 //! handle were re-lowered (copied) instead of passed by identity, the sink's
 //! `greet()` call would fail or read the wrong resource.
 
-#![cfg(feature = "wasip3")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};

--- a/crates/wash-runtime/tests/integration_p3_resources.rs
+++ b/crates/wash-runtime/tests/integration_p3_resources.rs
@@ -1,0 +1,92 @@
+//! Integration test for passing a guest resource handle across the WASIP3
+//! dynamic linker.
+//!
+//! `res-caller-p3` (the HTTP entrypoint) gets a `token` resource from
+//! `res-producer-p3` and hands it to `res-sink-p3`, which calls a method on
+//! it. The handle crosses the linker as a host `ResourceAny`, so the call to
+//! `accept(token)` exercises `engine::value::lower_with_type`'s resource
+//! identity passthrough — the path the streaming tests do not cover. If the
+//! handle were re-lowered (copied) instead of passed by identity, the sink's
+//! `greet()` call would fail or read the wrong resource.
+
+#![cfg(feature = "wasip3")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use anyhow::{Context, Result};
+use std::{collections::HashMap, time::Duration};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    host::HostApi,
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+};
+
+mod common;
+use common::{http_only_host_interfaces, start_host_with_p3};
+
+const RES_CALLER_P3_WASM: &[u8] = include_bytes!("wasm/res_caller_p3.wasm");
+const RES_PRODUCER_P3_WASM: &[u8] = include_bytes!("wasm/res_producer_p3.wasm");
+const RES_SINK_P3_WASM: &[u8] = include_bytes!("wasm/res_sink_p3.wasm");
+
+fn component(name: &str, bytes: &'static [u8]) -> Component {
+    Component {
+        name: name.to_string(),
+        digest: None,
+        bytes: bytes::Bytes::from_static(bytes),
+        local_resources: LocalResources::default(),
+        pool_size: 1,
+        max_invocations: 100,
+    }
+}
+
+#[tokio::test]
+async fn test_p3_resource_handle_crosses_linker() -> Result<()> {
+    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "p3-resource-passing".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![
+                component("res-caller", RES_CALLER_P3_WASM),
+                component("res-producer", RES_PRODUCER_P3_WASM),
+                component("res-sink", RES_SINK_P3_WASM),
+            ],
+            host_interfaces: http_only_host_interfaces("p3-resource"),
+            volumes: vec![],
+        },
+    };
+
+    host.workload_start(req)
+        .await
+        .context("resource-passing workload should start")?;
+
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "p3-resource")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+
+    assert!(
+        response.status().is_success(),
+        "resource-passing handler should return 2xx, got {}",
+        response.status()
+    );
+
+    // producer makes a token for "world"; sink greets it -> "hello world",
+    // wrapped as "sink:hello world". Getting this back proves the same token
+    // resource survived the trip across the linker into the sink.
+    let body = response.text().await?;
+    assert_eq!(body, "sink:hello world");
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_p3_resources.rs
+++ b/crates/wash-runtime/tests/integration_p3_resources.rs
@@ -1,13 +1,28 @@
 //! Integration test for passing a guest resource handle across the WASIP3
 //! dynamic linker.
 //!
-//! `res-caller-p3` (the HTTP entrypoint) gets a `token` resource from
-//! `res-producer-p3` and hands it to `res-sink-p3`, which calls a method on
-//! it. The handle crosses the linker as a host `ResourceAny`, so the call to
-//! `accept(token)` exercises `engine::value::lower_with_type`'s resource
-//! identity passthrough — the path the streaming tests do not cover. If the
-//! handle were re-lowered (copied) instead of passed by identity, the sink's
-//! `greet()` call would fail or read the wrong resource.
+//! Three P3 components are linked together in one workload, and a single HTTP
+//! request drives a resource handle through both linker hops:
+//!
+//! 1. A request hits `res-caller-p3`, the workload's HTTP entrypoint.
+//! 2. `res-caller-p3` calls `res-producer-p3` (hop 1) and gets back a `token`
+//!    resource, created for the string `"world"`.
+//! 3. `res-caller-p3` passes that same `token` to `res-sink-p3` (hop 2) via
+//!    `accept(token)`. The handle crosses the linker as a host `ResourceAny`.
+//! 4. `res-sink-p3` calls `greet()` on the token (`"hello world"`) and wraps it
+//!    as `"sink:hello world"`, which `res-caller-p3` returns as the body.
+//!
+//! What this exercises:
+//!
+//! - Each linker hop lowers the `token` via `engine::value::lower_with_type`,
+//!   which must pass the resource by *identity* rather than re-lowering
+//!   (copying) it.
+//! - If identity were not preserved, `res-sink-p3` would receive a different /
+//!   stale resource and its `greet()` call would fail or read the wrong token,
+//!   so the body would not come back as `"sink:hello world"`.
+//!
+//! Asserting the exact `"sink:hello world"` body therefore proves the one
+//! `token` resource survived both hops across the dynamic linker intact.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 

--- a/crates/wash-runtime/tests/integration_p3_streams.rs
+++ b/crates/wash-runtime/tests/integration_p3_streams.rs
@@ -15,8 +15,15 @@
 //! (`stream-pacer-p3`) proves that the incoming-handler body actually
 //! streams (first byte arrives long before the last) rather than being
 //! buffered to completion before the response is sent.
+//!
+//! `test_p3_cross_component_stream_streams_incrementally`: the cross-component
+//! analog of the pacer test. The producer paces its bytes, and the test times
+//! their arrival at the client to prove the `stream<u8>` stays concurrent as
+//! it crosses the linker (first chunk arrives well before the last) rather
+//! than being buffered at the linker boundary. The pacer test alone can't show
+//! this — it never crosses the linker — and the byte-for-byte test above can't
+//! either, since a buffer-then-forward implementation would satisfy it too.
 
-#![cfg(feature = "wasip3")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
@@ -211,6 +218,129 @@ async fn test_p3_incoming_handler_streams_incrementally() -> Result<()> {
         String::from_utf8(body).context("body not utf8")?,
         expected,
         "streamed body should reassemble to all paced chunks in order"
+    );
+
+    Ok(())
+}
+
+/// Proves a stream that *crosses the dynamic linker* stays concurrent.
+///
+/// `stream-producer-p3` paces its bytes one per tick on a background task and
+/// returns the reader immediately; `stream-consumer-p3` (a *separate*
+/// component, linked in at runtime) drains that reader and forwards each byte
+/// to its HTTP response body. We time arrivals at the client from *before* the
+/// request:
+///   - Concurrent/streamed: the producer's first byte propagates across the
+///     linker and out to the client within ~one tick, while the last lands
+///     ~0.75s later.
+///   - Buffered at the boundary: if the linker collected the producer's
+///     `stream<u8>` to completion before handing it over (or the consumer
+///     buffered it), first ≈ last and the response would only start near the
+///     end.
+///
+/// This is the cross-component counterpart to
+/// `test_p3_incoming_handler_streams_incrementally`, which never crosses the
+/// linker, and a sharper check than `test_p3_cross_component_stream_to_http`,
+/// which only asserts the final bytes and so passes even on a buffered path.
+#[tokio::test]
+async fn test_p3_cross_component_stream_streams_incrementally() -> Result<()> {
+    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+
+    // Same two-component workload as the byte-for-byte test; here we measure
+    // *when* the producer's bytes arrive, not just that they all do.
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "p3-cross-component-stream-paced".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![
+                Component {
+                    name: "stream-consumer".to_string(),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(STREAM_CONSUMER_P3_WASM),
+                    local_resources: LocalResources::default(),
+                    pool_size: 1,
+                    max_invocations: 100,
+                },
+                Component {
+                    name: "stream-producer".to_string(),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(STREAM_PRODUCER_P3_WASM),
+                    local_resources: LocalResources::default(),
+                    pool_size: 1,
+                    max_invocations: 100,
+                },
+            ],
+            host_interfaces: http_only_host_interfaces("p3-stream-paced"),
+            volumes: vec![],
+        },
+    };
+
+    host.workload_start(req)
+        .await
+        .context("paced cross-component stream workload should start")?;
+
+    let start = Instant::now();
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "p3-stream-paced")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+    assert!(
+        response.status().is_success(),
+        "paced cross-component stream handler should return 2xx, got {}",
+        response.status()
+    );
+
+    let mut stream = response.bytes_stream();
+    let mut first_at: Option<Duration> = None;
+    let mut last_at = Duration::ZERO;
+    let mut body = Vec::new();
+    while let Some(chunk) = timeout(Duration::from_secs(10), stream.next())
+        .await
+        .context("body chunk timed out")?
+        .transpose()?
+    {
+        if chunk.is_empty() {
+            continue;
+        }
+        let now = start.elapsed();
+        first_at.get_or_insert(now);
+        last_at = now;
+        body.extend_from_slice(&chunk);
+    }
+
+    let first_at = first_at.context("response body was empty")?;
+
+    // Sanity: the producer really did pace its bytes across the linker (16
+    // bytes at a 50ms tick ≈ 0.75s). Loose bound to stay CI-stable.
+    assert!(
+        last_at >= Duration::from_millis(300),
+        "expected paced output to span >=300ms, last chunk at {last_at:?}"
+    );
+
+    // The concurrency assertion: the producer's bytes reach the client
+    // incrementally through the linker, not all bunched at the end. Under a
+    // buffered path first ≈ last and this fails.
+    assert!(
+        first_at < last_at / 2,
+        "cross-component stream was buffered, not streamed: first chunk at \
+         {first_at:?}, last at {last_at:?} (first should be < last/2)"
+    );
+
+    // And it must still reassemble to the producer's output byte-for-byte.
+    assert_eq!(
+        String::from_utf8(body).context("body not utf8")?,
+        "abcdefghijklmnop",
+        "streamed body should reassemble to the producer's output"
     );
 
     Ok(())

--- a/crates/wash-runtime/tests/integration_p3_streams.rs
+++ b/crates/wash-runtime/tests/integration_p3_streams.rs
@@ -1,0 +1,217 @@
+//! Integration tests for WASIP3 streaming.
+//!
+//! `test_p3_cross_component_stream_to_http`: a P3 HTTP handler
+//! (`stream-consumer-p3`) imports a `produce` function from a second P3
+//! component (`stream-producer-p3`) and forwards the returned `stream<u8>`
+//! to its response body. This exercises:
+//!   - the stream handle crossing the dynamic linker boundary intact
+//!     (`engine::value::lower_with_type` resource-identity passthrough),
+//!   - auto-linking every component in a workload
+//!     (`ResolvedWorkload::component_ids_except`),
+//!   - streaming a P3 response body straight through to hyper
+//!     (`host::http_p3::handle_component_request_p3`).
+//!
+//! `test_p3_incoming_handler_streams_incrementally`: a single paced handler
+//! (`stream-pacer-p3`) proves that the incoming-handler body actually
+//! streams (first byte arrives long before the last) rather than being
+//! buffered to completion before the response is sent.
+
+#![cfg(feature = "wasip3")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    host::HostApi,
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+};
+
+mod common;
+use common::{http_only_host_interfaces, start_host_with_p3};
+
+const STREAM_PRODUCER_P3_WASM: &[u8] = include_bytes!("wasm/stream_producer_p3.wasm");
+const STREAM_CONSUMER_P3_WASM: &[u8] = include_bytes!("wasm/stream_consumer_p3.wasm");
+const STREAM_PACER_P3_WASM: &[u8] = include_bytes!("wasm/stream_pacer_p3.wasm");
+
+#[tokio::test]
+async fn test_p3_cross_component_stream_to_http() -> Result<()> {
+    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+
+    // The consumer exports wasi:http/handler and is the workload's incoming
+    // entrypoint; the producer is linked in and supplies the byte stream.
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "p3-cross-component-stream".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![
+                Component {
+                    name: "stream-consumer".to_string(),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(STREAM_CONSUMER_P3_WASM),
+                    local_resources: LocalResources::default(),
+                    pool_size: 1,
+                    max_invocations: 100,
+                },
+                Component {
+                    name: "stream-producer".to_string(),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(STREAM_PRODUCER_P3_WASM),
+                    local_resources: LocalResources::default(),
+                    pool_size: 1,
+                    max_invocations: 100,
+                },
+            ],
+            host_interfaces: http_only_host_interfaces("p3-stream"),
+            volumes: vec![],
+        },
+    };
+
+    host.workload_start(req)
+        .await
+        .context("cross-component stream workload should start")?;
+
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "p3-stream")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+
+    assert!(
+        response.status().is_success(),
+        "cross-component stream handler should return 2xx, got {}",
+        response.status()
+    );
+
+    // Producer emits `n = 16` bytes 'a'..'p'; the consumer forwards them
+    // verbatim, so the streamed-through body must reassemble exactly.
+    let body = response.text().await?;
+    assert_eq!(
+        body, "abcdefghijklmnop",
+        "streamed body should match the producer's output byte-for-byte"
+    );
+
+    Ok(())
+}
+
+/// Proves the P3 incoming-handler path streams the response body through to
+/// hyper rather than buffering it.
+///
+/// `stream-pacer-p3` emits 10 chunks 100ms apart. We time arrivals from
+/// *before* the request is sent:
+///   - Streaming: the response headers come back immediately, so the first
+///     chunk lands within ~one tick while the last lands ~0.9s later.
+///   - Buffering (the old `body.collect().await` path): the handler can't
+///     return a response until the whole body is produced, so the first and
+///     last chunks arrive together near the ~0.9s mark.
+///
+/// Asserting `first < last / 2` fails on the buffered path and passes on the
+/// streaming path. Margins are deliberately loose to stay CI-stable.
+#[tokio::test]
+async fn test_p3_incoming_handler_streams_incrementally() -> Result<()> {
+    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "p3-stream-pacer".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "stream-pacer".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(STREAM_PACER_P3_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces: http_only_host_interfaces("p3-pacer"),
+            volumes: vec![],
+        },
+    };
+
+    host.workload_start(req)
+        .await
+        .context("pacer workload should start")?;
+
+    // Time from before the request: under buffering the response itself is
+    // withheld until the body is complete, so `send()` blocks for the full
+    // ~0.9s and the first chunk can't arrive early.
+    let start = Instant::now();
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "p3-pacer")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+    assert!(
+        response.status().is_success(),
+        "pacer handler should return 2xx, got {}",
+        response.status()
+    );
+
+    let mut stream = response.bytes_stream();
+    let mut first_at: Option<Duration> = None;
+    let mut last_at = Duration::ZERO;
+    let mut body = Vec::new();
+    while let Some(chunk) = timeout(Duration::from_secs(10), stream.next())
+        .await
+        .context("body chunk timed out")?
+        .transpose()?
+    {
+        if chunk.is_empty() {
+            continue;
+        }
+        let now = start.elapsed();
+        first_at.get_or_insert(now);
+        last_at = now;
+        body.extend_from_slice(&chunk);
+    }
+
+    let first_at = first_at.context("response body was empty")?;
+
+    // Sanity: the producer really did pace its output over time. Both the
+    // streaming and buffering paths satisfy this (the producer takes ~0.9s
+    // either way); it just guards against a degenerate instant body.
+    assert!(
+        last_at >= Duration::from_millis(400),
+        "expected paced output to span >=400ms, last chunk at {last_at:?}"
+    );
+
+    // The streaming assertion: the first chunk must arrive well before the
+    // last. Under the old buffered path first ≈ last and this fails.
+    assert!(
+        first_at < last_at / 2,
+        "response body was buffered, not streamed: first chunk at {first_at:?}, \
+         last at {last_at:?} (first should be < last/2)"
+    );
+
+    let expected: String = (0..10).map(|i| format!("chunk-{i}\n")).collect();
+    assert_eq!(
+        String::from_utf8(body).context("body not utf8")?,
+        expected,
+        "streamed body should reassemble to all paced chunks in order"
+    );
+
+    Ok(())
+}

--- a/crates/wash/src/lib.rs
+++ b/crates/wash/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../../../README.md")]
+#![recursion_limit = "512"]
 
 /// The current version of the wash package, set at build time
 pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -103,6 +103,12 @@ const P3_FIXTURES: &[&str] = &[
     "tls-echo-client-p3",
     "inter-component-call-p3-caller",
     "inter-component-call-p3-callee",
+    "stream-producer-p3",
+    "stream-consumer-p3",
+    "stream-pacer-p3",
+    "res-producer-p3",
+    "res-sink-p3",
+    "res-caller-p3",
 ];
 
 // Fixtures with local-only WIT worlds (no wasi imports). Copying shared

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -109,6 +109,8 @@ const P3_FIXTURES: &[&str] = &[
     "res-producer-p3",
     "res-sink-p3",
     "res-caller-p3",
+    "ephemeral-callee-p3",
+    "ephemeral-caller-p3",
 ];
 
 // Fixtures with local-only WIT worlds (no wasi imports). Copying shared


### PR DESCRIPTION
## Summary

wash supports **dynamic linking**: a component can import an interface that's satisfied at runtime by another component (a "peer"/linked export) rather than by the host. That worked for plain synchronous wasip2 calls, but fell apart the moment wasip3's async component-model types entered the picture. This PR makes wasip3 `stream<T>`, `future<T>`, `error-context`, and resource handles flow correctly across the dynamic linker — including calling resource methods on a resource owned by another component — and reworks instance lifetime so the pooling allocator doesn't run out of slots under concurrent load.

## Background

Under wasip3 the component model gains first-class async: async functions, plus the `stream<T>`, `future<T>`, and `error-context` types. These aren't plain values — at the canonical-ABI level they're **handles** into a specific store's resource tables, the same way `own<T>` / `borrow<T>` resource handles are.

wash's existing cross-component bridge lowered call params, invoked the peer's export, and lifted the results using wasmtime's *synchronous* typed-func path. Against a wasip3 component that path has two problems:

1. It bails with **"async not supported"** as soon as a linked import or export references `stream` / `future` / `error-context`, or is an async function.
2. It tries to *copy* values across the call boundary. You can copy a plain value, but you can't copy a handle — copying a `stream` / `future` / resource handle out of its store's table produces a dangling reference. The same underlying object has to be referenced **by identity** on both sides.

So linked calls involving any of those types either errored outright or were unsound.

## What this changes

### 1. Concurrent canonical-ABI bridge

Switch the cross-component bridge to wasmtime's concurrent APIs — `func_new_concurrent` to register the host-side shim, `call_concurrent` / `run_concurrent` to drive the peer, and `Accessor` / `accessor.with(...)` for scoped store access inside the concurrent closure. This is the path that supports async exports and the async value types, so linked calls that touch `stream` / `future` / `error-context` — or that are simply async functions — now run instead of being rejected with "async not supported."

### 2. Identity-passing of `stream` / `future` / `error-context`

At the canonical-ABI level a `stream` / `future` / `error-context` isn't a value you can copy — it's a handle into a specific store's tables. In lift/lower we special-case those `Val` variants so the handle is passed through **by identity** rather than re-created. A `stream<T>` produced inside peer B and returned to caller A keeps referring to the same underlying stream, so data written on one side is observed on the other. Plain values continue to be lifted/lowered normally.

### 3. Cross-component resource handles and method calls

Resource handles now cross the dynamic linker, and methods can be called on a resource from a component other than the one that implements it.

When component A receives a `resource` produced by component B, the handle is carried across the linker **by identity** as a host `ResourceAny` (via `lower_with_type`) rather than copied. Calling a method on that handle from A then dispatches **back through the linker into B**, where the resource's implementation actually lives — so resource methods work transparently across the component boundary.

### 4. Per-store exporter-instance cache

To call peer B's export you need a live `Instance` of B in the store. The natural move — `pre.instantiate_async(&mut store)` — doesn't work here:

- The concurrent bridge hands us a **synchronous** `accessor.with(|access| ...)` closure. You can't `.await` inside it, so you can't instantiate there.
- By the time the p2/p3 HTTP handler has dispatched into the component, the store is already in **async-required** mode, so a synchronous instantiate is out too.

The fix is to **pre-instantiate** each linked exporter into the store *before* dispatch and cache the resulting `Instance` keyed by `(component_id, store_id)`. Inside the sync concurrent closure we just look the instance up. The cache is cleared on store teardown. (The shared-store path is intentionally **error-on-miss** — see design notes.)

### 5. Ephemeral stores for plain-value async linked calls

The cache above keeps each linked instance alive for as long as its store lives — and a request store lives for the whole response. With the pooling allocator every instance holds a fixed core-instance slot, so under concurrent P3 load long-lived request stores pin slots and you exhaust capacity.

For the common case where a linked call's signature is **entirely plain values** — no `own` / `borrow` / `stream` / `future` / `error-context` anywhere in params or results — the callee doesn't need to share the request store's tables at all. So we run it in a **short-lived store** that is created, instantiated, called, and dropped within that single call, reclaiming its pooling slots immediately instead of at end-of-response.

The decision is made per call via `func_is_ephemeral_safe` / `type_is_ephemeral_safe`. Any signature carrying a handle stays on the shared request store, because those handles are bound to that store and can't be moved to a throwaway one.

## Test coverage

Each capability is exercised end-to-end through fixture components linked at runtime:

- **`integration_p3_streams`** — three cases: `test_p3_cross_component_stream_to_http` sends a `stream<u8>` from one peer through another to the HTTP response and checks it reassembles byte-for-byte; `test_p3_cross_component_stream_streams_incrementally` paces the producer and times arrivals at the client, proving the stream stays *concurrent across the linker* (first chunk `< last/2`) rather than being buffered at the boundary — the byte-for-byte test above passes even on a buffered path, so this is the one that actually pins down the concurrency; `test_p3_incoming_handler_streams_incrementally` runs the same timing check on a single self-contained handler.
- **`integration_p3_resources`** — the `res-producer-p3` / `res-caller-p3` / `res-sink-p3` trio: the producer mints a `token` and implements `token.greet()`; the caller hands that token to the sink; the sink calls `token.greet()`, which routes **back to the producer**; the test asserts the round-trip body `"sink:hello world"`. If the handle were copied instead of passed by identity, `greet()` would read the wrong resource or fail.
- **`integration_p3_ephemeral`** — *new.* The stream and resource fixtures all carry handles, so they only ever take the shared-store path and would never touch the ephemeral path. This adds an `ephemeral-callee-p3` / `ephemeral-caller-p3` pair with a plain-value async signature and asserts the call goes through, giving the ephemeral path real regression coverage.

## Design notes & limitations

- **Error-on-miss, not lazy-instantiate.** The shared-store path errors if a linked exporter is missing from the cache rather than instantiating on demand, because the wasmtime fork in use doesn't expose an accessor-side instantiate, and pre-instantiation already covers every legitimate call site. This keeps a missing-instance situation loud instead of silently slow.
- **Ephemeral is plain-value-only by construction.** It is never selected for handle-bearing signatures, so it can't accidentally orphan a resource / stream / future. When in doubt, it falls back to the shared store.
- **Pooling-allocator interaction.** The whole instance-lifetime story (cache + ephemeral stores) exists specifically because of the pooling allocator's fixed per-instance slots; with the on-demand allocator the slot pressure this addresses wouldn't arise, but pooling is what production hosts run.

## Upstream dependencies

- **Wasmtime 46**, via the `release-46.0.0-implements` fork patch — the concurrent canonical-ABI APIs this PR relies on come from there.
- Builds on upstream making **wasip3 the default**: the old `wasip3` Cargo feature is gone, and the P3 WIT deps are pinned to `wasi:*@0.3.0`.

## Test plan

- [ ] `cargo build -p wash` from the repo root succeeds (wasip3 is on by default now).
- [ ] `cargo test -p wash-runtime` passes — in particular:
  - [ ] `integration_p3_streams::test_p3_cross_component_stream_to_http` (cross-component `stream<u8>` → HTTP body == `"abcdefghijklmnop"`).
  - [ ] `integration_p3_streams::test_p3_cross_component_stream_streams_incrementally` (paced producer; first chunk < last/2 → stream stays concurrent across the linker).
  - [ ] `integration_p3_streams::test_p3_incoming_handler_streams_incrementally` (first chunk < last/2 → streamed, not buffered).
  - [ ] `integration_p3_resources::test_p3_resource_handle_crosses_linker` (resource handle + cross-component `greet()` → `"sink:hello world"`).
  - [ ] `integration_p3_ephemeral` (plain-value async linked call takes the ephemeral path).
- [ ] No regression in `cargo test -p wash`.
