### PR TITLE
fix(wash): scope new.command to template config

### DIFF
--- a/crates/wash/src/cli/new.rs
+++ b/crates/wash/src/cli/new.rs
@@ -11,7 +11,7 @@ use tracing::{info, instrument};
 
 use crate::{
     cli::{CliCommand, CliContext, CommandOutput},
-    config::{Config, load_config},
+    config::{load_config_from_file, locate_project_config},
     new::{clone_template, copy_dir_recursive, extract_subfolder},
 };
 
@@ -69,12 +69,8 @@ impl CliCommand for NewCommand {
                 .context("failed to copy cloned repository to output directory")?;
         }
 
-        // Check if the output directory has a wash config
-        let template_config =
-            load_config(&ctx.user_config_path(), Some(&output_dir), None::<Config>)
-                .context("couldn't load template config")?;
-
-        if let Some(new_cmd) = template_config.new.and_then(|nc| nc.command)
+        if let Some(new_cmd) =
+            load_template_new_command(&output_dir).context("couldn't load template config")?
             && ctx.request_confirmation(format!(
                 "Execute template setup command '{new_cmd}'? This may modify the new project."
             ))?
@@ -122,6 +118,17 @@ impl NewCommand {
     }
 }
 
+fn load_template_new_command(project_dir: &Path) -> anyhow::Result<Option<String>> {
+    let config_path = locate_project_config(project_dir);
+    if !config_path.exists() {
+        return Ok(None);
+    }
+
+    Ok(load_config_from_file(&config_path)?
+        .new
+        .and_then(|nc| nc.command))
+}
+
 /// Execute a template's `new.command` shell command in `working_dir`.
 /// Returns an error if the command exits non-zero.
 async fn run_new_command(new_cmd: &str, working_dir: &Path) -> anyhow::Result<()> {
@@ -161,6 +168,7 @@ async fn run_new_command(new_cmd: &str, working_dir: &Path) -> anyhow::Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     // `exit N` is a builtin in both POSIX `sh` and Windows `cmd`, so these tests
     // exercise the same code path that production uses on each platform.
@@ -182,5 +190,32 @@ mod tests {
         run_new_command("exit 0", tempdir.path())
             .await
             .expect("zero-exit command should succeed");
+    }
+
+    #[test]
+    fn template_new_command_is_absent_without_project_config() {
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let new_cmd = load_template_new_command(tempdir.path())
+            .expect("missing project config should not error");
+
+        assert_eq!(new_cmd, None);
+    }
+
+    #[test]
+    fn template_new_command_comes_from_project_config() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let config_dir = tempdir.path().join(".wash");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.yaml"),
+            "new:\n  command: cargo test\n",
+        )
+        .unwrap();
+
+        let new_cmd =
+            load_template_new_command(tempdir.path()).expect("project config should parse");
+
+        assert_eq!(new_cmd.as_deref(), Some("cargo test"));
     }
 }


### PR DESCRIPTION
`wash new` was reading merged user and project config when it decided whether to run `new.command`.
That means a user-level `new.command` can leak into any scaffold, even if the template has no `.wash/config` at all. Kinda sneaky.

This keeps `new.command` scoped to the scaffolded template config only. Template hooks still work, global hooks stop bleeding in.

Repro on `main`:
1. Put this in a user config file:
   `new.command: sh -c 'echo fired >/tmp/wash-new-hook'`
2. Make a git template repo with no `.wash/config`.
3. Run `wash new <repo> --name demo` and accept the prompt.
4. `/tmp/wash-new-hook` gets created, even though the template never asked for it.

Checks:
`cargo test -p wash cli::new -- --nocapture`

Related area: #5154
