### PR TITLE
close skip propagation gaps

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,10 +28,12 @@ name: release-tag
 # (e.g. DCO bounces and a human finishes the merge manually), the train
 # run's conclusion is `failure` and this workflow stays skipped. Dispatch
 # manually with `sha=<merge-sha>` once canary builds on that SHA are green
-# — verify-head reads the version from that SHA's commit subject, and
-# every downstream step is idempotent. Pinning to a SHA matters because
-# follow-up commits (like merging this recovery hatch itself) push the
-# release commit out of HEAD on main.
+# — when sha is passed, verify-head reads the version from Cargo.toml at
+# that sha and skips the commit-subject match, so the recovery path works
+# against any SHA whose Cargo.toml carries the version we want to release
+# (useful when the original release commit has been pushed off main HEAD
+# by follow-up commits, or when re-tagging an arbitrary sha). Every
+# downstream step is idempotent against pre-existing tags and manifests.
 #
 # Idempotency:
 #   - If an X.Y.Z OCI tag already exists at GHCR, the retag step skips it
@@ -99,32 +101,45 @@ jobs:
           git config user.name "wasmcloud-bot"
           git config user.email "wasmcloud-bot@users.noreply.github.com"
 
-      - name: Verify HEAD is a release commit and read version
+      - name: Verify HEAD and read version
         id: ver
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
         run: |
           set -euo pipefail
           echo "STAGE=verify-head" >> "${GITHUB_ENV}"
           SUBJECT=$(git log -1 --pretty=%s)
           MERGE_SHA=$(git rev-parse HEAD)
-          # release-train uses rebase-merge so the subject is exactly
-          # "release: vX.Y.Z" or "release: vX.Y.Z-rc.N", with no PR ref
-          # appended. The optional "(#NNN)" group is defensive in case
-          # someone manually squash-merges in the offline-train path (the
-          # runbook still says to rebase-merge, but humans).
-          if [[ ! "${SUBJECT}" =~ ^release:\ v([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?)([[:space:]]\(#[0-9]+\))?$ ]]; then
-            echo "HEAD subject is not a release commit: ${SUBJECT}" >&2
-            echo "abort — release-tag will not tag a non-release HEAD" >&2
-            exit 1
-          fi
-          VERSION="${BASH_REMATCH[1]}"
           WS_VERSION=$(awk -F'"' '
             /^\[workspace\.package\]/ { in_pkg = 1; next }
             /^\[/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
             in_pkg && /^version = "/ { print $2; exit }
           ' Cargo.toml)
-          if [[ "${VERSION}" != "${WS_VERSION}" ]]; then
-            echo "commit subject says v${VERSION} but Cargo.toml says ${WS_VERSION}" >&2
-            exit 1
+          if [[ -n "${INPUT_SHA}" ]]; then
+            # Manual recovery dispatch — caller explicitly chose this sha
+            # (e.g., re-tagging an older release after a downstream step
+            # failed mid-promotion). Trust them: take the version straight
+            # from Cargo.toml at that sha and skip the subject check. The
+            # release-train automatic path still hits the strict check
+            # below because workflow_run never sets inputs.sha.
+            echo "manual dispatch with sha=${INPUT_SHA} — using Cargo.toml v${WS_VERSION} (subject check skipped)"
+            VERSION="${WS_VERSION}"
+          else
+            # release-train uses rebase-merge so the subject is exactly
+            # "release: vX.Y.Z" or "release: vX.Y.Z-rc.N", with no PR ref
+            # appended. The optional "(#NNN)" group is defensive in case
+            # someone manually squash-merges in the offline-train path (the
+            # runbook still says to rebase-merge, but humans).
+            if [[ ! "${SUBJECT}" =~ ^release:\ v([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?)([[:space:]]\(#[0-9]+\))?$ ]]; then
+              echo "HEAD subject is not a release commit: ${SUBJECT}" >&2
+              echo "abort — release-tag will not tag a non-release HEAD" >&2
+              exit 1
+            fi
+            VERSION="${BASH_REMATCH[1]}"
+            if [[ "${VERSION}" != "${WS_VERSION}" ]]; then
+              echo "commit subject says v${VERSION} but Cargo.toml says ${WS_VERSION}" >&2
+              exit 1
+            fi
           fi
           {
             echo "version=${VERSION}"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -281,7 +281,15 @@ jobs:
             exit 1
           fi
           mkdir -p ./artifacts
-          gh run download "${RUN_ID}" --dir ./artifacts --pattern 'wash-*'
+          # Narrow patterns to the per-target binary artifacts only.
+          # A bare `wash-*` also matches `wash-image-tarball-*` /
+          # `wash-image-digest-*` (kept around for canary-publish), and
+          # those include 0-byte digest marker files that GH's release-
+          # asset API rejects with "size must be greater than or equal
+          # to 1" when the GitHub Release upload step runs them through.
+          gh run download "${RUN_ID}" --dir ./artifacts \
+            --pattern 'wash-x86_64-*' \
+            --pattern 'wash-aarch64-*'
           echo "run_id=${RUN_ID}" >> "${GITHUB_OUTPUT}"
           echo "--- downloaded ---"
           find ./artifacts -type f | sort

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -436,7 +436,17 @@ jobs:
   # every commit. Manual fallback (train offline): push a `release: vX.Y.Z`
   # commit by hand and this job fires.
   canary-binaries:
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'release: v')"
+    # `always()` is required to break the skipped-`changes` propagation
+    # that otherwise marks this skipped even when every need succeeded.
+    # See the same pattern on runtime-operator-e2e / canary-publish above.
+    if: |
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      startsWith(github.event.head_commit.message, 'release: v') &&
+      needs.check.result == 'success' &&
+      needs.lint.result == 'success' &&
+      needs.runtime-operator-e2e.result == 'success'
     needs:
       - check
       - lint

--- a/.github/workflows/wit.yml
+++ b/.github/workflows/wit.yml
@@ -203,7 +203,16 @@ jobs:
     # publishes exactly one package using the wasm bytes validate built —
     # not a rebuild — so the attestation we record covers the same bits
     # that passed validation.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.validate.outputs.has_packages == 'true'
+    # `always()` is required to break the skipped-`changes` propagation
+    # through `validate` (which uses `always()` itself to bypass the
+    # PR-only `changes` gate). Without it, this job silently skips on
+    # every main push even when `validate` succeeded.
+    if: |
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.validate.result == 'success' &&
+      needs.validate.outputs.has_packages == 'true'
     needs:
       - validate
     runs-on: ubuntu-latest


### PR DESCRIPTION

Three latent bugs spotted while debugging why v2.2.0 release-tag failed
to attach binaries:

1. `wash.yml::canary-binaries` had a bare
    `if: github.event_name == 'push' && ... && startsWith(...)`. With
    `needs: [check, lint, runtime-operator-e2e]`.

2. `wit.yml::publish` has the same bug. `validate` uses
    `always()` to bypass `changes`, but `publish` only checks
    `needs.validate.outputs.has_packages`, no `always()` and no
    `needs.validate.result == 'success'`

3. `release-tag.yml::Download canary-binaries artifacts` used
    `--pattern 'wash-*'`, which matches not just the per-target
    binary artifacts (`wash-x86_64-…`, `wash-aarch64-…`) but also
    `wash-image-tarball-*` and `wash-image-digest-*`. The digest
    artifacts contain 0-byte marker files (created by `touch` in
    `Export digest`), and `softprops/action-gh-release` then tries
    to upload one as a release asset, which the GH API rejects:
    "size must be greater than or equal to 1". Narrow to the two
    CPU-arch prefixes so wash-image-* artifacts never enter the
    release upload glob.

Also disables guard for release commit when a manual override with sha.