### PR TITLE
feat(wash-runtime): namespace host plugin spans by WIT package

### DIFF
--- a/crates/wash-runtime/src/plugin/wasi_blobstore/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/filesystem.rs
@@ -88,7 +88,7 @@ impl FilesystemBlobstore {
 
 // Implementation for the main blobstore interface
 impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.create_container", skip(self))]
     async fn create_container(
         &mut self,
         name: ContainerName,
@@ -113,7 +113,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.get_container", skip(self))]
     async fn get_container(
         &mut self,
         name: ContainerName,
@@ -139,7 +139,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.delete_container", skip(self))]
     async fn delete_container(
         &mut self,
         name: ContainerName,
@@ -162,7 +162,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.container_exists", skip(self))]
     async fn container_exists(
         &mut self,
         name: ContainerName,
@@ -178,7 +178,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(path.exists()))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.copy_object", skip(self))]
     async fn copy_object(
         &mut self,
         src: ObjectId,
@@ -219,7 +219,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.move_object", skip(self))]
     async fn move_object(
         &mut self,
         src: ObjectId,
@@ -282,7 +282,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }))
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.get_data", skip(self, container))]
     async fn get_data(
         &mut self,
         container: Resource<ContainerData>,
@@ -305,7 +305,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
-    #[instrument(skip(self, container, data))]
+    #[instrument(name = "wasi.blobstore.write_data", skip(self, container, data))]
     async fn write_data(
         &mut self,
         container: Resource<ContainerData>,
@@ -327,7 +327,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.list_objects", skip(self, container))]
     async fn list_objects(
         &mut self,
         container: Resource<ContainerData>,
@@ -357,7 +357,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.delete_object", skip(self, container))]
     async fn delete_object(
         &mut self,
         container: Resource<ContainerData>,
@@ -374,7 +374,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.delete_objects", skip(self, container))]
     async fn delete_objects(
         &mut self,
         container: Resource<ContainerData>,
@@ -394,7 +394,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.has_object", skip(self, container))]
     async fn has_object(
         &mut self,
         container: Resource<ContainerData>,
@@ -408,6 +408,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         Ok(Ok(path.exists()))
     }
 
+    #[instrument(name = "wasi.blobstore.object_info", skip(self, container))]
     async fn object_info(
         &mut self,
         container: Resource<ContainerData>,
@@ -430,7 +431,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }))
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.clear", skip(self, container))]
     async fn clear(
         &mut self,
         container: Resource<ContainerData>,
@@ -511,6 +512,7 @@ impl<'a> bindings::wasi::blobstore::container::HostStreamObjectNames for ActiveC
 }
 
 impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
+    #[instrument(name = "wasi.blobstore.new_outgoing_value", skip(self))]
     async fn new_outgoing_value(&mut self) -> wasmtime::Result<Resource<OutgoingValueHandle>> {
         let temp_file = tempfile::Builder::new()
             .tempfile()
@@ -526,6 +528,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         Ok(resource)
     }
 
+    #[instrument(name = "wasi.blobstore.outgoing_value_write_body", skip(self))]
     async fn outgoing_value_write_body(
         &mut self,
         outgoing_value: Resource<OutgoingValueHandle>,
@@ -544,7 +547,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
-    #[instrument(skip_all)]
+    #[instrument(name = "wasi.blobstore.finish", skip_all)]
     async fn finish(
         &mut self,
         outgoing_value: Resource<OutgoingValueHandle>,
@@ -598,7 +601,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
 }
 
 impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
-    #[instrument(skip_all)]
+    #[instrument(name = "wasi.blobstore.incoming_value_consume_sync", skip_all)]
     async fn incoming_value_consume_sync(
         &mut self,
         incoming_value: Resource<IncomingValueHandle>,
@@ -642,7 +645,7 @@ impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
         Ok(Ok(buf))
     }
 
-    #[instrument(skip_all)]
+    #[instrument(name = "wasi.blobstore.incoming_value_consume_async", skip_all)]
     async fn incoming_value_consume_async(
         &mut self,
         incoming_value: Resource<IncomingValueHandle>,

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/in_memory.rs
@@ -11,6 +11,7 @@ use std::{
 
 const WASI_BLOBSTORE_ID: &str = "wasi-blobstore";
 use tokio::sync::RwLock;
+use tracing::instrument;
 use wasmtime::component::Resource;
 use wasmtime_wasi::p2::{
     InputStream, OutputStream,
@@ -109,6 +110,7 @@ impl InMemoryBlobstore {
 
 // Implementation for the main blobstore interface
 impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.blobstore.create_container", skip(self))]
     async fn create_container(
         &mut self,
         name: ContainerName,
@@ -135,6 +137,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
+    #[instrument(name = "wasi.blobstore.get_container", skip(self))]
     async fn get_container(
         &mut self,
         name: ContainerName,
@@ -157,6 +160,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
+    #[instrument(name = "wasi.blobstore.delete_container", skip(self))]
     async fn delete_container(
         &mut self,
         name: ContainerName,
@@ -172,6 +176,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
+    #[instrument(name = "wasi.blobstore.container_exists", skip(self))]
     async fn container_exists(
         &mut self,
         name: ContainerName,
@@ -189,6 +194,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(workload_storage.contains_key(&name)))
     }
 
+    #[instrument(name = "wasi.blobstore.copy_object", skip(self))]
     async fn copy_object(
         &mut self,
         src: ObjectId,
@@ -244,6 +250,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
+    #[instrument(name = "wasi.blobstore.move_object", skip(self))]
     async fn move_object(
         &mut self,
         src: ObjectId,
@@ -303,6 +310,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.blobstore.get_data", skip(self, container))]
     async fn get_data(
         &mut self,
         container: Resource<String>,
@@ -376,6 +384,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.blobstore.write_data", skip(self, container, data))]
     async fn write_data(
         &mut self,
         container: Resource<String>,
@@ -427,6 +436,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
+    #[instrument(name = "wasi.blobstore.list_objects", skip(self, container))]
     async fn list_objects(
         &mut self,
         container: Resource<String>,
@@ -457,6 +467,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.blobstore.delete_object", skip(self, container))]
     async fn delete_object(
         &mut self,
         container: Resource<String>,
@@ -480,6 +491,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.blobstore.delete_objects", skip(self, container, names))]
     async fn delete_objects(
         &mut self,
         container: Resource<String>,
@@ -505,6 +517,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.blobstore.has_object", skip(self, container))]
     async fn has_object(
         &mut self,
         container: Resource<String>,
@@ -528,6 +541,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.blobstore.object_info", skip(self, container))]
     async fn object_info(
         &mut self,
         container: Resource<String>,
@@ -559,6 +573,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.blobstore.clear", skip(self, container))]
     async fn clear(
         &mut self,
         container: Resource<String>,
@@ -652,6 +667,7 @@ impl<'a> bindings::wasi::blobstore::container::HostStreamObjectNames for ActiveC
 }
 
 impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
+    #[instrument(name = "wasi.blobstore.new_outgoing_value", skip(self))]
     async fn new_outgoing_value(&mut self) -> wasmtime::Result<Resource<OutgoingValueHandle>> {
         tracing::debug!(workload_id = self.id, "Creating new OutgoingValue");
 
@@ -692,6 +708,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.blobstore.outgoing_value_write_body", skip(self))]
     async fn outgoing_value_write_body(
         &mut self,
         outgoing_value: Resource<OutgoingValueHandle>,
@@ -751,6 +768,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.blobstore.finish", skip(self))]
     async fn finish(
         &mut self,
         outgoing_value: Resource<OutgoingValueHandle>,
@@ -840,6 +858,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
 }
 
 impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
+    #[instrument(name = "wasi.blobstore.incoming_value_consume_sync", skip(self))]
     async fn incoming_value_consume_sync(
         &mut self,
         incoming_value: Resource<IncomingValueHandle>,
@@ -855,6 +874,7 @@ impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
         Ok(Ok(data))
     }
 
+    #[instrument(name = "wasi.blobstore.incoming_value_consume_async", skip(self))]
     async fn incoming_value_consume_async(
         &mut self,
         incoming_value: Resource<IncomingValueHandle>,

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/nats.rs
@@ -150,7 +150,7 @@ impl NatsBlobstore {
 
 // Implementation for the main blobstore interface
 impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.create_container", skip(self))]
     async fn create_container(
         &mut self,
         name: ContainerName,
@@ -189,7 +189,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.get_container", skip(self))]
     async fn get_container(
         &mut self,
         name: ContainerName,
@@ -224,7 +224,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.delete_container", skip(self))]
     async fn delete_container(
         &mut self,
         name: ContainerName,
@@ -247,7 +247,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.container_exists", skip(self))]
     async fn container_exists(
         &mut self,
         name: ContainerName,
@@ -269,7 +269,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.copy_object", skip(self))]
     async fn copy_object(
         &mut self,
         src: ObjectId,
@@ -324,7 +324,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.move_object", skip(self))]
     async fn move_object(
         &mut self,
         src: ObjectId,
@@ -384,7 +384,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }))
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.get_data", skip(self, container))]
     async fn get_data(
         &mut self,
         container: Resource<ContainerData>,
@@ -411,7 +411,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
-    #[instrument(skip(self, container, data))]
+    #[instrument(name = "wasi.blobstore.write_data", skip(self, container, data))]
     async fn write_data(
         &mut self,
         container: Resource<ContainerData>,
@@ -442,7 +442,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.list_objects", skip(self, container))]
     async fn list_objects(
         &mut self,
         container: Resource<ContainerData>,
@@ -466,7 +466,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.delete_object", skip(self, container))]
     async fn delete_object(
         &mut self,
         container: Resource<ContainerData>,
@@ -493,7 +493,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip(self, container, names))]
+    #[instrument(name = "wasi.blobstore.delete_objects", skip(self, container, names))]
     async fn delete_objects(
         &mut self,
         container: Resource<ContainerData>,
@@ -523,7 +523,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.has_object", skip(self, container))]
     async fn has_object(
         &mut self,
         container: Resource<ContainerData>,
@@ -536,7 +536,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.object_info", skip(self, container))]
     async fn object_info(
         &mut self,
         container: Resource<ContainerData>,
@@ -554,7 +554,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip(self, container))]
+    #[instrument(name = "wasi.blobstore.clear", skip(self, container))]
     async fn clear(
         &mut self,
         container: Resource<ContainerData>,
@@ -681,7 +681,7 @@ impl<'a> bindings::wasi::blobstore::container::HostStreamObjectNames for ActiveC
 }
 
 impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.new_outgoing_value", skip(self))]
     async fn new_outgoing_value(&mut self) -> wasmtime::Result<Resource<OutgoingValueHandle>> {
         let temp_file = tempfile::Builder::new()
             .tempfile()
@@ -697,7 +697,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         Ok(resource)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.outgoing_value_write_body", skip(self))]
     async fn outgoing_value_write_body(
         &mut self,
         outgoing_value: Resource<OutgoingValueHandle>,
@@ -715,7 +715,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         Ok(Ok(resource))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.finish", skip(self))]
     async fn finish(
         &mut self,
         outgoing_value: Resource<OutgoingValueHandle>,
@@ -764,7 +764,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
 }
 
 impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.incoming_value_consume_sync", skip(self))]
     async fn incoming_value_consume_sync(
         &mut self,
         incoming_value: Resource<IncomingValueHandle>,
@@ -778,7 +778,7 @@ impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.blobstore.incoming_value_consume_async", skip(self))]
     async fn incoming_value_consume_async(
         &mut self,
         incoming_value: Resource<IncomingValueHandle>,

--- a/crates/wash-runtime/src/plugin/wasi_config/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_config/mod.rs
@@ -66,7 +66,7 @@ impl DynamicConfig {
 }
 
 impl<'a> bindings::wasi::config::store::Host for ActiveCtx<'a> {
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.config.get", skip(self))]
     async fn get(
         &mut self,
         key: String,
@@ -81,7 +81,7 @@ impl<'a> bindings::wasi::config::store::Host for ActiveCtx<'a> {
             .map_or(Ok(Ok(None)), |v| Ok(Ok(Some(v))))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.config.get_all", skip(self))]
     async fn get_all(
         &mut self,
     ) -> wasmtime::Result<Result<Vec<(String, String)>, bindings::wasi::config::store::Error>> {

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
@@ -78,7 +78,7 @@ impl FilesystemKeyValue {
 
 // Implementation for the store interface
 impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
-    #[instrument(skip(self))]
+    #[instrument(name = "wasi.keyvalue.open", skip(self))]
     async fn open(
         &mut self,
         identifier: String,
@@ -111,7 +111,7 @@ impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
 
 // Resource host trait implementations for bucket
 impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
-    #[instrument(skip(self, bucket))]
+    #[instrument(name = "wasi.keyvalue.get", skip(self, bucket))]
     async fn get(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -140,7 +140,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         Ok(Ok(entry))
     }
 
-    #[instrument(skip(self, bucket, value))]
+    #[instrument(name = "wasi.keyvalue.set", skip(self, bucket, value))]
     async fn set(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -169,7 +169,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip(self, bucket))]
+    #[instrument(name = "wasi.keyvalue.delete", skip(self, bucket))]
     async fn delete(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -196,7 +196,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip(self, bucket))]
+    #[instrument(name = "wasi.keyvalue.exists", skip(self, bucket))]
     async fn exists(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -223,7 +223,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         Ok(Ok(path.exists()))
     }
 
-    #[instrument(skip(self, bucket))]
+    #[instrument(name = "wasi.keyvalue.list_keys", skip(self, bucket))]
     async fn list_keys(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -287,7 +287,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
 
 // Implementation for the atomics interface
 impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
-    #[instrument(skip(self, bucket))]
+    #[instrument(name = "wasi.keyvalue.increment", skip(self, bucket))]
     async fn increment(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -329,7 +329,7 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
 
 // Implementation for the batch interface
 impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
-    #[instrument(skip(self, bucket, keys))]
+    #[instrument(name = "wasi.keyvalue.get_many", skip(self, bucket, keys))]
     #[allow(clippy::type_complexity)]
     async fn get_many(
         &mut self,
@@ -373,7 +373,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         Ok(Ok(result))
     }
 
-    #[instrument(skip(self, bucket, key_values))]
+    #[instrument(name = "wasi.keyvalue.set_many", skip(self, bucket, key_values))]
     async fn set_many(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -415,7 +415,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
-    #[instrument(skip(self, bucket, keys))]
+    #[instrument(name = "wasi.keyvalue.delete_many", skip(self, bucket, keys))]
     async fn delete_many(
         &mut self,
         bucket: Resource<BucketHandle>,

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/in_memory.rs
@@ -10,6 +10,7 @@ use std::{
 
 const WASI_KEYVALUE_ID: &str = "wasi-keyvalue";
 use tokio::sync::RwLock;
+use tracing::instrument;
 use wasmtime::component::Resource;
 
 use crate::{
@@ -59,6 +60,7 @@ impl InMemoryKeyValue {
 
 // Implementation for the store interface
 impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.open", skip(self))]
     async fn open(
         &mut self,
         identifier: String,
@@ -87,6 +89,7 @@ impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
 
 // Resource host trait implementations for bucket
 impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.get", skip(self, bucket))]
     async fn get(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -117,6 +120,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.set", skip(self, bucket, value))]
     async fn set(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -145,6 +149,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.delete", skip(self, bucket))]
     async fn delete(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -172,6 +177,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.exists", skip(self, bucket))]
     async fn exists(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -199,6 +205,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.list_keys", skip(self, bucket))]
     async fn list_keys(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -265,6 +272,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
 
 // Implementation for the atomics interface
 impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.increment", skip(self, bucket))]
     async fn increment(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -316,6 +324,8 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
 
 // Implementation for the batch interface
 impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.get_many", skip(self, bucket, keys))]
+    #[allow(clippy::type_complexity)]
     async fn get_many(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -355,6 +365,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.set_many", skip(self, bucket, key_values))]
     async fn set_many(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -384,6 +395,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.delete_many", skip(self, bucket, keys))]
     async fn delete_many(
         &mut self,
         bucket: Resource<BucketHandle>,

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
@@ -15,6 +15,7 @@ use crate::engine::workload::WorkloadItem;
 use crate::plugin::HostPlugin;
 use crate::wit::{WitInterface, WitWorld};
 use futures::StreamExt;
+use tracing::instrument;
 use wasmtime::component::Resource;
 
 const LIST_KEYS_BATCH_SIZE: usize = 1000;
@@ -78,6 +79,7 @@ impl NatsKeyValue {
 
 // Implementation for the store interface
 impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.open", skip(self))]
     async fn open(
         &mut self,
         identifier: String,
@@ -111,6 +113,7 @@ impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
 
 // Resource host trait implementations for bucket
 impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.get", skip(self, bucket))]
     async fn get(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -139,6 +142,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.set", skip(self, bucket, value))]
     async fn set(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -150,7 +154,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
                 "keyvalue plugin not available".to_string(),
             )));
         };
-        plugin.record_operation("get");
+        plugin.record_operation("set");
 
         let bucket_handle = self.table.get(&bucket)?;
 
@@ -163,6 +167,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.delete", skip(self, bucket))]
     async fn delete(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -186,6 +191,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.exists", skip(self, bucket))]
     async fn exists(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -210,6 +216,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.list_keys", skip(self, bucket))]
     async fn list_keys(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -269,6 +276,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
 
 // Implementation for the atomics interface
 impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.increment", skip(self, bucket))]
     async fn increment(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -330,6 +338,8 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
 
 // Implementation for the batch interface
 impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.get_many", skip(self, bucket, keys))]
+    #[allow(clippy::type_complexity)]
     async fn get_many(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -369,6 +379,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         Ok(Ok(result))
     }
 
+    #[instrument(name = "wasi.keyvalue.set_many", skip(self, bucket, key_values))]
     async fn set_many(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -411,6 +422,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         Ok(Ok(()))
     }
 
+    #[instrument(name = "wasi.keyvalue.delete_many", skip(self, bucket, keys))]
     async fn delete_many(
         &mut self,
         bucket: Resource<BucketHandle>,

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
@@ -15,6 +15,7 @@ use crate::plugin::HostPlugin;
 use crate::wit::{WitInterface, WitWorld};
 use futures::StreamExt;
 use redis::AsyncCommands;
+use tracing::instrument;
 use wasmtime::component::Resource;
 
 const LIST_KEYS_BATCH_SIZE: usize = 1000;
@@ -90,6 +91,7 @@ impl RedisKeyValue {
 
 // Implementation for the store interface
 impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.open", skip(self))]
     async fn open(
         &mut self,
         identifier: String,
@@ -123,6 +125,7 @@ impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
 
 // Resource host trait implementations for bucket
 impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.get", skip(self, bucket))]
     async fn get(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -148,6 +151,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.set", skip(self, bucket, value))]
     async fn set(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -174,6 +178,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.delete", skip(self, bucket))]
     async fn delete(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -199,6 +204,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.exists", skip(self, bucket))]
     async fn exists(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -224,6 +230,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.list_keys", skip(self, bucket))]
     async fn list_keys(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -291,6 +298,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
 // Atomics use Redis' native INCRBY for atomic increment, storing values as
 // Redis integer strings rather than big-endian bytes.
 impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.increment", skip(self, bucket))]
     async fn increment(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -322,6 +330,8 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
 
 // Implementation for the batch interface
 impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.keyvalue.get_many", skip(self, bucket, keys))]
+    #[allow(clippy::type_complexity)]
     async fn get_many(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -360,6 +370,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         Ok(Ok(result))
     }
 
+    #[instrument(name = "wasi.keyvalue.set_many", skip(self, bucket, key_values))]
     async fn set_many(
         &mut self,
         bucket: Resource<BucketHandle>,
@@ -393,6 +404,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         }
     }
 
+    #[instrument(name = "wasi.keyvalue.delete_many", skip(self, bucket, keys))]
     async fn delete_many(
         &mut self,
         bucket: Resource<BucketHandle>,

--- a/crates/wash-runtime/src/plugin/wasi_logging/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_logging/mod.rs
@@ -12,6 +12,7 @@ use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
 use crate::plugin::HostPlugin;
 use crate::wit::{WitInterface, WitWorld};
+use tracing::instrument;
 use wasmtime::bail;
 
 const PLUGIN_LOGGING_ID: &str = "wasi-logging";
@@ -40,6 +41,7 @@ struct ComponentInfo {
 }
 
 impl<'a> bindings::wasi::logging::logging::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasi.logging.log", skip(self, message))]
     async fn log(
         &mut self,
         level: Level,

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -77,7 +77,7 @@ impl Default for InMemoryMessaging {
 }
 
 impl<'a> Host for ActiveCtx<'a> {
-    #[instrument(skip_all, fields(subject = %subject, timeout_ms))]
+    #[instrument(name = "wasmcloud.messaging.request", skip_all, fields(subject = %subject, timeout_ms))]
     async fn request(
         &mut self,
         subject: String,
@@ -162,7 +162,7 @@ impl<'a> Host for ActiveCtx<'a> {
         }
     }
 
-    #[instrument(skip_all, fields(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>")))]
+    #[instrument(name = "wasmcloud.messaging.publish", skip_all, fields(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>")))]
     async fn publish(&mut self, msg: types::BrokerMessage) -> wasmtime::Result<Result<(), String>> {
         let Some(plugin) = self.get_plugin::<InMemoryMessaging>(PLUGIN_MESSAGING_MEMORY_ID) else {
             return Ok(Err("plugin not available".to_string()));

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -88,7 +88,7 @@ impl NatsMessaging {
 }
 
 impl<'a> Host for ActiveCtx<'a> {
-    #[instrument(skip_all, fields(subject = %subject, timeout_ms))]
+    #[instrument(name = "wasmcloud.messaging.request", skip_all, fields(subject = %subject, timeout_ms))]
     async fn request(
         &mut self,
         subject: String,
@@ -121,7 +121,7 @@ impl<'a> Host for ActiveCtx<'a> {
         }))
     }
 
-    #[instrument(skip_all, fields(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>")))]
+    #[instrument(name = "wasmcloud.messaging.publish", skip_all, fields(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>")))]
     async fn publish(&mut self, msg: types::BrokerMessage) -> wasmtime::Result<Result<(), String>> {
         let Some(plugin) = self.get_plugin::<NatsMessaging>(PLUGIN_MESSAGING_ID) else {
             return Ok(Err("plugin not available".to_string()));
@@ -218,7 +218,7 @@ impl HostPlugin for NatsMessaging {
         Ok(())
     }
 
-    #[instrument(skip_all, fields(component_id = %component_id, workload.id = %workload.id()))]
+    #[instrument(name = "wasmcloud.messaging.on_workload_resolved", skip_all, fields(component_id = %component_id, workload.id = %workload.id()))]
     async fn on_workload_resolved(
         &self,
         workload: &ResolvedWorkload,

--- a/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
@@ -178,7 +178,7 @@ fn extract_tls_requirement(url: &Url) -> bool {
 impl<'a> types::Host for ActiveCtx<'a> {}
 
 impl<'a> query::Host for ActiveCtx<'a> {
-    #[instrument(skip_all, fields(query = %q))]
+    #[instrument(name = "wasmcloud.postgres.query", skip_all, fields(query = %q))]
     async fn query(
         &mut self,
         q: String,
@@ -243,7 +243,7 @@ impl<'a> query::Host for ActiveCtx<'a> {
         Ok(Ok(result))
     }
 
-    #[instrument(skip_all, fields(query = %q))]
+    #[instrument(name = "wasmcloud.postgres.query_batch", skip_all, fields(query = %q))]
     async fn query_batch(&mut self, q: String) -> wasmtime::Result<Result<(), QueryError>> {
         let Some(plugin) = self.get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID) else {
             return Ok(Err(QueryError::Unexpected(
@@ -289,7 +289,7 @@ impl<'a> query::Host for ActiveCtx<'a> {
 }
 
 impl<'a> prepared::Host for ActiveCtx<'a> {
-    #[instrument(skip_all)]
+    #[instrument(name = "wasmcloud.postgres.prepare", skip_all)]
     async fn prepare(
         &mut self,
         statement: String,
@@ -353,7 +353,7 @@ impl<'a> prepared::Host for ActiveCtx<'a> {
         Ok(Ok(token))
     }
 
-    #[instrument(skip_all, fields(stmt_token = %stmt_token))]
+    #[instrument(name = "wasmcloud.postgres.exec", skip_all, fields(stmt_token = %stmt_token))]
     async fn exec(
         &mut self,
         stmt_token: String,

--- a/crates/wash-runtime/tests/integration_blobstore_span_names.rs
+++ b/crates/wash-runtime/tests/integration_blobstore_span_names.rs
@@ -1,0 +1,194 @@
+//! Integration test asserting that `wasi:blobstore` host calls emit OTEL spans
+//! named per the `<namespace>.<package>.<fn>` convention.
+//!
+//! Exercises the same http-blobstore component as `integration_http_blobstore`,
+//! but installs a custom `tracing::Layer` that records every span name created
+//! during the run. After the request round-trips, the recorded set is checked
+//! against the names the host plugin should have produced.
+
+use anyhow::{Context, Result};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::time::timeout;
+use tracing::{Subscriber, span::Attributes};
+use tracing_subscriber::{Layer, layer::Context as LayerContext, prelude::*, registry::Registry};
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::wasi_blobstore::InMemoryBlobstore,
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+    wit::WitInterface,
+};
+
+const HTTP_BLOBSTORE_WASM: &[u8] = include_bytes!("wasm/http_blobstore.wasm");
+
+/// Layer that appends each new span's name to a shared `Vec`. Pure recorder —
+/// does not filter, so it sees every span regardless of subscriber-level level
+/// filters added by other layers.
+#[derive(Clone, Default)]
+struct SpanNameRecorder {
+    names: Arc<Mutex<Vec<String>>>,
+}
+
+impl<S: Subscriber> Layer<S> for SpanNameRecorder {
+    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &tracing::Id, _ctx: LayerContext<'_, S>) {
+        self.names
+            .lock()
+            .unwrap()
+            .push(attrs.metadata().name().to_string());
+    }
+}
+
+#[tokio::test]
+async fn wasi_blobstore_handlers_emit_namespaced_spans() -> Result<()> {
+    let recorder = SpanNameRecorder::default();
+    let names = recorder.names.clone();
+
+    // Install a global subscriber for this test binary. Only one test in this
+    // file, so no contention with set_global_default.
+    Registry::default()
+        .with(recorder)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_filter(tracing_subscriber::EnvFilter::from_default_env()),
+        )
+        .try_init()
+        .context("failed to install tracing subscriber")?;
+
+    let engine = Engine::builder().build()?;
+    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_plugin.addr();
+    let blobstore_plugin = InMemoryBlobstore::new(None);
+
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_plugin))
+        .with_plugin(Arc::new(blobstore_plugin))?
+        .build()?;
+    let host = host.start().await.context("Failed to start host")?;
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "span-name-workload".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "http-blobstore-component".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_BLOBSTORE_WASM),
+                local_resources: LocalResources {
+                    memory_limit_mb: 256,
+                    cpu_limit: 1,
+                    config: HashMap::new(),
+                    environment: HashMap::new(),
+                    volume_mounts: vec![],
+                    allowed_hosts: Default::default(),
+                },
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces: vec![
+                WitInterface {
+                    namespace: "wasi".to_string(),
+                    package: "http".to_string(),
+                    interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+                    version: Some(semver::Version::parse("0.2.2").unwrap()),
+                    config: {
+                        let mut config = HashMap::new();
+                        config.insert("host".to_string(), "foo".to_string());
+                        config
+                    },
+                    name: None,
+                },
+                WitInterface {
+                    namespace: "wasi".to_string(),
+                    package: "blobstore".to_string(),
+                    interfaces: [
+                        "blobstore".to_string(),
+                        "container".to_string(),
+                        "types".to_string(),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+                    config: HashMap::new(),
+                    name: None,
+                },
+            ],
+            volumes: vec![],
+        },
+    };
+    host.workload_start(req)
+        .await
+        .context("Failed to start workload")?;
+
+    let test_data = "span-naming-payload";
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(5),
+        client
+            .post(format!("http://{addr}/"))
+            .header("HOST", "foo")
+            .body(test_data)
+            .send(),
+    )
+    .await
+    .context("HTTP request timed out")??;
+    assert!(response.status().is_success());
+    let body = response.text().await?;
+    assert_eq!(body.trim(), test_data);
+
+    // The http-blobstore component (see tests/fixtures/http-blobstore/src/lib.rs)
+    // exercises each of these host functions on every request. If any of these
+    // names goes missing, downstream Tempo / Grafana filters that key off the
+    // `wasi.blobstore.*` prefix lose visibility.
+    let captured = names.lock().unwrap().clone();
+    let expected = [
+        "wasi.blobstore.create_container",
+        "wasi.blobstore.new_outgoing_value",
+        "wasi.blobstore.outgoing_value_write_body",
+        "wasi.blobstore.write_data",
+        "wasi.blobstore.finish",
+        "wasi.blobstore.get_data",
+        "wasi.blobstore.incoming_value_consume_async",
+    ];
+    for name in expected {
+        assert!(
+            captured.iter().any(|n| n == name),
+            "expected span {name} was not emitted; captured wasi.blobstore.* spans: {:?}",
+            captured
+                .iter()
+                .filter(|n| n.starts_with("wasi.blobstore."))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    // Catch drift: every wasi.blobstore.* span the run produces must match the
+    // <ns>.<pkg>.<fn> shape. Three dot-separated segments, all lowercase
+    // ASCII / digits / underscores.
+    for n in captured.iter().filter(|n| n.starts_with("wasi.blobstore.")) {
+        let parts: Vec<&str> = n.split('.').collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "span name `{n}` is not <namespace>.<package>.<fn>"
+        );
+        assert!(
+            parts[2]
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+            "span name `{n}` has an unexpected fn segment"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Plugin handler spans were named with just the bare Rust fn (create_container,
get_data, finish, ...), which collided with anything else of the same name
and gave Tempo/Grafana no prefix to filter on. Add an explicit
`name = "<namespace>.<package>.<fn>"` to every #[instrument] on a WIT-bound
handler so dashboards can select e.g. `{ name =~ "wasi.blobstore.*" }`.

- wasi:blobstore (nats, filesystem, in_memory): rename existing spans,
  add instruments to the handlers that were missing them
  (object_info, new_outgoing_value, outgoing_value_write_body in
  filesystem; all 19 handlers in in_memory)
- wasi:keyvalue (nats, redis, in_memory): add #[instrument] across
  store/atomics/batch handlers — previously had none on the non-fs
  backends, so per-op spans never appeared in Tempo at all
- wasi:config, wasi:logging: rename existing spans; add to logging.log
- wasmcloud:messaging, wasmcloud:postgres: rename existing spans

Also fixes an unrelated bug in wasi_keyvalue/nats.rs where `set`
recorded the OTel operation counter as "get".

Adds tests/integration_blobstore_span_names.rs which drives the
http-blobstore fixture end-to-end, captures every span via a custom
tracing Layer, and asserts the expected wasi.blobstore.* spans are
emitted with the right shape — guards against future drift.

Closes #5185
