### PR TITLE
test(runtime-operator): add fuzz tests

### DIFF
--- a/runtime-operator/api/condition/condition_fuzz_test.go
+++ b/runtime-operator/api/condition/condition_fuzz_test.go
@@ -1,0 +1,180 @@
+package condition
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// FuzzSetConditions verifies SetConditions never panics and upholds two
+// invariants under arbitrary inputs:
+//  1. GetCondition always returns the type that was set.
+//  2. Calling SetConditions twice with the same Type never grows the slice
+//     beyond one entry for that type (dedup).
+func FuzzSetConditions(f *testing.F) {
+	f.Add("Ready", "True", "Available", "all good", "False")
+	f.Add("", "", "", "", "")
+	f.Add("Sync", "False", "ReconcileError", "something went wrong", "True")
+	f.Add("HostSelection", "Unknown", "", "", "True")
+	f.Add("很长的类型名", "True", "Reason", "message with unicode 🎉", "Unknown")
+
+	f.Fuzz(func(t *testing.T, condType, status1, reason, message, status2 string) {
+		s := &ConditionedStatus{}
+
+		s.SetConditions(Condition{
+			Type:    ConditionType(condType),
+			Status:  corev1.ConditionStatus(status1),
+			Reason:  ConditionReason(reason),
+			Message: message,
+		})
+
+		// Invariant 1: GetCondition returns the type we set.
+		got := s.GetCondition(ConditionType(condType))
+		if got.Type != ConditionType(condType) {
+			t.Errorf("GetCondition returned type %q, want %q", got.Type, condType)
+		}
+		if len(s.Conditions) != 1 {
+			t.Errorf("expected 1 condition after first SetConditions, got %d", len(s.Conditions))
+		}
+
+		// Invariant 2: a second call with the same type must not grow the slice.
+		s.SetConditions(Condition{
+			Type:   ConditionType(condType),
+			Status: corev1.ConditionStatus(status2),
+		})
+		count := 0
+		for _, c := range s.Conditions {
+			if c.Type == ConditionType(condType) {
+				count++
+			}
+		}
+		if count > 1 {
+			t.Errorf("found %d entries for type %q after second SetConditions, want at most 1", count, condType)
+		}
+	})
+}
+
+// FuzzAllTrue verifies AllTrue and ErrAllTrue never panic and stay consistent
+// with each other across arbitrary condition types, statuses, and
+// ObservedGenerations.
+//
+// The generation seeds specifically exercise the mismatch branch in ErrAllTrue:
+// two True conditions with different non-zero ObservedGenerations must not be
+// considered all-true, even though both statuses are True.
+func FuzzAllTrue(f *testing.F) {
+	f.Add("Ready", "True", int64(0), "Sync", "True", int64(0))
+	f.Add("Ready", "False", int64(0), "Sync", "Unknown", int64(0))
+	f.Add("", "", int64(0), "", "", int64(0))
+	// Matching non-zero generations — should be AllTrue.
+	f.Add("Ready", "True", int64(5), "Sync", "True", int64(5))
+	// Mismatched non-zero generations — ErrAllTrue must return an error even
+	// though both statuses are True.
+	f.Add("Ready", "True", int64(1), "Sync", "True", int64(2))
+	// One condition tracks generation, the other does not (0 means untracked).
+	f.Add("Ready", "True", int64(3), "Sync", "True", int64(0))
+
+	f.Fuzz(func(t *testing.T, ct1, st1 string, gen1 int64, ct2, st2 string, gen2 int64) {
+		s := &ConditionedStatus{}
+		s.SetConditions(
+			Condition{
+				Type:               ConditionType(ct1),
+				Status:             corev1.ConditionStatus(st1),
+				ObservedGeneration: gen1,
+			},
+			Condition{
+				Type:               ConditionType(ct2),
+				Status:             corev1.ConditionStatus(st2),
+				ObservedGeneration: gen2,
+			},
+		)
+
+		all := s.AllTrue(ConditionType(ct1), ConditionType(ct2))
+		err := s.ErrAllTrue(ConditionType(ct1), ConditionType(ct2))
+
+		// AllTrue and ErrAllTrue must agree.
+		if all && err != nil {
+			t.Errorf("AllTrue=true but ErrAllTrue=%v", err)
+		}
+		if !all && err == nil {
+			t.Error("AllTrue=false but ErrAllTrue=nil")
+		}
+
+		// Two True conditions with distinct non-zero generations must not pass.
+		if ct1 != ct2 &&
+			corev1.ConditionStatus(st1) == ConditionTrue && gen1 > 0 &&
+			corev1.ConditionStatus(st2) == ConditionTrue && gen2 > 0 &&
+			gen1 != gen2 {
+			if all {
+				t.Errorf("AllTrue=true for mismatched generations %d vs %d", gen1, gen2)
+			}
+		}
+	})
+}
+
+// FuzzAnyUnknown verifies AnyUnknown never panics and is consistent with
+// GetCondition: if AnyUnknown returns true, at least one of the queried
+// conditions must have Unknown status.
+func FuzzAnyUnknown(f *testing.F) {
+	f.Add("Ready", "Unknown", "Sync", "True")
+	f.Add("", "", "", "")
+	f.Add("X", "False", "Y", "Unknown")
+
+	f.Fuzz(func(t *testing.T, ct1, st1, ct2, st2 string) {
+		s := &ConditionedStatus{}
+		s.SetConditions(
+			Condition{Type: ConditionType(ct1), Status: corev1.ConditionStatus(st1)},
+			Condition{Type: ConditionType(ct2), Status: corev1.ConditionStatus(st2)},
+		)
+
+		if s.AnyUnknown(ConditionType(ct1), ConditionType(ct2)) {
+			c1 := s.GetCondition(ConditionType(ct1))
+			c2 := s.GetCondition(ConditionType(ct2))
+			if c1.Status != ConditionUnknown && c2.Status != ConditionUnknown {
+				t.Error("AnyUnknown=true but neither condition has Unknown status")
+			}
+		}
+	})
+}
+
+// FuzzConditionedStatusEqual verifies Equal is reflexive, symmetric, and
+// correctly distinguishes statuses built from different inputs.
+func FuzzConditionedStatusEqual(f *testing.F) {
+	// Identical inputs → Equal must be true.
+	f.Add("Ready", "True", "reason", "msg", "Ready", "True", "reason", "msg")
+	f.Add("", "", "", "", "", "", "", "")
+	// Differing status → Equal must be false.
+	f.Add("Ready", "True", "reason", "msg", "Ready", "False", "reason", "msg")
+	// Differing type → Equal must be false.
+	f.Add("Ready", "True", "reason", "msg", "Sync", "True", "reason", "msg")
+
+	f.Fuzz(func(t *testing.T, ct1, st1, reason1, msg1, ct2, st2, reason2, msg2 string) {
+		c1 := Condition{
+			Type:    ConditionType(ct1),
+			Status:  corev1.ConditionStatus(st1),
+			Reason:  ConditionReason(reason1),
+			Message: msg1,
+		}
+		c2 := Condition{
+			Type:    ConditionType(ct2),
+			Status:  corev1.ConditionStatus(st2),
+			Reason:  ConditionReason(reason2),
+			Message: msg2,
+		}
+
+		s1 := NewConditionedStatus(c1)
+		s2 := NewConditionedStatus(c2)
+
+		if !s1.Equal(s1) {
+			t.Error("Equal is not reflexive")
+		}
+		if s1.Equal(s2) != s2.Equal(s1) {
+			t.Error("Equal is not symmetric")
+		}
+		if c1.Equal(c2) && !s1.Equal(s2) {
+			t.Error("conditions are Equal but ConditionedStatus.Equal returned false")
+		}
+		if ct1 != ct2 && s1.Equal(s2) {
+			t.Errorf("statuses with different condition types %q vs %q reported Equal", ct1, ct2)
+		}
+	})
+}

--- a/runtime-operator/api/runtime/v1alpha1/workload_fuzz_test.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_fuzz_test.go
@@ -1,0 +1,99 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// FuzzEnsureHostInterface verifies EnsureHostInterface never panics and
+// maintains two invariants under arbitrary inputs:
+//
+//  1. Same (namespace, package, name) key → interfaces are merged, count stays
+//     1, and config entries from both calls are present.
+//  2. Different key → a new entry is appended, count grows to 2.
+func FuzzEnsureHostInterface(f *testing.F) {
+	// Interface merge — same key.
+	f.Add("wasi", "keyvalue", "cache", "store", "ck", "cv", "wasi", "keyvalue", "cache", "atomics")
+	// Unnamed backwards-compatible merge.
+	f.Add("wasi", "http", "", "incoming-handler", "", "", "wasi", "http", "", "outgoing-handler")
+	// Different name — must stay separate.
+	f.Add("wasi", "keyvalue", "a", "store", "k", "v", "wasi", "keyvalue", "b", "store")
+	// Entirely different namespace+package.
+	f.Add("ns1", "pkg1", "n1", "iface1", "", "", "ns2", "pkg2", "n2", "iface2")
+	// All empty.
+	f.Add("", "", "", "", "", "", "", "", "", "")
+
+	f.Fuzz(func(t *testing.T,
+		ns1, pkg1, name1, iface1, configKey, configVal string,
+		ns2, pkg2, name2, iface2 string,
+	) {
+		spec := &WorkloadSpec{}
+
+		spec.EnsureHostInterface(HostInterface{
+			Namespace:  ns1,
+			Package:    pkg1,
+			Name:       name1,
+			Interfaces: []string{iface1},
+			ConfigLayer: ConfigLayer{
+				Config: map[string]string{configKey: configVal},
+			},
+		})
+		spec.EnsureHostInterface(HostInterface{
+			Namespace:  ns2,
+			Package:    pkg2,
+			Name:       name2,
+			Interfaces: []string{iface2},
+		})
+
+		sameKey := ns1 == ns2 && pkg1 == pkg2 && name1 == name2
+		if sameKey {
+			if len(spec.HostInterfaces) != 1 {
+				t.Errorf("same key: expected 1 HostInterface, got %d", len(spec.HostInterfaces))
+			}
+			merged := spec.HostInterfaces[0]
+			if !merged.HasInterface(iface1) {
+				t.Errorf("merged interface missing %q", iface1)
+			}
+			if !merged.HasInterface(iface2) {
+				t.Errorf("merged interface missing %q", iface2)
+			}
+			if merged.Config == nil {
+				t.Fatal("Config is nil after merge")
+			}
+			if _, ok := merged.Config[configKey]; !ok {
+				t.Errorf("config missing key %q after merge", configKey)
+			}
+		} else {
+			if len(spec.HostInterfaces) != 2 {
+				t.Errorf("different key: expected 2 HostInterfaces, got %d", len(spec.HostInterfaces))
+			}
+		}
+	})
+}
+
+// FuzzWorkloadSpecJSON verifies that unmarshaling arbitrary bytes into
+// WorkloadSpec never panics, and that any successfully-decoded spec can be
+// hashed without panic and produces a non-empty result.
+//
+// This is the primary fuzzing surface for the operator's core data type:
+// the API server can deliver unusual-but-valid JSON that no human would write
+// as a test case.
+func FuzzWorkloadSpecJSON(f *testing.F) {
+	f.Add([]byte(`{"environment":"dev","components":[{"name":"c","image":"nginx"}]}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`{"hostInterfaces":[{"namespace":"wasi","package":"http","interfaces":["incoming-handler"]}]}`))
+	f.Add([]byte(`{"volumes":[{"name":"tmp","ephemeral":{}}]}`))
+
+	f.Fuzz(func(t *testing.T, specJSON []byte) {
+		spec := &WorkloadSpec{}
+		if err := json.Unmarshal(specJSON, spec); err != nil {
+			return // malformed JSON is expected and fine
+		}
+
+		tmpl := WorkloadReplicaTemplate{Spec: *spec}
+		if h := tmpl.Hash(); h == "" {
+			t.Error("Hash returned empty string for valid spec")
+		}
+	})
+}

--- a/runtime-operator/internal/controller/runtime/utils_fuzz_test.go
+++ b/runtime-operator/internal/controller/runtime/utils_fuzz_test.go
@@ -1,0 +1,93 @@
+package runtime
+
+import (
+	"testing"
+
+	runtimev2 "go.wasmcloud.dev/runtime-operator/v2/pkg/rpc/wasmcloud/runtime/v2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// FuzzMergeMaps verifies MergeMaps never panics, never returns nil, and
+// preserves last-writer-wins semantics. Nil and empty maps in the variadic
+// argument are also verified to be safe on every call.
+func FuzzMergeMaps(f *testing.F) {
+	f.Add("host", "localhost", "port", "8080")
+	f.Add("", "", "", "")
+	f.Add("key", "first", "key", "second")
+	f.Add("a", "1", "b", "2")
+
+	f.Fuzz(func(t *testing.T, k1, v1, k2, v2 string) {
+		// Nil and empty inputs must never panic or return nil.
+		if r := MergeMaps(); r == nil {
+			t.Error("MergeMaps() returned nil")
+		}
+		if r := MergeMaps(nil, map[string]string{k1: v1}); r == nil {
+			t.Error("MergeMaps(nil, m) returned nil")
+		}
+
+		m1 := map[string]string{k1: v1}
+		m2 := map[string]string{k2: v2}
+		result := MergeMaps(m1, m2)
+
+		if result == nil {
+			t.Fatal("MergeMaps returned nil")
+		}
+		// m2 is last — its value must win on collision.
+		if got := result[k2]; got != v2 {
+			t.Errorf("result[%q]=%q, want %q (last-writer-wins)", k2, got, v2)
+		}
+		// k1 survives if not overwritten.
+		if k1 != k2 {
+			if got := result[k1]; got != v1 {
+				t.Errorf("result[%q]=%q, want %q", k1, got, v1)
+			}
+		}
+	})
+}
+
+// FuzzTranslatePullPolicy verifies translatePullPolicy never panics and that
+// the three canonical Kubernetes pull policies never map to UNSPECIFIED.
+func FuzzTranslatePullPolicy(f *testing.F) {
+	f.Add(string(corev1.PullAlways))
+	f.Add(string(corev1.PullIfNotPresent))
+	f.Add(string(corev1.PullNever))
+	f.Add("")
+	f.Add("UnknownPolicy")
+	f.Add("always") // wrong case
+
+	f.Fuzz(func(t *testing.T, policy string) {
+		result := translatePullPolicy(corev1.PullPolicy(policy))
+		switch corev1.PullPolicy(policy) {
+		case corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever:
+			if result == runtimev2.ImagePullPolicy_IMAGE_PULL_POLICY_UNSPECIFIED {
+				t.Errorf("translatePullPolicy(%q) returned UNSPECIFIED for a known policy", policy)
+			}
+		}
+	})
+}
+
+// FuzzGetAuthConfigKey verifies getAuthConfigKey never panics and applies the
+// docker.io normalization rule correctly for all inputs.
+func FuzzGetAuthConfigKey(f *testing.F) {
+	f.Add("docker.io")
+	f.Add("index.docker.io")
+	f.Add("ghcr.io")
+	f.Add("")
+	f.Add("my.private.registry.example.com")
+	f.Add("localhost:5000")
+
+	f.Fuzz(func(t *testing.T, domain string) {
+		result := getAuthConfigKey(domain)
+		switch domain {
+		case "docker.io", "index.docker.io":
+			const want = "https://index.docker.io/v1/"
+			if result != want {
+				t.Errorf("getAuthConfigKey(%q)=%q, want %q", domain, result, want)
+			}
+		default:
+			if result != domain {
+				t.Errorf("getAuthConfigKey(%q)=%q, want domain unchanged", domain, result)
+			}
+		}
+	})
+}

--- a/runtime-operator/pkg/crdtools/crdtools_fuzz_test.go
+++ b/runtime-operator/pkg/crdtools/crdtools_fuzz_test.go
@@ -1,0 +1,89 @@
+package crdtools
+
+import (
+	"sort"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// FuzzMergeLabels verifies MergeLabels never panics, never returns nil, and
+// upholds last-writer-wins semantics for two- and three-map merges.
+func FuzzMergeLabels(f *testing.F) {
+	f.Add("app", "myapp", "env", "prod", "tier", "backend")
+	f.Add("", "", "", "", "", "")
+	f.Add("a/b", "val1", "a/b", "val2", "a/b", "val3")
+	f.Add("k8s.io/arch", "amd64", "k8s.io/os", "linux", "k8s.io/arch", "arm64")
+
+	f.Fuzz(func(t *testing.T, k1, v1, k2, v2, k3, v3 string) {
+		m1 := map[string]string{k1: v1}
+		m2 := map[string]string{k2: v2}
+		m3 := map[string]string{k3: v3}
+
+		two := MergeLabels(m1, m2)
+		three := MergeLabels(m1, m2, m3)
+
+		if two == nil || three == nil {
+			t.Fatal("MergeLabels returned nil")
+		}
+
+		// Last map wins for two-way merge.
+		if got := two[k2]; got != v2 {
+			t.Errorf("two[%q]=%q, want %q (last-writer-wins)", k2, got, v2)
+		}
+		// k1 survives if not overwritten.
+		if k1 != k2 {
+			if got := two[k1]; got != v1 {
+				t.Errorf("two[%q]=%q, want %q", k1, got, v1)
+			}
+		}
+
+		// Last map wins for three-way merge.
+		if got := three[k3]; got != v3 {
+			t.Errorf("three[%q]=%q, want %q (last-writer-wins)", k3, got, v3)
+		}
+	})
+}
+
+// FuzzMergeEnvVar verifies MergeEnvVar never panics, deduplicates by name
+// (last writer wins), and always returns a sorted result.
+func FuzzMergeEnvVar(f *testing.F) {
+	f.Add("HOME", "/root", "HOME", "/home/user")
+	f.Add("", "", "", "")
+	f.Add("A", "1", "B", "2")
+	f.Add("PATH", "/usr/bin", "GOPATH", "/go")
+
+	f.Fuzz(func(t *testing.T, name1, val1, name2, val2 string) {
+		slice1 := []corev1.EnvVar{{Name: name1, Value: val1}}
+		slice2 := []corev1.EnvVar{{Name: name2, Value: val2}}
+
+		result := MergeEnvVar(slice1, slice2)
+
+		// Names must be unique.
+		seen := make(map[string]int)
+		for _, ev := range result {
+			seen[ev.Name]++
+			if seen[ev.Name] > 1 {
+				t.Errorf("duplicate name %q in result", ev.Name)
+			}
+		}
+
+		// Result must be sorted by name.
+		names := make([]string, len(result))
+		for i, ev := range result {
+			names[i] = ev.Name
+		}
+		if !sort.StringsAreSorted(names) {
+			t.Errorf("result is not sorted: %v", names)
+		}
+
+		// Last writer wins on collision.
+		if name1 == name2 {
+			for _, ev := range result {
+				if ev.Name == name2 && ev.Value != val2 {
+					t.Errorf("last-writer-wins violated: got %q, want %q", ev.Value, val2)
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
Adds fuzz tests across four packages covering the operator's core.

- api/condition: SetConditions never panics
- api/runtime/v1alpha1: EnsureHostInterface merge-or-append and config
  merge invariants, WorkloadSpec JSON unmarshal has Hash safety
- pkg/crdtools: MergeLabels last-writer-wins (two- and three-map),
  MergeEnvVar dedup and sort invariants
- internal/controller/runtime: MergeMaps nil/empty safety and
  last-writer-wins, translatePullPolicy canonical mapping,
  getAuthConfigKey docker.io normalization

Seed corpus runs as part of `make test` with no flags. Run individual
targets with -fuzz and -fuzztime for sustained fuzzing.

I ran these locally for an hour. Once we're happy with them, go fuzz tests are already compatible with OSSFuzz.

If you want to do your own run:

```bash
cd runtime-operator

go test ./api/condition/...              -fuzz='^FuzzSetConditions$'        -fuzztime=32m &
go test ./api/condition/...              -fuzz='^FuzzAllTrue$'               -fuzztime=32m &
go test ./api/condition/...              -fuzz='^FuzzAnyUnknown$'            -fuzztime=32m &
go test ./api/condition/...              -fuzz='^FuzzConditionedStatusEqual$' -fuzztime=32m &
go test ./api/runtime/v1alpha1/...       -fuzz='^FuzzEnsureHostInterface$'   -fuzztime=32m &
go test ./api/runtime/v1alpha1/...       -fuzz='^FuzzWorkloadSpecJSON$'      -fuzztime=32m &
go test ./pkg/crdtools/...               -fuzz='^FuzzMergeLabels$'           -fuzztime=32m &
go test ./pkg/crdtools/...               -fuzz='^FuzzMergeEnvVar$'           -fuzztime=32m &
go test ./internal/controller/runtime/... -fuzz='^FuzzMergeMaps$'            -fuzztime=32m &
go test ./internal/controller/runtime/... -fuzz='^FuzzTranslatePullPolicy$'  -fuzztime=32m &
go test ./internal/controller/runtime/... -fuzz='^FuzzGetAuthConfigKey$'     -fuzztime=32m &

wait && echo "done"
```

Basically this suite focuses fuzzing on spec/status JSON parsing where it's possible to receive malformed payloads. A couple projects I referenced: 
- [github.com/istio/istio](https://github.com/istio/istio) which has 60+ fuzzers across control and data plane; has a pkg/fuzz helper library for constructing random Kubernetes objects. This caught CVE-2022-23635 (unauthenticated DoS to control plane via malformed requests) 
- Cluster API: kubebuilder origin, OSS-Fuzz integrated
- [github.com/cert-manager/cert-manager](https://github.com/cert-manager/cert-manager) has a nice guide [cert-manager.io/docs/contributing/oss-fuzz](https://cert-manager.io/docs/contributing/oss-fuzz/)