### PR TITLE
refactor(bench): rename iai-callgrind → gungraun and bump to 0.19.1

### DIFF
--- a/.github/scripts/bench-preflight.mjs
+++ b/.github/scripts/bench-preflight.mjs
@@ -57,12 +57,21 @@ if (actualHostname !== expectedHostname) {
 }
 ok(`host: ${expectedHostname}`);
 
-// 2. nproc == 6 (nosmt active).
-const nprocOut = parseInt(runStdout('nproc'), 10);
+// 2. nproc --all == 6 (nosmt active).
+//    Use `--all`, not bare `nproc`: bare `nproc` honors the caller's
+//    `sched_getaffinity` mask, which systemd (>= 240) narrows to
+//    "online CPUs minus isolcpus" for every service unit it manages —
+//    so inside the actions.runner service we'd see 5, not 6, and this
+//    check would mis-flag a correctly-configured host. `nproc --all`
+//    ignores affinity and reports the absolute online count, which is
+//    what we actually want to assert (`nosmt` collapsed 12 SMT → 6 cores).
+//    The isolcpus assertion (#4 below) covers the orthogonal concern of
+//    "is one core reserved".
+const nprocOut = parseInt(runStdout('nproc', ['--all']), 10);
 if (nprocOut !== EXPECTED_NPROC) {
   fail(`expected ${EXPECTED_NPROC} online CPUs (nosmt); got ${nprocOut}`);
 }
-ok(`nproc: ${nprocOut}  (nosmt active)`);
+ok(`nproc --all: ${nprocOut}  (nosmt active)`);
 
 // 3. cpufreq governor == "performance" on every CPU.
 const governors = runStdout('sh', [

--- a/.github/scripts/bench-push-results.mjs
+++ b/.github/scripts/bench-push-results.mjs
@@ -9,7 +9,7 @@
 // Per-run layout (private; only the bench role can read):
 //   s3://${WASMCLOUD_BENCH_S3_BUCKET}/runs/<date>/<short-sha>/<run-id>/<bench>/
 //     ├─ criterion.tar.zst   raw criterion data
-//     ├─ iai.tar.zst         raw iai-callgrind data (when applicable)
+//     ├─ gungraun.tar.zst    raw gungraun (cachegrind) data (when applicable)
 //     ├─ results.jsonl       one JSON row per (group, param, metric)
 //     ├─ metadata.json       run-level facts
 //     └─ run.log             cargo bench stdout/stderr
@@ -51,7 +51,7 @@ const distId = required('WASMCLOUD_BENCH_CF_DISTRIBUTION_ID');
 
 const targetDir = process.env.CARGO_TARGET_DIR ?? '/var/lib/bench/target';
 const critDir = join(targetDir, 'criterion');
-const iaiDir = join(targetDir, 'iai');
+const gungraunDir = join(targetDir, 'gungraun');
 
 const runId = process.env.GITHUB_RUN_ID ?? 'local';
 const sha = run('git', ['rev-parse', 'HEAD']);
@@ -78,12 +78,12 @@ if (existsSync(critDir)) {
   run('tar', ['-cf', join(work, 'criterion.tar.zst'), '-I', 'zstd -19 -T0', '-C', critDir, '.']);
   archived++;
 }
-if (existsSync(iaiDir)) {
-  run('tar', ['-cf', join(work, 'iai.tar.zst'), '-I', 'zstd -19 -T0', '-C', iaiDir, '.']);
+if (existsSync(gungraunDir)) {
+  run('tar', ['-cf', join(work, 'gungraun.tar.zst'), '-I', 'zstd -19 -T0', '-C', gungraunDir, '.']);
   archived++;
 }
 if (archived === 0) {
-  console.log(`::warning::no criterion or iai output at ${targetDir}; uploading metadata only`);
+  console.log(`::warning::no criterion or gungraun output at ${targetDir}; uploading metadata only`);
 }
 
 // 2. Per-(group, param) JSONL rows for trend ingestion. bench-tools jsonl
@@ -126,7 +126,7 @@ if (existsSync(logSrc)) {
 console.log(`uploading per-run artifacts to s3://${bucket}/${prefix}/`);
 for (const file of [
   'criterion.tar.zst',
-  'iai.tar.zst',
+  'gungraun.tar.zst',
   'results.jsonl',
   'metadata.json',
   'run.log',

--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -32,10 +32,10 @@ on:
       bench:
         description: which bench to compare
         type: choice
-        default: iai_callgrind
+        default: gungraun
         options:
           - http_invoke
-          - iai_callgrind
+          - gungraun
           - wasmtime_baseline
           - wasmtime_serve
       ref_a:

--- a/.github/workflows/bench-host-checks.yml
+++ b/.github/workflows/bench-host-checks.yml
@@ -2,7 +2,7 @@ name: bench-host-checks
 
 # Monthly upstream-version checks for the wasmCloud bench host. Today
 # this only covers the GitHub Actions self-hosted runner; new checks
-# (e.g. valgrind, iai-callgrind-runner, Node LTS) can be added as
+# (e.g. valgrind, gungraun-runner, Node LTS) can be added as
 # additional jobs alongside `runner-version`.
 #
 # Jobs run on hosted ubuntu-latest — they do NOT touch the bench host

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,7 +9,7 @@ on:
         default: http_invoke
         options:
           - http_invoke
-          - iai_callgrind
+          - gungraun
           - wasmtime_baseline
           - wasmtime_serve
       ref:
@@ -61,7 +61,7 @@ jobs:
       # published`. wasmtime_* are reference baselines for wasmtime itself
       # and don't shift with our changes — run them on demand via
       # workflow_dispatch when wasmtime is upgraded.
-      RELEASE_BENCHES: '["http_invoke","iai_callgrind"]'
+      RELEASE_BENCHES: '["http_invoke","gungraun"]'
     steps:
       - id: set
         env:
@@ -139,12 +139,12 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-${{ matrix.bench }}-${{ github.run_id }}
-          # criterion benches write to target/criterion/, iai-callgrind benches
-          # (iai_callgrind) write to target/iai/. A genuinely-empty run is a
-          # bug worth flagging loudly — fail rather than warn.
+          # criterion benches write to target/criterion/, gungraun benches
+          # (gungraun) write to target/gungraun/. A genuinely-empty run is
+          # a bug worth flagging loudly — fail rather than warn.
           path: |
             ${{ env.CARGO_TARGET_DIR }}/criterion/
-            ${{ env.CARGO_TARGET_DIR }}/iai/
+            ${{ env.CARGO_TARGET_DIR }}/gungraun/
           retention-days: 90
           if-no-files-found: error
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,12 +608,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bincode-next"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "dbe9e7e6d14aeb39557f226bff158a30e367fac279d0e69b8b42fb41999f9a86"
 dependencies = [
  "serde",
+ "unty-next",
 ]
 
 [[package]]
@@ -2600,6 +2601,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "gungraun"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4d8da7e495043e7050236881e37c8c7cbd896a8674c2fa49b13f2ff8c9505b"
+dependencies = [
+ "bincode-next",
+ "derive_more",
+ "gungraun-macros",
+ "gungraun-runner",
+]
+
+[[package]]
+name = "gungraun-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc6269e89921872ec32af29af3a992618b9bd2ef47cbf3704af476066cb7182"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "gungraun-runner"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d412a9c97a337ee83ab57c8e4e377cee1a519afaebbeb803c696ecd1e93173e2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,42 +2984,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
-]
-
-[[package]]
-name = "iai-callgrind"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
-dependencies = [
- "bincode",
- "derive_more",
- "iai-callgrind-macros",
- "iai-callgrind-runner",
-]
-
-[[package]]
-name = "iai-callgrind-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
-dependencies = [
- "derive_more",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn",
-]
-
-[[package]]
-name = "iai-callgrind-runner"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7065,6 +7067,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa66022bbd1ab992fad72bdedcfd07a0023b6f5ecc83d50121e39e3a3caed41"
+
+[[package]]
 name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7371,12 +7379,12 @@ dependencies = [
  "futures",
  "gag",
  "geo-types",
+ "gungraun",
  "hostname",
  "http",
  "http-body-util",
  "hyper",
  "hyper-util",
- "iai-callgrind",
  "io-lifetimes",
  "moka",
  "names",

--- a/crates/bench-tools/Cargo.toml
+++ b/crates/bench-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bench-tools"
-description = "Internal CLI for processing wasmCloud bench output (criterion + iai-callgrind)."
+description = "Internal CLI for processing wasmCloud bench output (criterion + gungraun)."
 edition.workspace = true
 rust-version.workspace = true
 version.workspace = true

--- a/crates/bench-tools/src/callgrind.rs
+++ b/crates/bench-tools/src/callgrind.rs
@@ -1,16 +1,21 @@
 //! Parser for valgrind's `callgrind.out` output — pulls instruction counts
 //! out of the trailing `events:` / `summary:` lines.
 //!
-//! iai-callgrind invokes valgrind with `--tool=callgrind`, which writes per
-//! bench a tree under `target/iai/`:
+//! gungraun invokes valgrind
+//! with `--tool=callgrind`, which writes per bench a tree under
+//! `target/gungraun/`:
 //!
 //! ```text
-//! target/iai/
+//! target/gungraun/
 //!   <package>/<bench_target>/<function>.<id>/
 //!     callgrind.out
 //!     summary.json     (we don't use this — schema changes across versions)
 //!     callgrind.out.old (baseline if any)
 //! ```
+//!
+//! The file format itself is callgrind's, set by valgrind, and is stable
+//! across the gungraun rename — so this parser's name stays `callgrind`
+//! rather than tracking the upstream crate.
 //!
 //! callgrind.out itself ends with two lines whose format is set by valgrind
 //! and very stable:
@@ -39,7 +44,7 @@ pub struct Row {
     pub ir: u64,
 }
 
-/// Walk `iai_dir`, returning one [`Row`] per `callgrind.out` found.
+/// Walk `gungraun_dir`, returning one [`Row`] per `callgrind.out` found.
 ///
 /// Every accepted file is logged to stderr in the form
 /// `bench-tools callgrind: <path> → (<group>, <param>) Ir=<ir>` so an
@@ -47,12 +52,12 @@ pub struct Row {
 /// because we derive `(group, param)` from path components, a stray
 /// callgrind.out in the tree (e.g. leftover from manual debugging) would
 /// otherwise silently appear as a real bench row.
-pub fn walk(iai_dir: &Path) -> Result<Vec<Row>> {
-    if !iai_dir.exists() {
+pub fn walk(gungraun_dir: &Path) -> Result<Vec<Row>> {
+    if !gungraun_dir.exists() {
         return Ok(Vec::new());
     }
     let mut rows = Vec::new();
-    for entry in WalkDir::new(iai_dir).sort_by_file_name() {
+    for entry in WalkDir::new(gungraun_dir).sort_by_file_name() {
         let entry = entry?;
         if !entry.file_type().is_file() {
             continue;
@@ -60,7 +65,7 @@ pub fn walk(iai_dir: &Path) -> Result<Vec<Row>> {
         if entry.file_name() != "callgrind.out" {
             continue;
         }
-        let Some(row) = parse_one(iai_dir, entry.path())? else {
+        let Some(row) = parse_one(gungraun_dir, entry.path())? else {
             continue;
         };
         eprintln!(
@@ -75,14 +80,14 @@ pub fn walk(iai_dir: &Path) -> Result<Vec<Row>> {
     Ok(rows)
 }
 
-fn parse_one(iai_dir: &Path, path: &Path) -> Result<Option<Row>> {
+fn parse_one(gungraun_dir: &Path, path: &Path) -> Result<Option<Row>> {
     let rel = path
-        .strip_prefix(iai_dir)
-        .with_context(|| format!("strip_prefix({})", iai_dir.display()))?;
+        .strip_prefix(gungraun_dir)
+        .with_context(|| format!("strip_prefix({})", gungraun_dir.display()))?;
 
     // `<package>/<group>/<param>/callgrind.out`
     // We pick the last two non-file components as (group, param). This is
-    // robust against iai-callgrind nesting one or more extra levels above
+    // robust against gungraun nesting one or more extra levels above
     // <group>, which it has done in some versions (e.g. <package>/<binary>/…).
     let components: Vec<_> = rel
         .components()
@@ -145,5 +150,5 @@ pub fn read_ir(path: &Path) -> Result<Option<u64>> {
 }
 
 pub fn dir_from_target(target_dir: &Path) -> PathBuf {
-    target_dir.join("iai")
+    target_dir.join("gungraun")
 }

--- a/crates/bench-tools/src/commands/delta.rs
+++ b/crates/bench-tools/src/commands/delta.rs
@@ -6,14 +6,14 @@
 //! ```text
 //! $WASMCLOUD_BENCH_COMPARE_DIR/
 //!   a/iter-1/criterion/ …
-//!   a/iter-1/iai/       …
+//!   a/iter-1/gungraun/       …
 //!   a/iter-2/…          (when criterion benches run 3× interleaved)
 //!   b/iter-1/criterion/ …
-//!   b/iter-1/iai/       …
+//!   b/iter-1/gungraun/       …
 //! ```
 //!
 //! For each side we collect one numeric value per `(group, param)` per
-//! iteration (criterion → `mean_ns`; iai → `Ir`), take the median across
+//! iteration (criterion → `mean_ns`; gungraun → `Ir`), take the median across
 //! iterations, then compute `Δ = (B − A) / A · 100`. Output is markdown
 //! plus a sibling `$WASMCLOUD_BENCH_COMPARE_DIR/delta.md` file that the
 //! bench-compare workflow appends to `$GITHUB_STEP_SUMMARY`.
@@ -72,14 +72,14 @@ pub fn run(args: Args) -> Result<()> {
 enum Kind {
     /// criterion mean_ns; "lower is better".
     Time,
-    /// iai-callgrind Ir; "lower is better".
+    /// gungraun Ir; "lower is better".
     Instructions,
 }
 
 impl Kind {
     fn for_bench(bench: &str) -> Self {
         match bench {
-            "iai_callgrind" => Kind::Instructions,
+            "gungraun" => Kind::Instructions,
             _ => Kind::Time,
         }
     }
@@ -120,7 +120,7 @@ fn collect_side(side_dir: &Path, kind: Kind) -> Result<Series> {
         }
         match kind {
             Kind::Time => collect_criterion(&iter_dir, &mut series)?,
-            Kind::Instructions => collect_iai(&iter_dir, &mut series)?,
+            Kind::Instructions => collect_gungraun(&iter_dir, &mut series)?,
         }
     }
     Ok(series)
@@ -140,9 +140,9 @@ fn collect_criterion(iter_dir: &Path, series: &mut Series) -> Result<()> {
     Ok(())
 }
 
-fn collect_iai(iter_dir: &Path, series: &mut Series) -> Result<()> {
-    let iai_dir = iter_dir.join("iai");
-    let rows = callgrind::walk(&iai_dir)?;
+fn collect_gungraun(iter_dir: &Path, series: &mut Series) -> Result<()> {
+    let gungraun_dir = iter_dir.join("gungraun");
+    let rows = callgrind::walk(&gungraun_dir)?;
     for row in rows {
         series
             .entry((row.group, row.param))
@@ -160,7 +160,7 @@ fn median(values: &[f64]) -> Option<f64> {
     sorted.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
     let mid = sorted.len() / 2;
     // Matches the jq implementation we replaced: pick the upper-middle for
-    // even-length series. Single-iteration runs (iai) hit the mid=0 path.
+    // even-length series. Single-iteration runs (gungraun) hit the mid=0 path.
     sorted.get(mid).copied()
 }
 
@@ -234,7 +234,7 @@ fn render(args: &Args, kind: Kind, meta: &Meta, a: &Series, b: &Series) -> Strin
     let _ = writeln!(
         out,
         "_Δ is `(B − A) / A · 100` of the median across {} iteration(s). \
-         Single-iteration comparisons (`iai_callgrind`) are deterministic; \
+         Single-iteration comparisons (`gungraun`) are deterministic; \
          multi-iteration comparisons use the median to dampen run-to-run noise._",
         args.iters
     );

--- a/crates/bench-tools/src/commands/jsonl.rs
+++ b/crates/bench-tools/src/commands/jsonl.rs
@@ -7,7 +7,7 @@
 //!   (`mean_ns`, `median_ns`, `std_dev_ns`, `ci_low_ns`, `ci_high_ns`,
 //!   `throughput`) so the existing `arewefastyet` reader doesn't break
 //!   on the schema bump.
-//! - iai rows carry only `metric` + `value` (Ir instruction counts).
+//! - gungraun rows carry only `metric` + `value` (Ir instruction counts).
 //!
 //! The dedup key in `push-s3.sh` is widened to include `.metric`, which
 //! lets `(bench, group, param)` map to multiple rows, one per metric,
@@ -59,7 +59,7 @@ struct CriterionRow<'a> {
 }
 
 #[derive(Debug, Serialize)]
-struct IaiRow<'a> {
+struct GungraunRow<'a> {
     bench: &'a str,
     group: String,
     param: String,
@@ -83,8 +83,8 @@ pub fn run(args: Args) -> Result<()> {
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
 
-    if args.bench == "iai_callgrind" {
-        return emit_iai(&mut out, &args.bench, &meta, &target_dir);
+    if args.bench == "gungraun" {
+        return emit_gungraun(&mut out, &args.bench, &meta, &target_dir);
     }
 
     emit_criterion(
@@ -136,16 +136,16 @@ fn emit_criterion<W: Write>(
     Ok(())
 }
 
-fn emit_iai<W: Write>(
+fn emit_gungraun<W: Write>(
     out: &mut W,
     bench: &str,
     meta: &Meta,
     target_dir: &std::path::Path,
 ) -> Result<()> {
-    let iai_dir = callgrind::dir_from_target(target_dir);
-    let rows = callgrind::walk(&iai_dir)?;
+    let gungraun_dir = callgrind::dir_from_target(target_dir);
+    let rows = callgrind::walk(&gungraun_dir)?;
     for row in rows {
-        let serialized = IaiRow {
+        let serialized = GungraunRow {
             bench,
             group: row.group,
             param: row.param,

--- a/crates/bench-tools/src/commands/summary.rs
+++ b/crates/bench-tools/src/commands/summary.rs
@@ -1,9 +1,10 @@
 //! `bench-tools summary` renders a markdown table for `$GITHUB_STEP_SUMMARY`
 //!
 //! Per-row metric is RPS for batch throughput, B/s for byte throughput,
-//! and time otherwise. For `iai_callgrind` we render a separate
-//! instruction-count table from the iai output with different schema and unit,
-//! but same rough shape so the step summary stays consistent.
+//! and time otherwise. For `gungraun` we render a separate
+//! instruction-count table from the callgrind output with different
+//! schema and unit, but same rough shape so the step summary stays
+//! consistent.
 
 use std::io::Write;
 use std::path::PathBuf;
@@ -39,8 +40,8 @@ pub fn run(args: Args) -> Result<()> {
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
 
-    if args.bench == "iai_callgrind" {
-        return render_iai_stub(&mut out, &args.bench, &meta, &target_dir, &run_id);
+    if args.bench == "gungraun" {
+        return render_gungraun_stub(&mut out, &args.bench, &meta, &target_dir, &run_id);
     }
 
     let crit_dir = criterion::dir_from_target(&target_dir);
@@ -107,14 +108,14 @@ fn render_criterion<W: Write>(
     Ok(())
 }
 
-fn render_iai_stub<W: Write>(
+fn render_gungraun_stub<W: Write>(
     out: &mut W,
     bench: &str,
     meta: &Meta,
     target_dir: &std::path::Path,
     run_id: &str,
 ) -> Result<()> {
-    writeln!(out, "## bench: `{bench}` (iai-callgrind)")?;
+    writeln!(out, "## bench: `{bench}` (gungraun · cachegrind)")?;
     writeln!(out)?;
     writeln!(
         out,
@@ -124,14 +125,14 @@ fn render_iai_stub<W: Write>(
     writeln!(out)?;
     writeln!(
         out,
-        "Instruction-count bench (cachegrind via iai-callgrind). Raw counts \
+        "Instruction-count bench (cachegrind via gungraun). Raw counts \
          and callgrind output are archived under the workflow artifact \
          `bench-{bench}-{run_id}` and in S3 (see scripts/bench/README.md).",
     )?;
     writeln!(out)?;
 
-    let iai_dir = callgrind::dir_from_target(target_dir);
-    let rows = callgrind::walk(&iai_dir)?;
+    let gungraun_dir = callgrind::dir_from_target(target_dir);
+    let rows = callgrind::walk(&gungraun_dir)?;
     if !rows.is_empty() {
         writeln!(out, "| group | param | Ir (instructions) |")?;
         writeln!(out, "|---|---|---:|")?;

--- a/crates/bench-tools/src/main.rs
+++ b/crates/bench-tools/src/main.rs
@@ -1,4 +1,4 @@
-//! Internal CLI for processing wasmCloud bench output (criterion + iai-callgrind).
+//! Internal CLI for processing wasmCloud bench output (criterion + gungraun).
 //!
 //! Run via `cargo run -p bench-tools -- <subcommand>` from CI or from any
 //! script in `scripts/bench/`. The output schemas match what the trend
@@ -17,7 +17,7 @@ mod meta;
 #[command(
     name = "bench-tools",
     version,
-    about = "wasmCloud bench data processing (criterion + iai-callgrind)"
+    about = "wasmCloud bench data processing (criterion + gungraun)"
 )]
 struct Cli {
     #[command(subcommand)]

--- a/crates/bench-tools/src/markdown.rs
+++ b/crates/bench-tools/src/markdown.rs
@@ -132,7 +132,7 @@ fn fmt_bps(bps: f64) -> String {
 }
 
 /// `1_234_567` → `"1,234,567"`. Used by callers that want a human-readable
-/// integer count (e.g. instruction totals in the iai summary).
+/// integer count (e.g. instruction totals in the gungraun summary).
 pub fn fmt_thousands(n: u64) -> String {
     let s = n.to_string();
     let bytes = s.as_bytes();

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -163,11 +163,11 @@ gag = "1.0"
 rcgen = { version = "0.14.7", default-features = false, features = ["crypto", "aws_lc_rs", "pem"] }
 testcontainers = { workspace = true }
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
-# Pinned to match the iai-callgrind-runner version the bench host's
-# Ansible playbook installs (scripts/bench/ansible/provision.yml).
-# iai-callgrind enforces equality between this crate version and the
-# runner binary at run time.
-iai-callgrind = "0.16.1"
+# Pinned to match the gungraun-runner version the bench host's Ansible
+# playbook installs (scripts/bench/ansible/provision.yml). gungraun
+# enforces equality between this crate version and the runner binary at
+# run time.
+gungraun = "0.19.1"
 
 [[bench]]
 name = "http_invoke"
@@ -175,7 +175,7 @@ harness = false
 required-features = ["wasip3"]
 
 [[bench]]
-name = "iai_callgrind"
+name = "gungraun"
 harness = false
 required-features = ["wasip3"]
 

--- a/crates/wash-runtime/benches/gungraun.rs
+++ b/crates/wash-runtime/benches/gungraun.rs
@@ -1,20 +1,20 @@
 //! Valgrind/cachegrind-based instruction-count benchmarks for wash-runtime.
 //!
-//! Uses `iai-callgrind` to count CPU instructions deterministically — which
-//! makes this suite suitable for CI regression detection where wall-clock
-//! timing on shared runners is too noisy. See `http_invoke` for the
-//! wall-clock counterpart.
+//! Uses `gungraun` (formerly `iai-callgrind`, renamed at 0.17.0) to count
+//! CPU instructions deterministically — which makes this suite suitable
+//! for CI regression detection where wall-clock timing on shared runners
+//! is too noisy. See `http_invoke` for the wall-clock counterpart.
 //!
 //! Measures the same hot-invocation path as `http_invoke`: a single HTTP
 //! request through the full wash-runtime stack (hyper → router →
 //! component). A cold-path measurement is included to track startup-cost
 //! drift (component compile + host build + first request).
 //!
-//! Requires the `iai-callgrind-runner` binary on `PATH` and `valgrind`
+//! Requires the `gungraun-runner` binary on `PATH` and `valgrind`
 //! installed:
 //! ```text
-//! cargo install iai-callgrind-runner --version 0.16.1
-//! cargo bench -p wash-runtime --features wasip3 --bench iai_callgrind
+//! cargo install gungraun-runner --version 0.19.1
+//! cargo bench -p wash-runtime --features wasip3 --bench gungraun
 //! ```
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -24,7 +24,7 @@ mod common;
 use std::{collections::HashMap, hint::black_box, sync::Arc};
 
 use common::Flavor;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use tokio::runtime::Runtime;
 
 use wash_runtime::{
@@ -155,10 +155,16 @@ fn drop_warm(warm: Warm) {
 
 // Hot path: one HTTP request against an already-warm host. Setup builds
 // the host and is excluded from instruction counts; teardown drops it.
+//
+// fn name is the leaf segment of the callgrind output path and becomes
+// the `param` in history.json rows (`hot_invocation.p2` etc.). The
+// `gungraun_` prefix that used to live here was redundant with the
+// (renamed) bench target name — keep this short and let the bench
+// target carry the harness identity.
 #[library_benchmark]
 #[bench::p2(args = (Flavor::P2), setup = setup_warm, teardown = drop_warm)]
 #[bench::p3(args = (Flavor::P3), setup = setup_warm, teardown = drop_warm)]
-fn iai_hot_invocation(warm: Warm) -> Warm {
+fn hot_invocation(warm: Warm) -> Warm {
     warm.rt.block_on(async {
         let resp = warm
             .client
@@ -180,13 +186,13 @@ fn iai_hot_invocation(warm: Warm) -> Warm {
 #[library_benchmark]
 #[bench::p2(args = (Flavor::P2), teardown = drop_warm)]
 #[bench::p3(args = (Flavor::P3), teardown = drop_warm)]
-fn iai_cold_invocation(flavor: Flavor) -> Warm {
+fn cold_invocation(flavor: Flavor) -> Warm {
     setup_warm(flavor)
 }
 
 library_benchmark_group!(
     name = http;
-    benchmarks = iai_hot_invocation, iai_cold_invocation
+    benchmarks = hot_invocation, cold_invocation
 );
 
 main!(library_benchmark_groups = http);

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -169,7 +169,7 @@ pin a bench process to it.
 
 **Why:** even with `nosmt` and the performance governor, the kernel can
 still preempt a bench thread for IRQ handling, RCU callbacks, or the
-periodic scheduler tick. For `iai_callgrind` (deterministic instruction
+periodic scheduler tick. For `gungraun` (deterministic instruction
 counts via valgrind/cachegrind) preemption doesn't affect the *result*,
 but it bloats runtime by ~2–3×. For wall-clock benches that we may pin
 later, scheduler interference is a direct source of p99 variance.
@@ -187,8 +187,8 @@ CPU index `5` is the last with `nosmt` (CPUs 0..5). Reserving the
 trailing CPU leaves 5 cores for the runner agent + system, which is
 plenty.
 
-**How it's used:** [`run-bench.sh`](./run-bench.sh) wraps `iai_callgrind`
-(and only `iai_callgrind` — the criterion benches are multi-threaded and
+**How it's used:** [`run-bench.sh`](./run-bench.sh) wraps `gungraun`
+(and only `gungraun` — the criterion benches are multi-threaded and
 would lose throughput) in `taskset -c 5`. The criterion benches run
 unpinned across CPUs 0–4. Override the CPU index via `WASMCLOUD_BENCH_ISOLATED_CPU=`
 if the host was staged with a different reservation.
@@ -291,7 +291,7 @@ lives under a different label.
 ```sh
 cd scripts/bench/ansible
 ansible-playbook provision.yml                  # everything
-ansible-playbook provision.yml --tags toolchain # apt + rustup + iai only
+ansible-playbook provision.yml --tags toolchain # apt + rustup + gungraun only
 ansible-playbook provision.yml --tags kernel    # just GRUB drop-in
 ansible-playbook provision.yml --check          # dry-run; no changes
 ```
@@ -305,19 +305,19 @@ The playbook installs (as `root` on the bench host):
   - `libprotobuf-dev` provides `/usr/include/google/protobuf/*.proto`
     (the well-known types like `timestamp.proto`); without it,
     `protoc` finds the binary but fails to import.
-  - `valgrind` is the measurement engine for the `iai_callgrind`
-    instruction-count bench (see §9 and the `iai-callgrind-runner`
+  - `valgrind` is the measurement engine for the `gungraun`
+    instruction-count bench (see §9 and the `gungraun-runner`
     bullet below).
 - **rustup** as `root`, with `stable` as the default toolchain. Inside
   the wasmCloud workspace the repo's `rust-toolchain.toml` takes
   precedence (also `stable`, with the `wasm32-unknown-unknown`,
   `wasm32-wasip1`, and `wasm32-wasip2` targets). The default is set so
   out-of-tree `cargo install` invocations (notably
-  `iai-callgrind-runner` below) have something to pick.
-- **`iai-callgrind-runner`** via `cargo install --version 0.16.1`
-  (pinned). iai-callgrind enforces equality between the runner binary
-  and the `iai-callgrind` crate version pinned in
-  `crates/wash-runtime/Cargo.toml`; bump them together.
+  `gungraun-runner` below) have something to pick.
+- **`gungraun-runner`** via `cargo install --version 0.19.1`
+  (pinned). gungraun (formerly `iai-callgrind`; renamed at 0.17.0)
+  enforces equality between the runner binary and the `gungraun` crate
+  version pinned in `crates/wash-runtime/Cargo.toml`; bump them together.
 - **Node.js (current LTS)** from NodeSource's apt repo. The CI
   workflow runs `.github/scripts/*.mjs` via `run: node …`, which
   needs an OS-level `node` on `PATH` (self-hosted runners do not
@@ -341,7 +341,7 @@ uname -r                           # 6.8.0-* (Ubuntu Noble)
 cargo --version                    # rustup-pinned stable
 protoc --version                   # libprotoc 3.21.x or newer
 valgrind --version                 # valgrind-3.22.x or newer
-iai-callgrind-runner --version     # 0.16.1
+gungraun-runner --version          # 0.19.1
 node --version                     # the node_lts_major pinned in provision.yml
 cat /etc/wasmcloud-bench-stage     # post-install marker
 ```
@@ -491,9 +491,9 @@ touches the repo, a CI log, or `/proc/<pid>/cmdline` (env-only).
    `(group, param)`. Unit semantics live in
    [`crates/bench-tools/src/markdown.rs`](../../crates/bench-tools/src/markdown.rs):
    RPS for batch-throughput benches, B/s for byte throughput, time
-   otherwise. For `iai_callgrind` the same subcommand emits an
-   instruction-count table from the iai output instead.
-4. **Upload artifact** — the criterion and/or iai output dirs as
+   otherwise. For `gungraun` the same subcommand emits an
+   instruction-count table from the gungraun output instead.
+4. **Upload artifact** — the criterion and/or gungraun output dirs as
    `bench-<bench>-<run-id>` with 90-day retention.
 5. **Configure AWS** — `aws-actions/configure-aws-credentials@v6.1.1`
    assumes the `WASMCLOUD_BENCH_AWS_ROLE_ARN` role via OIDC.
@@ -566,7 +566,7 @@ GitHub → **Actions** → **bench** → **Run workflow**:
 
 | Input   | Description                                                                                | Default          |
 | ------- | ------------------------------------------------------------------------------------------ | ---------------- |
-| `bench` | which bench to run (`http_invoke`, `iai_callgrind`, `wasmtime_baseline`, `wasmtime_serve`) | `http_invoke`    |
+| `bench` | which bench to run (`http_invoke`, `gungraun`, `wasmtime_baseline`, `wasmtime_serve`) | `http_invoke`    |
 | `ref`   | git ref to bench (branch, tag, or sha)                                                     | the workflow ref |
 
 **Bench types:**
@@ -574,7 +574,7 @@ GitHub → **Actions** → **bench** → **Run workflow**:
 | Bench               | Harness       | Measures                           | Notes                                                                                                                                                          |
 | ------------------- | ------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `http_invoke`       | criterion     | wall-clock (ns / req/s)            | wash-runtime HTTP path; cold + hot invocations                                                                                                                 |
-| `iai_callgrind`     | iai-callgrind | CPU instruction count (cachegrind) | deterministic regression detection; not subject to shared-runner timing noise; output schema differs from criterion and does **not** feed `history.json` today |
+| `gungraun`          | gungraun      | CPU instruction count (cachegrind) | deterministic regression detection; not subject to shared-runner timing noise. `gungraun` is the renamed/refreshed `iai-callgrind` (rename landed upstream at 0.17.0) |
 | `wasmtime_baseline` | criterion     | wall-clock                         | wasmtime-only baseline for context                                                                                                                             |
 | `wasmtime_serve`    | criterion     | wall-clock                         | wasmtime serve subcommand baseline                                                                                                                             |
 
@@ -627,7 +627,7 @@ and produces a delta.
 **One entry point:** `workflow_dispatch`. Actions → bench-compare → Run
 workflow; supply:
 
-- `bench` — which bench to compare (default `iai_callgrind`).
+- `bench` — which bench to compare (default `gungraun`).
 - `ref_a` — baseline ref (default `main`).
 - `ref_b` — candidate ref. To compare a PR, paste the PR's head sha
   here (the PR page shows it; `gh pr view <N> --json headRefOid` also
@@ -635,7 +635,7 @@ workflow; supply:
 
 **Variance handling:**
 
-- `iai_callgrind`: **1×** per ref. Instruction counts via valgrind are
+- `gungraun`: **1×** per ref. Instruction counts via valgrind are
   deterministic, so repeats don't reduce noise.
 - Criterion benches (`http_invoke`, `wasmtime_*`): **3× interleaved**
   (a₁ b₁ a₂ b₂ a₃ b₃); the median of the three is what the delta is
@@ -701,8 +701,8 @@ Per-run uploads (private; only the WRITE role can read):
 s3://<bucket>/runs/<YYYY-MM-DD>/<short-sha>/<run-id>/<bench>/
   ├─ criterion.tar.zst   raw criterion data (samples, estimates, SVG reports)
                          only present for criterion-based benches
-  ├─ iai.tar.zst         raw iai-callgrind output (summary.json, callgrind.out, …)
-                         only present for iai-callgrind benches (iai_callgrind)
+  ├─ gungraun.tar.zst    raw gungraun output (summary.json, callgrind.out, …)
+                         only present for the gungraun bench
   ├─ results.jsonl       one JSON row per (group, param, metric) for trend tools
   ├─ metadata.json       run-level facts (git, host, kernel, timestamps, run URL)
   └─ run.log             cargo bench stdout/stderr
@@ -727,7 +727,7 @@ after each run. This is safe without locking because the workflow is
 **Row schema.** Every row carries `metric` (the measurement name) and
 `value` (the measurement). Criterion rows additionally carry the
 original sibling statistics so older renderers keep working through
-the schema bump; iai rows carry only `metric`/`value` because the
+the schema bump; gungraun rows carry only `metric`/`value` because the
 callgrind summary line doesn't produce per-iteration CIs.
 
 Criterion row (`metric: "mean_ns"`):
@@ -754,11 +754,11 @@ Criterion row (`metric: "mean_ns"`):
 }
 ```
 
-iai row (`metric: "Ir"`):
+gungraun row (`metric: "Ir"`):
 
 ```json
 {
-  "bench": "iai_callgrind",
+  "bench": "gungraun",
   "group": "http",
   "param": "iaps_hot_invocation.p2",
   "sha": "...", "short_sha": "...", "ref": "main",
@@ -774,7 +774,7 @@ iai row (`metric: "Ir"`):
 
 The `throughput` field on criterion rows is captured from criterion's
 `benchmark.json` and tells the renderer whether to display this row as
-time (latency-style) or as ops/sec (throughput-style). iai rows have no
+time (latency-style) or as ops/sec (throughput-style). gungraun rows have no
 throughput field — instruction counts are unit-less in that sense.
 
 ## 12. Re-staging from scratch
@@ -878,13 +878,13 @@ cache). For longer staleness:
 | [`hetzner-postinstall.sh`](./hetzner-postinstall.sh)                                                           | Chroot hook: `nosmt` + perf governor                                                                                                                                                                                      |
 | [`op-env.sh`](./op-env.sh)                                                                                     | `source`-only helper: pulls `WASMCLOUD_BENCH_HOST_IP` / `WASMCLOUD_BENCH_HOSTNAME` / `WASMCLOUD_BENCH_HOST_IPV6` from the 1Password item `WASMCLOUD_BENCH_BOX` into the current shell                                     |
 | [`stage-hetzner.sh`](./stage-hetzner.sh)                                                                       | Phase 1 from your laptop: rescue → installed OS                                                                                                                                                                           |
-| [`ansible/`](./ansible/)                                                                                       | Phase 2 from your laptop: deps + Rust + valgrind + iai-callgrind-runner + repo + kernel cmdline + perf governor. Idempotent; re-run to apply drift or as the "patch a live box without re-staging" path (`--tags kernel`) |
-| [`install-runner.sh`](./install-runner.sh)                                                                     | Phase 3 on the host: GH Actions runner under `bench` user; also installs iai-callgrind-runner. Kept as bash because runner registration takes a one-shot token whose lifecycle is awkward to model declaratively.         |
+| [`ansible/`](./ansible/)                                                                                       | Phase 2 from your laptop: deps + Rust + valgrind + gungraun-runner + repo + kernel cmdline + perf governor. Idempotent; re-run to apply drift or as the "patch a live box without re-staging" path (`--tags kernel`) |
+| [`install-runner.sh`](./install-runner.sh)                                                                     | Phase 3 on the host: GH Actions runner under `bench` user; also installs gungraun-runner. Kept as bash because runner registration takes a one-shot token whose lifecycle is awkward to model declaratively.             |
 | [`../../.github/scripts/bench-preflight.mjs`](../../.github/scripts/bench-preflight.mjs)                       | CI step: refuses to bench on a drifted host (env: `WASMCLOUD_BENCH_HOSTNAME`). GHA-only — runs via `node` from the workflow.                                                                                              |
 | [`run-bench.sh`](./run-bench.sh)                                                                               | CI step + local: invokes `cargo bench`, writes a run log. Stays bash because compare-bench.sh invokes it on the host for local operator runs.                                                                             |
-| [`../../.github/scripts/bench-push-results.mjs`](../../.github/scripts/bench-push-results.mjs)                 | CI step: per-run upload + history.json aggregate + CloudFront invalidate; archives `target/criterion/` and/or `target/iai/`. GHA-only.                                                                                    |
-| [`compare-bench.sh`](./compare-bench.sh)                                                                       | Pair-bench script: runs one bench against two refs (interleaved for criterion, 1× for iai) and snapshots per-iteration data                                                                                               |
-| [`../../crates/bench-tools/`](../../crates/bench-tools/)                                                       | Rust binary that parses criterion + iai-callgrind output and renders the JSONL trend rows, the step-summary markdown, and comparison deltas — see "Data processing" below                                                |
+| [`../../.github/scripts/bench-push-results.mjs`](../../.github/scripts/bench-push-results.mjs)                 | CI step: per-run upload + history.json aggregate + CloudFront invalidate; archives `target/criterion/` and/or `target/gungraun/`. GHA-only.                                                                                    |
+| [`compare-bench.sh`](./compare-bench.sh)                                                                       | Pair-bench script: runs one bench against two refs (interleaved for criterion, 1× for gungraun) and snapshots per-iteration data                                                                                               |
+| [`../../crates/bench-tools/`](../../crates/bench-tools/)                                                       | Rust binary that parses criterion + gungraun output and renders the JSONL trend rows, the step-summary markdown, and comparison deltas — see "Data processing" below                                                     |
 | [`build-history.sh`](./build-history.sh)                                                                       | Maintenance: rebuild `history.json` from scratch by scanning all per-run JSONL in S3                                                                                                                                      |
 | [`aws/setup-aws.sh`](./aws/setup-aws.sh)                                                                       | One-shot: bucket + OAC + CloudFront + WRITE role                                                                                                                                                                          |
 | [`../../.github/workflows/bench.yml`](../../.github/workflows/bench.yml)                                       | Trends pipeline (workflow_dispatch + release auto-trigger)                                                                                                                                                                |
@@ -931,11 +931,11 @@ into layers, each with its own cadence.
 | Layer                                  | Cadence                                           | Pin location                                                                                       | Notes                                                                                                                                                                                                                  |
 | -------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Ubuntu security patches                | continuous (auto)                                 | `unattended-upgrades` (default-on in Noble)                                                        | Only the `-security` pocket. sshd / openssl / glibc fixes go in continuously; kernel held back.                                                                                                                        |
-| Kernel                                 | quarterly, deliberate                             | apt — held back implicitly because we don't run blanket `apt upgrade`                              | Scheduler / cgroup / cpufreq behavior is the measurement substrate. A kernel jump can shift `iai_callgrind` Ir counts and criterion p99 in ways that look like regressions. Annotate the dashboard with the bump date. |
+| Kernel                                 | quarterly, deliberate                             | apt — held back implicitly because we don't run blanket `apt upgrade`                              | Scheduler / cgroup / cpufreq behavior is the measurement substrate. A kernel jump can shift `gungraun` Ir counts and criterion p99 in ways that look like regressions. Annotate the dashboard with the bump date.      |
 | glibc / libstdc++                      | with the kernel                                   | apt                                                                                                | Same reason.                                                                                                                                                                                                           |
-| valgrind                               | yearly, or when iai-callgrind asks for it         | apt                                                                                                | Major valgrind bumps have historically renamed cachegrind event columns; our `Ir` parser is robust to that, but verify.                                                                                                |
+| valgrind                               | yearly, or when gungraun asks for it              | apt                                                                                                | Major valgrind bumps have historically renamed cachegrind event columns; our `Ir` parser is robust to that, but verify.                                                                                                |
 | Rust toolchain                         | rolls with `rust-toolchain.toml` (monthly stable) | repo file                                                                                          | No bench-host-specific pin.                                                                                                                                                                                            |
-| `iai-callgrind` crate + runner         | when the bench fails to start, or yearly          | `crates/wash-runtime/Cargo.toml` + `provision.yml` (`iai_callgrind_version`) + `install-runner.sh` | All three sites must match — iai-callgrind enforces crate-vs-runner equality at run time.                                                                                                                              |
+| `gungraun` crate + runner              | when the bench fails to start, or yearly          | `crates/wash-runtime/Cargo.toml` (single source of truth)                                          | Bump the dep version in `Cargo.toml`; `provision.yml` and `install-runner.sh` both derive the runner version from there at install time. gungraun enforces crate-vs-runner equality at run time.                       |
 | Node.js                                | quarterly (with the kernel bump)                  | `provision.yml` (`node_lts_major`)                                                                 | Bump to the current active LTS line. Built-ins-only scripts; Node version changes are usually low-risk.                                                                                                                |
 | GitHub Actions runner agent            | monthly check, bump on changelog review           | `install-runner.sh` (`RUNNER_VERSION` + `RUNNER_SHA256`)                                           | Auto-tracked via [`bench-host-checks.yml`](../../.github/workflows/bench-host-checks.yml); see below.                                                                                                                  |
 | Action SHA pins (`actions/checkout@…`) | weekly via Dependabot                             | `.github/workflows/*.yml`                                                                          | Low risk — these execute on hosted runners, not the bench host.                                                                                                                                                        |
@@ -968,7 +968,7 @@ dashboard shows one annotated step instead of N small ones:
 2. Bump apt: `apt update && apt upgrade` on the bench host. This is where
    kernel + glibc + valgrind move forward.
 3. Re-run `ansible-playbook provision.yml` — picks up the `node_lts_major`,
-   `iai_callgrind_version` bumps you've staged in the repo.
+   `gungraun_version` bumps you've staged in the repo.
 4. If the kernel cmdline drop-in changed: reboot the host.
 5. Verify with `cat /etc/wasmcloud-bench-stage` + the `nproc`/`isolcpus` checks
    from §4.

--- a/scripts/bench/ansible/provision.yml
+++ b/scripts/bench/ansible/provision.yml
@@ -5,7 +5,7 @@
 # stage-hetzner.sh + hetzner-postinstall.sh because Ansible needs a
 # running system with SSH, which we don't have during installimage.
 #
-# Idempotent. Re-running applies any drift: a new iai-callgrind-runner
+# Idempotent. Re-running applies any drift: a new gungraun-runner
 # version pinned below, a new apt dep, a kernel-cmdline change, etc.
 #
 # Run from scripts/bench/ansible/ with the env vars from inventory.yml's
@@ -13,7 +13,7 @@
 #
 #   ansible-playbook provision.yml                  # everything
 #   ansible-playbook provision.yml --tags kernel    # just the GRUB drop-in
-#   ansible-playbook provision.yml --tags toolchain # apt + rustup + iai
+#   ansible-playbook provision.yml --tags toolchain # apt + rustup + gungraun
 #   ansible-playbook provision.yml --check          # dry-run
 #
 # After --tags kernel changes, a reboot is required for the new cmdline
@@ -28,10 +28,13 @@
     expected_hostname: "{{ lookup('env', 'WASMCLOUD_BENCH_HOSTNAME') }}"
     repo_url: "https://github.com/wasmCloud/wasmCloud.git"
     repo_dir: /opt/wasmcloud
-    # iai-callgrind enforces equality between the runner binary version and
-    # the iai-callgrind crate version pinned in
-    # crates/wash-runtime/Cargo.toml. Bump both together.
-    iai_callgrind_version: "0.16.1"
+    # gungraun enforces equality between the runner binary version and the
+    # gungraun crate version at run time. Derive the runner version from the
+    # crate dep in crates/wash-runtime/Cargo.toml so a `cargo update gungraun`
+    # bump there is the single source of truth.
+    gungraun_version: >-
+      {{ (lookup('file', playbook_dir + '/../../../crates/wash-runtime/Cargo.toml')
+          | regex_findall('(?m)^gungraun = "([^"]+)"'))[0] }}
     # CPU index reserved by isolcpus / nohz_full / rcu_nocbs. Must match
     # WASMCLOUD_BENCH_ISOLATED_CPU in scripts/bench/run-bench.sh.
     isolated_cpu: 5
@@ -40,7 +43,7 @@
     # each quarterly bench-host maintenance window. Ubuntu 24.04 ships
     # Node 18 in `main`, which is past EOL; NodeSource gives us a current
     # LTS without competing with the OS package.
-    node_lts_major: 22
+    node_lts_major: 24
 
   pre_tasks:
     - name: Refuse to run if WASMCLOUD_BENCH_HOSTNAME isn't exported
@@ -90,7 +93,7 @@
           # it, protoc finds the binary but fails to import.
           - protobuf-compiler
           - libprotobuf-dev
-          # Valgrind is the measurement engine for iai_callgrind.
+          # Valgrind is the measurement engine for the gungraun bench.
           - valgrind
           # zstd for criterion.tar.zst archiving; AWS CLI installed
           # separately by install-runner.sh (apt's awscli is v1).
@@ -108,7 +111,7 @@
       args:
         # `creates:` makes this a no-op once rustup is in place. We install
         # `stable` as the default toolchain so out-of-tree `cargo install`
-        # invocations (e.g. iai-callgrind-runner below) have something to
+        # invocations (e.g. gungraun-runner below) have something to
         # pick. Inside the wasmCloud workspace the repo's
         # rust-toolchain.toml still wins — it also pins `stable` today, so
         # there's no drift between the default and the workspace toolchain.
@@ -170,22 +173,22 @@
       ansible.builtin.command: /root/.cargo/bin/cargo install --list
       register: cargo_installed
       changed_when: false
-      tags: [toolchain, iai]
+      tags: [toolchain, gungraun]
 
-    - name: Install or upgrade iai-callgrind-runner
+    - name: Install or upgrade gungraun-runner
       ansible.builtin.shell: |
         set -euo pipefail
         . "$HOME/.cargo/env"
-        cargo install iai-callgrind-runner --version {{ iai_callgrind_version }}
+        cargo install gungraun-runner --version {{ gungraun_version }}
       args:
         executable: /bin/bash
       # `cargo install --list` is the canonical way to query installed
       # binaries. Each crate's entry has the shape `<name> v<version>:`
-      # on its own line — the trailing colon disambiguates `0.16.1` from
-      # `0.16.10` etc., so a plain substring check is safe here (no
+      # on its own line — the trailing colon disambiguates `0.19.1` from
+      # `0.19.10` etc., so a plain substring check is safe here (no
       # regex, no split/last on a possibly-empty value).
-      when: ('iai-callgrind-runner v' ~ iai_callgrind_version ~ ':') not in cargo_installed.stdout
-      tags: [toolchain, iai]
+      when: ('gungraun-runner v' ~ gungraun_version ~ ':') not in cargo_installed.stdout
+      tags: [toolchain, gungraun]
 
     # ── Repo clone for ad-hoc / manual benches ────────────────────────────
     - name: Clone wasmCloud repo to {{ repo_dir }}
@@ -257,7 +260,7 @@
           kernel-tweak: nosmt isolcpus={{ isolated_cpu }} nohz_full={{ isolated_cpu }} rcu_nocbs={{ isolated_cpu }}
           cpufreq-governor: performance
           isolated-cpu: {{ isolated_cpu }}
-          iai-callgrind-runner: {{ iai_callgrind_version }}
+          gungraun-runner: {{ gungraun_version }}
           node-lts-major: {{ node_lts_major }}
       tags: [marker]
 

--- a/scripts/bench/compare-bench.sh
+++ b/scripts/bench/compare-bench.sh
@@ -5,7 +5,7 @@
 #   ./scripts/bench/compare-bench.sh <bench> <ref_a> <ref_b>
 #
 # Variance handling (per the design call — see scripts/bench/README.md §9.4):
-#   - iai_callgrind: 1 run per ref (instruction counts are deterministic).
+#   - gungraun: 1 run per ref (instruction counts are deterministic).
 #   - criterion benches: 3 interleaved runs per ref (a₁ b₁ a₂ b₂ a₃ b₃);
 #     median of the three is what the delta is computed from.
 #
@@ -35,7 +35,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # wall-clock benches do. Override via WASMCLOUD_BENCH_COMPARE_ITERS=N for testing.
 if [ -n "${WASMCLOUD_BENCH_COMPARE_ITERS:-}" ]; then
   iters="$WASMCLOUD_BENCH_COMPARE_ITERS"
-elif [ "$bench" = "iai_callgrind" ]; then
+elif [ "$bench" = "gungraun" ]; then
   iters=1
 else
   iters=3
@@ -100,16 +100,16 @@ trap cleanup EXIT
 
 step() { printf '\n=== %s ===\n' "$*"; }
 
-# Snapshot the bench output dirs that exist (criterion and/or iai) into a
-# numbered iteration dir under ${compare_dir}/{a,b}/. Wipes the live dirs
-# afterwards so the next iteration starts clean (run-bench.sh also wipes,
-# but doing it here guarantees no inter-iteration leak even if run-bench.sh
-# changes later).
+# Snapshot the bench output dirs that exist (criterion and/or gungraun)
+# into a numbered iteration dir under ${compare_dir}/{a,b}/. Wipes the
+# live dirs afterwards so the next iteration starts clean (run-bench.sh
+# also wipes, but doing it here guarantees no inter-iteration leak even
+# if run-bench.sh changes later).
 snapshot() {
   local side="$1" iter="$2"
   local dest="${compare_dir}/${side}/iter-${iter}"
   mkdir -p "$dest"
-  for d in criterion iai; do
+  for d in criterion gungraun; do
     if [ -d "${CARGO_TARGET_DIR}/${d}" ]; then
       cp -a "${CARGO_TARGET_DIR}/${d}" "${dest}/${d}"
     fi

--- a/scripts/bench/hetzner-postinstall.sh
+++ b/scripts/bench/hetzner-postinstall.sh
@@ -11,7 +11,7 @@
 #                        scheduler tick and offload RCU callbacks off
 #                        that core. Bench processes that want a quiet
 #                        core taskset themselves onto CPU 5 (currently
-#                        only iai_callgrind; criterion benches are
+#                        only the gungraun bench; criterion benches are
 #                        multi-threaded and don't pin).
 #   3. governor=perf   - systemd unit pins every CPU's scaling_governor to
 #                        `performance` on boot, eliminating freq scaling

--- a/scripts/bench/install-runner.sh
+++ b/scripts/bench/install-runner.sh
@@ -88,7 +88,7 @@ aws --version
 
 step "install rustup for the bench user"
 # The runner runs as `bench`, so it needs its own cargo. Default to `stable`
-# so out-of-tree `cargo install` invocations (e.g. iai-callgrind-runner
+# so out-of-tree `cargo install` invocations (e.g. gungraun-runner
 # below) have something to pick. Inside the wasmCloud workspace the
 # repo's rust-toolchain.toml still wins — it also pins `stable` today,
 # so there's no drift between the default and the workspace toolchain.
@@ -104,17 +104,39 @@ fi
 # when stable is already the default; downloads + sets it otherwise.
 sudo -u bench -H bash -c '. $HOME/.cargo/env && rustup default stable && rustup --version'
 
-step "install iai-callgrind-runner for the bench user"
-# Required by the iai_callgrind bench. Version must equal the iai-callgrind
-# crate version pinned in crates/wash-runtime/Cargo.toml — iai-callgrind
-# enforces equality at run time.
-sudo -u bench -H bash -c '
+step "install gungraun-runner for the bench user"
+# Required by the gungraun bench. Version must equal the gungraun crate
+# version pinned in crates/wash-runtime/Cargo.toml — gungraun enforces
+# equality at run time, so they're derived from a single source of truth
+# (the Cargo.toml dep) rather than re-pinned here. `provision.yml` does
+# the same derivation, so a `cargo update gungraun` bump propagates to
+# both install paths without a separate edit.
+#
+# Version check uses `cargo install --list` rather than
+# `gungraun-runner --version`: the runner inspects the nearest Cargo.toml
+# at every invocation and bails with "No version information found for
+# gungraun" when it's run from the wasmCloud workspace root (the gungraun
+# dep lives in crates/wash-runtime/Cargo.toml as a dev-dependency, not in
+# [workspace.dependencies]). The install-time check below is
+# cwd-independent, so it works whether the operator runs the script from
+# /opt/wasmcloud, /tmp, or anywhere else.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cargo_toml="$script_dir/../../crates/wash-runtime/Cargo.toml"
+gungraun_version=$(awk -F'"' '/^gungraun = "/ { print $2; exit }' "$cargo_toml")
+if [ -z "$gungraun_version" ]; then
+  echo "could not extract gungraun version from $cargo_toml" >&2
+  echo "expected a line like: gungraun = \"X.Y.Z\"" >&2
+  exit 1
+fi
+echo "installing gungraun-runner v${gungraun_version} (from $cargo_toml)"
+sudo --preserve-env=GUNGRAUN_VERSION -u bench -H \
+  env GUNGRAUN_VERSION="$gungraun_version" bash -c '
+  set -euo pipefail
   . $HOME/.cargo/env
-  if ! command -v iai-callgrind-runner >/dev/null 2>&1 \
-       || [ "$(iai-callgrind-runner --version 2>/dev/null | awk "{print \$2}")" != "0.16.1" ]; then
-    cargo install iai-callgrind-runner --version 0.16.1
+  if ! cargo install --list | grep -qx "gungraun-runner v${GUNGRAUN_VERSION}:"; then
+    cargo install gungraun-runner --version "${GUNGRAUN_VERSION}"
   fi
-  iai-callgrind-runner --version
+  cargo install --list | grep "^gungraun-runner "
 '
 
 step "download + verify + extract actions-runner v${RUNNER_VERSION}"

--- a/scripts/bench/run-bench.sh
+++ b/scripts/bench/run-bench.sh
@@ -6,7 +6,7 @@
 # Two harness types share this script:
 #   - criterion benches (http_invoke, wasmtime_baseline, wasmtime_serve)
 #     write to $CARGO_TARGET_DIR/criterion/.
-#   - iai-callgrind benches (iai_callgrind) write to $CARGO_TARGET_DIR/iai/
+#   - gungraun benches (gungraun) write to $CARGO_TARGET_DIR/gungraun/
 #     and are pinned to the isolated CPU (set by hetzner-postinstall.sh
 #     via isolcpus=) so that scheduler interference doesn't leak into
 #     instruction counts. valgrind serializes threads, so single-core
@@ -58,8 +58,8 @@ log="${CARGO_TARGET_DIR}/run-${bench}-${GITHUB_RUN_ID:-local}.log"
 # otherwise leak across benches because the dir at $CARGO_TARGET_DIR is
 # persistent (kept for the *build* cache, not the measurement output).
 # The build cache lives elsewhere in $CARGO_TARGET_DIR and is preserved.
-# Both criterion and iai keep "previous run" baseline data we don't use.
-rm -rf "${CARGO_TARGET_DIR}/criterion" "${CARGO_TARGET_DIR}/iai"
+# Both criterion and gungraun keep "previous run" baseline data we don't use.
+rm -rf "${CARGO_TARGET_DIR}/criterion" "${CARGO_TARGET_DIR}/gungraun"
 
 # Touch the run marker right before invoking cargo so `find -newer "$marker"`
 # in `bench-tools jsonl` picks up exactly the files this run produced.
@@ -67,11 +67,11 @@ rm -rf "${CARGO_TARGET_DIR}/criterion" "${CARGO_TARGET_DIR}/iai"
 # manual partial run), the marker still bounds what gets emitted.
 touch "$marker"
 
-# iai_callgrind: pin to the isolated CPU. The criterion-style benches are
+# gungraun: pin to the isolated CPU. The criterion-style benches are
 # multi-threaded (tokio + hyper) and would lose throughput under taskset,
 # so they run unpinned across the non-isolated cores.
 prefix=()
-if [ "$bench" = "iai_callgrind" ]; then
+if [ "$bench" = "gungraun" ]; then
   if [ -x "$(command -v taskset)" ]; then
     prefix=(taskset -c "$isolated_cpu")
     echo "pinning $bench to CPU $isolated_cpu via taskset" | tee -a "$log"


### PR DESCRIPTION
- crates/wash-runtime: dep + bench target rename; drop the redundant
  `iai_` prefix on the bench fns
- bench-tools, scripts, workflows: bench identifier + target/iai →
  target/gungraun; preserve callgrind.rs (file format unchanged)
- install-runner.sh, provision.yml: derive runner version from the
  Cargo.toml dep (single source of truth — gungraun enforces equality)
- install-runner.sh: replace runtime `gungraun --version` probe with
  `cargo install --list` (probe bails when run from workspace root)
- bench-preflight.mjs: `nproc --all` so systemd's affinity narrowing
  from isolcpus doesn't trip the 6-core assertion where 1 core is
  actually reserved (6 cores available on the host, only 5 for bench).
- provision.yml: bump node_lts_major 22 → 24
