### PR TITLE
ci: resolve windows timeouts and canary publish

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -65,6 +65,24 @@ runs:
           --no-self-update
 
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        # Only save the cache on main pushes; PR runs restore but never save.
+        # Tar+zstd of `target/` over the GHA cache API runs a very long time on
+        # Windows runners and was timing out the `check (windows-latest)` job.
+        # Main builds keep refreshing the cache PRs read from, so PR runs
+        # don't need to save anything themselves.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+        # Drop `target/` from the cache on Windows. Git's tar.exe + zstd
+        # over the GHA cache API is the slow path, and target/ is the bulk
+        # of what gets tarred. Windows builds will recompile deps from the
+        # cached registry source instead of restoring artifacts, which still
+        # finishes well inside the job timeout. Linux/macOS keep target/
+        # caching because their tar throughput handles it fine.
+        cache-targets: ${{ runner.os != 'Windows' }}
+        # Don't cache .cargo/bin.. rustup re-installs the toolchain on every
+        # run regardless (it's idempotent and fast), and taiki-e/install-action
+        # callers handle their own binary caching. Nothing else lands here.
+        cache-bin: false
 
     - name: Install Zig for zigbuild
       if: ${{ inputs.install-zigbuild == 'true' }}

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -55,7 +55,7 @@ jobs:
       - changes
     if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -274,6 +274,13 @@ jobs:
   runtime-operator-e2e:
     needs:
       - wash-image
+    # `wash-image` runs via `if: always() && ...` to bypass the skipped
+    # `changes` job on main pushes. Without an explicit `if:` here, GHA
+    # propagates the skipped state of that indirect upstream through and
+    # marks this job skipped even though `wash-image` itself succeeded.
+    # Result: canary-publish never fires on main. Explicit gate on
+    # wash-image's actual result is the documented workaround.
+    if: always() && needs.wash-image.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -353,10 +360,21 @@ jobs:
   # `canary` itself moves on every subsequent main push, so we cannot
   # rely on it.
   canary-publish:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Gate canary on the things that actually exercise the published bytes:
+    # `wash-image` is what gets pushed by digest, and `runtime-operator-e2e`
+    # loads that exact image into kind and runs the suite. `check`/`lint`
+    # are workspace-level signals that have no bearing on the image we're
+    # promoting, so they intentionally aren't gates here. `always()` is
+    # required to break the chained-skip propagation from the path-filter
+    # `changes` job (skipped on main) which would otherwise mark this job
+    # skipped before evaluating the explicit gate.
+    if: |
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.wash-image.result == 'success' &&
+      needs.runtime-operator-e2e.result == 'success'
     needs:
-      - check
-      - lint
       - runtime-operator-e2e
       - wash-image
     runs-on: ubuntu-latest


### PR DESCRIPTION
Observed twice today that the Post Setup Rust cache-save step
timed out the `check (windows-latest)` job: where
tar+zstd of `target/` over the GHA cache runs for a long time.
Three changes to `.github/actions/setup-rust/action.yml`:

- `save-if: main` so PR runs only restore, never save
- `cache-targets: false` on Windows only so the multi-GB `target/`
  tree from the tar; `~/.cargo/registry` still gets cached so deps
  don't redownload
- `cache-bin: false` everywhere since rustup repopulates
  `.cargo/bin` on every run anyway

Also bump `check` job timeout 45 → 60min to give ourselves more headroom.

Additionally fixes needed for CI and release automation: 
`runtime-operator-e2e` and `canary-publish` have been silently
skipped on every main push since 8d0f62acd because the path-filter
`changes` job is skipped on main, and GHA propagates that skipped
state through dependents that don't override with `if: always()` —
even when their direct `needs` succeeded. Result: the `canary` tag
hasn't actually moved in two weeks.

- runtime-operator-e2e: add `if: always() && needs.wash-image.result
  == 'success'` so the kind suite runs whenever the image built.
- canary-publish: drop `check`/`lint` from both `needs` and `if` —
  workspace-level signals don't exercise the bytes we're publishing,
  only wash-image (what gets pushed) and runtime-operator-e2e (what
  loads that exact tarball into kind) do. Wrap with `always() &&`
  for the same skip-propagation reason.
