### PR TITLE
chore(wash-runtime): use format string interpolation and fix eprintln in error handlers

### DIFF
--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
@@ -131,8 +131,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         let entry = match bucket_handle.kv.get(key).await {
             Ok(entry) => entry,
             Err(e) => {
-                tracing::error!("JetStream error getting key: {}", e);
-                return Ok(Err(StoreError::Other(format!("JetStream error: {}", e))));
+                tracing::error!("JetStream error getting key: {e}");
+                return Ok(Err(StoreError::Other(format!("JetStream error: {e}"))));
             }
         };
 
@@ -161,8 +161,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         match bucket_handle.kv.put(key, value.into()).await {
             Ok(_) => Ok(Ok(())),
             Err(e) => {
-                tracing::error!("JetStream error setting key: {}", e);
-                Ok(Err(StoreError::Other(format!("JetStream error: {}", e))))
+                tracing::error!("JetStream error setting key: {e}");
+                Ok(Err(StoreError::Other(format!("JetStream error: {e}"))))
             }
         }
     }
@@ -185,8 +185,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         match bucket_handle.kv.delete(key).await {
             Ok(_) => Ok(Ok(())),
             Err(e) => {
-                tracing::error!("JetStream error deleting key: {}", e);
-                Ok(Err(StoreError::Other(format!("JetStream error: {}", e))))
+                tracing::error!("JetStream error deleting key: {e}");
+                Ok(Err(StoreError::Other(format!("JetStream error: {e}"))))
             }
         }
     }
@@ -210,8 +210,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
             Ok(Some(_)) => Ok(Ok(true)),
             Ok(None) => Ok(Ok(false)),
             Err(e) => {
-                tracing::error!("JetStream error getting key: {}", e);
-                Ok(Err(StoreError::Other(format!("JetStream error: {}", e))))
+                tracing::error!("JetStream error getting key: {e}");
+                Ok(Err(StoreError::Other(format!("JetStream error: {e}"))))
             }
         }
     }
@@ -234,8 +234,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         let keys_iter = match bucket_handle.kv.keys().await {
             Ok(i) => i,
             Err(e) => {
-                tracing::error!("JetStream error getting key: {}", e);
-                return Ok(Err(StoreError::Other(format!("JetStream error: {}", e))));
+                tracing::error!("JetStream error getting key: {e}");
+                return Ok(Err(StoreError::Other(format!("JetStream error: {e}"))));
             }
         };
 
@@ -300,8 +300,8 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
             }
             Ok(None) => (None, 0),
             Err(e) => {
-                tracing::error!("JetStream error getting key entry: {}", e);
-                return Ok(Err(StoreError::Other(format!("JetStream error: {}", e))));
+                tracing::error!("JetStream error getting key entry: {e}");
+                return Ok(Err(StoreError::Other(format!("JetStream error: {e}"))));
             }
         };
 
@@ -317,8 +317,8 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
                 match res {
                     Ok(_) => Ok(Ok(new_value)),
                     Err(e) => {
-                        tracing::error!("JetStream error updating key: {}", e);
-                        Ok(Err(StoreError::Other(format!("JetStream error: {}", e))))
+                        tracing::error!("JetStream error updating key: {e}");
+                        Ok(Err(StoreError::Other(format!("JetStream error: {e}"))))
                     }
                 }
             }
@@ -327,8 +327,8 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
                 match res {
                     Ok(_) => Ok(Ok(new_value)),
                     Err(e) => {
-                        tracing::error!("JetStream error putting key: {}", e);
-                        Ok(Err(StoreError::Other(format!("JetStream error: {}", e))))
+                        tracing::error!("JetStream error putting key: {e}");
+                        Ok(Err(StoreError::Other(format!("JetStream error: {e}"))))
                     }
                 }
             }
@@ -359,8 +359,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
                 Ok(Some(entry)) => Ok(Some((key.clone(), entry.to_vec()))),
                 Ok(None) => Ok(None),
                 Err(e) => {
-                    tracing::error!("JetStream error getting key: {}", e);
-                    Err(StoreError::Other(format!("JetStream error: {}", e)))
+                    tracing::error!("JetStream error getting key: {e}");
+                    Err(StoreError::Other(format!("JetStream error: {e}")))
                 }
             }
         }))
@@ -403,8 +403,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
                 {
                     Ok(_) => Ok(()),
                     Err(e) => {
-                        tracing::error!("JetStream error putting key: {}", e);
-                        Err(StoreError::Other(format!("JetStream error: {}", e)))
+                        tracing::error!("JetStream error putting key: {e}");
+                        Err(StoreError::Other(format!("JetStream error: {e}")))
                     }
                 }
             },
@@ -441,8 +441,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
             match bucket_handle.kv.delete(key.clone()).await {
                 Ok(_) => Ok(()),
                 Err(e) => {
-                    tracing::error!("JetStream error deleting key: {}", e);
-                    Err(StoreError::Other(format!("JetStream error: {}", e)))
+                    tracing::error!("JetStream error deleting key: {e}");
+                    Err(StoreError::Other(format!("JetStream error: {e}")))
                 }
             }
         }))

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -200,7 +200,7 @@ pub async fn run_cluster_host(
                 _ = oci_cleanup_timer.tick() => {
                     if let Some(cache_dir) = host.config().oci_cache_dir.as_ref() &&
                     let Err(e) = oci::cleanup_cache(cache_dir, cluster_host.cleanup_age).await {
-                        error!("Error during OCI cache cleanup: {}", e);
+                        error!("error during OCI cache cleanup: {e}");
                     }
                 }
                 // Send heartbeat
@@ -220,7 +220,7 @@ pub async fn run_cluster_host(
                             }
                         }
                         Err(e) => {
-                            eprintln!("Error handling command: {}", e);
+                            error!("error handling command: {e}");
                         }
                     }
                 }


### PR DESCRIPTION
Two style violations in `wash-runtime` that go against [CONTRIBUTING.md](./CONTRIBUTING.md):

**1. `washlet/mod.rs` - banned `eprintln!`**

`eprintln!` is explicitly forbidden by the style guide - tracing macros should be used instead. `error!` was already imported right at the top of the file, so this is just a slip.

Before:
```rust
eprintln!("Error handling command: {}", e);
```

After:
```rust
error!("error handling command: {e}");
```

Also fixed the neighboring `error!` call on the OCI cleanup path - same issues (uppercase + old `{}` style).

**2. `wasi_keyvalue/nats.rs` - inconsistent format strings**

The file already uses the modern `{e}` interpolation style on line 100, but all 11 error branches below it still use the old `"{}", e` form. Cleaned em all up to match.

**Reproducing**

```bash
grep -n '".*{}", e' crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
grep -n 'eprintln!' crates/wash-runtime/src/washlet/mod.rs
```

Both commands should return hits on the unpatched code and nothing on the patched version.