### PR TITLE
ci(release-tag): dispatch wasmcloud.com on release to bump docs version

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -444,6 +444,23 @@ jobs:
             -f event_type=brew-formula-update \
             -f "client_payload[tag_version]=${VERSION}"
 
+      - name: Dispatch docs version bump
+        # Notifies wasmCloud/wasmcloud.com to bump WASMCLOUD_VERSION in
+        # src/wasmcloud-version.ts and open a PR. Skipped for pre-releases
+        # — the docs always reflect the latest stable. Mirrors the
+        # Homebrew dispatch pattern above; the receiving workflow is
+        # update-version.yml in wasmCloud/wasmcloud.com.
+        if: ${{ !contains(steps.ver.outputs.tag, '-') }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          echo "STAGE=docs-version-bump" >> "${GITHUB_ENV}"
+          gh api repos/wasmCloud/wasmcloud.com/dispatches \
+            -f event_type=wasmcloud-release \
+            -f "client_payload[version]=${VERSION}"
+
       - name: Set stage — winget
         if: ${{ !contains(steps.ver.outputs.tag, '-') }}
         run: echo "STAGE=winget" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Adds a step to `release-tag.yml` that dispatches a `wasmcloud-release` event to `wasmCloud/wasmcloud.com` after the GitHub Release is created, paralleling the existing Homebrew dispatch. The receiving workflow (`update-version.yml` in wasmcloud.com) has been in place but the sending half was never wired up, so the docs site's `WASMCLOUD_VERSION` constant has been getting bumped by hand on each release.