### PR TITLE
feat: update to wasmtime 46 and enable wasip3 by default

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -117,16 +117,13 @@ jobs:
           NATS_INTEGRATION_TESTS: ${{ matrix.os == 'ubuntu-latest' && '1' || '' }}
         run: |
           cargo test --workspace
-      - name: Test with wasip3
+      - name: Test with wasi-tls
         run: |
-          cargo test -p wash-runtime --features wasip3
-      - name: Test with wasi-tls + wasip3
-        run: |
-          cargo test -p wash-runtime --features wasi-tls,wasip3
+          cargo test -p wash-runtime --features wasi-tls
       - name: Build benchmarks
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cargo bench -p wash-runtime --features wasip3 --no-run
+          cargo bench -p wash-runtime --no-run
 
   lint:
     needs:
@@ -162,7 +159,7 @@ jobs:
           cargo +nightly fmt -- --check
       - name: Lint
         run: |
-          cargo clippy --workspace --features wasip3,wasi-tls
+          cargo clippy --workspace --features wasi-tls
       - name: Lint anyhow context message casing
         run: |
           # anyhow `.context()` / `.with_context()` strings are error messages,

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -351,7 +351,6 @@ jobs:
       - check
       - lint
       - wash-image
-      - wash-image-wasip3
       - runtime-operator-e2e
       - canary-publish
       - canary-binaries
@@ -466,33 +465,6 @@ jobs:
           docker buildx imagetools inspect "ghcr.io/wasmcloud/wash:${STEPS_META_OUTPUTS_VERSION}"
         env:
           STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
-
-  # wasip3 image variant. Builds wash with the `wasip3,wasi-tls` features
-  # (WASI Preview 3 compiled in) and publishes it as `canary-wasip3` /
-  # `sha-<full-sha>-wasip3`.
-  wash-image-wasip3:
-    needs:
-      - changes
-      - runtime-operator-e2e
-    if: |
-      always() &&
-      (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true') &&
-      (((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main')) &&
-      needs.runtime-operator-e2e.result == 'success'
-    permissions:
-      contents: write
-      packages: write
-    uses: ./.github/workflows/docker-build-push.yml
-    with:
-      image: ghcr.io/wasmcloud/wash
-      build-args: |
-        CARGO_FEATURES=wasip3,wasi-tls
-      # Push (and the manifest merge) only on main; PRs build to validate.
-      push: ${{ github.event_name != 'pull_request' }}
-      push-by-digest: ${{ github.event_name != 'pull_request' }}
-      tags: |
-        type=raw,value=canary-wasip3
-        type=sha,format=long,prefix=sha-,suffix=-wasip3
 
   # Canary matrix binary build. Runs on every push to main so each commit
   # exercises the full per-target matrix (including the s390x/musl cross

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -123,7 +123,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-assembler-x64-meta 0.133.0",
 ]
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64-meta"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-srcgen 0.133.0",
 ]
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-entity 0.133.0",
  "wasmtime-internal-core 46.0.0",
@@ -1379,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bitset"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64 0.133.0",
@@ -1460,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-assembler-x64-meta 0.133.0",
  "cranelift-codegen-shared 0.133.0",
@@ -1478,7 +1478,7 @@ checksum = "78fdb83ab012d0ee6a44ced7ca8788a444f17cf821c62f95d6ef87c9f0262518"
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 
 [[package]]
 name = "cranelift-control"
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "cranelift-control"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "arbitrary",
 ]
@@ -1512,7 +1512,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-bitset 0.133.0",
  "serde",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-codegen 0.133.0",
  "hashbrown 0.17.1",
@@ -1553,7 +1553,7 @@ checksum = "94eaf429c32a12715429c7c6ddfdd43c170f4cdd7e97bfa507bd68a652091087"
 [[package]]
 name = "cranelift-isle"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 
 [[package]]
 name = "cranelift-native"
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-codegen 0.133.0",
  "libc",
@@ -1585,7 +1585,7 @@ checksum = "cba7c0ff5941842c36653da155580ce41e675c204a67ac1b4e1c478a9347bbb7"
 [[package]]
 name = "cranelift-srcgen"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 
 [[package]]
 name = "crc32fast"
@@ -2241,7 +2241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3140,7 +3140,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -3350,7 +3350,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3952,7 +3952,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5024,7 +5024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -5044,8 +5044,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5079,7 +5079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -5193,7 +5193,7 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-bitset 0.133.0",
  "log",
@@ -5215,7 +5215,7 @@ dependencies = [
 [[package]]
 name = "pulley-macros"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5684,7 +5684,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6207,7 +6207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6439,7 +6439,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6458,7 +6458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7110,7 +7110,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -8251,7 +8251,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-macro"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8271,7 +8271,7 @@ checksum = "9d2eeb9b53222859e6f5dc73d2ccfb33254d672469cac11b693a71912e2f3817"
 [[package]]
 name = "wasmtime-internal-component-util"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 
 [[package]]
 name = "wasmtime-internal-core"
@@ -8288,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-core"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cranelift"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen 0.133.0",
@@ -8367,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-fiber"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cc",
  "cfg-if",
@@ -8393,7 +8393,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-debug"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros 46.0.0",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -8438,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-unwinder"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen 0.133.0",
@@ -8461,7 +8461,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8501,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -8543,7 +8543,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -8570,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8606,7 +8606,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-io"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-tls"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -8921,7 +8921,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -123,7 +123,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -878,7 +878,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -907,7 +907,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -1133,7 +1133,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
- "unicode-width 0.2.2",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1314,28 +1314,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc293b86236abcc45f2f72e2d18e2bd636f2a08b75eb286bae31e71e1430c91"
-dependencies = [
- "cranelift-assembler-x64-meta 0.132.2",
-]
-
-[[package]]
-name = "cranelift-assembler-x64"
 version = "0.133.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
- "cranelift-assembler-x64-meta 0.133.0",
-]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b954c826eddaf1b001402cb8aecf1764c6f6d637ba69fb9e3311f1ebac965be6"
-dependencies = [
- "cranelift-srcgen 0.132.2",
+ "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
@@ -1343,17 +1325,7 @@ name = "cranelift-assembler-x64-meta"
 version = "0.133.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
- "cranelift-srcgen 0.133.0",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4053fa2575ef4a5c35d2708533df2200400ae979226cea9cc92a578b811bd4e7"
-dependencies = [
- "cranelift-entity 0.132.2",
- "wasmtime-internal-core 45.0.2",
+ "cranelift-srcgen",
 ]
 
 [[package]]
@@ -1361,19 +1333,8 @@ name = "cranelift-bforest"
 version = "0.133.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
- "cranelift-entity 0.133.0",
- "wasmtime-internal-core 46.0.0",
-]
-
-[[package]]
-name = "cranelift-bitset"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d216663191014aa63e1d2cffd058e609eaf207646d40b739d88250f65b2c4f69"
-dependencies = [
- "serde",
- "serde_derive",
- "wasmtime-internal-core 45.0.2",
+ "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1383,35 +1344,7 @@ source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-impleme
 dependencies = [
  "serde",
  "serde_derive",
- "wasmtime-internal-core 46.0.0",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5e7e7aad6a425a51da1ad7ab9e5d280ea97eb7c7c4545fafb567915a75aadb"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64 0.132.2",
- "cranelift-bforest 0.132.2",
- "cranelift-bitset 0.132.2",
- "cranelift-codegen-meta 0.132.2",
- "cranelift-codegen-shared 0.132.2",
- "cranelift-control 0.132.2",
- "cranelift-entity 0.132.2",
- "cranelift-isle 0.132.2",
- "gimli",
- "hashbrown 0.17.1",
- "libm",
- "log",
- "pulley-interpreter 45.0.2",
- "regalloc2",
- "rustc-hash 2.1.2",
- "serde",
- "smallvec",
- "target-lexicon",
- "wasmtime-internal-core 45.0.2",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1420,20 +1353,20 @@ version = "0.133.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.133.0",
- "cranelift-bforest 0.133.0",
- "cranelift-bitset 0.133.0",
- "cranelift-codegen-meta 0.133.0",
- "cranelift-codegen-shared 0.133.0",
- "cranelift-control 0.133.0",
- "cranelift-entity 0.133.0",
- "cranelift-isle 0.133.0",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
  "gimli",
  "hashbrown 0.17.1",
  "libm",
  "log",
  "postcard",
- "pulley-interpreter 46.0.0",
+ "pulley-interpreter",
  "regalloc2",
  "rustc-hash 2.1.2",
  "serde",
@@ -1441,20 +1374,7 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-core 46.0.0",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c421d80a9a85f806cb02a2983b5b5368a335c319795b1f1b4b771a24479af5b0"
-dependencies = [
- "cranelift-assembler-x64-meta 0.132.2",
- "cranelift-codegen-shared 0.132.2",
- "cranelift-srcgen 0.132.2",
- "heck 0.5.0",
- "pulley-interpreter 45.0.2",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1462,32 +1382,17 @@ name = "cranelift-codegen-meta"
 version = "0.133.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
- "cranelift-assembler-x64-meta 0.133.0",
- "cranelift-codegen-shared 0.133.0",
- "cranelift-srcgen 0.133.0",
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
  "heck 0.5.0",
- "pulley-interpreter 46.0.0",
+ "pulley-interpreter",
 ]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fdb83ab012d0ee6a44ced7ca8788a444f17cf821c62f95d6ef87c9f0262518"
 
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.133.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
-
-[[package]]
-name = "cranelift-control"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b75adc6eb7bb4ac6365106afb6cac4f12fe1ddfa02ddc9fd7015ca1469b471b"
-dependencies = [
- "arbitrary",
-]
 
 [[package]]
 name = "cranelift-control"
@@ -1499,37 +1404,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668e56db75a54816cbdd7c7b7bfc558b08bf7b2cda9d0846491517e92f3b393b"
-dependencies = [
- "cranelift-bitset 0.132.2",
- "serde",
- "serde_derive",
- "wasmtime-internal-core 45.0.2",
-]
-
-[[package]]
-name = "cranelift-entity"
 version = "0.133.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
- "cranelift-bitset 0.133.0",
+ "cranelift-bitset",
  "serde",
  "serde_derive",
- "wasmtime-internal-core 46.0.0",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63892dc1cc3ae48680183fa66997f60ffe7f1e200c8d390f8ee66edff4aef5a"
-dependencies = [
- "cranelift-codegen 0.132.2",
- "log",
- "smallvec",
- "target-lexicon",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1537,7 +1418,7 @@ name = "cranelift-frontend"
 version = "0.133.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
- "cranelift-codegen 0.133.0",
+ "cranelift-codegen",
  "hashbrown 0.17.1",
  "log",
  "smallvec",
@@ -1546,41 +1427,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94eaf429c32a12715429c7c6ddfdd43c170f4cdd7e97bfa507bd68a652091087"
-
-[[package]]
-name = "cranelift-isle"
 version = "0.133.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
-
-[[package]]
-name = "cranelift-native"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd77674904ae9be11c1e1efdba54788b59f3d6658d747b97534bfbba2909aacc"
-dependencies = [
- "cranelift-codegen 0.132.2",
- "libc",
- "target-lexicon",
-]
 
 [[package]]
 name = "cranelift-native"
 version = "0.133.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
- "cranelift-codegen 0.133.0",
+ "cranelift-codegen",
  "libc",
  "target-lexicon",
 ]
-
-[[package]]
-name = "cranelift-srcgen"
-version = "0.132.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba7c0ff5941842c36653da155580ce41e675c204a67ac1b4e1c478a9347bbb7"
 
 [[package]]
 name = "cranelift-srcgen"
@@ -2241,7 +2099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2436,7 +2294,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2708,7 +2566,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -3140,7 +2998,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3327,7 +3185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3350,7 +3208,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3703,15 +3561,6 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
@@ -3952,7 +3801,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5180,36 +5029,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9880c1985ccccaed3646b0ef793dc39a4b117403ed4afc6fa3ef6027c5200f"
-dependencies = [
- "cranelift-bitset 0.132.2",
- "log",
- "pulley-macros 45.0.2",
- "wasmtime-internal-core 45.0.2",
-]
-
-[[package]]
-name = "pulley-interpreter"
 version = "46.0.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
- "cranelift-bitset 0.133.0",
+ "cranelift-bitset",
  "log",
- "pulley-macros 46.0.0",
- "wasmtime-internal-core 46.0.0",
-]
-
-[[package]]
-name = "pulley-macros"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee249346855ad102580e474da5463f86f8a7d449e6d49e00fefb304e448e2983"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pulley-macros",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -5274,7 +5100,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5684,7 +5510,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6115,11 +5941,11 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/wasi-gfx/wasi-gfx-runtime.git?rev=24ac92e1a2fff283b2326a8607dd9b96c302237d#24ac92e1a2fff283b2326a8607dd9b96c302237d"
+source = "git+https://github.com/wasi-gfx/wasi-gfx-runtime.git?rev=301716b5591bc6e08eca852b936fc8a17dea5379#301716b5591bc6e08eca852b936fc8a17dea5379"
 dependencies = [
  "async-broadcast",
  "async-trait",
- "wasmtime-wasi-io 45.0.2",
+ "wasmtime-wasi-io",
 ]
 
 [[package]]
@@ -6207,7 +6033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6439,7 +6265,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6458,7 +6284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7110,7 +6936,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7571,10 +7397,10 @@ dependencies = [
  "uuid",
  "wasi-graphics-context-wasmtime",
  "wasi-webgpu-wasmtime",
- "wasmtime 46.0.0",
- "wasmtime-wasi 46.0.0",
+ "wasmtime",
+ "wasmtime-wasi",
  "wasmtime-wasi-http",
- "wasmtime-wasi-io 46.0.0",
+ "wasmtime-wasi-io",
  "wasmtime-wasi-tls",
  "wat",
  "webpki-roots 0.26.11",
@@ -7599,12 +7425,12 @@ dependencies = [
 [[package]]
 name = "wasi-graphics-context-wasmtime"
 version = "0.1.0"
-source = "git+https://github.com/wasi-gfx/wasi-gfx-runtime.git?rev=24ac92e1a2fff283b2326a8607dd9b96c302237d#24ac92e1a2fff283b2326a8607dd9b96c302237d"
+source = "git+https://github.com/wasi-gfx/wasi-gfx-runtime.git?rev=301716b5591bc6e08eca852b936fc8a17dea5379#301716b5591bc6e08eca852b936fc8a17dea5379"
 dependencies = [
  "raw-window-handle",
- "wasmtime 45.0.2",
- "wasmtime-wasi 45.0.2",
- "wasmtime-wasi-io 45.0.2",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wasmtime-wasi-io",
 ]
 
 [[package]]
@@ -7616,7 +7442,7 @@ checksum = "17218dd1de5aa7b0b5c7afec3cdd69d780632eb31f3925a8b8728cd6e29ebb73"
 [[package]]
 name = "wasi-webgpu-wasmtime"
 version = "0.1.0"
-source = "git+https://github.com/wasi-gfx/wasi-gfx-runtime.git?rev=24ac92e1a2fff283b2326a8607dd9b96c302237d#24ac92e1a2fff283b2326a8607dd9b96c302237d"
+source = "git+https://github.com/wasi-gfx/wasi-gfx-runtime.git?rev=301716b5591bc6e08eca852b936fc8a17dea5379#301716b5591bc6e08eca852b936fc8a17dea5379"
 dependencies = [
  "async-broadcast",
  "callback-future",
@@ -7625,9 +7451,9 @@ dependencies = [
  "raw-window-handle",
  "shared",
  "wasi-graphics-context-wasmtime",
- "wasmtime 45.0.2",
- "wasmtime-wasi 45.0.2",
- "wasmtime-wasi-io 45.0.2",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wasmtime-wasi-io",
  "wgpu-core",
  "wgpu-types",
 ]
@@ -7737,9 +7563,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.248.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
+checksum = "b089037d7eb453ed57b560fe7833de0707411c8b9fdc429745ced77e2a1bacb9"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -7747,8 +7573,8 @@ dependencies = [
  "log",
  "petgraph 0.6.5",
  "smallvec",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wat",
 ]
 
@@ -7998,7 +7824,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
- "serde",
 ]
 
 [[package]]
@@ -8037,17 +7862,6 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.248.0",
-]
-
-[[package]]
-name = "wasmprinter"
 version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
@@ -8055,59 +7869,6 @@ dependencies = [
  "anyhow",
  "termcolor",
  "wasmparser 0.251.0",
-]
-
-[[package]]
-name = "wasmtime"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ce9aa2c67f75fadcfdc6aa9097d03e7c39485dfe316f2ed6a7c0fd186c527"
-dependencies = [
- "addr2line",
- "async-trait",
- "bitflags",
- "bumpalo",
- "cc",
- "cfg-if",
- "encoding_rs",
- "futures",
- "fxprof-processed-profile",
- "gimli",
- "ittapi",
- "libc",
- "log",
- "mach2 0.4.3",
- "memfd",
- "object",
- "once_cell",
- "postcard",
- "pulley-interpreter 45.0.2",
- "rayon",
- "rustix",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "smallvec",
- "target-lexicon",
- "tempfile",
- "wasm-compose 0.248.0",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wasmtime-environ 45.0.2",
- "wasmtime-internal-cache",
- "wasmtime-internal-component-macro 45.0.2",
- "wasmtime-internal-component-util 45.0.2",
- "wasmtime-internal-core 45.0.2",
- "wasmtime-internal-cranelift 45.0.2",
- "wasmtime-internal-fiber 45.0.2",
- "wasmtime-internal-jit-debug 45.0.2",
- "wasmtime-internal-jit-icache-coherence 45.0.2",
- "wasmtime-internal-unwinder 45.0.2",
- "wasmtime-internal-versioned-export-macros 45.0.2",
- "wasmtime-internal-winch",
- "wat",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8124,63 +7885,43 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "futures",
+ "fxprof-processed-profile",
+ "gimli",
+ "ittapi",
  "libc",
  "log",
- "mach2 0.6.0",
+ "mach2",
  "memfd",
  "object",
  "once_cell",
  "postcard",
- "pulley-interpreter 46.0.0",
+ "pulley-interpreter",
+ "rayon",
  "rustix",
  "semver",
  "serde",
  "serde_derive",
+ "serde_json",
  "smallvec",
  "target-lexicon",
+ "tempfile",
+ "wasm-compose 0.251.0",
+ "wasm-encoder 0.251.0",
  "wasmparser 0.251.0",
- "wasmtime-environ 46.0.0",
- "wasmtime-internal-component-macro 46.0.0",
- "wasmtime-internal-component-util 46.0.0",
- "wasmtime-internal-core 46.0.0",
- "wasmtime-internal-cranelift 46.0.0",
- "wasmtime-internal-fiber 46.0.0",
- "wasmtime-internal-jit-debug 46.0.0",
- "wasmtime-internal-jit-icache-coherence 46.0.0",
- "wasmtime-internal-unwinder 46.0.0",
- "wasmtime-internal-versioned-export-macros 46.0.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wat",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fb157bd1fbf689ac89d570433a700db6f33bdfcb5ffc30e3f1c49e4c70de71"
-dependencies = [
- "anyhow",
- "cpp_demangle",
- "cranelift-bforest 0.132.2",
- "cranelift-bitset 0.132.2",
- "cranelift-entity 0.132.2",
- "gimli",
- "hashbrown 0.17.1",
- "indexmap 2.14.0",
- "log",
- "object",
- "postcard",
- "rustc-demangle",
- "semver",
- "serde",
- "serde_derive",
- "sha2 0.10.9",
- "smallvec",
- "target-lexicon",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wasmprinter 0.248.0",
- "wasmtime-internal-component-util 45.0.2",
- "wasmtime-internal-core 45.0.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -8190,9 +7931,9 @@ source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-impleme
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-bforest 0.133.0",
- "cranelift-bitset 0.133.0",
- "cranelift-entity 0.133.0",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
  "gimli",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -8209,15 +7950,14 @@ dependencies = [
  "wasm-encoder 0.251.0",
  "wasmparser 0.251.0",
  "wasmprinter 0.251.0",
- "wasmtime-internal-component-util 46.0.0",
- "wasmtime-internal-core 46.0.0",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d1a46c4a2360186b59c6ed7a74a1121ac97925ae9a18db1b2f146cc27ac0b7"
+version = "46.0.0"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -8228,28 +7968,13 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.9",
  "toml 0.9.12+spec-1.1.0",
- "wasmtime-environ 45.0.2",
+ "wasmtime-environ",
  "windows-sys 0.61.2",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96c17f35fae2ab574667aba0c58fd56349a6f788ac42541a2e543116d5cfb91"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn",
- "wasmtime-internal-component-util 45.0.2",
- "wasmtime-internal-wit-bindgen 45.0.2",
- "wit-parser 0.248.0",
-]
-
-[[package]]
-name = "wasmtime-internal-component-macro"
 version = "46.0.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
@@ -8257,33 +7982,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wasmtime-internal-component-util 46.0.0",
- "wasmtime-internal-wit-bindgen 46.0.0",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
  "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2eeb9b53222859e6f5dc73d2ccfb33254d672469cac11b693a71912e2f3817"
-
-[[package]]
-name = "wasmtime-internal-component-util"
 version = "46.0.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
-
-[[package]]
-name = "wasmtime-internal-core"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1deaf6bc3430abd7497b00c64f06ca2b97ca0fe41af87836446ca30949965c"
-dependencies = [
- "anyhow",
- "hashbrown 0.17.1",
- "libm",
- "serde",
-]
 
 [[package]]
 name = "wasmtime-internal-core"
@@ -8298,70 +8005,28 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845f83b5b04b11bc48329b53eb4fa8cf9f28a43c71ed8e1203f68ffa9806d1b"
-dependencies = [
- "cfg-if",
- "cranelift-codegen 0.132.2",
- "cranelift-control 0.132.2",
- "cranelift-entity 0.132.2",
- "cranelift-frontend 0.132.2",
- "cranelift-native 0.132.2",
- "gimli",
- "itertools 0.14.0",
- "log",
- "object",
- "pulley-interpreter 45.0.2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.248.0",
- "wasmtime-environ 45.0.2",
- "wasmtime-internal-core 45.0.2",
- "wasmtime-internal-unwinder 45.0.2",
- "wasmtime-internal-versioned-export-macros 45.0.2",
-]
-
-[[package]]
-name = "wasmtime-internal-cranelift"
 version = "46.0.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.133.0",
- "cranelift-control 0.133.0",
- "cranelift-entity 0.133.0",
- "cranelift-frontend 0.133.0",
- "cranelift-native 0.133.0",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
  "gimli",
  "itertools 0.14.0",
  "log",
  "object",
- "pulley-interpreter 46.0.0",
+ "pulley-interpreter",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
  "wasmparser 0.251.0",
- "wasmtime-environ 46.0.0",
- "wasmtime-internal-core 46.0.0",
- "wasmtime-internal-unwinder 46.0.0",
- "wasmtime-internal-versioned-export-macros 46.0.0",
-]
-
-[[package]]
-name = "wasmtime-internal-fiber"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10c8466f72965ae85c250f90aaa7992c089a2f8502009bd0d2c9e7d6409174a"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "rustix",
- "wasmtime-environ 45.0.2",
- "wasmtime-internal-versioned-export-macros 45.0.2",
- "windows-sys 0.61.2",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
@@ -8373,21 +8038,9 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix",
- "wasmtime-environ 46.0.0",
- "wasmtime-internal-versioned-export-macros 46.0.0",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-debug"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3adfecf5621b14d8f8871f4cb4ed9f844197b1ddefc702ef4c859552cd9551"
-dependencies = [
- "cc",
- "object",
- "rustix",
- "wasmtime-internal-versioned-export-macros 45.0.2",
 ]
 
 [[package]]
@@ -8396,19 +8049,9 @@ version = "46.0.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cc",
- "wasmtime-internal-versioned-export-macros 46.0.0",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-icache-coherence"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3c1e9fb618ec45c9b3477ea683cd37bee427273d7b13bba5c66a1caaf1dd6"
-dependencies = [
- "cfg-if",
- "libc",
- "wasmtime-internal-core 45.0.2",
- "windows-sys 0.61.2",
+ "object",
+ "rustix",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
@@ -8418,21 +8061,8 @@ source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-impleme
 dependencies = [
  "cfg-if",
  "libc",
- "wasmtime-internal-core 46.0.0",
+ "wasmtime-internal-core",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-internal-unwinder"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa91132b81f1e172ec7e7c3c114ac34209ee6b3524b3a8d6943af99803f66c5"
-dependencies = [
- "cfg-if",
- "cranelift-codegen 0.132.2",
- "log",
- "object",
- "wasmtime-environ 45.0.2",
 ]
 
 [[package]]
@@ -8441,21 +8071,10 @@ version = "46.0.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.133.0",
+ "cranelift-codegen",
  "log",
  "object",
- "wasmtime-environ 46.0.0",
-]
-
-[[package]]
-name = "wasmtime-internal-versioned-export-macros"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea811ffe23f597cc7708327ea25d9eb018dcf760ffe15ccb7d0b27ad635de61"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "wasmtime-environ",
 ]
 
 [[package]]
@@ -8466,36 +8085,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828b66175c54a0d00b4c1c1c76658d8aa73aeb9fa3553575c5eee56d40f2eb18"
-dependencies = [
- "cranelift-codegen 0.132.2",
- "gimli",
- "log",
- "object",
- "target-lexicon",
- "wasmparser 0.248.0",
- "wasmtime-environ 45.0.2",
- "wasmtime-internal-cranelift 45.0.2",
- "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-internal-wit-bindgen"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae00896ad9bef1b3ca6401ae9a841daa6f357dd91541b6baf87082946d1bde1"
-dependencies = [
- "anyhow",
- "bitflags",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "wit-parser 0.248.0",
 ]
 
 [[package]]
@@ -8512,36 +8101,6 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032ceffcb74cf30a2cdac298a4d6ce219058f08479ce1ab38434aadc044000b"
-dependencies = [
- "async-trait",
- "bitflags",
- "bytes",
- "cap-fs-ext",
- "cap-net-ext",
- "cap-std",
- "cap-time-ext",
- "cfg-if",
- "fs-set-times",
- "futures",
- "io-extras",
- "io-lifetimes",
- "rand 0.10.1",
- "rustix",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "wasmtime 45.0.2",
- "wasmtime-wasi-io 45.0.2",
- "wiggle",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-wasi"
 version = "46.0.0"
 source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
@@ -8562,8 +8121,9 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtime 46.0.0",
- "wasmtime-wasi-io 46.0.0",
+ "wasmtime",
+ "wasmtime-wasi-io",
+ "wiggle",
  "windows-sys 0.61.2",
 ]
 
@@ -8584,23 +8144,10 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tracing",
- "wasmtime 46.0.0",
- "wasmtime-wasi 46.0.0",
- "wasmtime-wasi-io 46.0.0",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wasmtime-wasi-io",
  "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "wasmtime-wasi-io"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b6e6868e5b93e1e10983a17afb631b39c236d8b6b4abe9faffe78f1ee0c6e7"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "tracing",
- "wasmtime 45.0.2",
 ]
 
 [[package]]
@@ -8612,7 +8159,7 @@ dependencies = [
  "bytes",
  "futures",
  "tracing",
- "wasmtime 46.0.0",
+ "wasmtime",
 ]
 
 [[package]]
@@ -8626,8 +8173,8 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
- "wasmtime 46.0.0",
- "wasmtime-wasi 46.0.0",
+ "wasmtime",
+ "wasmtime-wasi",
  "webpki-roots 0.26.11",
 ]
 
@@ -8861,37 +8408,34 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176527a028d6a426a514e3ca650c251a60541cde26df421f781339f27553ff9f"
+version = "46.0.0"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "bitflags",
  "thiserror 2.0.18",
  "tracing",
- "wasmtime 45.0.2",
- "wasmtime-environ 45.0.2",
+ "wasmtime",
+ "wasmtime-environ",
  "wiggle-macro",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604976b16d40f15606ae47ca22473c7574b317a6445ea2e3986f834a2ca0f449"
+version = "46.0.0"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
- "wasmtime-environ 45.0.2",
+ "wasmtime-environ",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7252f1689c33cf77cfac6115047c6a8b53f188c25c644f7856ad66c881c4077"
+version = "46.0.0"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8921,7 +8465,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8929,25 +8473,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c09acfdfa281b3340e1e94ef3cf6618d69eab975280f881e154c29f49419c1"
-dependencies = [
- "cranelift-assembler-x64 0.132.2",
- "cranelift-codegen 0.132.2",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.248.0",
- "wasmtime-environ 45.0.2",
- "wasmtime-internal-core 45.0.2",
- "wasmtime-internal-cranelift 45.0.2",
-]
 
 [[package]]
 name = "windows"
@@ -9379,7 +8904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -465,15 +465,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -637,12 +637,15 @@ name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -667,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -756,8 +759,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "tonic",
  "tonic-prost",
  "ureq",
@@ -772,7 +775,7 @@ dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "prost 0.14.3",
+ "prost 0.14.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -781,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -791,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
  "darling 0.23.0",
  "ident_case",
@@ -805,10 +808,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 dependencies = [
  "allocator-api2",
 ]
@@ -942,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -977,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1066,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -1102,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -1306,7 +1318,15 @@ version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bc293b86236abcc45f2f72e2d18e2bd636f2a08b75eb286bae31e71e1430c91"
 dependencies = [
- "cranelift-assembler-x64-meta",
+ "cranelift-assembler-x64-meta 0.132.2",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.133.0",
 ]
 
 [[package]]
@@ -1315,7 +1335,15 @@ version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b954c826eddaf1b001402cb8aecf1764c6f6d637ba69fb9e3311f1ebac965be6"
 dependencies = [
- "cranelift-srcgen",
+ "cranelift-srcgen 0.132.2",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cranelift-srcgen 0.133.0",
 ]
 
 [[package]]
@@ -1324,8 +1352,17 @@ version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4053fa2575ef4a5c35d2708533df2200400ae979226cea9cc92a578b811bd4e7"
 dependencies = [
- "cranelift-entity",
- "wasmtime-internal-core",
+ "cranelift-entity 0.132.2",
+ "wasmtime-internal-core 45.0.2",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cranelift-entity 0.133.0",
+ "wasmtime-internal-core 46.0.0",
 ]
 
 [[package]]
@@ -1336,7 +1373,17 @@ checksum = "d216663191014aa63e1d2cffd058e609eaf207646d40b739d88250f65b2c4f69"
 dependencies = [
  "serde",
  "serde_derive",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 45.0.2",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core 46.0.0",
 ]
 
 [[package]]
@@ -1346,25 +1393,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5e7e7aad6a425a51da1ad7ab9e5d280ea97eb7c7c4545fafb567915a75aadb"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
+ "cranelift-assembler-x64 0.132.2",
+ "cranelift-bforest 0.132.2",
+ "cranelift-bitset 0.132.2",
+ "cranelift-codegen-meta 0.132.2",
+ "cranelift-codegen-shared 0.132.2",
+ "cranelift-control 0.132.2",
+ "cranelift-entity 0.132.2",
+ "cranelift-isle 0.132.2",
  "gimli",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "libm",
  "log",
- "pulley-interpreter",
+ "pulley-interpreter 45.0.2",
  "regalloc2",
  "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 45.0.2",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64 0.133.0",
+ "cranelift-bforest 0.133.0",
+ "cranelift-bitset 0.133.0",
+ "cranelift-codegen-meta 0.133.0",
+ "cranelift-codegen-shared 0.133.0",
+ "cranelift-control 0.133.0",
+ "cranelift-entity 0.133.0",
+ "cranelift-isle 0.133.0",
+ "gimli",
+ "hashbrown 0.17.1",
+ "libm",
+ "log",
+ "postcard",
+ "pulley-interpreter 46.0.0",
+ "regalloc2",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core 46.0.0",
 ]
 
 [[package]]
@@ -1373,11 +1450,23 @@ version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c421d80a9a85f806cb02a2983b5b5368a335c319795b1f1b4b771a24479af5b0"
 dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared",
- "cranelift-srcgen",
+ "cranelift-assembler-x64-meta 0.132.2",
+ "cranelift-codegen-shared 0.132.2",
+ "cranelift-srcgen 0.132.2",
  "heck 0.5.0",
- "pulley-interpreter",
+ "pulley-interpreter 45.0.2",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.133.0",
+ "cranelift-codegen-shared 0.133.0",
+ "cranelift-srcgen 0.133.0",
+ "heck 0.5.0",
+ "pulley-interpreter 46.0.0",
 ]
 
 [[package]]
@@ -1385,6 +1474,11 @@ name = "cranelift-codegen-shared"
 version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78fdb83ab012d0ee6a44ced7ca8788a444f17cf821c62f95d6ef87c9f0262518"
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
 
 [[package]]
 name = "cranelift-control"
@@ -1396,15 +1490,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-control"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
 name = "cranelift-entity"
 version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "668e56db75a54816cbdd7c7b7bfc558b08bf7b2cda9d0846491517e92f3b393b"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.132.2",
  "serde",
  "serde_derive",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 45.0.2",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cranelift-bitset 0.133.0",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core 46.0.0",
 ]
 
 [[package]]
@@ -1413,7 +1526,19 @@ version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c63892dc1cc3ae48680183fa66997f60ffe7f1e200c8d390f8ee66edff4aef5a"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.132.2",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cranelift-codegen 0.133.0",
+ "hashbrown 0.17.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -1426,12 +1551,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94eaf429c32a12715429c7c6ddfdd43c170f4cdd7e97bfa507bd68a652091087"
 
 [[package]]
+name = "cranelift-isle"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+
+[[package]]
 name = "cranelift-native"
 version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd77674904ae9be11c1e1efdba54788b59f3d6658d747b97534bfbba2909aacc"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.132.2",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cranelift-codegen 0.133.0",
  "libc",
  "target-lexicon",
 ]
@@ -1441,6 +1581,11 @@ name = "cranelift-srcgen"
 version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cba7c0ff5941842c36653da155580ce41e675c204a67ac1b4e1c478a9347bbb7"
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.133.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
 
 [[package]]
 name = "crc32fast"
@@ -1553,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1567,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1651,19 +1796,19 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dbus"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
 dependencies = [
  "libc",
  "libdbus-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1772,7 +1917,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1856,13 +2000,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1931,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1960,11 +2104,11 @@ dependencies = [
 
 [[package]]
 name = "docker_credential"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "serde",
  "serde_json",
 ]
@@ -2006,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -2215,13 +2359,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -2501,11 +2644,10 @@ dependencies = [
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -2602,9 +2744,9 @@ dependencies = [
 
 [[package]]
 name = "gungraun"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4d8da7e495043e7050236881e37c8c7cbd896a8674c2fa49b13f2ff8c9505b"
+checksum = "7dcd6043b1ff8096c10cdd5c59930139b52ba63cbd1a3452bc3ff95d996f9334"
 dependencies = [
  "bincode-next",
  "derive_more",
@@ -2614,12 +2756,12 @@ dependencies = [
 
 [[package]]
 name = "gungraun-macros"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc6269e89921872ec32af29af3a992618b9bd2ef47cbf3704af476066cb7182"
+checksum = "d7f3214bae6cfd6739f4f29edb262bae439c6393a7b7b12c4eeb96417c2e50df"
 dependencies = [
  "derive_more",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2630,18 +2772,18 @@ dependencies = [
 
 [[package]]
 name = "gungraun-runner"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d412a9c97a337ee83ab57c8e4e377cee1a519afaebbeb803c696ecd1e93173e2"
+checksum = "6965c4e60026245b5600b05ab4c4af5ae1eaf72b8ec5da86c9cc6af01258d8cc"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2706,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash 0.2.0",
  "serde",
@@ -2778,7 +2920,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2803,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2872,18 +3014,18 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3117,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3157,7 +3299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3199,16 +3341,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -3338,13 +3470,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3438,9 +3569,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -3450,9 +3581,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -3481,14 +3612,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3530,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "logos"
@@ -3583,6 +3711,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,14 +3744,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memfd"
@@ -3683,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -3717,9 +3851,9 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "naga"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -3774,9 +3908,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3796,9 +3930,9 @@ dependencies = [
 
 [[package]]
 name = "normpath"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3856,9 +3990,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3989,7 +4123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "memchr",
 ]
@@ -4204,7 +4338,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost 0.14.4",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -4218,7 +4352,7 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
  "tonic-prost",
 ]
@@ -4324,7 +4458,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -4400,8 +4534,8 @@ checksum = "af22d08a625a2213a78dbb0ffa253318c5c79ce3133d32d296655a7bdfb02095"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
 ]
 
 [[package]]
@@ -4429,8 +4563,8 @@ dependencies = [
  "chrono",
  "pbjson 0.8.0",
  "pbjson-build 0.8.0",
- "prost 0.14.3",
- "prost-build 0.14.3",
+ "prost 0.14.4",
+ "prost-build 0.14.4",
  "serde",
 ]
 
@@ -4580,18 +4714,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4630,12 +4764,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -4699,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.13"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacf632d0554ff75f58183694f41dc8999c8a3a43a386994d0ec2d034f1dfbe1"
+checksum = "33ad20e0aa0b24f5a394eab4f78c781d248982b22b25cecc7e3aa46a681605bd"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -4816,26 +4944,26 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
  "syn",
@@ -4865,9 +4993,9 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "prost"
@@ -4881,12 +5009,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -4912,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
@@ -4922,8 +5050,8 @@ dependencies = [
  "multimap",
  "petgraph 0.8.3",
  "prettyplease",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
@@ -4946,9 +5074,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -4981,11 +5109,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -5032,9 +5160,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "memchr",
@@ -5056,10 +5184,21 @@ version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9880c1985ccccaed3646b0ef793dc39a4b117403ed4afc6fa3ef6027c5200f"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.132.2",
  "log",
- "pulley-macros",
- "wasmtime-internal-core",
+ "pulley-macros 45.0.2",
+ "wasmtime-internal-core 45.0.2",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cranelift-bitset 0.133.0",
+ "log",
+ "pulley-macros 46.0.0",
+ "wasmtime-internal-core 46.0.0",
 ]
 
 [[package]]
@@ -5067,6 +5206,16 @@ name = "pulley-macros"
 version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee249346855ad102580e474da5463f86f8a7d449e6d49e00fefb304e448e2983"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5280,9 +5429,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "aws-lc-rs",
  "pem",
@@ -5319,15 +5468,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -5371,17 +5511,18 @@ checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "log",
  "rustc-hash 2.1.2",
+ "serde",
  "smallvec",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5402,9 +5543,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -5558,9 +5699,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5574,9 +5715,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -5586,9 +5727,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5797,9 +5938,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -5860,11 +6001,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5879,9 +6021,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -5945,7 +6087,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5977,7 +6119,7 @@ source = "git+https://github.com/wasi-gfx/wasi-gfx-runtime.git?rev=24ac92e1a2fff
 dependencies = [
  "async-broadcast",
  "async-trait",
- "wasmtime-wasi-io",
+ "wasmtime-wasi-io 45.0.2",
 ]
 
 [[package]]
@@ -5988,9 +6130,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -6020,9 +6162,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sized-chunks"
@@ -6051,18 +6193,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6202,9 +6344,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6401,12 +6543,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6416,15 +6557,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6506,9 +6647,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6699,14 +6840,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6715,7 +6856,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6732,9 +6873,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -6764,9 +6905,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6776,25 +6917,25 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
 ]
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.14.3",
- "prost-types 0.14.3",
+ "prost-build 0.14.4",
+ "prost-types 0.14.4",
  "quote",
  "syn",
  "tempfile",
@@ -6828,20 +6969,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6951,9 +7092,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -7026,9 +7167,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -7132,9 +7273,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7401,7 +7542,7 @@ dependencies = [
  "pbjson-types 0.8.0",
  "pg_bigdecimal",
  "postgres-types",
- "prost 0.14.3",
+ "prost 0.14.4",
  "rcgen",
  "redis",
  "reqwest",
@@ -7430,10 +7571,10 @@ dependencies = [
  "uuid",
  "wasi-graphics-context-wasmtime",
  "wasi-webgpu-wasmtime",
- "wasmtime",
- "wasmtime-wasi",
+ "wasmtime 46.0.0",
+ "wasmtime-wasi 46.0.0",
  "wasmtime-wasi-http",
- "wasmtime-wasi-io",
+ "wasmtime-wasi-io 46.0.0",
  "wasmtime-wasi-tls",
  "wat",
  "webpki-roots 0.26.11",
@@ -7461,16 +7602,16 @@ version = "0.1.0"
 source = "git+https://github.com/wasi-gfx/wasi-gfx-runtime.git?rev=24ac92e1a2fff283b2326a8607dd9b96c302237d#24ac92e1a2fff283b2326a8607dd9b96c302237d"
 dependencies = [
  "raw-window-handle",
- "wasmtime",
- "wasmtime-wasi",
- "wasmtime-wasi-io",
+ "wasmtime 45.0.2",
+ "wasmtime-wasi 45.0.2",
+ "wasmtime-wasi-io 45.0.2",
 ]
 
 [[package]]
 name = "wasi-preview1-component-adapter-provider"
-version = "45.0.0"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f912a3f8ead075800ffaaa13cb978bbcaa359c427688a753b10cd2f1e01fdf28"
+checksum = "17218dd1de5aa7b0b5c7afec3cdd69d780632eb31f3925a8b8728cd6e29ebb73"
 
 [[package]]
 name = "wasi-webgpu-wasmtime"
@@ -7484,18 +7625,18 @@ dependencies = [
  "raw-window-handle",
  "shared",
  "wasi-graphics-context-wasmtime",
- "wasmtime",
- "wasmtime-wasi",
- "wasmtime-wasi-io",
+ "wasmtime 45.0.2",
+ "wasmtime-wasi 45.0.2",
+ "wasmtime-wasi-io 45.0.2",
  "wgpu-core",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -7520,9 +7661,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7533,9 +7674,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7543,9 +7684,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7553,9 +7694,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7566,9 +7707,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -7653,12 +7794,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2271adb766023046af314460f1fae02cc34ea16d736d93404d3b65be44270923"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -7844,7 +7995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
  "bitflags",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
  "serde",
@@ -7852,9 +8003,22 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071d99cdfb8111603ed05500506c3298a940b58d609dd0259d3981785dd33556"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags",
  "indexmap 2.14.0",
@@ -7883,6 +8047,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmprinter"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.251.0",
+]
+
+[[package]]
 name = "wasmtime"
 version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7892,7 +8067,6 @@ dependencies = [
  "async-trait",
  "bitflags",
  "bumpalo",
- "bytes",
  "cc",
  "cfg-if",
  "encoding_rs",
@@ -7902,12 +8076,12 @@ dependencies = [
  "ittapi",
  "libc",
  "log",
- "mach2",
+ "mach2 0.4.3",
  "memfd",
  "object",
  "once_cell",
  "postcard",
- "pulley-interpreter",
+ "pulley-interpreter 45.0.2",
  "rayon",
  "rustix",
  "semver",
@@ -7920,19 +8094,61 @@ dependencies = [
  "wasm-compose 0.248.0",
  "wasm-encoder 0.248.0",
  "wasmparser 0.248.0",
- "wasmtime-environ",
+ "wasmtime-environ 45.0.2",
  "wasmtime-internal-cache",
- "wasmtime-internal-component-macro",
- "wasmtime-internal-component-util",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-fiber",
- "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-component-macro 45.0.2",
+ "wasmtime-internal-component-util 45.0.2",
+ "wasmtime-internal-core 45.0.2",
+ "wasmtime-internal-cranelift 45.0.2",
+ "wasmtime-internal-fiber 45.0.2",
+ "wasmtime-internal-jit-debug 45.0.2",
+ "wasmtime-internal-jit-icache-coherence 45.0.2",
+ "wasmtime-internal-unwinder 45.0.2",
+ "wasmtime-internal-versioned-export-macros 45.0.2",
  "wasmtime-internal-winch",
  "wat",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "addr2line",
+ "async-trait",
+ "bitflags",
+ "bumpalo",
+ "bytes",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "futures",
+ "libc",
+ "log",
+ "mach2 0.6.0",
+ "memfd",
+ "object",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter 46.0.0",
+ "rustix",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser 0.251.0",
+ "wasmtime-environ 46.0.0",
+ "wasmtime-internal-component-macro 46.0.0",
+ "wasmtime-internal-component-util 46.0.0",
+ "wasmtime-internal-core 46.0.0",
+ "wasmtime-internal-cranelift 46.0.0",
+ "wasmtime-internal-fiber 46.0.0",
+ "wasmtime-internal-jit-debug 46.0.0",
+ "wasmtime-internal-jit-icache-coherence 46.0.0",
+ "wasmtime-internal-unwinder 46.0.0",
+ "wasmtime-internal-versioned-export-macros 46.0.0",
  "windows-sys 0.61.2",
 ]
 
@@ -7944,11 +8160,11 @@ checksum = "c8fb157bd1fbf689ac89d570433a700db6f33bdfcb5ffc30e3f1c49e4c70de71"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-entity",
+ "cranelift-bforest 0.132.2",
+ "cranelift-bitset 0.132.2",
+ "cranelift-entity 0.132.2",
  "gimli",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "log",
  "object",
@@ -7963,8 +8179,38 @@ dependencies = [
  "wasm-encoder 0.248.0",
  "wasmparser 0.248.0",
  "wasmprinter 0.248.0",
- "wasmtime-internal-component-util",
- "wasmtime-internal-core",
+ "wasmtime-internal-component-util 45.0.2",
+ "wasmtime-internal-core 45.0.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest 0.133.0",
+ "cranelift-bitset 0.133.0",
+ "cranelift-entity 0.133.0",
+ "gimli",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
+ "wasmprinter 0.251.0",
+ "wasmtime-internal-component-util 46.0.0",
+ "wasmtime-internal-core 46.0.0",
 ]
 
 [[package]]
@@ -7982,7 +8228,7 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.9",
  "toml 0.9.12+spec-1.1.0",
- "wasmtime-environ",
+ "wasmtime-environ 45.0.2",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -7997,9 +8243,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wasmtime-internal-component-util",
- "wasmtime-internal-wit-bindgen",
+ "wasmtime-internal-component-util 45.0.2",
+ "wasmtime-internal-wit-bindgen 45.0.2",
  "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-internal-component-util 46.0.0",
+ "wasmtime-internal-wit-bindgen 46.0.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -8009,13 +8269,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d2eeb9b53222859e6f5dc73d2ccfb33254d672469cac11b693a71912e2f3817"
 
 [[package]]
+name = "wasmtime-internal-component-util"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+
+[[package]]
 name = "wasmtime-internal-core"
 version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1deaf6bc3430abd7497b00c64f06ca2b97ca0fe41af87836446ca30949965c"
 dependencies = [
  "anyhow",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
  "libm",
  "serde",
 ]
@@ -8027,24 +8303,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b845f83b5b04b11bc48329b53eb4fa8cf9f28a43c71ed8e1203f68ffa9806d1b"
 dependencies = [
  "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
+ "cranelift-codegen 0.132.2",
+ "cranelift-control 0.132.2",
+ "cranelift-entity 0.132.2",
+ "cranelift-frontend 0.132.2",
+ "cranelift-native 0.132.2",
  "gimli",
  "itertools 0.14.0",
  "log",
  "object",
- "pulley-interpreter",
+ "pulley-interpreter 45.0.2",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
  "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-environ 45.0.2",
+ "wasmtime-internal-core 45.0.2",
+ "wasmtime-internal-unwinder 45.0.2",
+ "wasmtime-internal-versioned-export-macros 45.0.2",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen 0.133.0",
+ "cranelift-control 0.133.0",
+ "cranelift-entity 0.133.0",
+ "cranelift-frontend 0.133.0",
+ "cranelift-native 0.133.0",
+ "gimli",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "pulley-interpreter 46.0.0",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.251.0",
+ "wasmtime-environ 46.0.0",
+ "wasmtime-internal-core 46.0.0",
+ "wasmtime-internal-unwinder 46.0.0",
+ "wasmtime-internal-versioned-export-macros 46.0.0",
 ]
 
 [[package]]
@@ -8057,8 +8359,22 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix",
- "wasmtime-environ",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-environ 45.0.2",
+ "wasmtime-internal-versioned-export-macros 45.0.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-environ 46.0.0",
+ "wasmtime-internal-versioned-export-macros 46.0.0",
  "windows-sys 0.61.2",
 ]
 
@@ -8071,7 +8387,16 @@ dependencies = [
  "cc",
  "object",
  "rustix",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-versioned-export-macros 45.0.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros 46.0.0",
 ]
 
 [[package]]
@@ -8082,7 +8407,18 @@ checksum = "08d3c1e9fb618ec45c9b3477ea683cd37bee427273d7b13bba5c66a1caaf1dd6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 45.0.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core 46.0.0",
  "windows-sys 0.61.2",
 ]
 
@@ -8093,10 +8429,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aa91132b81f1e172ec7e7c3c114ac34209ee6b3524b3a8d6943af99803f66c5"
 dependencies = [
  "cfg-if",
- "cranelift-codegen",
+ "cranelift-codegen 0.132.2",
  "log",
  "object",
- "wasmtime-environ",
+ "wasmtime-environ 45.0.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen 0.133.0",
+ "log",
+ "object",
+ "wasmtime-environ 46.0.0",
 ]
 
 [[package]]
@@ -8111,19 +8459,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "wasmtime-internal-winch"
 version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "828b66175c54a0d00b4c1c1c76658d8aa73aeb9fa3553575c5eee56d40f2eb18"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.132.2",
  "gimli",
  "log",
  "object",
  "target-lexicon",
  "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
+ "wasmtime-environ 45.0.2",
+ "wasmtime-internal-cranelift 45.0.2",
  "winch-codegen",
 ]
 
@@ -8138,6 +8496,18 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.14.0",
  "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -8164,17 +8534,43 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtime",
- "wasmtime-wasi-io",
+ "wasmtime 45.0.2",
+ "wasmtime-wasi-io 45.0.2",
  "wiggle",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
+name = "wasmtime-wasi"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "bytes",
+ "cap-fs-ext",
+ "cap-net-ext",
+ "cap-std",
+ "cap-time-ext",
+ "cfg-if",
+ "futures",
+ "io-extras",
+ "io-lifetimes",
+ "rand 0.10.1",
+ "rustix",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtime 46.0.0",
+ "wasmtime-wasi-io 46.0.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "wasmtime-wasi-http"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb570dc29e051beeb016aa62839871fde20d9b305b3809655d09461c304d71b2"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8188,9 +8584,9 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tracing",
- "wasmtime",
- "wasmtime-wasi",
- "wasmtime-wasi-io",
+ "wasmtime 46.0.0",
+ "wasmtime-wasi 46.0.0",
+ "wasmtime-wasi-io 46.0.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -8204,14 +8600,25 @@ dependencies = [
  "bytes",
  "futures",
  "tracing",
- "wasmtime",
+ "wasmtime 45.0.2",
+]
+
+[[package]]
+name = "wasmtime-wasi-io"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "tracing",
+ "wasmtime 46.0.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "45.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27a47053e969d38cf0d199f2ae2b0782b476aa72b79346b251a9652c02afdd9"
+version = "46.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -8219,8 +8626,8 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
- "wasmtime",
- "wasmtime-wasi",
+ "wasmtime 46.0.0",
+ "wasmtime-wasi 46.0.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -8235,24 +8642,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "250.0.0"
+version = "252.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e9294a1f0204aeb5c47e95165517f43ef3cc895918c4f3e939380d4c290f4a"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.250.0",
+ "wasm-encoder 0.252.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.250.0"
+version = "1.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a549ed329a70e444e0f7796391ab2a87d0aef30ddde9f60e16e429224fafd02"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
 dependencies = [
- "wast 250.0.0",
+ "wast 252.0.0",
 ]
 
 [[package]]
@@ -8269,9 +8676,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8307,9 +8714,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e80ac6cf1895df6342f87d975162108f9d98772a0d74bc404ab7304ac29469e"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -8339,36 +8746,36 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725d5c006a8c02967b6d93ef04f6537ec4593313e330cfe86d9d3f946eb90f28"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -8412,13 +8819,14 @@ dependencies = [
  "wgpu-types",
  "windows 0.62.2",
  "windows-core 0.62.2",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -8426,9 +8834,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -8440,9 +8848,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
  "libc",
  "libredox",
@@ -8460,8 +8868,8 @@ dependencies = [
  "bitflags",
  "thiserror 2.0.18",
  "tracing",
- "wasmtime",
- "wasmtime-environ",
+ "wasmtime 45.0.2",
+ "wasmtime-environ 45.0.2",
  "wiggle-macro",
 ]
 
@@ -8475,7 +8883,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wasmtime-environ",
+ "wasmtime-environ 45.0.2",
  "witx",
 ]
 
@@ -8528,17 +8936,17 @@ version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89c09acfdfa281b3340e1e94ef3cf6618d69eab975280f881e154c29f49419c1"
 dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
+ "cranelift-assembler-x64 0.132.2",
+ "cranelift-codegen 0.132.2",
  "gimli",
  "regalloc2",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
  "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
+ "wasmtime-environ 45.0.2",
+ "wasmtime-internal-core 45.0.2",
+ "wasmtime-internal-cranelift 45.0.2",
 ]
 
 [[package]]
@@ -8957,9 +9365,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -9131,7 +9539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
 dependencies = [
  "anyhow",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "id-arena",
  "indexmap 2.14.0",
  "log",
@@ -9141,6 +9549,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -9246,18 +9673,19 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -9340,18 +9768,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9360,9 +9788,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -9381,18 +9809,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,13 +120,14 @@ wasm-pkg-client = { version = "0.10.0", default-features = false }
 wasm-pkg-core = { version = "0.10.0", default-features = false }
 wasm-metadata = { version = "0.248.0", default-features = false, features = ["oci"] }
 wasmcloud = { path = "crates/wasmcloud", default-features = false }
-# wasmtime 46 is not yet released to crates.io; pin to the release-46.0.0
-# branch HEAD. Bump the rev together when picking up release-branch fixes,
-# and switch back to a crates.io `version` once 46.0.0 ships.
-# The resource-implements feature (bytecodealliance/wasmtime#13666) merged to
-# `main` and will ship in wasmtime 47 — it is NOT on the 46 release branch. To
-# run it on 46 we maintain a backport and pull it in via the
-# `[patch."https://github.com/bytecodealliance/wasmtime"]` section below.
+# Pinned to the release-46.0.0 branch HEAD rather than the crates.io 46.0.0
+# release because we need the resource-implements feature
+# (bytecodealliance/wasmtime#13666): it merged to `main` and ships in wasmtime
+# 47 — it is NOT on the 46 release branch. To run it on 46 we maintain a
+# backport and pull it in via the
+# `[patch."https://github.com/bytecodealliance/wasmtime"]` section below. Bump
+# the rev when picking up release-branch fixes. Drop the git pin for a crates.io
+# `version` once the feature lands in a stock release (wasmtime 47).
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
@@ -169,6 +170,16 @@ ignored = [
 [patch.crates-io]
 # Pinned for async component support (fixes #187). Remove after https://github.com/bytecodealliance/rust-oci-wasm/issues/28
 oci-wasm = { git = "https://github.com/bytecodealliance/rust-oci-wasm", rev = "5ee16fa1" }
+
+# The wasi-gfx deps (behind the `wasi-webgpu` feature) depend on wasmtime 46
+# from crates.io, while the rest of the workspace uses the forked git wasmtime
+# below. Without this, two distinct wasmtime crates end up in the graph and the
+# gfx `add_to_linker` calls fail to typecheck. Redirect crates.io wasmtime to
+# the same fork so the whole graph shares one wasmtime. Retire alongside the
+# git-source patch block when the workspace moves to wasmtime 47.
+wasmtime = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi-io = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
 
 # Redirect upstream wasmtime to a 46 backport carrying the resource-implements
 # feature (bytecodealliance/wasmtime#13666). The feature merged to `main` (47.0.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,10 @@ wasmcloud = { path = "crates/wasmcloud", default-features = false }
 # wasmtime 46 is not yet released to crates.io; pin to the release-46.0.0
 # branch HEAD. Bump the rev together when picking up release-branch fixes,
 # and switch back to a crates.io `version` once 46.0.0 ships.
+# The resource-implements feature (bytecodealliance/wasmtime#13666) merged to
+# `main` and will ship in wasmtime 47 — it is NOT on the 46 release branch. To
+# run it on 46 we maintain a backport and pull it in via the
+# `[patch."https://github.com/bytecodealliance/wasmtime"]` section below.
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
@@ -165,3 +169,22 @@ ignored = [
 [patch.crates-io]
 # Pinned for async component support (fixes #187). Remove after https://github.com/bytecodealliance/rust-oci-wasm/issues/28
 oci-wasm = { git = "https://github.com/bytecodealliance/rust-oci-wasm", rev = "5ee16fa1" }
+
+# Redirect upstream wasmtime to a 46 backport carrying the resource-implements
+# feature (bytecodealliance/wasmtime#13666). The feature merged to `main` (47.0.0)
+# but is not on the 46 release branch, and wasmtime does not backport features to
+# release branches — so to ship it on 46 we maintain `release-46.0.0-implements`
+# on the fork: `release-46.0.0` + the cherry-picked implements commits. Cargo
+# requires the patch source to be version-compatible with the upstream dep, so the
+# branch MUST stay based on release-46.0.0 (46.0.0) to match the rev pinned above
+# — a main-based (47.0.0) branch will fail to apply.
+#
+# Re-cherry-pick onto a newer release-46.0.x base when bumping the rev above.
+# Retire this whole block (and the fork branch) once the workspace moves to
+# wasmtime 47, where the feature ships in the stock release.
+[patch."https://github.com/bytecodealliance/wasmtime"]
+wasmtime = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi-io = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi-http = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi-tls = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ members = [
 [workspace.package]
 authors = ["The wasmCloud Team"]
 edition = "2024"
-rust-version = "1.91.0"
 version = "2.4.0"
+rust-version = "1.94.0"
 
 [workspace.lints.rust]
 warnings = 'deny' # Treat all warnings as errors
@@ -120,11 +120,14 @@ wasm-pkg-client = { version = "0.10.0", default-features = false }
 wasm-pkg-core = { version = "0.10.0", default-features = false }
 wasm-metadata = { version = "0.248.0", default-features = false, features = ["oci"] }
 wasmcloud = { path = "crates/wasmcloud", default-features = false }
-wasmtime = { version = "45.0.2", default-features = false }
-wasmtime-wasi = { version = "45.0.2", default-features = false }
-wasmtime-wasi-io = { version = "45.0.2", default-features = false }
-wasmtime-wasi-http = { version = "45.0.2", default-features = false }
-wasmtime-wasi-tls = { version = "45.0.2", default-features = false }
+# wasmtime 46 is not yet released to crates.io; pin to the release-46.0.0
+# branch HEAD. Bump the rev together when picking up release-branch fixes,
+# and switch back to a crates.io `version` once 46.0.0 ships.
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
+wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
+wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
+wasmtime-wasi-http = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
+wasmtime-wasi-tls = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wit-component = { version = "0.248.0", default-features = false }
 wash-runtime = { path = "crates/wash-runtime", default-features = false }
 wat = { version = "1.248.0", default-features = false }

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ USER nonroot
 # copy source code
 COPY --chown=nonroot:nonroot . .
 
-# Optional comma-separated cargo feature list (e.g. "wasip3,wasi-tls").
-# Empty by default so the standard image stays on WASI Preview 2.
+# Optional comma-separated cargo feature list for opt-in extras (e.g.
+# "wasi-tls", "wasi-webgpu"). WASI Preview 3 is already compiled into the
+# default wash build, so it needs no feature flag here.
 ARG CARGO_FEATURES=""
 
 # build static binary

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -55,12 +55,7 @@ wasmcloud-postgres = [
     "dep:bit-vec", "dep:cidr", "dep:geo-types",
     "dep:ulid",
 ]
-wasip3 = [
-    "wasmtime-wasi/p3",
-    "wasmtime-wasi-http/p3",
-    "wasmtime-wasi-http/component-model-async",
-]
-wasi-tls = ["dep:wasmtime-wasi-tls", "wasip3"]
+wasi-tls = ["dep:wasmtime-wasi-tls"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -85,9 +80,9 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["sync", "net", "macros"] }
 tracing = { workspace = true }
 wasmtime = { workspace = true, features = ["anyhow", "component-model", "component-model-async", "cranelift", "pooling-allocator", "gc", "gc-null", "threads"] }
-wasmtime-wasi = { workspace = true }
+wasmtime-wasi = { workspace = true, features = ["p3"] }
 wasmtime-wasi-io = { workspace = true }
-wasmtime-wasi-http = { workspace = true, features = ["default-send-request", "p2"] }
+wasmtime-wasi-http = { workspace = true, features = ["default-send-request", "p2", "p3", "component-model-async"] }
 wasmtime-wasi-tls = { workspace = true, optional = true, features = ["p3", "rustls"] }
 cap-net-ext = { workspace = true }
 cap-std = { workspace = true }
@@ -175,20 +170,16 @@ gungraun = "0.19.1"
 [[bench]]
 name = "http_invoke"
 harness = false
-required-features = ["wasip3"]
 
 [[bench]]
 name = "gungraun"
 harness = false
-required-features = ["wasip3"]
 
 [[bench]]
 name = "wasmtime_baseline"
 harness = false
-required-features = ["wasip3"]
 
 [[bench]]
 name = "wasmtime_serve"
 harness = false
-required-features = ["wasip3"]
 

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -37,7 +37,7 @@ path = "src/lib.rs"
 workspace = true
 
 [features]
-default = ["wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "washlet", "wasi-otel"]
+default = ["wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "washlet", "wasi-otel", "wasi-webgpu"]
 oci = ["dep:oci-client", "dep:oci-wasm", "dep:docker_credential", "dep:sha2", "dep:wit-component"]
 wasi-otel = []
 washlet = ["oci"]
@@ -115,8 +115,6 @@ opentelemetry-http = { workspace = true }
 # Otel dependencies (optional, behind 'wasi-otel' feature)
 opentelemetry-otlp = { workspace = true, features = ["grpc-tonic","http-proto", "trace", "metrics", "logs"] }
 opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"] }
-wasi-graphics-context-wasmtime = { git = "https://github.com/wasi-gfx/wasi-gfx-runtime.git", rev = "24ac92e1a2fff283b2326a8607dd9b96c302237d", optional = true }
-wasi-webgpu-wasmtime = { git = "https://github.com/wasi-gfx/wasi-gfx-runtime.git", rev = "24ac92e1a2fff283b2326a8607dd9b96c302237d", optional = true }
 
 # OCI dependencies (optional, behind 'oci' feature)
 docker_credential = { workspace = true, optional = true }
@@ -138,6 +136,14 @@ tokio-postgres-rustls = { optional = true, workspace = true }
 ulid = { optional = true, workspace = true, features = ["std"] }
 url = { workspace = true }
 webpki-roots = { workspace = true }
+
+# wasi-webgpu dependencies (optional, behind 'wasi-webgpu' feature). Pulled in
+# only on platforms where the `wasi_webgpu` plugin module compiles: wgpu-hal
+# fails to build on Windows and s390x, so the deps are gated to match the
+# `#[cfg]` on `plugin::wasi_webgpu`.
+[target.'cfg(all(not(target_os = "windows"), not(target_arch = "s390x")))'.dependencies]
+wasi-graphics-context-wasmtime = { git = "https://github.com/wasi-gfx/wasi-gfx-runtime.git", rev = "301716b5591bc6e08eca852b936fc8a17dea5379", optional = true }
+wasi-webgpu-wasmtime = { git = "https://github.com/wasi-gfx/wasi-gfx-runtime.git", rev = "301716b5591bc6e08eca852b936fc8a17dea5379", optional = true }
 
 # Proto codegen only. Wasm fixtures are built by `cargo xtask
 # build-fixtures` (see /xtask), which owns wit-component and the WASI

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -45,6 +45,8 @@ wasi-config = []
 wasi-logging = []
 wasi-blobstore = []
 wasi-keyvalue = []
+# Component-model `(implements ..)` / `named_imports` multiplexing
+wasm_component_model_implements = []
 wasi-webgpu = ["dep:wasi-webgpu-wasmtime", "dep:wasi-graphics-context-wasmtime"]
 wasmcloud-postgres = [
     "dep:tokio-postgres", "dep:tokio-postgres-rustls",

--- a/crates/wash-runtime/benches/gungraun.rs
+++ b/crates/wash-runtime/benches/gungraun.rs
@@ -14,7 +14,7 @@
 //! installed:
 //! ```text
 //! cargo install gungraun-runner --version 0.19.1
-//! cargo bench -p wash-runtime --features wasip3 --bench gungraun
+//! cargo bench -p wash-runtime --bench gungraun
 //! ```
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -45,10 +45,7 @@ fn flavor_host_header(flavor: Flavor) -> &'static str {
 }
 
 fn engine() -> Engine {
-    Engine::builder()
-        .with_wasip3(true)
-        .build()
-        .expect("failed to build engine with wasip3")
+    Engine::builder().build().expect("failed to build engine")
 }
 
 fn http_host_interfaces(host: &str) -> Vec<WitInterface> {

--- a/crates/wash-runtime/benches/http_invoke.rs
+++ b/crates/wash-runtime/benches/http_invoke.rs
@@ -18,7 +18,7 @@
 //!
 //! Run with:
 //! ```text
-//! cargo bench -p wash-runtime --features wasip3 --bench http_invoke
+//! cargo bench -p wash-runtime --bench http_invoke
 //! ```
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -56,11 +56,7 @@ fn flavor_host_header(flavor: Flavor) -> &'static str {
 }
 
 fn engine() -> Engine {
-    // Enable P3 unconditionally so the same engine can serve both flavors.
-    Engine::builder()
-        .with_wasip3(true)
-        .build()
-        .expect("failed to build engine with wasip3")
+    Engine::builder().build().expect("failed to build engine")
 }
 
 fn http_host_interfaces(host: &str) -> Vec<WitInterface> {

--- a/crates/wash-runtime/benches/wasmtime_baseline.rs
+++ b/crates/wash-runtime/benches/wasmtime_baseline.rs
@@ -18,7 +18,7 @@
 //!
 //! Run with:
 //! ```text
-//! cargo bench -p wash-runtime --features wasip3 --bench wasmtime_baseline
+//! cargo bench -p wash-runtime --bench wasmtime_baseline
 //! ```
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -95,7 +95,6 @@ impl wasmtime_wasi_http::p2::WasiHttpView for Ctx {
     }
 }
 
-#[cfg(feature = "wasip3")]
 impl wasmtime_wasi_http::p3::WasiHttpView for Ctx {
     fn http(&mut self) -> wasmtime_wasi_http::p3::WasiHttpCtxView<'_> {
         wasmtime_wasi_http::p3::WasiHttpCtxView {
@@ -119,7 +118,6 @@ fn build_engine() -> anyhow::Result<Engine> {
     pool.total_tables(100);
     pool.total_component_instances(100);
     cfg.allocation_strategy(wasmtime::InstanceAllocationStrategy::Pooling(pool));
-    #[cfg(feature = "wasip3")]
     cfg.wasm_component_model_async(true);
     Ok(Engine::new(&cfg)?)
 }
@@ -132,12 +130,9 @@ fn build_linker(engine: &Engine) -> anyhow::Result<Linker<Ctx>> {
     wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
     wasmtime_wasi_http::p2::add_only_http_to_linker_async(&mut linker)?;
 
-    // P3 WASI + wasi:http bindings (only present when the wasip3 feature is on).
-    #[cfg(feature = "wasip3")]
-    {
-        wasmtime_wasi::p3::add_to_linker(&mut linker)?;
-        wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
-    }
+    // P3 WASI + wasi:http bindings.
+    wasmtime_wasi::p3::add_to_linker(&mut linker)?;
+    wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
 
     Ok(linker)
 }
@@ -187,7 +182,6 @@ async fn handle_p2(
 }
 
 /// Handle a P3 request via `wasi:http/handler@0.3.x`.
-#[cfg(feature = "wasip3")]
 async fn handle_p3(
     pre: wasmtime::component::InstancePre<Ctx>,
     req: hyper::Request<Incoming>,
@@ -304,10 +298,7 @@ impl Server {
                             async move {
                                 let resp = match flavor_copy {
                                     Flavor::P2 => handle_p2(pre, req).await,
-                                    #[cfg(feature = "wasip3")]
                                     Flavor::P3 => handle_p3(pre, req).await,
-                                    #[cfg(not(feature = "wasip3"))]
-                                    Flavor::P3 => unreachable!("wasip3 feature disabled"),
                                 };
                                 match resp {
                                     Ok(r) => Ok::<_, hyper::Error>(r),

--- a/crates/wash-runtime/benches/wasmtime_serve.rs
+++ b/crates/wash-runtime/benches/wasmtime_serve.rs
@@ -17,7 +17,7 @@
 //!
 //! Run with:
 //! ```text
-//! cargo bench -p wash-runtime --features wasip3 --bench wasmtime_serve
+//! cargo bench -p wash-runtime --bench wasmtime_serve
 //! ```
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -25,15 +25,17 @@
 mod common;
 
 use std::{
+    future::Future,
     net::SocketAddr,
+    pin::Pin,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
+    task::{Context, Poll},
     time::{Duration, Instant},
 };
 
-use anyhow::Context as _;
 use common::Flavor;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use http_body_util::BodyExt;
@@ -44,20 +46,26 @@ use hyper_util::{
 };
 use tokio::{net::TcpListener, runtime::Runtime, sync::oneshot, task::JoinHandle};
 use wasmtime::{
-    Engine, Store,
-    component::{Component, Linker, ResourceTable},
+    Engine, Store, StoreContextMut,
+    component::{Component, GuestTaskId, Linker, ResourceTable},
 };
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wasi_http::{
     WasiHttpCtx,
-    handler::{HandlerState, Proxy, ProxyHandler, ProxyPre as HandlerProxyPre, StoreBundle},
-    p2::body::HyperOutgoingBody,
+    handler::{
+        HandlerState, Instance, ProxyHandler, ProxyPre, ShouldAccept, ViewFn, WorkerExpiration,
+        WorkerState, WorkerStatus,
+    },
 };
 
 // Defaults lifted from wasmtime-cli/src/commands/serve.rs.
 const DEFAULT_WASIP3_MAX_INSTANCE_REUSE_COUNT: usize = 128;
 const DEFAULT_WASIP2_MAX_INSTANCE_REUSE_COUNT: usize = 1;
 const DEFAULT_WASIP3_MAX_INSTANCE_CONCURRENT_REUSE_COUNT: usize = 16;
+
+/// Unified response body produced by `handler::ProxyHandler::handle` for both
+/// the P2 and P3 dispatch paths.
+type ServeBody = http_body_util::combinators::UnsyncBoxBody<bytes::Bytes, wasmtime::Error>;
 
 // ---------------------------------------------------------------------------
 // Store context
@@ -98,7 +106,6 @@ impl wasmtime_wasi_http::p2::WasiHttpView for Ctx {
     }
 }
 
-#[cfg(feature = "wasip3")]
 impl wasmtime_wasi_http::p3::WasiHttpView for Ctx {
     fn http(&mut self) -> wasmtime_wasi_http::p3::WasiHttpCtxView<'_> {
         wasmtime_wasi_http::p3::WasiHttpCtxView {
@@ -134,7 +141,6 @@ fn build_engine() -> anyhow::Result<Engine> {
     pool.total_tables(100);
     pool.total_component_instances(100);
     cfg.allocation_strategy(wasmtime::InstanceAllocationStrategy::Pooling(pool));
-    #[cfg(feature = "wasip3")]
     cfg.wasm_component_model_async(true);
     Ok(Engine::new(&cfg)?)
 }
@@ -143,185 +149,125 @@ fn build_linker(engine: &Engine) -> anyhow::Result<Linker<Ctx>> {
     let mut linker: Linker<Ctx> = Linker::new(engine);
     wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
     wasmtime_wasi_http::p2::add_only_http_to_linker_async(&mut linker)?;
-    #[cfg(feature = "wasip3")]
-    {
-        wasmtime_wasi::p3::add_to_linker(&mut linker)?;
-        wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
-    }
+    wasmtime_wasi::p3::add_to_linker(&mut linker)?;
+    wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
     Ok(linker)
 }
 
 // ---------------------------------------------------------------------------
-// HandlerState  - tells ProxyHandler how to produce Stores and bound reuse
+// HandlerState  - tells ProxyHandler how to instantiate workers and how each
+// worker decides whether to accept more requests (instance reuse policy).
 // ---------------------------------------------------------------------------
 
 struct State {
     engine: Engine,
+    pre: ProxyPre<Ctx>,
+    view: ViewFn<Ctx>,
     max_instance_reuse_count: usize,
     max_instance_concurrent_reuse_count: usize,
+    next_request_id: AtomicU64,
 }
 
 impl HandlerState for State {
     type StoreData = Ctx;
+    type WorkerExpiration = NeverExpire;
+    type WorkerState = ReuseState;
 
-    fn new_store(&self, _req_id: Option<u64>) -> wasmtime::Result<StoreBundle<Ctx>> {
-        let store = Store::new(&self.engine, Ctx::new());
-        Ok(StoreBundle {
+    async fn instantiate(&self) -> wasmtime::Result<Instance<Ctx, NeverExpire, ReuseState>> {
+        let mut store = Store::new(&self.engine, Ctx::new());
+        let proxy = self.pre.instantiate_async(&mut store).await?;
+        Ok(Instance {
             store,
-            write_profile: Box::new(|_| ()),
+            proxy,
+            view: self.view,
+            expiration: NeverExpire,
+            state: ReuseState {
+                max_instance_reuse_count: self.max_instance_reuse_count,
+                max_instance_concurrent_reuse_count: self.max_instance_concurrent_reuse_count,
+            },
         })
     }
+}
 
-    fn request_timeout(&self) -> Duration {
-        Duration::MAX
+/// Workers never time out on their own; the bench drops the whole server when
+/// a group finishes, and the reuse cap in [`ReuseState`] retires instances.
+struct NeverExpire;
+
+impl WorkerExpiration for NeverExpire {
+    fn poll(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _status: WorkerStatus,
+        _start: Instant,
+    ) -> Poll<()> {
+        Poll::Pending
+    }
+}
+
+/// Instance-reuse policy mirroring `wasmtime serve`: retire an instance once it
+/// has served `max_instance_reuse_count` requests, and cap in-flight requests
+/// per instance at `max_instance_concurrent_reuse_count`.
+struct ReuseState {
+    max_instance_reuse_count: usize,
+    max_instance_concurrent_reuse_count: usize,
+}
+
+impl WorkerState for ReuseState {
+    type StoreData = Ctx;
+    type RequestId = u64;
+
+    fn should_accept_request(&self, concurrent_count: usize, total_count: usize) -> ShouldAccept {
+        if total_count >= self.max_instance_reuse_count {
+            ShouldAccept::Never
+        } else if concurrent_count >= self.max_instance_concurrent_reuse_count {
+            ShouldAccept::No
+        } else {
+            ShouldAccept::Yes
+        }
     }
 
-    fn idle_instance_timeout(&self) -> Duration {
-        // Short enough that idle workers don't linger across bench groups,
-        // long enough that it never fires mid-run.
-        Duration::from_secs(60)
+    fn on_request_start(
+        &self,
+        _store: StoreContextMut<'_, Ctx>,
+        _id: u64,
+        _task: GuestTaskId,
+    ) -> Pin<Box<dyn Future<Output = ()> + 'static + Send + Sync>> {
+        // The bench never expires requests; this future stays pending so the
+        // guest is the only thing that ends a request.
+        Box::pin(std::future::pending())
     }
 
-    fn max_instance_reuse_count(&self) -> usize {
-        self.max_instance_reuse_count
-    }
-
-    fn max_instance_concurrent_reuse_count(&self) -> usize {
-        self.max_instance_concurrent_reuse_count
-    }
-
-    fn handle_worker_error(&self, error: wasmtime::Error) {
-        eprintln!("[wasmtime_serve bench] worker error: {error:?}");
+    fn drop(&self, store: Store<Ctx>, result: wasmtime::Result<()>) {
+        if let Err(error) = result {
+            eprintln!("[wasmtime_serve bench] worker failed: {error:?}");
+        }
+        drop(store);
     }
 }
 
 // ---------------------------------------------------------------------------
-// Request dispatch  - mirrors wasmtime-cli/src/commands/serve.rs::handle_request
+// Request dispatch  - hand the request to ProxyHandler, which routes P2/P3 and
+// applies the reuse policy, then return its unified response.
 // ---------------------------------------------------------------------------
-
-type P2Response = Result<
-    hyper::Response<HyperOutgoingBody>,
-    wasmtime_wasi_http::p2::bindings::http::types::ErrorCode,
->;
-type P3Response =
-    hyper::Response<http_body_util::combinators::UnsyncBoxBody<bytes::Bytes, wasmtime::Error>>;
-
-enum Sender {
-    P2(oneshot::Sender<P2Response>),
-    P3(oneshot::Sender<P3Response>),
-}
-
-enum Receiver {
-    P2(oneshot::Receiver<P2Response>),
-    P3(oneshot::Receiver<P3Response>),
-}
 
 async fn handle_request(
     handler: ProxyHandler<State>,
     req: hyper::Request<Incoming>,
-) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
-    let req_id = handler.next_req_id();
+) -> anyhow::Result<hyper::Response<ServeBody>> {
+    use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
 
-    let (tx, rx) = match handler.instance_pre() {
-        HandlerProxyPre::P2(_) => {
-            let (tx, rx) = oneshot::channel();
-            (Sender::P2(tx), Receiver::P2(rx))
-        }
-        HandlerProxyPre::P3(_) => {
-            let (tx, rx) = oneshot::channel();
-            (Sender::P3(tx), Receiver::P3(rx))
-        }
-    };
+    let request_id = handler
+        .state()
+        .next_request_id
+        .fetch_add(1, Ordering::Relaxed);
 
-    handler.spawn(
-        if handler.state().max_instance_reuse_count() == 1 {
-            Some(req_id)
-        } else {
-            None
-        },
-        Box::new(move |accessor, proxy| {
-            Box::pin(async move {
-                let result: wasmtime::Result<()> = match proxy {
-                    Proxy::P2(proxy) => {
-                        let Sender::P2(tx) = tx else { unreachable!() };
-                        let setup: wasmtime::Result<_> = accessor.with(move |mut store| {
-                            let req = wasmtime_wasi_http::p2::WasiHttpView::http(store.data_mut())
-                                .new_incoming_request(
-                                    wasmtime_wasi_http::p2::bindings::http::types::Scheme::Http,
-                                    req,
-                                )?;
-                            let out = wasmtime_wasi_http::p2::WasiHttpView::http(store.data_mut())
-                                .new_response_outparam(tx)?;
-                            wasmtime::error::Ok((req, out))
-                        });
-                        let (req, out) = match setup {
-                            Ok(v) => v,
-                            Err(e) => return eprintln!("[{req_id}] setup: {e:?}"),
-                        };
-                        proxy
-                            .wasi_http_incoming_handler()
-                            .call_handle(accessor, req, out)
-                            .await
-                    }
-                    Proxy::P3(proxy) => {
-                        let Sender::P3(tx) = tx else { unreachable!() };
-                        use wasmtime_wasi_http::p3::bindings::http::types::{ErrorCode, Request};
+    let req = req.map(|body| {
+        body.map_err(ErrorCode::from_hyper_request_error)
+            .map_err(wasmtime_wasi_http::handler::ErrorCode::from)
+            .boxed_unsync()
+    });
 
-                        let (parts, body) = req.into_parts();
-                        let body = body.map_err(ErrorCode::from_hyper_request_error);
-                        let req = hyper::Request::from_parts(parts, body);
-                        let (request, request_io_result) = Request::from_http(req);
-
-                        let res = match proxy.handle(accessor, request).await {
-                            Ok(Ok(r)) => r,
-                            Ok(Err(code)) => {
-                                return eprintln!("[{req_id}] handler err: {code:?}");
-                            }
-                            Err(e) => return eprintln!("[{req_id}] trap: {e:?}"),
-                        };
-
-                        let res =
-                            accessor.with(|mut store| res.into_http(&mut store, request_io_result));
-                        let res = match res {
-                            Ok(r) => r,
-                            Err(e) => return eprintln!("[{req_id}] into_http: {e:?}"),
-                        };
-
-                        let res = res.map(|body| body.map_err(|e| e.into()).boxed_unsync());
-                        let _ = tx.send(res);
-                        Ok(())
-                    }
-                };
-                if let Err(e) = result {
-                    eprintln!("[{req_id}] :: {e:?}");
-                }
-            })
-        }),
-    );
-
-    match rx {
-        Receiver::P2(rx) => {
-            let resp = rx
-                .await
-                .context("guest never invoked response-outparam::set")?;
-            Ok(resp.map_err(wasmtime::Error::from)?)
-        }
-        Receiver::P3(rx) => {
-            let resp = rx.await?;
-            let (parts, body) = resp.into_parts();
-            // Collect and re-wrap so the outer response body type matches the
-            // P2 path. For the minimal fixtures this is cheap (tiny payload).
-            let body = body
-                .collect()
-                .await
-                .map_err(|e| anyhow::anyhow!("collect p3 body: {e:?}"))?
-                .to_bytes();
-            let body: HyperOutgoingBody = http_body_util::Full::new(body)
-                .map_err(|never| match never {})
-                .boxed_unsync();
-            Ok(hyper::Response::from_parts(parts, body))
-        }
-    }
+    Ok(handler.handle(request_id, req).await?)
 }
 
 // ---------------------------------------------------------------------------
@@ -341,27 +287,31 @@ impl Server {
         let component = Component::from_binary(&engine, flavor.wasm())?;
         let instance_pre = linker.instantiate_pre(&component)?;
 
-        // Wrap InstancePre in the right handler::ProxyPre variant.
-        let handler_pre = match flavor {
-            Flavor::P2 => HandlerProxyPre::P2(
-                wasmtime_wasi_http::handler::p2::bindings::ProxyPre::new(instance_pre)?,
+        // Wrap the `InstancePre` in the right handler variant and pair it with
+        // the matching `WasiHttpView` getter.
+        let (pre, view) = match flavor {
+            Flavor::P2 => (
+                ProxyPre::P2(wasmtime_wasi_http::p2::bindings::ProxyPre::new(
+                    instance_pre,
+                )?),
+                ViewFn::P2(wasmtime_wasi_http::p2::WasiHttpView::http),
             ),
-            #[cfg(feature = "wasip3")]
-            Flavor::P3 => HandlerProxyPre::P3(wasmtime_wasi_http::p3::bindings::ServicePre::new(
-                instance_pre,
-            )?),
-            #[cfg(not(feature = "wasip3"))]
-            Flavor::P3 => anyhow::bail!("wasip3 feature disabled"),
+            Flavor::P3 => (
+                ProxyPre::P3(wasmtime_wasi_http::p3::bindings::ServicePre::new(
+                    instance_pre,
+                )?),
+                ViewFn::P3(wasmtime_wasi_http::p3::WasiHttpView::http),
+            ),
         };
 
-        let handler = ProxyHandler::new(
-            State {
-                engine,
-                max_instance_reuse_count: max_instance_reuse(flavor),
-                max_instance_concurrent_reuse_count: max_concurrent_reuse(flavor),
-            },
-            handler_pre,
-        );
+        let handler = ProxyHandler::new(State {
+            engine,
+            pre,
+            view,
+            max_instance_reuse_count: max_instance_reuse(flavor),
+            max_instance_concurrent_reuse_count: max_concurrent_reuse(flavor),
+            next_request_id: AtomicU64::new(0),
+        });
 
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let addr = listener.local_addr()?;
@@ -426,8 +376,8 @@ impl Drop for Server {
     }
 }
 
-fn error_response(status: u16) -> hyper::Response<HyperOutgoingBody> {
-    let body: HyperOutgoingBody = http_body_util::Empty::<bytes::Bytes>::new()
+fn error_response(status: u16) -> hyper::Response<ServeBody> {
+    let body: ServeBody = http_body_util::Empty::<bytes::Bytes>::new()
         .map_err(|never| match never {})
         .boxed_unsync();
     hyper::Response::builder()

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -158,7 +158,6 @@ pub struct Ctx {
     /// The HTTP hooks for outgoing HTTP requests (implements WasiHttpHooks for P2).
     http_hooks: CtxHttpHooks,
     /// The HTTP hooks for outgoing HTTP requests (implements WasiHttpHooks for P3).
-    #[cfg(feature = "wasip3")]
     http_hooks_p3: CtxHttpHooksP3,
 }
 
@@ -246,7 +245,6 @@ impl WasiTlsView for SharedCtx {
 }
 
 // Implement WasiHttpView for wasi:http P3
-#[cfg(feature = "wasip3")]
 impl wasmtime_wasi_http::p3::WasiHttpView for SharedCtx {
     fn http(&mut self) -> wasmtime_wasi_http::p3::WasiHttpCtxView<'_> {
         wasmtime_wasi_http::p3::WasiHttpCtxView {
@@ -286,14 +284,12 @@ impl WasiHttpHooks for CtxHttpHooks {
 /// configured [`HostHandler`](crate::host::http::HostHandler), so custom egress
 /// (allowed-hosts policy, alternate transports, etc.) applies uniformly to
 /// both P2 and P3 components.
-#[cfg(feature = "wasip3")]
 struct CtxHttpHooksP3 {
     http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
     workload_id: Arc<str>,
     allowed_hosts: Arc<[AllowedHost]>,
 }
 
-#[cfg(feature = "wasip3")]
 impl wasmtime_wasi_http::p3::WasiHttpHooks for CtxHttpHooksP3 {
     fn send_request(
         &mut self,
@@ -434,7 +430,6 @@ impl CtxBuilder {
             .map(|(k, v)| (k, v as Arc<dyn Any + Send + Sync>))
             .collect();
 
-        #[cfg(feature = "wasip3")]
         let http_hooks_p3 = CtxHttpHooksP3 {
             http_handler: self.http_handler.clone(),
             workload_id: self.workload_id.clone(),
@@ -472,7 +467,6 @@ impl CtxBuilder {
             },
             plugins,
             http_hooks,
-            #[cfg(feature = "wasip3")]
             http_hooks_p3,
         }
     }

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -104,10 +104,8 @@ fn add_wasi_to_linker(
     )?;
 
     // CLI
-    let cli_options = cli::exit::LinkOptions::default();
     cli::exit::add_to_linker::<SharedCtx, wasmtime_wasi::cli::WasiCli>(
         linker,
-        &cli_options,
         <SharedCtx as wasmtime_wasi::cli::WasiCliView>::cli,
     )?;
     cli::environment::add_to_linker::<SharedCtx, wasmtime_wasi::cli::WasiCli>(

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -625,6 +625,14 @@ pub enum WasmProposal {
     /// Component model async ABI (`stream`/`future`/`error-context` types).
     /// Enables `wasm_component_model_async`. Required for WASIP3.
     ComponentModelAsync,
+    /// Component model `(implements ..)` named imports, letting a component
+    /// import the same interface multiple times under distinct names so host
+    /// plugins can route each independently. Enables
+    /// `wasm_component_model_implements`. Requires the backported wasmtime
+    /// support, so it is only available with the `wasm_component_model_implements`
+    /// crate feature.
+    #[cfg(feature = "wasm_component_model_implements")]
+    WasmComponentModelImplements,
     /// Garbage collection. Enables `wasm_function_references` (a prerequisite)
     /// and `wasm_gc`.
     Gc,
@@ -644,6 +652,10 @@ impl WasmProposal {
         match self {
             WasmProposal::ComponentModelAsync => {
                 cfg.wasm_component_model_async(true);
+            }
+            #[cfg(feature = "wasm_component_model_implements")]
+            WasmProposal::WasmComponentModelImplements => {
+                cfg.wasm_component_model_implements(true);
             }
             WasmProposal::Gc => {
                 // GC builds on the function-references proposal.
@@ -866,6 +878,16 @@ impl EngineBuilder {
         if self.wasip3 {
             self.proposals.insert(WasmProposal::ComponentModelAsync);
         }
+
+        // Accept components that import an interface multiple times via the
+        // component-model `(implements ..)` annotation, so host plugins can
+        // route each named import (e.g. two `wasi:keyvalue/store` imports
+        // backed by redis vs NATS) independently. Only available with the
+        // backported wasmtime support behind the
+        // `wasm_component_model_implements` feature.
+        #[cfg(feature = "wasm_component_model_implements")]
+        self.proposals
+            .insert(WasmProposal::WasmComponentModelImplements);
 
         for proposal in &self.proposals {
             proposal.apply(&mut config);

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -59,13 +59,10 @@ use std::str::FromStr;
 use std::{path::PathBuf, sync::Arc};
 use wasmtime_wasi::WasiView;
 
-/// Add all WASI@0.2 interfaces to the linker, using upstream for non-socket interfaces
+/// Add all WASI interfaces to the linker, using upstream for non-socket interfaces
 /// and our custom socket implementation (with loopback support) for socket interfaces.
-/// When `wasip3` is true (and the feature is compiled in), P3 bindings are also registered.
-fn add_wasi_to_linker(
-    linker: &mut Linker<SharedCtx>,
-    #[cfg(feature = "wasip3")] wasip3: bool,
-) -> anyhow::Result<()> {
+/// Both P2 and P3 bindings are registered.
+fn add_wasi_to_linker(linker: &mut Linker<SharedCtx>) -> anyhow::Result<()> {
     use wasmtime_wasi::p2::bindings::{cli, clocks, filesystem, random, sockets};
 
     // IO interfaces (error, poll, streams)
@@ -177,29 +174,25 @@ fn add_wasi_to_linker(
         ctx::extract_sockets,
     )?;
 
-    #[cfg(feature = "wasip3")]
-    if wasip3 {
-        // CLI, clocks, filesystem, random — upstream P3 add_to_linker
-        wasmtime_wasi::p3::cli::add_to_linker(linker)?;
-        wasmtime_wasi::p3::clocks::add_to_linker(linker)?;
-        wasmtime_wasi::p3::filesystem::add_to_linker(linker)?;
-        wasmtime_wasi::p3::random::add_to_linker(linker)?;
+    // CLI, clocks, filesystem, random — upstream P3 add_to_linker
+    wasmtime_wasi::p3::cli::add_to_linker(linker)?;
+    wasmtime_wasi::p3::clocks::add_to_linker(linker)?;
+    wasmtime_wasi::p3::filesystem::add_to_linker(linker)?;
+    wasmtime_wasi::p3::random::add_to_linker(linker)?;
 
-        // Sockets with our custom P3 implementation (with loopback)
-        crate::sockets::add_p3_to_linker(linker)?;
+    // Sockets with our custom P3 implementation (with loopback)
+    crate::sockets::add_p3_to_linker(linker)?;
 
-        // wasi:tls@0.3.0-draft (p3).
-        #[cfg(feature = "wasi-tls")]
-        wasmtime_wasi_tls::p3::add_to_linker(linker)?;
-    }
+    // wasi:tls@0.3.0-draft (p3).
+    #[cfg(feature = "wasi-tls")]
+    wasmtime_wasi_tls::p3::add_to_linker(linker)?;
 
     Ok(())
 }
 
 /// Detect whether a component targets WASIP3 by checking for `@0.3` in WASI imports/exports.
-/// This is a pure detection function — the caller is responsible for checking whether
-/// WASIP3 support is enabled on the engine.
-#[cfg(feature = "wasip3")]
+/// This is a pure detection function used to pick the P2 vs P3 dispatch path; P3 bindings
+/// are always registered on the linker.
 pub fn targets_wasip3(component: &Component) -> bool {
     let ty = component.component_type();
     let engine = component.engine();
@@ -214,7 +207,6 @@ pub fn targets_wasip3(component: &Component) -> bool {
 /// `wasi:http` imports/exports with `@0.3`. Used for HTTP dispatch to avoid
 /// routing a component that imports `wasi:cli@0.3` but exports `wasi:http@0.2`
 /// through the P3 HTTP handler.
-#[cfg(feature = "wasip3")]
 pub fn targets_wasip3_http(component: &Component) -> bool {
     let ty = component.component_type();
     let engine = component.engine();
@@ -239,9 +231,6 @@ pub struct Engine {
     // wasmtime engine
     pub(crate) inner: wasmtime::Engine,
     pub(crate) cache: Cache<CacheKey, CacheValue>,
-    /// Whether WASIP3 support is enabled for this engine.
-    #[cfg(feature = "wasip3")]
-    wasip3: bool,
     /// TLS provider override for `wasi:tls` client connections.
     #[cfg(feature = "wasi-tls")]
     pub(crate) tls_provider: Option<SharedTlsProvider>,
@@ -250,8 +239,6 @@ pub struct Engine {
 impl std::fmt::Debug for Engine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut s = f.debug_struct("Engine");
-        #[cfg(feature = "wasip3")]
-        s.field("wasip3", &self.wasip3);
         #[cfg(feature = "wasi-tls")]
         s.field("tls_provider", &self.tls_provider.is_some());
         s.finish_non_exhaustive()
@@ -282,12 +269,6 @@ impl Engine {
     /// Gets a reference to the inner wasmtime engine.
     pub fn inner(&self) -> &wasmtime::Engine {
         &self.inner
-    }
-
-    /// Returns whether WASIP3 support is enabled for this engine.
-    #[cfg(feature = "wasip3")]
-    pub fn wasip3(&self) -> bool {
-        self.wasip3
     }
 
     /// Initializes a workload by validating and preparing all its components.
@@ -432,25 +413,16 @@ impl Engine {
         // Create a linker for this component
         let mut linker: Linker<SharedCtx> = Linker::new(&self.inner);
 
-        // Add WASI@0.2 interfaces to the linker (with custom socket implementation)
-        add_wasi_to_linker(
-            &mut linker,
-            #[cfg(feature = "wasip3")]
-            self.wasip3(),
-        )
-        .context("failed to add WASI to linker")?;
+        // Add WASI interfaces to the linker (with custom socket implementation)
+        add_wasi_to_linker(&mut linker).context("failed to add WASI to linker")?;
 
-        // Add HTTP interfaces to the linker if feature is enabled and component uses them
+        // Add HTTP interfaces to the linker if the component uses them
         if uses_wasi_http(&wasmtime_component) {
             wasmtime_wasi_http::p2::add_only_http_to_linker_async(&mut linker)
                 .map_err(anyhow::Error::from)
                 .context("failed to add wasi:http/types to linker")?;
-            #[cfg(feature = "wasip3")]
-            if self.wasip3() {
-                wasmtime_wasi_http::p3::add_to_linker(&mut linker).map_err(|e| {
-                    anyhow::anyhow!(e).context("failed to add wasi:http p3 to linker")
-                })?;
-            }
+            wasmtime_wasi_http::p3::add_to_linker(&mut linker)
+                .map_err(|e| anyhow::anyhow!(e).context("failed to add wasi:http p3 to linker"))?;
         }
 
         // Build volume mounts for this component by looking up validated volumes
@@ -476,8 +448,6 @@ impl Engine {
             service.local_resources,
             service.max_restarts,
             loopback,
-            #[cfg(feature = "wasip3")]
-            self.wasip3(),
         );
 
         let world = service.world();
@@ -548,25 +518,16 @@ impl Engine {
         // Create a linker for this component
         let mut linker: Linker<SharedCtx> = Linker::new(&self.inner);
 
-        // Add WASI@0.2 interfaces to the linker (with custom socket implementation)
-        add_wasi_to_linker(
-            &mut linker,
-            #[cfg(feature = "wasip3")]
-            self.wasip3(),
-        )
-        .context("failed to add WASI to linker")?;
+        // Add WASI interfaces to the linker (with custom socket implementation)
+        add_wasi_to_linker(&mut linker).context("failed to add WASI to linker")?;
 
         // Add HTTP interfaces to the linker
         if uses_wasi_http(&wasmtime_component) {
             wasmtime_wasi_http::p2::add_only_http_to_linker_async(&mut linker)
                 .map_err(anyhow::Error::from)
                 .context("failed to add wasi:http/types to linker")?;
-            #[cfg(feature = "wasip3")]
-            if self.wasip3() {
-                wasmtime_wasi_http::p3::add_to_linker(&mut linker).map_err(|e| {
-                    anyhow::anyhow!(e).context("failed to add wasi:http p3 to linker")
-                })?;
-            }
+            wasmtime_wasi_http::p3::add_to_linker(&mut linker)
+                .map_err(|e| anyhow::anyhow!(e).context("failed to add wasi:http p3 to linker"))?;
         }
 
         // Build volume mounts for this component by looking up validated volumes
@@ -593,8 +554,6 @@ impl Engine {
             component_volume_mounts,
             component.local_resources,
             loopback,
-            #[cfg(feature = "wasip3")]
-            self.wasip3(),
             // TODO: implement pooling and instance limits
             // component.pool_size,
             // component.max_invocations,
@@ -703,8 +662,6 @@ pub struct EngineBuilder {
     compilation_cache_size: Option<u64>,
     compilation_cache_ttl: Option<Duration>,
     fuel_consumption: Option<bool>,
-    #[cfg(feature = "wasip3")]
-    wasip3: bool,
     /// Optional TLS provider override for wasi:tls client connections.
     #[cfg(feature = "wasi-tls")]
     tls_provider: Option<SharedTlsProvider>,
@@ -797,18 +754,6 @@ impl EngineBuilder {
         self
     }
 
-    /// Enables or disables WASIP3 support.
-    ///
-    /// When enabled (and compiled with the `wasip3` feature), both P2 and P3
-    /// bindings are registered in component linkers, and
-    /// [`WasmProposal::ComponentModelAsync`] is enabled on the wasmtime config
-    /// (i.e. `wasm_component_model_async`), which the P3 async ABI requires.
-    #[cfg(feature = "wasip3")]
-    pub fn with_wasip3(mut self, enable: bool) -> Self {
-        self.wasip3 = enable;
-        self
-    }
-
     /// Override the TLS provider used for `wasi:tls` client connections.
     ///
     /// Use this to plug in an alternative TLS backend, install a custom root
@@ -874,10 +819,7 @@ impl EngineBuilder {
         }
 
         // WASIP3's async ABI requires the component-model async proposal.
-        #[cfg(feature = "wasip3")]
-        if self.wasip3 {
-            self.proposals.insert(WasmProposal::ComponentModelAsync);
-        }
+        self.proposals.insert(WasmProposal::ComponentModelAsync);
 
         // Accept components that import an interface multiple times via the
         // component-model `(implements ..)` annotation, so host plugins can
@@ -904,8 +846,6 @@ impl EngineBuilder {
         Ok(Engine {
             inner,
             cache,
-            #[cfg(feature = "wasip3")]
-            wasip3: self.wasip3,
             #[cfg(feature = "wasi-tls")]
             tls_provider: self.tls_provider,
         })

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -141,6 +141,7 @@ impl WorkloadMetadata {
             .component
             .component_type()
             .exports(self.component.engine())
+            .map(|(name, item)| (name, item.ty))
             .filter_map(|(name, item)| {
                 if matches!(item, ComponentItem::ComponentInstance(_)) {
                     Some((name.to_string(), item))
@@ -180,7 +181,7 @@ impl WorkloadMetadata {
             .component_type()
             .imports(self.component.engine())
         {
-            if let ComponentItem::ComponentInstance(_) = import_item {
+            if let ComponentItem::ComponentInstance(_) = import_item.ty {
                 let interface = WitInterface::from(import_name);
                 let k = interface.instance();
                 imports
@@ -203,7 +204,7 @@ impl WorkloadMetadata {
             .component_type()
             .exports(self.component.engine())
         {
-            if let ComponentItem::ComponentInstance(_) = export_item {
+            if let ComponentItem::ComponentInstance(_) = export_item.ty {
                 let interface = WitInterface::from(export_name);
                 let k = interface.instance();
                 exports
@@ -709,7 +710,7 @@ impl ResolvedWorkload {
                 let ty = component.metadata.component.component_type();
                 for (import_name, import_item) in ty.imports(component.metadata.component.engine())
                 {
-                    if !matches!(import_item, ComponentItem::ComponentInstance(_)) {
+                    if !matches!(import_item.ty, ComponentItem::ComponentInstance(_)) {
                         continue;
                     }
                     // An interface exported by multiple components can't be
@@ -820,7 +821,7 @@ impl ResolvedWorkload {
 
         let instance: SharedInstanceSlot = Arc::default();
         for (import_name, import_item) in imports.into_iter() {
-            match import_item {
+            match import_item.ty {
                 ComponentItem::ComponentInstance(import_instance_ty) => {
                     trace!(name = import_name, "processing component instance import");
                     let mut all_components = self.components.write().await;
@@ -870,7 +871,7 @@ impl ResolvedWorkload {
                     for (export_name, export_ty) in
                         import_instance_ty.exports(plugin_component.metadata.component.engine())
                     {
-                        match export_ty {
+                        match export_ty.ty {
                             ComponentItem::ComponentFunc(_func_ty) => {
                                 let (item, func_idx) = match plugin_component
                                     .metadata

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -106,6 +106,11 @@ impl WorkloadMetadata {
         &mut self.linker
     }
 
+    /// Returns a reference to the wasmtime [`Component`].
+    pub fn component(&self) -> &Component {
+        &self.component
+    }
+
     /// Returns a reference to component local resources.
     pub fn local_resources(&self) -> &LocalResources {
         &self.local_resources
@@ -1484,6 +1489,18 @@ impl UnresolvedWorkload {
                 for wit_interface in required_interfaces.iter() {
                     // Check if plugin supports this interface
                     if plugin_interfaces.includes_bidirectional(wit_interface) {
+                        // an `(implements ..)` named interface is served only
+                        // by a plugin that supports named instances.
+                        let defer_to_other = if wit_interface.name.is_some() {
+                            !p.supports_named_instances()
+                                && other_plugin_serves(plugins, plugin_id, wit_interface, true)
+                        } else {
+                            p.supports_named_instances()
+                                && other_plugin_serves(plugins, plugin_id, wit_interface, false)
+                        };
+                        if defer_to_other {
+                            continue;
+                        }
                         matching_interfaces.insert(wit_interface.clone());
                     }
                 }
@@ -1876,6 +1893,23 @@ fn build_export_map(
     }
 
     (interface_map, ambiguous)
+}
+
+/// Returns whether some *other* registered plugin (not `self_id`) with
+/// `supports_named_instances() == want_named` can serve `iface`.
+/// Used to determine whether a plugin can defer an `(implements ..)`
+///  interface to a named-capable one, and vice versa).
+fn other_plugin_serves(
+    plugins: &HashMap<&'static str, Arc<dyn HostPlugin + 'static>>,
+    self_id: &str,
+    iface: &WitInterface,
+    want_named: bool,
+) -> bool {
+    plugins.iter().any(|(id, q)| {
+        *id != self_id
+            && q.supports_named_instances() == want_named
+            && q.world().includes_bidirectional(iface)
+    })
 }
 
 fn topological_sort_components(
@@ -2962,6 +2996,57 @@ mod tests {
         if let Err(e) = result {
             panic!("Single named entry should not require named instance support: {e}");
         }
+    }
+
+    /// Coexistence: a regular (standalone) plugin and a named-capable
+    /// (multiplexed) plugin both matching the same package bind together, with
+    /// the unnamed interface routed to the regular plugin and the `(implements
+    /// ..)` named interfaces routed to the named-capable one. Without the
+    /// name-aware dispatch this errors (the regular plugin would claim the two
+    /// named entries it cannot serve).
+    #[tokio::test]
+    async fn test_named_and_regular_plugins_coexist() {
+        let regular = Arc::new(MockPlugin::new(
+            "kv-standalone",
+            vec![],
+            vec![keyvalue_interface(None)],
+        ));
+        let multiplexed = Arc::new(
+            MockPlugin::new("kv-multiplexed", vec![], vec![keyvalue_interface(None)])
+                .with_named_instance_support(),
+        );
+
+        let mut plugins = HashMap::new();
+        plugins.insert(regular.id(), regular.clone() as Arc<dyn HostPlugin>);
+        plugins.insert(multiplexed.id(), multiplexed.clone() as Arc<dyn HostPlugin>);
+
+        let mut workload = UnresolvedWorkload::new(
+            "test-workload-id".to_string(),
+            "test-workload".to_string(),
+            "test-namespace".to_string(),
+            None,
+            vec![create_test_component("component1")],
+            vec![
+                keyvalue_interface(None),
+                keyvalue_interface(Some("cache")),
+                keyvalue_interface(Some("sessions")),
+            ],
+        );
+
+        let bound = workload
+            .bind_plugins(&plugins)
+            .await
+            .expect("standalone + multiplexed plugins should bind together");
+        let bound_ids: std::collections::HashSet<&str> =
+            bound.iter().map(|(p, _)| p.id()).collect();
+        assert!(
+            bound_ids.contains("kv-standalone"),
+            "regular plugin must bind the unnamed interface"
+        );
+        assert!(
+            bound_ids.contains("kv-multiplexed"),
+            "named-capable plugin must bind the named interfaces"
+        );
     }
 
     /// Existing unnamed entries -> no change in behavior

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -70,9 +70,6 @@ pub struct WorkloadMetadata {
     loopback: Arc<std::sync::Mutex<loopback::Network>>,
     /// Linked component ids
     linked_components: HashSet<Arc<str>>,
-    /// Whether WASIP3 support is enabled for this component's engine.
-    #[cfg(feature = "wasip3")]
-    wasip3_enabled: bool,
 }
 
 impl WorkloadMetadata {
@@ -169,10 +166,9 @@ impl WorkloadMetadata {
         crate::engine::exports_wasi_http(&self.component)
     }
 
-    /// Returns whether this component targets WASIP3 and the engine has P3 enabled.
-    #[cfg(feature = "wasip3")]
+    /// Returns whether this component targets WASIP3.
     pub fn targets_p3(&self) -> bool {
-        self.wasip3_enabled && crate::engine::targets_wasip3(&self.component)
+        crate::engine::targets_wasip3(&self.component)
     }
 
     /// Computes and returns the [`WitWorld`] of this component.
@@ -259,7 +255,6 @@ impl WorkloadService {
         local_resources: LocalResources,
         max_restarts: u64,
         loopback: Arc<std::sync::Mutex<loopback::Network>>,
-        #[cfg(feature = "wasip3")] wasip3_enabled: bool,
     ) -> Self {
         Self {
             metadata: WorkloadMetadata {
@@ -274,8 +269,6 @@ impl WorkloadService {
                 plugins: None,
                 loopback,
                 linked_components: Default::default(),
-                #[cfg(feature = "wasip3")]
-                wasip3_enabled,
             },
             handle: None,
             max_restarts,
@@ -291,7 +284,6 @@ impl WorkloadService {
     }
 
     /// Pre-instantiate the component for P3 execution.
-    #[cfg(feature = "wasip3")]
     pub fn pre_instantiate_p3(
         &mut self,
     ) -> anyhow::Result<wasmtime_wasi::p3::bindings::CommandPre<SharedCtx>> {
@@ -339,7 +331,6 @@ impl WorkloadComponent {
         volume_mounts: Vec<(PathBuf, VolumeMount)>,
         local_resources: LocalResources,
         loopback: Arc<std::sync::Mutex<loopback::Network>>,
-        #[cfg(feature = "wasip3")] wasip3_enabled: bool,
     ) -> Self {
         Self {
             metadata: WorkloadMetadata {
@@ -354,8 +345,6 @@ impl WorkloadComponent {
                 plugins: None,
                 loopback,
                 linked_components: Default::default(),
-                #[cfg(feature = "wasip3")]
-                wasip3_enabled,
             },
             name: component_name.into(),
             // TODO: Implement pooling and instance limits
@@ -527,7 +516,6 @@ impl ResolvedWorkload {
     /// Executes the service, if present, and returns whether it was run.
     #[instrument(name="execute_service", skip_all, fields(workload.id = self.id.as_ref(), workload.name = self.name.as_ref(), workload.namespace = self.namespace.as_ref()))]
     pub(crate) async fn execute_service(&mut self) -> anyhow::Result<Option<Arc<JoinHandle<()>>>> {
-        #[cfg(feature = "wasip3")]
         if self
             .service
             .as_ref()
@@ -573,7 +561,6 @@ impl ResolvedWorkload {
     }
 
     /// Execute a service using P3 (wasi:cli@0.3) CommandPre.
-    #[cfg(feature = "wasip3")]
     async fn execute_service_p3(&mut self) -> anyhow::Result<Option<Arc<JoinHandle<()>>>> {
         let service = self
             .service
@@ -2171,8 +2158,6 @@ mod tests {
             Vec::new(),
             local_resources,
             Arc::default(),
-            #[cfg(feature = "wasip3")]
-            false,
         )
     }
 
@@ -2195,8 +2180,6 @@ mod tests {
             Vec::new(),
             local_resources,
             Arc::default(),
-            #[cfg(feature = "wasip3")]
-            false,
         )
     }
 
@@ -2219,8 +2202,6 @@ mod tests {
             local_resources,
             3,
             Arc::default(),
-            #[cfg(feature = "wasip3")]
-            false,
         )
     }
 
@@ -2290,8 +2271,6 @@ mod tests {
                 Vec::new(),
                 LocalResources::default(),
                 Arc::default(),
-                #[cfg(feature = "wasip3")]
-                false,
             )
         };
         for (plugin, iface) in cases {

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -148,7 +148,6 @@ pub trait Router: Send + Sync + 'static {
     ) -> anyhow::Result<()>;
 
     /// Determine if a P3 outgoing request is allowed.
-    #[cfg(feature = "wasip3")]
     fn allow_outgoing_request_p3(
         &self,
         _workload_id: &str,
@@ -320,7 +319,6 @@ pub trait OutgoingHandler: Send + Sync + 'static {
     /// it (`_fut`). It is provided so that custom transports with out-of-band
     /// error channels can still deliver upload errors to the component after
     /// the response has been returned.
-    #[cfg(feature = "wasip3")]
     fn send_request_p3(
         &self,
         workload_id: &str,
@@ -361,7 +359,6 @@ impl OutgoingHandler for DefaultOutgoingHandler {
         );
         Ok(HostFutureIncomingResponse::pending(handle))
     }
-    #[cfg(feature = "wasip3")]
     fn send_request_p3(
         &self,
         _workload_id: &str,
@@ -481,7 +478,6 @@ pub trait HostHandler: Send + Sync + 'static {
     /// Override to apply custom egress logic (e.g. alternate transports or
     /// per-workload TLS configuration) while still honouring the allowlist via
     /// [`check_allowed_hosts`].
-    #[cfg(feature = "wasip3")]
     fn outgoing_request_p3(
         &self,
         workload_id: &str,
@@ -557,7 +553,6 @@ impl HostHandler for NullServer {
         ))
     }
 
-    #[cfg(feature = "wasip3")]
     fn outgoing_request_p3(
         &self,
         _workload_id: &str,
@@ -866,7 +861,6 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
             .send_request(workload_id, request, config)
     }
 
-    #[cfg(feature = "wasip3")]
     fn outgoing_request_p3(
         &self,
         workload_id: &str,
@@ -1303,7 +1297,6 @@ async fn invoke_component_handler(
     let store = workload_handle.new_store(component_id).await?;
 
     // Check if this component targets WASIP3 and dispatch accordingly
-    #[cfg(feature = "wasip3")]
     if crate::engine::targets_wasip3_http(instance_pre.component()) {
         let resp =
             crate::host::http_p3::handle_component_request_p3(store, instance_pre, req, fuel_meter)
@@ -1673,7 +1666,6 @@ async fn send_grpc_request_handler(
 }
 
 /// P3 sibling of send_grpc_request: HTTP/2 sender for P3 outgoing gRPC.
-#[cfg(feature = "wasip3")]
 fn send_grpc_request_p3(
     request: hyper::Request<crate::host::http_p3::P3Body>,
     options: Option<wasmtime_wasi_http::p3::RequestOptions>,
@@ -1688,13 +1680,11 @@ fn send_grpc_request_p3(
 /// fires (or the stream ends / errors), releasing the underlying HTTP/2 stream
 /// and TCP connection eagerly instead of leaving it pinned until the guest
 /// drops its body handle.
-#[cfg(feature = "wasip3")]
 struct TimedBody<B> {
     inner: Option<B>,
     interval: tokio::time::Interval,
 }
 
-#[cfg(feature = "wasip3")]
 impl<B> hyper::body::Body for TimedBody<B>
 where
     B: hyper::body::Body<Data = bytes::Bytes, Error = hyper::Error> + Unpin,
@@ -1748,7 +1738,6 @@ where
     }
 }
 
-#[cfg(feature = "wasip3")]
 async fn send_grpc_request_p3_handler(
     mut request: hyper::Request<crate::host::http_p3::P3Body>,
     options: Option<wasmtime_wasi_http::p3::RequestOptions>,
@@ -2040,7 +2029,6 @@ mod tests {
             ))
         }
 
-        #[cfg(feature = "wasip3")]
         fn send_request_p3(
             &self,
             _workload_id: &str,
@@ -2099,7 +2087,6 @@ mod tests {
     /// `ConnectionReadTimeout` *and* eagerly drop the inner body so the
     /// underlying connection is released immediately rather than lingering
     /// until the guest drops its body handle.
-    #[cfg(feature = "wasip3")]
     #[tokio::test]
     async fn timed_body_releases_inner_on_between_bytes_timeout() {
         use http_body_util::BodyExt;
@@ -2198,7 +2185,6 @@ mod tests {
 
     /// NullServer must deny P3 outgoing requests with an internal error,
     /// matching its P2 behaviour of returning "http client not available".
-    #[cfg(feature = "wasip3")]
     #[tokio::test]
     async fn null_server_denies_p3_outgoing_request() {
         use crate::host::http_p3::{P3Body, P3RequestErrorFuture};

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -64,7 +64,6 @@ use sysinfo::SystemMonitor;
 
 pub mod allowed_hosts;
 pub mod http;
-#[cfg(feature = "wasip3")]
 pub mod http_p3;
 
 /// The API for interacting with a wasmcloud host.

--- a/crates/wash-runtime/src/sockets/host_ip_name_lookup_p3.rs
+++ b/crates/wash-runtime/src/sockets/host_ip_name_lookup_p3.rs
@@ -8,8 +8,8 @@ use wasmtime::component::Accessor;
 use wasmtime_wasi::p3::bindings::sockets::ip_name_lookup::{Host, HostWithStore};
 use wasmtime_wasi::p3::bindings::sockets::{ip_name_lookup::ErrorCode, types};
 
-impl HostWithStore for WasiSockets {
-    async fn resolve_addresses<U>(
+impl<U> HostWithStore<U> for WasiSockets {
+    async fn resolve_addresses(
         store: &Accessor<U, Self>,
         name: String,
     ) -> wasmtime::Result<Result<Vec<types::IpAddress>, ErrorCode>> {

--- a/crates/wash-runtime/src/sockets/host_tcp_p3.rs
+++ b/crates/wash-runtime/src/sockets/host_tcp_p3.rs
@@ -9,7 +9,6 @@ use bytes::BytesMut;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use io_lifetimes::AsSocketlike as _;
-use std::io::Cursor;
 use std::net::{Shutdown, SocketAddr};
 use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
@@ -123,7 +122,7 @@ impl ReceiveStreamProducer {
 
 impl<D> StreamProducer<D> for ReceiveStreamProducer {
     type Item = u8;
-    type Buffer = Cursor<BytesMut>;
+    type Buffer = BytesMut;
 
     fn poll_produce<'a>(
         mut self: Pin<&mut Self>,
@@ -248,8 +247,8 @@ impl types::Host for WasiSocketsCtxView<'_> {
     }
 }
 
-impl HostTcpSocketWithStore for WasiSockets {
-    async fn connect<T>(
+impl<T> HostTcpSocketWithStore<T> for WasiSockets {
+    async fn connect(
         store: &Accessor<T, Self>,
         socket: Resource<UpstreamTcpSocket>,
         remote_address: IpSocketAddress,
@@ -294,7 +293,7 @@ impl HostTcpSocketWithStore for WasiSockets {
         })
     }
 
-    fn listen<T: 'static>(
+    fn listen(
         mut store: Access<'_, T, Self>,
         socket: Resource<UpstreamTcpSocket>,
     ) -> SocketResult<StreamReader<Resource<UpstreamTcpSocket>>> {
@@ -396,7 +395,7 @@ impl HostTcpSocketWithStore for WasiSockets {
         }
     }
 
-    fn send<T: 'static>(
+    fn send(
         mut store: Access<'_, T, Self>,
         socket: Resource<UpstreamTcpSocket>,
         mut data: StreamReader<u8>,
@@ -437,7 +436,7 @@ impl HostTcpSocketWithStore for WasiSockets {
         }
     }
 
-    fn receive<T: 'static>(
+    fn receive(
         mut store: Access<T, Self>,
         socket: Resource<UpstreamTcpSocket>,
     ) -> wasmtime::Result<(StreamReader<u8>, FutureReader<Result<(), types::ErrorCode>>)> {
@@ -851,7 +850,7 @@ impl Drop for LoopbackReceiveStreamProducer {
 
 impl<D> StreamProducer<D> for LoopbackReceiveStreamProducer {
     type Item = u8;
-    type Buffer = Cursor<BytesMut>;
+    type Buffer = BytesMut;
 
     fn poll_produce<'a>(
         mut self: Pin<&mut Self>,

--- a/crates/wash-runtime/src/sockets/host_udp_create_socket.rs
+++ b/crates/wash-runtime/src/sockets/host_udp_create_socket.rs
@@ -11,7 +11,11 @@ impl udp_create_socket::Host for WasiSocketsCtxView<'_> {
         &mut self,
         address_family: IpAddressFamily,
     ) -> SocketResult<Resource<UpstreamUdpSocket>> {
-        let socket = UdpSocket::new(self.ctx, address_family.into())
+        let address_family = match address_family {
+            IpAddressFamily::Ipv4 => cap_net_ext::AddressFamily::Ipv4,
+            IpAddressFamily::Ipv6 => cap_net_ext::AddressFamily::Ipv6,
+        };
+        let socket = UdpSocket::new(self.ctx, address_family)
             .map_err(super::network::socket_error_from_util)?;
         let socket = self.table.push(socket)?;
         Ok(Resource::new_own(socket.rep()))

--- a/crates/wash-runtime/src/sockets/host_udp_p3.rs
+++ b/crates/wash-runtime/src/sockets/host_udp_p3.rs
@@ -40,8 +40,8 @@ fn get_socket_mut<'a>(
         .map_err(SocketError::trap)
 }
 
-impl HostUdpSocketWithStore for WasiSockets {
-    async fn send<T>(
+impl<T> HostUdpSocketWithStore<T> for WasiSockets {
+    async fn send(
         store: &Accessor<T, Self>,
         socket: Resource<UpstreamUdpSocket>,
         data: Vec<u8>,
@@ -152,7 +152,7 @@ impl HostUdpSocketWithStore for WasiSockets {
         Ok(())
     }
 
-    async fn receive<T>(
+    async fn receive(
         store: &Accessor<T, Self>,
         socket: Resource<UpstreamUdpSocket>,
     ) -> SocketResult<(Vec<u8>, IpSocketAddress)> {

--- a/crates/wash-runtime/src/sockets/mod.rs
+++ b/crates/wash-runtime/src/sockets/mod.rs
@@ -20,11 +20,8 @@ pub(crate) mod tcp;
 pub(crate) mod udp;
 pub(crate) mod util;
 
-#[cfg(feature = "wasip3")]
 pub(crate) mod host_ip_name_lookup_p3;
-#[cfg(feature = "wasip3")]
 pub(crate) mod host_tcp_p3;
-#[cfg(feature = "wasip3")]
 pub(crate) mod host_udp_p3;
 
 pub use tcp::TcpSocket;
@@ -171,7 +168,6 @@ pub enum SocketAddrUse {
 /// `Unknown` maps to `Other(None)` and there is nothing to forward. Callers that
 /// have a meaningful message should construct `P3ErrorCode::Other(Some(..))`
 /// directly rather than routing through this helper.
-#[cfg(feature = "wasip3")]
 pub(crate) fn p3_error_code_from_util(
     error: util::ErrorCode,
 ) -> wasmtime_wasi::p3::bindings::sockets::types::ErrorCode {
@@ -197,7 +193,6 @@ pub(crate) fn p3_error_code_from_util(
 }
 
 /// Convert our `util::ErrorCode` to a P3 `SocketError` (TrappableError).
-#[cfg(feature = "wasip3")]
 pub(crate) fn p3_socket_error_from_util(
     error: util::ErrorCode,
 ) -> wasmtime_wasi::p3::sockets::SocketError {
@@ -205,7 +200,6 @@ pub(crate) fn p3_socket_error_from_util(
 }
 
 /// Register P3 socket interfaces with the linker using our custom socket implementation.
-#[cfg(feature = "wasip3")]
 pub fn add_p3_to_linker(
     linker: &mut wasmtime::component::Linker<crate::engine::ctx::SharedCtx>,
 ) -> anyhow::Result<()> {
@@ -221,7 +215,6 @@ pub(crate) enum SocketAddressFamily {
     Ipv6,
 }
 
-#[cfg(feature = "wasip3")]
 impl From<SocketAddressFamily> for wasmtime_wasi::p3::bindings::sockets::types::IpAddressFamily {
     fn from(family: SocketAddressFamily) -> Self {
         match family {
@@ -231,7 +224,7 @@ impl From<SocketAddressFamily> for wasmtime_wasi::p3::bindings::sockets::types::
     }
 }
 
-#[cfg(all(test, feature = "wasip3"))]
+#[cfg(test)]
 mod tests_p3 {
     use super::*;
 

--- a/crates/wash-runtime/src/sockets/tcp.rs
+++ b/crates/wash-runtime/src/sockets/tcp.rs
@@ -129,11 +129,9 @@ pub struct NetworkTcpSocket {
     options: NonInheritedOptions,
 
     /// Tracks whether the send stream has been taken (P3 only).
-    #[cfg(feature = "wasip3")]
     send_taken: bool,
 
     /// Tracks whether the receive stream has been taken (P3 only).
-    #[cfg(feature = "wasip3")]
     receive_taken: bool,
 }
 
@@ -205,15 +203,12 @@ impl NetworkTcpSocket {
             listen_backlog_size: DEFAULT_TCP_BACKLOG,
             family,
             options: Default::default(),
-            #[cfg(feature = "wasip3")]
             send_taken: false,
-            #[cfg(feature = "wasip3")]
             receive_taken: false,
         })
     }
 
     /// Create an error socket (P3 only, for deferred accept errors).
-    #[cfg(feature = "wasip3")]
     pub(crate) fn new_error(_err: std::io::Error, family: SocketAddressFamily) -> Self {
         // Create a closed socket to represent the error.
         // The upstream uses a dedicated Error state, but for simplicity
@@ -228,9 +223,7 @@ impl NetworkTcpSocket {
             listen_backlog_size: DEFAULT_TCP_BACKLOG,
             family,
             options: Default::default(),
-            #[cfg(feature = "wasip3")]
             send_taken: false,
-            #[cfg(feature = "wasip3")]
             receive_taken: false,
         }
     }
@@ -584,7 +577,6 @@ impl NetworkTcpSocket {
     ///
     /// Returns the shared listener so callers (and tests) can build accept
     /// streams without a follow-up [`Self::tcp_listener_arc`] call.
-    #[cfg(feature = "wasip3")]
     pub(crate) fn listen_p3(&mut self) -> Result<Arc<tokio::net::TcpListener>, ErrorCode> {
         let tokio_socket = match mem::replace(&mut self.tcp_state, TcpState::Closed) {
             TcpState::Bound(tokio_socket) => tokio_socket,
@@ -620,7 +612,6 @@ impl NetworkTcpSocket {
     ///
     /// Returns an owned clone of the `Arc` so callers don't have to clone it
     /// themselves.
-    #[cfg(feature = "wasip3")]
     pub(crate) fn tcp_listener_arc(&self) -> Result<Arc<tokio::net::TcpListener>, ErrorCode> {
         match &self.tcp_state {
             TcpState::Listening { listener, .. } => Ok(Arc::clone(listener)),
@@ -629,7 +620,6 @@ impl NetworkTcpSocket {
     }
 
     /// Take the send stream Arc (P3 only).
-    #[cfg(feature = "wasip3")]
     pub(crate) fn take_send_stream(&mut self) -> Result<Arc<tokio::net::TcpStream>, ErrorCode> {
         if self.send_taken {
             return Err(ErrorCode::InvalidState);
@@ -644,7 +634,6 @@ impl NetworkTcpSocket {
     }
 
     /// Take the receive stream Arc (P3 only).
-    #[cfg(feature = "wasip3")]
     pub(crate) fn take_receive_stream(&mut self) -> Result<Arc<tokio::net::TcpStream>, ErrorCode> {
         if self.receive_taken {
             return Err(ErrorCode::InvalidState);
@@ -659,7 +648,6 @@ impl NetworkTcpSocket {
     }
 
     /// Get non-inherited options reference (for accepted sockets).
-    #[cfg(feature = "wasip3")]
     pub(crate) fn non_inherited_options(&self) -> &NonInheritedOptions {
         &self.options
     }
@@ -975,9 +963,7 @@ impl TcpSocket {
                     listen_backlog_size: socket.listen_backlog_size,
                     family: socket.family,
                     options: socket.options.clone(),
-                    #[cfg(feature = "wasip3")]
                     send_taken: false,
-                    #[cfg(feature = "wasip3")]
                     receive_taken: false,
                 },
                 lo,
@@ -1384,7 +1370,6 @@ impl TcpSocket {
     /// Take the loopback accept channel for P3 listen streaming.
     ///
     /// Returns the receiver that yields incoming `TcpConn` connections.
-    #[cfg(feature = "wasip3")]
     pub(crate) fn take_loopback_listen_rx(&mut self) -> Result<P3LoopbackListenInfo, ErrorCode> {
         let lo = match self {
             Self::Loopback(socket) => socket,
@@ -1397,7 +1382,6 @@ impl TcpSocket {
     /// Listen using P3 semantics (with implicit bind).
     ///
     /// For loopback, requires the loopback network to register the listener.
-    #[cfg(feature = "wasip3")]
     pub(crate) fn listen_p3(
         &mut self,
         loopback: &mut super::loopback::Network,
@@ -1419,7 +1403,6 @@ impl TcpSocket {
     /// Take the send stream (P3 only).
     ///
     /// Returns the underlying stream or channel for sending data.
-    #[cfg(feature = "wasip3")]
     pub(crate) fn take_send_stream(&mut self) -> Result<P3SendStream, ErrorCode> {
         match self {
             Self::Network(socket) => socket.take_send_stream().map(P3SendStream::Network),
@@ -1445,7 +1428,6 @@ impl TcpSocket {
     /// Take the receive stream (P3 only).
     ///
     /// Returns the underlying stream or channel for receiving data.
-    #[cfg(feature = "wasip3")]
     pub(crate) fn take_receive_stream(&mut self) -> Result<P3ReceiveStream, ErrorCode> {
         match self {
             Self::Network(socket) => socket.take_receive_stream().map(P3ReceiveStream::Network),
@@ -1662,7 +1644,6 @@ mod tests {
         assert!(size > 0);
     }
 
-    #[cfg(feature = "wasip3")]
     mod p3 {
         use super::*;
         use crate::sockets::loopback;
@@ -1919,7 +1900,6 @@ mod tests {
 /// Captured when a listener is taken (see [`take_loopback_listen_info`]) so
 /// that each accepted connection can be seeded with the listener's options via
 /// [`LoopbackSocketProps::to_accepted_socket`].
-#[cfg(feature = "wasip3")]
 #[derive(Clone)]
 #[allow(dead_code)]
 pub(crate) struct LoopbackSocketProps {
@@ -1934,7 +1914,6 @@ pub(crate) struct LoopbackSocketProps {
     pub family: SocketAddressFamily,
 }
 
-#[cfg(feature = "wasip3")]
 impl From<&super::loopback::TcpSocket> for LoopbackSocketProps {
     fn from(socket: &super::loopback::TcpSocket) -> Self {
         Self {
@@ -1951,7 +1930,6 @@ impl From<&super::loopback::TcpSocket> for LoopbackSocketProps {
     }
 }
 
-#[cfg(feature = "wasip3")]
 impl LoopbackSocketProps {
     /// Create a loopback TcpSocket in the Connected state from an accepted connection.
     pub(crate) fn to_accepted_socket(
@@ -1977,7 +1955,6 @@ impl LoopbackSocketProps {
 }
 
 /// P3 send stream type, either a network TcpStream or loopback channel.
-#[cfg(feature = "wasip3")]
 pub(crate) enum P3SendStream {
     Network(Arc<tokio::net::TcpStream>),
     Loopback {
@@ -1987,7 +1964,6 @@ pub(crate) enum P3SendStream {
 }
 
 /// P3 receive stream type.
-#[cfg(feature = "wasip3")]
 pub(crate) enum P3ReceiveStream {
     Network(Arc<tokio::net::TcpStream>),
     Loopback(
@@ -1996,7 +1972,6 @@ pub(crate) enum P3ReceiveStream {
 }
 
 /// Extract the accept channel from a loopback TcpSocket in Listening state.
-#[cfg(feature = "wasip3")]
 fn take_loopback_listen_info(
     lo: &mut super::loopback::TcpSocket,
 ) -> Result<P3LoopbackListenInfo, ErrorCode> {
@@ -2018,7 +1993,6 @@ fn take_loopback_listen_info(
 }
 
 /// P3 listen stream info for loopback, holding the accept channel.
-#[cfg(feature = "wasip3")]
 pub(crate) struct P3LoopbackListenInfo {
     pub rx: tokio::sync::mpsc::Receiver<super::loopback::TcpConn>,
     pub socket_props: LoopbackSocketProps,

--- a/crates/wash-runtime/src/sockets/util.rs
+++ b/crates/wash-runtime/src/sockets/util.rs
@@ -455,7 +455,6 @@ pub fn parse_host(name: &str) -> Result<url::Host, ErrorCode> {
 
 /// Returns the implicit bind address for a given address family (port 0, unspecified IP).
 /// Used by P3 for implicit bind before listen.
-#[cfg(feature = "wasip3")]
 pub fn implicit_bind_addr(family: SocketAddressFamily) -> SocketAddr {
     let ip = match family {
         SocketAddressFamily::Ipv4 => IpAddr::V4(Ipv4Addr::UNSPECIFIED),

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -250,9 +250,8 @@ pub async fn start_host_with_tls(
 
 /// Start a host with `wasip3` enabled on the engine, a `DevRouter` backed
 /// HTTP server, and the standard plugin set.
-#[cfg(feature = "wasip3")]
 pub async fn start_host_with_p3(addr: &str) -> Result<(std::net::SocketAddr, impl HostApi)> {
-    let engine = Engine::builder().with_wasip3(true).build()?;
+    let engine = Engine::builder().build()?;
     let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
     let bound_addr = http_server.addr();
     let host = with_standard_plugins(

--- a/crates/wash-runtime/tests/common/tls.rs
+++ b/crates/wash-runtime/tests/common/tls.rs
@@ -227,7 +227,6 @@ fn test_tls_provider(cert_der: &[u8]) -> Result<SharedTlsProvider> {
 /// Build an engine with P3 and a custom TLS provider that trusts `cert_der`.
 pub fn engine_with_p3_and_tls(cert_der: &[u8]) -> Result<Engine> {
     Engine::builder()
-        .with_wasip3(true)
         .with_tls_provider(test_tls_provider(cert_der)?)
         .build()
         .context("failed to build P3+TLS engine")

--- a/crates/wash-runtime/tests/fixtures/cli-service-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/cli-service-p3/wit/world.wit
@@ -1,11 +1,11 @@
 package wasmcloud:test-p3@0.1.0;
 
 world cli-service {
-    import wasi:cli/environment@0.3.0-rc-2026-03-15;
-    import wasi:cli/stderr@0.3.0-rc-2026-03-15;
-    import wasi:cli/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
+    import wasi:cli/environment@0.3.0;
+    import wasi:cli/stderr@0.3.0;
+    import wasi:cli/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:clocks/monotonic-clock@0.3.0;
 
-    export wasi:cli/run@0.3.0-rc-2026-03-15;
+    export wasi:cli/run@0.3.0;
 }

--- a/crates/wash-runtime/tests/fixtures/http-blobstore-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/http-blobstore-p3/wit/world.wit
@@ -1,12 +1,12 @@
 package wasmcloud:test-p3@0.1.0;
 
 world http-blobstore {
-    import wasi:http/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
-    import wasi:random/random@0.3.0-rc-2026-03-15;
+    import wasi:http/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:random/random@0.3.0;
     import wasi:blobstore/blobstore@0.2.0-draft;
     import wasi:blobstore/container@0.2.0-draft;
     import wasi:blobstore/types@0.2.0-draft;
 
-    export wasi:http/handler@0.3.0-rc-2026-03-15;
+    export wasi:http/handler@0.3.0;
 }

--- a/crates/wash-runtime/tests/fixtures/http-handler-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/http-handler-p3/wit/world.wit
@@ -1,9 +1,9 @@
 package wasmcloud:test-p3@0.1.0;
 
 world http-handler {
-    import wasi:http/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
-    import wasi:random/random@0.3.0-rc-2026-03-15;
+    import wasi:http/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:random/random@0.3.0;
 
-    export wasi:http/handler@0.3.0-rc-2026-03-15;
+    export wasi:http/handler@0.3.0;
 }

--- a/crates/wash-runtime/tests/fixtures/inter-component-call-p3-callee/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/inter-component-call-p3-callee/wit/world.wit
@@ -5,8 +5,8 @@ interface receiver {
 }
 
 world component {
-    import wasi:cli/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
+    import wasi:cli/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
 
     export receiver;
 }

--- a/crates/wash-runtime/tests/fixtures/inter-component-call-p3-caller/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/inter-component-call-p3-caller/wit/world.wit
@@ -5,10 +5,10 @@ interface middleware {
 }
 
 world component {
-    import wasi:http/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
-    import wasi:random/random@0.3.0-rc-2026-03-15;
+    import wasi:http/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:random/random@0.3.0;
     import middleware;
 
-    export wasi:http/handler@0.3.0-rc-2026-03-15;
+    export wasi:http/handler@0.3.0;
 }

--- a/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-cli-0.3.0/package.wit
+++ b/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-cli-0.3.0/package.wit
@@ -1,6 +1,6 @@
-package wasi:cli@0.3.0-rc-2026-03-15;
+package wasi:cli@0.3.0;
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface environment {
   /// Get the POSIX-style environment variables.
   ///
@@ -10,23 +10,23 @@ interface environment {
   /// Morally, these are a value import, but until value imports are available
   /// in the component model, this import function should return the same
   /// values each time it is called.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-environment: func() -> list<tuple<string, string>>;
 
   /// Get the POSIX-style arguments to the program.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-arguments: func() -> list<string>;
 
   /// Return a path that programs should use as their initial current working
   /// directory, interpreting `.` as shorthand for this.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-initial-cwd: func() -> option<string>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface exit {
   /// Exit the current instance and any linked instances.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   exit: func(status: result);
 
   /// Exit the current instance and any linked instances, reporting the
@@ -41,16 +41,16 @@ interface exit {
   exit-with-code: func(status-code: u8);
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface run {
   /// Run the program.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   run: async func() -> result;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface types {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   enum error-code {
     /// Input/output error
     io,
@@ -61,7 +61,7 @@ interface types {
   }
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface stdin {
   use types.{error-code};
 
@@ -78,11 +78,11 @@ interface stdin {
   ///
   /// Multiple streams may be active at the same time. The behavior of concurrent
   /// reads is implementation-specific.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface stdout {
   use types.{error-code};
 
@@ -94,11 +94,11 @@ interface stdout {
   ///
   /// Otherwise if there is an error the readable end of the stream will be
   /// dropped and this function will return an error-code.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface stderr {
   use types.{error-code};
 
@@ -110,7 +110,7 @@ interface stderr {
   ///
   /// Otherwise if there is an error the readable end of the stream will be
   /// dropped and this function will return an error-code.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 }
 
@@ -119,10 +119,10 @@ interface stderr {
 /// In the future, this may include functions for disabling echoing,
 /// disabling input buffering so that keyboard events are sent through
 /// immediately, querying supported features, and so on.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface terminal-input {
   /// The input side of a terminal.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource terminal-input;
 }
 
@@ -131,126 +131,126 @@ interface terminal-input {
 /// In the future, this may include functions for querying the terminal
 /// size, being notified of terminal size changes, querying supported
 /// features, and so on.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface terminal-output {
   /// The output side of a terminal.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource terminal-output;
 }
 
 /// An interface providing an optional `terminal-input` for stdin as a
 /// link-time authority.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface terminal-stdin {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   use terminal-input.{terminal-input};
 
   /// If stdin is connected to a terminal, return a `terminal-input` handle
   /// allowing further interaction with it.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-terminal-stdin: func() -> option<terminal-input>;
 }
 
 /// An interface providing an optional `terminal-output` for stdout as a
 /// link-time authority.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface terminal-stdout {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   use terminal-output.{terminal-output};
 
   /// If stdout is connected to a terminal, return a `terminal-output` handle
   /// allowing further interaction with it.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-terminal-stdout: func() -> option<terminal-output>;
 }
 
 /// An interface providing an optional `terminal-output` for stderr as a
 /// link-time authority.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface terminal-stderr {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   use terminal-output.{terminal-output};
 
   /// If stderr is connected to a terminal, return a `terminal-output` handle
   /// allowing further interaction with it.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-terminal-stderr: func() -> option<terminal-output>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world imports {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import environment;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import exit;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import types;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stdin;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stdout;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stderr;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-input;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-output;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stdin;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stdout;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stderr;
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/types@0.3.0;
+  import wasi:clocks/monotonic-clock@0.3.0;
+  import wasi:clocks/system-clock@0.3.0;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
-  import wasi:filesystem/types@0.3.0-rc-2026-03-15;
-  import wasi:filesystem/preopens@0.3.0-rc-2026-03-15;
-  import wasi:sockets/types@0.3.0-rc-2026-03-15;
-  import wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15;
-  import wasi:random/random@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
+  import wasi:clocks/timezone@0.3.0;
+  import wasi:filesystem/types@0.3.0;
+  import wasi:filesystem/preopens@0.3.0;
+  import wasi:sockets/types@0.3.0;
+  import wasi:sockets/ip-name-lookup@0.3.0;
+  import wasi:random/random@0.3.0;
+  import wasi:random/insecure@0.3.0;
+  import wasi:random/insecure-seed@0.3.0;
 }
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world command {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import environment;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import exit;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import types;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stdin;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stdout;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import stderr;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-input;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-output;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stdin;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stdout;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import terminal-stderr;
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/types@0.3.0;
+  import wasi:clocks/monotonic-clock@0.3.0;
+  import wasi:clocks/system-clock@0.3.0;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
-  import wasi:filesystem/types@0.3.0-rc-2026-03-15;
-  import wasi:filesystem/preopens@0.3.0-rc-2026-03-15;
-  import wasi:sockets/types@0.3.0-rc-2026-03-15;
-  import wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15;
-  import wasi:random/random@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
+  import wasi:clocks/timezone@0.3.0;
+  import wasi:filesystem/types@0.3.0;
+  import wasi:filesystem/preopens@0.3.0;
+  import wasi:sockets/types@0.3.0;
+  import wasi:sockets/ip-name-lookup@0.3.0;
+  import wasi:random/random@0.3.0;
+  import wasi:random/insecure@0.3.0;
+  import wasi:random/insecure-seed@0.3.0;
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   export run;
 }

--- a/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-clocks-0.3.0/package.wit
+++ b/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-clocks-0.3.0/package.wit
@@ -1,10 +1,10 @@
-package wasi:clocks@0.3.0-rc-2026-03-15;
+package wasi:clocks@0.3.0;
 
 /// This interface common types used throughout wasi:clocks.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface types {
   /// A duration of time, in nanoseconds.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type duration = u64;
 }
 
@@ -16,14 +16,14 @@ interface types {
 ///
 /// A monotonic clock is a clock which has an unspecified initial value, and
 /// successive reads of the clock will produce non-decreasing values.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface monotonic-clock {
   use types.{duration};
 
   /// A mark on a monotonic clock is a number of nanoseconds since an
   /// unspecified initial value, and can only be compared to instances from
   /// the same monotonic-clock.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type mark = u64;
 
   /// Read the current value of the clock.
@@ -35,20 +35,20 @@ interface monotonic-clock {
   /// the value of the clock in a `mark`. Consequently, implementations
   /// should ensure that the starting time is low enough to avoid the
   /// possibility of overflow in practice.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   now: func() -> mark;
 
   /// Query the resolution of the clock. Returns the duration of time
   /// corresponding to a clock tick.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-resolution: func() -> duration;
 
   /// Wait until the specified mark has occurred.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   wait-until: async func(when: mark);
 
   /// Wait for the specified duration to elapse.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   wait-for: async func(how-long: duration);
 }
 
@@ -62,7 +62,7 @@ interface monotonic-clock {
 /// monotonic, making it unsuitable for measuring elapsed time.
 ///
 /// It is intended for reporting the current date and time for humans.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface system-clock {
   use types.{duration};
 
@@ -82,7 +82,7 @@ interface system-clock {
   ///
   /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
   /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record instant {
     seconds: s64,
     nanoseconds: u32,
@@ -94,12 +94,12 @@ interface system-clock {
   /// will not necessarily produce a sequence of non-decreasing values.
   ///
   /// The nanoseconds field of the output is always less than 1000000000.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   now: func() -> instant;
 
   /// Query the resolution of the clock. Returns the smallest duration of time
   /// that the implementation permits distinguishing.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-resolution: func() -> duration;
 }
 
@@ -148,13 +148,13 @@ interface timezone {
   to-debug-string: func() -> string;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world imports {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import types;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import monotonic-clock;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import system-clock;
   @unstable(feature = clocks-timezone)
   import timezone;

--- a/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-filesystem-0.3.0/package.wit
+++ b/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-filesystem-0.3.0/package.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.3.0-rc-2026-03-15;
+package wasi:filesystem@0.3.0;
 
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
@@ -35,19 +35,19 @@ package wasi:filesystem@0.3.0-rc-2026-03-15;
 /// store or a database instead.
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface types {
-  @since(version = 0.3.0-rc-2026-03-15)
-  use wasi:clocks/system-clock@0.3.0-rc-2026-03-15.{instant};
+  @since(version = 0.3.0)
+  use wasi:clocks/system-clock@0.3.0.{instant};
 
   /// File size or length of a region within a file.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type filesize = u64;
 
   /// The type of a filesystem object referenced by a descriptor.
   ///
   /// Note: This was called `filetype` in earlier versions of WASI.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant descriptor-type {
     /// The descriptor refers to a block device inode.
     block-device,
@@ -71,7 +71,7 @@ interface types {
   /// Descriptor flags.
   ///
   /// Note: This was called `fdflags` in earlier versions of WASI.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   flags descriptor-flags {
     /// Read mode: Data can be read.
     read,
@@ -113,7 +113,7 @@ interface types {
   }
 
   /// Flags determining the method of how paths are resolved.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   flags path-flags {
     /// As long as the resolved path corresponds to a symbolic link, it is
     /// expanded.
@@ -121,7 +121,7 @@ interface types {
   }
 
   /// Open flags used by `open-at`.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   flags open-flags {
     /// Create file if it does not exist, similar to `O_CREAT` in POSIX.
     create,
@@ -134,13 +134,13 @@ interface types {
   }
 
   /// Number of hard links to an inode.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type link-count = u64;
 
   /// File attributes.
   ///
   /// Note: This was called `filestat` in earlier versions of WASI.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record descriptor-stat {
     /// File type.
     %type: descriptor-type,
@@ -167,7 +167,7 @@ interface types {
   }
 
   /// When setting a timestamp, this gives the value to set it to.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant new-timestamp {
     /// Leave the timestamp set to its previous value.
     no-change,
@@ -179,7 +179,7 @@ interface types {
   }
 
   /// A directory entry.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record directory-entry {
     /// The type of the file referred to by this directory entry.
     %type: descriptor-type,
@@ -191,7 +191,7 @@ interface types {
   /// Not all of these error codes are returned by the functions provided by this
   /// API; some are used in higher-level library layers, and others are provided
   /// merely for alignment with POSIX.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant error-code {
     /// Permission denied, similar to `EACCES` in POSIX.
     access,
@@ -272,7 +272,7 @@ interface types {
   }
 
   /// File or memory access pattern advisory information.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   enum advice {
     /// The application has no advice to give on its behavior with respect
     /// to the specified data.
@@ -296,7 +296,7 @@ interface types {
 
   /// A 128-bit hash value, split into parts because wasm doesn't have a
   /// 128-bit integer type.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record metadata-hash-value {
     /// 64 bits of a 128-bit hash value.
     lower: u64,
@@ -307,7 +307,7 @@ interface types {
   /// A descriptor is a reference to a filesystem object, which may be a file,
   /// directory, named pipe, special file, or other object on which filesystem
   /// calls may be made.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource descriptor {
     /// Return a stream for reading from a file.
     ///
@@ -325,7 +325,7 @@ interface types {
     /// resolves to `err` with an `error-code`.
     ///
     /// Note: This is similar to `pread` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     read-via-stream: func(offset: filesize) -> tuple<stream<u8>, future<result<_, error-code>>>;
     /// Return a stream for writing to a file, if available.
     ///
@@ -339,7 +339,7 @@ interface types {
     /// written or an error is encountered.
     ///
     /// Note: This is similar to `pwrite` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     write-via-stream: func(data: stream<u8>, offset: filesize) -> future<result<_, error-code>>;
     /// Return a stream for appending to a file, if available.
     ///
@@ -349,12 +349,12 @@ interface types {
     /// written or an error is encountered.
     ///
     /// Note: This is similar to `write` with `O_APPEND` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     append-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
     /// Provide file advisory information on a descriptor.
     ///
     /// This is similar to `posix_fadvise` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     advise: async func(offset: filesize, length: filesize, advice: advice) -> result<_, error-code>;
     /// Synchronize the data of a file to disk.
     ///
@@ -362,7 +362,7 @@ interface types {
     /// opened for writing.
     ///
     /// Note: This is similar to `fdatasync` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     sync-data: async func() -> result<_, error-code>;
     /// Get flags associated with a descriptor.
     ///
@@ -370,7 +370,7 @@ interface types {
     ///
     /// Note: This returns the value that was the `fs_flags` value returned
     /// from `fdstat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-flags: async func() -> result<descriptor-flags, error-code>;
     /// Get the dynamic type of a descriptor.
     ///
@@ -382,20 +382,20 @@ interface types {
     ///
     /// Note: This returns the value that was the `fs_filetype` value returned
     /// from `fdstat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-type: async func() -> result<descriptor-type, error-code>;
     /// Adjust the size of an open file. If this increases the file's size, the
     /// extra bytes are filled with zeros.
     ///
     /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-size: async func(size: filesize) -> result<_, error-code>;
     /// Adjust the timestamps of an open file or directory.
     ///
     /// Note: This is similar to `futimens` in POSIX.
     ///
     /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-times: async func(data-access-timestamp: new-timestamp, data-modification-timestamp: new-timestamp) -> result<_, error-code>;
     /// Read directory entries from a directory.
     ///
@@ -409,7 +409,7 @@ interface types {
     ///
     /// This function returns a future, which will resolve to an error code if
     /// reading full contents of the directory fails.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     read-directory: func() -> tuple<stream<directory-entry>, future<result<_, error-code>>>;
     /// Synchronize the data and metadata of a file to disk.
     ///
@@ -417,12 +417,12 @@ interface types {
     /// opened for writing.
     ///
     /// Note: This is similar to `fsync` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     sync: async func() -> result<_, error-code>;
     /// Create a directory.
     ///
     /// Note: This is similar to `mkdirat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     create-directory-at: async func(path: string) -> result<_, error-code>;
     /// Return the attributes of an open file or directory.
     ///
@@ -433,7 +433,7 @@ interface types {
     /// modified, use `metadata-hash`.
     ///
     /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     stat: async func() -> result<descriptor-stat, error-code>;
     /// Return the attributes of a file or directory.
     ///
@@ -442,7 +442,7 @@ interface types {
     /// discussion of alternatives.
     ///
     /// Note: This was called `path_filestat_get` in earlier versions of WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     stat-at: async func(path-flags: path-flags, path: string) -> result<descriptor-stat, error-code>;
     /// Adjust the timestamps of a file or directory.
     ///
@@ -450,7 +450,7 @@ interface types {
     ///
     /// Note: This was called `path_filestat_set_times` in earlier versions of
     /// WASI.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-times-at: async func(path-flags: path-flags, path: string, data-access-timestamp: new-timestamp, data-modification-timestamp: new-timestamp) -> result<_, error-code>;
     /// Create a hard link.
     ///
@@ -459,7 +459,7 @@ interface types {
     /// `error-code::not-permitted` if the old path is not a file.
     ///
     /// Note: This is similar to `linkat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     link-at: async func(old-path-flags: path-flags, old-path: string, new-descriptor: borrow<descriptor>, new-path: string) -> result<_, error-code>;
     /// Open a file or directory.
     ///
@@ -473,7 +473,7 @@ interface types {
     /// `error-code::read-only`.
     ///
     /// Note: This is similar to `openat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     open-at: async func(path-flags: path-flags, path: string, open-flags: open-flags, %flags: descriptor-flags) -> result<descriptor, error-code>;
     /// Read the contents of a symbolic link.
     ///
@@ -481,19 +481,19 @@ interface types {
     /// filesystem, this function fails with `error-code::not-permitted`.
     ///
     /// Note: This is similar to `readlinkat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     readlink-at: async func(path: string) -> result<string, error-code>;
     /// Remove a directory.
     ///
     /// Return `error-code::not-empty` if the directory is not empty.
     ///
     /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     remove-directory-at: async func(path: string) -> result<_, error-code>;
     /// Rename a filesystem object.
     ///
     /// Note: This is similar to `renameat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     rename-at: async func(old-path: string, new-descriptor: borrow<descriptor>, new-path: string) -> result<_, error-code>;
     /// Create a symbolic link (also known as a "symlink").
     ///
@@ -501,7 +501,7 @@ interface types {
     /// `error-code::not-permitted`.
     ///
     /// Note: This is similar to `symlinkat` in POSIX.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     symlink-at: async func(old-path: string, new-path: string) -> result<_, error-code>;
     /// Unlink a filesystem object that is not a directory.
     ///
@@ -512,7 +512,7 @@ interface types {
     /// If the filesystem object is a directory, `error-code::access` or
     /// `error-code::is-directory` may be returned instead of the
     /// POSIX-specified `error-code::not-permitted`.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     unlink-file-at: async func(path: string) -> result<_, error-code>;
     /// Test whether two descriptors refer to the same filesystem object.
     ///
@@ -520,7 +520,7 @@ interface types {
     /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
     /// wasi-filesystem does not expose device and inode numbers, so this function
     /// may be used instead.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     is-same-object: async func(other: borrow<descriptor>) -> bool;
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a descriptor.
@@ -541,35 +541,35 @@ interface types {
     ///    computed hash.
     ///
     /// However, none of these is required.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     metadata-hash: async func() -> result<metadata-hash-value, error-code>;
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a directory descriptor and a relative path.
     ///
     /// This performs the same hash computation as `metadata-hash`.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     metadata-hash-at: async func(path-flags: path-flags, path: string) -> result<metadata-hash-value, error-code>;
   }
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface preopens {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   use types.{descriptor};
 
   /// Return the set of preopened directories, and their paths.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-directories: func() -> list<tuple<descriptor, string>>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world imports {
-  @since(version = 0.3.0-rc-2026-03-15)
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
-  @since(version = 0.3.0-rc-2026-03-15)
-  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
+  import wasi:clocks/types@0.3.0;
+  @since(version = 0.3.0)
+  import wasi:clocks/system-clock@0.3.0;
+  @since(version = 0.3.0)
   import types;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import preopens;
 }

--- a/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-http-0.3.0/package.wit
+++ b/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-http-0.3.0/package.wit
@@ -1,13 +1,13 @@
-package wasi:http@0.3.0-rc-2026-03-15;
+package wasi:http@0.3.0;
 
 /// This interface defines all of the types and methods for implementing HTTP
 /// Requests and Responses, as well as their headers, trailers, and bodies.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface types {
-  use wasi:clocks/types@0.3.0-rc-2026-03-15.{duration};
+  use wasi:clocks/types@0.3.0.{duration};
 
   /// This type corresponds to HTTP standard Methods.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant method {
     get,
     head,
@@ -22,7 +22,7 @@ interface types {
   }
 
   /// This type corresponds to HTTP standard Related Schemes.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant scheme {
     HTTP,
     HTTPS,
@@ -30,21 +30,21 @@ interface types {
   }
 
   /// Defines the case payload type for `DNS-error` above:
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record DNS-error-payload {
     rcode: option<string>,
     info-code: option<u16>,
   }
 
   /// Defines the case payload type for `TLS-alert-received` above:
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record TLS-alert-received-payload {
     alert-id: option<u8>,
     alert-message: option<string>,
   }
 
   /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record field-size-payload {
     field-name: option<string>,
     field-size: option<u32>,
@@ -52,7 +52,7 @@ interface types {
 
   /// These cases are inspired by the IANA HTTP Proxy Error Types:
   ///   <https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types>
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant error-code {
     DNS-timeout,
     DNS-error(DNS-error-payload),
@@ -102,7 +102,7 @@ interface types {
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting or appending to a `fields` resource.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant header-error {
     /// This error indicates that a `field-name` or `field-value` was
     /// syntactically invalid when used with an operation that sets headers in a
@@ -130,7 +130,7 @@ interface types {
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting fields of a `request-options` resource.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant request-options-error {
     /// Indicates the specified field is not supported by this implementation.
     not-supported,
@@ -150,13 +150,13 @@ interface types {
   ///
   /// Field names should always be treated as case insensitive by the `fields`
   /// resource for the purposes of equality checking.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type field-name = string;
 
   /// Field values should always be ASCII strings. However, in
   /// reality, HTTP implementations often have to interpret malformed values,
   /// so they are provided as a list of bytes.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type field-value = list<u8>;
 
   /// This following block defines the `fields` resource which corresponds to
@@ -178,7 +178,7 @@ interface types {
   /// Implementations may impose limits on individual field values and on total
   /// aggregate field section size. Operations that would exceed these limits
   /// fail with `header-error.size-exceeded`
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource fields {
     /// Construct an empty HTTP Fields.
     ///
@@ -254,15 +254,15 @@ interface types {
   }
 
   /// Headers is an alias for Fields.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type headers = fields;
 
   /// Trailers is an alias for Fields.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type trailers = fields;
 
   /// Represents an HTTP Request.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource request {
     /// Construct a new `request` with a default `method` of `GET`, and
     /// `none` values for `path-with-query`, `scheme`, and `authority`.
@@ -349,7 +349,7 @@ interface types {
   ///
   /// These timeouts are separate from any the user may use to bound an
   /// asynchronous call.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource request-options {
     /// Construct a default `request-options` value.
     constructor();
@@ -378,11 +378,11 @@ interface types {
   }
 
   /// This type corresponds to the HTTP standard Status Code.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type status-code = u16;
 
   /// Represents an HTTP Response.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource response {
     /// Construct a new `response`, with a default `status-code` of `200`.
     /// If a different `status-code` is needed, it must be set via the
@@ -431,7 +431,7 @@ interface types {
 ///
 /// In `wasi:http/middleware` this interface is both exported and imported as
 /// the "downstream" and "upstream" directions of the middleware chain.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface handler {
   use types.{request, response, error-code};
 
@@ -450,7 +450,7 @@ interface handler {
 /// (including WIT itself) is unable to represent a component importing two
 /// instances of the same interface. A `client.send` import may be linked
 /// directly to a `handler.handle` export to bypass the network.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface client {
   use types.{request, response, error-code};
 
@@ -462,22 +462,22 @@ interface client {
 /// The `wasi:http/service` world captures a broad category of HTTP services
 /// including web applications, API servers, and proxies. It may be `include`d
 /// in more specific worlds such as `wasi:http/middleware`.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world service {
-  import wasi:cli/types@0.3.0-rc-2026-03-15;
-  import wasi:cli/stdout@0.3.0-rc-2026-03-15;
-  import wasi:cli/stderr@0.3.0-rc-2026-03-15;
-  import wasi:cli/stdin@0.3.0-rc-2026-03-15;
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
+  import wasi:cli/types@0.3.0;
+  import wasi:cli/stdout@0.3.0;
+  import wasi:cli/stderr@0.3.0;
+  import wasi:cli/stdin@0.3.0;
+  import wasi:clocks/types@0.3.0;
   import types;
   import client;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/monotonic-clock@0.3.0;
+  import wasi:clocks/system-clock@0.3.0;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
-  import wasi:random/random@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
+  import wasi:clocks/timezone@0.3.0;
+  import wasi:random/random@0.3.0;
+  import wasi:random/insecure@0.3.0;
+  import wasi:random/insecure-seed@0.3.0;
 
   export handler;
 }
@@ -487,23 +487,23 @@ world service {
 /// Components may implement this world to allow them to participate in handler
 /// "chains" where a `request` flows through handlers on its way to some terminal
 /// `service` and corresponding `response` flows in the opposite direction.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world middleware {
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
+  import wasi:clocks/types@0.3.0;
   import types;
   import handler;
-  import wasi:cli/types@0.3.0-rc-2026-03-15;
-  import wasi:cli/stdout@0.3.0-rc-2026-03-15;
-  import wasi:cli/stderr@0.3.0-rc-2026-03-15;
-  import wasi:cli/stdin@0.3.0-rc-2026-03-15;
+  import wasi:cli/types@0.3.0;
+  import wasi:cli/stdout@0.3.0;
+  import wasi:cli/stderr@0.3.0;
+  import wasi:cli/stdin@0.3.0;
   import client;
-  import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
-  import wasi:clocks/system-clock@0.3.0-rc-2026-03-15;
+  import wasi:clocks/monotonic-clock@0.3.0;
+  import wasi:clocks/system-clock@0.3.0;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.3.0-rc-2026-03-15;
-  import wasi:random/random@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure@0.3.0-rc-2026-03-15;
-  import wasi:random/insecure-seed@0.3.0-rc-2026-03-15;
+  import wasi:clocks/timezone@0.3.0;
+  import wasi:random/random@0.3.0;
+  import wasi:random/insecure@0.3.0;
+  import wasi:random/insecure-seed@0.3.0;
 
   export handler;
 }

--- a/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-random-0.3.0/package.wit
+++ b/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-random-0.3.0/package.wit
@@ -1,10 +1,10 @@
-package wasi:random@0.3.0-rc-2026-03-15;
+package wasi:random@0.3.0;
 
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface insecure-seed {
   /// Return a 128-bit value that may contain a pseudo-random value.
   ///
@@ -23,7 +23,7 @@ interface insecure-seed {
   /// This will likely be changed to a value import, to prevent it from being
   /// called multiple times and potentially used for purposes other than DoS
   /// protection.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-insecure-seed: func() -> tuple<u64, u64>;
 }
 
@@ -31,7 +31,7 @@ interface insecure-seed {
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface insecure {
   /// Return up to `max-len` insecure pseudo-random bytes.
   ///
@@ -48,14 +48,14 @@ interface insecure {
   /// Implementations MUST return at least 1 byte when `max-len` is greater
   /// than zero. When `max-len` is zero, implementations MUST return an empty
   /// list without trapping.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-insecure-random-bytes: func(max-len: u64) -> list<u8>;
 
   /// Return an insecure pseudo-random `u64` value.
   ///
   /// This function returns the same type of pseudo-random data as
   /// `get-insecure-random-bytes`, represented as a `u64`.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-insecure-random-u64: func() -> u64;
 }
 
@@ -63,7 +63,7 @@ interface insecure {
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface random {
   /// Return up to `max-len` cryptographically-secure random or pseudo-random
   /// bytes.
@@ -85,23 +85,23 @@ interface random {
   /// This function must always return fresh data. Deterministic environments
   /// must omit this function, rather than implementing it with deterministic
   /// data.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-random-bytes: func(max-len: u64) -> list<u8>;
 
   /// Return a cryptographically-secure random or pseudo-random `u64` value.
   ///
   /// This function returns the same type of data as `get-random-bytes`,
   /// represented as a `u64`.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   get-random-u64: func() -> u64;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world imports {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import random;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import insecure;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import insecure-seed;
 }

--- a/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-sockets-0.3.0/package.wit
+++ b/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasi-sockets-0.3.0/package.wit
@@ -1,9 +1,9 @@
-package wasi:sockets@0.3.0-rc-2026-03-15;
+package wasi:sockets@0.3.0;
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface types {
-  @since(version = 0.3.0-rc-2026-03-15)
-  use wasi:clocks/types@0.3.0-rc-2026-03-15.{duration};
+  @since(version = 0.3.0)
+  use wasi:clocks/types@0.3.0.{duration};
 
   /// Error codes.
   ///
@@ -16,7 +16,7 @@ interface types {
   /// - `out-of-memory`
   ///
   /// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant error-code {
     /// Access denied.
     ///
@@ -80,7 +80,7 @@ interface types {
     other(option<string>),
   }
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   enum ip-address-family {
     /// Similar to `AF_INET` in POSIX.
     ipv4,
@@ -88,19 +88,19 @@ interface types {
     ipv6,
   }
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type ipv4-address = tuple<u8, u8, u8, u8>;
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant ip-address {
     ipv4(ipv4-address),
     ipv6(ipv6-address),
   }
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record ipv4-socket-address {
     /// sin_port
     port: u16,
@@ -108,7 +108,7 @@ interface types {
     address: ipv4-address,
   }
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   record ipv6-socket-address {
     /// sin6_port
     port: u16,
@@ -120,7 +120,7 @@ interface types {
     scope-id: u32,
   }
 
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant ip-socket-address {
     ipv4(ipv4-socket-address),
     ipv6(ipv6-socket-address),
@@ -158,7 +158,7 @@ interface types {
   /// In addition to the general error codes documented on the
   /// `types::error-code` type, TCP socket methods may always return
   /// `error(invalid-state)` when in the `closed` state.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource tcp-socket {
     /// Create a new TCP socket.
     ///
@@ -178,7 +178,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     create: static func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
     /// Bind the socket to the provided IP address and port.
     ///
@@ -213,7 +213,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     bind: func(local-address: ip-socket-address) -> result<_, error-code>;
     /// Connect to a remote endpoint.
     ///
@@ -249,7 +249,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     connect: async func(remote-address: ip-socket-address) -> result<_, error-code>;
     /// Start listening and return a stream of new inbound connections.
     ///
@@ -321,7 +321,7 @@ interface types {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     listen: func() -> result<stream<tcp-socket>, error-code>;
     /// Transmit data to peer.
     ///
@@ -345,7 +345,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/send.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     send: func(data: stream<u8>) -> future<result<_, error-code>>;
     /// Read data from peer.
     ///
@@ -374,7 +374,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/recv.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     receive: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
     /// Get the bound local address.
     ///
@@ -393,7 +393,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
     /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-local-address: func() -> result<ip-socket-address, error-code>;
     /// Get the remote address.
     ///
@@ -405,19 +405,19 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-remote-address: func() -> result<ip-socket-address, error-code>;
     /// Whether the socket is in the `listening` state.
     ///
     /// Equivalent to the SO_ACCEPTCONN socket option.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-is-listening: func() -> bool;
     /// Whether this is a IPv4 or IPv6 socket.
     ///
     /// This is the value passed to the constructor.
     ///
     /// Equivalent to the SO_DOMAIN socket option.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-address-family: func() -> ip-address-family;
     /// Hints the desired listen queue size. Implementations are free to
     /// ignore this.
@@ -430,7 +430,7 @@ interface types {
     /// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
     /// - `invalid-argument`:     (set) The provided value was 0.
     /// - `invalid-state`:        (set) The socket is in the `connecting` or `connected` state.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
     /// Enables or disables keepalive.
     ///
@@ -442,9 +442,9 @@ interface types {
     /// false, but only come into effect when `keep-alive-enabled` is true.
     ///
     /// Equivalent to the SO_KEEPALIVE socket option.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-keep-alive-enabled: func() -> result<bool, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-keep-alive-enabled: func(value: bool) -> result<_, error-code>;
     /// Amount of time the connection has to be idle before TCP starts
     /// sending keepalive packets.
@@ -458,9 +458,9 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-keep-alive-idle-time: func() -> result<duration, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-keep-alive-idle-time: func(value: duration) -> result<_, error-code>;
     /// The time between keepalive packets.
     ///
@@ -473,9 +473,9 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-keep-alive-interval: func() -> result<duration, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-keep-alive-interval: func(value: duration) -> result<_, error-code>;
     /// The maximum amount of keepalive packets TCP should send before
     /// aborting the connection.
@@ -489,9 +489,9 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-keep-alive-count: func() -> result<u32, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-keep-alive-count: func(value: u32) -> result<_, error-code>;
     /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
     ///
@@ -499,9 +499,9 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-hop-limit: func() -> result<u8, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-hop-limit: func(value: u8) -> result<_, error-code>;
     /// Kernel buffer space reserved for sending/receiving on this socket.
     /// Implementations usually treat this as a cap the buffer can grow to,
@@ -524,18 +524,18 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-receive-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-send-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-send-buffer-size: func(value: u64) -> result<_, error-code>;
   }
 
   /// A UDP socket handle.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resource udp-socket {
     /// Create a new UDP socket.
     ///
@@ -552,7 +552,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     create: static func(address-family: ip-address-family) -> result<udp-socket, error-code>;
     /// Bind the socket to the provided IP address and port.
     ///
@@ -573,7 +573,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     bind: func(local-address: ip-socket-address) -> result<_, error-code>;
     /// Associate this socket with a specific peer address.
     ///
@@ -611,7 +611,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     connect: func(remote-address: ip-socket-address) -> result<_, error-code>;
     /// Dissociate this socket from its peer address.
     ///
@@ -628,7 +628,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
     /// - <https://man.freebsd.org/cgi/man.cgi?connect>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     disconnect: func() -> result<_, error-code>;
     /// Send a message on the socket to a particular peer.
     ///
@@ -672,7 +672,7 @@ interface types {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     send: async func(data: list<u8>, remote-address: option<ip-socket-address>) -> result<_, error-code>;
     /// Receive a message on the socket.
     ///
@@ -697,7 +697,7 @@ interface types {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/mswsock/nc-mswsock-lpfn_wsarecvmsg>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     receive: async func() -> result<tuple<list<u8>, ip-socket-address>, error-code>;
     /// Get the current bound address.
     ///
@@ -716,7 +716,7 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
     /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-local-address: func() -> result<ip-socket-address, error-code>;
     /// Get the address the socket is currently "connected" to.
     ///
@@ -728,14 +728,14 @@ interface types {
     /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-remote-address: func() -> result<ip-socket-address, error-code>;
     /// Whether this is a IPv4 or IPv6 socket.
     ///
     /// This is the value passed to the constructor.
     ///
     /// Equivalent to the SO_DOMAIN socket option.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-address-family: func() -> ip-address-family;
     /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
     ///
@@ -743,9 +743,9 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-unicast-hop-limit: func() -> result<u8, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
     /// Kernel buffer space reserved for sending/receiving on this socket.
     /// Implementations usually treat this as a cap the buffer can grow to,
@@ -760,24 +760,24 @@ interface types {
     ///
     /// # Typical errors
     /// - `invalid-argument`:     (set) The provided value was 0.
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-receive-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     get-send-buffer-size: func() -> result<u64, error-code>;
-    @since(version = 0.3.0-rc-2026-03-15)
+    @since(version = 0.3.0)
     set-send-buffer-size: func(value: u64) -> result<_, error-code>;
   }
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 interface ip-name-lookup {
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   use types.{ip-address};
 
   /// Lookup error codes.
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   variant error-code {
     /// Access denied.
     ///
@@ -824,16 +824,16 @@ interface ip-name-lookup {
   /// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
   /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
   /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   resolve-addresses: async func(name: string) -> result<list<ip-address>, error-code>;
 }
 
-@since(version = 0.3.0-rc-2026-03-15)
+@since(version = 0.3.0)
 world imports {
-  @since(version = 0.3.0-rc-2026-03-15)
-  import wasi:clocks/types@0.3.0-rc-2026-03-15;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
+  import wasi:clocks/types@0.3.0;
+  @since(version = 0.3.0)
   import types;
-  @since(version = 0.3.0-rc-2026-03-15)
+  @since(version = 0.3.0)
   import ip-name-lookup;
 }

--- a/crates/wash-runtime/tests/fixtures/socket-test-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/socket-test-p3/wit/world.wit
@@ -1,13 +1,13 @@
 package wasmcloud:test-p3@0.1.0;
 
 world socket-test {
-    import wasi:cli/environment@0.3.0-rc-2026-03-15;
-    import wasi:cli/stderr@0.3.0-rc-2026-03-15;
-    import wasi:cli/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/types@0.3.0-rc-2026-03-15;
-    import wasi:clocks/monotonic-clock@0.3.0-rc-2026-03-15;
-    import wasi:sockets/types@0.3.0-rc-2026-03-15;
-    import wasi:sockets/ip-name-lookup@0.3.0-rc-2026-03-15;
+    import wasi:cli/environment@0.3.0;
+    import wasi:cli/stderr@0.3.0;
+    import wasi:cli/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:clocks/monotonic-clock@0.3.0;
+    import wasi:sockets/types@0.3.0;
+    import wasi:sockets/ip-name-lookup@0.3.0;
 
-    export wasi:cli/run@0.3.0-rc-2026-03-15;
+    export wasi:cli/run@0.3.0;
 }

--- a/crates/wash-runtime/tests/fixtures/tls-echo-client-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/tls-echo-client-p3/wit/world.wit
@@ -2,10 +2,10 @@ package wasmcloud:tls-echo-client-p3@0.1.0;
 
 world tls-echo-client-p3 {
     // Server address is passed via the ECHO_ADDR environment variable.
-    import wasi:cli/stderr@0.3.0-rc-2026-03-15;
-    import wasi:sockets/types@0.3.0-rc-2026-03-15;
+    import wasi:cli/stderr@0.3.0;
+    import wasi:sockets/types@0.3.0;
     import wasi:tls/client@0.3.0-draft;
     import wasi:tls/types@0.3.0-draft;
 
-    export wasi:cli/run@0.3.0-rc-2026-03-15;
+    export wasi:cli/run@0.3.0;
 }

--- a/crates/wash-runtime/tests/integration_http_allowed_hosts.rs
+++ b/crates/wash-runtime/tests/integration_http_allowed_hosts.rs
@@ -93,7 +93,6 @@ impl OutgoingHandler for FakeOutgoingHandler {
         Ok(HostFutureIncomingResponse::pending(handle))
     }
 
-    #[cfg(feature = "wasip3")]
     fn send_request_p3(
         &self,
         _workload_id: &str,

--- a/crates/wash-runtime/tests/integration_http_webgpu.rs
+++ b/crates/wash-runtime/tests/integration_http_webgpu.rs
@@ -9,7 +9,11 @@
 //! Note: This is a basic integration test that verifies plugin loading and host functionality.
 //! Full component binding and request routing would require proper WIT interface configuration.
 //!
-#![cfg(feature = "wasi-webgpu")]
+#![cfg(all(
+    feature = "wasi-webgpu",
+    not(target_os = "windows"),
+    not(target_arch = "s390x")
+))]
 
 use anyhow::{Context, Result};
 use std::{collections::HashMap, sync::Arc, time::Duration};

--- a/crates/wash-runtime/tests/integration_nats_blobstore.rs
+++ b/crates/wash-runtime/tests/integration_nats_blobstore.rs
@@ -117,9 +117,9 @@ async fn setup() -> Result<TestHarness> {
                     ]
                     .into_iter()
                     .collect(),
-                    version: Some(
-                        semver::Version::parse("0.2.0-draft").expect("valid semver version"),
-                    ),
+                    version: Some(semver::Version::parse("0.2.0-draft").map_err(|e| {
+                        anyhow::anyhow!("invalid blobstore interface version: {e}")
+                    })?),
                     config: {
                         let mut config = HashMap::new();
                         config.insert("buckets".to_string(), "my-container-real".to_string());

--- a/crates/wash-runtime/tests/integration_p2_p3_matrix.rs
+++ b/crates/wash-runtime/tests/integration_p2_p3_matrix.rs
@@ -8,7 +8,6 @@
 //! - Mixed P2/P3 components in same workload
 //! - P2 regression with P3 engine enabled
 
-#![cfg(feature = "wasip3")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
@@ -47,7 +46,6 @@ const P2_CALLEE_WASM: &[u8] = include_bytes!("wasm/inter_component_call_callee.w
 
 fn engine_with_p3() -> Engine {
     Engine::builder()
-        .with_wasip3(true)
         .build()
         .expect("failed to build engine with wasip3")
 }

--- a/crates/wash-runtime/tests/integration_p3_sockets.rs
+++ b/crates/wash-runtime/tests/integration_p3_sockets.rs
@@ -9,7 +9,6 @@
 //! - `sockets/host_udp_p3.rs`: HostUdpSocketWithStore send/receive
 //! - `sockets/mod.rs`: add_p3_to_linker, error code mapping
 
-#![cfg(feature = "wasip3")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
@@ -25,7 +24,6 @@ const SOCKET_TEST_P3_WASM: &[u8] = include_bytes!("wasm/socket_test_p3.wasm");
 
 fn engine_with_p3() -> Engine {
     Engine::builder()
-        .with_wasip3(true)
         .build()
         .expect("failed to build engine with wasip3")
 }

--- a/crates/wash-runtime/tests/integration_tls_socket.rs
+++ b/crates/wash-runtime/tests/integration_tls_socket.rs
@@ -59,7 +59,6 @@ fn echo_client_workload_request(
 /// - TLS handshake against a self-signed cert via the custom `TestTlsProvider`
 /// - Plaintext `PING\r\n` write through the encrypted stream
 /// - Receipt verified via oneshot channel on the server side
-#[cfg(feature = "wasip3")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_p3_tls_tcp_round_trip() -> Result<()> {
     install_default_crypto_provider();

--- a/crates/wash-runtime/tests/integration_wasip3.rs
+++ b/crates/wash-runtime/tests/integration_wasip3.rs
@@ -1,10 +1,9 @@
 //! Integration tests for WASIP3 support.
 //!
-//! Tests that the wasip3 feature flag correctly enables P3 bindings,
-//! P2 components still work when P3 is enabled, and the detection
-//! logic correctly identifies P3 components.
+//! Tests that P3 bindings are registered, P2 components still work
+//! alongside P3, and the detection logic correctly identifies P3
+//! components.
 
-#![cfg(feature = "wasip3")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
@@ -22,30 +21,6 @@ use common::{http_counter_host_interfaces, start_host_with_p3};
 
 const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
 
-fn engine_with_p3() -> Engine {
-    Engine::builder()
-        .with_wasip3(true)
-        .build()
-        .expect("failed to build engine with wasip3")
-}
-
-// Engine configuration tests
-
-#[test]
-fn test_engine_builder_wasip3_flag() {
-    let engine = Engine::builder().with_wasip3(true).build().unwrap();
-    assert!(engine.wasip3(), "engine should report wasip3 enabled");
-
-    let engine = Engine::builder().with_wasip3(false).build().unwrap();
-    assert!(!engine.wasip3(), "engine should report wasip3 disabled");
-}
-
-#[test]
-fn test_engine_builder_wasip3_default_off() {
-    let engine = Engine::builder().build().unwrap();
-    assert!(!engine.wasip3(), "wasip3 should default to disabled");
-}
-
 // P3 component detection tests
 
 #[test]
@@ -58,7 +33,7 @@ fn test_targets_wasip3_detects_p3_import() {
     "#;
     let wasm = wat::parse_str(wat).expect("failed to parse WAT");
 
-    let engine = engine_with_p3();
+    let engine = Engine::builder().build().expect("failed to build engine");
     let component =
         wasmtime::component::Component::new(engine.inner(), &wasm).expect("failed to compile");
     assert!(
@@ -77,7 +52,7 @@ fn test_targets_wasip3_detects_p3_handler() {
     "#;
     let wasm = wat::parse_str(wat).expect("failed to parse WAT");
 
-    let engine = engine_with_p3();
+    let engine = Engine::builder().build().expect("failed to build engine");
     let component =
         wasmtime::component::Component::new(engine.inner(), &wasm).expect("failed to compile");
     assert!(
@@ -96,7 +71,7 @@ fn test_targets_wasip3_ignores_p2() {
     "#;
     let wasm = wat::parse_str(wat).expect("failed to parse WAT");
 
-    let engine = engine_with_p3();
+    let engine = Engine::builder().build().expect("failed to build engine");
     let component =
         wasmtime::component::Component::new(engine.inner(), &wasm).expect("failed to compile");
     assert!(
@@ -110,7 +85,7 @@ fn test_targets_wasip3_ignores_empty() {
     let wat = r#"(component)"#;
     let wasm = wat::parse_str(wat).expect("failed to parse WAT");
 
-    let engine = engine_with_p3();
+    let engine = Engine::builder().build().expect("failed to build engine");
     let component =
         wasmtime::component::Component::new(engine.inner(), &wasm).expect("failed to compile");
     assert!(
@@ -129,7 +104,7 @@ fn test_targets_wasip3_ignores_non_wasi() {
     "#;
     let wasm = wat::parse_str(wat).expect("failed to parse WAT");
 
-    let engine = engine_with_p3();
+    let engine = Engine::builder().build().expect("failed to build engine");
     let component =
         wasmtime::component::Component::new(engine.inner(), &wasm).expect("failed to compile");
     assert!(
@@ -272,7 +247,7 @@ async fn test_p2_concurrent_requests_with_p3_enabled() -> Result<()> {
 #[tokio::test]
 async fn test_p3_linker_accepts_p2_component() -> Result<()> {
     // Engine with P3 enabled should still initialize P2 components
-    let engine = engine_with_p3();
+    let engine = Engine::builder().build().expect("failed to build engine");
 
     let workload = Workload {
         namespace: "test".to_string(),
@@ -295,38 +270,6 @@ async fn test_p3_linker_accepts_p2_component() -> Result<()> {
     assert!(
         result.is_ok(),
         "P3-enabled engine should accept P2 component: {:?}",
-        result.err()
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_p3_disabled_engine_rejects_nothing() -> Result<()> {
-    // Engine without P3 should still work fine for P2
-    let engine = Engine::builder().with_wasip3(false).build()?;
-
-    let workload = Workload {
-        namespace: "test".to_string(),
-        name: "p2-no-p3".to_string(),
-        annotations: HashMap::new(),
-        service: None,
-        components: vec![Component {
-            name: "http-counter.wasm".to_string(),
-            digest: None,
-            bytes: bytes::Bytes::from_static(HTTP_COUNTER_WASM),
-            local_resources: LocalResources::default(),
-            pool_size: 1,
-            max_invocations: 100,
-        }],
-        host_interfaces: http_counter_host_interfaces("no-p3-test"),
-        volumes: vec![],
-    };
-
-    let result = engine.initialize_workload("test-id", workload);
-    assert!(
-        result.is_ok(),
-        "P2 component on non-P3 engine should work: {:?}",
         result.err()
     );
 

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -12,7 +12,6 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-wasip3 = ["wash-runtime/wasip3"]
 wasi-tls = ["wash-runtime/wasi-tls"]
 # Opt-in: pulls in wasi-gfx git deps that still target wasmtime 45 and do
 # not build against the pinned wasmtime 46. Re-add to the default build
@@ -64,7 +63,7 @@ uuid = { workspace = true }
 wasm-metadata = { workspace = true }
 wasm-pkg-client = { workspace = true }
 wasm-pkg-core = { workspace = true }
-wash-runtime = { workspace = true, features = ["washlet", "oci", "wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "wasi-otel", "wasip3"] }
+wash-runtime = { workspace = true, features = ["washlet", "oci", "wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "wasi-otel"] }
 wit-component = { workspace = true }
 
 # `O_NOFOLLOW` for the secret-file-open hardening in `crate::workload`.

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -14,6 +14,10 @@ version.workspace = true
 [features]
 wasip3 = ["wash-runtime/wasip3"]
 wasi-tls = ["wash-runtime/wasi-tls"]
+# Opt-in: pulls in wasi-gfx git deps that still target wasmtime 45 and do
+# not build against the pinned wasmtime 46. Re-add to the default build
+# once wasi-gfx-runtime supports wasmtime 46.
+wasi-webgpu = ["wash-runtime/wasi-webgpu"]
 
 [lints]
 workspace = true
@@ -60,15 +64,8 @@ uuid = { workspace = true }
 wasm-metadata = { workspace = true }
 wasm-pkg-client = { workspace = true }
 wasm-pkg-core = { workspace = true }
-wash-runtime = { workspace = true, features = ["washlet", "oci", "wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "wasi-otel"] }
+wash-runtime = { workspace = true, features = ["washlet", "oci", "wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "wasi-otel", "wasip3"] }
 wit-component = { workspace = true }
-
-# Enable WebGPU support on non-Windows platforms.
-# WebGPU is disabled on Windows due to dependency version conflicts with the windows crate.
-# It is also disabled on s390x because naga pulls in `half` (f16) and the zigbuild LLVM
-# backend can't lower the f16 conversions for the s390x target (LLVM ERROR in __fixhfsi).
-[target.'cfg(all(not(target_os = "windows"), not(target_arch = "s390x")))'.dependencies]
-wash-runtime = { workspace = true, features = ["wasi-webgpu"] }
 
 # `O_NOFOLLOW` for the secret-file-open hardening in `crate::workload`.
 # Unix-only. Windows has no portable equivalent.

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -12,10 +12,10 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
+default = ["wasi-webgpu"]
 wasi-tls = ["wash-runtime/wasi-tls"]
-# Opt-in: pulls in wasi-gfx git deps that still target wasmtime 45 and do
-# not build against the pinned wasmtime 46. Re-add to the default build
-# once wasi-gfx-runtime supports wasmtime 46.
+# On by default. Pulls in git-only wasi-gfx deps (no crates.io release);
+# disable with `--no-default-features` for a build without the git sources.
 wasi-webgpu = ["wash-runtime/wasi-webgpu"]
 
 [lints]

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -63,15 +63,10 @@ impl CliCommand for DevCommand {
             .clone()
             .unwrap_or_else(|| "0.0.0.0:8000".to_string());
 
-        #[allow(unused_mut)]
-        let mut engine_builder = Engine::builder()
+        let engine = Engine::builder()
             .with_pooling_allocator(true)
-            .with_fuel_consumption(ctx.enable_meters());
-        #[cfg(feature = "wasip3")]
-        {
-            engine_builder = engine_builder.with_wasip3(dev_config.wasip3.unwrap_or(true));
-        }
-        let engine = engine_builder.build()?;
+            .with_fuel_consumption(ctx.enable_meters())
+            .build()?;
 
         let mut host_builder = Host::builder()
             .with_engine(engine)

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -69,7 +69,7 @@ impl CliCommand for DevCommand {
             .with_fuel_consumption(ctx.enable_meters());
         #[cfg(feature = "wasip3")]
         {
-            engine_builder = engine_builder.with_wasip3(dev_config.wasip3);
+            engine_builder = engine_builder.with_wasip3(dev_config.wasip3.unwrap_or(true));
         }
         let engine = engine_builder.build()?;
 
@@ -242,7 +242,11 @@ impl CliCommand for DevCommand {
         }
 
         // Enable WASI WebGPU if requested
-        #[cfg(all(not(target_os = "windows"), not(target_arch = "s390x")))]
+        #[cfg(all(
+            not(target_os = "windows"),
+            not(target_arch = "s390x"),
+            feature = "wasi-webgpu"
+        ))]
         if dev_config.wasi_webgpu {
             host_builder =
                 host_builder.with_plugin(Arc::new(plugin::wasi_webgpu::WebGpu::default()))?;

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -87,7 +87,11 @@ pub struct HostCommand {
     pub tls_ca_path: Option<PathBuf>,
 
     /// Enable WASI WebGPU support
-    #[cfg(all(not(target_os = "windows"), not(target_arch = "s390x")))]
+    #[cfg(all(
+        not(target_os = "windows"),
+        not(target_arch = "s390x"),
+        feature = "wasi-webgpu"
+    ))]
     #[arg(long = "wasi-webgpu", default_value_t = false)]
     pub wasi_webgpu: bool,
 
@@ -114,7 +118,7 @@ pub struct HostCommand {
 
     /// Enable WASIP3 support for components that target wasi@0.3 interfaces
     #[cfg(feature = "wasip3")]
-    #[arg(long = "wasip3", env = "WASH_WASIP3", default_value_t = false)]
+    #[arg(long = "wasip3", env = "WASH_WASIP3", default_value_t = true)]
     pub wasip3: bool,
 }
 
@@ -227,7 +231,11 @@ impl CliCommand for HostCommand {
         }
 
         // Enable WASI WebGPU if requested
-        #[cfg(all(not(target_os = "windows"), not(target_arch = "s390x")))]
+        #[cfg(all(
+            not(target_os = "windows"),
+            not(target_arch = "s390x"),
+            feature = "wasi-webgpu"
+        ))]
         if self.wasi_webgpu {
             tracing::info!("WASI WebGPU support enabled");
             cluster_host_builder = cluster_host_builder

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -115,11 +115,6 @@ pub struct HostCommand {
     /// Enable WASI OpenTelemetry plugin
     #[arg(long = "wasi-otel", default_value_t = false)]
     pub wasi_otel: bool,
-
-    /// Enable WASIP3 support for components that target wasi@0.3 interfaces
-    #[cfg(feature = "wasip3")]
-    #[arg(long = "wasip3", env = "WASH_WASIP3", default_value_t = true)]
-    pub wasip3: bool,
 }
 
 impl CliCommand for HostCommand {
@@ -161,15 +156,10 @@ impl CliCommand for HostCommand {
             oci_cache_dir: self.oci_cache_dir.clone(),
         };
 
-        #[allow(unused_mut)]
-        let mut engine_builder = Engine::builder()
+        let engine = Engine::builder()
             .with_pooling_allocator(true)
-            .with_fuel_consumption(ctx.enable_meters());
-        #[cfg(feature = "wasip3")]
-        {
-            engine_builder = engine_builder.with_wasip3(self.wasip3);
-        }
-        let engine = engine_builder.build()?;
+            .with_fuel_consumption(ctx.enable_meters())
+            .build()?;
 
         let mut cluster_host_builder = wash_runtime::washlet::ClusterHostBuilder::default()
             .with_engine(engine)

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -461,9 +461,12 @@ pub struct DevConfig {
     #[serde(default)]
     pub wasi_otel: bool,
 
-    /// Enable WASIP3 support for components that target wasi@0.3 interfaces
-    #[serde(default)]
-    pub wasip3: bool,
+    /// Enable WASIP3 support for components that target wasi@0.3 interfaces.
+    /// `None` means use the default (enabled); set `wasip3: false` to opt out.
+    /// `Option` keeps "unset = enabled" consistent across `Default`, serde, and
+    /// direct construction without a hand-written `Default` impl.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wasip3: Option<bool>,
 }
 
 impl DevConfig {

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -460,13 +460,6 @@ pub struct DevConfig {
     /// Enable WASI OpenTelemetry support
     #[serde(default)]
     pub wasi_otel: bool,
-
-    /// Enable WASIP3 support for components that target wasi@0.3 interfaces.
-    /// `None` means use the default (enabled); set `wasip3: false` to opt out.
-    /// `Option` keeps "unset = enabled" consistent across `Default`, serde, and
-    /// direct construction without a hand-written `Default` impl.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub wasip3: Option<bool>,
 }
 
 impl DevConfig {

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -330,7 +330,7 @@ The playbook installs (as `root` on the bench host):
 - A **smoke build**:
   ```sh
   cargo xtask build-fixtures   # benches include_bytes! the wasm fixtures
-  cargo bench -p wash-runtime --features wasip3 --bench http_invoke --no-run
+  cargo bench -p wash-runtime --bench http_invoke --no-run
   ```
   to verify the bench binary compiles end-to-end. ~3 minutes cold.
   (`run-bench.sh` runs `cargo xtask build-fixtures` for you; it's only
@@ -487,7 +487,7 @@ touches the repo, a CI log, or `/proc/<pid>/cmdline` (env-only).
 
 1. **Pre-flight** ([`bench-preflight.mjs`](../../.github/scripts/bench-preflight.mjs)) — see §10.
 2. **Run bench** ([`run-bench.sh`](./run-bench.sh)) — sources cargo,
-   runs `cargo bench -p wash-runtime --features wasip3 --bench <name>`,
+   runs `cargo bench -p wash-runtime --bench <name>`,
    tees output to a per-run log under `$CARGO_TARGET_DIR`.
 3. **Summary** (`cargo run -p bench-tools -- summary --bench <name>`) —
    emits a markdown table to `$GITHUB_STEP_SUMMARY` with one row per
@@ -593,7 +593,7 @@ GitHub":
 ssh -i ~/.ssh/hetzner_bench root@<WASMCLOUD_BENCH_HOST_IP> \
   '. $HOME/.cargo/env && cd /opt/wasmcloud && \
    cargo xtask build-fixtures && \
-   cargo bench -p wash-runtime --features wasip3 --bench http_invoke'
+   cargo bench -p wash-runtime --bench http_invoke'
 ```
 
 Manual runs do **not** touch S3 or arewefastyet — only the GitHub

--- a/scripts/bench/run-bench.sh
+++ b/scripts/bench/run-bench.sh
@@ -89,7 +89,7 @@ if [ "$bench" = "gungraun" ]; then
   fi
 fi
 
-"${prefix[@]}" cargo bench -p wash-runtime --features wasip3 --bench "$bench" 2>&1 \
+"${prefix[@]}" cargo bench -p wash-runtime --bench "$bench" 2>&1 \
   | tee -a "$log"
 
 echo "WASMCLOUD_BENCH_LOG=${log}" >> "${GITHUB_OUTPUT:-/dev/null}"


### PR DESCRIPTION
Pin the wasmtime crates to the release-46.0.0 branch.

Drop our feature gate for wasip3 (enabled by default) for the wash binary.

Dependencies:
- wasmtime{,-wasi,-wasi-io,-wasi-http,-wasi-tls} -> git rev (release-46.0.0) and adds resource implements patch
- Bump workspace rust-version to 1.94.0 (46's MSRV).

Port wasmtime 45 -> 46 API changes:
- Component imports()/exports() now yield ComponentExtern; access .ty.
- p3 sockets *WithStore traits move their store generic onto the trait;
  drop the per-method generics (ip-name-lookup, tcp, udp).
- StreamProducer::Buffer no longer accepts Cursor<_>; use BytesMut.
- wasi:cli/exit LinkOptions removed (exit-with-code is now stable).
- HTTP needed no changes: the overhauled handler/body/host modules are
  internal to wasmtime-wasi-http; we consume only the unchanged
  ServicePre/Request/Response and default_send_request APIs.

WASI 0.3.0:
- interfaces from 0.3.0-rc-2026-03-15 -> 0.3.0. Update all P3 test fixtures' WIT
