### PR TITLE
Add s390 check in all webgpu locations

### DIFF
--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -52,7 +52,11 @@ pub mod wasi_otel;
 
 pub mod wasmcloud_messaging;
 
-#[cfg(all(feature = "wasi-webgpu", not(target_os = "windows")))]
+#[cfg(all(
+    feature = "wasi-webgpu",
+    not(target_os = "windows"),
+    not(target_arch = "s390x")
+))]
 pub mod wasi_webgpu;
 
 /// A wrapper around a [`std::collections::HashSet`] of [`crate::wit::WitInterface`] that provides convenience methods for looking up interfaces by namespace, package, and set of interfaces.

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -63,9 +63,11 @@ wasm-pkg-core = { workspace = true }
 wash-runtime = { workspace = true, features = ["washlet", "oci", "wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "wasi-otel"] }
 wit-component = { workspace = true }
 
-# Enable WebGPU support on non-Windows platforms
-# WebGPU is disabled on Windows due to dependency version conflicts with the windows crate
-[target.'cfg(not(target_os = "windows"))'.dependencies]
+# Enable WebGPU support on non-Windows platforms.
+# WebGPU is disabled on Windows due to dependency version conflicts with the windows crate.
+# It is also disabled on s390x because naga pulls in `half` (f16) and the zigbuild LLVM
+# backend can't lower the f16 conversions for the s390x target (LLVM ERROR in __fixhfsi).
+[target.'cfg(all(not(target_os = "windows"), not(target_arch = "s390x")))'.dependencies]
 wash-runtime = { workspace = true, features = ["wasi-webgpu"] }
 
 # `O_NOFOLLOW` for the secret-file-open hardening in `crate::workload`.

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -242,7 +242,7 @@ impl CliCommand for DevCommand {
         }
 
         // Enable WASI WebGPU if requested
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(all(not(target_os = "windows"), not(target_arch = "s390x")))]
         if dev_config.wasi_webgpu {
             host_builder =
                 host_builder.with_plugin(Arc::new(plugin::wasi_webgpu::WebGpu::default()))?;

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -87,7 +87,7 @@ pub struct HostCommand {
     pub tls_ca_path: Option<PathBuf>,
 
     /// Enable WASI WebGPU support
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_arch = "s390x")))]
     #[arg(long = "wasi-webgpu", default_value_t = false)]
     pub wasi_webgpu: bool,
 
@@ -227,7 +227,7 @@ impl CliCommand for HostCommand {
         }
 
         // Enable WASI WebGPU if requested
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(all(not(target_os = "windows"), not(target_arch = "s390x")))]
         if self.wasi_webgpu {
             tracing::info!("WASI WebGPU support enabled");
             cluster_host_builder = cluster_host_builder

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -519,6 +519,9 @@ impl DevConfig {
         if cfg!(target_os = "windows") && self.wasi_webgpu {
             errors.push("dev.wasi_webgpu is not supported on Windows".to_string());
         }
+        if cfg!(target_arch = "s390x") && self.wasi_webgpu {
+            errors.push("dev.wasi_webgpu is not supported on s390x".to_string());
+        }
 
         for comp in &self.components {
             if comp.name.trim().is_empty() {


### PR DESCRIPTION
Disables webgpu for s390 and reports error if trying to use when the target is s390 in the config, similar to Windows checks.

