### PR TITLE
Fix In-memory blobstore default

### DIFF
--- a/crates/wash-runtime/src/plugin/wasi_blobstore/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/in_memory.rs
@@ -84,12 +84,18 @@ pub struct StreamObjectNamesHandle {
 }
 
 /// Memory-based blobstore plugin
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct InMemoryBlobstore {
     /// Storage for all containers, keyed by store context ID
     storage: Arc<RwLock<HashMap<String, HashMap<String, ContainerData>>>>,
     /// The maximum size for objects stored in the blobstore
     max_object_size: usize,
+}
+
+impl Default for InMemoryBlobstore {
+    fn default() -> Self {
+        Self::new(None)
+    }
 }
 
 impl InMemoryBlobstore {
@@ -1023,6 +1029,12 @@ mod tests {
     fn test_custom_max_object_size() {
         let blobstore = InMemoryBlobstore::new(Some(512));
         assert_eq!(blobstore.max_object_size, 512);
+    }
+
+    #[test]
+    fn test_default_impl_matches_new() {
+        let blobstore = InMemoryBlobstore::default();
+        assert_eq!(blobstore.max_object_size, 1_000_000);
     }
 
     #[test]


### PR DESCRIPTION
InMemoryBlobstore derived Default, leaving max_object_size at 0, so the in-memory blobstore used by wash dev made a zero-capacity MemoryOutputPipe and any non-empty write trapped with "write beyond capacity of MemoryOutputPipe". Replaced the derive with a manual Default that delegates to `new(None)` (1MB), matching the explicit constructor.

Verified with wash dev on examples/blobby: POST/GET round-trips now succeed (28B, 256KB) where the released wash traps.

Fixes #5126
