### PR TITLE
multiple subscription workloads

### DIFF
--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -646,42 +646,36 @@ impl ResolvedWorkload {
 
     #[instrument(name="link_components", skip_all, fields(workload.id = self.id.as_ref(), workload.name = self.name.as_ref(), workload.namespace = self.namespace.as_ref()))]
     async fn link_components(&mut self) -> anyhow::Result<()> {
-        // A map from component ID to its exported interfaces
-        let mut interface_map: HashMap<String, Arc<str>> = HashMap::new();
-
-        // Determine available component exports to link to the rest of the workload
+        // Collect each component's exported component-instance interfaces.
+        let mut component_exports: Vec<(Arc<str>, Vec<String>)> = Vec::new();
         for c in self.components.read().await.values() {
-            let exported_instances = c.component_exports()?;
-            for (name, item) in exported_instances {
+            let mut names = Vec::new();
+            for (name, item) in c.component_exports()? {
                 // TODO(#11): It's probably a good idea to skip registering wasi@0.2 interfaces
-                match name.split_once('@') {
-                    Some(("wasmcloud:wash/plugin", _)) => {
-                        trace!(name, "skipping internal plugin export");
-                        continue;
-                    }
-                    None if name == "wasmcloud:wash/plugin" => {
-                        trace!(name, "skipping internal plugin export");
-                        continue;
-                    }
-                    None => {}
-                    _ => {}
+                if name == "wasmcloud:wash/plugin" || name.starts_with("wasmcloud:wash/plugin@") {
+                    trace!(name, "skipping internal plugin export");
+                    continue;
                 }
                 if let ComponentItem::ComponentInstance(_) = item {
-                    // Register the interface name to the component key
-                    if interface_map.contains_key(&name) {
-                        anyhow::bail!(
-                            "another component already implements the interface '{name}'"
-                        );
-                    }
-                    trace!(name, "registering component export for linking");
-                    interface_map.insert(name.clone(), Arc::from(c.id()));
+                    names.push(name);
                 } else {
                     warn!(name, "exported item is not a component instance, skipping");
                 }
             }
+            component_exports.push((Arc::from(c.id()), names));
         }
 
-        self.resolve_workload_imports(&interface_map).await?;
+        // Build the export→component map for intra-workload linking. An
+        // interface exported by more than one component is left out of the map
+        // and tracked as ambiguous; it only causes an error if a component
+        // actually imports it (host-invoked exports such as
+        // `wasmcloud:messaging/handler` or `wasi:http/incoming-handler` are
+        // consumed by host plugins, never imported intra-workload, so multiple
+        // exporters are fine).
+        let (interface_map, ambiguous_exports) = build_export_map(&component_exports);
+
+        self.resolve_workload_imports(&interface_map, &ambiguous_exports)
+            .await?;
 
         Ok(())
     }
@@ -696,6 +690,7 @@ impl ResolvedWorkload {
     async fn resolve_workload_imports(
         &mut self,
         interface_map: &HashMap<String, Arc<str>>,
+        ambiguous_exports: &HashSet<String>,
     ) -> anyhow::Result<()> {
         // Build a dependency graph: for each component, track which other components it imports from
         let mut dependencies: HashMap<Arc<str>, HashSet<Arc<str>>> = HashMap::new();
@@ -707,8 +702,21 @@ impl ResolvedWorkload {
                 let ty = component.metadata.component.component_type();
                 for (import_name, import_item) in ty.imports(component.metadata.component.engine())
                 {
-                    if matches!(import_item, ComponentItem::ComponentInstance(_))
-                        && let Some(exporter_id) = interface_map.get(import_name)
+                    if !matches!(import_item, ComponentItem::ComponentInstance(_)) {
+                        continue;
+                    }
+                    // An interface exported by multiple components can't be
+                    // resolved to a single provider for an intra-workload
+                    // import — that's the genuine ambiguity the link check
+                    // guards against.
+                    if ambiguous_exports.contains(import_name) {
+                        anyhow::bail!(
+                            "component '{component_id}' imports interface '{import_name}', \
+                             which is exported by multiple components in the workload; \
+                             cannot disambiguate the provider"
+                        );
+                    }
+                    if let Some(exporter_id) = interface_map.get(import_name)
                         && exporter_id != component_id
                     {
                         // This import is provided by another component in the workload
@@ -1818,6 +1826,44 @@ impl UnresolvedWorkload {
 /// # Returns
 /// A vector of component IDs in topological order (dependencies first), or an error
 /// if a circular dependency is detected.
+/// Builds the export→component map used to wire intra-workload component
+/// imports. An interface exported by exactly one component is registered for
+/// linking; an interface exported by more than one component is "ambiguous" —
+/// left out of the map and returned in the second set instead.
+///
+/// Ambiguity is not an error on its own: host-invoked exports (e.g.
+/// `wasmcloud:messaging/handler`, `wasi:http/incoming-handler`) are consumed
+/// by host plugins and never imported by another component, so multiple
+/// exporters are expected. The importer side ([`resolve_workload_imports`])
+/// errors only if a component actually imports an ambiguous interface.
+fn build_export_map(
+    component_exports: &[(Arc<str>, Vec<String>)],
+) -> (HashMap<String, Arc<str>>, HashSet<String>) {
+    let mut interface_map: HashMap<String, Arc<str>> = HashMap::new();
+    let mut ambiguous: HashSet<String> = HashSet::new();
+
+    for (component_id, names) in component_exports {
+        for name in names {
+            if ambiguous.contains(name) {
+                continue;
+            }
+            if interface_map.remove(name).is_some() {
+                // A second exporter for this interface: mark it ambiguous.
+                trace!(
+                    name,
+                    "interface exported by multiple components; deferring to import side"
+                );
+                ambiguous.insert(name.clone());
+            } else {
+                trace!(name, "registering component export for linking");
+                interface_map.insert(name.clone(), component_id.clone());
+            }
+        }
+    }
+
+    (interface_map, ambiguous)
+}
+
 fn topological_sort_components(
     dependencies: &HashMap<Arc<str>, HashSet<Arc<str>>>,
 ) -> anyhow::Result<Vec<Arc<str>>> {
@@ -2410,6 +2456,59 @@ mod tests {
 
     /// Tests topological sort with a chain dependency: A -> B -> C
     /// Expected order: C, B, A (or any valid topological order)
+    #[test]
+    fn build_export_map_registers_unique_exports() {
+        let exports = vec![
+            (
+                Arc::from("comp-a") as Arc<str>,
+                vec!["wasi:http/incoming-handler".to_string()],
+            ),
+            (
+                Arc::from("comp-b") as Arc<str>,
+                vec!["custom:pkg/iface".to_string()],
+            ),
+        ];
+        let (map, ambiguous) = build_export_map(&exports);
+        assert_eq!(
+            map.get("custom:pkg/iface").map(|c| c.as_ref()),
+            Some("comp-b")
+        );
+        assert!(ambiguous.is_empty());
+    }
+
+    #[test]
+    fn build_export_map_marks_duplicate_exports_ambiguous() {
+        // Two workers exporting the same handler interface: ambiguous, and
+        // dropped from the resolvable map (only an importer would error).
+        let exports = vec![
+            (
+                Arc::from("task-leet") as Arc<str>,
+                vec!["wasmcloud:messaging/handler@0.2.0".to_string()],
+            ),
+            (
+                Arc::from("task-reverse") as Arc<str>,
+                vec!["wasmcloud:messaging/handler@0.2.0".to_string()],
+            ),
+        ];
+        let (map, ambiguous) = build_export_map(&exports);
+        assert!(!map.contains_key("wasmcloud:messaging/handler@0.2.0"));
+        assert!(ambiguous.contains("wasmcloud:messaging/handler@0.2.0"));
+    }
+
+    #[test]
+    fn build_export_map_three_exporters_stay_ambiguous() {
+        // A third exporter must not accidentally re-register the interface.
+        let iface = "wasmcloud:messaging/handler@0.2.0".to_string();
+        let exports = vec![
+            (Arc::from("a") as Arc<str>, vec![iface.clone()]),
+            (Arc::from("b") as Arc<str>, vec![iface.clone()]),
+            (Arc::from("c") as Arc<str>, vec![iface.clone()]),
+        ];
+        let (map, ambiguous) = build_export_map(&exports);
+        assert!(!map.contains_key(&iface));
+        assert!(ambiguous.contains(&iface));
+    }
+
     #[test]
     fn test_topological_sort_chain() {
         let a: Arc<str> = Arc::from("component-a");

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -14,6 +14,10 @@ use tracing::{Instrument, debug, instrument, warn};
 const PLUGIN_MESSAGING_MEMORY_ID: &str = "wasmcloud-messaging-memory";
 const MAX_QUEUE_SIZE: usize = 10000;
 
+/// A component's message inbox, shared between the publisher side
+/// (`route_to_subscribers`) and the component's processing task.
+type Inbox = Arc<RwLock<VecDeque<types::BrokerMessage>>>;
+
 mod bindings {
     crate::wasmtime::component::bindgen!({
         world: "messaging",
@@ -27,27 +31,87 @@ use bindings::wasmcloud::messaging::types;
 
 use crate::plugin::WorkloadTracker;
 
-/// Per-workload tracking data
+/// Per-workload tracking data. Holds the reply-routing table shared by every
+/// component in the workload; message delivery itself is per-component (see
+/// [`ComponentData`]).
+#[derive(Default)]
 struct WorkloadData {
-    pending_messages: Arc<RwLock<VecDeque<types::BrokerMessage>>>,
     pending_requests: Arc<RwLock<HashMap<String, oneshot::Sender<types::BrokerMessage>>>>,
-    notify: Arc<Notify>,
 }
 
-impl Default for WorkloadData {
-    fn default() -> Self {
-        Self {
-            pending_messages: Arc::default(),
-            pending_requests: Arc::default(),
-            notify: Arc::new(Notify::new()),
-        }
-    }
-}
-
-/// Per-component tracking data
+/// Per-component tracking data. Each handler component has its own subject
+/// subscriptions and inbox queue, so a published message is delivered only to
+/// the components whose subscriptions match its subject.
 struct ComponentData {
     cancel_token: tokio_util::sync::CancellationToken,
     task_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Subjects this component subscribes to (NATS tokens: `*` one token,
+    /// `>` one or more trailing tokens). Empty means "receive everything",
+    /// preserving the single-handler behavior of earlier versions.
+    subscriptions: Vec<String>,
+    /// This component's inbox. `publish`/`request` push matching messages
+    /// here; the component's processing task drains it.
+    inbox: Inbox,
+    notify: Arc<Notify>,
+}
+
+/// Returns whether `subject` matches NATS subscription `pattern`, where `*`
+/// matches exactly one token and `>` matches one or more trailing tokens.
+fn subject_matches(pattern: &str, subject: &str) -> bool {
+    let mut subject_tokens = subject.split('.');
+    let mut pattern_tokens = pattern.split('.').peekable();
+    while let Some(pat) = pattern_tokens.next() {
+        if pat == ">" {
+            // `>` is only valid as the final token and matches one or more
+            // remaining subject tokens.
+            return pattern_tokens.peek().is_none() && subject_tokens.next().is_some();
+        }
+        match subject_tokens.next() {
+            Some(sub) if pat == "*" || pat == sub => continue,
+            _ => return false,
+        }
+    }
+    // Every pattern token matched; the subject must be fully consumed too.
+    subject_tokens.next().is_none()
+}
+
+/// Whether any of a component's `subscriptions` match `subject`. An empty
+/// subscription list matches everything (single-handler back-compat).
+fn subscriptions_match(subscriptions: &[String], subject: &str) -> bool {
+    subscriptions.is_empty() || subscriptions.iter().any(|s| subject_matches(s, subject))
+}
+
+/// Pushes `msg` onto the inbox of every component in `workload_id` whose
+/// subscriptions match its subject, waking each one. Returns an error only if
+/// the workload is untracked or a target inbox is full.
+async fn route_to_subscribers(
+    plugin: &InMemoryMessaging,
+    workload_id: &str,
+    msg: &types::BrokerMessage,
+) -> Result<(), String> {
+    let targets: Vec<(Inbox, Arc<Notify>)> = {
+        let lock = plugin.tracker.read().await;
+        let Some(item) = lock.workloads.get(workload_id) else {
+            return Err("workload state not found".to_string());
+        };
+        item.components
+            .values()
+            .filter(|c| subscriptions_match(&c.subscriptions, &msg.subject))
+            .map(|c| (c.inbox.clone(), c.notify.clone()))
+            .collect()
+    };
+
+    for (inbox, notify) in targets {
+        {
+            let mut queue = inbox.write().await;
+            if queue.len() >= MAX_QUEUE_SIZE {
+                return Err("message queue full".to_string());
+            }
+            queue.push_back(msg.clone());
+        }
+        notify.notify_one();
+    }
+    Ok(())
 }
 
 /// In-memory messaging plugin for wash dev and mocking scenarios.
@@ -90,14 +154,10 @@ impl<'a> Host for ActiveCtx<'a> {
 
         let workload_id = self.ctx.workload_id.to_string();
 
-        let (pending_messages, pending_requests, notify) = {
+        let pending_requests = {
             let lock = plugin.tracker.read().await;
             match lock.get_workload_data(&workload_id) {
-                Some(data) => (
-                    data.pending_messages.clone(),
-                    data.pending_requests.clone(),
-                    data.notify.clone(),
-                ),
+                Some(data) => data.pending_requests.clone(),
                 None => wasmtime::bail!("workload state not found"),
             }
         };
@@ -122,24 +182,10 @@ impl<'a> Host for ActiveCtx<'a> {
         };
 
         debug!(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"), "Sending request");
-        // Push the message to the queue
-        let queue_full = {
-            let mut msg_lock = pending_messages.write().await;
-
-            if msg_lock.len() >= MAX_QUEUE_SIZE {
-                true
-            } else {
-                msg_lock.push_back(msg);
-                false
-            }
-        };
-
-        if !queue_full {
-            notify.notify_one();
-        } else {
-            let mut req_lock = pending_requests.write().await;
-            req_lock.remove(&reply_to);
-            return Ok(Err("message queue full".to_string()));
+        // Route the request to subscribers of its subject.
+        if let Err(e) = route_to_subscribers(&plugin, &workload_id, &msg).await {
+            pending_requests.write().await.remove(&reply_to);
+            return Ok(Err(e));
         }
 
         // Wait for the response with timeout
@@ -169,21 +215,18 @@ impl<'a> Host for ActiveCtx<'a> {
         };
 
         let workload_id = self.ctx.workload_id.to_string();
-        let (pending_messages, pending_requests, notify) = {
+        let pending_requests = {
             let lock = plugin.tracker.read().await;
             match lock.get_workload_data(&workload_id) {
-                Some(data) => (
-                    data.pending_messages.clone(),
-                    data.pending_requests.clone(),
-                    data.notify.clone(),
-                ),
+                Some(data) => data.pending_requests.clone(),
                 None => wasmtime::bail!("workload state not found"),
             }
         };
 
         {
             let mut lock = pending_requests.write().await;
-            // Check if this is a reply to a pending request
+            // Check if this is a reply to a pending request. Reply subjects
+            // (`_INBOX.*`) are routed here, not to subscribers.
             if let Some(sender) = lock.remove(&msg.subject) {
                 debug!(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"), "Responding message");
                 // This is a response to a request - send it via the oneshot channel
@@ -194,17 +237,11 @@ impl<'a> Host for ActiveCtx<'a> {
 
         debug!(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"), "Publishing message");
 
-        // Regular publish - push to the pending messages queue
-        {
-            let mut lock = pending_messages.write().await;
-            if lock.len() >= MAX_QUEUE_SIZE {
-                return Ok(Err("message queue full".to_string()));
-            }
-
-            lock.push_back(msg);
+        // Regular publish - deliver to every subscriber of this subject.
+        match route_to_subscribers(&plugin, &workload_id, &msg).await {
+            Ok(()) => Ok(Ok(())),
+            Err(e) => Ok(Err(e)),
         }
-        notify.notify_one();
-        Ok(Ok(()))
     }
 }
 
@@ -269,6 +306,18 @@ impl HostPlugin for InMemoryMessaging {
             extract_active_ctx,
         )?;
 
+        // Per-component subscriptions come from this component's
+        // `LocalResources.config` (set via `dev.components[].config` or a
+        // WorkloadDeployment), so workers in one workload can subscribe to
+        // different subjects.
+        let subscriptions = super::parse_subscriptions(
+            component_handle
+                .local_resources()
+                .config
+                .get("subscriptions")
+                .map(String::as_str),
+        );
+
         let WorkloadItem::Component(component_handle) = component_handle else {
             // Only track components
             return Ok(());
@@ -279,12 +328,15 @@ impl HostPlugin for InMemoryMessaging {
             .exports
             .contains(&WitInterface::from("wasmcloud:messaging/handler@0.2.0"))
         {
-            debug!("Tracking component in in-memory messaging");
+            debug!(?subscriptions, "Tracking component in in-memory messaging");
             self.tracker.write().await.add_component(
                 component_handle,
                 ComponentData {
                     cancel_token: tokio_util::sync::CancellationToken::new(),
                     task_handle: None,
+                    subscriptions,
+                    inbox: Arc::default(),
+                    notify: Arc::new(Notify::new()),
                 },
             );
         }
@@ -297,18 +349,14 @@ impl HostPlugin for InMemoryMessaging {
         workload: &ResolvedWorkload,
         component_id: &str,
     ) -> anyhow::Result<()> {
-        let (pending_messages, notify) = {
-            let lock = self.tracker.read().await;
-            match lock.get_workload_data(workload.id()) {
-                Some(data) => (data.pending_messages.clone(), data.notify.clone()),
-                None => return Ok(()),
-            }
-        };
-
-        let cancel_token = {
+        let (inbox, notify, cancel_token) = {
             let lock = self.tracker.read().await;
             match lock.get_component_data(component_id) {
-                Some(data) => data.cancel_token.clone(),
+                Some(data) => (
+                    data.inbox.clone(),
+                    data.notify.clone(),
+                    data.cancel_token.clone(),
+                ),
                 None => return Ok(()),
             }
         };
@@ -335,11 +383,13 @@ impl HostPlugin for InMemoryMessaging {
                         break;
                     }
                     _ = notify.notified() => {
-                        // Try to get a message from the queue
-                        let msg = pending_messages.write().await.pop_front();
+                        // Drain every message queued since the last wakeup, so a
+                        // coalesced notification can't strand a message.
+                        loop {
+                        let msg = inbox.write().await.pop_front();
 
                         let Some(msg) = msg else {
-                            continue;
+                            break;
                         };
 
                         debug!(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"), "Processing message");
@@ -395,6 +445,7 @@ impl HostPlugin for InMemoryMessaging {
                                 }
                             };
                         });
+                        }
                     }
                 }
             }
@@ -432,5 +483,50 @@ impl HostPlugin for InMemoryMessaging {
             .await;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{subject_matches, subscriptions_match};
+
+    #[test]
+    fn exact_and_literal_tokens() {
+        assert!(subject_matches("tasks.leet", "tasks.leet"));
+        assert!(!subject_matches("tasks.leet", "tasks.reverse"));
+        // Token counts must match for a literal pattern.
+        assert!(!subject_matches("tasks.leet", "tasks.leet.extra"));
+        assert!(!subject_matches("tasks.leet.extra", "tasks.leet"));
+    }
+
+    #[test]
+    fn single_token_wildcard() {
+        assert!(subject_matches("tasks.*", "tasks.leet"));
+        assert!(subject_matches("tasks.*", "tasks.reverse"));
+        // `*` matches exactly one token, not zero and not many.
+        assert!(!subject_matches("tasks.*", "tasks"));
+        assert!(!subject_matches("tasks.*", "tasks.leet.v2"));
+    }
+
+    #[test]
+    fn multi_token_wildcard() {
+        assert!(subject_matches("tasks.>", "tasks.leet"));
+        assert!(subject_matches("tasks.>", "tasks.leet.v2"));
+        // `>` requires at least one trailing token.
+        assert!(!subject_matches("tasks.>", "tasks"));
+    }
+
+    #[test]
+    fn empty_subscriptions_match_everything() {
+        // Back-compat: a handler with no configured subscriptions receives
+        // every subject, preserving single-handler behavior.
+        assert!(subscriptions_match(&[], "anything.at.all"));
+    }
+
+    #[test]
+    fn non_empty_subscriptions_match_only_listed_subjects() {
+        let subs = vec!["tasks.leet".to_string()];
+        assert!(subscriptions_match(&subs, "tasks.leet"));
+        assert!(!subscriptions_match(&subs, "tasks.reverse"));
     }
 }

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
@@ -3,3 +3,46 @@ mod nats;
 
 pub use in_memory::InMemoryMessaging;
 pub use nats::NatsMessaging;
+
+/// Parses a comma-separated `subscriptions` config value into trimmed,
+/// non-empty subjects. Shared by the in-memory and NATS backends so they
+/// agree on how a configured subscription string maps to subjects.
+pub(crate) fn parse_subscriptions(raw: Option<&str>) -> Vec<String> {
+    raw.map(|s| {
+        s.split(',')
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect()
+    })
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_subscriptions;
+
+    #[test]
+    fn parses_single_subject() {
+        assert_eq!(
+            parse_subscriptions(Some("tasks.task-worker")),
+            vec!["tasks.task-worker".to_string()]
+        );
+    }
+
+    #[test]
+    fn parses_multiple_subjects() {
+        assert_eq!(
+            parse_subscriptions(Some("a,b,c")),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace_and_drops_empties() {
+        assert_eq!(
+            parse_subscriptions(Some(" tasks.leet , tasks.reverse ,, ")),
+            vec!["tasks.leet".to_string(), "tasks.reverse".to_string()]
+        );
+        assert!(parse_subscriptions(None).is_empty());
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -454,7 +454,6 @@ mod tests {
     use crate::plugin::WorkloadTrackerItem;
     use std::time::Duration;
 
-
     /// Tracker round-trip: stored subscriptions and a stored cancellation
     /// token are retrievable by the same component_id; cleanup cancels the
     /// stored token. Does not exercise the NATS client at all — the goal is

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -181,6 +181,12 @@ impl HostPlugin for NatsMessaging {
             return Ok(());
         };
 
+        // Subscriptions come from this component's own `LocalResources.config`
+        // (so workers in one workload can subscribe to different subjects),
+        // falling back to the workload-scoped host interface config. Capture
+        // the host-interface fallback before borrowing the component.
+        let interface_subscriptions = interface.config.get("subscriptions").cloned();
+
         bindings::wasmcloud::messaging::types::add_to_linker::<_, SharedCtx>(
             component_handle.linker(),
             extract_active_ctx,
@@ -190,15 +196,29 @@ impl HostPlugin for NatsMessaging {
             extract_active_ctx,
         )?;
 
-        if interface.interfaces.iter().any(|i| i == "handler") {
-            let raw_subscriptions = match interface.config.get("subscriptions") {
-                Some(subs) => subs.split(',').map(|s| s.to_string()).collect(),
-                None => vec![],
-            };
+        let local_subscriptions = component_handle
+            .local_resources()
+            .config
+            .get("subscriptions")
+            .cloned();
 
-            let WorkloadItem::Component(component_handle) = component_handle else {
-                anyhow::bail!("Service can not be tracked");
-            };
+        // Only components are tracked as handlers; services just get the
+        // consumer linker wired above.
+        let WorkloadItem::Component(component_handle) = component_handle else {
+            return Ok(());
+        };
+
+        // Track this component as a subscriber when its world exports the
+        // messaging handler, mirroring the in-memory backend. This works
+        // whether or not the workload declares a `wasmcloud:messaging` host
+        // interface entry.
+        if component_handle
+            .world()
+            .exports
+            .contains(&WitInterface::from("wasmcloud:messaging/handler@0.2.0"))
+        {
+            let raw = local_subscriptions.or(interface_subscriptions);
+            let raw_subscriptions = super::parse_subscriptions(raw.as_deref());
 
             debug!(
                 component_id = component_handle.id(),
@@ -434,36 +454,6 @@ mod tests {
     use crate::plugin::WorkloadTrackerItem;
     use std::time::Duration;
 
-    /// Mirrors `on_workload_item_bind`'s parsing of the `subscriptions`
-    /// config string. Locks in the comma-split contract so a regression
-    /// (e.g. switching to a different separator, accidentally trimming) is
-    /// caught without spinning up the full plugin lifecycle.
-    fn parse_subscriptions(s: &str) -> Vec<String> {
-        s.split(',').map(|s| s.to_string()).collect()
-    }
-
-    #[test]
-    fn subscriptions_config_single() {
-        assert_eq!(
-            parse_subscriptions("tasks.task-worker"),
-            vec!["tasks.task-worker"]
-        );
-    }
-
-    #[test]
-    fn subscriptions_config_multiple() {
-        assert_eq!(
-            parse_subscriptions("a,b,c"),
-            vec!["a".to_string(), "b".to_string(), "c".to_string()]
-        );
-    }
-
-    #[test]
-    fn subscriptions_config_preserves_inner_whitespace() {
-        // Subjects with whitespace are unusual but the chart and operator
-        // pass the value through verbatim — make sure we don't trim.
-        assert_eq!(parse_subscriptions(" tasks.x "), vec![" tasks.x "]);
-    }
 
     /// Tracker round-trip: stored subscriptions and a stored cancellation
     /// token are retrievable by the same component_id; cleanup cancels the

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -100,17 +100,9 @@ impl CliCommand for DevCommand {
             None
         };
 
-        // Enable wasmcloud:messaging — NATS when a messaging URL or the shared
-        // data_nats_url is configured, otherwise the in-memory backend.
-        if let Some(nats_url) = &dev_config.wasmcloud_messaging_nats_url {
-            let nats_client = async_nats::connect(nats_url.as_str())
-                .await
-                .context("failed to connect to NATS for messaging plugin")?;
-            host_builder = host_builder.with_plugin(Arc::new(
-                plugin::wasmcloud_messaging::NatsMessaging::new(Arc::new(nats_client)),
-            ))?;
-            debug!(url = %nats_url, "wasmcloud:messaging plugin registered with NATS backend");
-        } else if let Some(client) = &data_nats_client {
+        // Enable wasmcloud:messaging — NATS when data_nats_url is configured,
+        // otherwise the in-memory backend.
+        if let Some(client) = &data_nats_client {
             host_builder = host_builder.with_plugin(Arc::new(
                 plugin::wasmcloud_messaging::NatsMessaging::new(client.clone()),
             ))?;

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -87,12 +87,45 @@ impl CliCommand for DevCommand {
                 .build(),
         ))?;
 
-        // Enable wasmcloud:messaging
-        host_builder = host_builder.with_plugin(Arc::new(
-            plugin::wasmcloud_messaging::InMemoryMessaging::default(),
-        ))?;
+        // Shared data-plane NATS connection, mirroring `wash host`
+        // `--data-nats-url`. When `dev.data_nats_url` is set it backs
+        // blobstore, keyvalue, and messaging unless a per-plugin config overrides
+        // it. Connected once and shared across the three plugins.
+        let data_nats_client = if let Some(url) = &dev_config.data_nats_url {
+            let client = async_nats::connect(url.as_str())
+                .await
+                .context("failed to connect to NATS for dev.data_nats_url")?;
+            Some(Arc::new(client))
+        } else {
+            None
+        };
 
-        // Add blobstore plugin
+        // Enable wasmcloud:messaging — NATS when a messaging URL or the shared
+        // data_nats_url is configured, otherwise the in-memory backend.
+        if let Some(nats_url) = &dev_config.wasmcloud_messaging_nats_url {
+            let nats_client = async_nats::connect(nats_url.as_str())
+                .await
+                .context("failed to connect to NATS for messaging plugin")?;
+            host_builder = host_builder.with_plugin(Arc::new(
+                plugin::wasmcloud_messaging::NatsMessaging::new(Arc::new(nats_client)),
+            ))?;
+            debug!(url = %nats_url, "wasmcloud:messaging plugin registered with NATS backend");
+        } else if let Some(client) = &data_nats_client {
+            host_builder = host_builder.with_plugin(Arc::new(
+                plugin::wasmcloud_messaging::NatsMessaging::new(client.clone()),
+            ))?;
+            debug!("wasmcloud:messaging plugin registered with NATS backend (data_nats_url)");
+        } else {
+            host_builder = host_builder.with_plugin(Arc::new(
+                plugin::wasmcloud_messaging::InMemoryMessaging::default(),
+            ))?;
+            debug!("wasmcloud:messaging plugin registered with in-memory backend");
+        }
+
+        // Per-plugin settings override the in-memory default. The order of precedence is:
+        // use a filesystem backend if there is a path override,
+        // otherwise it uses NATS if `data_nats_url` is set, otherwise it falls back to
+        // the in-memory plugin.
         if let Some(blobstore_path) = &dev_config.wasi_blobstore_path {
             host_builder = host_builder.with_plugin(Arc::new(
                 plugin::wasi_blobstore::FilesystemBlobstore::new(blobstore_path.clone()),
@@ -101,6 +134,10 @@ impl CliCommand for DevCommand {
                 path = %blobstore_path.display(),
                 "WASI Blobstore plugin registered with filesystem backend"
             );
+        } else if let Some(client) = &data_nats_client {
+            host_builder = host_builder
+                .with_plugin(Arc::new(plugin::wasi_blobstore::NatsBlobstore::new(client)))?;
+            debug!("WASI Blobstore plugin registered with NATS backend (data_nats_url)");
         } else {
             host_builder = host_builder.with_plugin(Arc::new(
                 plugin::wasi_blobstore::InMemoryBlobstore::default(),
@@ -161,7 +198,9 @@ impl CliCommand for DevCommand {
             host_builder.with_plugin(Arc::new(plugin::wasi_logging::TracingLogger::default()))?;
         debug!("Logging plugin registered");
 
-        // Add keyvalue plugin — Redis > NATS > filesystem > in-memory
+        // Add keyvalue plugin — Redis > NATS override > filesystem >
+        // NATS (data_nats_url) > in-memory. Per-plugin settings win over the
+        // shared data_nats_url default.
         if let Some(redis_url) = &dev_config.wasi_keyvalue_redis_url {
             host_builder = host_builder.with_plugin(Arc::new(
                 plugin::wasi_keyvalue::RedisKeyValue::from_url(redis_url)
@@ -184,6 +223,10 @@ impl CliCommand for DevCommand {
                 path = %keyvalue_path.display(),
                 "WASI KeyValue plugin registered with filesystem backend"
             );
+        } else if let Some(client) = &data_nats_client {
+            host_builder = host_builder
+                .with_plugin(Arc::new(plugin::wasi_keyvalue::NatsKeyValue::new(client)))?;
+            debug!("WASI KeyValue plugin registered with NATS backend (data_nats_url)");
         } else {
             host_builder = host_builder
                 .with_plugin(Arc::new(plugin::wasi_keyvalue::InMemoryKeyValue::default()))?;

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -422,6 +422,16 @@ pub struct DevConfig {
     #[serde(default)]
     pub wasi_webgpu: bool,
 
+    /// Shared NATS connection URL for the data-plane plugins
+    /// blobstore, keyvalue, and messaging. Mirroring the `wash host`
+    /// with `--data-nats-url`. When set, all three use NATS unless a per-plugin
+    /// URL below overrides it (e.g. `wasi_keyvalue_redis_url`,
+    /// `wasi_keyvalue_path`, `wasi_keyvalue_nats_url`,
+    /// `wasmcloud_messaging_nats_url`, `wasi_blobstore_path`).
+    /// Example: nats://127.0.0.1:4222
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_nats_url: Option<String>,
+
     /// Optional Redis connection URL for the WASI keyvalue plugin.
     /// Example: redis://127.0.0.1:6379
     /// When set, takes precedence over wasi_keyvalue_path.
@@ -432,11 +442,20 @@ pub struct DevConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wasi_keyvalue_path: Option<PathBuf>,
 
-    /// Optional NATS connection URL for the WASI keyvalue plugin.
+    /// Optional NATS connection URL for the WASI keyvalue plugin. Overrides
+    /// `data_nats_url` for keyvalue.
     /// Example: nats://127.0.0.1:4222
     /// When set, takes precedence over wasi_keyvalue_path but is overridden by wasi_keyvalue_redis_url.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wasi_keyvalue_nats_url: Option<String>,
+
+    /// Optional NATS connection URL for the wasmcloud:messaging plugin.
+    /// Overrides `data_nats_url` for messaging.
+    /// Example: nats://127.0.0.1:4222
+    /// When set (or when `data_nats_url` is set), components subscribe to real
+    /// NATS subjects; otherwise an in-memory backend is used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wasmcloud_messaging_nats_url: Option<String>,
 
     /// Optional path for WASI blobstore filesystem storage. If not set, an in-memory store is used.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -478,6 +497,9 @@ impl DevConfig {
             _ => {}
         }
 
+        if let Some(url) = &self.data_nats_url {
+            check_url_scheme("dev.data_nats_url", url, &["nats", "tls"], &mut errors);
+        }
         if let Some(url) = &self.wasi_keyvalue_redis_url {
             check_url_scheme(
                 "dev.wasi_keyvalue_redis_url",
@@ -489,6 +511,14 @@ impl DevConfig {
         if let Some(url) = &self.wasi_keyvalue_nats_url {
             check_url_scheme(
                 "dev.wasi_keyvalue_nats_url",
+                url,
+                &["nats", "tls"],
+                &mut errors,
+            );
+        }
+        if let Some(url) = &self.wasmcloud_messaging_nats_url {
+            check_url_scheme(
+                "dev.wasmcloud_messaging_nats_url",
                 url,
                 &["nats", "tls"],
                 &mut errors,
@@ -769,9 +799,11 @@ pub fn example_config() -> Config {
                 config: HashMap::new(),
                 name: None,
             }],
+            data_nats_url: Some("nats://127.0.0.1:4222".to_string()),
             wasi_keyvalue_redis_url: Some("redis://127.0.0.1:6379".to_string()),
             wasi_keyvalue_path: Some(PathBuf::from("./data/keyvalue")),
             wasi_keyvalue_nats_url: Some("nats://127.0.0.1:4222".to_string()),
+            wasmcloud_messaging_nats_url: Some("nats://127.0.0.1:4222".to_string()),
             wasi_blobstore_path: Some(PathBuf::from("./data/blobstore")),
             postgres_url: Some("postgres://user:pass@127.0.0.1:5432".to_string()),
             ..Default::default()
@@ -1020,6 +1052,44 @@ workload:
     fn dev_nats_valid_scheme_is_ok() {
         let cfg = DevConfig {
             wasi_keyvalue_nats_url: Some("nats://127.0.0.1:4222".to_string()),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn dev_data_nats_wrong_scheme_is_err() {
+        let cfg = DevConfig {
+            data_nats_url: Some("http://localhost:4222".to_string()),
+            ..Default::default()
+        };
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(err.contains("data_nats_url"));
+    }
+
+    #[test]
+    fn dev_data_nats_valid_scheme_is_ok() {
+        let cfg = DevConfig {
+            data_nats_url: Some("nats://127.0.0.1:4222".to_string()),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn dev_messaging_nats_wrong_scheme_is_err() {
+        let cfg = DevConfig {
+            wasmcloud_messaging_nats_url: Some("http://localhost:4222".to_string()),
+            ..Default::default()
+        };
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(err.contains("wasmcloud_messaging_nats_url"));
+    }
+
+    #[test]
+    fn dev_messaging_nats_valid_scheme_is_ok() {
+        let cfg = DevConfig {
+            wasmcloud_messaging_nats_url: Some("nats://127.0.0.1:4222".to_string()),
             ..Default::default()
         };
         assert!(cfg.validate().is_ok());

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -426,8 +426,7 @@ pub struct DevConfig {
     /// blobstore, keyvalue, and messaging. Mirroring the `wash host`
     /// with `--data-nats-url`. When set, all three use NATS unless a per-plugin
     /// URL below overrides it (e.g. `wasi_keyvalue_redis_url`,
-    /// `wasi_keyvalue_path`, `wasi_keyvalue_nats_url`,
-    /// `wasmcloud_messaging_nats_url`, `wasi_blobstore_path`).
+    /// `wasi_keyvalue_path`, `wasi_keyvalue_nats_url`, `wasi_blobstore_path`).
     /// Example: nats://127.0.0.1:4222
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_nats_url: Option<String>,
@@ -448,14 +447,6 @@ pub struct DevConfig {
     /// When set, takes precedence over wasi_keyvalue_path but is overridden by wasi_keyvalue_redis_url.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wasi_keyvalue_nats_url: Option<String>,
-
-    /// Optional NATS connection URL for the wasmcloud:messaging plugin.
-    /// Overrides `data_nats_url` for messaging.
-    /// Example: nats://127.0.0.1:4222
-    /// When set (or when `data_nats_url` is set), components subscribe to real
-    /// NATS subjects; otherwise an in-memory backend is used.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub wasmcloud_messaging_nats_url: Option<String>,
 
     /// Optional path for WASI blobstore filesystem storage. If not set, an in-memory store is used.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -511,14 +502,6 @@ impl DevConfig {
         if let Some(url) = &self.wasi_keyvalue_nats_url {
             check_url_scheme(
                 "dev.wasi_keyvalue_nats_url",
-                url,
-                &["nats", "tls"],
-                &mut errors,
-            );
-        }
-        if let Some(url) = &self.wasmcloud_messaging_nats_url {
-            check_url_scheme(
-                "dev.wasmcloud_messaging_nats_url",
                 url,
                 &["nats", "tls"],
                 &mut errors,
@@ -803,7 +786,6 @@ pub fn example_config() -> Config {
             wasi_keyvalue_redis_url: Some("redis://127.0.0.1:6379".to_string()),
             wasi_keyvalue_path: Some(PathBuf::from("./data/keyvalue")),
             wasi_keyvalue_nats_url: Some("nats://127.0.0.1:4222".to_string()),
-            wasmcloud_messaging_nats_url: Some("nats://127.0.0.1:4222".to_string()),
             wasi_blobstore_path: Some(PathBuf::from("./data/blobstore")),
             postgres_url: Some("postgres://user:pass@127.0.0.1:5432".to_string()),
             ..Default::default()
@@ -1071,25 +1053,6 @@ workload:
     fn dev_data_nats_valid_scheme_is_ok() {
         let cfg = DevConfig {
             data_nats_url: Some("nats://127.0.0.1:4222".to_string()),
-            ..Default::default()
-        };
-        assert!(cfg.validate().is_ok());
-    }
-
-    #[test]
-    fn dev_messaging_nats_wrong_scheme_is_err() {
-        let cfg = DevConfig {
-            wasmcloud_messaging_nats_url: Some("http://localhost:4222".to_string()),
-            ..Default::default()
-        };
-        let err = cfg.validate().unwrap_err().to_string();
-        assert!(err.contains("wasmcloud_messaging_nats_url"));
-    }
-
-    #[test]
-    fn dev_messaging_nats_valid_scheme_is_ok() {
-        let cfg = DevConfig {
-            wasmcloud_messaging_nats_url: Some("nats://127.0.0.1:4222".to_string()),
             ..Default::default()
         };
         assert!(cfg.validate().is_ok());

--- a/templates/http-api-with-distributed-workloads/.wash/config.yaml
+++ b/templates/http-api-with-distributed-workloads/.wash/config.yaml
@@ -6,21 +6,23 @@ build:
 
 dev:
   components:
+    # Each worker subscribes to its own subject, so `tasks.leet` routes to
+    # task-leet and `tasks.reverse` routes to task-reverse. `subscriptions`
+    # is per-component config read by the messaging backend (in-memory for
+    # `wash dev`, or NATS when `data_nats_url` is set).
     - name: task-leet
       file: target/wasm32-wasip2/release/task_leet.wasm
-      # Per-component config overrides the workload defaults below for this
-      # worker only: it leetifies aggressively and prefixes its replies.
+      # Per-component config for this worker
       config:
+        subscriptions: tasks.leet
         leet.mode: aggressive
         leet.prefix: "🤖 "
-
-# Workload-level values are the shared base layer for every component. The
-# task-leet worker reads these via wasi:config/store, overriding them with
-# its own `config:` block above.
-workload:
-  config:
-    leet.mode: basic
-    leet.prefix: ""
+    - name: task-reverse
+      file: target/wasm32-wasip2/release/task_reverse.wasm
+      config:
+        subscriptions: tasks.reverse
+        reverse.mode: words
+        reverse.prefix: "🔁 "
 
 new:
   command: cargo fetch

--- a/templates/http-api-with-distributed-workloads/Cargo.lock
+++ b/templates/http-api-with-distributed-workloads/Cargo.lock
@@ -315,6 +315,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "task-reverse"
+version = "0.1.0"
+dependencies = [
+ "wit-bindgen",
+ "wstd",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/templates/http-api-with-distributed-workloads/Cargo.toml
+++ b/templates/http-api-with-distributed-workloads/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "3"
 package.edition = "2024"
 package.authors = ["The wasmCloud Team"]
-members = ["http-api", "task-leet"]
+members = ["http-api", "task-leet", "task-reverse"]
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/templates/http-api-with-distributed-workloads/README.md
+++ b/templates/http-api-with-distributed-workloads/README.md
@@ -1,83 +1,115 @@
-# HTTP API with Distributed Workloads
+# http-api-with-distributed-workloads
 
-A wasmCloud template demonstrating distributed workloads using messaging. An HTTP API receives requests and delegates processing to background workers via a message broker.
+A wasmCloud template demonstrating an HTTP API with distributed workloads via
+[`wasmcloud:messaging`][messaging]. An HTTP API receives requests and delegates
+processing to background worker components over the messaging interface, with
+each worker subscribed to its own subject.
+
+[messaging]: https://github.com/wasmCloud/wasmCloud/tree/main/wit/messaging
+
+| Part | Type | What it does |
+|---|---|---|
+| `http-api/` | wasmCloud **component** | HTTP API — `POST /task` dispatches work to `tasks.{worker}` via `wasmcloud:messaging/consumer` and returns the reply |
+| `task-leet/` | wasmCloud **component** | Worker subscribed to `tasks.leet` — exports `wasmcloud:messaging/handler`, converts payloads to leet speak |
+| `task-reverse/` | wasmCloud **component** | Worker subscribed to `tasks.reverse` — exports `wasmcloud:messaging/handler`, reverses the text |
 
 ## Architecture
 
 ```
-┌────────┐      ┌──────────┐      ┌─────────────────┐      ┌─────────────┐
-│ Client │─────▶│ HTTP API │─────▶│ Message Broker  │─────▶│ Task Worker │
-│        │◀─────│ (:8000)  │◀─────│ (NATS)          │◀─────│ (task-leet) │
-└────────┘      └──────────┘      └─────────────────┘      └─────────────┘
-                    │                                            │
-              POST /task                                   Transforms text
-              { worker, payload }                          to leet speak
+┌────────┐      ┌──────────┐      ┌────────────────┐      ┌──────────────┐
+│ Client │─────▶│ HTTP API │─────▶│ Message Broker │──┬──▶│ task-leet    │  tasks.leet
+│        │◀─────│ (:8000)  │◀─────│ (in-memory or  │  │   └──────────────┘
+└────────┘      └──────────┘      │     NATS)      │  │   ┌──────────────┐
+                    │             └────────────────┘  └──▶│ task-reverse │  tasks.reverse
+              POST /task                                   └──────────────┘
+              { worker, payload }
 ```
 
-### Components
+1. Client sends a POST request to `/task` with a JSON payload.
+2. `http-api` publishes a request to subject `tasks.{worker}` (default: `tasks.leet`).
+3. The broker routes the message to the worker subscribed to that subject.
+4. The worker processes the payload and publishes the response to the `reply_to` subject.
+5. `http-api` returns the transformed response to the HTTP client.
 
-- **http-api**: HTTP server exposing the `/task` endpoint
-- **task-leet**: Message handler that processes tasks (converts text to leet speak)
+During development with `wash dev`, the wasmCloud runtime routes calls between
+components in-process — no NATS server required. In production, the runtime's
+built-in messaging plugin connects to NATS automatically when the host starts
+with a NATS URL (`wash host --data-nats-url nats://...`). No separate provider
+deployment is needed.
 
-### How It Works
+## Prerequisites
 
-1. Client sends a POST request to `/task` with a JSON payload
-2. HTTP API publishes a request to subject `tasks.{worker}` (default: `tasks.default`)
-3. Task worker receives the message and processes the payload
-4. Worker publishes the response back via the `reply_to` subject
-5. HTTP API returns the transformed response to the client
+- [Wasm Shell (`wash`)][wash]
+- [Rust toolchain][rust] with the `wasm32-wasip2` target (`rustup target add wasm32-wasip2`)
 
-The request has a 5-second timeout for the worker to respond.
+[wash]: https://wasmcloud.com/docs/installation
+[rust]: https://www.rust-lang.org/tools/install
 
-## The /task Endpoint
+## Quick start
 
-### Request
+Use `wash new` to scaffold a new project:
 
-```
-POST /task
-Content-Type: application/json
-
-{
-  "worker": "default",  // optional, defaults to "default"
-  "payload": "Hello World"
-}
-```
-
-The `worker` field determines the messaging subject (`tasks.{worker}`), allowing you to route to different workers.
-
-### Response
-
-The transformed payload from the worker:
-
-```
-🤖 H3110 W0r1d
+```shell
+wash new https://github.com/wasmCloud/wasmCloud.git \
+  --name http-api-with-distributed-workloads \
+  --subfolder templates/http-api-with-distributed-workloads
 ```
 
-The `🤖 ` prefix and aggressive leet substitution come from the worker's
-per-component config — see [Per-component configuration](#per-component-configuration).
+```shell
+cd http-api-with-distributed-workloads
+```
 
-### Example
+Start the development server:
 
-```bash
+```shell
 wash dev
 ```
 
-Then open [http://localhost:8000/](http://localhost:8000/).
+Then open http://localhost:8000 to use the web UI, or test with curl:
 
-Using the `/task` endpoint directly:
+```shell
+# Routes to task-leet (tasks.leet)
+curl -s -X POST http://localhost:8000/task \
+  -H 'Content-Type: application/json' \
+  -d '{"worker": "leet", "payload": "Hello World"}'
+# => 🤖 H3110 W0r1d
 
-```bash
-curl -X POST http://localhost:8000/task \
-  -H "Content-Type: application/json" \
-  -d '{"payload": "Hello World", "worker": "leet"}'
+# Routes to task-reverse (tasks.reverse)
+curl -s -X POST http://localhost:8000/task \
+  -H 'Content-Type: application/json' \
+  -d '{"worker": "reverse", "payload": "Hello World"}'
+# => 🔁 World Hello
+```
+
+The `worker` field selects the subject (`tasks.{worker}`), routing the request
+to the worker subscribed to it: `leet` → task-leet, `reverse` → task-reverse.
+The request has a 5-second timeout for the worker to respond.
+
+## Project structure
+
+```
+.
+├── .wash/config.yaml          # wash build & dev configuration (workload + per-component config)
+├── Cargo.toml                 # cargo workspace root
+│
+├── http-api/                  # HTTP front-end component
+│   ├── src/lib.rs             # wstd HTTP server + messaging consumer usage
+│   ├── ui.html                # branded task-submission UI
+│   └── ...
+│
+├── task-leet/                 # Leet-speak worker (tasks.leet)
+│   └── src/lib.rs             # messaging handler + wasi:config + leet logic
+│
+├── task-reverse/              # Reverse worker (tasks.reverse)
+│   └── src/lib.rs             # messaging handler + wasi:config + reverse logic
+│
+└── wit/world.wit              # shared WIT worlds for the components
 ```
 
 ## Per-component configuration
 
 `.wash/config.yaml` shows how config is layered across a multi-component
-workload. The `workload:` block is the shared base.
-Each `dev.components` entry can override it on a per-key basis, mirroring the
-per-component `localResources` of a Kubernetes CRD `WorkloadDeployment`:
+workload.
 
 ```yaml
 dev:
@@ -85,18 +117,113 @@ dev:
     - name: task-leet
       file: target/wasm32-wasip2/release/task_leet.wasm
       config:                  # this worker's overrides
+        subscriptions: tasks.leet
         leet.mode: aggressive
         leet.prefix: "🤖 "
-
-workload:
-  config:                      # shared defaults for every component
-    leet.mode: basic
-    leet.prefix: ""
+    - name: task-reverse
+      file: target/wasm32-wasip2/release/task_reverse.wasm
+      config:
+        subscriptions: tasks.reverse
+        reverse.mode: words
+        reverse.prefix: "🔁 "
 ```
 
-The `task-leet` worker reads these via `wasi:config/store` (see
-`task-leet/src/lib.rs`): `leet.mode` toggles whether `l`/`t` are also
-substituted, and `leet.prefix` is prepended to each reply. Because the
-component's `config:` overrides the workload defaults, it runs in `aggressive`
-mode with the `🤖 ` prefix. Drop the per-component block and it falls back to
-the workload defaults (`basic`, no prefix → `H3llo W0rld`).
+Two kinds of per-component config are at work:
+
+- **`subscriptions`** is read by the messaging backend (in-memory for
+  `wash dev`, or NATS) to decide which subjects each worker receives. This is
+  what makes `tasks.leet` route to task-leet and `tasks.reverse` to
+  task-reverse rather than both workers competing for every message.
+- **`leet.*` / `reverse.*`** are read by the worker itself via
+  `wasi:config/store` (see `task-leet/src/lib.rs`, `task-reverse/src/lib.rs`).
+  `leet.mode` toggles whether `l`/`t` are also substituted; `reverse.mode`
+  switches between reversing characters and words; the `*.prefix` is prepended
+  to each reply.
+
+## wasmcloud:messaging
+
+This template demonstrates both sides of the `wasmcloud:messaging` interface:
+
+| Interface | Direction | Purpose |
+|---|---|---|
+| `wasmcloud:messaging/consumer` | import | Send messages (`request`, `publish`) |
+| `wasmcloud:messaging/handler` | export | Receive messages (`handle-message`) |
+
+All three components import `consumer` — `http-api` to dispatch tasks via
+`request()`, the workers to publish replies via `publish()`. Each worker exports
+`handler` and subscribes to its own subject.
+
+## Build Wasm binaries
+
+```bash
+wash build
+```
+
+Artifacts:
+- `target/wasm32-wasip2/release/http_api.wasm`
+- `target/wasm32-wasip2/release/task_leet.wasm`
+- `target/wasm32-wasip2/release/task_reverse.wasm`
+
+## WIT interfaces
+
+```wit
+// wit/world.wit
+world http-api {
+  import wasmcloud:messaging/consumer@0.2.0;
+  // wasi:http/incoming-handler is exported via wstd's #[http_server] macro.
+}
+
+world task {
+  import wasmcloud:messaging/consumer@0.2.0;
+  import wasi:config/store@0.2.0-rc.1;
+  export wasmcloud:messaging/handler@0.2.0;
+}
+```
+
+## Production deployment
+
+All three components run on the same wasmCloud host. Deploy them together using
+a `WorkloadDeployment` manifest, giving each worker its own `subscriptions`:
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: http-api-with-distributed-workloads
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: your-domain.example.com    # HTTP Host header used for routing
+      components:
+        - name: http-api
+          image: <registry>/http_api:latest
+        - name: task-leet
+          image: <registry>/task_leet:latest
+          localResources:
+            config:
+              subscriptions: tasks.leet      # subjects this worker subscribes to
+              leet.mode: aggressive
+              leet.prefix: "🤖 "
+        - name: task-reverse
+          image: <registry>/task_reverse:latest
+          localResources:
+            config:
+              subscriptions: tasks.reverse
+              reverse.mode: words
+              reverse.prefix: "🔁 "
+```
+
+The `hostInterfaces` block declares which built-in capabilities the workload
+needs. No separate HTTP server or NATS messaging component is required; both are
+provided by the runtime. `subscriptions` is comma-separated NATS subject
+patterns; e.g. `tasks.>` matches any subject starting with `tasks.`.
+
+For Kubernetes deployment, see the
+[runtime-operator documentation](https://github.com/wasmCloud/wasmCloud/tree/main/runtime-operator).

--- a/templates/http-api-with-distributed-workloads/http-api/src/lib.rs
+++ b/templates/http-api-with-distributed-workloads/http-api/src/lib.rs
@@ -47,9 +47,11 @@ async fn create_task(mut req: Request<Body>) -> anyhow::Result<Response<Body>> {
         .await
         .context("failed to parse body")?;
 
+    // The worker name selects the subject (`tasks.{worker}`), which routes to
+    // the worker subscribed to it (see `.wash/config.yaml`).
     let subject = format!(
         "tasks.{}",
-        task_request.worker.unwrap_or_else(|| "default".to_string())
+        task_request.worker.unwrap_or_else(|| "leet".to_string())
     );
 
     let body = task_request.payload.into_bytes();

--- a/templates/http-api-with-distributed-workloads/http-api/ui.html
+++ b/templates/http-api-with-distributed-workloads/http-api/ui.html
@@ -3,21 +3,41 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Task API</title>
+    <title>Task API · wasmCloud</title>
     <style>
-        * {
-            box-sizing: border-box;
-        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            max-width: 600px;
-            margin: 40px auto;
-            padding: 20px;
-            background: #f5f5f5;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: linear-gradient(135deg, #0a0a0a 0%, #1a0f2e 50%, #0a0a0a 100%);
+            min-height: 100vh;
+            padding: 2rem;
+            color: #1a1a1a;
         }
+        .container { max-width: 600px; margin: 0 auto; }
+
+        .header { text-align: center; margin-bottom: 2rem; }
         h1 {
-            color: #333;
-            margin-bottom: 24px;
+            color: white;
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+        }
+        .powered-by {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            color: rgba(255, 255, 255, 0.9);
+            font-size: 0.9rem;
+        }
+        .wasmcloud-logo { height: 24px; width: auto; vertical-align: middle; }
+
+        .card {
+            background: white;
+            border-radius: 12px;
+            padding: 2rem;
+            margin-bottom: 2rem;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
         }
         label {
             display: block;
@@ -29,38 +49,40 @@
             width: 100%;
             padding: 10px;
             border: 1px solid #ccc;
-            border-radius: 4px;
+            border-radius: 6px;
             font-size: 14px;
             margin-bottom: 16px;
+        }
+        select:focus, textarea:focus {
+            outline: none;
+            border-color: #685bc7;
+            box-shadow: 0 0 0 3px rgba(104, 91, 199, 0.15);
         }
         textarea {
             min-height: 120px;
             resize: vertical;
         }
         button {
-            background: #0066cc;
+            background: #685bc7;
             color: white;
             border: none;
             padding: 12px 24px;
-            border-radius: 4px;
+            border-radius: 6px;
             font-size: 14px;
+            font-weight: 600;
             cursor: pointer;
         }
-        button:hover {
-            background: #0052a3;
-        }
-        button:disabled {
-            background: #999;
-            cursor: not-allowed;
-        }
+        button:hover { background: #574aae; }
+        button:disabled { background: #999; cursor: not-allowed; }
         #result {
             margin-top: 24px;
             padding: 16px;
-            background: white;
+            background: #f8f7ff;
             border: 1px solid #ddd;
-            border-radius: 4px;
+            border-radius: 6px;
             white-space: pre-wrap;
             word-break: break-word;
+            font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
             display: none;
         }
         #result.error {
@@ -69,26 +91,116 @@
             color: #cc0000;
         }
         #result.success {
-            border-color: #00cc66;
-            background: #f5fff5;
+            border-color: #685bc7;
+            background: #f8f7ff;
         }
+
+        h2 {
+            color: #1a1a1a;
+            font-size: 1.25rem;
+            margin-bottom: 1.25rem;
+            border-bottom: 2px solid #685bc7;
+            padding-bottom: 0.4rem;
+        }
+        .arch { display: flex; flex-direction: column; align-items: center; gap: 0.35rem; }
+        .arch-node {
+            background: #f8f7ff;
+            border: 1px solid #685bc7;
+            border-radius: 8px;
+            padding: 0.55rem 1rem;
+            font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #4c1d95;
+            text-align: center;
+        }
+        .arch-node.broker { width: 100%; }
+        .arch-muted { color: #8b7fd8; font-weight: 400; }
+        .arch-arrow { color: #685bc7; line-height: 1.1; font-size: 0.9rem; }
+        .arch-label { font-size: 0.72rem; color: #777; font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace; }
+        .arch-branches { display: flex; gap: 1.5rem; width: 100%; justify-content: center; flex-wrap: wrap; }
+        .arch-branch { display: flex; flex-direction: column; align-items: center; gap: 0.25rem; }
+        .arch-note { margin-top: 1.25rem; color: #666; font-size: 0.8rem; line-height: 1.5; }
+        .arch-note code {
+            background: #f8f7ff;
+            color: #4c1d95;
+            padding: 1px 5px;
+            border-radius: 4px;
+            font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+            font-size: 0.9em;
+        }
+
+        .footer {
+            text-align: center;
+            padding: 1.5rem;
+            color: rgba(255, 255, 255, 0.8);
+            font-size: 0.85rem;
+        }
+        .footer a { color: white; text-decoration: none; font-weight: 600; }
+        .footer a:hover { text-decoration: underline; }
     </style>
 </head>
 <body>
-    <h1>Task API</h1>
-    <form id="taskForm">
-        <label for="worker">Worker</label>
-        <select id="worker" name="worker">
-            <option value="task-leet" selected>Leet Speak</option>
-        </select>
+    <div class="container">
+        <div class="header">
+            <h1>Task API</h1>
+            <div class="powered-by">
+                Built with
+                <img
+                    src="https://cdn.prod.website-files.com/68e941b736876afc9468db2b/68e941b736876afc9468dcda_Wasmcloud.Logo-Hrztl_Color.png"
+                    alt="CNCF wasmCloud"
+                    class="wasmcloud-logo"
+                />
+            </div>
+        </div>
 
-        <label for="payload">Payload</label>
-        <textarea id="payload" name="payload" placeholder="Enter your message here..."></textarea>
+        <div class="card">
+            <h2>Architecture</h2>
+            <div class="arch">
+                <div class="arch-node">Browser</div>
+                <div class="arch-arrow">│ POST /task</div>
+                <div class="arch-arrow">▼</div>
+                <div class="arch-node">http-api <span class="arch-muted">:8000</span></div>
+                <div class="arch-arrow">│ publish <span class="arch-label">tasks.{worker}</span></div>
+                <div class="arch-arrow">▼</div>
+                <div class="arch-node broker">Message Broker <span class="arch-muted">in-memory · NATS</span></div>
+                <div class="arch-arrow">▼</div>
+                <div class="arch-branches">
+                    <div class="arch-branch">
+                        <span class="arch-label">tasks.leet</span>
+                        <div class="arch-node">task-leet</div>
+                    </div>
+                    <div class="arch-branch">
+                        <span class="arch-label">tasks.reverse</span>
+                        <div class="arch-node">task-reverse</div>
+                    </div>
+                </div>
+            </div>
+            <p class="arch-note">The HTTP API publishes to <code>tasks.{worker}</code>; the broker routes to the worker subscribed to that subject, which replies back to the caller.</p>
+        </div>
 
-        <button type="submit" id="submitBtn">Send Task</button>
-    </form>
+        <div class="card">
+            <form id="taskForm">
+                <label for="worker">Worker</label>
+                <select id="worker" name="worker">
+                    <option value="leet" selected>Leet Speak</option>
+                    <option value="reverse">Reverse Words</option>
+                </select>
 
-    <div id="result"></div>
+                <label for="payload">Payload</label>
+                <textarea id="payload" name="payload" placeholder="Enter your message here..."></textarea>
+
+                <button type="submit" id="submitBtn">Send Task</button>
+            </form>
+
+            <div id="result"></div>
+        </div>
+
+        <div class="footer">
+            Built with
+            <a href="https://wasmcloud.com" target="_blank" rel="noopener">wasmCloud</a>, a CNCF Incubating project
+        </div>
+    </div>
 
     <script>
         const form = document.getElementById('taskForm');

--- a/templates/http-api-with-distributed-workloads/task-reverse/Cargo.toml
+++ b/templates/http-api-with-distributed-workloads/task-reverse/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "task-reverse"
+version = "0.1.0"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true }
+wstd = { workspace = true }

--- a/templates/http-api-with-distributed-workloads/task-reverse/src/lib.rs
+++ b/templates/http-api-with-distributed-workloads/task-reverse/src/lib.rs
@@ -1,0 +1,71 @@
+mod bindings {
+    wit_bindgen::generate!({
+        path: "../wit",
+        world: "task",
+        generate_all,
+    });
+}
+
+use bindings::wasi::config::store;
+use bindings::wasmcloud::messaging::consumer;
+use bindings::wasmcloud::messaging::types::BrokerMessage;
+#[allow(unused)]
+use wstd::prelude::*;
+
+struct Component;
+
+/// Per-worker behavior, read from `wasi:config/store`. Values come from the
+/// workload-level `config:` block, with this component's `dev.components`
+/// entry overriding on a per-key basis (see `.wash/config.yaml`).
+struct Settings {
+    /// `chars` reverses the characters; `words` reverses the word order.
+    by_words: bool,
+    /// Prepended to every reply. Empty by default.
+    prefix: String,
+}
+
+impl Settings {
+    fn load() -> Self {
+        // `get` returns Ok(None) when unset and Err only on a store fault;
+        // fall back to the character-reversal, unprefixed defaults either way.
+        let get = |key: &str| store::get(key).ok().flatten();
+        Settings {
+            by_words: get("reverse.mode").as_deref() == Some("words"),
+            prefix: get("reverse.prefix").unwrap_or_default(),
+        }
+    }
+}
+
+#[allow(unsafe_code)] // bindings::export! emits unsafe FFI shims
+mod export {
+    use super::{Component, bindings};
+    bindings::export!(Component with_types_in bindings);
+}
+
+impl bindings::exports::wasmcloud::messaging::handler::Guest for Component {
+    fn handle_message(msg: BrokerMessage) -> Result<(), String> {
+        let Some(subject) = msg.reply_to else {
+            return Err("missing reply_to".to_string());
+        };
+
+        let payload = String::from_utf8(msg.body.to_vec())
+            .map_err(|e| format!("Failed to decode message body: {}", e))?;
+
+        let settings = Settings::load();
+        let reply = BrokerMessage {
+            subject,
+            body: format!("{}{}", settings.prefix, reverse(&payload, &settings)).into(),
+            reply_to: None,
+        };
+
+        consumer::publish(&reply)
+    }
+}
+
+fn reverse(input: &str, settings: &Settings) -> String {
+    if settings.by_words {
+        input.split_whitespace().rev().collect::<Vec<_>>().join(" ")
+    } else {
+        input.chars().rev().collect()
+    }
+}


### PR DESCRIPTION
Builds on the work in #5242. Marking as draft until #5242 lands.

Make `wash dev` hosts support workloads with multiple components and messaging subscriptions.

Both the In-memory messaging plugin and NATS plugin now reads: `subscriptions` from per-component config (host-interface fallback) and tracks handlers by world export.
Subscription parsing is shared between both backends.

We do this by adding a single `dev.data_nats_url` that points blobstore, keyvalue, and messaging at NATS at once (mirroring the production host's `--data-nats-url`), with the existing per-plugin URLs kept as overrides (although I'm leaning towwards deprecating these). Note this also gives wash dev a blobstore NATS backend for the first time.

The `templates/http-api-with-distributed-workloads` template is extended to exercise this with two subscriptions.

There is one runtime behavior change that I'd appreciate extra eyes on... we now allow multiple components to export the same host-invoked interface. Workload linking previously rejected any interface exported by more than one component, which blocked workloads with multiple components each with messaging handlers in one workload (`another component already implements the interface`). The uniqueness check is now deferred to the import side: duplicate exports are fine for host-invoked interfaces like `wasmcloud:messaging/handler` and `wasi:http/incoming-handler` that no component imports; genuinely ambiguous component-to-component imports still error.

Another behavior change for the dev host that I think is correct, but worth calling out: when `data_nats_url` points at a NATS without JetStream, messaging works (core subjects) but blobstore and keyvalue ops fail at runtime. This matches `wash host` and k8s, but a potential footgun. It's very edge case. The defaults are in-memory so the scenario where it might surprise folks is if they didn't set a file path or some other config and therefore are getting in-memory plugins, then they set a data_nats_url thinking they only want this for messaging.

What didn't change:  Single-component dev workloads behave as they did before. No subscriptions then they will receive all messages.

This change is broken down into several commits to make it easier to review:
- **feat(dev): nats plugin with multi-component subs**
- **fix(runtime): allow multiple components to export the same host-invoked interface**
- **feat(dev): subject-based routing for in-memory messaging**
- **feat(templates): add task-reverse worker and branded UI**