### PR TITLE
release: v2.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7248,7 +7248,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7293,7 +7293,7 @@ dependencies = [
 
 [[package]]
 name = "wash-runtime"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 authors = ["The wasmCloud Team"]
 edition = "2024"
 rust-version = "1.91.0"
-version = "2.2.0"
+version = "2.2.1"
 
 [workspace.lints.rust]
 warnings = 'deny' # Treat all warnings as errors

--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.4.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.2.0"
+appVersion: "2.2.1"


### PR DESCRIPTION
Automated release-train PR for **v2.2.1**.

**Action required:** a maintainer needs to approve this PR. Once required checks pass and approval is recorded, auto-merge fires. After merge, `release-tag.yml` waits for canary builds on `main` to pass and then pushes the immutable `v2.2.1` tag, which the existing tag-triggered workflows pick up.

If CI fails: fix forward and push to this branch, or close this PR. The train does not skip — patch releases out-of-cycle can be triggered via `workflow_dispatch` on `release-train.yml`.
