### PR TITLE
docs: fix stale wash project structure in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,21 +46,46 @@ cargo test --bin wash
 
 ## Project Structure
 
-This repository is a workspace. The `wash` CLI lives in `crates/wash`:
+This repository is a workspace. The `wash` CLI lives in `crates/wash` and the core Wasm runtime it depends on lives in `crates/wash-runtime`:
 
 ```text
 crates/
-├── bench-tools/        # Benchmarking utilities
-├── wash/               # wash CLI crate
+├── bench-tools/            # Benchmarking utilities
+├── wash/                   # wash CLI crate
 │   └── src/
-│       ├── cli/        # CLI structs and command handling
+│       ├── cli/            # CLI structs and command handling
 │       │   ├── mod.rs
 │       │   └── <subcommand>.rs
-│       ├── lib.rs      # Module exports
-│       ├── main.rs     # The wash binary entrypoint
-│       ├── config.rs   # Configuration management
-│       └── new.rs      # Project creation functionality
-└── wash-runtime/       # Runtime support used by wash
+│       ├── lib.rs          # Module exports
+│       ├── main.rs         # The wash binary entrypoint
+│       ├── config.rs       # Configuration management
+│       └── new.rs          # Project creation functionality
+└── wash-runtime/           # Core Wasm runtime powering wash
+    └── src/
+        ├── engine/         # Wasmtime engine setup and execution context
+        │   ├── ctx.rs      # Store context (WASI, linking state)
+        │   ├── value.rs    # Runtime value types
+        │   └── workload.rs # Workload execution logic
+        ├── host/           # Host-side interface implementations
+        │   ├── allowed_hosts.rs        # Network allow-list enforcement
+        │   ├── http.rs / http_p3.rs    # HTTP outbound host (P2 and P3)
+        │   └── sysinfo.rs              # System information host
+        ├── plugin/         # WASI and wasmCloud capability plugins
+        │   ├── wasi_blobstore/         # wasi:blobstore implementation
+        │   ├── wasi_config/            # wasi:config implementation
+        │   ├── wasi_keyvalue/          # wasi:keyvalue implementation
+        │   ├── wasi_logging/           # wasi:logging implementation
+        │   ├── wasi_otel/              # OpenTelemetry WASI bridge
+        │   ├── wasi_webgpu/            # wasi:webgpu implementation
+        │   ├── wasmcloud_messaging/    # wasmCloud messaging capability
+        │   └── wasmcloud_postgres/     # wasmCloud Postgres capability
+        ├── sockets/        # WASI sockets host implementations (TCP/UDP/network)
+        ├── washlet/        # Washlet runner (embedded Wasm plugin host)
+        ├── lib.rs          # Crate root and module exports
+        ├── observability.rs # Tracing and metrics setup
+        ├── oci.rs          # OCI registry image pulling
+        ├── types.rs        # Shared runtime types
+        └── wit.rs          # WIT interface bindings
 ```
 
 ## Code Style and Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,19 +46,21 @@ cargo test --bin wash
 
 ## Project Structure
 
-The `wash` crate is organized as a single crate with both binary and library targets:
+This repository is a workspace. The `wash` CLI lives in `crates/wash`:
 
 ```text
-src/                # The wash binary
-└── main.rs
-crates/wash/src/
-├── cli/            # CLI structs and command handling
-│   ├── mod.rs
-│   └── <subcommand>.rs
-├── <subcommand>.rs # Reusable types and libraries for commands
-├── lib.rs          # Module exports
-├── config.rs       # Configuration management
-└── new.rs          # Project creation functionality
+crates/
+├── bench-tools/        # Benchmarking utilities
+├── wash/               # wash CLI crate
+│   └── src/
+│       ├── cli/        # CLI structs and command handling
+│       │   ├── mod.rs
+│       │   └── <subcommand>.rs
+│       ├── lib.rs      # Module exports
+│       ├── main.rs     # The wash binary entrypoint
+│       ├── config.rs   # Configuration management
+│       └── new.rs      # Project creation functionality
+└── wash-runtime/       # Runtime support used by wash
 ```
 
 ## Code Style and Conventions


### PR DESCRIPTION
Why
`CONTRIBUTING.md` points folks to `src/main.rs`, but this repo has no root `src/`. The real CLI crate is under `crates/wash/`, so new contributors get sent to a ghost path. Kinda confusing tbh.

What
Update the project structure snippet so it matches the current workspace layout.

Repro on `main`
1. `sed -n '37,52p' CONTRIBUTING.md`
2. `test -d src || echo missing`
3. `ls crates/wash/src/main.rs`

Result: docs say `src/main.rs`, actual entrypoint is `crates/wash/src/main.rs`.
