### PR TITLE
ci(wash): build and publish a wasip3 canary image

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -66,7 +66,7 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -405,6 +405,7 @@ jobs:
       - check
       - lint
       - wash-image
+      - wash-image-wasip3
       - runtime-operator-e2e
       - canary-publish
       - canary-binaries
@@ -520,6 +521,33 @@ jobs:
           docker buildx imagetools inspect "ghcr.io/wasmcloud/wash:${STEPS_META_OUTPUTS_VERSION}"
         env:
           STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
+
+  # wasip3 image variant. Builds wash with the `wasip3,wasi-tls` features
+  # (WASI Preview 3 compiled in) and publishes it as `canary-wasip3` /
+  # `sha-<full-sha>-wasip3`.
+  wash-image-wasip3:
+    needs:
+      - changes
+      - runtime-operator-e2e
+    if: |
+      always() &&
+      (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true') &&
+      (((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main')) &&
+      needs.runtime-operator-e2e.result == 'success'
+    permissions:
+      contents: write
+      packages: write
+    uses: ./.github/workflows/docker-build-push.yml
+    with:
+      image: ghcr.io/wasmcloud/wash
+      build-args: |
+        CARGO_FEATURES=wasip3,wasi-tls
+      # Push (and the manifest merge) only on main; PRs build to validate.
+      push: ${{ github.event_name != 'pull_request' }}
+      push-by-digest: ${{ github.event_name != 'pull_request' }}
+      tags: |
+        type=raw,value=canary-wasip3
+        type=sha,format=long,prefix=sha-,suffix=-wasip3
 
   # Canary matrix binary build. Runs on every release commit on main —
   # detected by `release-detect` as a Cargo.toml workspace version bump

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,12 @@ USER nonroot
 # copy source code
 COPY --chown=nonroot:nonroot . .
 
+# Optional comma-separated cargo feature list (e.g. "wasip3,wasi-tls").
+# Empty by default so the standard image stays on WASI Preview 2.
+ARG CARGO_FEATURES=""
+
 # build static binary
-RUN cargo build --release --bin wash
+RUN cargo build --release --bin wash ${CARGO_FEATURES:+--features ${CARGO_FEATURES}}
 
 # Release image
 FROM cgr.dev/chainguard/wolfi-base

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 
 [features]
 wasip3 = ["wash-runtime/wasip3"]
+wasi-tls = ["wash-runtime/wasi-tls"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
Produce a wash image with WASIP3 compiled in, published on every
main push as `ghcr.io/wasmcloud/wash:canary-wasip3` and
`sha-<full-sha>-wasip3` alongside the default (P2) tags.

- Dockerfile: add an optional `CARGO_FEATURES` build-arg. Empty by
  default, so the standard image stays on WASIP2.
- crates/wash: add a `wasi-tls` feature that re-exports
  `wash-runtime/wasi-tls` (the crate previously only re-exported
  `wasip3`), so `--bin wash --features wasip3,wasi-tls` resolves.
- wash.yml: add a `wash-image-wasip3` job that delegates to the shared
  docker-build-push reusable workflow with `CARGO_FEATURES=wasip3,wasi-tls`
- docker-build-push.yml: raise the build timeout 30→60 min to fit wash's
  Rust release build (wasmtime + rustls)