### PR TITLE
release: v2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bench-tools"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -7312,7 +7312,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7360,7 +7360,7 @@ dependencies = [
 
 [[package]]
 name = "wash-runtime"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9219,7 +9219,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xtask"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 authors = ["The wasmCloud Team"]
 edition = "2024"
 rust-version = "1.91.0"
-version = "2.2.1"
+version = "2.3.0"
 
 [workspace.lints.rust]
 warnings = 'deny' # Treat all warnings as errors

--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.4.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.2.1"
+appVersion: "2.3.0"


### PR DESCRIPTION
Automated release-train PR for **v2.3.0**.

**Action required:** a maintainer needs to approve this PR. Once required checks pass and approval is recorded, auto-merge fires. After merge, `release-tag.yml` waits for canary builds on `main` to pass and then pushes the immutable `v2.3.0` tag, which the existing tag-triggered workflows pick up.

If CI fails: fix forward and push to this branch, or close this PR. The train does not skip — patch releases out-of-cycle can be triggered via `workflow_dispatch` on `release-train.yml`.
