### PR TITLE
release pipeline hardening

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -232,10 +232,12 @@ jobs:
           )
           for KEY in wash gateway operator; do
             IMG="${IMAGES[${KEY}]}"
-            if docker buildx imagetools inspect "${IMG}:${IMAGE_TAG}" >/dev/null 2>&1; then
+            # Three outcomes: tag exists (skip), manifest unknown
+            # (promote), any other error (abort with the captured stderr).
+            if INSPECT_OUT=$(docker buildx imagetools inspect "${IMG}:${IMAGE_TAG}" --format '{{json .Manifest}}' 2>&1); then
               echo "${IMG}:${IMAGE_TAG} already exists — skipping (immutable)"
-              DST=$(docker buildx imagetools inspect "${IMG}:${IMAGE_TAG}" --format '{{json .Manifest}}' | jq -r .digest)
-            else
+              DST=$(echo "${INSPECT_OUT}" | jq -r .digest)
+            elif echo "${INSPECT_OUT}" | grep -qiE 'manifest unknown|no such manifest|not found|MANIFEST_UNKNOWN'; then
               SRC="${IMG}:sha-${MERGE_SHA}"
               echo "promoting ${SRC} -> ${IMG}:${IMAGE_TAG}"
               SRC_DIGEST=$(docker buildx imagetools inspect "${SRC}" --format '{{json .Manifest}}' | jq -r .digest)
@@ -244,6 +246,10 @@ jobs:
               if [[ "${DST}" != "${SRC_DIGEST}" ]]; then
                 echo "WARN: retag digest (${DST}) differs from canary source (${SRC_DIGEST}) — same content, different manifest envelope. Attestation below covers ${DST}." >&2
               fi
+            else
+              echo "destination check for ${IMG}:${IMAGE_TAG} failed — refusing to promote" >&2
+              echo "${INSPECT_OUT}" >&2
+              exit 1
             fi
             echo "${KEY}_digest=${DST}" >> "${GITHUB_OUTPUT}"
           done
@@ -278,6 +284,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
           MERGE_SHA: ${{ steps.ver.outputs.sha }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           echo "STAGE=download-binaries" >> "${GITHUB_ENV}"
@@ -293,6 +300,21 @@ jobs:
             --jq 'map(select(.status == "completed" and .conclusion == "success")) | .[0].databaseId // empty')
           if [[ -z "${RUN_ID}" ]]; then
             echo "no successful wash.yml run found for ${MERGE_SHA}" >&2
+            exit 1
+          fi
+          # Require every canary-binaries matrix entry to be success.
+          # The wash.yml run conclusion can be "success" even when
+          # canary-binaries was skipped — confirm via the jobs API.
+          JOBS_JSON=$(gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}/jobs" --paginate)
+          TOTAL=$(echo "${JOBS_JSON}" | jq -r '[.jobs[] | select(.name | startswith("canary-binaries"))] | length')
+          OK=$(echo "${JOBS_JSON}" | jq -r '[.jobs[] | select(.name | startswith("canary-binaries") and .conclusion == "success")] | length')
+          if (( TOTAL == 0 )); then
+            echo "wash.yml run ${RUN_ID} has no canary-binaries jobs — was the commit a 'release: v…' commit?" >&2
+            exit 1
+          fi
+          if (( OK != TOTAL )); then
+            echo "wash.yml run ${RUN_ID}: only ${OK}/${TOTAL} canary-binaries matrix entries succeeded" >&2
+            echo "${JOBS_JSON}" | jq '.jobs[] | select(.name | startswith("canary-binaries")) | {name, conclusion}' >&2
             exit 1
           fi
           mkdir -p ./artifacts

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -332,14 +332,33 @@ jobs:
       - lint
       - wash-image
       - runtime-operator-e2e
+      - canary-publish
+      - canary-binaries
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped
         env:
           RESULTS: ${{ toJSON(needs.*.result) }}
+          CANARY_PUBLISH_RESULT: ${{ needs.canary-publish.result }}
+          CANARY_BINARIES_RESULT: ${{ needs.canary-binaries.result }}
+          REF: ${{ github.ref }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
+          set -euo pipefail
           if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            exit 1
+          fi
+          # Main pushes must publish canary.
+          if [[ "${REF}" == "refs/heads/main" ]] && [[ "${CANARY_PUBLISH_RESULT}" != "success" ]]; then
+            echo "canary-publish result=${CANARY_PUBLISH_RESULT} on main push; expected success" >&2
+            exit 1
+          fi
+          # Release commits must also build per-target binaries that
+          # release-tag.yml attaches to the GH Release.
+          if [[ "${REF}" == "refs/heads/main" ]] && [[ "${COMMIT_MESSAGE}" == "release: v"* ]] \
+             && [[ "${CANARY_BINARIES_RESULT}" != "success" ]]; then
+            echo "canary-binaries result=${CANARY_BINARIES_RESULT} on release commit; expected success" >&2
             exit 1
           fi
 

--- a/.github/workflows/wit.yml
+++ b/.github/workflows/wit.yml
@@ -230,14 +230,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.validate.outputs.matrix) }}
     steps:
-      # wash performs the push and emits the OCI manifest digest in its
-      # JSON output (see "Push and attest" below). oras stays for the
-      # immutability pre-check — wash has no equivalent "does this tag
-      # exist" probe. (oras is preinstalled on ubuntu-22.04 but not on
-      # 24.04 / ubuntu-latest, so we install it explicitly.)
+      # wash pushes and emits the OCI manifest digest in its JSON output
+      # (see "Push and attest" below). The destination-exists check uses
+      # `docker manifest inspect` so it shares credentials with
+      # docker/login-action.
       - uses: wasmcloud/setup-wash-action@47756fa211cc82f392c57e39504f43ef46fc0b3e # v2.1.0
-
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
 
       - name: Login to ghcr.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -265,20 +262,28 @@ jobs:
           # skip the push entirely. SemVer build metadata (`+build.42`)
           # is correctly treated as stable. Pre-release tags (-rc.N,
           # -draft, etc.) may be moved by re-running this workflow.
+          # Distinguish three outcomes: tag exists (skip), manifest
+          # unknown (proceed), any other error from the inspect (abort).
           if [[ ! "${VERSION}" =~ - ]]; then
-            if oras manifest fetch "${REF}" >/dev/null 2>&1; then
+            if INSPECT_ERR=$(docker manifest inspect "${REF}" 2>&1 >/dev/null); then
               echo "${REF} already exists at the destination and version is stable — skipping (immutable)"
               echo "skipped=true" >> "${GITHUB_OUTPUT}"
               exit 0
+            elif echo "${INSPECT_ERR}" | grep -qiE 'manifest unknown|no such manifest|not found'; then
+              echo "${REF} not yet published — proceeding with push"
+            else
+              echo "destination check for ${REF} failed — refusing to push" >&2
+              echo "${INSPECT_ERR}" >&2
+              exit 1
             fi
           fi
-          # `wash -o json oci push` emits a single JSON object whose
-          # `digest` field is the OCI manifest digest we need to attest.
-          # We capture stdout, fail loudly if the field is missing, and
-          # mirror the human-readable output to the workflow log.
+          # `wash -o json oci push` wraps the response as
+          # `{ "success": true, "data": { "digest": "sha256:…" } }`.
+          # `.digest` fallback is for older wash builds that emitted
+          # the unwrapped form.
           PUSH_OUT=$(wash -o json oci push "${REF}" "${ARTIFACT}")
           echo "${PUSH_OUT}"
-          DIGEST=$(echo "${PUSH_OUT}" | jq -r '.digest // empty')
+          DIGEST=$(echo "${PUSH_OUT}" | jq -r '.data.digest // .digest // empty')
           if [[ -z "${DIGEST}" ]]; then
             echo "wash oci push did not report a manifest digest for ${REF}" >&2
             exit 1


### PR DESCRIPTION
Release pipeline hardenings prompted by the v2.2.0 post-mortem. Each closes a class of failure that would have caught an earlier stage before irreversible state (overwritten OCI tags, stale git tags, partial releases) got written.

- **`release-tag.yml` promote step**: add destination-check errors instead of conflating auth/network failures with "tag not found".
- **`wash.yml::gate`**: include `canary-publish` and `canary-binaries` in `needs:` and explicitly fail when either silently skipped on a main push / release commit. Backstops any future variant of the chained-skip bug at the workflow level so release-tag never moves forward against a partial wash.yml run.
- **`release-tag.yml` download step**: verify all `canary-binaries` matrix entries succeeded on the wash.yml run before downloading. Catches missing binaries with a clear diagnostic instead of failing at GH Release upload several steps later.
- **`wit.yml::publish`**: same `oras manifest fetch >/dev/null 2>&1` anti-pattern that the release-tag promote fix addresses — silently overwrote already-published immutable WIT interface tags. Switch to `docker manifest inspect` (shares creds with docker/login-action) with fail-closed three-way decision. Also fix `.data.digest`
extraction (`wash -o json oci push` wraps its response in a `data` envelope, not at top level).
