### PR TITLE
chore: lowercase error context messages to match conventions

### DIFF
--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1264,7 +1264,7 @@ async fn load_tls_config(
     let mut config = ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(cert_chain, key)
-        .context("Failed to create TLS configuration")?;
+        .context("failed to create TLS configuration")?;
 
     // Advertise both h2 and http/1.1 via ALPN
     config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];

--- a/crates/wash/src/cli/inspect.rs
+++ b/crates/wash/src/cli/inspect.rs
@@ -45,12 +45,12 @@ impl CliCommand for InspectCommand {
 
         let component = decode_component(bytes.as_slice())
             .await
-            .context("Failed to decode component")?;
+            .context("failed to decode component")?;
 
         // Print the component WIT
         let wit = get_component_wit(component)
             .await
-            .context("Failed to print component WIT")?;
+            .context("failed to print component WIT")?;
 
         Ok(CommandOutput::ok(
             wit.to_owned(),

--- a/crates/wash/src/cli/update.rs
+++ b/crates/wash/src/cli/update.rs
@@ -353,7 +353,7 @@ impl UpdateConfig {
             headers.insert(
                 AUTHORIZATION,
                 HeaderValue::from_str(&auth_header)
-                    .context("Failed to create authorization header")?,
+                    .context("failed to create authorization header")?,
             );
             debug!("Using GitHub token for authentication");
         }
@@ -361,6 +361,6 @@ impl UpdateConfig {
         Client::builder()
             .default_headers(headers)
             .build()
-            .context("Failed to create HTTP client")
+            .context("failed to create HTTP client")
     }
 }

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -541,7 +541,7 @@ where
 
     figment
         .extract()
-        .context("Failed to load wash configuration")
+        .context("failed to load wash configuration")
 }
 
 pub fn locate_project_config(project_dir: &Path) -> PathBuf {
@@ -616,7 +616,7 @@ pub async fn save_config(config: &Config, path: &Path) -> Result<()> {
     }
 
     let yaml_config =
-        serde_yaml_ng::to_string(config).context("Failed to serialize configuration")?;
+        serde_yaml_ng::to_string(config).context("failed to serialize configuration")?;
 
     tokio::fs::write(path, yaml_config)
         .await

--- a/crates/wash/src/new.rs
+++ b/crates/wash/src/new.rs
@@ -81,7 +81,7 @@ pub(crate) async fn clone_template(
         debug!("Removing .git directory from cloned repository");
         tokio::fs::remove_dir_all(&git_dir)
             .await
-            .context("Failed to remove .git directory")?;
+            .context("failed to remove .git directory")?;
     }
 
     Ok(())
@@ -129,7 +129,7 @@ pub(crate) fn copy_dir_recursive<'a>(
 
         let src_metadata = tokio::fs::metadata(src)
             .await
-            .with_context(|| format!("Failed to read source path: {src}", src = src.display()))?;
+            .with_context(|| format!("failed to read source path: {}", src.display()))?;
 
         if !src_metadata.is_dir() {
             bail!("Source is not a directory: {src}", src = src.display());
@@ -137,16 +137,16 @@ pub(crate) fn copy_dir_recursive<'a>(
 
         tokio::fs::create_dir_all(dst)
             .await
-            .with_context(|| format!("Failed to create directory: {dst}", dst = dst.display()))?;
+            .with_context(|| format!("failed to create directory: {}", dst.display()))?;
 
         let mut entries = tokio::fs::read_dir(src)
             .await
-            .with_context(|| format!("Failed to read directory: {src}", src = src.display()))?;
+            .with_context(|| format!("failed to read directory: {}", src.display()))?;
 
         while let Some(entry) = entries
             .next_entry()
             .await
-            .context("Failed to read directory entry")?
+            .context("failed to read directory entry")?
         {
             let path = entry.path();
             let name = entry.file_name();
@@ -161,14 +161,14 @@ pub(crate) fn copy_dir_recursive<'a>(
             let metadata = entry
                 .metadata()
                 .await
-                .context("Failed to read entry metadata")?;
+                .context("failed to read entry metadata")?;
 
             if metadata.is_dir() {
                 copy_dir_recursive(&path, &dst_path).await?;
             } else {
                 tokio::fs::copy(&path, &dst_path).await.with_context(|| {
                     format!(
-                        "Failed to copy file {} to {}",
+                        "failed to copy file {} to {}",
                         path.display(),
                         dst_path.display()
                     )


### PR DESCRIPTION
CONTRIBUTING.md says error messages and log contexts should start with lowercase and not end with periods. Found 14 spots across 5 files where `.context("Failed to ...")` slipped through with a capital F.

Spotted after looking at d9df934fd which fixed the same thing in error handlers - figured there were more hiding elsewhere, and yep there were.

Files touched: `new.rs`, `inspect.rs`, `update.rs`, `config.rs`, `host/http.rs`.

Reproduce by grepping the codebase:
```
grep -rn 'context("Failed' crates/
```

Returns 14 hits before this PR, zero after.