### PR TITLE
ci(runtime-operator): guard RBAC drift

### DIFF
--- a/.github/scripts/runtime-operator-rbac-parity.mjs
+++ b/.github/scripts/runtime-operator-rbac-parity.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Verifies that the runtime-operator Helm chart grants every (apiGroup,
+// resource, verb) tuple that controller-gen emits into
+// runtime-operator/config/rbac/role.yaml.
+//
+// The chart is hand-mapped from role.yaml — it splits the single generated
+// ClusterRole across a structural layout of (Cluster)Role + (Cluster)RoleBinding
+// (e.g. pods move to a namespaced Role in the operator's namespace and per-host
+// namespaces; configmaps/secrets/services/events move to a ClusterRole bound
+// per-namespace when operator.watchNamespaces is set). Because the mapping is
+// manual, a new `+kubebuilder:rbac` marker can land in code and `role.yaml`
+// without the corresponding chart edit, and the operator hits a permissions
+// error only at runtime on a cluster with OwnerReferencesPermissionEnforcement
+// (or any plugin that exercises the missing verb) enabled.
+//
+// This check renders the chart in two modes — defaults and with
+// watchNamespaces/hostNamespaces set — so a marker missing from either path
+// is caught. The "union of granted verbs" is compared against role.yaml
+// without regard to scope; namespaced-vs-cluster-wide is the chart's
+// deliberate structural choice and not what this script polices.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const CHART_DIR = 'charts/runtime-operator';
+const GENERATED_ROLE = 'runtime-operator/config/rbac/role.yaml';
+// `runtime-operator.fullname` collapses to the release name when the release
+// name already contains the chart name, so picking a release name like this
+// keeps the rendered SA name short and predictable.
+const RELEASE_NAME = 'runtime-operator';
+const OPERATOR_SA = RELEASE_NAME;
+
+const RENDER_MODES = [
+  {
+    name: 'defaults (watchNamespaces empty, hostNamespaces empty)',
+    sets: [],
+  },
+  {
+    name: 'watched (watchNamespaces=[ns-a], hostNamespaces=[ns-b])',
+    sets: [
+      'operator.watchNamespaces[0]=ns-a',
+      'operator.hostNamespaces[0]=ns-b',
+    ],
+  },
+];
+
+function yamlToDocs(yamlText) {
+  // yq -I 0 emits one compact JSON object per YAML doc, one per line.
+  const r = spawnSync('yq', ['-o', 'json', '-I', '0'], {
+    input: yamlText,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (r.status !== 0) {
+    throw new Error(`yq failed (exit ${r.status}): ${r.stderr.trim()}`);
+  }
+  // Empty YAML docs (`---` with no body) round-trip through yq as `null`;
+  // drop them so downstream code can assume every doc is an object.
+  return r.stdout
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line))
+    .filter((doc) => doc != null);
+}
+
+function helmTemplate(sets) {
+  const args = ['template', RELEASE_NAME, CHART_DIR];
+  for (const s of sets) {
+    args.push('--set', s);
+  }
+  return execFileSync('helm', args, {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+// Walk bindings, return the set of (Cluster)Role names attached to the
+// operator's service account. A (Cluster)Role that isn't bound to the operator
+// is irrelevant — e.g. the gateway ClusterRole also lists `workloads`, but
+// that grant goes to the gateway SA, not the operator.
+function operatorBoundRoleNames(docs) {
+  const names = new Set();
+  for (const doc of docs) {
+    if (doc.kind !== 'ClusterRoleBinding' && doc.kind !== 'RoleBinding') continue;
+    const bindsOperator = (doc.subjects ?? []).some(
+      (s) => s.kind === 'ServiceAccount' && s.name === OPERATOR_SA,
+    );
+    if (!bindsOperator) continue;
+    if (doc.roleRef?.name) names.add(doc.roleRef.name);
+  }
+  return names;
+}
+
+function operatorRules(docs) {
+  const boundRoles = operatorBoundRoleNames(docs);
+  const rules = [];
+  for (const doc of docs) {
+    if (doc.kind !== 'Role' && doc.kind !== 'ClusterRole') continue;
+    if (!boundRoles.has(doc.metadata?.name)) continue;
+    for (const rule of doc.rules ?? []) {
+      rules.push(rule);
+    }
+  }
+  return rules;
+}
+
+function expandTuples(rule) {
+  const out = [];
+  for (const g of rule.apiGroups ?? []) {
+    for (const r of rule.resources ?? []) {
+      for (const v of rule.verbs ?? []) {
+        out.push([g, r, v]);
+      }
+    }
+  }
+  return out;
+}
+
+function ruleCovers(rule, group, resource, verb) {
+  return (
+    (rule.apiGroups ?? []).includes(group) &&
+    (rule.resources ?? []).includes(resource) &&
+    (rule.verbs ?? []).includes(verb)
+  );
+}
+
+function tupleKey(t) {
+  return t.join('\0');
+}
+
+const generatedDocs = yamlToDocs(readFileSync(GENERATED_ROLE, 'utf8'));
+const neededTuples = generatedDocs
+  .filter((d) => d?.kind === 'ClusterRole' || d?.kind === 'Role')
+  .flatMap((d) => d.rules ?? [])
+  .flatMap(expandTuples);
+const dedupedNeeded = [...new Map(neededTuples.map((t) => [tupleKey(t), t])).values()];
+
+let failed = false;
+for (const mode of RENDER_MODES) {
+  const docs = yamlToDocs(helmTemplate(mode.sets));
+  const chartRules = operatorRules(docs);
+
+  const missing = dedupedNeeded.filter(
+    ([g, r, v]) => !chartRules.some((rule) => ruleCovers(rule, g, r, v)),
+  );
+
+  if (missing.length === 0) {
+    console.log(
+      `OK   ${mode.name}: chart covers all ${dedupedNeeded.length} tuples in ${GENERATED_ROLE}`,
+    );
+    continue;
+  }
+
+  failed = true;
+  console.error(
+    `FAIL ${mode.name}: chart is missing ${missing.length} of ${dedupedNeeded.length} tuples:`,
+  );
+  for (const [g, r, v] of missing) {
+    const groupLabel = g === '' ? '(core)' : g;
+    console.error(`       - apiGroup=${groupLabel} resource=${r} verb=${v}`);
+  }
+}
+
+if (failed) {
+  console.error('');
+  console.error(`Chart ${CHART_DIR} does not grant the operator service account`);
+  console.error(`every permission that ${GENERATED_ROLE} (the controller-gen output)`);
+  console.error('says the operator needs. Add the missing rules to the appropriate');
+  console.error(`template under ${CHART_DIR}/templates/operator/ — typically`);
+  console.error('clusterrole.yaml for cluster-wide rules, role.yaml for the operator');
+  console.error('namespace, or workload-namespace-role.yaml for the watched-namespace');
+  console.error('path.');
+  process.exit(1);
+}

--- a/.github/workflows/runtime-operator.yml
+++ b/.github/workflows/runtime-operator.yml
@@ -56,6 +56,39 @@ jobs:
         with:
           working-directory: runtime-operator
 
+  # Two related checks bundled in one job because they share the same source
+  # of truth (controller-gen `+kubebuilder:rbac` annotations → config/rbac/role.yaml):
+  #   1. `make manifests` produces no diff — catches annotations that were
+  #      added/edited without re-running controller-gen, and annotations
+  #      placed where controller-gen silently skips them.
+  #   2. The Helm chart grants every (apiGroup, resource, verb) tuple in
+  #      role.yaml — catches new markers landing in code without the matching
+  #      chart update (the chart is hand-mapped from role.yaml).
+  manifests:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true' || contains(github.event.pull_request.labels.*.name, 'canary'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-go
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.16.4
+      - name: Regenerate manifests
+        working-directory: runtime-operator
+        run: make manifests
+      - uses: ./.github/actions/no-diff
+        with:
+          path: runtime-operator
+          fixup-command: "(cd runtime-operator && make manifests)"
+      - name: Verify Helm chart RBAC parity with controller-gen output
+        run: node .github/scripts/runtime-operator-rbac-parity.mjs
+
   test:
     needs:
       - changes
@@ -160,6 +193,7 @@ jobs:
     needs:
       - lint
       - test
+      - manifests
       - build
       - test-e2e
     if: always()

--- a/deploy/kind/kind-config.yaml
+++ b/deploy/kind/kind-config.yaml
@@ -1,5 +1,22 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+# Enable OwnerReferencesPermissionEnforcement on the apiserver. Without this
+# plugin (opt-in upstream but on by default on GKE/AKS/OpenShift and most
+# hardened distros), the operator's RBAC gaps around `<owner>/finalizers`
+# go undetected in e2e — any caller can stamp `blockOwnerDeletion: true`
+# regardless of whether they hold `update` on the owner's `/finalizers`
+# subresource. NodeRestriction is re-listed because
+# `--enable-admission-plugins` overrides kubeadm's default set.
+#
+# extraArgs is a map[string]string here because kind generates a
+# kubeadm.k8s.io/v1beta3 base ClusterConfiguration; v1beta4 (list-form) will
+# require switching to `- name: …, value: …` entries.
+kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        enable-admission-plugins: NodeRestriction,OwnerReferencesPermissionEnforcement
 nodes:
   - role: control-plane
     extraPortMappings:

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -73,8 +73,10 @@ var (
 
 	// canary is published on every merge to main
 	runtimeImageTag = "canary"
-	// runtimeSupportsHostAliases indicates whether the runtime supports HostAliases,
-	// which is required for testing with EndpointSlices.
+	// runtimeSupportsHostAliases gates the HTTP traffic assertion in the
+	// EndpointSlice context. That test relies on the wash runtime
+	// resolving the Service hostname via /etc/hosts. EndpointSlice
+	// creation itself is exercised regardless of this flag.
 	runtimeSupportsHostAliases = false
 )
 

--- a/runtime-operator/test/e2e/e2e_test.go
+++ b/runtime-operator/test/e2e/e2e_test.go
@@ -221,10 +221,13 @@ var _ = Describe("Manager", Ordered, func() {
 	})
 
 	Context("Workload Lifecycle", func() {
-		const sampleDeployment = "config/samples/deployment.yaml"
+		const (
+			sampleDeployment = "config/samples/deployment.yaml"
+			deploymentName   = "hello"
+		)
 
 		It("should deploy a workload and become ready", func() {
-			verifyWorkloadDeploy(sampleDeployment)
+			verifyWorkloadDeploy(sampleDeployment, deploymentName)
 		})
 
 		It("should serve HTTP traffic through the gateway", func() {
@@ -242,7 +245,7 @@ var _ = Describe("Manager", Ordered, func() {
 
 		It("should clean up workload resources on delete", func() {
 			By("deleting the WorkloadDeployment")
-			cmd := exec.Command("kubectl", "delete", "workloaddeployment", "hello",
+			cmd := exec.Command("kubectl", "delete", "workloaddeployment", deploymentName,
 				"-n", namespace)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -261,13 +264,10 @@ var _ = Describe("Manager", Ordered, func() {
 	})
 
 	Context("Workload w/Service Lifecycle", func() {
-		BeforeEach(func() {
-			if !runtimeSupportsHostAliases {
-				Skip("runtime does not support HostAliases, skipping EndpointSlice tests")
-			}
-		})
-
-		const sampleDeployment = "config/samples/service_deployment.yaml"
+		const (
+			sampleDeployment = "config/samples/service_deployment.yaml"
+			deploymentName   = "hello-workload"
+		)
 
 		// Delete runtime-gateway Service and Deployment before tests in this context
 		// to ensure we're testing the Service with EndpointSlices.
@@ -284,10 +284,49 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 
 		It("should deploy a workload and become ready", func() {
-			verifyWorkloadDeploy(sampleDeployment)
+			verifyWorkloadDeploy(sampleDeployment, deploymentName)
+		})
+
+		// The route controller stamps an EndpointSlice with a Service
+		// ownerRef + blockOwnerDeletion=true once a referencing Workload is
+		// Ready. EndpointSlice creation is independent of whether the wash
+		// runtime supports HostAliases, and missing RBAC on
+		// services/finalizers (under OwnerReferencesPermissionEnforcement)
+		// surfaces only via this assertion. Workload readiness reports
+		// success even when the route controller's Create is denied.
+		It("should create an EndpointSlice for the workload service", func() {
+			verifyEndpointSlice := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "endpointslices",
+					"-n", namespace,
+					"-l", "kubernetes.io/service-name=hello-workload,wasmcloud.dev/route-manager=true",
+					"-o", "jsonpath={.items}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(Equal("[]"), "no operator-managed EndpointSlice for hello-workload")
+			}
+			Eventually(verifyEndpointSlice).WithTimeout(30 * time.Second).Should(Succeed())
+		})
+
+		// Catch admission denials the operator has tried-and-logged but that
+		// don't surface via a specific resource assertion. The Kubernetes API
+		// formats all RBAC rejections as `<resource>.<group> "<name>" is
+		// forbidden: <reason>`, so a substring grep on the operator log is a
+		// reliable generic signal.
+		It("should not have logged any forbidden errors", func() {
+			cmd := exec.Command("kubectl", "logs",
+				"-n", namespace,
+				"-l", "wasmcloud.com/name=runtime-operator",
+				"--tail=500")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(ContainSubstring("is forbidden"),
+				"operator log contains an admission-denied error — likely a missing RBAC rule")
 		})
 
 		It("should serve HTTP traffic through the gateway", func() {
+			if !runtimeSupportsHostAliases {
+				Skip("runtime does not support HostAliases, skipping HTTP traffic test")
+			}
 			verifyHTTP := func(g Gomega) {
 				cmd := exec.Command("curl", "-s", "-o", "/dev/null",
 					"-w", "%{http_code}",
@@ -301,8 +340,13 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 
 		It("should clean up workload resources on delete", func() {
-			By("deleting the WorkloadDeployment")
-			cmd := exec.Command("kubectl", "delete", "workloaddeployment", "hello",
+			// Delete via the manifest so the hello-workload Service (which
+			// claimed nodePort 30950 once the gateway was removed) is also
+			// torn down — otherwise the next context's `helm upgrade`,
+			// which re-creates the gateway Service on the same port, fails
+			// with "provided port is already allocated".
+			By("deleting the sample manifest")
+			cmd := exec.Command("kubectl", "delete", "-f", sampleDeployment,
 				"-n", namespace)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -564,7 +608,9 @@ spec:
 
 // verifyWorkloadDeploy applies a WorkloadDeployment manifest and verifies the
 // deployment becomes ready, along with its ReplicaSet and Workload CRs.
-func verifyWorkloadDeploy(sampleDeployment string) {
+// deploymentName is the metadata.name of the WorkloadDeployment in the sample
+// manifest — needed so the Ready check targets the right CR.
+func verifyWorkloadDeploy(sampleDeployment, deploymentName string) {
 	By("applying the sample WorkloadDeployment")
 	cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", sampleDeployment)
 	_, err := utils.Run(cmd)
@@ -572,7 +618,7 @@ func verifyWorkloadDeploy(sampleDeployment string) {
 
 	By("waiting for WorkloadDeployment to become Ready")
 	verifyWorkloadReady := func(g Gomega) {
-		cmd := exec.Command("kubectl", "get", "workloaddeployment", "hello",
+		cmd := exec.Command("kubectl", "get", "workloaddeployment", deploymentName,
 			"-n", namespace,
 			"-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].status}")
 		output, err := utils.Run(cmd)


### PR DESCRIPTION
Three checks that would have caught the missing `*/finalizers` rule fixed in https://github.com/wasmCloud/wasmCloud/pull/5186

* Enable OwnerReferencesPermissionEnforcement in the kind e2e cluster so the existing WorkloadReplicaSet-creation assertion exercises the same admission check that surfaces blockOwnerDeletion RBAC gaps in production (GKE/AKS/OpenShift). NodeRestriction is re-listed because `--enable-admission-plugins` overrides kubeadm's default set.
* New `manifests` job runs `make manifests` and fails on diff via the existing no-diff action — catches +kubebuilder:rbac markers that were edited without regenerating, and markers placed where controller-gen silently skips them.
* New runtime-operator-rbac-parity.mjs renders the chart in two modes (defaults and watchNamespaces=[ns-a], hostNamespaces=[ns-b]), walks RoleBindings/ClusterRoleBindings to find roles bound to the operator SA, and asserts every (apiGroup, resource, verb) tuple in config/rbac/role.yaml is granted by at least one. Scope-agnostic by design — the chart's deliberate cluster-wide → namespaced re-mapping is not what this script polices.