### PR TITLE
chore(lint): pin Rust to 1.96.0 and make clippy --all-targets clean

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,9 @@
+# Test code is allowed to unwrap/expect/panic/index freely. The workspace
+# denies these restriction lints (see [workspace.lints.clippy] in Cargo.toml)
+# so production `src/` stays panic-free, but failing fast is fine in tests.
+# These knobs only relax code clippy identifies as a test, so `cargo clippy
+# --all-targets` is clean without weakening the production lint surface.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+allow-indexing-slicing-in-tests = true

--- a/crates/wash-runtime/benches/http_invoke.rs
+++ b/crates/wash-runtime/benches/http_invoke.rs
@@ -136,15 +136,13 @@ async fn start_warm_host(flavor: Flavor) -> anyhow::Result<WarmHost> {
         .await?;
     anyhow::ensure!(
         warmup.status().is_success(),
-        "warmup request failed for {:?}: {}",
-        flavor,
+        "warmup request failed for {flavor:?}: {}",
         warmup.status()
     );
     let body = warmup.text().await?;
     anyhow::ensure!(
         body == flavor.expected_body(),
-        "unexpected warmup body for {:?}: {body:?}",
-        flavor
+        "unexpected warmup body for {flavor:?}: {body:?}"
     );
 
     Ok(WarmHost {

--- a/crates/wash-runtime/benches/wasmtime_baseline.rs
+++ b/crates/wash-runtime/benches/wasmtime_baseline.rs
@@ -383,15 +383,13 @@ async fn start_warm(flavor: Flavor) -> anyhow::Result<Warm> {
         .await?;
     anyhow::ensure!(
         warmup.status().is_success(),
-        "warmup failed for {:?}: {}",
-        flavor,
+        "warmup failed for {flavor:?}: {}",
         warmup.status()
     );
     let body = warmup.text().await?;
     anyhow::ensure!(
         body == flavor.expected_body(),
-        "unexpected warmup body for {:?}: {body:?}",
-        flavor
+        "unexpected warmup body for {flavor:?}: {body:?}"
     );
     Ok(Warm { server, client })
 }

--- a/crates/wash-runtime/benches/wasmtime_serve.rs
+++ b/crates/wash-runtime/benches/wasmtime_serve.rs
@@ -457,15 +457,13 @@ async fn start_warm(flavor: Flavor) -> anyhow::Result<Warm> {
         .await?;
     anyhow::ensure!(
         warmup.status().is_success(),
-        "warmup failed for {:?}: {}",
-        flavor,
+        "warmup failed for {flavor:?}: {}",
         warmup.status()
     );
     let body = warmup.text().await?;
     anyhow::ensure!(
         body == flavor.expected_body(),
-        "unexpected warmup body for {:?}: {body:?}",
-        flavor
+        "unexpected warmup body for {flavor:?}: {body:?}"
     );
     Ok(Warm { server, client })
 }

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -2506,8 +2506,7 @@ mod tests {
         let result = topological_sort_components(&dependencies);
         assert!(
             result.is_err(),
-            "Should detect circular dependency: {:?}",
-            result
+            "Should detect circular dependency: {result:?}"
         );
     }
 

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -716,31 +716,28 @@ mod tests {
     #[test]
     fn test_display() {
         let iface = create_interface("wasi", "http", &["incoming-handler"]);
-        assert_eq!(format!("{}", iface), "wasi:http/incoming-handler");
+        assert_eq!(format!("{iface}"), "wasi:http/incoming-handler");
 
         let iface_with_version =
             create_interface_with_version("wasi", "http", &["incoming-handler"], "0.2.0");
         assert_eq!(
-            format!("{}", iface_with_version),
+            format!("{iface_with_version}"),
             "wasi:http/incoming-handler@0.2.0"
         );
 
         let iface_no_interfaces = create_interface("wasi", "logging", &[]);
-        assert_eq!(format!("{}", iface_no_interfaces), "wasi:logging");
+        assert_eq!(format!("{iface_no_interfaces}"), "wasi:logging");
     }
 
     #[test]
     fn test_display_with_name() {
         let mut iface = create_interface("wasi", "keyvalue", &["store"]);
         iface.name = Some("cache".to_string());
-        assert_eq!(format!("{}", iface), "wasi:keyvalue [cache]/store");
+        assert_eq!(format!("{iface}"), "wasi:keyvalue [cache]/store");
 
         let mut iface_no_interfaces = create_interface("wasi", "keyvalue", &[]);
         iface_no_interfaces.name = Some("sessions".to_string());
-        assert_eq!(
-            format!("{}", iface_no_interfaces),
-            "wasi:keyvalue [sessions]"
-        );
+        assert_eq!(format!("{iface_no_interfaces}"), "wasi:keyvalue [sessions]");
     }
 
     #[test]

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -1,6 +1,11 @@
 //! Shared helpers for wash-runtime integration tests.
 
 #![allow(dead_code)]
+// Shared builder helpers unwrap/expect on constant fixtures in non-`#[test]`
+// fns, which the clippy.toml in-tests allows don't cover. This module is
+// included by many test crates, so keep the allow self-contained here rather
+// than relying on every consumer to carry one.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 #[cfg(feature = "wasi-tls")]
 pub mod tls;
@@ -175,11 +180,11 @@ pub fn default_counter_resources() -> LocalResources {
 fn with_standard_plugins(
     builder: wash_runtime::host::HostBuilder,
 ) -> Result<wash_runtime::host::HostBuilder> {
-    Ok(builder
+    builder
         .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
         .with_plugin(Arc::new(InMemoryKeyValue::new()))?
         .with_plugin(Arc::new(TracingLogger::default()))?
-        .with_plugin(Arc::new(DynamicConfig::default()))?)
+        .with_plugin(Arc::new(DynamicConfig::default()))
 }
 
 /// Start a host with a "DevRouter" backed HTTP server and the standard plugin

--- a/crates/wash-runtime/tests/common/tls.rs
+++ b/crates/wash-runtime/tests/common/tls.rs
@@ -111,7 +111,10 @@ pub async fn start_tls_echo_server() -> Result<EchoServer> {
                     match tls_stream.read(&mut buf).await {
                         Ok(0) => return,
                         Ok(n) => {
-                            received.extend_from_slice(&buf[..n]);
+                            // `n <= buf.len()` always holds for `read`; `get`
+                            // keeps it panic-free.
+                            let Some(chunk) = buf.get(..n) else { return };
+                            received.extend_from_slice(chunk);
                             if received.windows(2).any(|w| w == b"\r\n") {
                                 break;
                             }

--- a/crates/wash-runtime/tests/integration_blobstore_span_names.rs
+++ b/crates/wash-runtime/tests/integration_blobstore_span_names.rs
@@ -41,7 +41,7 @@ impl<S: Subscriber> Layer<S> for SpanNameRecorder {
     fn on_new_span(&self, attrs: &Attributes<'_>, _id: &tracing::Id, _ctx: LayerContext<'_, S>) {
         self.names
             .lock()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .push(attrs.metadata().name().to_string());
     }
 }
@@ -101,7 +101,7 @@ async fn wasi_blobstore_handlers_emit_namespaced_spans() -> Result<()> {
                     namespace: "wasi".to_string(),
                     package: "http".to_string(),
                     interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-                    version: Some(semver::Version::parse("0.2.2").unwrap()),
+                    version: Some(semver::Version::new(0, 2, 2)),
                     config: {
                         let mut config = HashMap::new();
                         config.insert("host".to_string(), "foo".to_string());
@@ -119,7 +119,9 @@ async fn wasi_blobstore_handlers_emit_namespaced_spans() -> Result<()> {
                     ]
                     .into_iter()
                     .collect(),
-                    version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+                    version: Some(
+                        semver::Version::parse("0.2.0-draft").expect("valid semver version"),
+                    ),
                     config: HashMap::new(),
                     name: None,
                 },

--- a/crates/wash-runtime/tests/integration_cron_service.rs
+++ b/crates/wash-runtime/tests/integration_cron_service.rs
@@ -84,30 +84,24 @@ async fn test_cron_service_integration() -> Result<()> {
         .expect("failed to read captured stderr");
 
     println!("\n=== Captured stderr ===");
-    println!("{}", output);
+    println!("{output}");
     println!("=====================\n");
 
     // Verify expected messages
     assert!(
         output.contains("Starting cron-service with 1 second intervals..."),
-        "Expected to find 'Starting cron-service with 1 second intervals...' in stderr.\nCaptured stderr:\n{}",
-        output
+        "Expected to find 'Starting cron-service with 1 second intervals...' in stderr.\nCaptured stderr:\n{output}"
     );
 
     // Check that "Hello from the cron-component!" appears at least 3 times
     let hello_count = output.matches("Hello from the cron-component!").count();
     assert!(
         hello_count >= 3,
-        "Expected at least 3 'Hello from the cron-component!' messages, but found {}.\nCaptured stderr:\n{}",
-        hello_count,
-        output
+        "Expected at least 3 'Hello from the cron-component!' messages, but found {hello_count}.\nCaptured stderr:\n{output}"
     );
 
     println!("✓ Found cron service start message");
-    println!(
-        "✓ Found {} cron-component messages (expected at least 3)",
-        hello_count
-    );
+    println!("✓ Found {hello_count} cron-component messages (expected at least 3)");
 
     Ok(())
 }

--- a/crates/wash-runtime/tests/integration_http_allowed_hosts.rs
+++ b/crates/wash-runtime/tests/integration_http_allowed_hosts.rs
@@ -14,11 +14,11 @@
 //!
 //! The fixture reports the policy outcome via its own status, not the
 //! upstream's:
-//! - 200 OK          — request was permitted by policy and reached the
-//!                     outgoing handler (which the tests stub to a synthetic
-//!                     200 — see [`FakeOutgoingHandler`] — so the real network
-//!                     is never touched and runs are deterministic)
-//! - 403 Forbidden   — denied by the host's allowed_hosts policy
+//! - 200 OK — request was permitted by policy and reached the outgoing
+//!   handler (which the tests stub to a synthetic 200 — see
+//!   [`FakeOutgoingHandler`] — so the real network is never touched and runs
+//!   are deterministic)
+//! - 403 Forbidden — denied by the host's allowed_hosts policy
 //! - 502 Bad Gateway — any other client error from the fixture's perspective
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]

--- a/crates/wash-runtime/tests/integration_http_blobstore.rs
+++ b/crates/wash-runtime/tests/integration_http_blobstore.rs
@@ -141,7 +141,7 @@ async fn test_http_blobstore_integration() -> Result<()> {
     .context("Failed to make HTTP request")?;
 
     let status = response.status();
-    println!("HTTP Response Status: {}", status);
+    println!("HTTP Response Status: {status}");
 
     let response_text = response
         .text()
@@ -151,7 +151,7 @@ async fn test_http_blobstore_integration() -> Result<()> {
 
     // The blobstore-filesystem component should now work with proper plugin binding
     println!("Blobstore-filesystem component responded successfully");
-    assert!(status.is_success(), "Expected success, got {}", status);
+    assert!(status.is_success(), "Expected success, got {status}");
     assert!(
         !response_text.trim().is_empty(),
         "Expected response body content"

--- a/crates/wash-runtime/tests/integration_http_counter.rs
+++ b/crates/wash-runtime/tests/integration_http_counter.rs
@@ -3,8 +3,6 @@
 //! Tests HTTP request handling, counter persistence, concurrent access,
 //! error handling, and plugin isolation.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
-
 use anyhow::{Context, Result};
 use std::{collections::HashMap, time::Duration};
 use tokio::time::timeout;

--- a/crates/wash-runtime/tests/integration_http_webgpu.rs
+++ b/crates/wash-runtime/tests/integration_http_webgpu.rs
@@ -147,17 +147,17 @@ async fn test_http_webgpu_integration() -> Result<()> {
     .context("Failed to make HTTP request")?;
 
     let status = response.status();
-    println!("HTTP Response Status: {}", status);
+    println!("HTTP Response Status: {status}");
 
     let response_text = response
         .text()
         .await
         .context("Failed to read response body")?;
-    println!("HTTP Response Body: {}", response_text);
+    println!("HTTP Response Body: {response_text}");
 
     // The webgpu component should now work with proper plugin binding
     println!("Webgpu component responded successfully");
-    assert!(status.is_success(), "Expected success, got {}", status);
+    assert!(status.is_success(), "Expected success, got {status}");
     assert!(
         !response_text.trim().is_empty(),
         "Expected response body content"
@@ -165,7 +165,7 @@ async fn test_http_webgpu_integration() -> Result<()> {
     // parse the numbers from the response
     let response_numbers = response_text
         .chars()
-        .filter(|s| s == &',' || s.is_digit(10))
+        .filter(|s| s == &',' || s.is_ascii_digit())
         .collect::<String>()
         .split(",")
         .map(|s| s.parse::<u32>().unwrap())

--- a/crates/wash-runtime/tests/integration_inter_component_call.rs
+++ b/crates/wash-runtime/tests/integration_inter_component_call.rs
@@ -6,6 +6,11 @@
 //! 3. Verifying that the http-counter can use the blobstore-filesystem implementation
 //! 4. Testing the component resolution system that links them together
 
+// The test plugin's trait impl panics on an unexpected context to fail the test
+// loudly; that's in a trait method, not a `#[test]` fn, so the clippy.toml
+// in-tests allow doesn't cover it.
+#![allow(clippy::panic)]
+
 use anyhow::{Context, Result};
 use std::{
     collections::{HashMap, HashSet},
@@ -77,18 +82,13 @@ impl<'a> bindings::wasi::logging::logging::Host for ActiveCtx<'a> {
             .get(&*self.component_id)
             .cloned();
 
-        if !per_component_info.is_some_and(|info| info.workload_id == &*self.workload_id) {
+        if per_component_info.is_none_or(|info| info.workload_id != *self.workload_id) {
             return Err(wasmtime::format_err!("workload ID mismatch"));
         }
 
         let prev_ctx_id = plugin.prev_ctx_id.lock().await.clone();
-        match (prev_ctx_id, &self.id) {
-            (Some(prev_ctx_id), ctx_id) => {
-                if prev_ctx_id == *ctx_id {
-                    panic!("same context");
-                }
-            }
-            (_, _) => {}
+        if prev_ctx_id.as_ref() == Some(&self.id) {
+            panic!("same context");
         }
 
         *plugin.prev_ctx_id.lock().await = Some(self.id.clone());
@@ -134,8 +134,7 @@ impl HostPlugin for CustomLogging {
             || !interface.interfaces.contains("logging")
         {
             anyhow::bail!(
-                "Expected exactly one interface: wasi:logging/logging, got: {:?}",
-                interfaces
+                "Expected exactly one interface: wasi:logging/logging, got: {interfaces:?}"
             );
         }
 
@@ -299,12 +298,11 @@ async fn test_inter_component_call() -> Result<()> {
     .context("Failed to make first request")?;
 
     let status = response.status();
-    println!("First Response Status: {}", status);
+    println!("First Response Status: {status}");
 
     assert!(
         status.is_success(),
-        "First request failed with status {}",
-        status,
+        "First request failed with status {status}",
     );
 
     Ok(())

--- a/crates/wash-runtime/tests/integration_nats_blobstore.rs
+++ b/crates/wash-runtime/tests/integration_nats_blobstore.rs
@@ -99,7 +99,7 @@ async fn setup() -> Result<TestHarness> {
                     namespace: "wasi".to_string(),
                     package: "http".to_string(),
                     interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-                    version: Some(semver::Version::parse("0.2.2").unwrap()),
+                    version: Some(semver::Version::new(0, 2, 2)),
                     config: {
                         let mut config = HashMap::new();
                         config.insert("host".to_string(), "foo".to_string());
@@ -117,7 +117,9 @@ async fn setup() -> Result<TestHarness> {
                     ]
                     .into_iter()
                     .collect(),
-                    version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+                    version: Some(
+                        semver::Version::parse("0.2.0-draft").expect("valid semver version"),
+                    ),
                     config: {
                         let mut config = HashMap::new();
                         config.insert("buckets".to_string(), "my-container-real".to_string());

--- a/crates/wash-runtime/tests/integration_nats_messaging.rs
+++ b/crates/wash-runtime/tests/integration_nats_messaging.rs
@@ -127,7 +127,7 @@ async fn setup() -> Result<TestHarness> {
                 namespace: "wasmcloud".to_string(),
                 package: "messaging".to_string(),
                 interfaces: ["handler".to_string()].into_iter().collect(),
-                version: Some(semver::Version::parse("0.2.0").unwrap()),
+                version: Some(semver::Version::new(0, 2, 0)),
                 config: subscription_config,
                 name: None,
             }],

--- a/crates/wash-runtime/tests/integration_nats_messaging_fault.rs
+++ b/crates/wash-runtime/tests/integration_nats_messaging_fault.rs
@@ -136,11 +136,13 @@ async fn copy_with_latency<R, W>(
             Ok(0) | Err(_) => break,
             Ok(n) => n,
         };
-        capture.lock().await.extend_from_slice(&buf[..n]);
+        // `n <= buf.len()` always holds for `read`; `get` keeps it panic-free.
+        let Some(chunk) = buf.get(..n) else { break };
+        capture.lock().await.extend_from_slice(chunk);
         if !latency.is_zero() {
             tokio::time::sleep(latency).await;
         }
-        if writer.write_all(&buf[..n]).await.is_err() {
+        if writer.write_all(chunk).await.is_err() {
             break;
         }
         let _ = writer.flush().await;
@@ -235,7 +237,7 @@ async fn setup(latency: Duration) -> Result<TestHarness> {
                 namespace: "wasmcloud".to_string(),
                 package: "messaging".to_string(),
                 interfaces: ["handler".to_string()].into_iter().collect(),
-                version: Some(semver::Version::parse("0.2.0").unwrap()),
+                version: Some(semver::Version::new(0, 2, 0)),
                 config: subscription_config,
                 name: None,
             }],

--- a/crates/wash-runtime/tests/integration_router_dev.rs
+++ b/crates/wash-runtime/tests/integration_router_dev.rs
@@ -11,8 +11,6 @@
 //! - Concurrent reads racing a workload swap all resolve to a response (no
 //!   hangs, no panics from `try_read` contention).
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
-
 use anyhow::Result;
 use futures::future::join_all;
 use std::{collections::HashMap, time::Duration};

--- a/crates/wash-runtime/tests/integration_router_dynamic.rs
+++ b/crates/wash-runtime/tests/integration_router_dynamic.rs
@@ -2,7 +2,7 @@
 //! workloads by Host header (with optional comma-separated aliases).
 //!
 //! `DynamicRouter::route_incoming_request` uses `tokio::task::block_in_place`
-//! + `try_read`, so all tests run on the multi-thread runtime. Per-request
+//! with `try_read`, so all tests run on the multi-thread runtime. Per-request
 //! `timeout(...)` on individual HTTP calls guards against hangs.
 //!
 //! Covers:
@@ -17,8 +17,6 @@
 //! - HTTP/1.0 request without a Host header returns 400 (RouteError::MissingHost).
 //! - Invalid hostnames in host-aliases are silently filtered; only valid ones route.
 //! - Two workloads bound to the same host both serve requests (HashSet routing).
-
-#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
 use futures::future::join_all;

--- a/crates/wash-runtime/tests/integration_tls_socket.rs
+++ b/crates/wash-runtime/tests/integration_tls_socket.rs
@@ -5,7 +5,6 @@
 //! exchange against a local rustls echo server started in-process.
 
 #![cfg(feature = "wasi-tls")]
-#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
 use std::{collections::HashMap, time::Duration};

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -996,7 +996,7 @@ mod tests {
             "no workload values should have been merged in"
         );
         assert_eq!(entry.config.get("USER_KEY").unwrap(), "user_value");
-        assert!(entry.config.get("WORKLOAD_KEY").is_none());
+        assert!(!entry.config.contains_key("WORKLOAD_KEY"));
     }
 
     #[test]

--- a/crates/wash/src/cli/wit.rs
+++ b/crates/wash/src/cli/wit.rs
@@ -923,9 +923,8 @@ world example {
         assert!(content.contains("import wasi:cli@0.2.0;"));
 
         // Remove the import
-        let lines: Vec<&str> = content.lines().collect();
-        let new_lines: Vec<&str> = lines
-            .into_iter()
+        let new_lines: Vec<&str> = content
+            .lines()
             .filter(|line| {
                 let trimmed = line.trim();
                 !(trimmed.starts_with("import ") && trimmed.contains("wasi:cli"))
@@ -980,7 +979,7 @@ world example {
                 let trimmed = line.trim();
                 // Insert after the opening brace of the world block
                 if trimmed.starts_with("world ") && trimmed.ends_with('{') {
-                    new_lines.push(format!("   {}", import_line)); // Indent inside world block
+                    new_lines.push(format!("   {import_line}")); // Indent inside world block
                     inserted = true;
                 }
             }
@@ -1078,9 +1077,9 @@ world example {
         let version = Some("1.0.0".to_string());
 
         let filename = if let Some(ver) = &version {
-            format!("{}-{}.wasm", package_name, ver)
+            format!("{package_name}-{ver}.wasm")
         } else {
-            format!("{}.wasm", package_name)
+            format!("{package_name}.wasm")
         };
 
         assert_eq!(filename, "test-package-1.0.0.wasm");
@@ -1092,9 +1091,9 @@ world example {
         let version: Option<String> = None;
 
         let filename = if let Some(ver) = &version {
-            format!("{}-{}.wasm", package_name, ver)
+            format!("{package_name}-{ver}.wasm")
         } else {
-            format!("{}.wasm", package_name)
+            format!("{package_name}.wasm")
         };
 
         assert_eq!(filename, "test-package.wasm");
@@ -1254,9 +1253,8 @@ world example {
             .await
             .expect("failed to read world.wit");
 
-        let lines: Vec<&str> = read_content.lines().collect();
-        let new_lines: Vec<&str> = lines
-            .into_iter()
+        let new_lines: Vec<&str> = read_content
+            .lines()
             .filter(|line| {
                 let trimmed = line.trim();
                 if trimmed.starts_with("import ") {
@@ -1367,9 +1365,9 @@ digest = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456789
 
         // Simulate the default output path logic
         let filename = if let Some(ver) = &version {
-            format!("{}-{}.wasm", package_name, ver)
+            format!("{package_name}-{ver}.wasm")
         } else {
-            format!("{}.wasm", package_name)
+            format!("{package_name}.wasm")
         };
         let default_output = project_dir.join(filename);
 
@@ -1392,9 +1390,9 @@ digest = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456789
             output.to_path_buf()
         } else {
             let filename = if let Some(ver) = &version {
-                format!("{}-{}.wasm", package_name, ver)
+                format!("{package_name}-{ver}.wasm")
             } else {
-                format!("{}.wasm", package_name)
+                format!("{package_name}.wasm")
             };
             project_dir.join(filename)
         };
@@ -1493,20 +1491,16 @@ world example {
         let lines: Vec<&str> = content.lines().collect();
 
         // Verify comments are preserved and not mistaken for imports
-        let comment_lines: Vec<_> = lines
-            .iter()
-            .filter(|l| l.trim().starts_with("//"))
-            .collect();
-        assert_eq!(comment_lines.len(), 3, "Should preserve all comment lines");
+        let comment_count = lines.iter().filter(|l| l.trim().starts_with("//")).count();
+        assert_eq!(comment_count, 3, "Should preserve all comment lines");
 
         // Verify import detection works correctly (ignores comments)
-        let import_lines: Vec<_> = lines
+        let import_count = lines
             .iter()
             .filter(|l| l.trim().starts_with("import "))
-            .collect();
+            .count();
         assert_eq!(
-            import_lines.len(),
-            1,
+            import_count, 1,
             "Should find only actual import, not comments"
         );
     }
@@ -1533,9 +1527,8 @@ world example {
             .await
             .expect("failed to read world.wit");
 
-        let lines: Vec<&str> = content.lines().collect();
-        let new_lines: Vec<&str> = lines
-            .into_iter()
+        let new_lines: Vec<&str> = content
+            .lines()
             .filter(|line| {
                 let trimmed = line.trim();
                 if trimmed.starts_with("import ") {

--- a/crates/wash/src/workload.rs
+++ b/crates/wash/src/workload.rs
@@ -540,7 +540,7 @@ mod tests {
         std::fs::write(&outside, "X=1\n").unwrap();
 
         let err = resolve_contained_path(Path::new("../outside.env"), &project).unwrap_err();
-        let msg = format!("{:#}", err);
+        let msg = format!("{err:#}");
         assert!(msg.contains("outside the project directory"), "{}", msg);
     }
 
@@ -565,7 +565,7 @@ mod tests {
         std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o644)).unwrap();
         let handle = open_file_secure(&f).unwrap();
         let err = check_secret_file_perms(&handle, &f).unwrap_err();
-        assert!(format!("{:#}", err).contains("require 0600 or 0400"));
+        assert!(format!("{err:#}").contains("require 0600 or 0400"));
     }
 
     #[cfg(unix)]
@@ -619,7 +619,7 @@ mod tests {
             None,
         )
         .unwrap_err();
-        assert!(format!("{:#}", err).contains("missing"));
+        assert!(format!("{err:#}").contains("missing"));
     }
 
     #[test]
@@ -628,7 +628,7 @@ mod tests {
         let f = dir.path().join("a.env");
         std::fs::write(&f, "FOO=bar\nNOEQUALS\n").unwrap();
         let err = parse_env_file(open_file_secure(&f).unwrap(), &f).unwrap_err();
-        let msg = format!("{:#}", err);
+        let msg = format!("{err:#}");
         assert!(msg.contains("line 2"), "{}", msg);
         assert!(msg.contains("not KEY=VALUE"), "{}", msg);
     }
@@ -639,7 +639,7 @@ mod tests {
         let f = dir.path().join("a.env");
         std::fs::write(&f, "=value\n").unwrap();
         let err = parse_env_file(open_file_secure(&f).unwrap(), &f).unwrap_err();
-        assert!(format!("{:#}", err).contains("empty key"));
+        assert!(format!("{err:#}").contains("empty key"));
     }
 
     // SAFETY rationale for `std::env::{set,remove}_var` in tests below:
@@ -664,7 +664,7 @@ mod tests {
 
         unsafe { std::env::remove_var(&var) };
         let err = source.resolve("c", project.path()).unwrap_err();
-        assert!(format!("{:#}", err).contains(&var));
+        assert!(format!("{err:#}").contains(&var));
     }
 
     #[test]
@@ -676,7 +676,7 @@ mod tests {
         let var = format!("WASH_TEST_PREC_{}", uuid::Uuid::new_v4().simple());
 
         let f = project.path().join("a.env");
-        std::fs::write(&f, format!("{}=from_file\n", var)).unwrap();
+        std::fs::write(&f, format!("{var}=from_file\n")).unwrap();
 
         unsafe { std::env::set_var(&var, "from_env") };
 

--- a/crates/wash/tests/integration_wit.rs
+++ b/crates/wash/tests/integration_wit.rs
@@ -4,6 +4,10 @@
 
 // Increase the default recursion limit
 #![recursion_limit = "256"]
+// A test asserts success by panicking on the error path; clippy's
+// allow-panic-in-tests only recognizes `#[test]`, not the `#[tokio::test]`
+// wrapper, so silence the restriction lint at the file level.
+#![allow(clippy::panic)]
 
 use anyhow::{Context, Result};
 use std::fs;
@@ -195,7 +199,7 @@ world example {
 
     if !result.is_success() {
         let (msg, _) = result.render();
-        panic!("remove command should succeed, got error: {}", msg);
+        panic!("remove command should succeed, got error: {msg}");
     }
 
     // Verify removed from world.wit
@@ -324,8 +328,7 @@ async fn test_error_missing_world_wit() -> Result<()> {
     let (msg, _) = result.render();
     assert!(
         msg.contains("world") || msg.contains("WIT file"),
-        "error message should mention world or WIT file: {}",
-        msg
+        "error message should mention world or WIT file: {msg}"
     );
 
     Ok(())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,8 @@
 [toolchain]
-channel = "stable"
+# Pinned to an explicit stable so clippy is deterministic: a floating "stable"
+# silently turns CI red whenever a new toolchain ships new lints. Bump this in
+# a dedicated PR alongside any lint fixes the new toolchain requires.
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]
 targets = [
     "wasm32-unknown-unknown",


### PR DESCRIPTION
Pin rust-toolchain.toml to an explicit stable (1.96.0) instead of a
floating "stable", so clippy is deterministic.

MSRV (1.91.0) is unchanged.

Add clippy.toml with allow-{unwrap,expect,panic,indexing-slicing}-in-tests
so test code passes the workspace's denied restriction lints under
--all-targets, without weakening the production `src/` lint surface (CI's
src-only clippy is unaffected).

Fix the genuine lints the newer clippy flags across src, tests, and benches:
uninlined_format_args, needless_collect, manual is_none, char::is_digit ->
is_ascii_digit, nonminimal_bool/op_ref/single_match, and doc-list
formatting. Refactor helper-level unwraps where clean (Version::new, ?,
poison-tolerant lock, buf.get(..n)) and drop per-file test allows now
covered by clippy.toml; keep them only where module-level helpers still
need them, and make tests/common self-contained.
