### PR TITLE
feat: more flexible hosts creation in the runtime-operator helm chart

### DIFF
--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -62,6 +62,10 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .otel.endpoint }}
             {{- end }}
+            {{- range .extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
           args:
             {{- if .logLevel }}
             - "--log-level={{ .logLevel }}"
@@ -98,6 +102,9 @@ spec:
             {{- end }}
             {{- if and (.otel) (.otel.enabled) }}
             - "--wasi-otel"
+            {{- end }}
+            {{- range .extraArgs }}
+            - "{{ . }}"
             {{- end }}
           imagePullPolicy: {{ $top.Values.runtime.image.pull_policy }}
           volumeMounts:

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -58,9 +58,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if and (.otel) (.otel.enabled) }}
+            {{- if and (and (.otel) (.otel.enabled)) (.otel.endpoint) }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .otel.endpoint }}
+            {{- end }}
+            {{- if and (and (.otel) (.otel.enabled)) (.otel.protocol) }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .otel.protocol }}
             {{- end }}
             {{- range .extraEnv }}
             - name: {{ .name }}

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -58,6 +58,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if and (.otel) (.otel.enabled) }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .otel.endpoint }}
+            {{- end }}
           args:
             {{- if .logLevel }}
             - "--log-level={{ .logLevel }}"
@@ -91,6 +95,9 @@ spec:
             {{- end }}
             {{- if and (.wasip3) (.wasip3.enabled) }}
             - "--wasip3"
+            {{- end }}
+            {{- if and (.otel) (.otel.enabled) }}
+            - "--wasi-otel"
             {{- end }}
           imagePullPolicy: {{ $top.Values.runtime.image.pull_policy }}
           volumeMounts:

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -154,6 +154,7 @@ runtime:
       otel:
         enabled: false
         endpoint: ""
+        protocol: ""
       http:
         enabled: true
         port: 9191

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -151,6 +151,9 @@ runtime:
         enabled: false
       wasip3:
         enabled: false
+      otel:
+        enabled: false
+        endpoint: ""
       http:
         enabled: true
         port: 9191

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -175,6 +175,18 @@ runtime:
               # -- List of DNS Subject Alternative Names (SANs) for the generated TLS certificate.
               # Example: ["myapp.example.com", "myapp.default.svc.cluster.local"]
               domains: []
+        # Additional args to pass host process
+        # E.g.
+        # extrArgs:
+        #   - "--verbose"
+        #   - "--allow-insecure-registries"
+        extraArgs: []
+        # Additional environment variables to set in the host container
+        # E.g. 
+        # extraEnv:
+        #   - name: MY_ENV_VAR
+        #     value: my-value
+        extraEnv: []
       resources:
         requests:
           memory: "64Mi"


### PR DESCRIPTION
# Summary

I did minor modifications to the runtime-operator Helm chart to make the creation of hosts deployments more flexible:
- add possibilty to enable the `otel` plugin and configure the default endpoint through Helm values
- add `extraArgs` and `extraEnv` Helm values to pass custom args and environment variables to the host container