### PR TITLE
runtime-operator chart: optional hostGroups passthrough fields

### DIFF
--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -44,6 +44,12 @@ spec:
             secretName: {{ if and (.http.tls.certificate) (.http.tls.certificate.secretName) }}{{ .http.tls.certificate.secretName }}{{ else }}hostgroup-{{ .name }}-http-tls{{ end }}
         {{- end }}
         {{- end }}
+        {{- /* Optional pod volumes (e.g. ConfigMap / Secret mounts). Rendered
+               unconditionally — outside the global.tls.enabled guard above —
+               so they survive a TLS-off install. */}}
+        {{- with .volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       serviceAccountName: {{ include "runtime.serviceAccountName" $top }}
       {{- include "runtime-operator.imagePullSecrets" $top | nindent 6 }}
       containers:
@@ -58,6 +64,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- /* Optional host env (appended after operator-managed vars).
+                   Standard k8s env shape — supports valueFrom secretKeyRef /
+                   configMapKeyRef. */}}
+            {{- with .env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- /* Optional envFrom (defensive — symmetric with .env above). */}}
+          {{- with .envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             {{- if .logLevel }}
             - "--log-level={{ .logLevel }}"
@@ -109,6 +126,12 @@ spec:
               readOnly: true
             {{- end }}
             {{- end }}
+            {{- /* Optional host-container volumeMounts (pair with .volumes
+                   above). Rendered unconditionally so a TLS-off install still
+                   mounts user volumes. */}}
+            {{- with .volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -118,6 +141,13 @@ spec:
             - name: http
               containerPort: {{ .http.port }}
               protocol: TCP
+            {{- end }}
+            {{- /* Optional additional container ports (e.g. metrics scrape).
+                   Do NOT re-list the http port — the chart renders it from
+                   `.http.port` above; a duplicate containerPort fails
+                   Deployment validation. */}}
+            {{- with .ports }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           securityContext:
             capabilities:


### PR DESCRIPTION
Four `{{- with }}`-guarded optional fields on each `hostGroups[]` entry, letting chart users wire host-side configuration declaratively without forking the chart or post-rendering the release:

```text
hostGroups[].env (+ defensive envFrom) → host container env, appended
  after the operator-managed WASMCLOUD_HOST_* vars
hostGroups[].volumes               → pod spec.volumes
hostGroups[].volumeMounts          → host container volumeMounts
hostGroups[].ports                 → host container ports
                                     (e.g. metrics scrape port — do
                                     NOT re-list http; the chart
                                     already renders it from
                                     `.http.port`)
```

All four fields are optional. With the fields unset, the rendered Deployment is byte-identical to pre-patch:

```bash
helm template charts/runtime-operator --set global.tls.enabled=false
# vs pre-patch baseline → empty diff (verified locally)
```

The volumes / volumeMounts / ports passthroughs render unconditionally (outside the `global.tls.enabled` guard above them) so they survive a TLS-off install. The env / envFrom passthroughs render after the two operator-managed vars, so user vars can reference them but cannot collide.

Use cases the four close together:

- ConfigMap / Secret mounts for host-side config files
- secretKeyRef env for DB credentials, OIDC client secrets
- Prometheus metrics port
- Custom CA / docker auth config for OCI image pulls

No values.yaml defaults, no values.schema.json (the chart doesn't carry one today), no behaviour change for any existing user. Reviewers can verify locally with:

```bash
helm template charts/runtime-operator --set global.tls.enabled=false > /tmp/before.yaml
# apply this patch
helm template charts/runtime-operator --set global.tls.enabled=false > /tmp/after.yaml
diff /tmp/before.yaml /tmp/after.yaml
# expect: empty diff
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->
