### PR TITLE
Have container health use NATs connectivity status

### DIFF
--- a/charts/runtime-operator/templates/operator/deployment.yaml
+++ b/charts/runtime-operator/templates/operator/deployment.yaml
@@ -60,6 +60,23 @@ spec:
               mountPath: /operator-cert
               readOnly: true
           {{- end }}
+          ports:
+            - name: health
+              containerPort: 8082
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
           securityContext:
             capabilities:
               drop:

--- a/runtime-operator/cmd/main.go
+++ b/runtime-operator/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"flag"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -192,6 +193,19 @@ func main() {
 		operatorCfg.NatsOptions = append(operatorCfg.NatsOptions, nats.TLSHandshakeFirst())
 	}
 
+	// Surface NATS connection state.
+	operatorCfg.NatsOptions = append(operatorCfg.NatsOptions,
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			setupLog.Error(err, "nats disconnected")
+		}),
+		nats.ReconnectHandler(func(nc *nats.Conn) {
+			setupLog.Info("nats reconnected", "url", nc.ConnectedUrl())
+		}),
+		nats.ClosedHandler(func(_ *nats.Conn) {
+			setupLog.Error(nil, "nats connection closed")
+		}),
+	)
+
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
 	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
@@ -295,7 +309,7 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
-	_, err = runtime_operator.NewEmbeddedOperator(ctx, mgr, operatorCfg)
+	embeddedOperator, err := runtime_operator.NewEmbeddedOperator(ctx, mgr, operatorCfg)
 	if err != nil {
 		setupLog.Error(err, "unable to create runtime operator")
 		os.Exit(1)
@@ -307,6 +321,15 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
+	// Liveness must reflect NATS connectivity: a permanently closed connection
+	// means the operator can no longer observe host heartbeats, so the kubelet
+	// should restart the pod. Only the terminal closed state fails the probe —
+	// transient reconnecting stays healthy so routine NATS rollouts don't
+	// trigger restart storms.
+	if err := mgr.AddHealthzCheck("nats", natsLivenessCheck(embeddedOperator.NatsConn)); err != nil {
+		setupLog.Error(err, "unable to set up nats health check")
+		os.Exit(1)
+	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
@@ -316,6 +339,20 @@ func main() {
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
+	}
+}
+
+// natsLivenessCheck reports the operator as unhealthy only when the NATS
+// connection is permanently closed. A closed connection means the operator can
+// no longer observe host heartbeats, so Kubernetes should restart the pod. It
+// deliberately stays healthy while merely reconnecting so routine NATS rollouts
+// don't trigger restart storms.
+func natsLivenessCheck(nc *nats.Conn) healthz.Checker {
+	return func(_ *http.Request) error {
+		if nc.IsClosed() {
+			return errors.New("nats connection permanently closed")
+		}
+		return nil
 	}
 }
 

--- a/runtime-operator/cmd/main_test.go
+++ b/runtime-operator/cmd/main_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2024.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package main
 
 import (

--- a/runtime-operator/cmd/main_test.go
+++ b/runtime-operator/cmd/main_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus"
+)
+
+// startNatsOnFreePort starts an embedded NATS server on an ephemeral port to
+// avoid contention with the fixed-port servers used by the pkg/wasmbus tests,
+// which may run in parallel.
+func startNatsOnFreePort(t *testing.T) (url string, stop func()) {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+
+	s, err := server.NewServer(&server.Options{
+		Host:   "127.0.0.1",
+		Port:   port,
+		NoLog:  true,
+		NoSigs: true,
+	})
+	if err != nil {
+		t.Fatalf("new nats server: %v", err)
+	}
+	s.Start()
+	if !s.ReadyForConnections(10 * time.Second) {
+		s.Shutdown()
+		t.Fatal("nats server did not become ready")
+	}
+
+	return fmt.Sprintf("nats://127.0.0.1:%d", port), func() {
+		s.Shutdown()
+		s.WaitForShutdown()
+	}
+}
+
+// TestNatsLivenessCheck verifies the operator's liveness reflects NATS
+// connectivity: healthy while connected, and unhealthy once the connection is
+// permanently closed so the kubelet restarts the pod.
+func TestNatsLivenessCheck(t *testing.T) {
+	url, stop := startNatsOnFreePort(t)
+	defer stop()
+
+	nc, err := wasmbus.NatsConnect(url)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer nc.Close()
+
+	check := natsLivenessCheck(nc)
+
+	if err := check(nil); err != nil {
+		t.Fatalf("expected healthy while connected, got: %v", err)
+	}
+
+	nc.Close()
+	deadline := time.Now().Add(5 * time.Second)
+	for !nc.IsClosed() && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err := check(nil); err == nil {
+		t.Fatal("expected liveness to fail on a permanently closed nats connection")
+	}
+}

--- a/runtime-operator/pkg/wasmbus/nats.go
+++ b/runtime-operator/pkg/wasmbus/nats.go
@@ -33,6 +33,12 @@ func NatsConnect(url string, options ...NatsOption) (*nats.Conn, error) {
 		nats.FlusherTimeout(30 * time.Second), // default is 1m
 		nats.Timeout(5 * time.Second),         // default is 2s
 		nats.ReconnectWait(1 * time.Second),   // default is 2s
+		// Reconnect forever. The nats.go default caps reconnection at 60
+		// attempts, after which the connection is closed permanently and any
+		// subscriptions (e.g. the operator's host heartbeat watch) go silently
+		// deaf with no recovery.
+		nats.MaxReconnects(-1),
+		nats.ReconnectJitter(100*time.Millisecond, 1*time.Second), // spread reconnect storms
 	}, options...)
 
 	nc, err := nats.Connect(url, opts...)

--- a/runtime-operator/pkg/wasmbus/nats_reconnect_test.go
+++ b/runtime-operator/pkg/wasmbus/nats_reconnect_test.go
@@ -1,0 +1,116 @@
+package wasmbus
+
+import (
+	"testing"
+	"time"
+
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus/wasmbustest"
+)
+
+func waitFor(t *testing.T, timeout time.Duration, desc string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for %s", timeout, desc)
+}
+
+// TestNatsConnectReconnectsForever pins the resilience contract: NatsConnect
+// must never give up reconnecting. The nats.go default caps reconnection at 60
+// attempts and then closes the connection permanently, which would leave the
+// operator's heartbeat subscription silently deaf after a long NATS outage.
+func TestNatsConnectReconnectsForever(t *testing.T) {
+	defer wasmbustest.MustStartNats(t)()
+
+	nc, err := NatsConnect(NatsDefaultURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nc.Close()
+
+	if got := nc.Opts.MaxReconnect; got != -1 {
+		t.Fatalf("expected infinite reconnect (MaxReconnect == -1), got %d", got)
+	}
+}
+
+// TestNatsRecoversFromServerRestart reproduces the incident: the NATS server is
+// recycled out from under a live connection. The connection must not close
+// permanently while NATS is gone, must reconnect on its own when NATS returns,
+// and the subscription must resume delivering messages — no manual restart.
+func TestNatsRecoversFromServerRestart(t *testing.T) {
+	const subject = "runtime.operator.heartbeat.test"
+
+	stopNats := wasmbustest.MustStartNats(t)
+
+	nc, err := NatsConnect(NatsDefaultURL)
+	if err != nil {
+		stopNats()
+		t.Fatal(err)
+	}
+	defer nc.Close()
+	bus := NewNatsBus(nc)
+
+	sub, err := bus.Subscribe(subject, 10)
+	if err != nil {
+		stopNats()
+		t.Fatal(err)
+	}
+	defer func() { _ = sub.Drain() }()
+
+	received := make(chan string, 16)
+	sub.Handle(func(msg *Message) {
+		received <- string(msg.Data)
+	})
+
+	publish := func(payload string) {
+		t.Helper()
+		msg := NewMessage(subject)
+		msg.Data = []byte(payload)
+		if err := bus.Publish(msg); err != nil {
+			t.Fatalf("publish %q: %v", payload, err)
+		}
+		if err := nc.Flush(); err != nil {
+			t.Fatalf("flush %q: %v", payload, err)
+		}
+	}
+
+	expect := func(payload string) {
+		t.Helper()
+		select {
+		case got := <-received:
+			if got != payload {
+				t.Fatalf("expected to receive %q, got %q", payload, got)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting to receive %q", payload)
+		}
+	}
+
+	// Baseline: heartbeats flow.
+	publish("before")
+	expect("before")
+
+	// NATS is recycled. The connection drops but must not close permanently.
+	stopNats()
+	waitFor(t, 10*time.Second, "the connection to register the disconnect", func() bool {
+		return !nc.IsConnected()
+	})
+	if nc.IsClosed() {
+		t.Fatal("connection closed permanently on a NATS restart; reconnect must retry forever")
+	}
+
+	// NATS comes back on the same address. Register the restarted server via
+	// t.Cleanup so it outlives the deferred nc.Close()/sub.Drain() (cleanups run
+	// after deferred calls return). The connection must reconnect on its own and
+	// the subscription must resume delivering.
+	t.Cleanup(wasmbustest.MustStartNats(t))
+	waitFor(t, 30*time.Second, "the connection to reconnect after the NATS restart", func() bool {
+		return nc.IsConnected()
+	})
+	publish("after")
+	expect("after")
+}


### PR DESCRIPTION
- Adds a Health port to the runtime-operator deployment with a Health and Liveness probe configured
- Health of runtime-operator uses the underlying NATS connection status. This allows for automatic recovery if/when the NATS instance is unreachable (patch rollout for example).
- Adds an integration test to ensure that the runtime-operator can recover from a NATS restart.


Tested with a local Kind cluster using WasmCloud 2.3.0 host, and locally-build runtime-operator.


Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->