### PR TITLE
chore(lint): inline format args and enforce lowercase context casing

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -216,6 +216,21 @@ jobs:
       - name: Lint
         run: |
           cargo clippy --workspace --features wasip3,wasi-tls
+      - name: Lint anyhow context message casing
+        run: |
+          # anyhow `.context()` / `.with_context()` strings are error messages,
+          # which by Rust convention start lowercase so they compose into error
+          # chains. Match sentence-case prose (capital + lowercase) so acronyms
+          # and type names (HTTP, P3, DevRouter) are left untouched.
+          #
+          # Scope is production source only (crates/*/src), matching the clippy
+          # job above; integration tests are not checked. Only single-line
+          # context calls are matched.
+          if matches=$(grep -rn --include='*.rs' -E '\.(with_)?context\((\|\| )?(format!\()?"[A-Z][a-z]' crates/*/src); then
+            echo "::error::anyhow context messages should start with a lowercase letter (Rust convention); lowercase the first letter:"
+            echo "$matches"
+            exit 1
+          fi
       - name: Check for unused dependencies
         run: |
           cargo machete

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ transmute_ptr_to_ref = 'deny'
 transmute_undefined_repr = 'deny'
 trivially_copy_pass_by_ref = 'deny'
 uninit_vec = 'deny'
+uninlined_format_args = 'deny'
 unnecessary_box_returns = 'deny'
 
 [workspace.dependencies]

--- a/crates/bench-tools/src/commands/delta.rs
+++ b/crates/bench-tools/src/commands/delta.rs
@@ -251,7 +251,7 @@ fn fmt_value(v: Option<f64>, kind: Kind) -> String {
 
 fn fmt_delta(v: Option<f64>) -> String {
     match v {
-        Some(pct) => format!("{:.2}%", pct),
+        Some(pct) => format!("{pct:.2}%"),
         None => "—".to_string(),
     }
 }

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1870,10 +1870,7 @@ fn topological_sort_components(
             .filter(|id| !result.contains(id))
             .map(|id| id.as_ref())
             .collect();
-        bail!(
-            "circular dependency detected among components: {:?}",
-            unprocessed
-        );
+        bail!("circular dependency detected among components: {unprocessed:?}");
     }
 
     Ok(result)
@@ -1898,8 +1895,8 @@ impl AsRef<str> for IdFlavor {
 impl std::fmt::Display for IdFlavor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            IdFlavor::Component(id) => write!(f, "Component({})", id),
-            IdFlavor::Service(id) => write!(f, "Service({})", id),
+            IdFlavor::Component(id) => write!(f, "Component({id})"),
+            IdFlavor::Service(id) => write!(f, "Service({id})"),
         }
     }
 }

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -196,7 +196,7 @@ impl Router for DynamicRouter {
             .config
             .get("host")
             .cloned()
-            .context("No host header found")?;
+            .context("no host header found")?;
 
         anyhow::ensure!(
             is_valid_hostname(&primary_host),
@@ -1273,10 +1273,10 @@ async fn load_tls_config(
     if let Some(ca_path) = ca_path {
         let ca_data = tokio::fs::read(ca_path)
             .await
-            .context(format!("Failed to read CA file: {}", ca_path.display()))?;
+            .context(format!("failed to read CA file: {}", ca_path.display()))?;
         let ca_certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&ca_data)
             .collect::<Result<Vec<_>, _>>()
-            .context(format!("Failed to parse CA file: {}", ca_path.display()))?;
+            .context(format!("failed to parse CA file: {}", ca_path.display()))?;
 
         ensure!(
             !ca_certs.is_empty(),
@@ -1319,8 +1319,7 @@ pub fn check_allowed_hosts<B>(
 
     if allowed_hosts.is_empty() {
         anyhow::bail!(
-            "outgoing request to host '{}' denied: allowed_hosts policy is empty (deny-all)",
-            request_host
+            "outgoing request to host '{request_host}' denied: allowed_hosts policy is empty (deny-all)"
         );
     }
 
@@ -1329,8 +1328,7 @@ pub fn check_allowed_hosts<B>(
     }
 
     anyhow::bail!(
-        "outgoing request to host '{}' is not allowed by allowed_hosts policy",
-        request_host
+        "outgoing request to host '{request_host}' is not allowed by allowed_hosts policy"
     )
 }
 

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -169,7 +169,7 @@ impl std::fmt::Display for HostWorkload {
             HostWorkload::Starting => write!(f, "Starting"),
             HostWorkload::Running(_) => write!(f, "Running"),
             HostWorkload::Stopping => write!(f, "Stopping"),
-            HostWorkload::Error(err) => write!(f, "Error: {}", err),
+            HostWorkload::Error(err) => write!(f, "Error: {err}"),
         }
     }
 }

--- a/crates/wash-runtime/src/oci.rs
+++ b/crates/wash-runtime/src/oci.rs
@@ -434,10 +434,7 @@ pub async fn pull_component(
         tokio::time::timeout(timeout, pull_future)
             .await
             .with_context(|| {
-                format!(
-                    "timeout pulling component from {reference} after {:?}",
-                    timeout
-                )
+                format!("timeout pulling component from {reference} after {timeout:?}")
             })?
             .with_context(|| format!("failed to pull component from {reference}"))?
     } else {
@@ -600,12 +597,7 @@ pub async fn push_component(
     let push_result = if let Some(timeout) = config.timeout {
         tokio::time::timeout(timeout, push_future)
             .await
-            .with_context(|| {
-                format!(
-                    "timeout pushing component to {reference} after {:?}",
-                    timeout
-                )
-            })?
+            .with_context(|| format!("timeout pushing component to {reference} after {timeout:?}"))?
             .with_context(|| format!("failed to push component to {reference}"))?
     } else {
         push_future

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/filesystem.rs
@@ -127,7 +127,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         };
 
         if !root.exists() {
-            return Ok(Err(format!("bucket '{}' does not exist", name)));
+            return Ok(Err(format!("bucket '{name}' does not exist")));
         }
 
         let container_data = ContainerData {
@@ -152,7 +152,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
             return Ok(Err("invalid container name".to_string()));
         };
         if !path.exists() {
-            return Ok(Err(format!("bucket '{}' does not exist", name)));
+            return Ok(Err(format!("bucket '{name}' does not exist")));
         }
 
         if let Err(e) = tokio::fs::remove_dir_all(&path).await {
@@ -297,7 +297,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         };
 
         if !file.exists() {
-            return Ok(Err(format!("object '{}' does not exist", name)));
+            return Ok(Err(format!("object '{name}' does not exist")));
         }
 
         let resource = self.table.push(IncomingValueHandle { file, start, end })?;
@@ -365,7 +365,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<(), ContainerError>> {
         let container_data = self.table.get(&container)?;
         let Ok(path) = lock_root(&container_data.root, name.as_str()) else {
-            return Ok(Err(format!("invalid object name: {}", name)));
+            return Ok(Err(format!("invalid object name: {name}")));
         };
 
         match tokio::fs::remove_file(path).await {
@@ -384,7 +384,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
 
         for name in names {
             let Ok(path) = lock_root(&container_data.root, name.as_str()) else {
-                return Ok(Err(format!("invalid object name: {}", name)));
+                return Ok(Err(format!("invalid object name: {name}")));
             };
             if let Err(e) = tokio::fs::remove_file(path).await {
                 return Ok(Err(format!("failed to delete object: {e}")));

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
@@ -133,7 +133,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
             Ok(entry) => Some(entry.to_vec()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
             Err(e) => {
-                return Ok(Err(StoreError::Other(format!("Filesystem error: {}", e))));
+                return Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))));
             }
         };
 
@@ -164,7 +164,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
             Ok(_) => Ok(Ok(())),
             Err(e) => {
                 tracing::error!("Filesystem error setting key: {}", e);
-                Ok(Err(StoreError::Other(format!("Filesystem error: {}", e))))
+                Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))))
             }
         }
     }
@@ -191,7 +191,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
             Ok(_) => Ok(Ok(())),
             Err(e) => {
                 tracing::error!("Filesystem error deleting key: {}", e);
-                Ok(Err(StoreError::Other(format!("Filesystem error: {}", e))))
+                Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))))
             }
         }
     }
@@ -242,7 +242,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
             Ok(i) => i,
             Err(e) => {
                 tracing::error!("Filesystem error getting key: {}", e);
-                return Ok(Err(StoreError::Other(format!("Filesystem error: {}", e))));
+                return Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))));
             }
         };
 
@@ -311,7 +311,7 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
             Err(e) => {
                 tracing::error!("Filesystem error getting key entry: {}", e);
-                return Ok(Err(StoreError::Other(format!("Filesystem error: {}", e))));
+                return Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))));
             }
         };
 
@@ -321,7 +321,7 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
             Ok(_) => Ok(Ok(new_value)),
             Err(e) => {
                 tracing::error!("Filesystem error putting key: {}", e);
-                Ok(Err(StoreError::Other(format!("Filesystem error: {}", e))))
+                Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))))
             }
         }
     }
@@ -354,7 +354,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
                 Err(e) => {
                     tracing::error!("JetStream error getting key: {}", e);
-                    Err(StoreError::Other(format!("JetStream error: {}", e)))
+                    Err(StoreError::Other(format!("JetStream error: {e}")))
                 }
             }
         }))
@@ -397,7 +397,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
                     Ok(_) => Ok(()),
                     Err(e) => {
                         tracing::error!("JetStream error putting key: {}", e);
-                        Err(StoreError::Other(format!("JetStream error: {}", e)))
+                        Err(StoreError::Other(format!("JetStream error: {e}")))
                     }
                 }
             },
@@ -438,7 +438,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
                 Ok(_) => Ok(()),
                 Err(e) => {
                     tracing::error!("JetStream error deleting key: {}", e);
-                    Err(StoreError::Other(format!("JetStream error: {}", e)))
+                    Err(StoreError::Other(format!("JetStream error: {e}")))
                 }
             }
         }))

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
@@ -146,7 +146,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
             Ok(value) => Ok(Ok(value)),
             Err(e) => {
                 tracing::error!("Redis error getting key: {}", e);
-                Ok(Err(StoreError::Other(format!("Redis error: {}", e))))
+                Ok(Err(StoreError::Other(format!("Redis error: {e}"))))
             }
         }
     }
@@ -173,7 +173,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
             Ok(_) => Ok(Ok(())),
             Err(e) => {
                 tracing::error!("Redis error setting key: {}", e);
-                Ok(Err(StoreError::Other(format!("Redis error: {}", e))))
+                Ok(Err(StoreError::Other(format!("Redis error: {e}"))))
             }
         }
     }
@@ -199,7 +199,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
             Ok(_) => Ok(Ok(())),
             Err(e) => {
                 tracing::error!("Redis error deleting key: {}", e);
-                Ok(Err(StoreError::Other(format!("Redis error: {}", e))))
+                Ok(Err(StoreError::Other(format!("Redis error: {e}"))))
             }
         }
     }
@@ -225,7 +225,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
             Ok(exists) => Ok(Ok(exists)),
             Err(e) => {
                 tracing::error!("Redis error checking key existence: {}", e);
-                Ok(Err(StoreError::Other(format!("Redis error: {}", e))))
+                Ok(Err(StoreError::Other(format!("Redis error: {e}"))))
             }
         }
     }
@@ -260,7 +260,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
             Ok(result) => result,
             Err(e) => {
                 tracing::error!("Redis error listing keys: {}", e);
-                return Ok(Err(StoreError::Other(format!("Redis error: {}", e))));
+                return Ok(Err(StoreError::Other(format!("Redis error: {e}"))));
             }
         };
 
@@ -322,7 +322,7 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
             Ok(new_value) => Ok(Ok(new_value as u64)),
             Err(e) => {
                 tracing::error!("Redis error incrementing key: {}", e);
-                Ok(Err(StoreError::Other(format!("Redis error: {}", e))))
+                Ok(Err(StoreError::Other(format!("Redis error: {e}"))))
             }
         }
     }
@@ -357,7 +357,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
             Ok(v) => v,
             Err(e) => {
                 tracing::error!("Redis error getting keys: {}", e);
-                return Ok(Err(StoreError::Other(format!("Redis error: {}", e))));
+                return Ok(Err(StoreError::Other(format!("Redis error: {e}"))));
             }
         };
 
@@ -399,7 +399,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
             Ok(_) => Ok(Ok(())),
             Err(e) => {
                 tracing::error!("Redis error setting keys: {}", e);
-                Ok(Err(StoreError::Other(format!("Redis error: {}", e))))
+                Ok(Err(StoreError::Other(format!("Redis error: {e}"))))
             }
         }
     }
@@ -427,7 +427,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
                     Ok(_) => Ok(()),
                     Err(e) => {
                         tracing::error!("Redis error deleting key: {}", e);
-                        Err(StoreError::Other(format!("Redis error: {}", e)))
+                        Err(StoreError::Other(format!("Redis error: {e}")))
                     }
                 }
             }

--- a/crates/wash-runtime/src/plugin/wasi_otel/convert.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/convert.rs
@@ -373,7 +373,7 @@ pub fn summarize_span_data(span: &wasi_tracing::SpanData) -> SpanSummary {
     let status = match &span.status {
         wasi_tracing::Status::Unset => "unset".to_string(),
         wasi_tracing::Status::Ok => "ok".to_string(),
-        wasi_tracing::Status::Error(msg) => format!("error: {}", msg),
+        wasi_tracing::Status::Error(msg) => format!("error: {msg}"),
     };
 
     SpanSummary {

--- a/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
@@ -361,7 +361,7 @@ impl<'a> bindings::wasi::otel::metrics::Host for ActiveCtx<'a> {
                 // Force flush to export recorded metrics
                 if let Err(e) = provider.force_flush() {
                     tracing::warn!(error = %e, "Failed to flush metrics");
-                    return Ok(Err(format!("Failed to flush metrics: {}", e)));
+                    return Ok(Err(format!("Failed to flush metrics: {e}")));
                 }
 
                 tracing::info!(

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -235,7 +235,7 @@ impl Display for WitInterface {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}:{}", self.namespace, self.package)?;
         if let Some(name) = &self.name {
-            write!(f, " [{}]", name)?;
+            write!(f, " [{name}]")?;
         }
         if !self.interfaces.is_empty() {
             write!(f, "/")?;
@@ -243,7 +243,7 @@ impl Display for WitInterface {
             write!(f, "{}", interfaces.join(","))?;
         }
         if let Some(v) = &self.version {
-            write!(f, "@{}", v)?;
+            write!(f, "@{v}")?;
         }
         Ok(())
     }

--- a/crates/wash/src/cli/component_build.rs
+++ b/crates/wash/src/cli/component_build.rs
@@ -291,7 +291,7 @@ impl ComponentBuilder {
         let component_path = build_config
             .component_path
             .clone()
-            .unwrap_or(format!("{}.wasm", project_dir_name).into());
+            .unwrap_or_else(|| format!("{project_dir_name}.wasm").into());
 
         let (cmd_bin, first_arg) = {
             #[cfg(not(windows))]

--- a/crates/wash/src/cli/inspect.rs
+++ b/crates/wash/src/cli/inspect.rs
@@ -30,17 +30,15 @@ impl CliCommand for InspectCommand {
                     .context("failed to read component file")?
             } else if path.is_dir() {
                 anyhow::bail!(
-                    "Directory '{}' specified. Please provide a file path.",
-                    component_reference
+                    "Directory '{component_reference}' specified. Please provide a file path."
                 );
             } else {
                 anyhow::bail!(
-                    "Path '{}' exists but is neither a file nor directory",
-                    component_reference
+                    "Path '{component_reference}' exists but is neither a file nor directory"
                 );
             }
         } else {
-            anyhow::bail!("Path '{}' does not exist locally", component_reference);
+            anyhow::bail!("Path '{component_reference}' does not exist locally");
         };
 
         let component = decode_component(bytes.as_slice())

--- a/crates/wash/src/cli/new.rs
+++ b/crates/wash/src/cli/new.rs
@@ -76,8 +76,7 @@ impl CliCommand for NewCommand {
 
         if let Some(new_cmd) = template_config.new.and_then(|nc| nc.command)
             && ctx.request_confirmation(format!(
-                "Execute template setup command '{}'? This may modify the new project.",
-                new_cmd
+                "Execute template setup command '{new_cmd}'? This may modify the new project."
             ))?
         {
             run_new_command(&new_cmd, &output_dir).await?;

--- a/crates/wash/src/cli/wit.rs
+++ b/crates/wash/src/cli/wit.rs
@@ -194,15 +194,13 @@ fn validate_interface_ref(package: &str) -> Result<()> {
 
     if !name_part.contains(':') {
         bail!(
-            "Invalid package format '{}': must be in 'namespace:package/interface' format (e.g., 'wasi:http/types')",
-            name_part
+            "Invalid package format '{name_part}': must be in 'namespace:package/interface' format (e.g., 'wasi:http/types')"
         );
     }
 
     if !name_part.contains('/') {
         bail!(
-            "Invalid package format '{}': must include interface name in 'namespace:package/interface' format (e.g., 'wasi:http/types')",
-            name_part
+            "Invalid package format '{name_part}': must include interface name in 'namespace:package/interface' format (e.g., 'wasi:http/types')"
         );
     }
 
@@ -412,7 +410,7 @@ async fn handle_update(
 
         if lock_file.packages.len() == before_count {
             return Ok(CommandOutput::error(
-                format!("Package '{}' not found in lock file", package_name),
+                format!("Package '{package_name}' not found in lock file"),
                 None,
             ));
         }
@@ -435,7 +433,7 @@ async fn handle_update(
         handle_fetch(ctx, config, false).await?;
 
         Ok(CommandOutput::ok(
-            format!("Updated package: {}", package_name),
+            format!("Updated package: {package_name}"),
             Some(serde_json::json!({
                 "package": package_name,
                 "wit_dir": wit_dir.display().to_string(),
@@ -496,7 +494,7 @@ async fn handle_add(ctx: &CliContext, package: &str, config: &Config) -> Result<
     let world_wit_path = match find_world_wit_file(&wit_dir).await {
         Ok(path) => path,
         Err(e) => {
-            return Ok(CommandOutput::error(format!("{:#}", e), None));
+            return Ok(CommandOutput::error(format!("{e:#}"), None));
         }
     };
 
@@ -557,7 +555,7 @@ async fn handle_add(ctx: &CliContext, package: &str, config: &Config) -> Result<
 
                 if !has_more_imports {
                     // Insert after the last import
-                    new_lines.push(format!("{}{}", world_indent, import_line));
+                    new_lines.push(format!("{world_indent}{import_line}"));
                     inserted = true;
                 }
             } else if trimmed.starts_with("world ") && trimmed.ends_with('{') {
@@ -572,7 +570,7 @@ async fn handle_add(ctx: &CliContext, package: &str, config: &Config) -> Result<
 
                 if !has_imports {
                     // No imports yet, insert as first line in world block
-                    new_lines.push(format!("{}{}", world_indent, import_line));
+                    new_lines.push(format!("{world_indent}{import_line}"));
                     inserted = true;
                 }
             }
@@ -643,7 +641,7 @@ async fn handle_remove(_ctx: &CliContext, package: &str, config: &Config) -> Res
     let world_wit_path = match find_world_wit_file(&wit_dir).await {
         Ok(path) => path,
         Err(e) => {
-            return Ok(CommandOutput::error(format!("{:#}", e), None));
+            return Ok(CommandOutput::error(format!("{e:#}"), None));
         }
     };
 

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -590,7 +590,7 @@ fn load_config_file(file_path: &Path) -> Result<Figment> {
             figment = figment.merge(Toml::file_exact(file_path));
         }
         Some(ext) => {
-            bail!("Unsupported global config file extension: {}", ext);
+            bail!("Unsupported global config file extension: {ext}");
         }
         None => {
             bail!(

--- a/crates/wash/src/wit.rs
+++ b/crates/wash/src/wit.rs
@@ -122,7 +122,7 @@ impl TryFrom<RegistryPullSource> for RegistryMapping {
     fn try_from(source: RegistryPullSource) -> Result<Self, Self::Error> {
         match source {
             RegistryPullSource::RemoteOci(url) => Ok(RegistryMapping::Registry(url.parse()?)),
-            _ => bail!("Cannot convert {:?} to RegistryMapping", source),
+            _ => bail!("Cannot convert {source:?} to RegistryMapping"),
         }
     }
 }
@@ -293,13 +293,13 @@ impl WkgFetcher {
                 RegistryPullSource::RemoteHttp(_) => {
                     let wit_dir = download_and_extract_http(source)
                         .await
-                        .with_context(|| format!("failed to download HTTP source [{}]", source))?;
+                        .with_context(|| format!("failed to download HTTP source [{source}]"))?;
                     set_override_for_target(wkg_config_overrides, &ns, &pkgs, wit_dir);
                 }
                 RegistryPullSource::RemoteGit(_) => {
                     let wit_dir = clone_git_and_find_wit(source)
                         .await
-                        .with_context(|| format!("failed to clone Git source [{}]", source))?;
+                        .with_context(|| format!("failed to clone Git source [{source}]"))?;
                     set_override_for_target(wkg_config_overrides, &ns, &pkgs, wit_dir);
                 }
                 RegistryPullSource::RemoteOci(_) => {
@@ -447,7 +447,7 @@ fn set_override_for_target(
     } else {
         // Package-level override: "namespace:package" = { path = "..." }
         for package in packages {
-            let key = format!("{}:{}", namespace, package);
+            let key = format!("{namespace}:{package}");
             overrides.insert(
                 key,
                 Override {
@@ -461,10 +461,10 @@ fn set_override_for_target(
 
 /// Download and extract HTTP tar.gz source
 async fn download_and_extract_http(url: &str) -> Result<PathBuf> {
-    let parsed_url = Url::parse(url).with_context(|| format!("invalid HTTP URL [{}]", url))?;
+    let parsed_url = Url::parse(url).with_context(|| format!("invalid HTTP URL [{url}]"))?;
 
     let tempdir = tempfile::tempdir()
-        .with_context(|| format!("failed to create temp dir for downloading [{}]", url))?
+        .with_context(|| format!("failed to create temp dir for downloading [{url}]"))?
         .keep();
 
     let output_path = tempdir.join("unpacked");
@@ -478,19 +478,19 @@ async fn download_and_extract_http(url: &str) -> Result<PathBuf> {
         .get(parsed_url)
         .send()
         .await
-        .with_context(|| format!("failed to download from URL [{}]", url))?;
+        .with_context(|| format!("failed to download from URL [{url}]"))?;
 
     let bytes = response
         .bytes()
         .await
-        .with_context(|| format!("failed to read response from URL [{}]", url))?;
+        .with_context(|| format!("failed to read response from URL [{url}]"))?;
 
     // Extract tar.gz
     let decoder = flate2::read::GzDecoder::new(&bytes[..]);
     let mut archive = tar::Archive::new(decoder);
     archive
         .unpack(&output_path)
-        .with_context(|| format!("failed to unpack archive from URL [{}]", url))?;
+        .with_context(|| format!("failed to unpack archive from URL [{url}]"))?;
 
     find_wit_folder_in_path(&output_path).await
 }
@@ -498,7 +498,7 @@ async fn download_and_extract_http(url: &str) -> Result<PathBuf> {
 /// Clone git repository and find WIT directory
 async fn clone_git_and_find_wit(url: &str) -> Result<PathBuf> {
     let tempdir = tempfile::tempdir()
-        .with_context(|| format!("failed to create temp dir for cloning [{}]", url))?
+        .with_context(|| format!("failed to create temp dir for cloning [{url}]"))?
         .keep();
 
     // Parse git URL to handle git+ prefix
@@ -521,11 +521,11 @@ async fn clone_git_and_find_wit(url: &str) -> Result<PathBuf> {
     let output = cmd
         .output()
         .await
-        .with_context(|| format!("failed to execute git clone command for [{}]", git_url))?;
+        .with_context(|| format!("failed to execute git clone command for [{git_url}]"))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("Git clone failed for [{}]: {}", git_url, stderr);
+        bail!("Git clone failed for [{git_url}]: {stderr}");
     }
 
     debug!(url = git_url, "successfully cloned git repository");


### PR DESCRIPTION
Add `clippy::uninlined_format_args = 'deny'` to the workspace lints and
inline existing `format!("{}", x)`-style args across the workspace. These
are machine-applicable clippy fixes with no behavior change.

Add a CI step to the wash lint job flagging sentence-case anyhow
`.context()` / `.with_context()` strings, which by Rust convention start
lowercase so they compose into error chains. The check matches
capital-then-lowercase prose so acronyms and type names (HTTP, P3,
DevRouter) are left untouched, and is scoped to crates/*/src to match the
clippy job; integration tests are not checked. Lowercase the three
production-source messages it surfaced in wash-runtime.

Also switch an eager `unwrap_or(format!(...))` to `unwrap_or_else` so the
default component filename isn't allocated when an explicit path is set.

Automates the conventions previously applied by hand in #5207 (inlined
format args) and #5212 (lowercase context messages).
