### PR TITLE
ci: unblock off-cycle dispatch and de-flake gates

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -67,7 +67,7 @@ jobs:
   gate:
     needs:
       - cargo-audit
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -50,7 +50,7 @@ jobs:
   gate:
     needs:
       - test
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -151,7 +151,7 @@ jobs:
       - plan
       - coverage
       - build
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -82,7 +82,7 @@ jobs:
     needs:
       - actionlint
       - zizmor
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -82,7 +82,7 @@ jobs:
     needs:
       - lint
       - check-generated
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -519,17 +519,23 @@ jobs:
     # release-train's own gate skipped the release job (skipped jobs roll
     # up as `success`, so workflow_run still triggers). Without this gate,
     # release-tag fires every Tuesday and fails noisily in verify-head.
-    # workflow_dispatch always proceeds (recovery hatch).
+    # workflow_dispatch always proceeds — both when release-tag itself is
+    # dispatched (recovery hatch) and when the triggering release-train
+    # was dispatched (off-cycle patch). The latter is the only signal we
+    # have that the upstream was a manual run; without it, an off-cycle
+    # dispatch on an even-parity week would silently skip promote.
     runs-on: ubuntu-latest
     outputs:
       run: ${{ steps.gate.outputs.run }}
     steps:
       - name: ISO-week parity gate
         id: gate
+        env:
+          UPSTREAM_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "manual dispatch — bypassing every-two-weeks gate"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${UPSTREAM_EVENT}" == "workflow_dispatch" ]]; then
+            echo "manual dispatch (this workflow or upstream release-train) — bypassing every-two-weeks gate"
             echo "run=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi

--- a/.github/workflows/runtime-gateway.yml
+++ b/.github/workflows/runtime-gateway.yml
@@ -71,7 +71,7 @@ jobs:
     needs:
       - lint
       - test
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped

--- a/.github/workflows/runtime-operator.yml
+++ b/.github/workflows/runtime-operator.yml
@@ -162,7 +162,7 @@ jobs:
       - test
       - build
       - test-e2e
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -160,7 +160,7 @@ jobs:
       - plan
       - coverage
       - build
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -204,7 +204,7 @@ jobs:
     needs:
       - test-bash-install
       - test-powershell-install
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -394,7 +394,7 @@ jobs:
       - runtime-operator-e2e
       - canary-publish
       - canary-binaries
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped

--- a/.github/workflows/wit.yml
+++ b/.github/workflows/wit.yml
@@ -301,15 +301,18 @@ jobs:
 
   # Single pass/fail signal for required-check enforcement. Sits at the
   # bottom so the dependency list mirrors the visual job order, and
-  # `if: always()` ensures it runs whether upstream jobs passed, failed,
-  # or got skipped (e.g. publish skips on PR events — that's "skipped",
-  # not failure). The bash check rejects only failure/cancelled.
+  # `if: !cancelled()` ensures it runs whether upstream jobs passed,
+  # failed, or got skipped (e.g. publish skips on PR events — that's
+  # "skipped", not failure). The bash check rejects only failure/cancelled.
+  # Workflow-level cancellation (e.g. concurrency cancel-in-progress)
+  # skips the gate entirely so it doesn't post a phantom failure when a
+  # newer run will report the real verdict on the same SHA.
   gate:
     needs:
       - changes
       - validate
       - publish
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all jobs to pass or be skipped


### PR DESCRIPTION
release-train PR #5190 (v2.2.1) failed because the `examples` workflow
double-triggered on PR-create-with-label: GitHub fires `opened` and
`labeled` near-simultaneously, examples.yml's `cancel-in-progress: true`
group cancelled the first run, and the cancelled run's `gate` (if:
always()) still ran and reported "failure" because needs.*.result was
all "cancelled". `gh pr checks --watch --fail-fast --required` tripped
on that phantom failure, release-train exited 1, and release-tag then
skipped `promote` via `workflow_run.conclusion != 'success'`.

Two fixes:

- release-tag's ISO-week gate now also bypasses when the triggering
  release-train was itself workflow_dispatch (off-cycle patch).

- All 11 workflows using the `gate: needs: [...]; if: always()` pattern
  (audit, charts, examples, lint-workflows, proto, runtime-gateway,
  runtime-operator, templates, test-install-scripts, wash, wit) now use
  `if: ${{ !cancelled() }}`. Workflow-level cancellation (concurrency,
  user, timeout) skips the gate instead of posting a phantom failure;
  individual job cancellations still fail the gate via the existing
  RESULTS check.
