### PR TITLE
wasi-otel rc2

### DIFF
--- a/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
@@ -1,6 +1,6 @@
 //! # WASI OpenTelemetry Plugin
 //! This module implements an OpenTelemetry plugin for the wasmCloud runtime,
-//! providing the `wasi:otel@0.2.0-rc.1` interfaces.
+//! providing the `wasi:otel@0.2.0-rc.2` interfaces.
 
 mod convert;
 
@@ -117,7 +117,7 @@ impl HostPlugin for WasiOtel {
     fn world(&self) -> WitWorld {
         WitWorld {
             imports: HashSet::from([WitInterface::from(
-                "wasi:otel/types,tracing,metrics,logs@0.2.0-rc.1",
+                "wasi:otel/types,tracing,metrics,logs@0.2.0-rc.2",
             )]),
             ..Default::default()
         }

--- a/crates/wash-runtime/wit/deps/wasi-otel-0.2.0-rc.2/package.wit
+++ b/crates/wash-runtime/wit/deps/wasi-otel-0.2.0-rc.2/package.wit
@@ -1,4 +1,4 @@
-package wasi:otel@0.2.0-rc.1;
+package wasi:otel@0.2.0-rc.2;
 
 interface types {
   /// The key part of attribute `key-value` pairs.
@@ -8,6 +8,10 @@ interface types {
   ///
   /// This corresponds with the `AnyValue` type defined in the [attribute spec](https://opentelemetry.io/docs/specs/otel/common/#anyvalue).
   /// Because WIT doesn't support recursive types, the data needs to be serialized. JSON is used as the encoding format.
+  ///
+  /// Byte arrays require special encoding since JSON cannot distinguish them from number arrays.
+  /// They are base64-encoded with a prefix that follows the Data URI RFC 2397 convention:
+  /// `data:application/octet-stream;base64,<BASE64_ENCODED_BYTES>`
   type value = string;
 
   /// A key-value pair describing an attribute.

--- a/crates/wash-runtime/wit/world.wit
+++ b/crates/wash-runtime/wit/world.wit
@@ -39,8 +39,8 @@ world postgres {
 
 
 world otel {
-    import wasi:otel/types@0.2.0-rc.1;
-    import wasi:otel/tracing@0.2.0-rc.1;
-    import wasi:otel/metrics@0.2.0-rc.1;
-    import wasi:otel/logs@0.2.0-rc.1;
+    import wasi:otel/types@0.2.0-rc.2;
+    import wasi:otel/tracing@0.2.0-rc.2;
+    import wasi:otel/metrics@0.2.0-rc.2;
+    import wasi:otel/logs@0.2.0-rc.2;
 }

--- a/crates/wash-runtime/wkg.lock
+++ b/crates/wash-runtime/wkg.lock
@@ -52,9 +52,9 @@ name = "wasi:otel"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.2.0-rc.1"
-version = "0.2.0-rc.1"
-digest = "sha256:4f4969ab60f39ca84830fe654e51e2bf852097eafb79626f616cd2fba11fdd54"
+requirement = "=0.2.0-rc.2"
+version = "0.2.0-rc.2"
+digest = "sha256:cd1c073a1875e04072951871a2c29d1725d15d0e824a9e4c2ae730810eab1c54"
 
 [[packages]]
 name = "wasmcloud:messaging"

--- a/examples/otel-config/.wash/config.yaml
+++ b/examples/otel-config/.wash/config.yaml
@@ -3,10 +3,14 @@ build:
   component_path: target/wasm32-wasip2/release/otel_config.wasm
 
 dev:
+  address: 0.0.0.0:8001
   wasi_blobstore_path: tmp/blobstore
   wasi_keyvalue_path: tmp/keyvalue
   wasi_otel: true
   environment:
+    # Matches the .NET Aspire standalone dashboard's OTLP gRPC port (18889).
+    # See the demo page rendered by this component for a one-line
+    # `docker run` recipe.
     OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:18889
 
 # Workload-level configuration delivered to the component at runtime.

--- a/examples/otel-config/config/defaults.env
+++ b/examples/otel-config/config/defaults.env
@@ -4,4 +4,4 @@
 LOG_LEVEL=info
 SERVICE_NAME=otel-config-dev
 OUTBOUND_HOST=example.com
-request_timeout_ms=5000
+REQUEST_TIMEOUT_MS=5000

--- a/examples/otel-config/src/blobstore.rs
+++ b/examples/otel-config/src/blobstore.rs
@@ -1,0 +1,46 @@
+//! Blobstore helper for stashing the fetched response body.
+
+use anyhow::{Context, Result, anyhow};
+
+use crate::bindings::wasi::blobstore::{
+    blobstore::{Container, create_container, get_container},
+    types::OutgoingValue,
+};
+
+pub(crate) const CONTAINER_NAME: &str = "http-responses";
+pub(crate) const OBJECT_KEY: &str = "example-com-response";
+
+pub(crate) fn store_response_in_blobstore(body: &[u8]) -> Result<()> {
+    let container = open_or_create_container(CONTAINER_NAME)?;
+
+    let outgoing = OutgoingValue::new_outgoing_value();
+    let stream = outgoing
+        .outgoing_value_write_body()
+        .map_err(|()| anyhow!("failed to open blobstore output stream"))?;
+    stream
+        .blocking_write_and_flush(body)
+        .context("failed to write blob bytes")?;
+    drop(stream);
+
+    container
+        .write_data(OBJECT_KEY, &outgoing)
+        .map_err(|e| anyhow!("failed to write blob {OBJECT_KEY}: {e}"))?;
+    OutgoingValue::finish(outgoing).map_err(|e| anyhow!("failed to finish blob value: {e}"))?;
+    Ok(())
+}
+
+/// Try to open the container; if that fails, log the original error and
+/// attempt to create it. Logging the original keeps an auth/transport failure
+/// visible instead of being silently masked by a subsequent create failure.
+fn open_or_create_container(name: &str) -> Result<Container> {
+    match get_container(name) {
+        Ok(c) => Ok(c),
+        Err(get_err) => {
+            eprintln!(
+                "blobstore get_container({name}) failed: {get_err}; attempting create_container"
+            );
+            create_container(name)
+                .map_err(|e| anyhow!("failed to create blobstore container {name}: {e}"))
+        }
+    }
+}

--- a/examples/otel-config/src/config.rs
+++ b/examples/otel-config/src/config.rs
@@ -1,0 +1,86 @@
+//! Per-request app config sourced from `wasi:config/store` (populated by
+//! `workload.environment.{configFrom,secretFrom}` in `.wash/config.yaml`).
+
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use wstd::time::Duration;
+
+use crate::bindings::wasi::config::store::get_all;
+use crate::otel::{TraceFlags, otel_log};
+
+const DEFAULT_OUTBOUND_HOST: &str = "example.com";
+const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 5_000;
+
+/// OTLP endpoint to display in the demo UI. Matches the
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` value set by `.wash/config.yaml` and the
+/// .NET Aspire dashboard's gRPC port. Guest components can't currently read
+/// process env back out, so this is a static label rather than a live read.
+const DISPLAY_OTLP_ENDPOINT: &str = "http://localhost:18889";
+
+pub(crate) fn otlp_endpoint() -> &'static str {
+    DISPLAY_OTLP_ENDPOINT
+}
+
+pub(crate) struct AppConfig {
+    pub(crate) outbound_url: String,
+    pub(crate) request_timeout: Duration,
+    pub(crate) upstream_api_token: Option<String>,
+}
+
+static APP_CONFIG: OnceLock<AppConfig> = OnceLock::new();
+
+pub(crate) fn app_config() -> &'static AppConfig {
+    APP_CONFIG.get_or_init(build_app_config)
+}
+
+fn build_app_config() -> AppConfig {
+    let mut entries: BTreeMap<String, String> = BTreeMap::new();
+    if let Ok(config) = get_all() {
+        for (k, v) in config {
+            entries.insert(k, v);
+        }
+    }
+    let outbound_host = entries
+        .get("OUTBOUND_HOST")
+        .map(String::as_str)
+        .unwrap_or(DEFAULT_OUTBOUND_HOST);
+    let timeout_ms = entries
+        .get("REQUEST_TIMEOUT_MS")
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_REQUEST_TIMEOUT_MS);
+    AppConfig {
+        outbound_url: format!("https://{outbound_host}/"),
+        request_timeout: Duration::from_millis(timeout_ms),
+        upstream_api_token: entries.get("UPSTREAM_API_TOKEN").cloned(),
+    }
+}
+
+/// One-shot startup audit: emit a single OTel log line listing every
+/// `wasi:config/store` key visible to the component. **Keys only**,
+/// values are deliberately not included because secret values
+/// (`workload.environment.secretFrom` entries) land in this same map.
+///
+/// Latch is set only on success, so a transient cold-start failure of
+/// `wasi:config` does not permanently silence the audit log.
+pub(crate) fn log_runtime_config(trace_id: &str, span_id: &str, flags: TraceFlags) {
+    static LOGGED: AtomicBool = AtomicBool::new(false);
+    if LOGGED.load(Ordering::Relaxed) {
+        return;
+    }
+    let keys: Vec<String> = match get_all() {
+        Ok(entries) => entries.into_iter().map(|(k, _)| k).collect(),
+        Err(e) => {
+            eprintln!("warning: failed to read wasi:config/store: {e:?}");
+            return;
+        }
+    };
+    otel_log(
+        &format!("wasi:config keys: {}", keys.join(", ")),
+        trace_id,
+        span_id,
+        flags,
+    );
+    LOGGED.store(true, Ordering::Relaxed);
+}

--- a/examples/otel-config/src/keyvalue.rs
+++ b/examples/otel-config/src/keyvalue.rs
@@ -1,0 +1,12 @@
+//! Keyvalue helper for the request counter.
+
+use anyhow::{Context, Result, anyhow};
+
+use crate::bindings::wasi::keyvalue::{atomics::increment, store::open};
+
+pub(crate) const COUNTER_KEY: &str = "request-count";
+
+pub(crate) fn increment_counter() -> Result<u64> {
+    let bucket = open("").map_err(|e| anyhow!("failed to open keyvalue bucket: {e:?}"))?;
+    increment(&bucket, COUNTER_KEY, 1).context("failed to increment counter")
+}

--- a/examples/otel-config/src/lib.rs
+++ b/examples/otel-config/src/lib.rs
@@ -1,20 +1,18 @@
 //! `OTel` config example.
 //!
-//! Handles an incoming HTTP request, fetches `https://example.com`, stashes
+//! Handles an incoming HTTP request, fetches the configured upstream, stashes
 //! the body in a blob, increments a request counter, and exports the whole
 //! flow through `wasi:otel/{tracing,logs,metrics}`, including W3C trace
 //! context propagation on the outbound call. The OTel `Resource` is built
 //! from `wasi:config` (`otel.resource.*` keys).
 //!
-//! The reusable OTel scaffolding (cached resource/scope, [`otel_log`],
-//! [`ActiveSpan`] RAII guard) lives in [`mod@otel`].
+//! The reusable OTel scaffolding (cached resource/scope, [`otel::otel_log`],
+//! [`otel::ActiveSpan`] RAII guard, and all `wasi:otel` bindings re-exports)
+//! lives in [`mod@otel`]. Per-capability helpers live in their own modules
+//! (`config`, `outbound`, `blobstore`, `keyvalue`, `metrics`, `ui`).
 
-use std::collections::BTreeMap;
-use std::sync::OnceLock;
-
-use anyhow::{Context, Result, anyhow, bail};
-use wstd::http::{Body, Client, HeaderValue, Request, Response, StatusCode};
-use wstd::time::Duration;
+use anyhow::{Error, Result};
+use wstd::http::{Body, Request, Response, StatusCode};
 
 mod bindings {
     wit_bindgen::generate!({
@@ -24,106 +22,64 @@ mod bindings {
     });
 }
 
+mod blobstore;
+mod config;
+mod keyvalue;
+mod metrics;
 mod otel;
+mod outbound;
+mod ui;
 
-use bindings::wasi::blobstore::{
-    blobstore::{create_container, get_container},
-    types::OutgoingValue,
-};
-use bindings::wasi::config::store::get_all;
-use bindings::wasi::keyvalue::{atomics::increment, store::open};
-use bindings::wasi::otel as otel_bindings;
+use blobstore::{CONTAINER_NAME, OBJECT_KEY, store_response_in_blobstore};
+use config::{app_config, log_runtime_config, otlp_endpoint};
+use keyvalue::{COUNTER_KEY, increment_counter};
+use metrics::export_metrics;
 use otel::{
-    ActiveSpan, Event, SpanKind, TraceFlags, component_start, kv_num, kv_str, new_trace_id, now,
-    otel_log, outer_span_context, resource, scope, traceparent,
+    ActiveSpan, Event, SpanKind, TraceFlags, kv_num, kv_str, new_trace_id, now, otel_log,
+    outer_span_context,
 };
+use outbound::make_outgoing_request;
 
-const CONTAINER_NAME: &str = "http-responses";
-const OBJECT_KEY: &str = "example-com-response";
-const COUNTER_KEY: &str = "request-count";
-
-// Defaults applied if the corresponding `wasi:config` key is absent.
-const DEFAULT_OUTBOUND_HOST: &str = "example.com";
-const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 5_000;
-
-/// Per-request app config sourced from `wasi:config/store` (populated by
-/// `workload.environment.{configFrom,secretFrom}` in `.wash/config.yaml`).
-/// Built once on the first request and cached.
-struct AppConfig {
+/// Everything the response renderer needs to draw the demo page.
+struct Outcome {
+    count: u64,
+    response_len: usize,
     outbound_url: String,
-    request_timeout: Duration,
-    upstream_api_token: Option<String>,
-}
-
-static APP_CONFIG: OnceLock<AppConfig> = OnceLock::new();
-
-fn app_config() -> &'static AppConfig {
-    APP_CONFIG.get_or_init(build_app_config)
-}
-
-fn build_app_config() -> AppConfig {
-    let mut entries: BTreeMap<String, String> = BTreeMap::new();
-    if let Ok(config) = get_all() {
-        for (k, v) in config {
-            entries.insert(k, v);
-        }
-    }
-    let outbound_host = entries
-        .get("OUTBOUND_HOST")
-        .map(String::as_str)
-        .unwrap_or(DEFAULT_OUTBOUND_HOST);
-    let timeout_ms = entries
-        .get("request_timeout_ms")
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(DEFAULT_REQUEST_TIMEOUT_MS);
-    AppConfig {
-        outbound_url: format!("https://{outbound_host}/"),
-        request_timeout: Duration::from_millis(timeout_ms),
-        upstream_api_token: entries.get("UPSTREAM_API_TOKEN").cloned(),
-    }
-}
-
-/// One-shot startup audit: emit a single OTel log line listing every
-/// `wasi:config/store` key visible to the component. **Keys only**,
-/// values are deliberately not included because secret values
-/// (`workload.environment.secretFrom` entries) land in this same map.
-fn log_runtime_config(trace_id: &str, span_id: &str, flags: TraceFlags) {
-    static LOGGED: OnceLock<()> = OnceLock::new();
-    LOGGED.get_or_init(|| {
-        let keys: Vec<String> = match get_all() {
-            Ok(entries) => entries.into_iter().map(|(k, _)| k).collect(),
-            Err(e) => {
-                eprintln!("warning: failed to read wasi:config/store: {e:?}");
-                return;
-            }
-        };
-        otel_log(
-            &format!("wasi:config keys: {}", keys.join(", ")),
-            trace_id,
-            span_id,
-            flags,
-        );
-    });
+    trace_id: String,
+    request_span_id: String,
 }
 
 #[wstd::http_server]
 async fn main(_request: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
-    match handle_request().await {
-        Ok(count) => Response::builder()
-            .status(StatusCode::OK)
-            .body(Body::from(count))
-            .map_err(Into::into),
+    let (status, body) = match handle_request().await {
+        Ok(outcome) => {
+            let page = ui::render_page(&ui::PageData {
+                count: outcome.count,
+                response_len: outcome.response_len,
+                outbound_url: &outcome.outbound_url,
+                trace_id: &outcome.trace_id,
+                span_id: &outcome.request_span_id,
+                otlp_endpoint: otlp_endpoint(),
+            });
+            (StatusCode::OK, page)
+        }
         Err(e) => {
             eprintln!("error processing request: {e:?}");
-            Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Body::from(format!("Internal server error: {e}")))
-                .map_err(Into::into)
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ui::render_error(&format!("{e:#}")),
+            )
         }
-    }
+    };
+
+    Response::builder()
+        .status(status)
+        .header("content-type", "text/html; charset=utf-8")
+        .body(Body::from(body))
+        .map_err(Into::into)
 }
 
-async fn handle_request() -> Result<String> {
+async fn handle_request() -> Result<Outcome> {
     // Continue the host-provided trace if there is one; otherwise root a fresh
     // trace. Inherit the upstream sampling decision so we don't override a
     // host that asked us not to record.
@@ -152,205 +108,130 @@ async fn handle_request() -> Result<String> {
         flags,
     );
 
+    match handle_request_steps(&trace_id, &request_span_id, flags).await {
+        Ok((count, response_len, outbound_url)) => {
+            // Parent SERVER span carries summary attributes + a completion event.
+            request_span.finish_ok_with(
+                vec![kv_num("request.count", count)],
+                vec![Event {
+                    name: "request.completed".into(),
+                    time: now(),
+                    attributes: vec![kv_num("response.bytes", response_len)],
+                }],
+            );
+
+            otel_log(
+                &format!("request complete, count: {count}"),
+                &trace_id,
+                &request_span_id,
+                flags,
+            );
+
+            export_metrics(count, response_len, &outbound_url);
+            Ok(Outcome {
+                count,
+                response_len,
+                outbound_url,
+                trace_id,
+                request_span_id,
+            })
+        }
+        Err(e) => {
+            request_span.finish_err(format!("{e:#}"));
+            Err(e)
+        }
+    }
+}
+
+/// Inner workhorse: runs the http → blob → keyvalue chain, marking each
+/// child span as either `Ok` or `Err(message)` so the trace carries the real
+/// cause instead of the generic "exited via early return" message.
+async fn handle_request_steps(
+    trace_id: &str,
+    parent_span_id: &str,
+    flags: TraceFlags,
+) -> Result<(u64, usize, String)> {
+    let outbound_url = app_config().outbound_url.clone();
+
     // Outgoing http child CLIENT span, traceparent injected on the wire.
-    let outbound_url = &app_config().outbound_url;
     let http_span = ActiveSpan::start(
-        &trace_id,
+        trace_id,
         flags,
-        &request_span_id,
+        parent_span_id,
         SpanKind::Client,
         "outgoing http",
     );
     let http_span_id = http_span.span_id().to_owned();
-    let body_bytes = make_outgoing_request(&trace_id, &http_span_id, flags).await?;
+    let body_bytes = finish_span_with_result(
+        http_span,
+        make_outgoing_request(trace_id, &http_span_id, flags).await,
+        |b| {
+            vec![
+                kv_str("http.request.method", "GET"),
+                kv_str("url.full", &outbound_url),
+                kv_num("http.response.body.size", b.len()),
+            ]
+        },
+    )?;
     let response_len = body_bytes.len();
-    http_span.finish_ok(vec![
-        kv_str("http.request.method", "GET"),
-        kv_str("url.full", outbound_url),
-        kv_num("http.response.body.size", response_len),
-    ]);
 
     otel_log(
         &format!("retrieved {response_len} bytes from {outbound_url}"),
-        &trace_id,
-        &request_span_id,
+        trace_id,
+        parent_span_id,
         flags,
     );
 
     // Blobstore write — child CLIENT span.
     let blob_span = ActiveSpan::start(
-        &trace_id,
+        trace_id,
         flags,
-        &request_span_id,
+        parent_span_id,
         SpanKind::Client,
         "blobstore write",
     );
-    store_response_in_blobstore(&body_bytes)?;
-    blob_span.finish_ok(vec![
-        kv_str("blobstore.container", CONTAINER_NAME),
-        kv_str("blobstore.object", OBJECT_KEY),
-        kv_num("blobstore.object.size", response_len),
-    ]);
+    finish_span_with_result(blob_span, store_response_in_blobstore(&body_bytes), |()| {
+        vec![
+            kv_str("blobstore.container", CONTAINER_NAME),
+            kv_str("blobstore.object", OBJECT_KEY),
+            kv_num("blobstore.object.size", response_len),
+        ]
+    })?;
 
     // Keyvalue increment child CLIENT span.
     let kv_span = ActiveSpan::start(
-        &trace_id,
+        trace_id,
         flags,
-        &request_span_id,
+        parent_span_id,
         SpanKind::Client,
         "keyvalue increment",
     );
-    let count = increment_counter()?;
-    kv_span.finish_ok(vec![
-        kv_str("keyvalue.key", COUNTER_KEY),
-        kv_num("keyvalue.result", count),
-    ]);
-
-    // Parent SERVER span carries summary attributes + a completion event.
-    request_span.finish_ok_with(
-        vec![kv_num("request.count", count)],
-        vec![Event {
-            name: "request.completed".into(),
-            time: now(),
-            attributes: vec![kv_num("response.bytes", response_len)],
-        }],
-    );
-
-    otel_log(
-        &format!("request complete, count: {count}"),
-        &trace_id,
-        &request_span_id,
-        flags,
-    );
-
-    export_metrics(count, response_len);
-    Ok(count.to_string())
-}
-
-fn export_metrics(count: u64, response_len: usize) {
-    use otel_bindings::metrics::{
-        Gauge, GaugeDataPoint, Metric, MetricData, MetricNumber, ResourceMetrics, ScopeMetrics,
-        Sum, SumDataPoint, Temporality, export,
-    };
-
-    let metric_time = now();
-    let start_time = component_start();
-    let _ = export(&ResourceMetrics {
-        resource: resource().clone(),
-        scope_metrics: vec![ScopeMetrics {
-            scope: scope().clone(),
-            metrics: vec![
-                Metric {
-                    name: "http.server.request_count".into(),
-                    description: "Total number of HTTP requests handled".into(),
-                    unit: "{request}".into(),
-                    data: MetricData::U64Sum(Sum {
-                        data_points: vec![SumDataPoint {
-                            attributes: vec![],
-                            value: MetricNumber::U64(count),
-                            exemplars: vec![],
-                        }],
-                        // Per OTel spec, the first cumulative observation may
-                        // legitimately carry start_time == time; subsequent
-                        // exports keep the same start_time.
-                        start_time,
-                        time: metric_time,
-                        temporality: Temporality::Cumulative,
-                        is_monotonic: true,
-                    }),
-                },
-                Metric {
-                    name: "http.server.response_body.size".into(),
-                    description: "Size of the fetched HTTP response body".into(),
-                    unit: "By".into(),
-                    data: MetricData::U64Gauge(Gauge {
-                        data_points: vec![GaugeDataPoint {
-                            attributes: vec![kv_str("http.target", &app_config().outbound_url)],
-                            value: MetricNumber::U64(response_len as u64),
-                            exemplars: vec![],
-                        }],
-                        start_time: Some(start_time),
-                        time: metric_time,
-                    }),
-                },
-            ],
-        }],
-    });
-}
-
-async fn make_outgoing_request(
-    trace_id: &str,
-    span_id: &str,
-    flags: TraceFlags,
-) -> Result<Vec<u8>> {
-    let cfg = app_config();
-    let mut client = Client::new();
-    client.set_first_byte_timeout(cfg.request_timeout);
-    client.set_between_bytes_timeout(cfg.request_timeout);
-
-    let header = traceparent(trace_id, span_id, flags);
-    let mut builder = Request::get(&cfg.outbound_url).header(
-        "traceparent",
-        HeaderValue::from_str(&header).context("invalid traceparent header")?,
-    );
-
-    // Attach the upstream API token from `secrets.upstream-credentials`.
-    // Missing-token paths still work but skip the auth header so the example
-    // is exercisable without setting `UPSTREAM_API_TOKEN`.
-    if let Some(token) = cfg.upstream_api_token.as_deref() {
-        builder = builder.header(
-            "authorization",
-            HeaderValue::from_str(&format!("Bearer {token}"))
-                .context("invalid authorization header")?,
-        );
-    }
-
-    let request = builder
-        .body(Body::empty())
-        .context("failed to build outgoing request")?;
-
-    let response = client
-        .send(request)
-        .await
-        .context("outgoing request failed")?;
-
-    let status = response.status();
-    if !status.is_success() {
-        bail!("non-success status from {}: {status}", cfg.outbound_url);
-    }
-
-    let mut body = response.into_body();
-    let bytes = body
-        .contents()
-        .await
-        .context("failed to read response body")?
-        .to_vec();
-    Ok(bytes)
-}
-
-fn store_response_in_blobstore(body: &[u8]) -> Result<()> {
-    let container = get_container(CONTAINER_NAME).or_else(|_| {
-        create_container(CONTAINER_NAME)
-            .map_err(|e| anyhow!("failed to create blobstore container {CONTAINER_NAME}: {e}"))
+    let count = finish_span_with_result(kv_span, increment_counter(), |count| {
+        vec![
+            kv_str("keyvalue.key", COUNTER_KEY),
+            kv_num("keyvalue.result", *count),
+        ]
     })?;
 
-    let outgoing = OutgoingValue::new_outgoing_value();
-    let stream = outgoing
-        .outgoing_value_write_body()
-        .map_err(|()| anyhow!("failed to open blobstore output stream"))?;
-    stream
-        .blocking_write_and_flush(body)
-        .context("failed to write blob bytes")?;
-    drop(stream);
-
-    container
-        .write_data(OBJECT_KEY, &outgoing)
-        .map_err(|e| anyhow!("failed to write blob {OBJECT_KEY}: {e}"))?;
-    OutgoingValue::finish(outgoing).map_err(|e| anyhow!("failed to finish blob value: {e}"))?;
-    Ok(())
+    Ok((count, response_len, outbound_url))
 }
 
-fn increment_counter() -> Result<u64> {
-    let bucket = open("").map_err(|e| anyhow!("failed to open keyvalue bucket: {e:?}"))?;
-    increment(&bucket, COUNTER_KEY, 1).context("failed to increment counter")
+/// Settle `span` based on `result`: on `Ok`, attach `ok_attrs(&value)` and
+/// mark `Status::Ok`; on `Err`, record the error message on the span before
+/// returning the error to the caller.
+fn finish_span_with_result<T>(
+    span: ActiveSpan,
+    result: Result<T>,
+    ok_attrs: impl FnOnce(&T) -> Vec<otel::KeyValue>,
+) -> Result<T> {
+    match result {
+        Ok(v) => {
+            span.finish_ok(ok_attrs(&v));
+            Ok(v)
+        }
+        Err(e) => {
+            span.finish_err(format!("{e:#}"));
+            Err::<T, Error>(e)
+        }
+    }
 }

--- a/examples/otel-config/src/metrics.rs
+++ b/examples/otel-config/src/metrics.rs
@@ -1,0 +1,53 @@
+//! OTel metrics export for the request handler.
+
+use crate::otel::{
+    Gauge, GaugeDataPoint, Metric, MetricData, MetricNumber, ResourceMetrics, ScopeMetrics, Sum,
+    SumDataPoint, Temporality, component_start, export_metrics_bindings, kv_str, now, resource,
+    scope,
+};
+
+pub(crate) fn export_metrics(count: u64, response_len: usize, outbound_url: &str) {
+    // Seed the cumulative start time BEFORE sampling `metric_time`, so on the
+    // first export `start_time <= time` holds (OTel spec invariant for
+    // cumulative sums).
+    let start_time = component_start();
+    let metric_time = now();
+    let _ = export_metrics_bindings(&ResourceMetrics {
+        resource: resource().clone(),
+        scope_metrics: vec![ScopeMetrics {
+            scope: scope().clone(),
+            metrics: vec![
+                Metric {
+                    name: "http.server.request_count".into(),
+                    description: "Total number of HTTP requests handled".into(),
+                    unit: "{request}".into(),
+                    data: MetricData::U64Sum(Sum {
+                        data_points: vec![SumDataPoint {
+                            attributes: vec![],
+                            value: MetricNumber::U64(count),
+                            exemplars: vec![],
+                        }],
+                        start_time,
+                        time: metric_time,
+                        temporality: Temporality::Cumulative,
+                        is_monotonic: true,
+                    }),
+                },
+                Metric {
+                    name: "http.server.response_body.size".into(),
+                    description: "Size of the fetched HTTP response body".into(),
+                    unit: "By".into(),
+                    data: MetricData::U64Gauge(Gauge {
+                        data_points: vec![GaugeDataPoint {
+                            attributes: vec![kv_str("http.target", outbound_url)],
+                            value: MetricNumber::U64(response_len as u64),
+                            exemplars: vec![],
+                        }],
+                        start_time: Some(start_time),
+                        time: metric_time,
+                    }),
+                },
+            ],
+        }],
+    });
+}

--- a/examples/otel-config/src/otel.rs
+++ b/examples/otel-config/src/otel.rs
@@ -16,9 +16,14 @@ use crate::bindings::wasi::{
     clocks::wall_clock, config::store::get_all, otel, random::random::get_random_bytes,
 };
 
+pub(crate) use crate::bindings::wasi::otel::metrics::{
+    Gauge, GaugeDataPoint, Metric, MetricData, MetricNumber, ResourceMetrics, ScopeMetrics, Sum,
+    SumDataPoint, Temporality, export as export_metrics_bindings,
+};
 pub(crate) use crate::bindings::wasi::otel::tracing::{
     Event, SpanKind, TraceFlags, outer_span_context,
 };
+pub(crate) use crate::bindings::wasi::otel::types::KeyValue;
 
 const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -220,6 +225,14 @@ impl ActiveSpan {
         self.attributes = attributes;
         self.events = events;
         self.status = otel::tracing::Status::Ok;
+    }
+
+    /// Mark the span as failed with `msg` before it ends. Use this on the
+    /// error arm of a fallible call so the span carries the real cause instead
+    /// of the generic "span exited via early return" message that Drop would
+    /// otherwise apply.
+    pub(crate) fn finish_err(mut self, msg: impl Into<String>) {
+        self.status = otel::tracing::Status::Error(msg.into());
     }
 }
 

--- a/examples/otel-config/src/outbound.rs
+++ b/examples/otel-config/src/outbound.rs
@@ -1,0 +1,69 @@
+//! Outgoing HTTP request with W3C trace context propagation.
+
+use anyhow::{Context, Result, bail};
+use wstd::future::FutureExt;
+use wstd::http::{Body, Client, HeaderValue, Request};
+
+use crate::config::app_config;
+use crate::otel::{TraceFlags, traceparent};
+
+pub(crate) async fn make_outgoing_request(
+    trace_id: &str,
+    span_id: &str,
+    flags: TraceFlags,
+) -> Result<Vec<u8>> {
+    let cfg = app_config();
+    let mut client = Client::new();
+    // Per-chunk timers catch a stalled connection mid-stream; the surrounding
+    // `.timeout(cfg.request_timeout)` is the hard wall-clock budget so a
+    // slowloris-style upstream that drips bytes within the per-chunk window
+    // can't stretch the total call to `timeout * N`.
+    client.set_first_byte_timeout(cfg.request_timeout);
+    client.set_between_bytes_timeout(cfg.request_timeout);
+
+    let header = traceparent(trace_id, span_id, flags);
+    let mut builder = Request::get(&cfg.outbound_url).header(
+        "traceparent",
+        HeaderValue::from_str(&header).context("invalid traceparent header")?,
+    );
+
+    // Attach the upstream API token from `secrets.upstream-credentials`.
+    // Missing-token paths still work but skip the auth header so the example
+    // is exercisable without setting `UPSTREAM_API_TOKEN`.
+    if let Some(token) = cfg.upstream_api_token.as_deref() {
+        builder = builder.header(
+            "authorization",
+            HeaderValue::from_str(&format!("Bearer {token}"))
+                .context("invalid authorization header")?,
+        );
+    }
+
+    let request = builder
+        .body(Body::empty())
+        .context("failed to build outgoing request")?;
+
+    let send_and_read = async {
+        let response = client
+            .send(request)
+            .await
+            .context("outgoing request failed")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            bail!("non-success status from {}: {status}", cfg.outbound_url);
+        }
+
+        let mut body = response.into_body();
+        let bytes = body
+            .contents()
+            .await
+            .context("failed to read response body")?
+            .to_vec();
+        Ok(bytes)
+    };
+
+    send_and_read
+        .timeout(cfg.request_timeout)
+        .await
+        .with_context(|| format!("outgoing request to {} timed out", cfg.outbound_url))?
+}

--- a/examples/otel-config/src/ui.rs
+++ b/examples/otel-config/src/ui.rs
@@ -1,0 +1,43 @@
+//! HTML rendering for the demo landing page. Kept out of `lib.rs` so the
+//! handler reads as the story.
+
+pub(crate) struct PageData<'a> {
+    pub(crate) count: u64,
+    pub(crate) response_len: usize,
+    pub(crate) outbound_url: &'a str,
+    pub(crate) trace_id: &'a str,
+    pub(crate) span_id: &'a str,
+    pub(crate) otlp_endpoint: &'a str,
+}
+
+const PAGE_TEMPLATE: &str = include_str!("../templates/page.html");
+const ERROR_TEMPLATE: &str = include_str!("../templates/error.html");
+
+pub(crate) fn render_page(data: &PageData<'_>) -> String {
+    PAGE_TEMPLATE
+        .replace("{count}", &data.count.to_string())
+        .replace("{response_len}", &data.response_len.to_string())
+        .replace("{outbound_url}", &html_escape(data.outbound_url))
+        .replace("{trace_id}", &html_escape(data.trace_id))
+        .replace("{span_id}", &html_escape(data.span_id))
+        .replace("{otlp_endpoint}", &html_escape(data.otlp_endpoint))
+}
+
+pub(crate) fn render_error(message: &str) -> String {
+    ERROR_TEMPLATE.replace("{message}", &html_escape(message))
+}
+
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}

--- a/examples/otel-config/templates/error.html
+++ b/examples/otel-config/templates/error.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>otel-config · error</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: linear-gradient(135deg, #0a0a0a 0%, #1a0f2e 50%, #0a0a0a 100%);
+      min-height: 100vh;
+      padding: 2rem;
+    }
+    .container { max-width: 720px; margin: 0 auto; }
+    .card {
+      background: white;
+      border-radius: 12px;
+      padding: 2rem;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+      border-left: 6px solid #ef4444;
+    }
+    h1 { color: #991b1b; font-size: 1.75rem; margin-bottom: 1rem; }
+    p { color: #444; margin-bottom: 1rem; line-height: 1.55; }
+    pre {
+      background: #1a0f2e;
+      color: #ede9fe;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      overflow-x: auto;
+      font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="card">
+      <h1>Internal server error</h1>
+      <p>The component failed to handle the request. Check <code>wash dev</code> stderr for the full <code>anyhow</code> chain.</p>
+      <pre>{message}</pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/otel-config/templates/page.html
+++ b/examples/otel-config/templates/page.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>otel-config · wasmCloud</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      background: linear-gradient(135deg, #0a0a0a 0%, #1a0f2e 50%, #0a0a0a 100%);
+      min-height: 100vh;
+      padding: 2rem;
+      color: #1a1a1a;
+    }
+    .container { max-width: 880px; margin: 0 auto; }
+
+    .header { text-align: center; margin-bottom: 2rem; }
+    h1 {
+      color: white;
+      font-size: 2.5rem;
+      margin-bottom: 1rem;
+      text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+    }
+    .powered-by {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      color: rgba(255, 255, 255, 0.9);
+      font-size: 0.9rem;
+    }
+    .wasmcloud-logo { height: 24px; width: auto; vertical-align: middle; }
+
+    .card {
+      background: white;
+      border-radius: 12px;
+      padding: 2rem;
+      margin-bottom: 2rem;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    }
+    h2 {
+      color: #1a1a1a;
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+      border-bottom: 2px solid #685bc7;
+      padding-bottom: 0.5rem;
+    }
+    p { color: #444; line-height: 1.6; margin-bottom: 1rem; }
+    p:last-child { margin-bottom: 0; }
+    p a { color: #685bc7; text-decoration: none; font-weight: 600; }
+    p a:hover { text-decoration: underline; }
+    code.inline {
+      background: #f8f7ff;
+      color: #4c1d95;
+      padding: 1px 6px;
+      border-radius: 4px;
+      font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+      font-size: 0.9em;
+    }
+
+    .stat-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+    }
+    .stat {
+      background: #f8f7ff;
+      border-left: 4px solid #685bc7;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+    }
+    .stat .label {
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #685bc7;
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+    .stat .value {
+      font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+      font-size: 1rem;
+      color: #1a1a1a;
+      word-break: break-all;
+    }
+    .stat .value.big { font-size: 2rem; color: #4c1d95; font-weight: 700; }
+
+    .trace-row { margin-top: 1rem; }
+    .trace-row:first-of-type { margin-top: 0; }
+
+    .pill {
+      display: inline-block;
+      margin-left: 0.5rem;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      background: #ede9fe;
+      color: #4c1d95;
+      border: 1px solid #685bc7;
+      vertical-align: middle;
+      font-weight: 600;
+    }
+
+    pre {
+      background: #1a0f2e;
+      color: #ede9fe;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      overflow-x: auto;
+      font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+      font-size: 0.85rem;
+      line-height: 1.55;
+      margin-bottom: 1rem;
+      box-shadow: inset 0 0 0 1px rgba(104, 91, 199, 0.4);
+    }
+    pre .c { color: #8b7fd8; }
+    pre:last-child { margin-bottom: 0; }
+
+    .footer {
+      text-align: center;
+      padding: 1.5rem;
+      color: rgba(255, 255, 255, 0.8);
+      font-size: 0.85rem;
+    }
+    .footer a { color: white; text-decoration: none; font-weight: 600; }
+    .footer a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1>otel-config</h1>
+      <div class="powered-by">
+        Built with
+        <img
+          src="https://cdn.prod.website-files.com/68e941b736876afc9468db2b/68e941b736876afc9468dcda_Wasmcloud.Logo-Hrztl_Color.png"
+          alt="CNCF wasmCloud"
+          class="wasmcloud-logo"
+        />
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Request handled</h2>
+      <p>This component fetched <code class="inline">{outbound_url}</code>, stashed the body in <code class="inline">wasi:blobstore</code>, bumped a counter in <code class="inline">wasi:keyvalue</code>, and emitted spans / logs / metrics through <code class="inline">wasi:otel</code>.</p>
+      <div class="stat-grid">
+        <div class="stat">
+          <div class="label">Total requests</div>
+          <div class="value big">{count}</div>
+        </div>
+        <div class="stat">
+          <div class="label">Last response size</div>
+          <div class="value">{response_len} bytes</div>
+        </div>
+        <div class="stat">
+          <div class="label">Upstream</div>
+          <div class="value">{outbound_url}</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Trace context <span class="pill">w3c</span></h2>
+      <p>Search your OTel backend for this trace to see the full timeline: <code class="inline">handle-request</code> → <code class="inline">outgoing http</code> → <code class="inline">blobstore write</code> → <code class="inline">keyvalue increment</code>.</p>
+      <div class="stat trace-row">
+        <div class="label">trace_id</div>
+        <div class="value">{trace_id}</div>
+      </div>
+      <div class="stat trace-row">
+        <div class="label">request span_id</div>
+        <div class="value">{span_id}</div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Run a local OTel dashboard <span class="pill">docker</span></h2>
+      <p>Telemetry from this component ships via OTLP gRPC to <code class="inline">{otlp_endpoint}</code>. The <a href="https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/standalone" target="_blank" rel="noopener">.NET Aspire dashboard</a> is a standalone OTLP-compatible viewer that ships as a single Docker image — start it with one command:</p>
+      <pre><span class="c"># Aspire dashboard: UI on :18888, OTLP gRPC ingest on :18889.</span>
+docker run --rm -it \
+  -p 18888:18888 \
+  -p 18889:18889 \
+  -e DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true \
+  --name aspire-dashboard \
+  mcr.microsoft.com/dotnet/aspire-dashboard:latest</pre>
+      <p>This example's <code class="inline">.wash/config.yaml</code> already points <code class="inline">OTEL_EXPORTER_OTLP_ENDPOINT</code> at <code class="inline">http://localhost:18889</code>, so once the container is up the next request lands in the dashboard.</p>
+      <p>Open <a href="http://localhost:18888" target="_blank" rel="noopener">http://localhost:18888</a>, then explore <b>Traces</b> for the <code class="inline">handle-request</code> tree, <b>Structured logs</b> for the trace-correlated <code class="inline">INFO</code> lines, and <b>Metrics</b> for <code class="inline">http.server.request_count</code> / <code class="inline">http.server.response_body.size</code>.</p>
+    </div>
+
+    <div class="footer">
+      Built with
+      <a href="https://wasmcloud.com" target="_blank" rel="noopener">wasmCloud</a>, a CNCF Incubating project
+      &nbsp;·&nbsp; <code style="color: rgba(255,255,255,0.6);">wasi:otel@0.2.0-rc.2</code>
+      &nbsp;·&nbsp; refresh to bump the counter
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/otel-config/wit/world.wit
+++ b/examples/otel-config/wit/world.wit
@@ -11,8 +11,8 @@ world otel-config {
    import wasi:config/store@0.2.0-rc.1;
    import wasi:clocks/wall-clock@0.2.0;
    import wasi:random/random@0.2.2;
-   import wasi:otel/types@0.2.0-rc.1;
-   import wasi:otel/tracing@0.2.0-rc.1;
-   import wasi:otel/logs@0.2.0-rc.1;
-   import wasi:otel/metrics@0.2.0-rc.1;
+   import wasi:otel/types@0.2.0-rc.2;
+   import wasi:otel/tracing@0.2.0-rc.2;
+   import wasi:otel/logs@0.2.0-rc.2;
+   import wasi:otel/metrics@0.2.0-rc.2;
 }

--- a/examples/otel-config/wkg.lock
+++ b/examples/otel-config/wkg.lock
@@ -43,9 +43,9 @@ name = "wasi:otel"
 registry = "wasi.dev"
 
 [[packages.versions]]
-requirement = "=0.2.0-rc.1"
-version = "0.2.0-rc.1"
-digest = "sha256:4f4969ab60f39ca84830fe654e51e2bf852097eafb79626f616cd2fba11fdd54"
+requirement = "=0.2.0-rc.2"
+version = "0.2.0-rc.2"
+digest = "sha256:cd1c073a1875e04072951871a2c29d1725d15d0e824a9e4c2ae730810eab1c54"
 
 [[packages]]
 name = "wasi:random"


### PR DESCRIPTION
bump host + example to wasi:otel 0.2.0-rc.2

Additionally addresses code reviewer feedback for otel example from #5127

Refactored out helpers so the main handler is easy to read and split examples/otel-config/src/lib.rs into per-capability modules (config, outbound, blobstore, keyvalue, metrics, ui).

Add a blobby-styled demo UI (dark gradient + #685bc7 accents + the wasmCloud horizontal logo) rendering the counter, W3C trace context, and the README's Aspire dashboard docker recipe inline.