### PR TITLE
refactor(wash-runtime): harden p3 sockets

### DIFF
--- a/crates/wash-runtime/src/sockets/host_ip_name_lookup_p3.rs
+++ b/crates/wash-runtime/src/sockets/host_ip_name_lookup_p3.rs
@@ -13,47 +13,37 @@ impl HostWithStore for WasiSockets {
         store: &Accessor<U, Self>,
         name: String,
     ) -> wasmtime::Result<Result<Vec<types::IpAddress>, ErrorCode>> {
-        let allow_lookup =
-            store.with(|mut view| view.get().ctx.allowed_network_uses.ip_name_lookup);
-        if !allow_lookup {
+        // Mirror the ordering of the upstream wasmtime implementation: parse the
+        // name before consulting the capability so a malformed name reports
+        // `InvalidArgument` regardless of whether lookups are permitted.
+        let Ok(host) = parse_host(&name) else {
+            return Ok(Err(ErrorCode::InvalidArgument));
+        };
+        if !store.with(|mut view| view.get().ctx.allowed_network_uses.ip_name_lookup) {
             return Ok(Err(ErrorCode::PermanentResolverFailure));
         }
-
-        let host = match parse_host(&name) {
-            Ok(host) => host,
-            Err(_) => return Ok(Err(ErrorCode::InvalidArgument)),
-        };
-
-        // Perform DNS resolution in a blocking task
-        let result = tokio::task::spawn_blocking(move || blocking_resolve(&host))
-            .await
-            .map_err(|e| wasmtime::format_err!("DNS resolution task failed: {e}"))?;
-
-        Ok(result)
+        Ok(resolve(host).await)
     }
 }
 
 impl Host for WasiSocketsCtxView<'_> {}
 
-fn blocking_resolve(host: &url::Host) -> Result<Vec<types::IpAddress>, ErrorCode> {
-    use std::net::ToSocketAddrs;
-
+/// Resolve a host to a list of IP addresses.
+///
+/// Literal IPv4/IPv6 hosts are returned directly. Domains are resolved with
+/// [`tokio::net::lookup_host`], which performs the blocking `getaddrinfo` call
+/// on a dedicated blocking task internally, so we don't wrap it ourselves.
+async fn resolve(host: url::Host) -> Result<Vec<types::IpAddress>, ErrorCode> {
     match host {
-        url::Host::Ipv4(v4addr) => Ok(vec![types::IpAddress::Ipv4(from_ipv4_addr(*v4addr))]),
-        url::Host::Ipv6(v6addr) => Ok(vec![types::IpAddress::Ipv6(from_ipv6_addr(*v6addr))]),
+        url::Host::Ipv4(addr) => Ok(vec![types::IpAddress::Ipv4(from_ipv4_addr(addr))]),
+        url::Host::Ipv6(addr) => Ok(vec![types::IpAddress::Ipv6(from_ipv6_addr(addr))]),
         url::Host::Domain(domain) => {
-            let addresses = (domain.as_str(), 0)
-                .to_socket_addrs()
-                .map_err(|_| ErrorCode::NameUnresolvable)?
-                .map(|addr| {
-                    let ip = addr.ip().to_canonical();
-                    match ip {
-                        std::net::IpAddr::V4(v4) => types::IpAddress::Ipv4(from_ipv4_addr(v4)),
-                        std::net::IpAddr::V6(v6) => types::IpAddress::Ipv6(from_ipv6_addr(v6)),
-                    }
-                })
-                .collect();
-            Ok(addresses)
+            // Only names are resolved here, not ports, so force the port to 0.
+            let addrs = tokio::net::lookup_host((domain.as_str(), 0))
+                .await
+                .map_err(|_| ErrorCode::NameUnresolvable)?;
+            // `IpAddr` -> `types::IpAddress` via the conversion wasmtime defines.
+            Ok(addrs.map(|addr| addr.ip().to_canonical().into()).collect())
         }
     }
 }

--- a/crates/wash-runtime/src/sockets/host_tcp_p3.rs
+++ b/crates/wash-runtime/src/sockets/host_tcp_p3.rs
@@ -327,7 +327,7 @@ impl HostTcpSocketWithStore for WasiSockets {
 
             match socket_ref {
                 TcpSocket::Network(net) => {
-                    let listener = net.tcp_listener_arc().map_err(se)?.clone();
+                    let listener = net.tcp_listener_arc().map_err(se)?;
                     let family = net.address_family();
                     let options = net.non_inherited_options().clone();
                     ListenKind::Network {
@@ -337,7 +337,7 @@ impl HostTcpSocketWithStore for WasiSockets {
                     }
                 }
                 TcpSocket::Unspecified { net, .. } => {
-                    let listener = net.tcp_listener_arc().map_err(se)?.clone();
+                    let listener = net.tcp_listener_arc().map_err(se)?;
                     let options = net.non_inherited_options().clone();
                     let loopback_info = socket_ref.take_loopback_listen_rx().map_err(se)?;
                     ListenKind::Merged {

--- a/crates/wash-runtime/src/sockets/loopback/tcp.rs
+++ b/crates/wash-runtime/src/sockets/loopback/tcp.rs
@@ -30,8 +30,17 @@ pub enum TcpEndpoint {
 pub struct TcpConn {
     pub local_address: SocketAddr,
     pub remote_address: SocketAddr,
-    pub rx: mpsc::UnboundedReceiver<(Bytes, OwnedSemaphorePermit)>,
-    pub tx: mpsc::UnboundedSender<(Bytes, OwnedSemaphorePermit)>,
+    /// Receiver for the incoming half of the connection.
+    ///
+    /// Wrapped in an `Option` so the receive stream can be taken exactly once;
+    /// a second take observes `None` and is rejected rather than handed a fresh,
+    /// already-disconnected channel.
+    pub rx: Option<mpsc::UnboundedReceiver<(Bytes, OwnedSemaphorePermit)>>,
+    /// Sender for the outgoing half of the connection.
+    ///
+    /// Wrapped in an `Option` for the same reason as `rx`: the send stream is
+    /// taken exactly once, matching the take-once semantics of network sockets.
+    pub tx: Option<mpsc::UnboundedSender<(Bytes, OwnedSemaphorePermit)>>,
 }
 
 impl TcpConn {
@@ -43,14 +52,14 @@ impl TcpConn {
             Self {
                 local_address,
                 remote_address,
-                rx: local_rx,
-                tx: local_tx,
+                rx: Some(local_rx),
+                tx: Some(local_tx),
             },
             Self {
                 local_address: remote_address,
                 remote_address: local_address,
-                rx: remote_rx,
-                tx: remote_tx,
+                rx: Some(remote_rx),
+                tx: Some(remote_tx),
             },
         )
     }

--- a/crates/wash-runtime/src/sockets/mod.rs
+++ b/crates/wash-runtime/src/sockets/mod.rs
@@ -166,6 +166,11 @@ pub enum SocketAddrUse {
 }
 
 /// Convert our custom `util::ErrorCode` to the P3 bindings `ErrorCode`.
+///
+/// `util::ErrorCode` is a plain enum that carries no message payload, so
+/// `Unknown` maps to `Other(None)` and there is nothing to forward. Callers that
+/// have a meaningful message should construct `P3ErrorCode::Other(Some(..))`
+/// directly rather than routing through this helper.
 #[cfg(feature = "wasip3")]
 pub(crate) fn p3_error_code_from_util(
     error: util::ErrorCode,

--- a/crates/wash-runtime/src/sockets/p2_tcp.rs
+++ b/crates/wash-runtime/src/sockets/p2_tcp.rs
@@ -55,8 +55,8 @@ impl TcpSocket {
                         super::util::ErrorCode::InvalidState,
                     ));
                 };
-                let rx = Arc::new(Mutex::new(Some(rx)));
-                let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
+                let rx = Arc::new(Mutex::new(rx));
+                let tx = Arc::new(std::sync::Mutex::new(tx));
                 // Ensure `check-write` allows more than `send_buffer_size` bytes to be written to
                 // make this assertion succeed:
                 // https://github.com/bytecodealliance/wasmtime/blob/b1c7887c801b62f7fb39e3bd916d8737b3043135/crates/test-programs/src/bin/p2_tcp_streams.rs#L96

--- a/crates/wash-runtime/src/sockets/tcp.rs
+++ b/crates/wash-runtime/src/sockets/tcp.rs
@@ -581,8 +581,11 @@ impl NetworkTcpSocket {
     }
 
     /// Start listening using P3 semantics (with implicit bind).
+    ///
+    /// Returns the shared listener so callers (and tests) can build accept
+    /// streams without a follow-up [`Self::tcp_listener_arc`] call.
     #[cfg(feature = "wasip3")]
-    pub(crate) fn listen_p3(&mut self) -> Result<(), ErrorCode> {
+    pub(crate) fn listen_p3(&mut self) -> Result<Arc<tokio::net::TcpListener>, ErrorCode> {
         let tokio_socket = match mem::replace(&mut self.tcp_state, TcpState::Closed) {
             TcpState::Bound(tokio_socket) => tokio_socket,
             TcpState::Default(tokio_socket) => {
@@ -599,11 +602,12 @@ impl NetworkTcpSocket {
 
         match tokio_socket.listen(self.listen_backlog_size) {
             Ok(listener) => {
+                let listener = Arc::new(listener);
                 self.tcp_state = TcpState::Listening {
-                    listener: Arc::new(listener),
+                    listener: Arc::clone(&listener),
                     pending_accept: None,
                 };
-                Ok(())
+                Ok(listener)
             }
             Err(err) => {
                 self.tcp_state = TcpState::Closed;
@@ -613,10 +617,13 @@ impl NetworkTcpSocket {
     }
 
     /// Get the TCP listener Arc (P3 only, for creating accept streams).
+    ///
+    /// Returns an owned clone of the `Arc` so callers don't have to clone it
+    /// themselves.
     #[cfg(feature = "wasip3")]
-    pub(crate) fn tcp_listener_arc(&self) -> Result<&Arc<tokio::net::TcpListener>, ErrorCode> {
+    pub(crate) fn tcp_listener_arc(&self) -> Result<Arc<tokio::net::TcpListener>, ErrorCode> {
         match &self.tcp_state {
-            TcpState::Listening { listener, .. } => Ok(listener),
+            TcpState::Listening { listener, .. } => Ok(Arc::clone(listener)),
             _ => Err(ErrorCode::InvalidState),
         }
     }
@@ -1375,6 +1382,7 @@ impl TcpSocket {
     }
 
     /// Take the loopback accept channel for P3 listen streaming.
+    ///
     /// Returns the receiver that yields incoming `TcpConn` connections.
     #[cfg(feature = "wasip3")]
     pub(crate) fn take_loopback_listen_rx(&mut self) -> Result<P3LoopbackListenInfo, ErrorCode> {
@@ -1386,15 +1394,16 @@ impl TcpSocket {
         take_loopback_listen_info(lo)
     }
 
-    /// Listen using P3 semantics (with implicit bind). For loopback, requires
-    /// the loopback network to register the listener.
+    /// Listen using P3 semantics (with implicit bind).
+    ///
+    /// For loopback, requires the loopback network to register the listener.
     #[cfg(feature = "wasip3")]
     pub(crate) fn listen_p3(
         &mut self,
         loopback: &mut super::loopback::Network,
     ) -> Result<(), ErrorCode> {
         match self {
-            Self::Network(socket) => socket.listen_p3(),
+            Self::Network(socket) => socket.listen_p3().map(|_| ()),
             Self::Loopback(socket) => {
                 socket.start_listen(loopback)?;
                 socket.finish_listen()
@@ -1407,21 +1416,21 @@ impl TcpSocket {
         }
     }
 
-    /// Take the send stream (P3 only). Returns the underlying stream or
-    /// channel for sending data.
+    /// Take the send stream (P3 only).
+    ///
+    /// Returns the underlying stream or channel for sending data.
     #[cfg(feature = "wasip3")]
     pub(crate) fn take_send_stream(&mut self) -> Result<P3SendStream, ErrorCode> {
         match self {
             Self::Network(socket) => socket.take_send_stream().map(P3SendStream::Network),
             Self::Loopback(socket) => {
-                if let super::loopback::TcpState::Connected { ref conn, .. } = socket.state {
+                if let super::loopback::TcpState::Connected { ref mut conn, .. } = socket.state {
+                    // Take the sender, leaving `None` so a second take fails.
+                    let tx = conn.tx.take().ok_or(ErrorCode::InvalidState)?;
                     let permits = Arc::new(tokio::sync::Semaphore::new(
                         socket.send_buffer_size as usize,
                     ));
-                    Ok(P3SendStream::Loopback {
-                        tx: conn.tx.clone(),
-                        permits,
-                    })
+                    Ok(P3SendStream::Loopback { tx, permits })
                 } else {
                     Err(ErrorCode::InvalidState)
                 }
@@ -1433,17 +1442,17 @@ impl TcpSocket {
         }
     }
 
-    /// Take the receive stream (P3 only). Returns the underlying stream or
-    /// channel for receiving data.
+    /// Take the receive stream (P3 only).
+    ///
+    /// Returns the underlying stream or channel for receiving data.
     #[cfg(feature = "wasip3")]
     pub(crate) fn take_receive_stream(&mut self) -> Result<P3ReceiveStream, ErrorCode> {
         match self {
             Self::Network(socket) => socket.take_receive_stream().map(P3ReceiveStream::Network),
             Self::Loopback(socket) => {
                 if let super::loopback::TcpState::Connected { ref mut conn, .. } = socket.state {
-                    // Swap out the receiver, replacing with a closed one
-                    let (_, dummy_rx) = tokio::sync::mpsc::unbounded_channel();
-                    let rx = mem::replace(&mut conn.rx, dummy_rx);
+                    // Take the receiver, leaving `None` so a second take fails.
+                    let rx = conn.rx.take().ok_or(ErrorCode::InvalidState)?;
                     Ok(P3ReceiveStream::Loopback(rx))
                 } else {
                     Err(ErrorCode::InvalidState)
@@ -1713,8 +1722,7 @@ mod tests {
         async fn test_take_send_stream_from_connected() {
             let mut socket = make_ipv4_socket();
             bind_socket(&mut socket);
-            socket.listen_p3().unwrap();
-            let listener = socket.tcp_listener_arc().unwrap().clone();
+            let listener = socket.listen_p3().unwrap();
             let local_addr = listener.local_addr().unwrap();
 
             let client = tokio::net::TcpStream::connect(local_addr).await.unwrap();
@@ -1745,8 +1753,7 @@ mod tests {
         async fn test_take_receive_stream_from_connected() {
             let mut socket = make_ipv4_socket();
             bind_socket(&mut socket);
-            socket.listen_p3().unwrap();
-            let listener = socket.tcp_listener_arc().unwrap().clone();
+            let listener = socket.listen_p3().unwrap();
             let local_addr = listener.local_addr().unwrap();
 
             let client = tokio::net::TcpStream::connect(local_addr).await.unwrap();
@@ -1848,8 +1855,8 @@ mod tests {
             let conn = loopback::TcpConn {
                 local_address: "127.0.0.1:8080".parse().unwrap(),
                 remote_address: "127.0.0.1:9090".parse().unwrap(),
-                rx: remote_rx,
-                tx: local_tx,
+                rx: Some(remote_rx),
+                tx: Some(local_tx),
             };
 
             let accepted = props.to_accepted_socket(conn);
@@ -1861,10 +1868,57 @@ mod tests {
                 loopback::TcpState::Connected { accepted: true, .. }
             ));
         }
+
+        #[test]
+        fn test_loopback_streams_can_only_be_taken_once() {
+            let props = LoopbackSocketProps {
+                listen_backlog_size: 128,
+                keep_alive_enabled: false,
+                keep_alive_idle_time: 0,
+                keep_alive_interval: 0,
+                keep_alive_count: 0,
+                hop_limit: 64,
+                receive_buffer_size: 4096,
+                send_buffer_size: 4096,
+                family: SocketAddressFamily::Ipv4,
+            };
+
+            let (local_tx, _local_rx) = tokio::sync::mpsc::unbounded_channel();
+            let (_remote_tx, remote_rx) = tokio::sync::mpsc::unbounded_channel();
+            let conn = loopback::TcpConn {
+                local_address: "127.0.0.1:8080".parse().unwrap(),
+                remote_address: "127.0.0.1:9090".parse().unwrap(),
+                rx: Some(remote_rx),
+                tx: Some(local_tx),
+            };
+            let mut socket = TcpSocket::Loopback(props.to_accepted_socket(conn));
+
+            assert!(
+                socket.take_send_stream().is_ok(),
+                "first take_send_stream should succeed"
+            );
+            assert!(
+                matches!(socket.take_send_stream(), Err(ErrorCode::InvalidState)),
+                "second take_send_stream should fail"
+            );
+
+            assert!(
+                socket.take_receive_stream().is_ok(),
+                "first take_receive_stream should succeed"
+            );
+            assert!(
+                matches!(socket.take_receive_stream(), Err(ErrorCode::InvalidState)),
+                "second take_receive_stream should fail"
+            );
+        }
     }
 }
 
-/// Properties copied from a loopback TcpSocket for creating accepted sockets.
+/// Snapshot of a listening loopback [`loopback::TcpSocket`]'s configuration.
+///
+/// Captured when a listener is taken (see [`take_loopback_listen_info`]) so
+/// that each accepted connection can be seeded with the listener's options via
+/// [`LoopbackSocketProps::to_accepted_socket`].
 #[cfg(feature = "wasip3")]
 #[derive(Clone)]
 #[allow(dead_code)]


### PR DESCRIPTION
Address review feedback from #5022 (tracked in #5028) and bring the
p3 socket imp in line with the upstream wasmtime wasi-sockets.

- name lookup: resolve domains with tokio::net::lookup_host instead of
  spawn_blocking + to_socket_addrs (lookup_host already runs getaddrinfo
  on a blocking task), parse the host before the capability check, and
  convert addresses via the From<IpAddr> impl wasmtime provides. All
  matching the upstream implementation
- tcp: return an owned Arc from tcp_listener_arc and listen_p3 so callers
  drop redundant clone()/unwrap() panic paths
- tcp: make the loopback TcpConn send/receive halves Option so each stream
  is taken exactly once; a second take reports InvalidState instead of
  swapping in a throwaway unbounded channel (receive) or minting a fresh
  semaphore (send), matching the take-once semantics of network sockets
- document why p3_error_code_from_util maps Unknown to Other(None)
- doc cleanups on the p3 TcpSocket helpers
- add a unit test covering loopback take-once behavior.

Closes #5028