### PR TITLE
feat(examples): demonstrate cross-workload OTel trace roll-up

### DIFF
--- a/crates/wash-runtime/src/observability.rs
+++ b/crates/wash-runtime/src/observability.rs
@@ -117,6 +117,16 @@ pub fn initialize_observability(
 
     opentelemetry::global::set_meter_provider(meter_provider.clone());
 
+    // Register the W3C Trace Context propagator so the incoming-request path
+    // (`opentelemetry::global::get_text_map_propagator` in `host::http`) can
+    // parse the `traceparent` header into the OpenTelemetry context.
+    // Without this every workload roots its own trace instead of continuing the
+    // caller's. Registering it here is what lets a trace roll up across
+    // workload/host boundaries.
+    opentelemetry::global::set_text_map_propagator(
+        opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+    );
+
     // Return a shutdown function to flush providers on exit
     let shutdown_fn = move || {
         if let Err(e) = tracer_provider.shutdown() {

--- a/examples/otel-config/.gitignore
+++ b/examples/otel-config/.gitignore
@@ -7,6 +7,9 @@ build/
 # Wash dependencies
 wit/deps/
 
+# Per-workload local state written by the multi-workload chain demo.
+chain/*/tmp/
+
 # direnv local config: the `.envrc.example` template is checked in,
 # but the user-edited `.envrc` (with real secrets) must not be.
 .envrc

--- a/examples/otel-config/README.md
+++ b/examples/otel-config/README.md
@@ -172,6 +172,85 @@ Open the dashboard at [http://localhost:18888](http://localhost:18888). You shou
   `http.server.response_body.size` gauge, both labelled by the Resource attributes from
   `workload.config`.
 
+## Multi-workload trace roll-up
+
+The single workload above already shows the two ingredients of a distributed
+trace: it continues an inbound trace (via `outer-span-context`) and propagates
+its own context outward (via the W3C `traceparent` header on its egress call).
+The [`chain/`](chain) directory wires three instances of *this same component*
+into a call graph so you can watch a request flow across workload and host
+boundaries and roll up under **one** trace:
+
+```
+curl :8000  ──►  frontend ──►  middle ──►  backend ──►  https://example.com
+              (chain/frontend) (chain/middle) (chain/backend)
+```
+
+Each hop is an independent workload and its own
+host, e.g. own `wash dev` process, with its own OTel `Resource` (`service.name` = `otel-chain-{frontend,middle,backend}`).
+They differ only in `wash dev` configuration; there is no per-workload code.
+Every workload points `OUTBOUND_URL` at the next one (the leaf, `backend`,
+leaves the chain for `https://example.com`) and exports to the same OTLP
+endpoint, so the collector stitches their spans into a single trace.
+
+### Run the chain
+
+1. Build the component once from the example root to fetch the WIT
+   dependencies. Each chain workload then builds the same crate in this Cargo
+   workspace, so after this first fetch cargo just reuses the cached build:
+
+   ```bash
+   wash build
+   ```
+
+2. Start an OTLP viewer (the [Aspire dashboard](#end-to-end-with-an-otlp-compatible-viewer)
+   `docker run` recipe above works) so the three workloads have somewhere to
+   export to.
+
+3. Launch the three workloads, each in its own terminal. Start from the leaf so
+   every hop's downstream is already listening:
+
+   ```bash
+   wash -C chain/backend dev    # :8002 → https://example.com
+   wash -C chain/middle dev     # :8001 → :8002
+   wash -C chain/frontend dev   # :8000 → :8001
+   ```
+
+4. Hit the entry point:
+
+   ```bash
+   curl http://localhost:8000/
+   ```
+
+In the trace viewer you'll see one trace whose root is the `frontend`
+workload's incoming-request span, with the `frontend → middle → backend` server
+spans nested in turn, and each workload's `outgoing http` / `blobstore write` /
+`keyvalue increment` child spans hanging off its `handle-request` span. Because
+every span records start and end times, the slowest hop in the chain stands out
+visually. You can use this to answer questions like "which workload is slow?"
+
+### How the context propagates
+
+There are two distinct propagation mechanisms at work:
+
+- **In-process (within one workload).** `handle-request` is the parent server
+  span; `outgoing http`, `blobstore write`, and `keyvalue increment` are child
+  client spans created under it by reusing the same trace ID and naming
+  `handle-request` as their parent. No headers are involved. This is ordinary
+  parent/child span construction inside the component.
+- **Across hosts (workload to workload).** On its outbound call a workload
+  injects a W3C `traceparent` header carrying the current trace ID, the
+  `outgoing http` span ID, and the sampling flag. On the receiving side
+  wash-runtime parses that header into the OpenTelemetry context before it
+  invokes the component, so the component's `outer-span-context` returns the
+  caller's span as its parent and continues the trace instead of rooting a new
+  one. The sampling decision rides along, so a `traceparent` that wasn't
+  sampled keeps the whole downstream chain out of the backend too.
+
+That second mechanism is why the trace stays unified across three separate
+hosts: the trace ID minted at `frontend` is the trace ID that every span in
+`middle` and `backend` carries.
+
 ### Demo: `allowedHosts` in action
 
 Edit `config/defaults.env` and change:

--- a/examples/otel-config/chain/backend/.wash/config.yaml
+++ b/examples/otel-config/chain/backend/.wash/config.yaml
@@ -1,0 +1,32 @@
+# Backend workload is the leaf of the chain.
+#
+# Continues the trace exactly like the middle workload, but its outbound call
+# leaves the chain for `https://example.com`. The `traceparent` still rides
+# along on that request; example.com simply ignores it, which is the realistic
+# "trace context handed off to a service that doesn't participate" case.
+#
+# See chain/frontend/.wash/config.yaml for the shared-workspace build details.
+build:
+  command: cargo build --manifest-path ../../Cargo.toml --target wasm32-wasip2 --release
+  component_path: ../../target/wasm32-wasip2/release/otel_config.wasm
+
+wit:
+  skip_fetch: true
+
+dev:
+  address: 0.0.0.0:8002
+  wasi_blobstore_path: tmp/blobstore
+  wasi_keyvalue_path: tmp/keyvalue
+  wasi_otel: true
+  environment:
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:18889
+
+workload:
+  config:
+    # Leaf hop: leave the chain for a real upstream.
+    OUTBOUND_URL: https://example.com/
+    otel.resource.service.name: otel-chain-backend
+    otel.resource.deployment.environment: local
+    otel.resource.chain.position: "3-backend"
+  allowedHosts:
+    - example.com

--- a/examples/otel-config/chain/frontend/.wash/config.yaml
+++ b/examples/otel-config/chain/frontend/.wash/config.yaml
@@ -1,0 +1,41 @@
+# Frontend workload is the trace entry point.
+#
+# `curl http://localhost:8000/` lands here. With no inbound `traceparent`,
+# this workload roots a fresh trace and its `handle-request` span becomes the
+# root the whole chain rolls up under. Its outbound call targets the middle
+# workload, carrying W3C `traceparent` on the wire so the trace continues
+# across the host boundary.
+#
+# All three chain workloads build the one shared crate in this Cargo workspace
+# into the same target dir, so cargo caches and only the first build does real
+# work. `wit.skip_fetch` keeps wash from fetching into this config-only
+# directory — the WIT lives next to the source and is fetched by a `wash build`
+# from the example root once (see the README).
+build:
+  command: cargo build --manifest-path ../../Cargo.toml --target wasm32-wasip2 --release
+  component_path: ../../target/wasm32-wasip2/release/otel_config.wasm
+
+wit:
+  skip_fetch: true
+
+dev:
+  address: 0.0.0.0:8000
+  wasi_blobstore_path: tmp/blobstore
+  wasi_keyvalue_path: tmp/keyvalue
+  wasi_otel: true
+  environment:
+    # Every workload exports to the same OTLP endpoint, so the collector
+    # stitches their spans into one trace. Matches the Aspire dashboard's
+    # gRPC ingest port (see the example README).
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:18889
+
+workload:
+  config:
+    # Verbatim outbound target: the next workload in the chain.
+    OUTBOUND_URL: http://localhost:8001/
+    otel.resource.service.name: otel-chain-frontend
+    otel.resource.deployment.environment: local
+    otel.resource.chain.position: "1-frontend"
+  allowedHosts:
+    # The middle workload runs on localhost; a bare host matches any port.
+    - localhost

--- a/examples/otel-config/chain/middle/.wash/config.yaml
+++ b/examples/otel-config/chain/middle/.wash/config.yaml
@@ -1,0 +1,32 @@
+# Middle workload is a downstream hop.
+#
+# Receives the frontend's request with a W3C `traceparent` header. wash-runtime
+# extracts it into the OTel context, so this workload's `outer-span-context`
+# returns the frontend's span. Its own `handle-request` span therefore nests
+# under the frontend's outbound span instead of starting a new trace. It then
+# calls the backend workload, propagating the trace one more hop.
+#
+# See chain/frontend/.wash/config.yaml for the shared-workspace build details.
+build:
+  command: cargo build --manifest-path ../../Cargo.toml --target wasm32-wasip2 --release
+  component_path: ../../target/wasm32-wasip2/release/otel_config.wasm
+
+wit:
+  skip_fetch: true
+
+dev:
+  address: 0.0.0.0:8001
+  wasi_blobstore_path: tmp/blobstore
+  wasi_keyvalue_path: tmp/keyvalue
+  wasi_otel: true
+  environment:
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:18889
+
+workload:
+  config:
+    OUTBOUND_URL: http://localhost:8002/
+    otel.resource.service.name: otel-chain-middle
+    otel.resource.deployment.environment: local
+    otel.resource.chain.position: "2-middle"
+  allowedHosts:
+    - localhost

--- a/examples/otel-config/src/blobstore.rs
+++ b/examples/otel-config/src/blobstore.rs
@@ -17,9 +17,14 @@ pub(crate) fn store_response_in_blobstore(body: &[u8]) -> Result<()> {
     let stream = outgoing
         .outgoing_value_write_body()
         .map_err(|()| anyhow!("failed to open blobstore output stream"))?;
-    stream
-        .blocking_write_and_flush(body)
-        .context("failed to write blob bytes")?;
+    // `blocking-write-and-flush` accepts at most 4096 bytes per call and traps
+    // on more, so chunk the body. Upstream responses in a workload-to-workload
+    // chain are easily larger than a single permit.
+    for chunk in body.chunks(4096) {
+        stream
+            .blocking_write_and_flush(chunk)
+            .context("failed to write blob bytes")?;
+    }
     drop(stream);
 
     container

--- a/examples/otel-config/src/config.rs
+++ b/examples/otel-config/src/config.rs
@@ -42,16 +42,24 @@ fn build_app_config() -> AppConfig {
             entries.insert(k, v);
         }
     }
-    let outbound_host = entries
-        .get("OUTBOUND_HOST")
-        .map(String::as_str)
-        .unwrap_or(DEFAULT_OUTBOUND_HOST);
+    // `OUTBOUND_URL`, when set, is used verbatim. This lets a workload point at
+    // a sibling workload over `http://host:port/` (see the multi-workload
+    // roll-up demo in the README), where the bare-host + implicit-`https`
+    // shape of `OUTBOUND_HOST` doesn't fit. Otherwise fall back to
+    // `https://{OUTBOUND_HOST}/`.
+    let outbound_url = entries.get("OUTBOUND_URL").cloned().unwrap_or_else(|| {
+        let outbound_host = entries
+            .get("OUTBOUND_HOST")
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_OUTBOUND_HOST);
+        format!("https://{outbound_host}/")
+    });
     let timeout_ms = entries
         .get("REQUEST_TIMEOUT_MS")
         .and_then(|s| s.parse::<u64>().ok())
         .unwrap_or(DEFAULT_REQUEST_TIMEOUT_MS);
     AppConfig {
-        outbound_url: format!("https://{outbound_host}/"),
+        outbound_url,
         request_timeout: Duration::from_millis(timeout_ms),
         upstream_api_token: entries.get("UPSTREAM_API_TOKEN").cloned(),
     }


### PR DESCRIPTION
Add a multi-workload chain to the otel-config example
(frontend → middle → backend → example.com) that shows a single trace
rolling up across workload and host boundaries.

Three thin `wash dev` config dirs under examples/otel-config/chain/ reuse
the one component in the workspace; each points OUTBOUND_URL at the next
hop and exports to the same OTLP endpoint. The README documents in-process
(parent/child spans) vs. across-host (W3C traceparent) propagation.

This required two supporting fixes:

- wash-runtime: register the W3C TraceContextPropagator in
  initialize_observability. The incoming-request path already extracts
  traceparent via get_text_map_propagator, but with no propagator
  registered the global default is a no-op, so outer-span-context saw no
  parent and every workload rooted its own trace.

- otel-config: write the blob body in <=4096-byte chunks.
  blocking-write-and-flush traps above 4096 bytes; the single-workload
  demo only ever stored a 528-byte reply, but a chained workload stores
  the upstream's full page and trapped.

Closes #5050
