### PR TITLE
ci(wash): accept workflow_dispatch in wash-image and canary-publish event gates

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -231,7 +231,7 @@ jobs:
   wash-image:
     needs:
       - changes
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true') && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true') && (github.event_name == 'pull_request' || ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'))
     permissions:
       contents: read
       packages: write
@@ -440,7 +440,7 @@ jobs:
     # skipped before evaluating the explicit gate.
     if: |
       always() &&
-      github.event_name == 'push' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       github.ref == 'refs/heads/main' &&
       needs.wash-image.result == 'success' &&
       needs.runtime-operator-e2e.result == 'success'


### PR DESCRIPTION
The release-detection redesign added `workflow_dispatch` to the canary-
binaries event gate but missed wash-image and canary-publish. A manual
`gh workflow run wash.yml --ref main -f is_release=true` therefore
skipped wash-image (event_name not in {pull_request, push}), which
cascaded:

  wash-image                skipped (missing event gate)
    runtime-operator-e2e    skipped (needs.wash-image != 'success')
    canary-publish          skipped (missing event gate too)
    canary-binaries         skipped (needs.runtime-operator-e2e != 'success')
  gate                      failed  (canary-publish != 'success' on main)

Add `workflow_dispatch` to both gates so the manual force-release path
exercises the full canary pipeline.
