### PR TITLE
refactor(wash-runtime): improve host plugin API ergonomics

### DIFF
--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -164,8 +164,29 @@ pub struct Ctx {
 
 impl Ctx {
     /// Get a plugin by its string ID and downcast to the expected type
-    pub fn get_plugin<T: HostPlugin + 'static>(&self, plugin_id: &str) -> Option<Arc<T>> {
-        self.plugins.get(plugin_id)?.clone().downcast().ok()
+    ///
+    /// **Panics** if the plugin is not found or does not match the expected type.
+    pub fn get_plugin<T: HostPlugin + 'static>(&self, plugin_id: &str) -> Arc<T> {
+        self.try_get_plugin::<T>(plugin_id)
+            .expect("plugin not found")
+    }
+
+    /// Get a plugin by its string ID and downcast to the expected type, if it exists
+    pub fn try_get_plugin<T: HostPlugin + 'static>(
+        &self,
+        plugin_id: &str,
+    ) -> wasmtime::Result<Arc<T>> {
+        self.plugins
+            .get(plugin_id)
+            .ok_or_else(|| wasmtime::format_err!("plugin {plugin_id} not found"))?
+            .downcast_ref()
+            .ok_or_else(|| {
+                wasmtime::format_err!(
+                    "failed to downcast plugin to type {}",
+                    std::any::type_name::<T>()
+                )
+            })
+            .cloned()
     }
 
     /// Create a new [`CtxBuilder`] to construct a [`Ctx`]

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -166,6 +166,7 @@ impl Ctx {
     /// Get a plugin by its string ID and downcast to the expected type
     ///
     /// **Panics** if the plugin is not found or does not match the expected type.
+    #[allow(clippy::expect_used)] // Infallible accessor by contract; callers needing fallibility use `try_get_plugin`
     pub fn get_plugin<T: HostPlugin + 'static>(&self, plugin_id: &str) -> Arc<T> {
         self.try_get_plugin::<T>(plugin_id)
             .expect("plugin not found")

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -179,14 +179,14 @@ impl Ctx {
         self.plugins
             .get(plugin_id)
             .ok_or_else(|| wasmtime::format_err!("plugin {plugin_id} not found"))?
-            .downcast_ref()
-            .ok_or_else(|| {
+            .clone()
+            .downcast::<T>()
+            .map_err(|_| {
                 wasmtime::format_err!(
                     "failed to downcast plugin to type {}",
                     std::any::type_name::<T>()
                 )
             })
-            .cloned()
     }
 
     /// Create a new [`CtxBuilder`] to construct a [`Ctx`]

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -137,7 +137,7 @@ impl<'a> DerefMut for ActiveCtx<'a> {
 /// - wasi:http@0.2 interfaces
 pub struct Ctx {
     /// Unique identifier for this component context. This is a [uuid::Uuid::new_v4] string.
-    pub id: String,
+    pub id: Arc<str>,
     /// The unique identifier for the workload component this instance belongs to
     pub component_id: Arc<str>,
     /// The unique identifier for the workload this component belongs to
@@ -354,7 +354,7 @@ impl wasmtime_wasi_http::p3::WasiHttpHooks for CtxHttpHooksP3 {
 
 /// Helper struct to build a [`Ctx`] with a builder pattern
 pub struct CtxBuilder {
-    id: String,
+    id: Arc<str>,
     workload_id: Arc<str>,
     component_id: Arc<str>,
     ctx: Option<WasiCtx>,
@@ -370,7 +370,7 @@ pub struct CtxBuilder {
 impl CtxBuilder {
     pub fn new(workload_id: impl Into<Arc<str>>, component_id: impl Into<Arc<str>>) -> Self {
         Self {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: uuid::Uuid::new_v4().to_string().into(),
             component_id: component_id.into(),
             workload_id: workload_id.into(),
             ctx: None,

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -41,6 +41,10 @@ type BoundPluginWithInterfaces = (
     Vec<String>,
 );
 
+/// Shared slot holding the most recently instantiated component, keyed by its id.
+/// Used while resolving inter-component imports.
+type SharedInstanceSlot = Arc<RwLock<Option<(Arc<str>, Instance)>>>;
+
 /// Metadata associated with components and services within a workload.
 #[derive(Clone)]
 pub struct WorkloadMetadata {
@@ -814,7 +818,7 @@ impl ResolvedWorkload {
         let ty = component.component_type();
         let imports: Vec<_> = ty.imports(component.engine()).collect();
 
-        let instance: Arc<RwLock<Option<(Arc<str>, Instance)>>> = Arc::default();
+        let instance: SharedInstanceSlot = Arc::default();
         for (import_name, import_item) in imports.into_iter() {
             match import_item {
                 ComponentItem::ComponentInstance(import_instance_ty) => {

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -814,7 +814,7 @@ impl ResolvedWorkload {
         let ty = component.component_type();
         let imports: Vec<_> = ty.imports(component.engine()).collect();
 
-        let instance: Arc<RwLock<Option<(String, Instance)>>> = Arc::default();
+        let instance: Arc<RwLock<Option<(Arc<str>, Instance)>>> = Arc::default();
         for (import_name, import_item) in imports.into_iter() {
             match import_item {
                 ComponentItem::ComponentInstance(import_instance_ty) => {

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -8,7 +8,10 @@ use std::{
     time::Duration,
 };
 
-use crate::sockets::{self, SocketAddrUse, loopback};
+use crate::{
+    plugin::WitInterfaces,
+    sockets::{self, SocketAddrUse, loopback},
+};
 use anyhow::{Context as _, bail, ensure};
 use tokio::{sync::RwLock, task::JoinHandle, time::timeout};
 use tracing::{Instrument, debug, error, info, instrument, trace, warn};
@@ -1274,7 +1277,15 @@ impl ResolvedWorkload {
                         .cloned()
                         .collect::<std::collections::HashSet<_>>();
 
-                    if let Err(e) = plugin.on_workload_unbind(self.id(), bound_interfaces).await {
+                    if let Err(e) = plugin
+                        .on_workload_unbind(
+                            self.id(),
+                            WitInterfaces {
+                                inner: &bound_interfaces,
+                            },
+                        )
+                        .await
+                    {
                         warn!(
                             plugin_id,
                             component_id = component.id(),
@@ -1530,7 +1541,12 @@ impl UnresolvedWorkload {
 
                 // Call on_workload_bind with the workload and all matched interfaces
                 if let Err(e) = p
-                    .on_workload_bind(self, plugin_matched_interfaces.clone())
+                    .on_workload_bind(
+                        self,
+                        WitInterfaces {
+                            inner: &plugin_matched_interfaces,
+                        },
+                    )
                     .instrument(bind_span)
                     .await
                 {
@@ -1548,7 +1564,12 @@ impl UnresolvedWorkload {
                             "calling on_workload_unbind for cleanup after bind failure"
                         );
                         if let Err(cleanup_err) = bound_plugin
-                            .on_workload_unbind(self.id(), bound_interfaces.clone())
+                            .on_workload_unbind(
+                                self.id(),
+                                WitInterfaces {
+                                    inner: bound_interfaces,
+                                },
+                            )
                             .await
                         {
                             warn!(
@@ -1592,7 +1613,12 @@ impl UnresolvedWorkload {
                         plugin_id = plugin_id,
                     );
                     if let Err(e) = p
-                        .on_workload_item_bind(&mut workload_item, matching_interfaces.clone())
+                        .on_workload_item_bind(
+                            &mut workload_item,
+                            WitInterfaces {
+                                inner: &matching_interfaces,
+                            },
+                        )
                         .instrument(item_bind_span)
                         .await
                     {
@@ -1611,7 +1637,12 @@ impl UnresolvedWorkload {
                                 "calling on_workload_unbind for cleanup after component bind failure"
                             );
                             if let Err(cleanup_err) = bound_plugin
-                                .on_workload_unbind(self.id(), bound_interfaces.clone())
+                                .on_workload_unbind(
+                                    self.id(),
+                                    WitInterfaces {
+                                        inner: bound_interfaces,
+                                    },
+                                )
                                 .await
                             {
                                 warn!(
@@ -2037,14 +2068,14 @@ mod tests {
         async fn on_workload_bind(
             &self,
             _workload: &UnresolvedWorkload,
-            interfaces: HashSet<WitInterface>,
+            interfaces: WitInterfaces<'_>,
         ) -> anyhow::Result<()> {
             self.on_workload_bind_count.fetch_add(1, Ordering::SeqCst);
             self.call_records.lock().unwrap().push(CallRecord {
                 plugin_id: self.id.to_string(),
                 method: "on_workload_bind".to_string(),
                 component_id: None,
-                interfaces: interfaces.iter().map(|i| i.to_string()).collect(),
+                interfaces: interfaces.inner.iter().map(|i| i.to_string()).collect(),
             });
             Ok(())
         }
@@ -2052,7 +2083,7 @@ mod tests {
         async fn on_workload_item_bind<'a>(
             &self,
             item: &mut WorkloadItem<'a>,
-            interfaces: HashSet<WitInterface>,
+            interfaces: WitInterfaces<'_>,
         ) -> anyhow::Result<()> {
             self.on_workload_item_bind_count
                 .fetch_add(1, Ordering::SeqCst);
@@ -2060,7 +2091,7 @@ mod tests {
                 plugin_id: self.id.to_string(),
                 method: "on_workload_item_bind".to_string(),
                 component_id: Some(item.id().to_string()),
-                interfaces: interfaces.iter().map(|i| i.to_string()).collect(),
+                interfaces: interfaces.inner.iter().map(|i| i.to_string()).collect(),
             });
             Ok(())
         }

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1282,12 +1282,7 @@ impl ResolvedWorkload {
                         .collect::<std::collections::HashSet<_>>();
 
                     if let Err(e) = plugin
-                        .on_workload_unbind(
-                            self.id(),
-                            WitInterfaces {
-                                inner: &bound_interfaces,
-                            },
-                        )
+                        .on_workload_unbind(self.id(), WitInterfaces::new(&bound_interfaces))
                         .await
                     {
                         warn!(
@@ -1545,12 +1540,7 @@ impl UnresolvedWorkload {
 
                 // Call on_workload_bind with the workload and all matched interfaces
                 if let Err(e) = p
-                    .on_workload_bind(
-                        self,
-                        WitInterfaces {
-                            inner: &plugin_matched_interfaces,
-                        },
-                    )
+                    .on_workload_bind(self, WitInterfaces::new(&plugin_matched_interfaces))
                     .instrument(bind_span)
                     .await
                 {
@@ -1568,12 +1558,7 @@ impl UnresolvedWorkload {
                             "calling on_workload_unbind for cleanup after bind failure"
                         );
                         if let Err(cleanup_err) = bound_plugin
-                            .on_workload_unbind(
-                                self.id(),
-                                WitInterfaces {
-                                    inner: bound_interfaces,
-                                },
-                            )
+                            .on_workload_unbind(self.id(), WitInterfaces::new(bound_interfaces))
                             .await
                         {
                             warn!(
@@ -1619,9 +1604,7 @@ impl UnresolvedWorkload {
                     if let Err(e) = p
                         .on_workload_item_bind(
                             &mut workload_item,
-                            WitInterfaces {
-                                inner: &matching_interfaces,
-                            },
+                            WitInterfaces::new(&matching_interfaces),
                         )
                         .instrument(item_bind_span)
                         .await
@@ -1641,12 +1624,7 @@ impl UnresolvedWorkload {
                                 "calling on_workload_unbind for cleanup after component bind failure"
                             );
                             if let Err(cleanup_err) = bound_plugin
-                                .on_workload_unbind(
-                                    self.id(),
-                                    WitInterfaces {
-                                        inner: bound_interfaces,
-                                    },
-                                )
+                                .on_workload_unbind(self.id(), WitInterfaces::new(bound_interfaces))
                                 .await
                             {
                                 warn!(
@@ -2079,7 +2057,7 @@ mod tests {
                 plugin_id: self.id.to_string(),
                 method: "on_workload_bind".to_string(),
                 component_id: None,
-                interfaces: interfaces.inner.iter().map(|i| i.to_string()).collect(),
+                interfaces: interfaces.iter().map(|i| i.to_string()).collect(),
             });
             Ok(())
         }
@@ -2095,7 +2073,7 @@ mod tests {
                 plugin_id: self.id.to_string(),
                 method: "on_workload_item_bind".to_string(),
                 component_id: Some(item.id().to_string()),
-                interfaces: interfaces.inner.iter().map(|i| i.to_string()).collect(),
+                interfaces: interfaces.iter().map(|i| i.to_string()).collect(),
             });
             Ok(())
         }
@@ -2209,6 +2187,102 @@ mod tests {
             #[cfg(feature = "wasip3")]
             false,
         )
+    }
+
+    /// Every built-in plugin must actually bind the interface it advertises in its
+    /// `world()`. The bind hooks pick which interfaces to serve by matching
+    /// namespace / package / interface-name strings against the requested set, so a
+    /// wrong literal (a package typo, or a config key passed where an interface name
+    /// is expected) makes the plugin silently no-op instead of registering its host
+    /// functions. This guards that whole class of regression: feed each plugin an
+    /// interface it is designed to serve, then assert the first bind registers host
+    /// functions. Because a second bind of the same interface on the same linker
+    /// conflicts, a plugin that no-op'd (never touched the linker) is caught by the
+    /// second bind wrongly succeeding.
+    #[cfg(all(
+        feature = "wasmcloud-postgres",
+        feature = "wasi-blobstore",
+        feature = "wasi-keyvalue"
+    ))]
+    #[tokio::test]
+    async fn builtin_plugins_bind_their_declared_interfaces() {
+        use crate::plugin::wasi_blobstore::{FilesystemBlobstore, InMemoryBlobstore};
+        use crate::plugin::wasi_keyvalue::InMemoryKeyValue;
+        use crate::plugin::wasmcloud_postgres::WasmcloudPostgres;
+        // wasmcloud:postgres carries the target database as interface config, not as
+        // an interface name; the plugin reads it after matching on package.
+        let mut postgres_iface =
+            WitInterface::from("wasmcloud:postgres/types,query,prepared@0.1.1-draft");
+        postgres_iface
+            .config
+            .insert("database".to_string(), "testdb".to_string());
+        let blobstore_iface =
+            WitInterface::from("wasi:blobstore/blobstore,container,types@0.2.0-draft");
+        let keyvalue_iface = WitInterface::from("wasi:keyvalue/store,atomics,batch@0.2.0-draft");
+        let cases: Vec<(Arc<dyn HostPlugin>, WitInterface)> = vec![
+            (
+                Arc::new(WasmcloudPostgres::new("postgres://user:pass@localhost:5432/db").unwrap())
+                    as Arc<dyn HostPlugin>,
+                postgres_iface,
+            ),
+            (
+                Arc::new(FilesystemBlobstore::new(std::env::temp_dir())) as Arc<dyn HostPlugin>,
+                blobstore_iface.clone(),
+            ),
+            (
+                Arc::new(InMemoryBlobstore::new(None)) as Arc<dyn HostPlugin>,
+                blobstore_iface,
+            ),
+            (
+                Arc::new(InMemoryKeyValue::new()) as Arc<dyn HostPlugin>,
+                keyvalue_iface,
+            ),
+        ];
+        // A minimal empty component is enough: the bind hooks only mutate the linker.
+        let build_component = || {
+            let engine = wasmtime::Engine::default();
+            let linker = Linker::new(&engine);
+            // Minimal empty component: magic "\0asm" + component version + layer.
+            let component =
+                Component::new(&engine, [0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00]).unwrap();
+            WorkloadComponent::new(
+                "workload-bind".to_string(),
+                "test-workload-bind".to_string(),
+                "test-namespace".to_string(),
+                "test-component".to_string(),
+                component,
+                linker,
+                Vec::new(),
+                LocalResources::default(),
+                Arc::default(),
+                #[cfg(feature = "wasip3")]
+                false,
+            )
+        };
+        for (plugin, iface) in cases {
+            let id = plugin.id();
+            let set: HashSet<WitInterface> = std::iter::once(iface).collect();
+            let mut component = build_component();
+            let mut item = WorkloadItem::Component(&mut component);
+            plugin
+                .on_workload_item_bind(&mut item, WitInterfaces::new(&set))
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("plugin `{id}` failed to bind its declared interface: {e}")
+                });
+            // The first bind registered the plugin's host functions, so binding the
+            // same interface again on the same linker must conflict. If the plugin
+            // silently no-op'd (e.g. a matcher typo), it never touched the linker and
+            // this second bind wrongly succeeds.
+            let rebind = plugin
+                .on_workload_item_bind(&mut item, WitInterfaces::new(&set))
+                .await;
+            assert!(
+                rebind.is_err(),
+                "plugin `{id}` silently no-op'd on its declared interface instead of \
+                     registering host functions"
+            );
+        }
     }
 
     /// Tests basic plugin binding with one plugin and one component.

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -55,12 +55,14 @@ pub mod wasmcloud_messaging;
 #[cfg(all(feature = "wasi-webgpu", not(target_os = "windows")))]
 pub mod wasi_webgpu;
 
+/// A wrapper around a [`std::collections::HashSet`] of [`crate::wit::WitInterface`] that provides convenience methods for looking up interfaces by namespace, package, and set of interfaces.
 #[derive(Debug)]
 pub struct WitInterfaces<'a> {
     pub inner: &'a std::collections::HashSet<crate::wit::WitInterface>,
 }
 
 impl<'a> WitInterfaces<'a> {
+    /// Returns the [`crate::wit::WitInterface`] that matches the given namespace, package, and set of interfaces, if one exists.
     pub fn get(
         &self,
         namespace: &str,
@@ -78,6 +80,7 @@ impl<'a> WitInterfaces<'a> {
         None
     }
 
+    /// Returns `true` if the given namespace, package, and set of interfaces are contained within this collection of [`crate::wit::WitInterface`]s.
     pub fn contains(&self, namespace: &str, package: &str, interfaces: &[&str]) -> bool {
         self.get(namespace, package, interfaces).is_some()
     }

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -58,10 +58,20 @@ pub mod wasi_webgpu;
 /// A wrapper around a [`std::collections::HashSet`] of [`crate::wit::WitInterface`] that provides convenience methods for looking up interfaces by namespace, package, and set of interfaces.
 #[derive(Debug)]
 pub struct WitInterfaces<'a> {
-    pub inner: &'a std::collections::HashSet<crate::wit::WitInterface>,
+    inner: &'a std::collections::HashSet<crate::wit::WitInterface>,
 }
 
 impl<'a> WitInterfaces<'a> {
+    /// Wraps a borrowed set of [`crate::wit::WitInterface`]s.
+    pub fn new(inner: &'a std::collections::HashSet<crate::wit::WitInterface>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns an iterator over the wrapped [`crate::wit::WitInterface`]s.
+    pub fn iter(&self) -> impl Iterator<Item = &'a crate::wit::WitInterface> + 'a {
+        self.inner.iter()
+    }
+
     /// Returns the [`crate::wit::WitInterface`] that matches the given namespace, package, and set of interfaces, if one exists.
     pub fn get(
         &self,

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -69,15 +69,11 @@ impl<'a> WitInterfaces<'a> {
         package: &str,
         interfaces: &[&str],
     ) -> Option<&crate::wit::WitInterface> {
-        for interface in self.inner.iter() {
-            if interface.namespace == namespace
+        self.inner.iter().find(|interface| {
+            interface.namespace == namespace
                 && interface.package == package
                 && interfaces.iter().all(|i| interface.interfaces.contains(*i))
-            {
-                return Some(interface);
-            }
-        }
-        None
+        })
     }
 
     /// Returns `true` if the given namespace, package, and set of interfaces are contained within this collection of [`crate::wit::WitInterface`]s.

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -55,6 +55,34 @@ pub mod wasmcloud_messaging;
 #[cfg(all(feature = "wasi-webgpu", not(target_os = "windows")))]
 pub mod wasi_webgpu;
 
+#[derive(Debug)]
+pub struct WitInterfaces<'a> {
+    pub inner: &'a std::collections::HashSet<crate::wit::WitInterface>,
+}
+
+impl<'a> WitInterfaces<'a> {
+    pub fn get(
+        &self,
+        namespace: &str,
+        package: &str,
+        interfaces: &[&str],
+    ) -> Option<&crate::wit::WitInterface> {
+        for interface in self.inner.iter() {
+            if interface.namespace == namespace
+                && interface.package == package
+                && interfaces.iter().all(|i| interface.interfaces.contains(*i))
+            {
+                return Some(interface);
+            }
+        }
+        None
+    }
+
+    pub fn contains(&self, namespace: &str, package: &str, interfaces: &[&str]) -> bool {
+        self.get(namespace, package, interfaces).is_some()
+    }
+}
+
 /// The [`HostPlugin`] trait provides an interface for implementing built-in plugins for the host.
 /// A plugin is primarily responsible for implementing a specific [`WitWorld`] as a collection of
 /// imports and exports that will be directly linked to the workload's [`wasmtime::component::Linker`].
@@ -139,7 +167,7 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
     async fn on_workload_bind(
         &self,
         _workload: &UnresolvedWorkload,
-        _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -162,7 +190,7 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
     async fn on_workload_item_bind<'a>(
         &self,
         _item: &mut WorkloadItem<'a>,
-        _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -210,7 +238,7 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
     async fn on_workload_unbind(
         &self,
         _workload_id: &str,
-        _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         Ok(())
     }

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/filesystem.rs
@@ -93,9 +93,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<Resource<ContainerData>, BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let root = lock_root(&plugin.root, &name)
             .map_err(|e| wasmtime::format_err!("invalid container name: {e}"))?;
@@ -118,9 +116,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<Resource<ContainerData>, BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let Ok(root) = lock_root(&plugin.root, &name) else {
             return Ok(Err("invalid container name".to_string()));
@@ -144,9 +140,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<(), BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let Ok(path) = lock_root(&plugin.root, &name) else {
             return Ok(Err("invalid container name".to_string()));
@@ -167,9 +161,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<bool, BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let Ok(path) = lock_root(&plugin.root, &name) else {
             return Ok(Err("invalid container name".to_string()));
@@ -184,9 +176,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         src: ObjectId,
         dest: ObjectId,
     ) -> wasmtime::Result<Result<(), BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let Ok(read_container) = lock_root(&plugin.root, &src.container) else {
             return Ok(Err("invalid source container name".to_string()));
@@ -225,9 +215,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         src: ObjectId,
         dest: ObjectId,
     ) -> wasmtime::Result<Result<(), BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<FilesystemBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let Ok(read_container) = lock_root(&plugin.root, &src.container) else {
             return Ok(Err("invalid source container name".to_string()));

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/filesystem.rs
@@ -728,7 +728,7 @@ impl HostPlugin for FilesystemBlobstore {
         component_handle: &mut WorkloadItem<'a>,
         interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        if !interfaces.contains("wasi", "package", &[]) {
+        if !interfaces.contains("wasi", "blobstore", &[]) {
             return Ok(());
         }
 
@@ -760,7 +760,7 @@ impl HostPlugin for FilesystemBlobstore {
         workload: &crate::engine::workload::UnresolvedWorkload,
         host_interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        if !host_interfaces.contains("wasi", "package", &[]) {
+        if !host_interfaces.contains("wasi", "blobstore", &[]) {
             return Ok(());
         }
 

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/filesystem.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
-use crate::plugin::WorkloadTracker;
 use crate::plugin::{HostPlugin, lock_root};
+use crate::plugin::{WitInterfaces, WorkloadTracker};
 use crate::wit::{WitInterface, WitWorld};
 
 use tokio::sync::RwLock;
@@ -726,14 +726,11 @@ impl HostPlugin for FilesystemBlobstore {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        let Some(_interface) = interfaces
-            .iter()
-            .find(|i| i.namespace == "wasi" && i.package == "blobstore")
-        else {
+        if !interfaces.contains("wasi", "package", &[]) {
             return Ok(());
-        };
+        }
 
         tracing::debug!(
             workload_id = component_handle.workload_id(),
@@ -761,14 +758,11 @@ impl HostPlugin for FilesystemBlobstore {
     async fn on_workload_bind(
         &self,
         workload: &crate::engine::workload::UnresolvedWorkload,
-        host_interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        host_interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        let Some(_interface) = host_interfaces
-            .iter()
-            .find(|i| i.namespace == "wasi" && i.package == "blobstore")
-        else {
+        if !host_interfaces.contains("wasi", "package", &[]) {
             return Ok(());
-        };
+        }
 
         self.tracker.write().await.add_unresolved_workload(
             workload,
@@ -783,7 +777,7 @@ impl HostPlugin for FilesystemBlobstore {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         let workload_cleanup = |workload_data: Option<WorkloadData>| async {
             if let Some(data) = workload_data {

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/in_memory.rs
@@ -121,9 +121,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<Resource<String>, BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -148,9 +146,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<Resource<String>, BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -171,9 +167,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<(), BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -187,9 +181,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<bool, BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -206,9 +198,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         src: ObjectId,
         dest: ObjectId,
     ) -> wasmtime::Result<Result<(), BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -265,9 +255,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         // First copy the object
         let _ = self.copy_object(src.clone(), dest).await?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         // Then delete the source
         let mut storage = plugin.storage.write().await;
@@ -297,9 +285,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<ContainerMetadata, ContainerError>> {
         let container_name = self.table.get(&container)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -335,10 +321,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
             "Getting object data from container"
         );
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            tracing::error!("blobstore plugin not available for get_data");
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -406,10 +389,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
             "Initiating write_data for object"
         );
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            tracing::error!("blobstore plugin not available for write_data");
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         // Verify the container exists
         let storage = plugin.storage.read().await;
@@ -449,9 +429,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<Resource<StreamObjectNamesHandle>, ContainerError>> {
         let container_name = self.table.get(&container)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -481,9 +459,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<(), ContainerError>> {
         let container_name = self.table.get(&container)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -505,9 +481,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<(), ContainerError>> {
         let container_name = self.table.get(&container)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -531,9 +505,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<bool, ContainerError>> {
         let container_name = self.table.get(&container)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -555,9 +527,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<ObjectMetadata, ContainerError>> {
         let container_name = self.table.get(&container)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -586,9 +556,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<(), ContainerError>> {
         let container_name = self.table.get(&container)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -677,10 +645,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
     async fn new_outgoing_value(&mut self) -> wasmtime::Result<Resource<OutgoingValueHandle>> {
         tracing::debug!(workload_id = self.id, "Creating new OutgoingValue");
 
-        let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-            tracing::error!("blobstore plugin not available in new_outgoing_value");
-            return Err(wasmtime::format_err!("blobstore plugin not available"));
-        };
+        let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
         let handle = OutgoingValueHandle {
             pipe: MemoryOutputPipe::new(plugin.max_object_size),
@@ -793,10 +758,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         if let (Some(container_name), Some(object_name)) =
             (&handle.container_name, &handle.object_name)
         {
-            let Some(plugin) = self.get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID) else {
-                tracing::error!("blobstore plugin not available in finish()");
-                return Ok(Err("blobstore plugin not available".to_string()));
-            };
+            let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
             // Get the data from the pipe
             let data_bytes = handle.pipe.contents();

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/in_memory.rs
@@ -23,7 +23,7 @@ use crate::{
         ctx::{ActiveCtx, SharedCtx, extract_active_ctx},
         workload::WorkloadItem,
     },
-    plugin::HostPlugin,
+    plugin::{HostPlugin, WitInterfaces},
     wit::{WitInterface, WitWorld},
 };
 
@@ -914,14 +914,10 @@ impl HostPlugin for InMemoryBlobstore {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Check if any of the interfaces are wasi:blobstore related
-        let has_blobstore = interfaces
-            .iter()
-            .any(|i| i.namespace == "wasi" && i.package == "blobstore");
-
-        if !has_blobstore {
+        if !interfaces.contains("wasi", "blobstore", &[]) {
             tracing::warn!(
                 "WasiBlobstore plugin requested for non-wasi:blobstore interface(s): {:?}",
                 interfaces
@@ -965,7 +961,7 @@ impl HostPlugin for InMemoryBlobstore {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Clean up storage for this workload
         let mut storage = self.storage.write().await;

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/in_memory.rs
@@ -317,7 +317,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
             object = name,
             start = start,
             end = end,
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             "Getting object data from container"
         );
 
@@ -365,7 +365,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
             None => {
                 tracing::warn!(
                     container = container_name,
-                    workload_id = self.id,
+                    workload_id = &*self.workload_id,
                     "Container does not exist for workload"
                 );
                 Ok(Err(format!("container '{container_name}' does not exist")))
@@ -385,7 +385,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         tracing::debug!(
             container = container_name,
             object = name,
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             "Initiating write_data for object"
         );
 
@@ -401,7 +401,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         if !workload_storage.contains_key(&container_name) {
             tracing::warn!(
                 container = container_name,
-                workload_id = self.id,
+                workload_id = &*self.workload_id,
                 "Container does not exist for write_data"
             );
             return Ok(Err(format!("container '{container_name}' does not exist")));
@@ -573,7 +573,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
     async fn drop(&mut self, rep: Resource<String>) -> wasmtime::Result<()> {
         // Container resource cleanup - resource table handles this automatically
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             resource_id = ?rep,
             "Dropping container resource"
         );
@@ -631,7 +631,7 @@ impl<'a> bindings::wasi::blobstore::container::HostStreamObjectNames for ActiveC
     async fn drop(&mut self, rep: Resource<StreamObjectNamesHandle>) -> wasmtime::Result<()> {
         // StreamObjectNames resource cleanup
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             resource_id = ?rep,
             "Dropping StreamObjectNames resource"
         );
@@ -643,7 +643,10 @@ impl<'a> bindings::wasi::blobstore::container::HostStreamObjectNames for ActiveC
 impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
     #[instrument(name = "wasi.blobstore.new_outgoing_value", skip(self))]
     async fn new_outgoing_value(&mut self) -> wasmtime::Result<Resource<OutgoingValueHandle>> {
-        tracing::debug!(workload_id = self.id, "Creating new OutgoingValue");
+        tracing::debug!(
+            workload_id = &*self.workload_id,
+            "Creating new OutgoingValue"
+        );
 
         let plugin = self.try_get_plugin::<InMemoryBlobstore>(WASI_BLOBSTORE_ID)?;
 
@@ -654,7 +657,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         };
 
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             pipe_capacity = plugin.max_object_size,
             "Created OutgoingValueHandle with MemoryOutputPipe"
         );
@@ -662,7 +665,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         match self.table.push(handle) {
             Ok(resource) => {
                 tracing::debug!(
-                    workload_id = self.id,
+                    workload_id = &*self.workload_id,
                     resource_id = ?resource,
                     "Successfully pushed OutgoingValueHandle to resource table"
                 );
@@ -670,7 +673,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
             }
             Err(e) => {
                 tracing::error!(
-                    workload_id = self.id,
+                    workload_id = &*self.workload_id,
                     error = ?e,
                     "Failed to push OutgoingValueHandle to resource table in new_outgoing_value"
                 );
@@ -685,19 +688,24 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         outgoing_value: Resource<OutgoingValueHandle>,
     ) -> wasmtime::Result<Result<Resource<bindings::wasi::io0_2_1::streams::OutputStream>, ()>>
     {
-        tracing::debug!(workload_id = self.id, "outgoing_value_write_body called");
+        tracing::debug!(
+            workload_id = &*self.workload_id,
+            "outgoing_value_write_body called"
+        );
+
+        let workload = self.workload_id.clone();
 
         let handle = match self.table.get_mut(&outgoing_value) {
             Ok(h) => {
                 tracing::debug!(
-                    workload_id = self.ctx.id,
+                    workload_id = &*workload,
                     "Successfully retrieved OutgoingValueHandle from table"
                 );
                 h
             }
             Err(e) => {
                 tracing::error!(
-                    workload_id = self.id,
+                    workload_id = &*workload,
                     error = ?e,
                     "Failed to get OutgoingValueHandle from table"
                 );
@@ -706,7 +714,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         };
 
         tracing::debug!(
-            workload_id = self.ctx.id,
+            workload_id = &*workload,
             "Creating boxed OutputStream from pipe"
         );
 
@@ -714,14 +722,14 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         let boxed: Box<dyn OutputStream> = Box::new(handle.pipe.clone());
 
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             "Attempting to push OutputStream to resource table"
         );
 
         match self.table.push(boxed) {
             Ok(stream) => {
                 tracing::debug!(
-                    workload_id = self.id,
+                    workload_id = &*self.workload_id,
                     stream_resource_id = ?stream,
                     "Successfully pushed OutputStream to resource table"
                 );
@@ -729,7 +737,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
             }
             Err(e) => {
                 tracing::error!(
-                    workload_id = self.id,
+                    workload_id = &*self.workload_id,
                     error = ?e,
                     error_type = std::any::type_name::<anyhow::Error>(),
                     "Failed to push OutputStream to resource table - this is likely the TryFromIntError source"
@@ -744,7 +752,10 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
         &mut self,
         outgoing_value: Resource<OutgoingValueHandle>,
     ) -> wasmtime::Result<Result<(), BlobstoreError>> {
-        tracing::debug!(workload_id = self.id, "finish() called for OutgoingValue");
+        tracing::debug!(
+            workload_id = &*self.workload_id,
+            "finish() called for OutgoingValue"
+        );
 
         let handle = self.table.delete(outgoing_value)?;
 
@@ -796,7 +807,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
                 None => {
                     tracing::error!(
                         container = container_name,
-                        workload_id = self.id,
+                        workload_id = &*self.workload_id,
                         "Container does not exist in finish()"
                     );
                     return Ok(Err(format!("container '{container_name}' does not exist")));
@@ -804,7 +815,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
             }
         } else {
             tracing::warn!(
-                workload_id = self.id,
+                workload_id = &*self.workload_id,
                 "finish() called without container/object names set"
             );
         }
@@ -814,7 +825,7 @@ impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
 
     async fn drop(&mut self, rep: Resource<OutgoingValueHandle>) -> wasmtime::Result<()> {
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             resource_id = ?rep,
             "Dropping OutgoingValue resource"
         );
@@ -834,7 +845,7 @@ impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
         let data = self.table.delete(incoming_value)?;
 
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             data_size = data.len(),
             "incoming_value_consume_sync returning data"
         );
@@ -852,7 +863,7 @@ impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
         let data = self.table.get(&incoming_value)?;
 
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             data_size = data.len(),
             "incoming_value_consume_async creating MemoryInputPipe with data"
         );
@@ -861,7 +872,7 @@ impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
         let stream = self.table.push(stream)?;
 
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             "incoming_value_consume_async created stream resource"
         );
 
@@ -878,7 +889,7 @@ impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
 
     async fn drop(&mut self, rep: Resource<IncomingValueHandle>) -> wasmtime::Result<()> {
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             resource_id = ?rep,
             "Dropping IncomingValue resource"
         );

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/nats.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
-use crate::plugin::HostPlugin;
 use crate::plugin::WorkloadTracker;
+use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 use async_nats::jetstream::object_store::{self, List, Object, ObjectStore};
 use bytes::Bytes;
@@ -815,14 +815,11 @@ impl HostPlugin for NatsBlobstore {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        let Some(_interface) = interfaces
-            .iter()
-            .find(|i| i.namespace == "wasi" && i.package == "blobstore")
-        else {
+        if !interfaces.contains("wasi", "blobstore", &[]) {
             return Ok(());
-        };
+        }
 
         tracing::debug!(
             workload_id = component_handle.workload_id(),
@@ -850,12 +847,9 @@ impl HostPlugin for NatsBlobstore {
     async fn on_workload_bind(
         &self,
         workload: &crate::engine::workload::UnresolvedWorkload,
-        host_interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        host_interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        let Some(interface) = host_interfaces
-            .iter()
-            .find(|i| i.namespace == "wasi" && i.package == "blobstore")
-        else {
+        let Some(interface) = host_interfaces.get("wasi", "blobstore", &[]) else {
             return Ok(());
         };
 
@@ -884,7 +878,7 @@ impl HostPlugin for NatsBlobstore {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         let workload_cleanup = |workload_data: Option<WorkloadData>| async {
             if let Some(data) = workload_data {

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/nats.rs
@@ -155,9 +155,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<Resource<ContainerData>, BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let _workload_permit = match plugin.workload_permit(&self.workload_id, &name, true).await {
             Some(token) => token,
@@ -194,9 +192,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<Resource<ContainerData>, BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let _workload_permit = match plugin
             .workload_permit(&self.workload_id, &name, false)
@@ -229,9 +225,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<(), BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let _workload_permit = match plugin.workload_permit(&self.workload_id, &name, true).await {
             Some(token) => token,
@@ -252,9 +246,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         &mut self,
         name: ContainerName,
     ) -> wasmtime::Result<Result<bool, BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let _workload_permit = match plugin.workload_permit(&self.workload_id, &name, true).await {
             Some(token) => token,
@@ -275,9 +267,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         src: ObjectId,
         dest: ObjectId,
     ) -> wasmtime::Result<Result<(), BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let _read_permit = match plugin
             .workload_permit(&self.workload_id, &src.container, false)
@@ -330,9 +320,7 @@ impl<'a> bindings::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
         src: ObjectId,
         dest: ObjectId,
     ) -> wasmtime::Result<Result<(), BlobstoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         // requires an extra write permit on the src container to delete the object after copy
         let _write_permit = match plugin
@@ -418,9 +406,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         name: ObjectName,
         data: Resource<OutgoingValueHandle>,
     ) -> wasmtime::Result<Result<(), ContainerError>> {
-        let Some(plugin) = self.get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let container_data = self.table.get(&container).cloned()?;
         let _write_permit = match plugin
@@ -472,9 +458,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         container: Resource<ContainerData>,
         name: ObjectName,
     ) -> wasmtime::Result<Result<(), ContainerError>> {
-        let Some(plugin) = self.get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let container_data = self.table.get(&container)?;
         let _write_permit = match plugin
@@ -499,9 +483,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         container: Resource<ContainerData>,
         names: Vec<ObjectName>,
     ) -> wasmtime::Result<Result<(), ContainerError>> {
-        let Some(plugin) = self.get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let container_data = self.table.get(&container)?;
         let _write_permit = match plugin
@@ -559,9 +541,7 @@ impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
         &mut self,
         container: Resource<ContainerData>,
     ) -> wasmtime::Result<Result<(), ContainerError>> {
-        let Some(plugin) = self.get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsBlobstore>(PLUGIN_BLOBSTORE_ID)?;
 
         let container_data = self.table.get(&container)?;
         let _write_permit = match plugin

--- a/crates/wash-runtime/src/plugin/wasi_config/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_config/mod.rs
@@ -29,7 +29,7 @@ use crate::{
         ctx::{ActiveCtx, SharedCtx, extract_active_ctx},
         workload::WorkloadItem,
     },
-    plugin::HostPlugin,
+    plugin::{HostPlugin, WitInterfaces},
     wit::{WitInterface, WitWorld},
 };
 
@@ -121,12 +121,10 @@ impl HostPlugin for DynamicConfig {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Find the "wasi:config/store" interface, if present
-        let Some(interface) = interfaces.iter().find(|i| {
-            i.namespace == "wasi" && i.package == "config" && i.interfaces.contains("store")
-        }) else {
+        let Some(interface) = interfaces.get("wasi", "config", &["store"]) else {
             // Log a warning if the requested interfaces are not wasi:config/store
             tracing::warn!(
                 "WasiConfig plugin requested for non-wasi:config/store interface(s): {:?}",

--- a/crates/wash-runtime/src/plugin/wasi_config/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_config/mod.rs
@@ -82,9 +82,8 @@ impl<'a> bindings::wasi::config::store::Host for ActiveCtx<'a> {
         &mut self,
         key: String,
     ) -> wasmtime::Result<Result<Option<String>, bindings::wasi::config::store::Error>> {
-        let Some(plugin) = self.get_plugin::<DynamicConfig>(WASI_CONFIG_ID) else {
-            return Ok(Ok(None));
-        };
+        let plugin = self.try_get_plugin::<DynamicConfig>(WASI_CONFIG_ID)?;
+
         let config_guard = plugin.config.read().await;
         config_guard
             .get(&*self.component_id)
@@ -96,9 +95,8 @@ impl<'a> bindings::wasi::config::store::Host for ActiveCtx<'a> {
     async fn get_all(
         &mut self,
     ) -> wasmtime::Result<Result<Vec<(String, String)>, bindings::wasi::config::store::Error>> {
-        let Some(plugin) = self.get_plugin::<DynamicConfig>(WASI_CONFIG_ID) else {
-            return Ok(Ok(vec![]));
-        };
+        let plugin = self.try_get_plugin::<DynamicConfig>(WASI_CONFIG_ID)?;
+
         let config_guard = plugin.config.read().await;
         let entries = config_guard
             .get(&*self.component_id)

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
@@ -258,7 +258,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
 
     async fn drop(&mut self, rep: Resource<BucketHandle>) -> wasmtime::Result<()> {
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             resource_id = ?rep,
             "Dropping bucket resource"
         );

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
@@ -83,11 +83,8 @@ impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
         &mut self,
         identifier: String,
     ) -> wasmtime::Result<Result<Resource<BucketHandle>, StoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("open");
 
         let Ok(path) = lock_root(&plugin.root, &identifier) else {
@@ -117,11 +114,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key: String,
     ) -> wasmtime::Result<Result<Option<Vec<u8>>, StoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("get");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -147,11 +141,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         key: String,
         value: Vec<u8>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("set");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -175,11 +166,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key: String,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("delete");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -202,11 +190,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key: String,
     ) -> wasmtime::Result<Result<bool, StoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("exists");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -229,11 +214,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         cursor: Option<u64>,
     ) -> wasmtime::Result<Result<KeyResponse, StoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("list_keys");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -294,11 +276,8 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
         key: String,
         delta: u64,
     ) -> wasmtime::Result<Result<u64, StoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("increment");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -336,11 +315,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         keys: Vec<String>,
     ) -> wasmtime::Result<Result<Vec<Option<(String, Vec<u8>)>>, StoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("get_many");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -379,11 +355,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key_values: Vec<(String, Vec<u8>)>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("set_many");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -421,11 +394,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         keys: Vec<String>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("delete_many");
 
         let bucket_handle = self.table.get(&bucket)?;

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 const PLUGIN_KEYVALUE_ID: &str = "wasi-keyvalue";
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
-use crate::plugin::{HostPlugin, lock_root};
+use crate::plugin::{HostPlugin, WitInterfaces, lock_root};
 use crate::wit::{WitInterface, WitWorld};
 use futures::StreamExt;
 use tracing::instrument;
@@ -442,14 +442,10 @@ impl HostPlugin for FilesystemKeyValue {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Check if any of the interfaces are wasi:keyvalue related
-        let has_keyvalue = interfaces
-            .iter()
-            .any(|i| i.namespace == "wasi" && i.package == "keyvalue");
-
-        if !has_keyvalue {
+        if !interfaces.contains("wasi", "keyvalue", &[]) {
             tracing::warn!(
                 "WasiKeyvalue plugin requested for non-wasi:keyvalue interface(s): {:?}",
                 interfaces
@@ -484,7 +480,7 @@ impl HostPlugin for FilesystemKeyValue {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         tracing::debug!("WasiKeyvalue plugin unbound from workload '{workload_id}'");
 

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/in_memory.rs
@@ -65,11 +65,7 @@ impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
         &mut self,
         identifier: String,
     ) -> wasmtime::Result<Result<Resource<BucketHandle>, StoreError>> {
-        let Some(plugin) = self.get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -97,11 +93,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<Option<Vec<u8>>, StoreError>> {
         let bucket_name = self.table.get(&bucket)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -129,11 +121,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<(), StoreError>> {
         let bucket_name = self.table.get(&bucket)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -157,11 +145,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<(), StoreError>> {
         let bucket_name = self.table.get(&bucket)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -185,11 +169,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<bool, StoreError>> {
         let bucket_name = self.table.get(&bucket)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -213,11 +193,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<KeyResponse, StoreError>> {
         let bucket_name = self.table.get(&bucket)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -281,11 +257,7 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<u64, StoreError>> {
         let bucket_name = self.table.get(&bucket)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -333,11 +305,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<Vec<Option<(String, Vec<u8>)>>, StoreError>> {
         let bucket_name = self.table.get(&bucket)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID)?;
 
         let storage = plugin.storage.read().await;
         let empty_map = HashMap::new();
@@ -373,11 +341,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<(), StoreError>> {
         let bucket_name = self.table.get(&bucket)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
@@ -403,11 +367,7 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
     ) -> wasmtime::Result<Result<(), StoreError>> {
         let bucket_name = self.table.get(&bucket)?;
 
-        let Some(plugin) = self.get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<InMemoryKeyValue>(WASI_KEYVALUE_ID)?;
 
         let mut storage = plugin.storage.write().await;
         let workload_storage = storage.entry(self.workload_id.to_string()).or_default();

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/in_memory.rs
@@ -18,7 +18,7 @@ use crate::{
         ctx::{ActiveCtx, SharedCtx, extract_active_ctx},
         workload::WorkloadItem,
     },
-    plugin::HostPlugin,
+    plugin::{HostPlugin, WitInterfaces},
     wit::{WitInterface, WitWorld},
 };
 
@@ -404,14 +404,10 @@ impl HostPlugin for InMemoryKeyValue {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Check if any of the interfaces are wasi:keyvalue related
-        let has_keyvalue = interfaces
-            .iter()
-            .any(|i| i.namespace == "wasi" && i.package == "keyvalue");
-
-        if !has_keyvalue {
+        if !interfaces.contains("wasi", "keyvalue", &[]) {
             tracing::warn!(
                 "WasiKeyvalue plugin requested for non-wasi:keyvalue interface(s): {:?}",
                 interfaces
@@ -450,7 +446,7 @@ impl HostPlugin for InMemoryKeyValue {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Clean up storage for this workload
         let mut storage = self.storage.write().await;

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
@@ -12,7 +12,7 @@ use bytes::{Buf, Bytes};
 const PLUGIN_KEYVALUE_ID: &str = "wasi-keyvalue";
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
-use crate::plugin::HostPlugin;
+use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 use futures::StreamExt;
 use tracing::instrument;
@@ -446,14 +446,10 @@ impl HostPlugin for NatsKeyValue {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Check if any of the interfaces are wasi:keyvalue related
-        let has_keyvalue = interfaces
-            .iter()
-            .any(|i| i.namespace == "wasi" && i.package == "keyvalue");
-
-        if !has_keyvalue {
+        if !interfaces.contains("wasi", "keyvalue", &[]) {
             tracing::warn!(
                 "WasiKeyvalue plugin requested for non-wasi:keyvalue interface(s): {:?}",
                 interfaces
@@ -488,7 +484,7 @@ impl HostPlugin for NatsKeyValue {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         tracing::debug!("WasiKeyvalue plugin unbound from workload '{workload_id}'");
 

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
@@ -247,7 +247,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
 
     async fn drop(&mut self, rep: Resource<BucketHandle>) -> wasmtime::Result<()> {
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             resource_id = ?rep,
             "Dropping bucket resource"
         );

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
@@ -84,11 +84,8 @@ impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
         &mut self,
         identifier: String,
     ) -> wasmtime::Result<Result<Resource<BucketHandle>, StoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("open");
 
         let kv = match plugin.client.get_key_value(&identifier).await {
@@ -119,11 +116,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key: String,
     ) -> wasmtime::Result<Result<Option<Vec<u8>>, StoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("get");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -149,11 +143,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         key: String,
         value: Vec<u8>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("set");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -173,11 +164,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key: String,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("delete");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -197,11 +185,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key: String,
     ) -> wasmtime::Result<Result<bool, StoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("exists");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -222,11 +207,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         cursor: Option<u64>,
     ) -> wasmtime::Result<Result<KeyResponse, StoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("list_keys");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -283,11 +265,8 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
         key: String,
         delta: u64,
     ) -> wasmtime::Result<Result<u64, StoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("increment");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -345,11 +324,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         keys: Vec<String>,
     ) -> wasmtime::Result<Result<Vec<Option<(String, Vec<u8>)>>, StoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("get_many");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -385,11 +361,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key_values: Vec<(String, Vec<u8>)>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("set_many");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -428,11 +401,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         keys: Vec<String>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<NatsKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("delete_many");
 
         let bucket_handle = self.table.get(&bucket)?;

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
@@ -96,11 +96,8 @@ impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
         &mut self,
         identifier: String,
     ) -> wasmtime::Result<Result<Resource<BucketHandle>, StoreError>> {
-        let Some(plugin) = self.get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("open");
 
         let conn = match plugin.client.get_multiplexed_async_connection().await {
@@ -131,11 +128,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key: String,
     ) -> wasmtime::Result<Result<Option<Vec<u8>>, StoreError>> {
-        let Some(plugin) = self.get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("get");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -158,11 +152,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         key: String,
         value: Vec<u8>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("set");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -184,11 +175,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key: String,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("delete");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -210,11 +198,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key: String,
     ) -> wasmtime::Result<Result<bool, StoreError>> {
-        let Some(plugin) = self.get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("exists");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -236,11 +221,8 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         cursor: Option<u64>,
     ) -> wasmtime::Result<Result<KeyResponse, StoreError>> {
-        let Some(plugin) = self.get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("list_keys");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -305,11 +287,8 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
         key: String,
         delta: u64,
     ) -> wasmtime::Result<Result<u64, StoreError>> {
-        let Some(plugin) = self.get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("increment");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -337,11 +316,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         keys: Vec<String>,
     ) -> wasmtime::Result<Result<Vec<Option<(String, Vec<u8>)>>, StoreError>> {
-        let Some(plugin) = self.get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("get_many");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -376,11 +352,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         key_values: Vec<(String, Vec<u8>)>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("set_many");
 
         let bucket_handle = self.table.get(&bucket)?;
@@ -410,11 +383,8 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         bucket: Resource<BucketHandle>,
         keys: Vec<String>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
-        let Some(plugin) = self.get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID) else {
-            return Ok(Err(StoreError::Other(
-                "keyvalue plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<RedisKeyValue>(PLUGIN_KEYVALUE_ID)?;
+
         plugin.record_operation("delete_many");
 
         let bucket_handle = self.table.get(&bucket)?;

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
@@ -267,7 +267,7 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
 
     async fn drop(&mut self, rep: Resource<BucketHandle>) -> wasmtime::Result<()> {
         tracing::debug!(
-            workload_id = self.id,
+            workload_id = &*self.workload_id,
             resource_id = ?rep,
             "Dropping bucket resource"
         );

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 const PLUGIN_KEYVALUE_ID: &str = "wasi-keyvalue";
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
-use crate::plugin::HostPlugin;
+use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 use futures::StreamExt;
 use redis::AsyncCommands;
@@ -431,14 +431,10 @@ impl HostPlugin for RedisKeyValue {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Check if any of the interfaces are wasi:keyvalue related
-        let has_keyvalue = interfaces
-            .iter()
-            .any(|i| i.namespace == "wasi" && i.package == "keyvalue");
-
-        if !has_keyvalue {
+        if !interfaces.contains("wasi", "keyvalue", &[]) {
             tracing::warn!(
                 "WasiKeyvalue plugin requested for non-wasi:keyvalue interface(s): {:?}",
                 interfaces
@@ -473,7 +469,7 @@ impl HostPlugin for RedisKeyValue {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         tracing::debug!("WasiKeyvalue plugin unbound from workload '{workload_id}'");
 

--- a/crates/wash-runtime/src/plugin/wasi_logging/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_logging/mod.rs
@@ -48,9 +48,7 @@ impl<'a> bindings::wasi::logging::logging::Host for ActiveCtx<'a> {
         context: String,
         message: String,
     ) -> wasmtime::Result<()> {
-        let Some(plugin) = self.get_plugin::<TracingLogger>(PLUGIN_LOGGING_ID) else {
-            bail!("TracingLogger plugin not found in context");
-        };
+        let plugin = self.try_get_plugin::<TracingLogger>(PLUGIN_LOGGING_ID)?;
 
         let workloads = plugin.components.read().await;
         let Some(ComponentInfo {

--- a/crates/wash-runtime/src/plugin/wasi_logging/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_logging/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
-use crate::plugin::HostPlugin;
+use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 use tracing::instrument;
 use wasmtime::bail;
@@ -136,14 +136,10 @@ impl HostPlugin for TracingLogger {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Ensure exactly one interface: "wasi:logging/logging"
-        let has_logging = interfaces
-            .iter()
-            .any(|i| i.namespace == "wasi" && i.package == "logging");
-
-        if !has_logging {
+        if !interfaces.contains("wasi", "logging", &[]) {
             tracing::warn!(
                 "TracingLogger plugin requested for non-wasi:logging interface(s): {:?}",
                 interfaces

--- a/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
@@ -27,7 +27,7 @@ use tokio::sync::RwLock;
 use opentelemetry_otlp::{LogExporter, MetricExporter, SpanExporter};
 
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
-use crate::plugin::{HostPlugin, WorkloadItem, WorkloadTracker};
+use crate::plugin::{HostPlugin, WitInterfaces, WorkloadItem, WorkloadTracker};
 use crate::wit::{WitInterface, WitWorld};
 
 const WASI_OTEL_ID: &str = "wasi-otel";
@@ -211,7 +211,7 @@ impl HostPlugin for WasiOtel {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        _interfaces: HashSet<WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Add all wasi:otel interfaces to linker
         bindings::wasi::otel::types::add_to_linker::<_, SharedCtx>(
@@ -257,7 +257,7 @@ impl HostPlugin for WasiOtel {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: HashSet<WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         self.tracker
             .write()

--- a/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
@@ -295,7 +295,7 @@ impl<'a> bindings::wasi::otel::logs::Host for ActiveCtx<'a> {
         data: bindings::wasi::otel::logs::LogRecord,
     ) -> wasmtime::Result<()> {
         tracing::info!(?data, "emitting log record");
-        if let Some(plugin) = self.ctx.get_plugin::<WasiOtel>(WASI_OTEL_ID) {
+        if let Ok(plugin) = self.ctx.try_get_plugin::<WasiOtel>(WASI_OTEL_ID) {
             let service_name = plugin.config.service_name.clone();
             let provider = plugin.logger_provider.read().await;
 
@@ -316,7 +316,7 @@ impl<'a> bindings::wasi::otel::metrics::Host for ActiveCtx<'a> {
         &mut self,
         resource_metrics: bindings::wasi::otel::metrics::ResourceMetrics,
     ) -> wasmtime::Result<Result<(), bindings::wasi::otel::metrics::Error>> {
-        if let Some(plugin) = self.ctx.get_plugin::<WasiOtel>(WASI_OTEL_ID) {
+        if let Ok(plugin) = self.ctx.try_get_plugin::<WasiOtel>(WASI_OTEL_ID) {
             // Summarize incoming metrics for logging
             let summary = summarize_resource_metrics(&resource_metrics);
             tracing::info!(
@@ -398,7 +398,7 @@ impl<'a> bindings::wasi::otel::tracing::Host for ActiveCtx<'a> {
         &mut self,
         span_data: bindings::wasi::otel::tracing::SpanData,
     ) -> wasmtime::Result<()> {
-        if let Some(plugin) = self.ctx.get_plugin::<WasiOtel>(WASI_OTEL_ID) {
+        if let Ok(plugin) = self.ctx.try_get_plugin::<WasiOtel>(WASI_OTEL_ID) {
             let summary = summarize_span_data(&span_data);
             tracing::info!(
                 name = %summary.name,

--- a/crates/wash-runtime/src/plugin/wasi_webgpu/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_webgpu/mod.rs
@@ -9,7 +9,7 @@ const WASI_WEBGPU_ID: &str = "wasi-webgpu";
 
 use crate::{
     engine::{ctx::SharedCtx, workload::WorkloadItem},
-    plugin::HostPlugin,
+    plugin::{HostPlugin, WitInterfaces},
     wit::{WitInterface, WitWorld},
 };
 
@@ -112,14 +112,10 @@ impl HostPlugin for WebGpu {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Check if any of the interfaces are wasi:webgpu related
-        let has_webgpu = interfaces
-            .iter()
-            .any(|i| i.namespace == "wasi" && i.package == "webgpu");
-
-        if !has_webgpu {
+        if !interfaces.contains("wasi", "webgpu", &[]) {
             tracing::warn!(
                 "WasiWebgpu plugin requested for non-wasi:webgpu interface(s): {:?}",
                 interfaces

--- a/crates/wash-runtime/src/plugin/wasi_webgpu/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_webgpu/mod.rs
@@ -84,10 +84,7 @@ impl wasi_webgpu_wasmtime::MainThreadSpawner for UiThreadSpawner {
 impl wasi_webgpu_wasmtime::WasiWebGpuView for SharedCtx {
     #[allow(clippy::expect_used)] // Trait doesn't return Result; plugin is registered at startup
     fn instance(&self) -> Arc<wasi_webgpu_wasmtime::reexports::wgpu_core::global::Global> {
-        let plugin = self
-            .active_ctx
-            .get_plugin::<WebGpu>(WASI_WEBGPU_ID)
-            .expect("WebGpu plugin should be registered");
+        let plugin = self.active_ctx.get_plugin::<WebGpu>(WASI_WEBGPU_ID);
         Arc::clone(&plugin.gpu)
     }
 

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -148,9 +148,7 @@ impl<'a> Host for ActiveCtx<'a> {
         body: Vec<u8>,
         timeout_ms: u32,
     ) -> wasmtime::Result<Result<types::BrokerMessage, String>> {
-        let Some(plugin) = self.get_plugin::<InMemoryMessaging>(PLUGIN_MESSAGING_MEMORY_ID) else {
-            return Ok(Err("plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryMessaging>(PLUGIN_MESSAGING_MEMORY_ID)?;
 
         let workload_id = self.ctx.workload_id.to_string();
 
@@ -210,9 +208,7 @@ impl<'a> Host for ActiveCtx<'a> {
 
     #[instrument(name = "wasmcloud.messaging.publish", skip_all, fields(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>")))]
     async fn publish(&mut self, msg: types::BrokerMessage) -> wasmtime::Result<Result<(), String>> {
-        let Some(plugin) = self.get_plugin::<InMemoryMessaging>(PLUGIN_MESSAGING_MEMORY_ID) else {
-            return Ok(Err("plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<InMemoryMessaging>(PLUGIN_MESSAGING_MEMORY_ID)?;
 
         let workload_id = self.ctx.workload_id.to_string();
         let pending_requests = {

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::{ResolvedWorkload, UnresolvedWorkload, WorkloadItem};
 use crate::observability::Meters;
-use crate::plugin::HostPlugin;
+use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 use anyhow::Context;
 use opentelemetry::KeyValue;
@@ -265,14 +265,11 @@ impl HostPlugin for InMemoryMessaging {
     async fn on_workload_bind(
         &self,
         workload: &UnresolvedWorkload,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        let Some(_interface) = interfaces
-            .iter()
-            .find(|i| i.namespace == "wasmcloud" && i.package == "messaging")
-        else {
+        if !interfaces.contains("wasmcloud", "messaging", &[]) {
             return Ok(());
-        };
+        }
 
         self.tracker
             .write()
@@ -284,14 +281,11 @@ impl HostPlugin for InMemoryMessaging {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        let Some(_interface) = interfaces
-            .iter()
-            .find(|i| i.namespace == "wasmcloud" && i.package == "messaging")
-        else {
+        if !interfaces.contains("wasmcloud", "messaging", &[]) {
             return Ok(());
-        };
+        }
 
         bindings::wasmcloud::messaging::types::add_to_linker::<_, SharedCtx>(
             component_handle.linker(),
@@ -461,7 +455,7 @@ impl HostPlugin for InMemoryMessaging {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Clean up tracker
         let workload_cleanup = |_| async {};

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -95,9 +95,7 @@ impl<'a> Host for ActiveCtx<'a> {
         body: Vec<u8>,
         timeout_ms: u32,
     ) -> wasmtime::Result<Result<types::BrokerMessage, String>> {
-        let Some(plugin) = self.get_plugin::<NatsMessaging>(PLUGIN_MESSAGING_ID) else {
-            return Ok(Err("plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsMessaging>(PLUGIN_MESSAGING_ID)?;
 
         let timeout_duration = std::time::Duration::from_millis(timeout_ms as u64);
         let request_future = plugin.client.request(subject, body.into());
@@ -123,9 +121,7 @@ impl<'a> Host for ActiveCtx<'a> {
 
     #[instrument(name = "wasmcloud.messaging.publish", skip_all, fields(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>")))]
     async fn publish(&mut self, msg: types::BrokerMessage) -> wasmtime::Result<Result<(), String>> {
-        let Some(plugin) = self.get_plugin::<NatsMessaging>(PLUGIN_MESSAGING_ID) else {
-            return Ok(Err("plugin not available".to_string()));
-        };
+        let plugin = self.try_get_plugin::<NatsMessaging>(PLUGIN_MESSAGING_ID)?;
 
         let subject = msg.subject;
 

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -170,9 +170,9 @@ impl HostPlugin for NatsMessaging {
         component_handle: &mut WorkloadItem<'a>,
         interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        if !interfaces.contains("wasmcloud", "messaging", &[]) {
+        let Some(interface) = interfaces.get("wasmcloud", "messaging", &[]) else {
             return Ok(());
-        }
+        };
 
         // Subscriptions come from this component's own `LocalResources.config`
         // (so workers in one workload can subscribe to different subjects),

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::{ResolvedWorkload, WorkloadItem};
 use crate::observability::Meters;
-use crate::plugin::HostPlugin;
+use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 use async_nats::Subscriber;
 use futures::stream::StreamExt;
@@ -168,14 +168,11 @@ impl HostPlugin for NatsMessaging {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        let Some(interface) = interfaces
-            .iter()
-            .find(|i| i.namespace == "wasmcloud" && i.package == "messaging")
-        else {
+        if !interfaces.contains("wasmcloud", "messaging", &[]) {
             return Ok(());
-        };
+        }
 
         // Subscriptions come from this component's own `LocalResources.config`
         // (so workers in one workload can subscribe to different subjects),
@@ -418,7 +415,7 @@ impl HostPlugin for NatsMessaging {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: HashSet<crate::wit::WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         let workload_cleanup = |_| async {};
         let component_cleanup = |component_data: ComponentData| async move {

--- a/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
@@ -184,11 +184,7 @@ impl<'a> query::Host for ActiveCtx<'a> {
         q: String,
         params: Vec<PgValue>,
     ) -> wasmtime::Result<Result<Vec<query::ResultRow>, QueryError>> {
-        let Some(plugin) = self.get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID) else {
-            return Ok(Err(QueryError::Unexpected(
-                "postgres plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID)?;
 
         let component_id = self.component_id.to_string();
         let database = match plugin.database_for_component(&component_id).await {
@@ -245,11 +241,7 @@ impl<'a> query::Host for ActiveCtx<'a> {
 
     #[instrument(name = "wasmcloud.postgres.query_batch", skip_all, fields(query = %q))]
     async fn query_batch(&mut self, q: String) -> wasmtime::Result<Result<(), QueryError>> {
-        let Some(plugin) = self.get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID) else {
-            return Ok(Err(QueryError::Unexpected(
-                "postgres plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID)?;
 
         let component_id = self.component_id.to_string();
         let database = match plugin.database_for_component(&component_id).await {
@@ -294,11 +286,7 @@ impl<'a> prepared::Host for ActiveCtx<'a> {
         &mut self,
         statement: String,
     ) -> wasmtime::Result<Result<String, StatementPrepareError>> {
-        let Some(plugin) = self.get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID) else {
-            return Ok(Err(StatementPrepareError::Unexpected(
-                "postgres plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID)?;
 
         let component_id = self.component_id.to_string();
         let database = match plugin.database_for_component(&component_id).await {
@@ -359,11 +347,7 @@ impl<'a> prepared::Host for ActiveCtx<'a> {
         stmt_token: String,
         params: Vec<PgValue>,
     ) -> wasmtime::Result<Result<u64, PreparedStatementExecError>> {
-        let Some(plugin) = self.get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID) else {
-            return Ok(Err(PreparedStatementExecError::Unexpected(
-                "postgres plugin not available".to_string(),
-            )));
-        };
+        let plugin = self.try_get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID)?;
 
         let entry = {
             let stmts = plugin.prepared_statements.read().await;

--- a/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
-use crate::plugin::HostPlugin;
+use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 
 use conversions::into_result_row;
@@ -454,17 +454,15 @@ impl HostPlugin for WasmcloudPostgres {
     async fn on_workload_item_bind<'a>(
         &self,
         component_handle: &mut WorkloadItem<'a>,
-        interfaces: HashSet<WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        let database = match interfaces
-            .iter()
-            .find(|i| i.namespace == "wasmcloud" && i.package == "postgres")
-        {
-            Some(i) => match i.config.get("database").cloned() {
-                Some(db) => db,
-                None => bail!("wasmcloud:postgres requires a 'database' config parameter"),
-            },
+        let database = match interfaces.get("wasmcloud", "postgres", &["database"]) {
+            Some(i) => i.config.get("database"),
             None => return Ok(()),
+        };
+
+        let Some(database) = database.cloned() else {
+            bail!("wasmcloud:postgres requires a 'database' config parameter")
         };
 
         let component_id = component_handle.id().to_string();
@@ -502,7 +500,7 @@ impl HostPlugin for WasmcloudPostgres {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        _interfaces: HashSet<WitInterface>,
+        _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         tracing::debug!(workload_id = %workload_id, "Unbinding postgres plugin from workload");
 

--- a/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
@@ -456,7 +456,7 @@ impl HostPlugin for WasmcloudPostgres {
         component_handle: &mut WorkloadItem<'a>,
         interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        let database = match interfaces.get("wasmcloud", "postgres", &["database"]) {
+        let database = match interfaces.get("wasmcloud", "postgres", &[]) {
             Some(i) => i.config.get("database"),
             None => return Ok(()),
         };

--- a/crates/wash-runtime/tests/integration_inter_component_call.rs
+++ b/crates/wash-runtime/tests/integration_inter_component_call.rs
@@ -29,7 +29,9 @@ use wash_runtime::{
         HostApi, HostBuilder,
         http::{DevRouter, HttpServer},
     },
-    plugin::{HostPlugin, wasi_config::DynamicConfig, wasi_keyvalue::InMemoryKeyValue},
+    plugin::{
+        HostPlugin, WitInterfaces, wasi_config::DynamicConfig, wasi_keyvalue::InMemoryKeyValue,
+    },
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
     wit::{WitInterface, WitWorld},
 };
@@ -119,18 +121,10 @@ impl HostPlugin for CustomLogging {
     async fn on_workload_item_bind<'a>(
         &self,
         workload_handle: &mut WorkloadItem<'a>,
-        interfaces: std::collections::HashSet<wash_runtime::wit::WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // Ensure exactly one interface: "wasi:logging/logging"
-        let mut iter = interfaces.iter();
-        let Some(interface) = iter.next() else {
-            anyhow::bail!("No interfaces provided; expected wasi:logging/logging");
-        };
-        if iter.next().is_some()
-            || interface.namespace != "wasi"
-            || interface.package != "logging"
-            || !interface.interfaces.contains("logging")
-        {
+        if interfaces.contains("wasi", "logging", &["logging"]) {
             anyhow::bail!(
                 "Expected exactly one interface: wasi:logging/logging, got: {interfaces:?}"
             );

--- a/crates/wash-runtime/tests/integration_inter_component_call.rs
+++ b/crates/wash-runtime/tests/integration_inter_component_call.rs
@@ -63,7 +63,7 @@ pub struct PerComponentInfo {
 #[derive(Default)]
 pub struct CustomLogging {
     tracker: Mutex<HashMap<String, PerComponentInfo>>,
-    prev_ctx_id: Mutex<Option<String>>,
+    prev_ctx_id: Mutex<Option<Arc<str>>>,
 }
 
 impl<'a> bindings::wasi::logging::logging::Host for ActiveCtx<'a> {
@@ -94,12 +94,12 @@ impl<'a> bindings::wasi::logging::logging::Host for ActiveCtx<'a> {
         *plugin.prev_ctx_id.lock().await = Some(self.id.clone());
 
         match level {
-            Level::Critical => tracing::error!(id = &self.id, context, "{message}"),
-            Level::Error => tracing::error!(id = &self.id, context, "{message}"),
-            Level::Warn => tracing::warn!(id = &self.id, context, "{message}"),
-            Level::Info => tracing::info!(id = &self.id, context, "{message}"),
-            Level::Debug => tracing::debug!(id = &self.id, context, "{message}"),
-            Level::Trace => tracing::trace!(id = &self.id, context, "{message}"),
+            Level::Critical => tracing::error!(id = &*self.id, context, "{message}"),
+            Level::Error => tracing::error!(id = &*self.id, context, "{message}"),
+            Level::Warn => tracing::warn!(id = &*self.id, context, "{message}"),
+            Level::Info => tracing::info!(id = &*self.id, context, "{message}"),
+            Level::Debug => tracing::debug!(id = &*self.id, context, "{message}"),
+            Level::Trace => tracing::trace!(id = &*self.id, context, "{message}"),
         }
         Ok(())
     }

--- a/crates/wash-runtime/tests/integration_inter_component_call.rs
+++ b/crates/wash-runtime/tests/integration_inter_component_call.rs
@@ -123,8 +123,8 @@ impl HostPlugin for CustomLogging {
         workload_handle: &mut WorkloadItem<'a>,
         interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        // Ensure exactly one interface: "wasi:logging/logging"
-        if interfaces.contains("wasi", "logging", &["logging"]) {
+        // Ensure the expected interface is present: "wasi:logging/logging"
+        if !interfaces.contains("wasi", "logging", &["logging"]) {
             anyhow::bail!(
                 "Expected exactly one interface: wasi:logging/logging, got: {interfaces:?}"
             );

--- a/crates/wash-runtime/tests/integration_inter_component_call.rs
+++ b/crates/wash-runtime/tests/integration_inter_component_call.rs
@@ -71,9 +71,7 @@ impl<'a> bindings::wasi::logging::logging::Host for ActiveCtx<'a> {
         context: String,
         message: String,
     ) -> wasmtime::Result<()> {
-        let plugin = self
-            .get_plugin::<CustomLogging>("logging")
-            .ok_or_else(|| wasmtime::format_err!("failed to get plugin"))?;
+        let plugin = self.try_get_plugin::<CustomLogging>("logging")?;
 
         let per_component_info = plugin
             .tracker


### PR DESCRIPTION
Related #4942 

Hi there!

Refactors the `wash-runtime` host plugin API to reduce boilerplate at plugin call sites and give plugin authors a cleaner, less error-prone interface

1. `Ctx::try_get_plugin` / `get_plugin`

Replaced the old fallible accessor:

```rust
pub fn get_plugin<T: HostPlugin>(&self, id: &str) -> Option<Arc<T>>
```

with a pair:

- `try_get_plugin::<T>(id) -> wasmtime::Result<Arc<T>>` - returns a descriptive error (plugin missing / type mismatch) that composes with `?`.
- `get_plugin::<T>(id) -> Arc<T>` - infallible convenience wrapper that panics on miss.

This collapses the repeated `let Some(plugin) = self.get_plugin(...) else { return Ok(Err(...)) }` guard blocks across all plugins into a single `let plugin = self.try_get_plugin::<T>(ID)?;`, removing ~200 lines of duplicated error-handling.

2. **`WitInterfaces<'a>`** (`plugin/mod.rs`)

Introduces a borrowed wrapper around `&HashSet<WitInterface>` with `get()` / `contains()` lookup helpers, replacing the owned `HashSet<WitInterface>` previously passed by value to the `on_workload_bind`, `on_workload_item_bind`, and `on_workload_unbind` trait methods. Avoids cloning the interface set per plugin and gives binding code a readable `interfaces.contains("wasi", "blobstore", &[])` API.

3. **`Ctx.id: Arc<str>`**

Changed from an owned string to `Arc<str>` for cheaper cloning, consistent with the other id fields on `Ctx`.