### PR TITLE
ci(release-tag): pin previous_tag_name when generating release notes

### DIFF
--- a/.github/scripts/generate-release-notes.mjs
+++ b/.github/scripts/generate-release-notes.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Generates the body for a GitHub Release.
+//
+// GitHub's /releases/generate-notes API picks `previous_tag_name` by
+// walking every tag in the repo when not given an explicit one — that
+// includes the non-wasmcloud tag namespaces (wash-cli-v…,
+// runtime-operator/v…, control-interface-v…) and ends up picking the
+// wrong predecessor for the wasmCloud release `v…` series. Compute
+// the predecessor here from the release namespace only and pin it.
+//
+// Tag policy (matches semver release-namespace `vX.Y.Z[-prerelease]`):
+//   - GA `vX.Y.Z`         → previous = immediate semver predecessor.
+//   - RC `vX.Y.Z-rc.N`    → previous = `vX.Y.Z-rc.M` (same X.Y.Z base)
+//                           if present; otherwise empty body.
+//   - other pre-releases  → empty body (alpha/beta/draft/etc. don't
+//     (alpha, beta, …)      get auto-generated notes).
+//
+// Inputs (env):
+//   GH_TOKEN          GitHub PAT (or GITHUB_TOKEN) with `contents: read`.
+//   GITHUB_REPOSITORY owner/repo (set by GHA).
+//   TAG               The release tag being created, e.g. v2.2.0.
+//   MERGE_SHA         The commit being tagged.
+//   GITHUB_ENV        Set by GHA — STAGE marker is appended for the
+//                     failure-notification step downstream.
+//
+// Outputs:
+//   release-notes.md  The body to pass to action-gh-release as body_path.
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, writeFileSync } from 'node:fs';
+
+const RC_RE = /^v(\d+\.\d+\.\d+)-rc\.\d+$/;
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function pickPreviousTag(tag, tags) {
+  const idx = tags.indexOf(tag);
+  if (idx < 0 || idx + 1 >= tags.length) return '';
+
+  const rcMatch = tag.match(RC_RE);
+  if (rcMatch) {
+    // Only chain RCs of the same X.Y.Z base. The immediate successor
+    // in the descending sort is the last tag cut before this one.
+    const base = rcMatch[1];
+    const candidate = tags[idx + 1];
+    const cMatch = candidate.match(RC_RE);
+    return cMatch && cMatch[1] === base ? candidate : '';
+  }
+  if (tag.includes('-')) {
+    // Other pre-release flavors (alpha, beta, draft, etc.) don't chain.
+    return '';
+  }
+  return tags[idx + 1];
+}
+
+async function main() {
+  const token = requireEnv('GH_TOKEN');
+  const repo = requireEnv('GITHUB_REPOSITORY');
+  const tag = requireEnv('TAG');
+  const mergeSha = requireEnv('MERGE_SHA');
+
+  if (process.env.GITHUB_ENV) {
+    appendFileSync(process.env.GITHUB_ENV, 'STAGE=generate-notes\n');
+  }
+
+  // Wasmcloud release tags are `vX.Y.Z[-prerelease]`. The glob filters
+  // out other tag namespaces (their first segment doesn't start `v<digit>`).
+  // `--sort=-version:refname` is git's semver-aware descending sort.
+  const tagsOut = execFileSync(
+    'git',
+    ['tag', '--list', 'v[0-9]*.[0-9]*.[0-9]*', '--sort=-version:refname'],
+    { encoding: 'utf8' },
+  ).trim();
+  const tags = tagsOut.length ? tagsOut.split('\n') : [];
+  const previousTag = pickPreviousTag(tag, tags);
+
+  // Pre-release tags only get a body when there's an in-series RC
+  // predecessor. Anything else with a `-` (alpha/beta/draft/first RC
+  // of a base) ships empty — auto-generated notes from a prior GA
+  // would be noise on an in-progress release.
+  if (tag.includes('-') && !previousTag) {
+    console.log(`pre-release ${tag} has no in-series RC predecessor — empty body`);
+    writeFileSync('release-notes.md', '');
+    return;
+  }
+
+  const body = { tag_name: tag, target_commitish: mergeSha };
+  if (previousTag) {
+    body.previous_tag_name = previousTag;
+    console.log(`previous tag: ${previousTag}`);
+  } else {
+    console.log('no previous tag found — letting the API auto-detect');
+  }
+
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/releases/generate-notes`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) {
+    console.error(`generate-notes API ${res.status}: ${await res.text()}`);
+    process.exit(1);
+  }
+  const data = await res.json();
+  const notes = data.body ?? '';
+  writeFileSync('release-notes.md', notes);
+
+  console.log('--- generated body (first 20 lines) ---');
+  console.log(notes.split('\n').slice(0, 20).join('\n'));
+}
+
+await main();

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -398,6 +398,19 @@ jobs:
           git tag -a "${GO_TAG}" "${MERGE_SHA}" -m "Release ${GO_TAG}"
           git push origin "${GO_TAG}"
 
+      - name: Generate release notes
+        # Picks the previous wasmCloud release tag and pins it as
+        # `previous_tag_name` on the generate-notes API call, so the
+        # auto-detect doesn't pull in tags from unrelated namespaces
+        # (wash-cli-v…, runtime-operator/v…, control-interface-v…).
+        # Body is written to release-notes.md and passed via body_path
+        # below. See .github/scripts/generate-release-notes.mjs.
+        env:
+          GH_TOKEN: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          MERGE_SHA: ${{ steps.ver.outputs.sha }}
+        run: node .github/scripts/generate-release-notes.mjs
+
       - name: Set stage — create-release
         run: echo "STAGE=create-release" >> "${GITHUB_ENV}"
 
@@ -408,21 +421,25 @@ jobs:
         # prerelease so `gh release list` and the GitHub UI don't surface
         # them as the "latest" release.
         #
+        # `body_path` points at the notes computed above; `generate_release_notes`
+        # would auto-pick previous_tag from across every tag namespace in
+        # the repo, which is wrong for this repo's tag layout.
+        #
         # zizmor flags this as `superfluous-actions` (could use `gh release
         # create` directly). Keeping the action: it's SHA-pinned, and a
         # shell equivalent has to re-implement idempotent re-run handling,
-        # release-notes generation, glob fail-on-empty, and prerelease
-        # detection — ~25 lines of bash on a release-critical step.
+        # glob fail-on-empty, and prerelease detection — ~25 lines of bash
+        # on a release-critical step.
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0  # zizmor: ignore[superfluous-actions]
         with:
           name: ${{ steps.ver.outputs.tag }}
           tag_name: ${{ steps.ver.outputs.tag }}
           target_commitish: ${{ steps.ver.outputs.sha }}
+          body_path: release-notes.md
           files: |
             ./artifacts/*/*
           token: ${{ secrets.WASMCLOUD_BOT_PAT }}
           prerelease: ${{ contains(steps.ver.outputs.tag, '-') }}
-          generate_release_notes: true
           fail_on_unmatched_files: true
 
       # Package-manager publishing (homebrew + winget) is best-effort: the


### PR DESCRIPTION
`generate_release_notes: true` on action-gh-release delegated to GitHub's
/releases/generate-notes API without specifying which tag to compute the
diff from. The auto-pick walks every tag namespace in the repo
(wash-cli-v…, runtime-operator/v…, control-interface-v…, plus the
wasmCloud release v… series) and picked a tag well before v2.0.6 as
"previous" for v2.2.0, producing a body with ~84 PRs instead of the ~44
actually merged since v2.1.0.

Add `.github/scripts/generate-release-notes.mjs` (node built-ins only):
read the wasmCloud release tags via `git tag --list 'v[0-9]*.[0-9]*.[0-9]*'
--sort=-version:refname`, find the predecessor of the current tag, and
call generate-notes with `previous_tag_name` pinned.

Tag-type policy:
- GA `vX.Y.Z`: previous = immediate semver predecessor (or empty,
  first-release-ever → API auto-detect).
- RC `vX.Y.Z-rc.N`: previous = `vX.Y.Z-rc.M` (same X.Y.Z base) if
  present in the list; otherwise empty body. Lets a monotonic RC
  chain (rc.1 → rc.2 → rc.3) ship notes showing what changed
  between RCs.
- Anything else with `-` (alpha, beta, draft, prealpha, …): empty
  body. Auto-generated diffs against a prior GA are noise on an
  in-progress release.

action-gh-release now takes `body_path: release-notes.md` instead of
`generate_release_notes: true`.