### PR TITLE
refactor(wash-runtime): build wasm test fixtures via xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# `cargo xtask <task>` runs the repo task runner at /xtask. See the
+# cargo-xtask pattern: https://github.com/matklad/cargo-xtask
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,14 +75,19 @@ jobs:
           # fails to expand tracing::*, anyhow::*, and std macros like
           # vec!/format!, which tanks the "calls with resolved target"
           # quality metric. We deliberately do NOT set CARGO_TARGET_DIR as
-          # a job env: that env var propagates into any child `cargo build`
-          # invoked from a build script (e.g. wash-runtime's fixture
-          # builds), redirecting their outputs and breaking their
-          # post-build artifact lookups.
+          # a job env: that env var propagates into the child `cargo build`
+          # that `cargo xtask build-fixtures` runs in the nested fixtures
+          # workspace, redirecting its output and breaking xtask's
+          # post-build artifact lookup.
           config: |
             extraction:
               rust:
                 cargo_target_dir: ${{ github.workspace }}/target
+
+      # `cargo build --all-targets` compiles the wash-runtime test/bench
+      # targets, which `include_bytes!` the wasm fixtures. Build them first.
+      - name: Build test fixtures
+        run: cargo xtask build-fixtures
 
       - name: Build workspace
         run: cargo build --workspace --all-targets --locked

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -161,6 +161,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
+      # Compile the wash-runtime wasm test fixtures. The test/bench targets
+      # `include_bytes!` these, so they must exist before `cargo test`/`cargo
+      # bench` below. Targets wasm32-wasip2/wasip1 come from setup-rust.
+      - name: Build test fixtures
+        run: cargo xtask build-fixtures
       - name: Build
         run: cargo build
       - name: Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Pull requests are welcome! The [good first issue][1] label is a great way to fin
 
 - **Rust** (latest stable version)
 - **Git**
-- **WebAssembly targets**: `wasm32-wasip2` (installed via `rustup target add wasm32-wasip2`)
+- **WebAssembly targets**: `wasm32-wasip2` and `wasm32-wasip1` (installed via `rustup target add wasm32-wasip2 wasm32-wasip1`) are both needed to build the `wash-runtime` wasm test fixtures.
 
 ### Building from Source
 
@@ -24,6 +24,16 @@ cargo build
 ```
 
 ### Running Tests
+
+The `wash-runtime` integration tests and benchmarks load precompiled wasm
+components from `crates/wash-runtime/tests/wasm/`. Build them once with the
+`xtask` task runner before running those tests (re-run it whenever you change
+a fixture under `crates/wash-runtime/tests/fixtures/`):
+
+```bash
+# Build the wasm test fixtures (writes crates/wash-runtime/tests/wasm/*.wasm)
+cargo xtask build-fixtures
+```
 
 ```bash
 # Run all tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7429,7 +7429,6 @@ dependencies = [
  "url",
  "uuid",
  "wasi-graphics-context-wasmtime",
- "wasi-preview1-component-adapter-provider",
  "wasi-webgpu-wasmtime",
  "wasmtime",
  "wasmtime-wasi",
@@ -7469,9 +7468,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter-provider"
-version = "43.0.1"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e42a172c19dae1341c1586fc6aea8cd5159548fb761146a54f8a5ecd69b2a7"
+checksum = "f912a3f8ead075800ffaaa13cb978bbcaa359c427688a753b10cd2f1e01fdf28"
 
 [[package]]
 name = "wasi-webgpu-wasmtime"
@@ -9217,6 +9216,16 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xtask"
+version = "2.2.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "wasi-preview1-component-adapter-provider",
+ "wit-component 0.248.0",
+]
 
 [[package]]
 name = "yaml-rust2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ members = [
     "crates/bench-tools",
     "crates/wash-runtime",
     "crates/wash",
+    # Repo task runner (`cargo xtask`). Deliberately excluded from
+    # default-members so normal builds/tests don't pull it in.
+    "xtask",
 ]
 
 [workspace.package]

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -142,12 +142,13 @@ ulid = { optional = true, workspace = true, features = ["std"] }
 url = { workspace = true }
 webpki-roots = { workspace = true }
 
+# Proto codegen only. Wasm fixtures are built by `cargo xtask
+# build-fixtures` (see /xtask), which owns wit-component and the WASI
+# adapter provider.
 [build-dependencies]
 anyhow = { workspace = true, default-features = true }
 tonic-prost-build = { workspace = true, default-features = true }
 pbjson-build = { workspace = true, default-features = true }
-wasi-preview1-component-adapter-provider = "43"
-wit-component = { workspace = true, default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/crates/wash-runtime/README.md
+++ b/crates/wash-runtime/README.md
@@ -94,6 +94,19 @@ wash-runtime provides three main abstractions:
 2. **Host**: Runtime environment with plugin management
 3. **Workload**: High-level API for managing component lifecycles
 
+## Testing
+
+The integration tests and benchmarks load precompiled wasm components from
+`tests/wasm/`. Build them once before running them:
+
+```bash
+# from the repo root
+cargo xtask build-fixtures
+```
+
+Re-run it after editing a fixture under [`tests/fixtures/`](./tests/fixtures/)
+(see that directory's README for details).
+
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](../../LICENSE) file for details.

--- a/crates/wash-runtime/build.rs
+++ b/crates/wash-runtime/build.rs
@@ -1,14 +1,19 @@
 // Build scripts commonly use expect() since panics produce clear compile-time errors
 #![allow(clippy::expect_used)]
 
+//! Generates the Rust bindings for the `wasmcloud.runtime.v2` protobuf
+//! service into `OUT_DIR`, included from `src/washlet/mod.rs`.
+//!
+//! Proto codegen is all this build script does — it stays pure-Rust so the
+//! build never spawns a nested `cargo` ("cargo building cargo"). The wasm
+//! test fixtures are built separately by `cargo xtask build-fixtures`
+//! (see /xtask).
+
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
-use wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER;
-
-/// Returns the path to the workspace root directory
+/// Returns the path to the workspace root directory (the dir holding `Cargo.lock`).
 fn workspace_dir() -> anyhow::Result<PathBuf> {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     let mut current_path = PathBuf::from(manifest_dir);
@@ -24,235 +29,6 @@ fn workspace_dir() -> anyhow::Result<PathBuf> {
             anyhow::bail!("Could not find workspace root")
         }
     }
-}
-
-fn emit_fixture_rerun_if_changed(fixture_dir: &Path) {
-    println!(
-        "cargo:rerun-if-changed={}/Cargo.toml",
-        fixture_dir.display()
-    );
-    for sub in ["src", "wit"] {
-        let d = fixture_dir.join(sub);
-        if d.exists() {
-            println!("cargo:rerun-if-changed={}", d.display());
-        }
-    }
-}
-
-/// Returns `true` on success. Failures are reported via `cargo:warning`
-/// and swallowed so one bad fixture doesn't mask the rest.
-fn run_cargo_build_wasm(fixtures_dir: &Path, fixture: &str, target: &str) -> bool {
-    let status = Command::new("cargo")
-        .args(["build", "-p", fixture, "--target", target, "--release"])
-        .current_dir(fixtures_dir)
-        .status();
-    match status {
-        Ok(s) if s.success() => true,
-        Ok(_) => {
-            println!("cargo:warning=Failed to build {fixture}");
-            false
-        }
-        Err(e) => {
-            println!("cargo:warning=Failed to execute cargo for {fixture}: {e}");
-            false
-        }
-    }
-}
-
-/// Which preview of the WASI component model a fixture targets. Drives
-/// the `cargo` target triple and the post-build step: `P2` emits a
-/// component directly, `P3` builds a core module that we wrap with the
-/// WASI reactor adapter to produce a component.
-#[derive(Copy, Clone)]
-enum FixtureKind {
-    P2,
-    P3,
-}
-
-impl FixtureKind {
-    fn target(self) -> &'static str {
-        match self {
-            FixtureKind::P2 => "wasm32-wasip2",
-            FixtureKind::P3 => "wasm32-wasip1",
-        }
-    }
-
-    fn shared_wit_dir(self) -> &'static str {
-        match self {
-            FixtureKind::P2 => "p2-wit-deps",
-            FixtureKind::P3 => "p3-wit-deps",
-        }
-    }
-}
-
-/// Wrap a `wasm32-wasip1` core module with the WASI reactor adapter to
-/// produce a component. The adapter is pinned by the
-/// `wasi-preview1-component-adapter-provider` dep alongside our wasmtime
-/// version, so its ABI stays in lockstep.
-fn componentize(core_module: &[u8], adapter: &[u8]) -> Vec<u8> {
-    wit_component::ComponentEncoder::default()
-        .validate(true)
-        .module(core_module)
-        .expect("failed to set module")
-        .adapter("wasi_snapshot_preview1", adapter)
-        .expect("failed to set adapter")
-        .encode()
-        .expect("failed to encode component")
-}
-
-/// Build a batch of WIT fixtures: populate `wit/deps/` from the kind's
-/// shared WIT directory, run `cargo build` for the kind's target, and
-/// stage the resulting wasm under `tests/wasm/` (componentizing core
-/// modules for P3 on the way through).
-///
-/// `skip_shared_wit` lists fixtures whose world uses only local
-/// interfaces (no wasi imports). Copying shared deps into those
-/// fixtures would pollute their wit resolution with unneeded packages.
-fn build_fixtures(
-    workspace_dir: &Path,
-    fixtures: &[&str],
-    kind: FixtureKind,
-    skip_shared_wit: &[&str],
-) -> anyhow::Result<()> {
-    let fixtures_dir = workspace_dir.join("crates/wash-runtime/tests/fixtures");
-    let wasm_dir = workspace_dir.join("crates/wash-runtime/tests/wasm");
-
-    if !fixtures_dir.exists() {
-        anyhow::bail!("No fixtures dir found at {}", fixtures_dir.display());
-    }
-    fs::create_dir_all(&wasm_dir)?;
-
-    let shared_wit = fixtures_dir.join(kind.shared_wit_dir());
-    println!("cargo:rerun-if-changed={}", shared_wit.display());
-
-    let target = kind.target();
-    let artifact_dir = fixtures_dir.join(format!("target/{target}/release"));
-
-    for fixture in fixtures {
-        let fixture_dir = fixtures_dir.join(fixture);
-        if !fixture_dir.exists() {
-            anyhow::bail!("Fixture directory {} does not exist", fixture_dir.display());
-        }
-
-        emit_fixture_rerun_if_changed(&fixture_dir);
-
-        if fixture_dir.join("wit").exists() && !skip_shared_wit.contains(fixture) {
-            copy_shared_wit_deps(&shared_wit, &fixture_dir)?;
-        }
-
-        if !run_cargo_build_wasm(&fixtures_dir, fixture, target) {
-            continue;
-        }
-
-        //.  try the underscore name first (cdylib), fall back to the hyphenated name (bin)
-        let wasm_name = format!("{}.wasm", fixture.replace('-', "_"));
-        let wasm_path = artifact_dir
-            .join(&wasm_name)
-            .exists()
-            .then(|| artifact_dir.join(&wasm_name))
-            .or_else(|| {
-                let bin = artifact_dir.join(format!("{fixture}.wasm"));
-                bin.exists().then_some(bin)
-            });
-        let Some(wasm_path) = wasm_path else {
-            println!("cargo:warning=No artifact for fixture {fixture}");
-            continue;
-        };
-        let dest = wasm_dir.join(&wasm_name);
-
-        match kind {
-            FixtureKind::P2 => {
-                fs::copy(&wasm_path, dest)?;
-            }
-            FixtureKind::P3 => {
-                let core = fs::read(&wasm_path)?;
-                fs::write(
-                    dest,
-                    componentize(&core, WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER),
-                )?;
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Copy every `*.wit` file from each `{pkg}/` subdirectory of
-/// `shared_wit_dir` into the fixture's `wit/deps/{pkg}/`. Source dir
-/// names already include the version (e.g. `wasi-http-0.2.2`),
-/// matching the layout wit-bindgen expects.
-///
-/// We copy the full set of `.wit` files (not just `package.wit`)
-/// because some packages — notably `wasi-tls@0.3.0-draft` — split their
-/// definitions across multiple files (`client.wit`, `types.wit`,
-/// `world.wit`) instead of a single bundled `package.wit`.
-fn copy_shared_wit_deps(shared_wit_dir: &Path, fixture_dir: &Path) -> anyhow::Result<()> {
-    let deps_dir = fixture_dir.join("wit/deps");
-    fs::create_dir_all(&deps_dir)?;
-
-    for entry in fs::read_dir(shared_wit_dir)? {
-        let entry = entry?;
-        if !entry.file_type()?.is_dir() {
-            continue;
-        }
-        let wit_files: Vec<_> = fs::read_dir(entry.path())?
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .filter(|f| f.path().extension().and_then(|s| s.to_str()) == Some("wit"))
-            .collect();
-        if wit_files.is_empty() {
-            continue;
-        }
-        let dest_dir = deps_dir.join(entry.file_name());
-        fs::create_dir_all(&dest_dir)?;
-        for src in wit_files {
-            fs::copy(src.path(), dest_dir.join(src.file_name()))?;
-        }
-    }
-
-    Ok(())
-}
-
-const P2_FIXTURES: &[&str] = &[
-    "http-handler-p2",
-    "http-counter",
-    "cron-service",
-    "cron-component",
-    "http-blobstore",
-    "http-webgpu",
-    "cpu-usage-service",
-    "messaging-handler",
-    "messaging-echo",
-    "inter-component-call-caller",
-    "inter-component-call-callee",
-    "inter-component-call-middleware",
-    "http-allowed-hosts",
-];
-
-const P3_FIXTURES: &[&str] = &[
-    "http-handler-p3",
-    "http-blobstore-p3",
-    "cli-service-p3",
-    "socket-test-p3",
-    "tls-echo-client-p3",
-    "inter-component-call-p3-caller",
-    "inter-component-call-p3-callee",
-];
-
-// Fixtures with local-only WIT worlds (no wasi imports). Shared deps
-// would pollute their wit resolution with unneeded packages.
-const P2_SKIP_SHARED_WIT: &[&str] = &["cron-service", "cron-component"];
-
-fn build_all_fixtures(workspace_dir: &Path) {
-    build_fixtures(
-        workspace_dir,
-        P2_FIXTURES,
-        FixtureKind::P2,
-        P2_SKIP_SHARED_WIT,
-    )
-    .expect("failed to build P2 fixtures");
-    build_fixtures(workspace_dir, P3_FIXTURES, FixtureKind::P3, &[])
-        .expect("failed to build P3 fixtures");
 }
 
 fn compile_protos(workspace_dir: &Path, out_dir: &Path) {
@@ -295,11 +71,6 @@ fn main() {
     );
     let workspace_dir = workspace_dir().expect("failed to get workspace dir");
 
-    // Export WORKSPACE_ROOT so runtime code (`env!("WORKSPACE_ROOT")`)
-    // can locate fixture artifacts regardless of how it was invoked.
-    println!("cargo:rustc-env=WORKSPACE_ROOT={}", workspace_dir.display());
-
-    build_all_fixtures(&workspace_dir);
     compile_protos(&workspace_dir, &out_dir);
 
     println!("cargo:rerun-if-changed=build.rs");

--- a/crates/wash-runtime/tests/fixtures/.gitignore
+++ b/crates/wash-runtime/tests/fixtures/.gitignore
@@ -1,7 +1,7 @@
 # Fixture WIT deps are populated at build time from the shared
-# p2-wit-deps/ and p3-wit-deps/ directories (see build.rs). The
-# shared dirs themselves are *not* matched by this pattern because
-# they don't contain a `wit/` subtree.
+# p2-wit-deps/ and p3-wit-deps/ directories (see `cargo xtask
+# build-fixtures` in /xtask). The shared dirs themselves are *not*
+# matched by this pattern because they don't contain a `wit/` subtree.
 */wit/deps/
 
 # Fixtures with local-only WIT worlds manage their own deps

--- a/crates/wash-runtime/tests/fixtures/README.md
+++ b/crates/wash-runtime/tests/fixtures/README.md
@@ -1,0 +1,44 @@
+# wash-runtime test fixtures
+
+WebAssembly components used by the `wash-runtime` integration tests and
+benchmarks. Each subdirectory is a small Rust crate compiled to a wasm
+component; the tests load the compiled output from `../wasm/` via
+`include_bytes!` (and a few runtime reads).
+
+This directory is its **own** Cargo workspace (see `Cargo.toml` here),
+separate from the top-level workspace, so the fixtures can target
+`wasm32-wasip2` / `wasm32-wasip1` without dragging those targets into the
+host crates.
+
+## Building
+
+Fixtures are built by the `xtask` task runner, **not** by a build script:
+
+```bash
+# from the repo root
+cargo xtask build-fixtures
+```
+
+This compiles every fixture, componentizes the P3 (`wasm32-wasip1`) core
+modules with the WASI reactor adapter, and stages the results into
+`../wasm/*.wasm` (which is gitignored). Run it once before
+`cargo test`/`cargo bench` for `wash-runtime`, and again whenever you change
+a fixture's source or WIT.
+
+Fixtures are built by `xtask` rather than a build script so that `cargo test`
+doesn't trigger nested `cargo build` invocations (the "cargo building cargo"
+problem); the `wash-runtime` build script stays pure-Rust proto codegen. The
+build logic lives in `/xtask/src/main.rs`.
+
+## Adding a fixture
+
+1. Create a new crate directory here with its `Cargo.toml`, `src/`, and (if
+   it imports wasi interfaces) a `wit/` world.
+2. Add it to the `members` list in this directory's `Cargo.toml`.
+3. Add its package name to `P2_FIXTURES` or `P3_FIXTURES` in
+   `/xtask/src/main.rs`. If its world uses only local interfaces (no wasi
+   imports), also add it to `P2_SKIP_SHARED_WIT` so shared WIT deps aren't
+   copied in.
+
+Shared WIT dependencies live in `p2-wit-deps/` and `p3-wit-deps/`; `xtask`
+copies them into each fixture's `wit/deps/` at build time.

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -329,9 +329,12 @@ The playbook installs (as `root` on the bench host):
   the CI runner uses its own workspace, see §6).
 - A **smoke build**:
   ```sh
+  cargo xtask build-fixtures   # benches include_bytes! the wasm fixtures
   cargo bench -p wash-runtime --features wasip3 --bench http_invoke --no-run
   ```
   to verify the bench binary compiles end-to-end. ~3 minutes cold.
+  (`run-bench.sh` runs `cargo xtask build-fixtures` for you; it's only
+  needed by hand for manual `cargo bench` invocations like this one.)
 
 Verify after the script:
 
@@ -589,6 +592,7 @@ GitHub":
 ```sh
 ssh -i ~/.ssh/hetzner_bench root@<WASMCLOUD_BENCH_HOST_IP> \
   '. $HOME/.cargo/env && cd /opt/wasmcloud && \
+   cargo xtask build-fixtures && \
    cargo bench -p wash-runtime --features wasip3 --bench http_invoke'
 ```
 

--- a/scripts/bench/run-bench.sh
+++ b/scripts/bench/run-bench.sh
@@ -67,6 +67,15 @@ rm -rf "${CARGO_TARGET_DIR}/criterion" "${CARGO_TARGET_DIR}/gungraun"
 # manual partial run), the marker still bounds what gets emitted.
 touch "$marker"
 
+# Build the wasm fixtures the benches `include_bytes!`. Guarded on the
+# xtask dir because compare-bench.sh checks out arbitrary refs: refs that
+# predate the xtask crate build their fixtures during `cargo bench`
+# themselves, so the explicit step is skipped for them.
+if [ -d xtask ]; then
+  echo "building wasm test fixtures via xtask" | tee -a "$log"
+  cargo xtask build-fixtures 2>&1 | tee -a "$log"
+fi
+
 # gungraun: pin to the isolated CPU. The criterion-style benches are
 # multi-threaded (tokio + hyper) and would lose throughput under taskset,
 # so they run unpinned across the non-isolated cores.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,20 @@
+# Repo task runner (the cargo-xtask pattern). Not published; invoked via
+# the `cargo xtask` alias in /.cargo/config.toml. Kept out of
+# `default-members` so normal `cargo build`/`cargo test` never pull it in.
+[package]
+name = "xtask"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+publish = false
+
+[dependencies]
+anyhow = { workspace = true, default-features = true }
+# Workspace clap is default-features=false; xtask needs std on top.
+clap = { workspace = true, features = ["std"] }
+wit-component = { workspace = true }
+# Pins the WASI reactor adapter in lockstep with our wasmtime version
+# (used to componentize P3 core modules). Keep the major in sync with
+# the `wasmtime`/`wit-component` versions in the workspace manifest.
+wasi-preview1-component-adapter-provider = "45"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,295 @@
+//! Workspace task runner (the cargo-xtask pattern).
+//!
+//! Run via the `cargo xtask <task>` alias defined in `/.cargo/config.toml`.
+//!
+//! The primary task is `build-fixtures`, which compiles the wash-runtime
+//! wasm test fixtures and stages them under `tests/wasm/`.
+//! Run build-fixtures once, then the tests read `.wasm` files via `include_bytes!`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use clap::{Parser, Subcommand};
+use wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER;
+
+#[derive(Parser)]
+#[command(name = "xtask", about = "wasmCloud workspace tasks", version)]
+struct Cli {
+    #[command(subcommand)]
+    task: Task,
+}
+
+#[derive(Subcommand)]
+enum Task {
+    /// Build the wash-runtime wasm test fixtures into
+    /// `crates/wash-runtime/tests/wasm/`.
+    BuildFixtures,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let workspace = workspace_dir().context("failed to locate workspace root")?;
+    match cli.task {
+        Task::BuildFixtures => build_fixtures(&workspace),
+    }
+}
+
+/// Walk up from this crate's manifest dir to the workspace root (the
+/// directory holding `Cargo.lock`). Works regardless of the directory
+/// `cargo xtask` was invoked from.
+fn workspace_dir() -> Result<PathBuf> {
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        if dir.join("Cargo.lock").exists() {
+            return Ok(dir);
+        }
+        if !dir.pop() {
+            bail!("could not find workspace root (no Cargo.lock above the xtask crate)");
+        }
+    }
+}
+
+/// Which preview of the WASI component model a fixture targets. Drives the
+/// `cargo` target triple and the post-build step: `P2` emits a component
+/// directly, `P3` builds a core module that we wrap with the WASI reactor
+/// adapter to produce a component.
+#[derive(Copy, Clone)]
+enum FixtureKind {
+    P2,
+    P3,
+}
+
+impl FixtureKind {
+    fn target(self) -> &'static str {
+        match self {
+            FixtureKind::P2 => "wasm32-wasip2",
+            FixtureKind::P3 => "wasm32-wasip1",
+        }
+    }
+
+    fn shared_wit_dir(self) -> &'static str {
+        match self {
+            FixtureKind::P2 => "p2-wit-deps",
+            FixtureKind::P3 => "p3-wit-deps",
+        }
+    }
+}
+
+const P2_FIXTURES: &[&str] = &[
+    "http-handler-p2",
+    "http-counter",
+    "cron-service",
+    "cron-component",
+    "http-blobstore",
+    "http-webgpu",
+    "cpu-usage-service",
+    "messaging-handler",
+    "messaging-echo",
+    "inter-component-call-caller",
+    "inter-component-call-callee",
+    "inter-component-call-middleware",
+    "http-allowed-hosts",
+];
+
+const P3_FIXTURES: &[&str] = &[
+    "http-handler-p3",
+    "http-blobstore-p3",
+    "cli-service-p3",
+    "socket-test-p3",
+    "tls-echo-client-p3",
+    "inter-component-call-p3-caller",
+    "inter-component-call-p3-callee",
+];
+
+// Fixtures with local-only WIT worlds (no wasi imports). Copying shared
+// deps into these would pollute their wit resolution with unneeded packages.
+const P2_SKIP_SHARED_WIT: &[&str] = &["cron-service", "cron-component"];
+
+fn build_fixtures(workspace: &Path) -> Result<()> {
+    let fixtures_dir = workspace.join("crates/wash-runtime/tests/fixtures");
+    let wasm_dir = workspace.join("crates/wash-runtime/tests/wasm");
+
+    if !fixtures_dir.exists() {
+        bail!("no fixtures dir found at {}", fixtures_dir.display());
+    }
+    fs::create_dir_all(&wasm_dir)
+        .with_context(|| format!("failed to create {}", wasm_dir.display()))?;
+
+    build_kind(
+        &fixtures_dir,
+        &wasm_dir,
+        FixtureKind::P2,
+        P2_FIXTURES,
+        P2_SKIP_SHARED_WIT,
+    )?;
+    build_kind(&fixtures_dir, &wasm_dir, FixtureKind::P3, P3_FIXTURES, &[])?;
+
+    println!(
+        "staged {} fixtures into {}",
+        P2_FIXTURES.len() + P3_FIXTURES.len(),
+        wasm_dir.display()
+    );
+    Ok(())
+}
+
+/// Build every fixture for one WASI preview: populate each fixture's
+/// `wit/deps/` from the shared WIT dir, run a single `cargo build` for the
+/// kind's target, then stage the resulting wasm under `tests/wasm/`
+/// (componentizing core modules for P3 on the way through).
+fn build_kind(
+    fixtures_dir: &Path,
+    wasm_dir: &Path,
+    kind: FixtureKind,
+    fixtures: &[&str],
+    skip_shared_wit: &[&str],
+) -> Result<()> {
+    let shared_wit = fixtures_dir.join(kind.shared_wit_dir());
+
+    for fixture in fixtures {
+        let fixture_dir = fixtures_dir.join(fixture);
+        if !fixture_dir.exists() {
+            bail!("fixture directory {} does not exist", fixture_dir.display());
+        }
+        if fixture_dir.join("wit").exists() && !skip_shared_wit.contains(fixture) {
+            copy_shared_wit_deps(&shared_wit, &fixture_dir)
+                .with_context(|| format!("failed to stage wit deps for {fixture}"))?;
+        }
+    }
+
+    let target = kind.target();
+    println!("building {} fixtures for {target}…", fixtures.len());
+
+    // One cargo build for the whole batch instead of one per fixture. The
+    // nested fixtures workspace shares a target dir, so a single invocation
+    // builds shared deps once and parallelizes across fixtures.
+    let mut cmd = Command::new("cargo");
+    cmd.args(["build", "--release", "--target", target])
+        .current_dir(fixtures_dir)
+        // Drop any ambient CARGO_TARGET_DIR (the bench hosts set one job-wide)
+        // so the nested build lands in `fixtures_dir/target`, where the staging
+        // step below looks for artifacts. Without this, the build succeeds but
+        // writes elsewhere and staging fails to find anything.
+        .env_remove("CARGO_TARGET_DIR");
+    for fixture in fixtures {
+        cmd.args(["-p", fixture]);
+    }
+    let status = cmd
+        .status()
+        .with_context(|| format!("failed to execute cargo for {target} fixtures"))?;
+    if !status.success() {
+        // Fail the whole batch on any fixture error: a fixture that won't
+        // compile should turn the build red, not leave tests running
+        // against stale wasm.
+        bail!("cargo build failed for {target} fixtures");
+    }
+
+    let artifact_dir = fixtures_dir.join(format!("target/{target}/release"));
+    for fixture in fixtures {
+        stage_fixture(&artifact_dir, wasm_dir, fixture, kind)
+            .with_context(|| format!("failed to stage {fixture}"))?;
+    }
+
+    Ok(())
+}
+
+/// Copy the built wasm for one fixture into `tests/wasm/`, componentizing
+/// P3 core modules with the reactor adapter on the way.
+fn stage_fixture(
+    artifact_dir: &Path,
+    wasm_dir: &Path,
+    fixture: &str,
+    kind: FixtureKind,
+) -> Result<()> {
+    // cdylib crates emit the underscore name; bin crates emit the
+    // hyphenated name. Try the cdylib name first, fall back to the bin name.
+    let wasm_name = format!("{}.wasm", fixture.replace('-', "_"));
+    let cdylib = artifact_dir.join(&wasm_name);
+    let bin = artifact_dir.join(format!("{fixture}.wasm"));
+    let wasm_path = if cdylib.exists() {
+        cdylib
+    } else if bin.exists() {
+        bin
+    } else {
+        bail!(
+            "no wasm artifact for fixture {fixture} in {}",
+            artifact_dir.display()
+        );
+    };
+
+    let dest = wasm_dir.join(&wasm_name);
+    match kind {
+        FixtureKind::P2 => {
+            fs::copy(&wasm_path, &dest).with_context(|| {
+                format!(
+                    "failed to copy {} to {}",
+                    wasm_path.display(),
+                    dest.display()
+                )
+            })?;
+        }
+        FixtureKind::P3 => {
+            let core = fs::read(&wasm_path)
+                .with_context(|| format!("failed to read {}", wasm_path.display()))?;
+            let component = componentize(&core, WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER)
+                .with_context(|| format!("failed to componentize {fixture}"))?;
+            fs::write(&dest, component)
+                .with_context(|| format!("failed to write {}", dest.display()))?;
+        }
+    }
+    Ok(())
+}
+
+/// Wrap a `wasm32-wasip1` core module with the WASI reactor adapter to
+/// produce a component. The adapter is pinned by the
+/// `wasi-preview1-component-adapter-provider` dep alongside our wasmtime
+/// version, so its ABI stays in lockstep.
+fn componentize(core_module: &[u8], adapter: &[u8]) -> Result<Vec<u8>> {
+    wit_component::ComponentEncoder::default()
+        .validate(true)
+        .module(core_module)
+        .context("failed to set module")?
+        .adapter("wasi_snapshot_preview1", adapter)
+        .context("failed to set adapter")?
+        .encode()
+        .context("failed to encode component")
+}
+
+/// Copy every `*.wit` file from each `{pkg}/` subdirectory of
+/// `shared_wit_dir` into the fixture's `wit/deps/{pkg}/`. Source dir names
+/// already include the version (e.g. `wasi-http-0.2.2`), matching the
+/// layout wit-bindgen expects.
+///
+/// We copy the full set of `.wit` files (not just `package.wit`) because
+/// some packages — notably `wasi-tls@0.3.0-draft` — split their definitions
+/// across multiple files (`client.wit`, `types.wit`, `world.wit`) instead
+/// of a single bundled `package.wit`.
+fn copy_shared_wit_deps(shared_wit_dir: &Path, fixture_dir: &Path) -> Result<()> {
+    let deps_dir = fixture_dir.join("wit/deps");
+    fs::create_dir_all(&deps_dir)?;
+
+    for entry in fs::read_dir(shared_wit_dir)
+        .with_context(|| format!("failed to read {}", shared_wit_dir.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let wit_files: Vec<_> = fs::read_dir(entry.path())?
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .filter(|f| f.path().extension().and_then(|s| s.to_str()) == Some("wit"))
+            .collect();
+        if wit_files.is_empty() {
+            continue;
+        }
+        let dest_dir = deps_dir.join(entry.file_name());
+        fs::create_dir_all(&dest_dir)?;
+        for src in wit_files {
+            fs::copy(src.path(), dest_dir.join(src.file_name()))?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Move wasm test-fixture compilation out of `crates/wash-runtime/build.rs` into a new root-level xtask crate, invoked explicitly as `cargo xtask build-fixtures`.

Building fixtures from build.rs meant `cargo test`/`cargo build` spawned nested `cargo build` invocations ("cargo building cargo"), with the jobserver/lock contention and rebuild storms that come with it. Pulling the work into an explicitly-invoked binary keeps fixture compilation off the normal build path entirely, so build.rs is now pure-Rust proto codegen.

This is currently the problem blocking our benchmark suite.

This builds directly on @dman-os's work in **#5085** (and the earlier **#4998**), which introduced the `xtask`-based "explicit fixture building" approach. Huge thanks to @dman-os for working through the design and the prototype, this PR is co-authored with them.

There's also a sibling approach in **#5089**, which keeps fixture building in a `build.rs` but moves it into a sidecar crate added as a dev/test dependency. That's a clean way to stop fixtures rebuilding on plain `cargo build`, but it *relocates* the nested-`cargo` call rather than removing it.

- Add /xtask (excluded from default-members) with a build-fixtures task; one batched `cargo build` per WASI target rather than one spawn per fixture, failing loud on any error. Drops an ambient CARGO_TARGET_DIR so staging finds the artifacts on the bench hosts.
- Reduce build.rs to proto codegen (306 -> 78 lines);
- Run `cargo xtask build-fixtures` before tests in wash.yml and codeql.yml, and in scripts/bench/run-bench.sh
- Document the flow in CONTRIBUTING, the wash-runtime README, and a new tests/fixtures/README.

I opted to start a fresh PR based on latest main primarily because:
- #5085 is closed, and both it and #5089 live on @dman-os's fork branches. Rather than force-push over someone else's PR, I opted to attribute to them as `Co-authored-by`.
- #5085 was branched off an older `main` and predates a few changes that are now in tree (the multi-file WIT-dep copy needed for split packages like `wasi-tls@0.3.0-draft`, two newer fixtures, etc.), so a fresh implementation picks those up cleanly instead of reintroducing the old behavior.

## How it differs from #5085

- Crate at root `/xtask` with `src/main.rs` layout (the cargo-xtask convention), vs `crates/xtask` with files at the crate root. This seems to be the more common convention. Documented in `matklad/cargo-xtask` `README.md` and I referenced [rust-analyzer](https://github.com/rust-lang/rust-analyzer/tree/master/xtask) as the main example.
- Dependency-light: `anyhow` + `clap` + `wit-component` + the adapter. No `tokio` runtime, `dotenv-flow`, or tracing subscriber for what is synchronous file I/O.
- One batched `cargo build` per target (2 total). We could opt to do something more complex and do 20 per-fixture spawns. This was derived from the minimal deps design choice but I'm up for revisiting later if it becomes a problem.
- Wires up `codeql.yml` and the bench scripts (which also consume the fixtures).

## Tradeoff

Fixtures no longer rebuild automatically on source change. You re-run `cargo xtask build-fixtures` after editing a fixture (an incremental is practically a no-op and finishes in ~seconds). CI and the bench scripts do this for you; the dev flow is
documented in the updated CONTRIBUTING.

## Testing

- `cargo xtask build-fixtures` stages all 20 fixtures; P3 components validate with `wasm-tools validate --features all`.
- `cargo build -p wash-runtime` (proto codegen) and all wash-runtime integration test binaries compile.
- `cargo test -p wash-runtime --features wasip3 --test integration_wasip3` passes (exercises P3 component instantiation against the v45 adapter).
