### PR TITLE
fix(dev): deliver workload values to every dev component

### DIFF
--- a/crates/wash-runtime/src/plugin/wasi_config/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_config/mod.rs
@@ -48,7 +48,9 @@ type ConfigMap = HashMap<Arc<str>, HashMap<String, String>>;
 ///
 /// This plugin implements the WASI config interface, allowing components to
 /// retrieve configuration values and environment variables at runtime. Each
-/// component gets isolated access to its own configuration scope.
+/// component gets an isolated view: the workload-scoped `wasi:config`
+/// interface config layered with its own `LocalResources.config` (and, with
+/// `copy_environment`, its `LocalResources.environment`).
 ///
 /// Construct via [`DynamicConfig::builder`] (or [`Default::default`]) so new
 /// optional knobs land without breaking callers.
@@ -141,8 +143,15 @@ impl HostPlugin for DynamicConfig {
             extract_active_ctx,
         )?;
 
+        // Per-component view, later wins on key conflicts: interface
+        // config, then `LocalResources.config`, then (with
+        // `copy_environment`) the environment.
         let component_config = {
             let mut config_map = interface.config.clone();
+
+            for (key, value) in component_handle.local_resources().config.iter() {
+                config_map.insert(key.clone(), value.clone());
+            }
 
             if self.copy_environment {
                 for (key, value) in component_handle.local_resources().environment.iter() {

--- a/crates/wash-runtime/src/types.rs
+++ b/crates/wash-runtime/src/types.rs
@@ -78,6 +78,10 @@ pub struct LocalResources {
     /// Opaque key-value configuration shared between operator + runtime + plugins.
     /// Allows passing arbitrary configuration values to influence implementation behavior for all component interfaces.
     /// Example: tracing=disable
+    ///
+    /// Also surfaced per component via `wasi:config/store`, layered over
+    /// the interface config (see
+    /// [`crate::plugin::wasi_config::DynamicConfig`]).
     pub config: HashMap<String, String>,
     /// `wasi:cli/env` variables, copied to `WasiCtxBuilder` at component
     /// instantiation.

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    path::Path,
     sync::Arc,
 };
 
@@ -24,7 +25,7 @@ use crate::{
     cli::{CliCommand, CliContext, CommandOutput, component_build::build_dev_component},
     config::{Config, load_config},
     wit::WitConfig,
-    workload::{ResolvedWorkload, resolve_workload},
+    workload::{ResolvedWorkload, resolve_component_workload, resolve_workload},
 };
 
 /// Start a development server for a Wasm component
@@ -76,11 +77,10 @@ impl CliCommand for DevCommand {
             .with_engine(engine)
             .with_meters(Meters::new(ctx.enable_meters()));
 
-        // Enable wasi config. `copy_environment = true` causes the plugin to
-        // surface every entry of `LocalResources.environment` via
-        // `wasi:config/store::get`, so values from `workload.environment` are
-        // visible to the component as both env vars and wasi:config entries
-        // without further plumbing.
+        // Enable wasi config. `copy_environment = true` surfaces each
+        // component's `LocalResources.environment` via `wasi:config/store`,
+        // so resolved env vars are visible as both env vars and wasi:config
+        // entries without further plumbing.
         host_builder = host_builder.with_plugin(Arc::new(
             plugin::wasi_config::DynamicConfig::builder()
                 .copy_environment(true)
@@ -252,8 +252,14 @@ impl CliCommand for DevCommand {
         // gitignored-secret warning.
         let resolved_workload = resolve_workload(&config, project_dir, Some(project_dir))
             .context("failed to resolve workload-level configuration")?;
-        let workload =
-            create_workload(&host, &config, wasm_bytes.into(), &resolved_workload).await?;
+        let workload = create_workload(
+            &host,
+            &config,
+            project_dir,
+            wasm_bytes.into(),
+            &resolved_workload,
+        )
+        .await?;
         // Running workload ID for reloads
         let workload_id = reload_component(host.clone(), &workload, None).await?;
 
@@ -291,22 +297,26 @@ impl CliCommand for DevCommand {
     }
 }
 
-/// Loaded inputs for [`build_workload`]. Bundles a component's raw bytes
-/// with its already-extracted WIT interface set so the pure assembly step
-/// has everything it needs without further I/O or host calls.
+/// Loaded inputs for [`build_workload`]: a component's raw bytes, its
+/// extracted WIT interface set, and its resolved workload values (workload
+/// base merged with the component's overrides), so the pure assembly step
+/// needs no further I/O or host calls.
 struct LoadedComponent {
     name: String,
     bytes: Bytes,
     interfaces: HashSet<WitInterface>,
+    workload: ResolvedWorkload,
 }
 
 /// Thin wrapper around [`build_workload`]: extracts dev-component
-/// interfaces, loads sidecar bytes + interfaces, and (when configured)
-/// loads the service-file bytes. All workload-construction logic lives in
+/// interfaces, loads sidecar bytes + interfaces, resolves each sidecar's
+/// overrides over the workload-level base, and (when configured) loads the
+/// service-file bytes. All workload-construction logic lives in
 /// `build_workload`.
 async fn create_workload(
     host: &Host,
     config: &Config,
+    project_dir: &Path,
     bytes: Bytes,
     resolved_workload: &ResolvedWorkload,
 ) -> anyhow::Result<Workload> {
@@ -329,10 +339,19 @@ async fn create_workload(
         let interfaces = host
             .intersect_interfaces(&comp_bytes)
             .context("failed to extract component interfaces")?;
+        // Errors already name the component.
+        let workload = resolve_component_workload(
+            resolved_workload,
+            dev_component,
+            config,
+            project_dir,
+            Some(project_dir),
+        )?;
         sidecars.push(LoadedComponent {
             name: dev_component.name.clone(),
             bytes: Bytes::from(comp_bytes),
             interfaces,
+            workload,
         });
     }
 
@@ -364,12 +383,12 @@ async fn create_workload(
 /// vs component branch, volume wiring, and the wasi:config injection (via
 /// [`build_workload_host_interfaces`]).
 ///
-/// Per-component workload values (`environment`, `config`, `allowed_hosts`)
-/// land on the dev component when `dev.service = false`, or on the service
-/// when `dev.service = true`. Sidecars in `dev.components` and a
-/// `service_file_bytes`-loaded sidecar service get default `LocalResources`.
-/// Workload-level decisions (notably the `wasi:config` interface injection)
-/// consider every component's imports, including sidecars.
+/// Workload values (`environment`, `config`, `allowed_hosts`) land on every
+/// component and service: the dev component and any service carry the
+/// workload-level values; each `dev.components` sidecar carries its own
+/// pre-merged values from [`create_workload`]. Workload-level decisions
+/// (notably the `wasi:config` interface injection) consider every
+/// component's imports, including sidecars.
 fn build_workload(
     dev_config: &crate::config::DevConfig,
     bytes: Bytes,
@@ -408,16 +427,11 @@ fn build_workload(
         &resolved_workload.config,
     );
 
-    let dev_local_resources = || LocalResources {
+    let local_resources_for = |w: &ResolvedWorkload| LocalResources {
         volume_mounts: volume_mounts.clone(),
-        environment: resolved_workload.environment.clone(),
-        config: resolved_workload.config.clone(),
-        allowed_hosts: resolved_workload.allowed_hosts.clone().into(),
-        ..Default::default()
-    };
-
-    let default_local_resources = || LocalResources {
-        volume_mounts: volume_mounts.clone(),
+        environment: w.environment.clone(),
+        config: w.config.clone(),
+        allowed_hosts: w.allowed_hosts.clone().into(),
         ..Default::default()
     };
 
@@ -428,14 +442,14 @@ fn build_workload(
             bytes,
             digest: None,
             max_restarts: 0,
-            local_resources: dev_local_resources(),
+            local_resources: local_resources_for(resolved_workload),
         })
     } else {
         components.push(Component {
             name: "wash-dev-component".to_string(),
             bytes,
             digest: None,
-            local_resources: dev_local_resources(),
+            local_resources: local_resources_for(resolved_workload),
             pool_size: -1,
             max_invocations: -1,
         });
@@ -445,7 +459,7 @@ fn build_workload(
                 bytes: service_bytes,
                 digest: None,
                 max_restarts: 0,
-                local_resources: default_local_resources(),
+                local_resources: local_resources_for(resolved_workload),
             });
         }
     }
@@ -455,7 +469,7 @@ fn build_workload(
             name: sidecar.name,
             bytes: sidecar.bytes,
             digest: None,
-            local_resources: default_local_resources(),
+            local_resources: local_resources_for(&sidecar.workload),
             pool_size: -1,
             max_invocations: -1,
         });
@@ -608,9 +622,17 @@ mod tests {
     }
 
     fn dev_component_named(name: &str) -> DevComponent {
-        DevComponent {
+        DevComponent::new(name, format!("/dev/null/{name}.wasm"))
+    }
+
+    /// A sidecar input with the given pre-merged workload values, as
+    /// `create_workload` would produce it.
+    fn loaded_sidecar(name: &str, workload: ResolvedWorkload) -> LoadedComponent {
+        LoadedComponent {
             name: name.into(),
-            file: PathBuf::from(format!("/dev/null/{name}.wasm")),
+            bytes: fake_bytes(name),
+            interfaces: HashSet::new(),
+            workload,
         }
     }
 
@@ -620,10 +642,10 @@ mod tests {
     }
 
     #[test]
-    fn build_workload_lands_workload_values_on_dev_component_only() {
-        // The dev component (when not running as a service) is the one
-        // configured with the resolved workload's environment / config /
-        // allowed_hosts. Sidecars get default LocalResources.
+    fn build_workload_lands_workload_values_on_every_component() {
+        // Workload values (environment / config / allowed_hosts) are
+        // workload-wide: the dev component and every sidecar receive them.
+        // A sidecar without overrides carries the workload values unchanged.
         let resolved = ResolvedWorkload {
             environment: HashMap::from([("LOG".into(), "debug".into())]),
             config: HashMap::from([("flag".into(), "on".into())]),
@@ -633,11 +655,7 @@ mod tests {
             components: vec![dev_component_named("sidecar-a")],
             ..Default::default()
         };
-        let sidecars = vec![LoadedComponent {
-            name: "sidecar-a".into(),
-            bytes: fake_bytes("sidecar-a"),
-            interfaces: HashSet::new(),
-        }];
+        let sidecars = vec![loaded_sidecar("sidecar-a", resolved.clone())];
 
         let workload = build_workload(
             &dev_cfg,
@@ -657,9 +675,72 @@ mod tests {
         );
 
         let sidecar = find_component(&workload, "sidecar-a").unwrap();
-        assert!(sidecar.local_resources.environment.is_empty());
-        assert!(sidecar.local_resources.config.is_empty());
-        assert!(sidecar.local_resources.allowed_hosts.is_empty());
+        assert_eq!(
+            sidecar.local_resources.environment.get("LOG").unwrap(),
+            "debug"
+        );
+        assert_eq!(sidecar.local_resources.config.get("flag").unwrap(), "on");
+        assert_eq!(
+            &sidecar.local_resources.allowed_hosts[..],
+            &["https://api.example.com".parse().unwrap()]
+        );
+    }
+
+    #[test]
+    fn build_workload_sidecar_carries_its_own_merged_values() {
+        // A sidecar's pre-merged per-component values land on that sidecar's
+        // LocalResources; the dev component keeps the workload-level values.
+        let resolved = ResolvedWorkload {
+            environment: HashMap::from([("LOG".into(), "debug".into())]),
+            allowed_hosts: vec![wash_runtime::host::allowed_hosts::AllowedHost::Any],
+            ..Default::default()
+        };
+        let sidecar_resolved = ResolvedWorkload {
+            environment: HashMap::from([
+                ("LOG".into(), "trace".into()),
+                ("SIDECAR_ONLY".into(), "1".into()),
+            ]),
+            config: HashMap::from([("flag".into(), "on".into())]),
+            allowed_hosts: vec!["https://api.example.com".parse().unwrap()],
+        };
+        let dev_cfg = DevConfig {
+            components: vec![dev_component_named("sidecar-a")],
+            ..Default::default()
+        };
+        let sidecars = vec![loaded_sidecar("sidecar-a", sidecar_resolved)];
+
+        let workload = build_workload(
+            &dev_cfg,
+            fake_bytes("dev"),
+            HashSet::new(),
+            sidecars,
+            None,
+            &resolved,
+        );
+
+        let dev = find_component(&workload, "wash-dev-component").unwrap();
+        assert_eq!(dev.local_resources.environment.get("LOG").unwrap(), "debug");
+        assert!(!dev.local_resources.environment.contains_key("SIDECAR_ONLY"));
+        assert!(dev.local_resources.config.is_empty());
+
+        let sidecar = find_component(&workload, "sidecar-a").unwrap();
+        assert_eq!(
+            sidecar.local_resources.environment.get("LOG").unwrap(),
+            "trace"
+        );
+        assert_eq!(
+            sidecar
+                .local_resources
+                .environment
+                .get("SIDECAR_ONLY")
+                .unwrap(),
+            "1"
+        );
+        assert_eq!(sidecar.local_resources.config.get("flag").unwrap(), "on");
+        assert_eq!(
+            &sidecar.local_resources.allowed_hosts[..],
+            &["https://api.example.com".parse().unwrap()]
+        );
     }
 
     #[test]
@@ -695,11 +776,10 @@ mod tests {
     }
 
     #[test]
-    fn build_workload_service_file_sidecar_gets_default_local_resources() {
+    fn build_workload_service_file_sidecar_gets_workload_values() {
         // dev.service = false + dev.service_file = Some(...) loads a sidecar
-        // service alongside the dev component. That service is a sidecar —
-        // it should NOT receive workload values (those went to the dev
-        // component above).
+        // service alongside the dev component. Workload values are
+        // workload-wide, so the sidecar service receives them too.
         let resolved = ResolvedWorkload {
             environment: HashMap::from([("LOG".into(), "info".into())]),
             ..Default::default()
@@ -719,10 +799,7 @@ mod tests {
             .service
             .as_ref()
             .expect("service_file should produce a Service");
-        assert!(
-            svc.local_resources.environment.is_empty(),
-            "service-file sidecar must not receive workload values"
-        );
+        assert_eq!(svc.local_resources.environment.get("LOG").unwrap(), "info");
         let dev = find_component(&workload, "wash-dev-component").unwrap();
         assert_eq!(dev.local_resources.environment.get("LOG").unwrap(), "info");
     }
@@ -739,11 +816,7 @@ mod tests {
             components: vec![dev_component_named("sidecar")],
             ..Default::default()
         };
-        let sidecars = vec![LoadedComponent {
-            name: "sidecar".into(),
-            bytes: fake_bytes("sidecar"),
-            interfaces: HashSet::new(),
-        }];
+        let sidecars = vec![loaded_sidecar("sidecar", ResolvedWorkload::default())];
 
         let workload = build_workload(
             &dev_cfg,
@@ -789,6 +862,7 @@ mod tests {
             name: "sidecar".into(),
             bytes: fake_bytes("sidecar"),
             interfaces: HashSet::from([iface("wasi", "config")]),
+            workload: ResolvedWorkload::default(),
         }];
 
         let workload = build_workload(
@@ -819,16 +893,8 @@ mod tests {
             ..Default::default()
         };
         let sidecars = vec![
-            LoadedComponent {
-                name: "first-sidecar".into(),
-                bytes: fake_bytes("a"),
-                interfaces: HashSet::new(),
-            },
-            LoadedComponent {
-                name: "second-sidecar".into(),
-                bytes: fake_bytes("b"),
-                interfaces: HashSet::new(),
-            },
+            loaded_sidecar("first-sidecar", ResolvedWorkload::default()),
+            loaded_sidecar("second-sidecar", ResolvedWorkload::default()),
         ];
 
         let workload = build_workload(

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -327,12 +327,44 @@ pub struct DevVolume {
     pub guest_path: PathBuf,
 }
 
+/// A component loaded alongside the main dev component.
+///
+/// `environment` / `config` / `allowedHosts` override the workload-level
+/// `workload:` block for this component — see
+/// [`crate::workload::resolve_component_workload`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DevComponent {
     /// Name of the component
     pub name: String,
     /// Path to the component file
     pub file: PathBuf,
+    /// Environment variables (wasi:cli/env), merged over
+    /// `workload.environment`. This component wins on key conflicts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<EnvironmentLayer>,
+    /// Opaque key-value config, merged over `workload.config`. This
+    /// component wins on key conflicts.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub config: HashMap<String, String>,
+    /// Outbound HTTP allowlist. When set it replaces `workload.allowedHosts`
+    /// for this component (`[]` denies all egress); when omitted the
+    /// workload list applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_hosts: Option<Vec<AllowedHost>>,
+}
+
+impl DevComponent {
+    /// Creates a component entry with no per-component overrides.
+    pub fn new(name: impl Into<String>, file: impl Into<PathBuf>) -> Self {
+        Self {
+            name: name.into(),
+            file: file.into(),
+            environment: None,
+            config: HashMap::new(),
+            allowed_hosts: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -721,10 +753,10 @@ pub fn example_config() -> Config {
         dev: Some(DevConfig {
             address: Some("0.0.0.0:8000".to_string()),
             service_file: Some(PathBuf::from("example/path/to/service.wasm")),
-            components: vec![DevComponent {
-                name: "example-sidecar".to_string(),
-                file: PathBuf::from("example/path/to/sidecar.wasm"),
-            }],
+            components: vec![DevComponent::new(
+                "example-sidecar",
+                "example/path/to/sidecar.wasm",
+            )],
             volumes: vec![DevVolume {
                 host_path: PathBuf::from("./data"),
                 guest_path: PathBuf::from("/data"),
@@ -1024,10 +1056,7 @@ workload:
     #[test]
     fn dev_component_empty_name_is_err() {
         let cfg = DevConfig {
-            components: vec![DevComponent {
-                name: "  ".to_string(),
-                file: "comp.wasm".into(),
-            }],
+            components: vec![DevComponent::new("  ", "comp.wasm")],
             ..Default::default()
         };
         let err = cfg.validate().unwrap_err().to_string();
@@ -1037,10 +1066,7 @@ workload:
     #[test]
     fn dev_component_empty_file_is_err() {
         let cfg = DevConfig {
-            components: vec![DevComponent {
-                name: "sidecar".to_string(),
-                file: "".into(),
-            }],
+            components: vec![DevComponent::new("sidecar", "")],
             ..Default::default()
         };
         let err = cfg.validate().unwrap_err().to_string();
@@ -1050,13 +1076,51 @@ workload:
     #[test]
     fn dev_component_valid_is_ok() {
         let cfg = DevConfig {
-            components: vec![DevComponent {
-                name: "sidecar".to_string(),
-                file: "sidecar.wasm".into(),
-            }],
+            components: vec![DevComponent::new("sidecar", "sidecar.wasm")],
             ..Default::default()
         };
         assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn dev_component_overrides_parse_from_yaml() {
+        // Per-component overrides use the same camelCase shape as the
+        // `workload:` block (and the k8s `localResources` they mirror).
+        let yaml = r#"
+dev:
+  components:
+    - name: hello
+      file: hello.wasm
+      environment:
+        config:
+          MY_ENV_VAR: hello
+        configFrom:
+          - shared
+      config:
+        flag: "on"
+      allowedHosts:
+        - https://api.example.com
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let dev = config.dev();
+        let component = &dev.components[0];
+        let env = component.environment.as_ref().unwrap();
+        assert_eq!(env.config.get("MY_ENV_VAR").unwrap(), "hello");
+        assert_eq!(env.config_from, vec!["shared".to_string()]);
+        assert_eq!(component.config.get("flag").unwrap(), "on");
+        assert_eq!(
+            component.allowed_hosts.as_deref().unwrap(),
+            &["https://api.example.com".parse().unwrap()]
+        );
+
+        // Omitting all three leaves the overrides empty (inherit workload).
+        let yaml = "dev:\n  components:\n    - name: hello\n      file: hello.wasm\n";
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let dev = config.dev();
+        let component = &dev.components[0];
+        assert!(component.environment.is_none());
+        assert!(component.config.is_empty());
+        assert!(component.allowed_hosts.is_none());
     }
 
     #[test]

--- a/crates/wash/src/workload.rs
+++ b/crates/wash/src/workload.rs
@@ -33,7 +33,7 @@ use anyhow::{Context as _, Result, bail};
 use tracing::{trace, warn};
 use wash_runtime::host::allowed_hosts::AllowedHost;
 
-use crate::config::{Config, ConfigSource, SecretSource, WorkloadConfig};
+use crate::config::{Config, ConfigSource, DevComponent, EnvironmentLayer, SecretSource};
 
 /// Resolved workload values ready to be applied to a runtime `LocalResources`.
 #[derive(Debug, Default, Clone)]
@@ -74,8 +74,9 @@ pub fn resolve_workload(
         return Ok(ResolvedWorkload::default());
     };
 
-    let environment = resolve_environment(
-        workload,
+    let environment = resolve_environment_layer(
+        workload.environment.as_ref(),
+        "workload",
         &config.config_sources,
         &config.secret_sources,
         project_dir,
@@ -86,7 +87,7 @@ pub fn resolve_workload(
     // YAML omitted `allowedHosts` (via `default_allow_all_hosts`), or the
     // user's explicit list (including an explicit empty list, which the
     // runtime treats as deny-all). Either way, pass through unchanged.
-    //Tthe substitution lives on the serde default, not here.
+    // The substitution lives on the serde default, not here.
     Ok(ResolvedWorkload {
         environment,
         config: workload.config.clone(),
@@ -94,18 +95,69 @@ pub fn resolve_workload(
     })
 }
 
-/// Builds the flat env-var map for a workload by walking
+/// Resolves a `dev.components` entry's overrides on top of the resolved
+/// workload-level `base`.
+///
+/// `environment` / `config` merge over the workload's, component wins on
+/// key conflicts. `allowedHosts`, when set, replaces the workload list
+/// (an explicit `[]` denies all egress); when omitted the workload list
+/// applies.
+///
+/// # Errors
+///
+/// Same failure modes as [`resolve_workload`], for the component's own
+/// `environment.configFrom` / `environment.secretFrom` references.
+pub fn resolve_component_workload(
+    base: &ResolvedWorkload,
+    component: &DevComponent,
+    config: &Config,
+    project_dir: &Path,
+    repo_root: Option<&Path>,
+) -> Result<ResolvedWorkload> {
+    let owner = format!("dev component '{}'", component.name);
+    let overrides = resolve_environment_layer(
+        component.environment.as_ref(),
+        &owner,
+        &config.config_sources,
+        &config.secret_sources,
+        project_dir,
+        repo_root,
+    )?;
+
+    let mut environment = base.environment.clone();
+    environment.extend(overrides);
+
+    let mut merged_config = base.config.clone();
+    merged_config.extend(component.config.clone());
+
+    let allowed_hosts = component
+        .allowed_hosts
+        .clone()
+        .unwrap_or_else(|| base.allowed_hosts.clone());
+
+    Ok(ResolvedWorkload {
+        environment,
+        config: merged_config,
+        allowed_hosts,
+    })
+}
+
+/// Builds the flat env-var map for one [`EnvironmentLayer`] by walking
 /// `environment.inline`, `environment.configFrom`, and
 /// `environment.secretFrom` in K8s `envFrom` order (inline → configFrom →
 /// secretFrom, later wins on key conflicts).
-fn resolve_environment(
-    workload: &WorkloadConfig,
+///
+/// `owner` names the declaring scope (e.g. `"workload"` or
+/// `"dev component 'hello'"`) in error messages.
+fn resolve_environment_layer(
+    env: Option<&EnvironmentLayer>,
+    owner: &str,
     configs: &BTreeMap<String, ConfigSource>,
     secrets: &BTreeMap<String, SecretSource>,
     project_dir: &Path,
     repo_root: Option<&Path>,
 ) -> Result<HashMap<String, String>> {
-    let Some(env) = workload.environment.as_ref() else {
+    let Some(env) = env else {
         return Ok(HashMap::new());
     };
 
@@ -115,10 +167,17 @@ fn resolve_environment(
     // then secretFrom. Later layers overwrite earlier on key conflicts.
     out.extend(env.config.clone());
 
-    apply_config_refs(&env.config_from, configs, project_dir, &mut out)
-        .context("failed to resolve workload.environment.configFrom")?;
-    apply_secret_refs(&env.secret_from, secrets, project_dir, repo_root, &mut out)
-        .context("failed to resolve workload.environment.secretFrom")?;
+    apply_config_refs(&env.config_from, owner, configs, project_dir, &mut out)
+        .with_context(|| format!("failed to resolve {owner} environment.configFrom"))?;
+    apply_secret_refs(
+        &env.secret_from,
+        owner,
+        secrets,
+        project_dir,
+        repo_root,
+        &mut out,
+    )
+    .with_context(|| format!("failed to resolve {owner} environment.secretFrom"))?;
 
     Ok(out)
 }
@@ -128,6 +187,7 @@ fn resolve_environment(
 /// a hard error so typos in `configFrom` fail loudly.
 fn apply_config_refs(
     refs: &[String],
+    owner: &str,
     catalog: &BTreeMap<String, ConfigSource>,
     project_dir: &Path,
     out: &mut HashMap<String, String>,
@@ -135,7 +195,7 @@ fn apply_config_refs(
     for name in refs {
         let Some(source) = catalog.get(name) else {
             bail!(
-                "workload references config '{name}' which is not defined in the top-level `configs:` block",
+                "{owner} references config '{name}' which is not defined in the top-level `configs:` block",
             );
         };
         let resolved = source.resolve(name, project_dir)?;
@@ -149,6 +209,7 @@ fn apply_config_refs(
 /// a hard error so typos in `secretFrom` fail loudly.
 fn apply_secret_refs(
     refs: &[String],
+    owner: &str,
     catalog: &BTreeMap<String, SecretSource>,
     project_dir: &Path,
     repo_root: Option<&Path>,
@@ -157,7 +218,7 @@ fn apply_secret_refs(
     for name in refs {
         let Some(source) = catalog.get(name) else {
             bail!(
-                "workload references secret '{name}' which is not defined in the top-level `secrets:` block",
+                "{owner} references secret '{name}' which is not defined in the top-level `secrets:` block",
             );
         };
         let resolved = source.resolve(name, project_dir, repo_root)?;
@@ -518,7 +579,7 @@ fn parse_env_file(file: File, path: &Path) -> Result<HashMap<String, String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::EnvironmentLayer;
+    use crate::config::WorkloadConfig;
     use tempfile::TempDir;
 
     #[test]
@@ -606,13 +667,10 @@ mod tests {
     fn missing_named_ref_errors() {
         let mut env = EnvironmentLayer::default();
         env.config_from.push("missing".into());
-        let workload = WorkloadConfig {
-            environment: Some(env),
-            ..Default::default()
-        };
         let project = TempDir::new().unwrap();
-        let err = resolve_environment(
-            &workload,
+        let err = resolve_environment_layer(
+            Some(&env),
+            "workload",
             &BTreeMap::new(),
             &BTreeMap::new(),
             project.path(),
@@ -709,16 +767,13 @@ mod tests {
         // disjoint marker key so a regression that silently drops a layer is
         // caught even when the conflicting key still gets a winning value.
         let project = TempDir::new().unwrap();
-        let workload = WorkloadConfig {
-            environment: Some(EnvironmentLayer {
-                config: HashMap::from([
-                    ("KEY".into(), "from_inline".into()),
-                    ("ONLY_INLINE".into(), "1".into()),
-                ]),
-                config_from: vec!["shared_cfg".into()],
-                secret_from: vec!["shared_sec".into()],
-            }),
-            ..Default::default()
+        let env = EnvironmentLayer {
+            config: HashMap::from([
+                ("KEY".into(), "from_inline".into()),
+                ("ONLY_INLINE".into(), "1".into()),
+            ]),
+            config_from: vec!["shared_cfg".into()],
+            secret_from: vec!["shared_sec".into()],
         };
         let configs = BTreeMap::from([(
             "shared_cfg".to_string(),
@@ -742,7 +797,15 @@ mod tests {
         )]);
 
         // The secret source has no `file:`, so no perm check fires.
-        let env = resolve_environment(&workload, &configs, &secrets, project.path(), None).unwrap();
+        let env = resolve_environment_layer(
+            Some(&env),
+            "workload",
+            &configs,
+            &secrets,
+            project.path(),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             env.get("KEY").unwrap(),
             "from_secret",
@@ -843,6 +906,132 @@ mod tests {
             resolved.allowed_hosts,
             vec!["https://api.example.com".parse().unwrap()]
         );
+    }
+
+    #[test]
+    fn component_overrides_merge_over_workload_base() {
+        // environment / config: component entries win on key conflict, but
+        // workload-only keys survive the merge.
+        let base = ResolvedWorkload {
+            environment: HashMap::from([
+                ("LOG".into(), "debug".into()),
+                ("SHARED".into(), "from_workload".into()),
+            ]),
+            config: HashMap::from([
+                ("flag".into(), "off".into()),
+                ("base_only".into(), "1".into()),
+            ]),
+            allowed_hosts: vec![AllowedHost::Any],
+        };
+        let component = DevComponent {
+            environment: Some(EnvironmentLayer {
+                config: HashMap::from([("SHARED".into(), "from_component".into())]),
+                ..Default::default()
+            }),
+            config: HashMap::from([("flag".into(), "on".into())]),
+            ..DevComponent::new("sidecar", "sidecar.wasm")
+        };
+        let project = TempDir::new().unwrap();
+
+        let resolved =
+            resolve_component_workload(&base, &component, &Config::default(), project.path(), None)
+                .unwrap();
+
+        assert_eq!(resolved.environment.get("LOG").unwrap(), "debug");
+        assert_eq!(
+            resolved.environment.get("SHARED").unwrap(),
+            "from_component"
+        );
+        assert_eq!(resolved.config.get("flag").unwrap(), "on");
+        assert_eq!(resolved.config.get("base_only").unwrap(), "1");
+        // allowedHosts omitted on the component → workload list applies.
+        assert_eq!(resolved.allowed_hosts, vec![AllowedHost::Any]);
+    }
+
+    #[test]
+    fn component_allowed_hosts_replaces_workload_list() {
+        let base = ResolvedWorkload {
+            allowed_hosts: vec![AllowedHost::Any],
+            ..Default::default()
+        };
+        let project = TempDir::new().unwrap();
+
+        // Explicit list replaces (does not append to) the workload list.
+        let component = DevComponent {
+            allowed_hosts: Some(vec!["https://api.example.com".parse().unwrap()]),
+            ..DevComponent::new("locked", "locked.wasm")
+        };
+        let resolved =
+            resolve_component_workload(&base, &component, &Config::default(), project.path(), None)
+                .unwrap();
+        assert_eq!(
+            resolved.allowed_hosts,
+            vec!["https://api.example.com".parse().unwrap()]
+        );
+
+        // Explicit empty list replaces too — deny-all for this component
+        // even though the workload allows everything.
+        let component = DevComponent {
+            allowed_hosts: Some(vec![]),
+            ..DevComponent::new("sealed", "sealed.wasm")
+        };
+        let resolved =
+            resolve_component_workload(&base, &component, &Config::default(), project.path(), None)
+                .unwrap();
+        assert!(resolved.allowed_hosts.is_empty());
+    }
+
+    #[test]
+    fn component_env_refs_resolve_and_missing_ref_names_component() {
+        // A component's environment.configFrom resolves against the same
+        // top-level `configs:` catalog as the workload's...
+        let config = Config {
+            config_sources: BTreeMap::from([(
+                "sidecar_cfg".to_string(),
+                ConfigSource {
+                    inline: HashMap::from([("FROM_CATALOG".into(), "yes".into())]),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+        let component = DevComponent {
+            environment: Some(EnvironmentLayer {
+                config_from: vec!["sidecar_cfg".into()],
+                ..Default::default()
+            }),
+            ..DevComponent::new("sidecar", "sidecar.wasm")
+        };
+        let project = TempDir::new().unwrap();
+        let resolved = resolve_component_workload(
+            &ResolvedWorkload::default(),
+            &component,
+            &config,
+            project.path(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved.environment.get("FROM_CATALOG").unwrap(), "yes");
+
+        // ...and a missing reference names the component in the error.
+        let component = DevComponent {
+            environment: Some(EnvironmentLayer {
+                config_from: vec!["missing".into()],
+                ..Default::default()
+            }),
+            ..DevComponent::new("sidecar", "sidecar.wasm")
+        };
+        let err = resolve_component_workload(
+            &ResolvedWorkload::default(),
+            &component,
+            &Config::default(),
+            project.path(),
+            None,
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("dev component 'sidecar'"), "{}", msg);
+        assert!(msg.contains("missing"), "{}", msg);
     }
 
     #[test]

--- a/templates/http-api-with-distributed-workloads/.wash/config.yaml
+++ b/templates/http-api-with-distributed-workloads/.wash/config.yaml
@@ -8,6 +8,19 @@ dev:
   components:
     - name: task-leet
       file: target/wasm32-wasip2/release/task_leet.wasm
+      # Per-component config overrides the workload defaults below for this
+      # worker only: it leetifies aggressively and prefixes its replies.
+      config:
+        leet.mode: aggressive
+        leet.prefix: "🤖 "
+
+# Workload-level values are the shared base layer for every component. The
+# task-leet worker reads these via wasi:config/store, overriding them with
+# its own `config:` block above.
+workload:
+  config:
+    leet.mode: basic
+    leet.prefix: ""
 
 new:
   command: cargo fetch

--- a/templates/http-api-with-distributed-workloads/README.md
+++ b/templates/http-api-with-distributed-workloads/README.md
@@ -50,8 +50,11 @@ The `worker` field determines the messaging subject (`tasks.{worker}`), allowing
 The transformed payload from the worker:
 
 ```
-H3110 W0r1d
+🤖 H3110 W0r1d
 ```
+
+The `🤖 ` prefix and aggressive leet substitution come from the worker's
+per-component config — see [Per-component configuration](#per-component-configuration).
 
 ### Example
 
@@ -68,3 +71,32 @@ curl -X POST http://localhost:8000/task \
   -H "Content-Type: application/json" \
   -d '{"payload": "Hello World", "worker": "leet"}'
 ```
+
+## Per-component configuration
+
+`.wash/config.yaml` shows how config is layered across a multi-component
+workload. The `workload:` block is the shared base.
+Each `dev.components` entry can override it on a per-key basis, mirroring the
+per-component `localResources` of a Kubernetes CRD `WorkloadDeployment`:
+
+```yaml
+dev:
+  components:
+    - name: task-leet
+      file: target/wasm32-wasip2/release/task_leet.wasm
+      config:                  # this worker's overrides
+        leet.mode: aggressive
+        leet.prefix: "🤖 "
+
+workload:
+  config:                      # shared defaults for every component
+    leet.mode: basic
+    leet.prefix: ""
+```
+
+The `task-leet` worker reads these via `wasi:config/store` (see
+`task-leet/src/lib.rs`): `leet.mode` toggles whether `l`/`t` are also
+substituted, and `leet.prefix` is prepended to each reply. Because the
+component's `config:` overrides the workload defaults, it runs in `aggressive`
+mode with the `🤖 ` prefix. Drop the per-component block and it falls back to
+the workload defaults (`basic`, no prefix → `H3llo W0rld`).

--- a/templates/http-api-with-distributed-workloads/task-leet/src/lib.rs
+++ b/templates/http-api-with-distributed-workloads/task-leet/src/lib.rs
@@ -6,12 +6,35 @@ mod bindings {
     });
 }
 
+use bindings::wasi::config::store;
 use bindings::wasmcloud::messaging::consumer;
 use bindings::wasmcloud::messaging::types::BrokerMessage;
 #[allow(unused)]
 use wstd::prelude::*;
 
 struct Component;
+
+/// Per-worker behavior, read from `wasi:config/store`. Values come from the
+/// workload-level `config:` block, with this component's `dev.components`
+/// entry overriding on a per-key basis (see `.wash/config.yaml`).
+struct Settings {
+    /// `basic` substitutes vowels and `s`; `aggressive` also maps `l`/`t`.
+    aggressive: bool,
+    /// Prepended to every reply. Empty by default.
+    prefix: String,
+}
+
+impl Settings {
+    fn load() -> Self {
+        // `get` returns Ok(None) when unset and Err only on a store fault;
+        // fall back to the basic, unprefixed defaults in either case.
+        let get = |key: &str| store::get(key).ok().flatten();
+        Settings {
+            aggressive: get("leet.mode").as_deref() == Some("aggressive"),
+            prefix: get("leet.prefix").unwrap_or_default(),
+        }
+    }
+}
 
 #[allow(unsafe_code)] // bindings::export! emits unsafe FFI shims
 mod export {
@@ -28,9 +51,10 @@ impl bindings::exports::wasmcloud::messaging::handler::Guest for Component {
         let payload = String::from_utf8(msg.body.to_vec())
             .map_err(|e| format!("Failed to decode message body: {}", e))?;
 
+        let settings = Settings::load();
         let reply = BrokerMessage {
             subject,
-            body: to_leet_speak(&payload).into(),
+            body: format!("{}{}", settings.prefix, to_leet_speak(&payload, &settings)).into(),
             reply_to: None,
         };
 
@@ -38,7 +62,7 @@ impl bindings::exports::wasmcloud::messaging::handler::Guest for Component {
     }
 }
 
-fn to_leet_speak(input: &str) -> String {
+fn to_leet_speak(input: &str, settings: &Settings) -> String {
     input
         .chars()
         .map(|c| match c.to_ascii_lowercase() {
@@ -47,8 +71,8 @@ fn to_leet_speak(input: &str) -> String {
             'i' => '1',
             'o' => '0',
             's' => '5',
-            't' => '7',
-            'l' => '1',
+            't' if settings.aggressive => '7',
+            'l' if settings.aggressive => '1',
             _ => c,
         })
         .collect()

--- a/templates/http-api-with-distributed-workloads/wit/world.wit
+++ b/templates/http-api-with-distributed-workloads/wit/world.wit
@@ -8,5 +8,8 @@ world http-api {
 
 world task {
   import wasmcloud:messaging/consumer@0.2.0;
+  // Per-component config (workload defaults + this worker's overrides),
+  // read via wasi:config/store. See .wash/config.yaml.
+  import wasi:config/store@0.2.0-rc.1;
   export wasmcloud:messaging/handler@0.2.0;
 }

--- a/templates/http-api-with-distributed-workloads/wkg.lock
+++ b/templates/http-api-with-distributed-workloads/wkg.lock
@@ -3,6 +3,15 @@
 version = 1
 
 [[packages]]
+name = "wasi:config"
+registry = "wasi.dev"
+
+[[packages.versions]]
+requirement = "=0.2.0-rc.1"
+version = "0.2.0-rc.1"
+digest = "sha256:1b7f1b0fd07bb4cede16c6a6ec8852815dfb924639a78735fc7bdffdc164485d"
+
+[[packages]]
 name = "wasmcloud:messaging"
 registry = "wasmcloud.com"
 


### PR DESCRIPTION
`workload.environment`, `workload.config`, and `workload.allowedHosts`
were only attached to the main dev component (or the service when
`dev.service = true`). Sidecars from `dev.components` and the
`dev.service_file` sidecar service received default LocalResources, so
env vars and allowed-host policy never reached linked components.

Workload values are now the workload-wide base layer, and
dev.components entries accept per-component environment / config /
allowedHosts overrides, mirroring the per-component localResources
shape of a WorkloadDeployment. environment and
config merge with the component; allowedHosts
replaces the workload list when set (an explicit empty list denies all
egress for that component). configFrom /
secretFrom resolve against the same top-level configs:/secrets:

The wasi:config plugin now merges each component's
LocalResources.config into its wasi:config/store view, layered between
the workload-scoped interface config and (with copy_environment) the
component's env vars.