### PR TITLE
Allow for extra args and nats url to be set

### DIFF
--- a/charts/runtime-operator/templates/_helpers.tpl
+++ b/charts/runtime-operator/templates/_helpers.tpl
@@ -153,6 +153,38 @@ Callers parse the comma-separated string with `splitList ","`.
 {{- end }}
 
 {{/*
+Control-plane / scheduler NATS URL. Used by the operator (`-nats-url`) and the
+host runtime (`--scheduler-nats-url`).
+
+Resolution order (first non-empty wins):
+  1. Per-host-group override (`.schedulerNatsUrl`).
+  2. Chart-wide `global.nats.schedulerUrl`.
+  3. The in-cluster NATS service built from the release namespace
+     (`nats://nats.<namespace>.svc.cluster.local:4222`) — for backwards compatibility.
+
+Callable two ways:
+  {{ include "runtime-operator.schedulerNatsUrl" . }} (operator: ctx is top)
+  {{ include "runtime-operator.schedulerNatsUrl" (dict "ctx" $top "group" .) }}  (runtime: per-group)
+*/}}
+{{- define "runtime-operator.schedulerNatsUrl" -}}
+{{- $ctx := . }}{{- $group := dict }}
+{{- if and (kindIs "map" .) (hasKey . "ctx") }}{{- $ctx = .ctx }}{{- $group = default dict .group }}{{- end }}
+{{- $default := default (printf "nats://nats.%s.svc.cluster.local:4222" $ctx.Release.Namespace) $ctx.Values.global.nats.schedulerUrl }}
+{{- default $default $group.schedulerNatsUrl -}}
+{{- end }}
+
+{{/*
+Data-plane NATS URL. Used by the host runtime (`--data-nats-url`) so Wasm
+workloads can use a separate NATS cluster from the control plane if desired.
+*/}}
+{{- define "runtime-operator.dataNatsUrl" -}}
+{{- $ctx := . }}{{- $group := dict }}
+{{- if and (kindIs "map" .) (hasKey . "ctx") }}{{- $ctx = .ctx }}{{- $group = default dict .group }}{{- end }}
+{{- $default := default (printf "nats://nats.%s.svc.cluster.local:4222" $ctx.Release.Namespace) $ctx.Values.global.nats.dataUrl }}
+{{- default $default $group.dataNatsUrl -}}
+{{- end }}
+
+{{/*
 Create the imagePullSecrets section for the chart.
 */}}
 {{- define "runtime-operator.imagePullSecrets" -}}

--- a/charts/runtime-operator/templates/operator/deployment.yaml
+++ b/charts/runtime-operator/templates/operator/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: runtime-operator
           image: {{ if $registry }}{{ printf "%s/%s" $registry .Values.operator.image.repository }}{{ else }}{{ .Values.operator.image.repository }}{{ end }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}
           args:
-            - "-nats-url=nats://nats.{{ .Release.Namespace }}.svc.cluster.local:4222"
+            - "-nats-url={{ include "runtime-operator.schedulerNatsUrl" . }}"
             {{- if $.Values.global.tls.enabled }}
             - "-nats-ca=/operator-cert/ca.crt"
             - "-nats-client-cert=/operator-cert/tls.crt"
@@ -48,11 +48,21 @@ spec:
             - "-host-namespaces={{ . }}"
             {{- end }}
             - "-allow-shared-hosts={{ .Values.operator.allowSharedHosts }}"
+            {{- with .Values.operator.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with .Values.operator.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.operator.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           imagePullPolicy: {{ .Values.operator.image.pull_policy }}
           {{- if $.Values.global.tls.enabled }}
           volumeMounts:

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -64,16 +64,21 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- /* Optional host env (appended after operator-managed vars).
-                   Standard k8s env shape — supports valueFrom secretKeyRef /
-                   configMapKeyRef. */}}
+            {{- with $top.Values.runtime.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- /* Optional envFrom (defensive — symmetric with .env above). */}}
-          {{- with .envFrom }}
+          {{- /* Optional envFrom (chart-wide runtime.envFrom + per-host-group). */}}
+          {{- if or $top.Values.runtime.envFrom .envFrom }}
           envFrom:
+            {{- with $top.Values.runtime.envFrom }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           args:
             {{- if .logLevel }}
@@ -83,13 +88,13 @@ spec:
             - "--host-name=$(WASMCLOUD_HOST_IP)"
             - "--host-group={{ .name }}"
             - "--environment=$(WASMCLOUD_HOST_ENVIRONMENT)"
-            - "--scheduler-nats-url=nats://nats.{{ $top.Release.Namespace }}.svc.cluster.local:4222"
+            - "--scheduler-nats-url={{ include "runtime-operator.schedulerNatsUrl" (dict "ctx" $top "group" .) }}"
             {{- if $top.Values.global.tls.enabled }}
             - "--scheduler-nats-tls-ca=/runtime-cert/ca.crt"
             - "--scheduler-nats-tls-cert=/runtime-cert/tls.crt"
             - "--scheduler-nats-tls-key=/runtime-cert/tls.key"
             {{- end }}
-            - "--data-nats-url=nats://nats.{{ $top.Release.Namespace }}.svc.cluster.local:4222"
+            - "--data-nats-url={{ include "runtime-operator.dataNatsUrl" (dict "ctx" $top "group" .) }}"
             {{- if $top.Values.global.tls.enabled }}
             - "--data-nats-tls-ca=/data-cert/ca.crt"
             - "--data-nats-tls-cert=/data-cert/tls.crt"
@@ -108,6 +113,14 @@ spec:
             {{- end }}
             {{- if and (.wasip3) (.wasip3.enabled) }}
             - "--wasip3"
+            {{- end }}
+            {{- /* Chart-wide runtime.extraArgs applies to every host group; per-host-group
+                   .extraArgs is appended after it. */}}
+            {{- with $top.Values.runtime.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .extraArgs }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           imagePullPolicy: {{ $top.Values.runtime.image.pull_policy }}
           volumeMounts:

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -6,6 +6,21 @@ global:
     pullSecrets: []
   nameOverride: ""
   fullnameOverride: ""
+  nats:
+    # -- Control-plane / scheduler NATS URL. Used by the operator (`-nats-url`)
+    # and the host runtime (`--scheduler-nats-url`) so both connect to the same
+    # control plane. When empty, defaults to the in-cluster NATS service:
+    # `nats://nats.<release-namespace>.svc.cluster.local:4222`. Override to point
+    # at an external NATS cluster, a different service name/port, or NATS in
+    # another namespace. Can be overridden per host group via
+    # `runtime.hostGroups[].schedulerNatsUrl`.
+    schedulerUrl: ""
+    # -- Data-plane NATS URL. Used by the host runtime (`--data-nats-url`) for
+    # Wasm workload messaging, allowing workloads to use a separate NATS cluster
+    # from the control plane. When empty, defaults to the same in-cluster NATS
+    # service as `schedulerUrl`. Can be overridden per host group via
+    # `runtime.hostGroups[].dataNatsUrl`.
+    dataUrl: ""
   tls:
     # -- Enable TLS for NATS connections and certificate generation.
     # Set to false when a service mesh (e.g. Istio) provides mTLS.
@@ -93,6 +108,28 @@ operator:
   # `CrossEnvironmentSchedulingDenied` Warning Event and a
   # `HostSelection=False` condition on the Workload.
   allowSharedHosts: true
+  # -- Additional environment variables for the operator container, appended
+  # after the chart-managed vars. Standard Kubernetes env shape (supports
+  # `valueFrom` secretKeyRef / configMapKeyRef).
+  # Example:
+  #   env:
+  #     - name: LOG_LEVEL
+  #       value: debug
+  env: []
+  # -- Populate the operator container's environment from ConfigMaps/Secrets.
+  # Standard Kubernetes `envFrom` shape.
+  # Example:
+  #   envFrom:
+  #     - secretRef:
+  #         name: operator-extra-config
+  envFrom: []
+  # -- Additional CLI args appended verbatim to the operator container, for
+  # operator flags the chart does not template (e.g. `-leader-elect`,
+  # `-cpu-backpressure-threshold=75`).
+  # Example:
+  #   extraArgs:
+  #     - "-leader-elect"
+  extraArgs: []
 
 gateway:
   # -- DEPRECATED: runtime-gateway is being removed. HTTP routing is now handled
@@ -136,6 +173,17 @@ runtime:
     repository: wasmcloud/wash
     pull_policy: Always
     tag: ""
+  # -- Additional environment variables applied to every host group container,
+  # appended after the chart-managed vars and before any per-host-group `env`.
+  # Standard Kubernetes env shape (supports `valueFrom`).
+  env: []
+  # -- Populate every host group container's environment from
+  # ConfigMaps/Secrets. Merged with per-host-group `envFrom`. Standard
+  # Kubernetes `envFrom` shape.
+  envFrom: []
+  # -- Additional CLI args appended to every host group container, for host
+  # flags the chart does not template. Merged with per-host-group `extraArgs`.
+  extraArgs: []
   hostGroups:
     - name: default
       # -- Namespace to deploy this host group's Deployment, Service, generated
@@ -145,6 +193,19 @@ runtime:
       # has Pod RBAC + cache access to manage host Pod lifecycle there.
       namespace: ""
       replicas: 1
+      # -- Per-host-group override of the scheduler NATS URL. Empty falls back to
+      # `global.nats.schedulerUrl`, then the in-cluster NATS service.
+      schedulerNatsUrl: ""
+      # -- Per-host-group override of the data NATS URL. Empty falls back to
+      # `global.nats.dataUrl`, then the in-cluster NATS service.
+      dataNatsUrl: ""
+      # -- Per-host-group environment variables, appended after `runtime.env`.
+      # Standard Kubernetes env shape (supports `valueFrom`).
+      env: []
+      # -- Per-host-group `envFrom`, merged with `runtime.envFrom`.
+      envFrom: []
+      # -- Per-host-group extra CLI args, appended after `runtime.extraArgs`.
+      extraArgs: []
       service:
         type: ClusterIP
       webgpu:


### PR DESCRIPTION
Closes #5245 

### NATS URL change
Allows for the operator and host runtime's `nats-url` to be configured via values.yaml. The current hardcoded `nats://nats.<namespace>.svc.cluster.local:4222` is still the default, so this is backwards compatible.

For the NATS connection that is used by the operator and host for scheduling, there is a new value called `.schedulerNatsUrl` (should always be the same to ensure that the operator can communicate with the hosts).

For the NATS connection used by the Host for Wasm workloads to communicate with a NATS backend, this is configurable by `.dataNatsUrl` at the global level as well as each hostGroup level.

### Support for extra args
- `operator.extraArgs` passes additional arguments to the operator command
- `runtime.extraArgs` passes additional arguments to the host command (useful for custom host builds)

### Support for environment variables
- `operator.envFrom` is used to set a list of environment variables in the operator pod
- `operator.env` can be used for overriding a default environment variable (takes precedence)
- `runtime.envFrom` is used to set a list of environment variables in the host pod
- `runtime.env` is used to override a default environment variable (takes precedence)

### Testing
- [x] Default Helm install to make sure current functionality works
- [x] Install with overriding NATS connections, extra args (i.e. metrics enabled)

Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
