### PR TITLE
Add Autoscaling support for WorkloadDeployments

### DIFF
--- a/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloaddeployments.yaml
+++ b/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloaddeployments.yaml
@@ -98,6 +98,7 @@ spec:
                     type: object
                 type: object
               replicas:
+                default: 1
                 format: int32
                 type: integer
               template:
@@ -150,7 +151,26 @@ spec:
                                 will be made available to a workload component.
                               properties:
                                 allowedHosts:
+                                  description: |-
+                                    AllowedHosts is the outbound egress allowlist for this component.
+
+                                    Each entry must match one of:
+                                      - "*"                       (allow all)
+                                      - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                                      - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                                      - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                                      - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                                    This is a hosts policy, not a URL policy: entries must not include a
+                                    path (beyond bare `/`), query string, or fragment. The wildcard must
+                                    be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                                    Empty or absent allowedHosts denies all outgoing requests
+                                    (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                                    ["*"]` explicitly. Final validation runs in the runtime. This regex
+                                    is an admission-time guard, not the source of truth.
                                   items:
+                                    pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                                     type: string
                                   type: array
                                 config:
@@ -400,7 +420,26 @@ spec:
                               be made available to a workload component.
                             properties:
                               allowedHosts:
+                                description: |-
+                                  AllowedHosts is the outbound egress allowlist for this component.
+
+                                  Each entry must match one of:
+                                    - "*"                       (allow all)
+                                    - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                                    - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                                    - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                                    - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                                  This is a hosts policy, not a URL policy: entries must not include a
+                                  path (beyond bare `/`), query string, or fragment. The wildcard must
+                                  be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                                  Empty or absent allowedHosts denies all outgoing requests
+                                  (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                                  ["*"]` explicitly. Final validation runs in the runtime. This regex
+                                  is an admission-time guard, not the source of truth.
                                 items:
+                                  pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                                   type: string
                                 type: array
                               config:
@@ -587,6 +626,13 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              currentReplicas:
+                description: |-
+                  CurrentReplicas is the number of workload instances currently running.
+                  Exposed as the /scale subresource statusReplicasPath so HPA can read the
+                  current replica count. Mirrors .status.replicas.current as a flat int.
+                format: int32
+                type: integer
               previousReplicaSet:
                 description: |-
                   LocalObjectReference contains enough information to let you locate the
@@ -618,9 +664,19 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              selector:
+                description: |-
+                  Selector is the serialized label selector exposed by the /scale subresource
+                  (scale.status.selector). HPA requires a non-empty selector to compute
+                  metrics; without it scaling fails with "selector is required".
+                type: string
             type: object
         type: object
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.currentReplicas
       status: {}

--- a/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloadreplicasets.yaml
+++ b/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloadreplicasets.yaml
@@ -47,6 +47,7 @@ spec:
             description: WorkloadReplicaSetSpec defines the desired state of WorkloadReplicaSet.
             properties:
               replicas:
+                default: 1
                 format: int32
                 type: integer
               template:
@@ -99,7 +100,26 @@ spec:
                                 will be made available to a workload component.
                               properties:
                                 allowedHosts:
+                                  description: |-
+                                    AllowedHosts is the outbound egress allowlist for this component.
+
+                                    Each entry must match one of:
+                                      - "*"                       (allow all)
+                                      - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                                      - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                                      - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                                      - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                                    This is a hosts policy, not a URL policy: entries must not include a
+                                    path (beyond bare `/`), query string, or fragment. The wildcard must
+                                    be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                                    Empty or absent allowedHosts denies all outgoing requests
+                                    (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                                    ["*"]` explicitly. Final validation runs in the runtime. This regex
+                                    is an admission-time guard, not the source of truth.
                                   items:
+                                    pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                                     type: string
                                   type: array
                                 config:
@@ -349,7 +369,26 @@ spec:
                               be made available to a workload component.
                             properties:
                               allowedHosts:
+                                description: |-
+                                  AllowedHosts is the outbound egress allowlist for this component.
+
+                                  Each entry must match one of:
+                                    - "*"                       (allow all)
+                                    - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                                    - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                                    - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                                    - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                                  This is a hosts policy, not a URL policy: entries must not include a
+                                  path (beyond bare `/`), query string, or fragment. The wildcard must
+                                  be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                                  Empty or absent allowedHosts denies all outgoing requests
+                                  (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                                  ["*"]` explicitly. Final validation runs in the runtime. This regex
+                                  is an admission-time guard, not the source of truth.
                                 items:
+                                  pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                                   type: string
                                 type: array
                               config:

--- a/runtime-operator/api/runtime/v1alpha1/workload_deployment_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_deployment_types.go
@@ -53,10 +53,23 @@ type WorkloadDeploymentStatus struct {
 	PreviousReplicaSet *corev1.LocalObjectReference `json:"previousReplicaSet,omitempty"`
 	// +kubebuilder:validation:Optional
 	Replicas *ReplicaSetStatus `json:"replicas,omitempty"`
+
+	// CurrentReplicas is the number of workload instances currently running.
+	// Exposed as the /scale subresource statusReplicasPath so HPA can read the
+	// current replica count. Mirrors .status.replicas.current as a flat int.
+	// +kubebuilder:validation:Optional
+	CurrentReplicas int32 `json:"currentReplicas,omitempty"`
+
+	// Selector is the serialized label selector exposed by the /scale subresource
+	// (scale.status.selector). HPA requires a non-empty selector to compute
+	// metrics; without it scaling fails with "selector is required".
+	// +kubebuilder:validation:Optional
+	Selector string `json:"selector,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.currentReplicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="REPLICAS",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 

--- a/runtime-operator/api/runtime/v1alpha1/workload_replicaset_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_replicaset_types.go
@@ -35,6 +35,7 @@ func (w *WorkloadReplicaTemplate) Hash() string {
 // WorkloadReplicaSetSpec defines the desired state of WorkloadReplicaSet.
 type WorkloadReplicaSetSpec struct {
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=1
 	Replicas *int32 `json:"replicas,omitempty"`
 	// +kubebuilder:validation:Required
 	Template WorkloadReplicaTemplate `json:"template,omitempty"`

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloaddeployments.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloaddeployments.yaml
@@ -98,6 +98,7 @@ spec:
                     type: object
                 type: object
               replicas:
+                default: 1
                 format: int32
                 type: integer
               template:
@@ -625,6 +626,13 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              currentReplicas:
+                description: |-
+                  CurrentReplicas is the number of workload instances currently running.
+                  Exposed as the /scale subresource statusReplicasPath so HPA can read the
+                  current replica count. Mirrors .status.replicas.current as a flat int.
+                format: int32
+                type: integer
               previousReplicaSet:
                 description: |-
                   LocalObjectReference contains enough information to let you locate the
@@ -656,9 +664,19 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              selector:
+                description: |-
+                  Selector is the serialized label selector exposed by the /scale subresource
+                  (scale.status.selector). HPA requires a non-empty selector to compute
+                  metrics; without it scaling fails with "selector is required".
+                type: string
             type: object
         type: object
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.currentReplicas
       status: {}

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloadreplicasets.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloadreplicasets.yaml
@@ -47,6 +47,7 @@ spec:
             description: WorkloadReplicaSetSpec defines the desired state of WorkloadReplicaSet.
             properties:
               replicas:
+                default: 1
                 format: int32
                 type: integer
               template:

--- a/runtime-operator/config/samples/hpa.yaml
+++ b/runtime-operator/config/samples/hpa.yaml
@@ -1,10 +1,4 @@
 # Example HorizontalPodAutoscaler targeting a WorkloadDeployment.
-#
-# This works because WorkloadDeployment implements the /scale subresource
-# (specReplicasPath=.spec.replicas, statusReplicasPath=.status.currentReplicas,
-# labelSelectorPath=.status.selector). HPA — and KEDA, which builds on HPA —
-# can therefore read and write the deployment's replica count.
-#
 # wasmCloud workloads run on wasmCloud hosts rather than as Pods, so Pods/
 # Resource metrics do not apply. Use External or Object metrics (e.g. a
 # request-rate metric exposed via Prometheus Adapter / KEDA). The example

--- a/runtime-operator/config/samples/hpa.yaml
+++ b/runtime-operator/config/samples/hpa.yaml
@@ -1,0 +1,36 @@
+# Example HorizontalPodAutoscaler targeting a WorkloadDeployment.
+#
+# This works because WorkloadDeployment implements the /scale subresource
+# (specReplicasPath=.spec.replicas, statusReplicasPath=.status.currentReplicas,
+# labelSelectorPath=.status.selector). HPA — and KEDA, which builds on HPA —
+# can therefore read and write the deployment's replica count.
+#
+# wasmCloud workloads run on wasmCloud hosts rather than as Pods, so Pods/
+# Resource metrics do not apply. Use External or Object metrics (e.g. a
+# request-rate metric exposed via Prometheus Adapter / KEDA). The example
+# below scales on an external `http_requests_per_second` metric.
+#
+# Apply config/samples/deployment.yaml first; it creates the `hello`
+# WorkloadDeployment this HPA targets.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hello
+spec:
+  scaleTargetRef:
+    apiVersion: runtime.wasmcloud.dev/v1alpha1
+    kind: WorkloadDeployment
+    name: hello
+  minReplicas: 1
+  maxReplicas: 100
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: http_requests_per_second
+        target:
+          type: AverageValue
+          averageValue: "10"
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 60

--- a/runtime-operator/internal/controller/runtime/workload_deployment_controller.go
+++ b/runtime-operator/internal/controller/runtime/workload_deployment_controller.go
@@ -8,6 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,6 +22,10 @@ import (
 const (
 	workloadDeploymentReconcileInterval = 1 * time.Minute
 	workloadDeploymentNameIndex         = "workload.deployment.name"
+	// workloadDeploymentNameLabel is stamped onto the ReplicaSets a deployment
+	// owns and exposed via the /scale subresource's selector so HPA/KEDA can
+	// identify the deployment's workloads.
+	workloadDeploymentNameLabel = "runtime.wasmcloud.dev/workload-deployment"
 )
 
 // WorkloadDeploymentReconciler reconciles a WorkloadReplicaSet object
@@ -110,11 +115,20 @@ func (r *WorkloadDeploymentReconciler) reconcileDeploy(ctx context.Context, depl
 
 	replicaSetName := fmt.Sprintf("%s-%s", deployment.Name, randHash())
 
+	// Copy the deployment's labels and stamp the managed selector label so the
+	// /scale subresource's selector actually matches this deployment's
+	// ReplicaSets. Build a fresh map to avoid mutating deployment.Labels.
+	replicaSetLabels := make(map[string]string, len(deployment.Labels)+1)
+	for k, v := range deployment.Labels {
+		replicaSetLabels[k] = v
+	}
+	replicaSetLabels[workloadDeploymentNameLabel] = deployment.Name
+
 	newReplicaSet := &runtimev1alpha1.WorkloadReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   deployment.Namespace,
 			Name:        replicaSetName,
-			Labels:      deployment.Labels,
+			Labels:      replicaSetLabels,
 			Annotations: deployment.Annotations,
 		},
 		Spec: *replicaSetTemplate,
@@ -203,6 +217,13 @@ func (r *WorkloadDeploymentReconciler) reconcileScale(ctx context.Context, deplo
 		Unavailable: unavailableReplicas,
 	}
 	deployment.Status.Replicas = deploymentStatus
+
+	// Populate the flat /scale subresource fields (statusReplicasPath +
+	// selectorpath) so HPA/KEDA can read the current replica count and a
+	// non-empty selector. Set even on the not-available path below so status
+	// reflects what the operator observed.
+	deployment.Status.CurrentReplicas = currentReplicas
+	deployment.Status.Selector = labels.Set{workloadDeploymentNameLabel: deployment.Name}.String()
 
 	// Gate Scale on the active ReplicaSet actually being available, so
 	// WorkloadDeployment.Ready==True implies the underlying Workload is

--- a/runtime-operator/internal/controller/runtime/workload_deployment_controller_test.go
+++ b/runtime-operator/internal/controller/runtime/workload_deployment_controller_test.go
@@ -191,6 +191,12 @@ func TestReconcileScale_FreshDeploy_RSNotAvailable_ReturnsUnknown(t *testing.T) 
 	if got := wd.Status.Replicas.Unavailable; got != 1 {
 		t.Fatalf("expected Unavailable=1 in status, got %d", got)
 	}
+	// /scale selector must be set even while the RS is unavailable, so HPA
+	// never sees a missing selector during a deploy.
+	wantSelector := workloadDeploymentNameLabel + "=" + testDeploymentName
+	if wd.Status.Selector != wantSelector {
+		t.Fatalf("expected Status.Selector=%q on unavailable path, got %q", wantSelector, wd.Status.Selector)
+	}
 }
 
 // In production an RS exists for several reconcile cycles before
@@ -226,6 +232,15 @@ func TestReconcileScale_FreshDeploy_RSAvailable_ReturnsNil(t *testing.T) {
 	}
 	if wd.Status.Replicas == nil || wd.Status.Replicas.Ready != 1 {
 		t.Fatalf("expected Status.Replicas.Ready=1, got %+v", wd.Status.Replicas)
+	}
+	// The /scale subresource fields must be populated for HPA/KEDA: a flat
+	// current-replica count and a non-empty, correctly-formatted selector.
+	if wd.Status.CurrentReplicas != testReplicas {
+		t.Fatalf("expected Status.CurrentReplicas=%d, got %d", testReplicas, wd.Status.CurrentReplicas)
+	}
+	wantSelector := workloadDeploymentNameLabel + "=" + testDeploymentName
+	if wd.Status.Selector != wantSelector {
+		t.Fatalf("expected Status.Selector=%q, got %q", wantSelector, wd.Status.Selector)
 	}
 }
 


### PR DESCRIPTION
Closes #4939 

Makes `WorkloadDeployment` autoscalable by the Kubernetes Horizontal Pod
Autoscaler — and, by extension, KEDA (which builds on HPA) — by implementing
the `/scale` subresource correctly. `kubectl scale workloaddeployment <name>
--replicas=N` now works too.

HPA scales any resource that exposes a `/scale` subresource with three
JSONPaths: `specReplicasPath`, `statusReplicasPath`, and `labelSelectorPath`.
`WorkloadDeployment` didn't define the subresource at all, and the two things
needed to make it valid were missing:

1. **No selector.** HPA requires `scale.status.selector` to be a non-empty,
   parseable label selector; without it scaling never activates.
2. **`statusReplicasPath` had no integer to point at.** `.status.replicas` is
   an object (`ReplicaSetStatus`), but HPA needs a scalar replica count.

## Changes

### `/scale` subresource

- Added the kubebuilder scale marker to `WorkloadDeployment`

### New status fields

Added two flat fields to `WorkloadDeploymentStatus`:

- `currentReplicas` (`int32`) — the running replica count HPA reads via
  `statusReplicasPath` (mirrors `.status.replicas.current` as a scalar).
- `selector` (`string`) — the serialized label selector HPA reads via
  `labelSelectorPath`.

### Selector wiring

- Defined a managed label `runtime.wasmcloud.dev/workload-deployment=<name>`.
- The controller stamps this label onto the `WorkloadReplicaSet`s a deployment
  owns, so the selector truthfully matches the deployment's workloads.
- `reconcileScale` populates `status.currentReplicas` and `status.selector` on
  every reconcile — including the not-yet-available path — so HPA never
  observes a missing selector mid-deploy.

### `spec.replicas` defaults to 1

Matches native `Deployment` semantics. Without a value, HPA's `GET /scale`
errors on the missing `specReplicasPath`, and the workload would otherwise
scale to 0 when `replicas` is omitted.


### Testing
Tested with a local kind cluster using KEDA to scale the WorkloadDeployment using an OTEL metric from the Wasm component. Verified that scaling the number of components as well as EndpointSlices worked as expected.


Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
