### PR TITLE
ci(release): detect release via Cargo.toml version

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -24,16 +24,15 @@ name: release-tag
 #   - release-train.yml waits for the PR to actually merge before exiting,
 #     so by the time this workflow fires the merge commit is on main.
 #
-# workflow_dispatch is a recovery hatch: if release-train.yml fails late
-# (e.g. DCO bounces and a human finishes the merge manually), the train
-# run's conclusion is `failure` and this workflow stays skipped. Dispatch
-# manually with `sha=<merge-sha>` once canary builds on that SHA are green
-# — when sha is passed, verify-head reads the version from Cargo.toml at
-# that sha and skips the commit-subject match, so the recovery path works
-# against any SHA whose Cargo.toml carries the version we want to release
-# (useful when the original release commit has been pushed off main HEAD
-# by follow-up commits, or when re-tagging an arbitrary sha). Every
-# downstream step is idempotent against pre-existing tags and manifests.
+# workflow_dispatch is a recovery hatch. Dispatch manually with
+# `sha=<merge-sha>` once canary builds on that SHA are green — when sha
+# is passed, verify-head reads the version from Cargo.toml at that sha
+# and skips the version-bump check, so the recovery path works against
+# any SHA whose Cargo.toml carries the version we want to release. The
+# automatic path (workflow_run from release-train) instead requires
+# HEAD's Cargo.toml workspace version to differ from HEAD~1's, which is
+# the canonical "this commit is a release" signal. Every downstream
+# step is idempotent against pre-existing tags and manifests.
 #
 # Idempotency:
 #   - If an X.Y.Z OCI tag already exists at GHCR, the retag step skips it
@@ -108,38 +107,42 @@ jobs:
         run: |
           set -euo pipefail
           echo "STAGE=verify-head" >> "${GITHUB_ENV}"
-          SUBJECT=$(git log -1 --pretty=%s)
           MERGE_SHA=$(git rev-parse HEAD)
-          WS_VERSION=$(awk -F'"' '
-            /^\[workspace\.package\]/ { in_pkg = 1; next }
-            /^\[/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
-            in_pkg && /^version = "/ { print $2; exit }
-          ' Cargo.toml)
+          read_ws_version() {
+            local src="$1"
+            if [[ "${src}" == "HEAD" ]]; then
+              cat Cargo.toml
+            else
+              git show "${src}:Cargo.toml"
+            fi | awk -F'"' '
+              /^\[workspace\.package\]/ { in_pkg = 1; next }
+              /^\[/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
+              in_pkg && /^version = "/ { print $2; exit }
+            '
+          }
+          WS_VERSION=$(read_ws_version HEAD)
+          if [[ -z "${WS_VERSION}" ]]; then
+            echo "could not read [workspace.package] version from Cargo.toml at HEAD" >&2
+            exit 1
+          fi
           if [[ -n "${INPUT_SHA}" ]]; then
             # Manual recovery dispatch — caller explicitly chose this sha
-            # (e.g., re-tagging an older release after a downstream step
-            # failed mid-promotion). Trust them: take the version straight
-            # from Cargo.toml at that sha and skip the subject check. The
-            # release-train automatic path still hits the strict check
-            # below because workflow_run never sets inputs.sha.
-            echo "manual dispatch with sha=${INPUT_SHA} — using Cargo.toml v${WS_VERSION} (subject check skipped)"
+            # (re-tagging an older release after a downstream step failed
+            # mid-promotion, or finalizing a release whose canary build
+            # was driven via workflow_dispatch on wash.yml). Trust them.
+            echo "manual dispatch with sha=${INPUT_SHA} — using Cargo.toml v${WS_VERSION}"
             VERSION="${WS_VERSION}"
           else
-            # release-train uses rebase-merge so the subject is exactly
-            # "release: vX.Y.Z" or "release: vX.Y.Z-rc.N", with no PR ref
-            # appended. The optional "(#NNN)" group is defensive in case
-            # someone manually squash-merges in the offline-train path (the
-            # runbook still says to rebase-merge, but humans).
-            if [[ ! "${SUBJECT}" =~ ^release:\ v([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?)([[:space:]]\(#[0-9]+\))?$ ]]; then
-              echo "HEAD subject is not a release commit: ${SUBJECT}" >&2
-              echo "abort — release-tag will not tag a non-release HEAD" >&2
+            # Automatic path (workflow_run from release-train). Require
+            # HEAD to bump the workspace version vs its parent — that's
+            # the canonical "this commit is a release" signal, replacing
+            # the older "subject starts with release: v" convention.
+            PREV_VERSION=$(read_ws_version HEAD~1 2>/dev/null || true)
+            if [[ "${WS_VERSION}" == "${PREV_VERSION}" ]]; then
+              echo "HEAD does not bump [workspace.package].version (still ${PREV_VERSION}) — refusing to tag" >&2
               exit 1
             fi
-            VERSION="${BASH_REMATCH[1]}"
-            if [[ "${VERSION}" != "${WS_VERSION}" ]]; then
-              echo "commit subject says v${VERSION} but Cargo.toml says ${WS_VERSION}" >&2
-              exit 1
-            fi
+            VERSION="${WS_VERSION}"
           fi
           {
             echo "version=${VERSION}"

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -9,6 +9,12 @@ on:
       - main
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      is_release:
+        description: "Treat this run as a release: run canary-binaries, gate as if Cargo.toml had bumped. Use when re-releasing a SHA whose Cargo.toml is already at the target version, or when finalizing a release whose train run failed."
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -49,6 +55,59 @@ jobs:
               - 'runtime-operator/test/e2e/**'
               - 'charts/runtime-operator/**'
               - 'deploy/kind/kind-config.yaml'
+
+  # Detect whether this commit bumps the workspace version — the signal
+  # that "this is a release." Compare `[workspace.package].version` at
+  # HEAD against HEAD~1. workflow_dispatch can override via `is_release`
+  # input (e.g., re-releases where Cargo.toml is already at the target
+  # version, or finalizing a release whose train run failed).
+  release-detect:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      is_release: ${{ steps.detect.outputs.is_release }}
+      version: ${{ steps.detect.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+      - name: Detect workspace version bump
+        id: detect
+        env:
+          INPUT_IS_RELEASE: ${{ inputs.is_release }}
+        run: |
+          set -euo pipefail
+          read_ws_version() {
+            local src="$1"
+            if [[ "${src}" == "HEAD" ]]; then
+              cat Cargo.toml
+            else
+              git show "${src}:Cargo.toml"
+            fi | awk -F'"' '
+              /^\[workspace\.package\]/ { in_pkg = 1; next }
+              /^\[/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
+              in_pkg && /^version = "/ { print $2; exit }
+            '
+          }
+          CUR=$(read_ws_version HEAD)
+          PREV=$(read_ws_version HEAD~1 2>/dev/null || true)
+          if [[ "${INPUT_IS_RELEASE}" == "true" ]]; then
+            echo "workflow_dispatch with is_release=true — treating as release"
+            echo "is_release=true" >> "${GITHUB_OUTPUT}"
+            echo "version=${CUR}" >> "${GITHUB_OUTPUT}"
+          elif [[ -n "${CUR}" && "${CUR}" != "${PREV}" ]]; then
+            echo "version bump detected: ${PREV:-<none>} → ${CUR}"
+            echo "is_release=true" >> "${GITHUB_OUTPUT}"
+            echo "version=${CUR}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "no version bump (HEAD=${CUR}, HEAD~1=${PREV:-<none>}) — not a release"
+            echo "is_release=false" >> "${GITHUB_OUTPUT}"
+          fi
 
   check:
     needs:
@@ -328,6 +387,7 @@ jobs:
 
   gate:
     needs:
+      - release-detect
       - check
       - lint
       - wash-image
@@ -342,8 +402,8 @@ jobs:
           RESULTS: ${{ toJSON(needs.*.result) }}
           CANARY_PUBLISH_RESULT: ${{ needs.canary-publish.result }}
           CANARY_BINARIES_RESULT: ${{ needs.canary-binaries.result }}
+          IS_RELEASE: ${{ needs.release-detect.outputs.is_release }}
           REF: ${{ github.ref }}
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
           if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
@@ -356,8 +416,7 @@ jobs:
           fi
           # Release commits must also build per-target binaries that
           # release-tag.yml attaches to the GH Release.
-          if [[ "${REF}" == "refs/heads/main" ]] && [[ "${COMMIT_MESSAGE}" == "release: v"* ]] \
-             && [[ "${CANARY_BINARIES_RESULT}" != "success" ]]; then
+          if [[ "${IS_RELEASE}" == "true" ]] && [[ "${CANARY_BINARIES_RESULT}" != "success" ]]; then
             echo "canary-binaries result=${CANARY_BINARIES_RESULT} on release commit; expected success" >&2
             exit 1
           fi
@@ -448,25 +507,29 @@ jobs:
         env:
           STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
 
-  # Canary matrix binary build. Runs on every release commit on main (i.e.
-  # what release-train just merged) so release-tag.yml can promote the
-  # exact bytes that the canary CI tested instead of rebuilding on tag.
+  # Canary matrix binary build. Runs on every release commit on main —
+  # detected by `release-detect` as a Cargo.toml workspace version bump
+  # vs the parent commit — so release-tag.yml can promote the exact
+  # bytes that the canary CI tested instead of rebuilding on tag.
   # Skipped for non-release main pushes to avoid burning ~7 runners on
-  # every commit. Manual fallback (train offline): push a `release: vX.Y.Z`
-  # commit by hand and this job fires.
+  # every commit. Manual fallback: `gh workflow run wash.yml --ref main
+  # -f is_release=true`.
   canary-binaries:
-    # `always()` is required to break the skipped-`changes` propagation
-    # that otherwise marks this skipped even when every need succeeded.
-    # See the same pattern on runtime-operator-e2e / canary-publish above.
+    # Fires whenever `release-detect` says this is a release commit —
+    # detected via Cargo.toml workspace version bump (HEAD vs HEAD~1)
+    # or forced via `workflow_dispatch` input. `always()` breaks the
+    # skipped-`changes` propagation; the explicit per-need success
+    # gates restore the default `success()` check.
     if: |
       always() &&
-      github.event_name == 'push' &&
+      needs.release-detect.outputs.is_release == 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       github.ref == 'refs/heads/main' &&
-      startsWith(github.event.head_commit.message, 'release: v') &&
       needs.check.result == 'success' &&
       needs.lint.result == 'success' &&
       needs.runtime-operator-e2e.result == 'success'
     needs:
+      - release-detect
       - check
       - lint
       - runtime-operator-e2e


### PR DESCRIPTION
Removes the `startsWith(commit_msg, 'release: v')` convention as the
"this is a release" signal. The version-of-truth is now
`[workspace.package].version` in Cargo.toml; a release is detected by
comparing HEAD's value against HEAD~1's. Same observable behavior for
release-train's automatic flow (it bumps Cargo.toml before merging),
but the commit subject is no longer load-bearing — any subject the
contributor uses works.

wash.yml:
- New `release-detect` job, runs early. Outputs `is_release` and
  `version`. Reads `Cargo.toml` at HEAD and HEAD~1, marks `is_release=true`
  when they differ (or when the workflow_dispatch input `is_release` is
  true).
- `canary-binaries` gates on `needs.release-detect.outputs.is_release ==
  'true'` instead of `startsWith(...)`.
- `gate`'s release-commit check uses the same output (env var
  `IS_RELEASE` replaces `COMMIT_MESSAGE`).
- New `workflow_dispatch` trigger with optional `is_release` input. The
  manual recovery path becomes
    gh workflow run wash.yml --ref main -f is_release=true
  for cases where Cargo.toml is already at the target version and we
  need to re-build the binaries without bumping again (e.g., recovering
  a release after a partial release-tag run).

release-tag.yml verify-head:
- Manual-sha path unchanged (already reads Cargo.toml directly).
- Automatic path: drop the subject regex; require HEAD to bump the
  workspace version vs HEAD~1, matching wash.yml's release-detect.

Header docs and the canary-binaries comment block updated to describe
the new detection mechanism. release-train.yml is unchanged. Its
commits still happen to start with `release: v…` for human readability,
but nothing in CI checks for it any more.
