### PR TITLE
fix(wash-runtime): stream P3 HTTP responses and release timed-out gRPC bodies

### DIFF
--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -38,6 +38,10 @@ use hyper_util::{
     server::conn::auto,
 };
 use opentelemetry::{KeyValue, context::FutureExt};
+use opentelemetry_semantic_conventions::attribute::{
+    HTTP_REQUEST_METHOD, HTTP_RESPONSE_BODY_SIZE, HTTP_RESPONSE_STATUS_CODE, OTEL_STATUS_CODE,
+    RPC_GRPC_STATUS_CODE, SERVER_ADDRESS, SERVER_PORT, URL_FULL, URL_PATH,
+};
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tracing::{Instrument, debug, error, info, instrument, warn};
@@ -339,9 +343,23 @@ impl OutgoingHandler for DefaultOutgoingHandler {
         config: wasmtime_wasi_http::p2::types::OutgoingRequestConfig,
     ) -> wasmtime_wasi_http::p2::HttpResult<wasmtime_wasi_http::p2::types::HostFutureIncomingResponse>
     {
-        Ok(wasmtime_wasi_http::p2::default_send_request(
-            request, config,
-        ))
+        // Spawn the default handler ourselves (rather than calling
+        // `default_send_request`) so the request can be wrapped in a client
+        // span and the response status recorded once it arrives.
+        let span = outbound_client_span(request.method(), request.uri());
+        let handle = wasmtime_wasi::runtime::spawn(
+            async move {
+                let result =
+                    wasmtime_wasi_http::p2::default_send_request_handler(request, config).await;
+                match &result {
+                    Ok(incoming) => record_outbound_status(incoming.resp.status()),
+                    Err(_) => record_outbound_error(),
+                }
+                Ok(result)
+            }
+            .instrument(span),
+        );
+        Ok(HostFutureIncomingResponse::pending(handle))
     }
     #[cfg(feature = "wasip3")]
     fn send_request_p3(
@@ -857,23 +875,42 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
         fut: crate::host::http_p3::P3RequestErrorFuture,
         allowed_hosts: &[AllowedHost],
     ) -> crate::host::http_p3::P3SendFuture {
-        if let Err(e) =
-            self.router
-                .allow_outgoing_request_p3(workload_id, &request, options, allowed_hosts)
+        let span = outbound_client_span(request.method(), request.uri());
+        let inner: crate::host::http_p3::P3SendFuture = if let Err(e) = self
+            .router
+            .allow_outgoing_request_p3(workload_id, &request, options, allowed_hosts)
         {
             warn!(workload_id = %workload_id, err = %e, "P3 outgoing request denied by allowed_hosts policy");
             use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
-            return Box::new(async move {
+            Box::new(async move {
                 Err(wasmtime_wasi::TrappableError::from(
                     ErrorCode::HttpRequestDenied,
                 ))
-            });
-        }
-        if is_grpc_request(&request) {
-            return send_grpc_request_p3(request, options);
-        }
-        self.outgoing_handler
-            .send_request_p3(workload_id, request, options, fut)
+            })
+        } else if is_grpc_request(&request) {
+            send_grpc_request_p3(request, options)
+        } else {
+            self.outgoing_handler
+                .send_request_p3(workload_id, request, options, fut)
+        };
+        // Instrument the whole send so the span is current while the response
+        // is awaited; `record_outbound_status` then lands on this span.
+        Box::new(
+            async move {
+                let result = Box::into_pin(inner).await;
+                match &result {
+                    Ok((resp, _)) => {
+                        record_outbound_status(resp.status());
+                        // No-op unless the response carries a `grpc-status` header.
+                        record_grpc_status(resp.headers());
+                    }
+                    // Covers allowed-hosts denials and transport failures.
+                    Err(_) => record_outbound_error(),
+                }
+                result
+            }
+            .instrument(span),
+        )
     }
 }
 
@@ -984,15 +1021,22 @@ fn error_response(status: u16) -> hyper::Response<HyperOutgoingBody> {
 ///   collectors can break down requests by 2xx/4xx/5xx.
 /// - `otel.status_code` is set to `ERROR` for 5xx; 4xx stays UNSET per semconv.
 #[instrument(skip_all, fields(
+    // Legacy (pre-semconv) attribute names retained so dashboards built against
+    // them keep resolving.
     http.method = %req.method(),
-    http.request.method = %req.method(),
     http.uri = %req.uri(),
-    url.path = %req.uri().path(),
     http.host = %host_header(&req),
-    server.address = split_host_port(host_header(&req)).0,
-    server.port = tracing::field::Empty,
-    http.response.status_code = tracing::field::Empty,
-    otel.status_code = tracing::field::Empty,
+    // Current OTel HTTP semantic conventions, referenced via the
+    // `opentelemetry-semantic-conventions` constants (tracing's `{expr}` field
+    // syntax resolves the constant to its attribute name at compile time).
+    { HTTP_REQUEST_METHOD } = %req.method(),
+    { URL_PATH } = %req.uri().path(),
+    { SERVER_ADDRESS } = split_host_port(host_header(&req)).0,
+    { SERVER_PORT } = tracing::field::Empty,
+    { HTTP_RESPONSE_STATUS_CODE } = tracing::field::Empty,
+    // Recorded once the response body has been fully streamed (see `MeteredBody`).
+    { HTTP_RESPONSE_BODY_SIZE } = tracing::field::Empty,
+    { OTEL_STATUS_CODE } = tracing::field::Empty,
 ))]
 async fn handle_http_request<T: Router>(
     handler: Arc<T>,
@@ -1006,7 +1050,7 @@ async fn handle_http_request<T: Router>(
     // server.port is recorded separately from server.address per the OTel HTTP
     // semconv; only set it when the Host header actually carries a port.
     if let Some(port) = split_host_port(host_header(&req)).1 {
-        tracing::Span::current().record("server.port", port);
+        tracing::Span::current().record(SERVER_PORT, port);
     }
 
     let workload_id = match handler.route_incoming_request(&req) {
@@ -1062,6 +1106,13 @@ async fn handle_http_request<T: Router>(
     };
 
     record_response_status(&response);
+    // Carry the current span on the response body so `http.response.body.size`
+    // is recorded once the HTTP server finishes streaming the body. That
+    // happens after this handler future — and its `#[instrument]` span — has
+    // returned, so the body wrapper keeps a span handle alive to land the
+    // attribute before the span closes.
+    let response =
+        response.map(|body| MeteredBody::new(body, tracing::Span::current()).boxed_unsync());
     Ok(response)
 }
 
@@ -1071,9 +1122,145 @@ async fn handle_http_request<T: Router>(
 fn record_response_status<B>(response: &hyper::Response<B>) {
     let status = response.status().as_u16();
     let span = tracing::Span::current();
-    span.record("http.response.status_code", status);
+    span.record(HTTP_RESPONSE_STATUS_CODE, status);
     if status >= 500 {
-        span.record("otel.status_code", "ERROR");
+        span.record(OTEL_STATUS_CODE, "ERROR");
+    }
+}
+
+/// Build a `client` span for an outbound HTTP request following the OTel HTTP
+/// client semantic conventions. `http.response.status_code` and
+/// `otel.status_code` are left empty for [`record_outbound_status`] to fill in
+/// once the response arrives.
+///
+/// The span must be entered (e.g. via [`tracing::Instrument::instrument`]) for
+/// the duration of the request so that status recorded on the *current* span
+/// from inside the async work lands on this span.
+fn outbound_client_span(method: &hyper::Method, uri: &hyper::Uri) -> tracing::Span {
+    let span = tracing::info_span!(
+        "outbound_http_request",
+        otel.kind = "client",
+        { HTTP_REQUEST_METHOD } = %method,
+        { URL_FULL } = %uri,
+        { SERVER_ADDRESS } = uri.host().unwrap_or_default(),
+        { SERVER_PORT } = tracing::field::Empty,
+        { HTTP_RESPONSE_STATUS_CODE } = tracing::field::Empty,
+        { RPC_GRPC_STATUS_CODE } = tracing::field::Empty,
+        { OTEL_STATUS_CODE } = tracing::field::Empty,
+    );
+    if let Some(port) = uri.port_u16() {
+        span.record(SERVER_PORT, port);
+    }
+    span
+}
+
+/// Record an outbound response status on the current span. Per the HTTP client
+/// semconv, both 4xx and 5xx flip `otel.status_code` to `ERROR` for client
+/// spans (unlike server spans, where 4xx stays UNSET).
+fn record_outbound_status(status: hyper::StatusCode) {
+    let span = tracing::Span::current();
+    span.record(HTTP_RESPONSE_STATUS_CODE, status.as_u16());
+    if status.as_u16() >= 400 {
+        span.record(OTEL_STATUS_CODE, "ERROR");
+    }
+}
+
+/// Mark the current outbound span as failed when the request never produced a
+/// response (allowed-hosts denial, connection failure, transport error, …).
+fn record_outbound_error() {
+    tracing::Span::current().record(OTEL_STATUS_CODE, "ERROR");
+}
+
+/// Record the gRPC status as `rpc.grpc.status_code` on the current span when the
+/// response carries a `grpc-status` header. gRPC errors are typically
+/// trailers-only responses that put the status in headers, so this captures
+/// them; a status delivered in actual trailers (the streaming-success case) is
+/// not read here.
+fn record_grpc_status(headers: &hyper::HeaderMap) {
+    if let Some(code) = headers
+        .get("grpc-status")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<i64>().ok())
+    {
+        tracing::Span::current().record(RPC_GRPC_STATUS_CODE, code);
+    }
+}
+
+/// Response-body wrapper that tallies streamed bytes and records
+/// `http.response.body.size` on `span` once the body completes (ends, errors,
+/// or is dropped).
+///
+/// The HTTP server drains the body after the handler future returns, so the
+/// wrapper holds its own [`tracing::Span`] handle. That keeps the span open
+/// until the body is done, ensuring the attribute is recorded before the span
+/// closes.
+struct MeteredBody {
+    inner: HyperOutgoingBody,
+    span: tracing::Span,
+    bytes: u64,
+    recorded: bool,
+}
+
+impl MeteredBody {
+    fn new(inner: HyperOutgoingBody, span: tracing::Span) -> Self {
+        Self {
+            inner,
+            span,
+            bytes: 0,
+            recorded: false,
+        }
+    }
+
+    fn record(&mut self) {
+        if !self.recorded {
+            self.span.record(HTTP_RESPONSE_BODY_SIZE, self.bytes);
+            self.recorded = true;
+        }
+    }
+}
+
+impl hyper::body::Body for MeteredBody {
+    type Data = bytes::Bytes;
+    type Error = wasmtime_wasi_http::p2::bindings::http::types::ErrorCode;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        use std::task::Poll;
+        match std::pin::Pin::new(&mut self.inner).poll_frame(cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(data) = frame.data_ref() {
+                    self.bytes += data.len() as u64;
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Ready(Some(Err(e))) => {
+                self.record();
+                Poll::Ready(Some(Err(e)))
+            }
+            Poll::Ready(None) => {
+                self.record();
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+impl Drop for MeteredBody {
+    fn drop(&mut self) {
+        // Capture whatever was streamed if the body was dropped early (e.g. the
+        // client disconnected mid-response).
+        self.record();
     }
 }
 
@@ -1345,9 +1532,21 @@ fn send_grpc_request(
     request: hyper::Request<HyperOutgoingBody>,
     config: OutgoingRequestConfig,
 ) -> HostFutureIncomingResponse {
-    let handle = wasmtime_wasi::runtime::spawn(async move {
-        Ok(send_grpc_request_handler(request, config).await)
-    });
+    let span = outbound_client_span(request.method(), request.uri());
+    let handle = wasmtime_wasi::runtime::spawn(
+        async move {
+            let result = send_grpc_request_handler(request, config).await;
+            match &result {
+                Ok(incoming) => {
+                    record_outbound_status(incoming.resp.status());
+                    record_grpc_status(incoming.resp.headers());
+                }
+                Err(_) => record_outbound_error(),
+            }
+            Ok(result)
+        }
+        .instrument(span),
+    );
     HostFutureIncomingResponse::pending(handle)
 }
 
@@ -1482,6 +1681,73 @@ fn send_grpc_request_p3(
     Box::new(send_grpc_request_p3_handler(request, options))
 }
 
+/// Response-body wrapper enforcing a between-bytes read timeout on a streaming
+/// P3 outgoing response.
+///
+/// `inner` is held in an `Option` so it can be dropped the instant the timeout
+/// fires (or the stream ends / errors), releasing the underlying HTTP/2 stream
+/// and TCP connection eagerly instead of leaving it pinned until the guest
+/// drops its body handle.
+#[cfg(feature = "wasip3")]
+struct TimedBody<B> {
+    inner: Option<B>,
+    interval: tokio::time::Interval,
+}
+
+#[cfg(feature = "wasip3")]
+impl<B> hyper::body::Body for TimedBody<B>
+where
+    B: hyper::body::Body<Data = bytes::Bytes, Error = hyper::Error> + Unpin,
+{
+    type Data = bytes::Bytes;
+    type Error = wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        use std::task::{Poll, ready};
+        use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
+
+        let Some(inner) = self.inner.as_mut() else {
+            return Poll::Ready(None);
+        };
+        match std::pin::Pin::new(inner).poll_frame(cx) {
+            Poll::Ready(None) => {
+                self.inner = None;
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(Err(err))) => {
+                self.inner = None;
+                Poll::Ready(Some(Err(ErrorCode::from_hyper_request_error(err))))
+            }
+            Poll::Ready(Some(Ok(frame))) => {
+                self.interval.reset();
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Pending => {
+                ready!(self.interval.poll_tick(cx));
+                // Release the connection before surfacing the timeout rather
+                // than waiting for the guest to drop the body.
+                self.inner = None;
+                Poll::Ready(Some(Err(ErrorCode::ConnectionReadTimeout)))
+            }
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner
+            .as_ref()
+            .is_none_or(hyper::body::Body::is_end_stream)
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.inner
+            .as_ref()
+            .map_or_else(hyper::body::SizeHint::default, hyper::body::Body::size_hint)
+    }
+}
+
 #[cfg(feature = "wasip3")]
 async fn send_grpc_request_p3_handler(
     mut request: hyper::Request<crate::host::http_p3::P3Body>,
@@ -1594,47 +1860,10 @@ async fn send_grpc_request_p3_handler(
         .map_err(|_| ErrorCode::ConnectionReadTimeout)?
         .map_err(ErrorCode::from_hyper_request_error)?
         .map(|body| {
-            use http_body_util::BodyExt;
-            use std::pin::Pin;
-            use std::task::{Context, Poll, ready};
-            struct TimedBody {
-                inner: hyper::body::Incoming,
-                interval: tokio::time::Interval,
-            }
-            impl hyper::body::Body for TimedBody {
-                type Data = bytes::Bytes;
-                type Error = ErrorCode;
-                fn poll_frame(
-                    mut self: Pin<&mut Self>,
-                    cx: &mut Context<'_>,
-                ) -> Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>>
-                {
-                    match Pin::new(&mut self.as_mut().inner).poll_frame(cx) {
-                        Poll::Ready(None) => Poll::Ready(None),
-                        Poll::Ready(Some(Err(err))) => {
-                            Poll::Ready(Some(Err(ErrorCode::from_hyper_request_error(err))))
-                        }
-                        Poll::Ready(Some(Ok(frame))) => {
-                            self.interval.reset();
-                            Poll::Ready(Some(Ok(frame)))
-                        }
-                        Poll::Pending => {
-                            ready!(self.interval.poll_tick(cx));
-                            Poll::Ready(Some(Err(ErrorCode::ConnectionReadTimeout)))
-                        }
-                    }
-                }
-                fn is_end_stream(&self) -> bool {
-                    self.inner.is_end_stream()
-                }
-                fn size_hint(&self) -> hyper::body::SizeHint {
-                    self.inner.size_hint()
-                }
-            }
             let mut interval = tokio::time::interval(between_bytes_timeout);
             interval.reset();
             TimedBody {
-                inner: body,
+                inner: Some(body),
                 interval,
             }
             .boxed_unsync()
@@ -1864,6 +2093,107 @@ mod tests {
         let allow_any = [AllowedHost::Any];
         let _ = server.outgoing_request("test-workload", request, dummy_config(), &allow_any);
         assert!(!called.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    /// When the between-bytes timeout fires, [`TimedBody`] must surface
+    /// `ConnectionReadTimeout` *and* eagerly drop the inner body so the
+    /// underlying connection is released immediately rather than lingering
+    /// until the guest drops its body handle.
+    #[cfg(feature = "wasip3")]
+    #[tokio::test]
+    async fn timed_body_releases_inner_on_between_bytes_timeout() {
+        use http_body_util::BodyExt;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
+
+        // A body that never yields a frame — guarantees the between-bytes
+        // timeout fires. Its `Drop` flips a flag so the test can prove the
+        // inner body (and thus its connection) is released.
+        struct NeverBody {
+            dropped: Arc<AtomicBool>,
+        }
+        impl Drop for NeverBody {
+            fn drop(&mut self) {
+                self.dropped.store(true, Ordering::SeqCst);
+            }
+        }
+        impl hyper::body::Body for NeverBody {
+            type Data = bytes::Bytes;
+            type Error = hyper::Error;
+            fn poll_frame(
+                self: std::pin::Pin<&mut Self>,
+                _cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>>
+            {
+                std::task::Poll::Pending
+            }
+        }
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let mut interval = tokio::time::interval(Duration::from_millis(10));
+        interval.reset();
+        let mut body = TimedBody {
+            inner: Some(NeverBody {
+                dropped: dropped.clone(),
+            }),
+            interval,
+        };
+
+        // Awaiting the next frame parks on the interval until the timeout
+        // elapses, then yields the timeout error.
+        match body.frame().await {
+            Some(Err(ErrorCode::ConnectionReadTimeout)) => {}
+            other => panic!("expected ConnectionReadTimeout, got {other:?}"),
+        }
+        assert!(
+            body.inner.is_none(),
+            "inner body should be dropped from the wrapper on timeout"
+        );
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "inner body (and its connection) should be released eagerly on timeout"
+        );
+    }
+
+    /// `MeteredBody` must tally the bytes of data frames (excluding trailers)
+    /// and record the total once the body completes.
+    #[tokio::test]
+    async fn metered_body_counts_data_frame_bytes_excluding_trailers() {
+        use http_body_util::BodyExt;
+
+        struct FramesBody {
+            frames: std::collections::VecDeque<hyper::body::Frame<bytes::Bytes>>,
+        }
+        impl hyper::body::Body for FramesBody {
+            type Data = bytes::Bytes;
+            type Error = wasmtime_wasi_http::p2::bindings::http::types::ErrorCode;
+            fn poll_frame(
+                mut self: std::pin::Pin<&mut Self>,
+                _cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>>
+            {
+                std::task::Poll::Ready(self.frames.pop_front().map(Ok))
+            }
+        }
+
+        let frames = [
+            hyper::body::Frame::data(bytes::Bytes::from_static(b"ab")),
+            hyper::body::Frame::data(bytes::Bytes::from_static(b"cde")),
+            // Trailers carry no body bytes and must not be counted.
+            hyper::body::Frame::trailers(hyper::HeaderMap::new()),
+        ]
+        .into_iter()
+        .collect();
+        let inner: HyperOutgoingBody = FramesBody { frames }.boxed_unsync();
+
+        let mut body = MeteredBody::new(inner, tracing::Span::none());
+        while body.frame().await.is_some() {}
+
+        assert_eq!(body.bytes, 5, "should count 2 + 3 data bytes, not trailers");
+        assert!(
+            body.recorded,
+            "size should be recorded once the body completes"
+        );
     }
 
     /// NullServer must deny P3 outgoing requests with an internal error,

--- a/crates/wash-runtime/src/host/http_p3.rs
+++ b/crates/wash-runtime/src/host/http_p3.rs
@@ -12,6 +12,7 @@
 use crate::engine::ctx::SharedCtx;
 use crate::observability::FuelConsumptionMeter;
 use http_body_util::BodyExt;
+use tracing::Instrument;
 use wasmtime::Store;
 use wasmtime::component::InstancePre;
 use wasmtime_wasi_http::p3::bindings::ServicePre;
@@ -34,10 +35,42 @@ pub type P3SendResult = Result<
 /// Future returned by [`crate::host::http::OutgoingHandler::send_request_p3`].
 pub type P3SendFuture = Box<dyn std::future::Future<Output = P3SendResult> + Send>;
 
+/// Response body that yields frames forwarded from the component task over a
+/// bounded channel. End-of-stream is signalled when the sender (held by the
+/// component task) is dropped.
+struct ChannelBody {
+    rx: tokio::sync::mpsc::Receiver<Result<hyper::body::Frame<bytes::Bytes>, ErrorCode>>,
+    /// Aborts the component task when this body is dropped before the stream
+    /// completes (e.g. the client disconnects). Without this, a guest that is
+    /// busy computing — rather than parked on a frame send — would keep running
+    /// until its next send; there is no epoch/wall-clock backstop. Held only
+    /// for its `Drop`.
+    _task: tokio_util::task::AbortOnDropHandle<()>,
+}
+
+impl hyper::body::Body for ChannelBody {
+    type Data = bytes::Bytes;
+    type Error = ErrorCode;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
 /// Handle an HTTP request using the WASIP3 `wasi:http/handler` interface.
 ///
 /// P3 uses `ServicePre`/`Service` with `Store::run_concurrent` to get an
 /// `Accessor` for concurrent component-model async operations.
+///
+/// The response body is **streamed**: the component runs in a background task
+/// that owns the store and drives `run_concurrent`, forwarding response frames
+/// over a bounded channel as they are produced. The store and therefore the
+/// guest stays alive until the body has been fully drained, and a slow client
+/// applies backpressure to the guest rather than buffering the whole body in
+/// memory.
 pub async fn handle_component_request_p3(
     mut store: Store<SharedCtx>,
     pre: InstancePre<SharedCtx>,
@@ -57,65 +90,239 @@ pub async fn handle_component_request_p3(
     let req = hyper::Request::from_parts(parts, body);
     let (wasi_req, req_io) = wasmtime_wasi_http::p3::Request::from_http(req);
 
-    // Instantiate the service
-    let service = service_pre
-        .instantiate_async(&mut store)
-        .await
-        .map_err(|e| anyhow::anyhow!(e).context("failed to instantiate P3 service"))?;
+    // Bounded so a slow client applies backpressure to the guest instead of
+    // letting response frames accumulate without limit.
+    let (frame_tx, frame_rx) =
+        tokio::sync::mpsc::channel::<Result<hyper::body::Frame<bytes::Bytes>, ErrorCode>>(4);
+    // Delivers the response head (status + headers) as soon as the handler
+    // returns it, while the body is still streaming.
+    let (parts_tx, parts_rx) =
+        tokio::sync::oneshot::channel::<anyhow::Result<hyper::http::response::Parts>>();
 
-    // Use run_concurrent to get an Accessor for the P3 async component model.
-    // The handler invocation, response conversion, AND body collection must all
-    // happen inside run_concurrent since the body stream requires the concurrent
-    // runtime to pump data from the component.
-    let result: anyhow::Result<hyper::Response<http_body_util::Collected<bytes::Bytes>>> = store
-        .run_concurrent(async move |store| {
-            let handler_fut = async {
-                let result = service.handle(store, wasi_req).await;
-                match result {
-                    Ok(Ok(response)) => {
-                        let http_response =
-                            store.with(|s| response.into_http(s, async { Ok(()) }))?;
-                        let (parts, body) = http_response.into_parts();
-                        let body = body.collect().await.map_err(|e| {
-                            anyhow::anyhow!("failed to collect P3 response body: {e:?}")
-                        })?;
-                        Ok(hyper::Response::from_parts(parts, body))
-                    }
-                    Ok(Err(error_code)) => {
-                        tracing::error!(?error_code, "P3 HTTP handler returned error");
-                        let body = http_body_util::Empty::new()
-                            .map_err(|never| match never {})
-                            .boxed_unsync()
-                            .collect()
-                            .await
-                            .map_err(|e| anyhow::anyhow!("failed to collect error body: {e:?}"))?;
-                        Ok(hyper::Response::builder()
-                            .status(500)
-                            .body(body)
-                            .map_err(anyhow::Error::from)?)
-                    }
-                    Err(e) => Err(anyhow::anyhow!(e).context("P3 handler trap")),
+    // The store is owned by this task for the entire response lifetime.
+    // `run_concurrent` only resolves once every frame has been forwarded, so the
+    // guest keeps running until the body is fully drained. Wrapped in an
+    // `AbortOnDropHandle` immediately (not just once the body holds it) so that
+    // if this request future is cancelled while still awaiting the response head
+    // — e.g. the client disconnects before the guest produces a response — the
+    // task is aborted rather than detached to run unbounded.
+    let task = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(
+        async move {
+            let service = match service_pre.instantiate_async(&mut store).await {
+                Ok(service) => service,
+                Err(e) => {
+                    let _ = parts_tx.send(Err(
+                        anyhow::anyhow!(e).context("failed to instantiate P3 service")
+                    ));
+                    return;
                 }
             };
-            let io_fut = async {
-                if let Err(e) = req_io.await {
-                    tracing::error!(err = ?e, "P3 request I/O error");
-                }
-            };
-            let (handler_result, _) = tokio::join!(handler_fut, io_fut);
-            handler_result
-        })
-        .await?;
 
-    // Convert collected body back to a streaming body for the hyper response
-    match result {
-        Ok(response) => {
-            let (parts, collected) = response.into_parts();
-            let body: P3Body = http_body_util::Full::new(collected.to_bytes())
-                .map_err(|never| match never {})
-                .boxed_unsync();
-            Ok(hyper::Response::from_parts(parts, body))
+            let run = store
+                .run_concurrent(async move |store| {
+                    let mut parts_tx = Some(parts_tx);
+                    // `async move` so `handler_fut` owns `frame_tx`: it drops the
+                    // instant the response body completes, delivering end-of-stream
+                    // to the client without waiting for `io_fut` (request-body
+                    // upload) to finish in the `join!` below.
+                    let handler_fut = async move {
+                        let response = match service.handle(store, wasi_req).await {
+                            Ok(Ok(response)) => response,
+                            Ok(Err(error_code)) => {
+                                tracing::error!(?error_code, "P3 HTTP handler returned error");
+                                if let Some(tx) = parts_tx.take() {
+                                    let (mut head, ()) = hyper::Response::new(()).into_parts();
+                                    head.status = hyper::StatusCode::INTERNAL_SERVER_ERROR;
+                                    let _ = tx.send(Ok(head));
+                                }
+                                return Ok(());
+                            }
+                            Err(e) => {
+                                if let Some(tx) = parts_tx.take() {
+                                    let _ =
+                                        tx.send(Err(anyhow::anyhow!(e).context("P3 handler trap")));
+                                }
+                                return Ok(());
+                            }
+                        };
+                        // `into_http`'s `fut` reports the body-delivery outcome
+                        // back to the guest (it resolves the future returned by
+                        // `wasi:http/types.response#new`). Resolve it once we have
+                        // finished forwarding the body to the client, so a guest
+                        // that awaits the result learns whether delivery succeeded.
+                        let (finish_tx, finish_rx) =
+                            tokio::sync::oneshot::channel::<Result<(), ErrorCode>>();
+                        let http_response = match store.with(|s| {
+                            response.into_http(s, async move {
+                                match finish_rx.await {
+                                    Ok(result) => {
+                                        tracing::trace!(
+                                            ?result,
+                                            "P3 response body delivery finished"
+                                        );
+                                        result
+                                    }
+                                    // Sender dropped (task aborted mid-stream),
+                                    // e.g. the client disconnected; nothing to
+                                    // report back to the guest.
+                                    Err(_) => {
+                                        tracing::debug!(
+                                            "P3 response delivery future dropped before completion"
+                                        );
+                                        Ok(())
+                                    }
+                                }
+                            })
+                        }) {
+                            Ok(http_response) => http_response,
+                            Err(e) => {
+                                if let Some(tx) = parts_tx.take() {
+                                    let _ = tx.send(Err(anyhow::anyhow!(e)
+                                        .context("failed to convert P3 response to http")));
+                                }
+                                return Ok(());
+                            }
+                        };
+                        let (head, mut body) = http_response.into_parts();
+                        if let Some(tx) = parts_tx.take()
+                            && tx.send(Ok(head)).is_err()
+                        {
+                            // Caller dropped the receiver; report the failed
+                            // delivery to the guest and stop.
+                            let _ = finish_tx.send(Err(ErrorCode::ConnectionTerminated));
+                            return Ok(());
+                        }
+                        let mut delivery = Ok(());
+                        while let Some(frame) = body.frame().await {
+                            if frame_tx.send(frame).await.is_err() {
+                                // The hyper response body was dropped (e.g. the
+                                // client disconnected); stop pulling from the guest
+                                // and report the failed delivery.
+                                delivery = Err(ErrorCode::ConnectionTerminated);
+                                break;
+                            }
+                        }
+                        let _ = finish_tx.send(delivery);
+                        Ok::<(), anyhow::Error>(())
+                    };
+                    let io_fut = async {
+                        if let Err(e) = req_io.await {
+                            tracing::error!(err = ?e, "P3 request I/O error");
+                        }
+                    };
+                    let (handler_result, ()) = tokio::join!(handler_fut, io_fut);
+                    handler_result
+                })
+                .await;
+            match run {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::error!(err = ?e, "P3 response streaming failed"),
+                Err(e) => tracing::error!(err = ?e, "P3 run_concurrent failed"),
+            }
         }
-        Err(e) => Err(e),
+        .in_current_span(),
+    ));
+
+    let head = parts_rx
+        .await
+        .map_err(|_| anyhow::anyhow!("P3 component task ended before producing a response"))??;
+    let body: P3Body = ChannelBody {
+        rx: frame_rx,
+        _task: task,
+    }
+    .boxed_unsync();
+    Ok(hyper::Response::from_parts(head, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use hyper::body::Frame;
+
+    /// `ChannelBody` must forward frames **incrementally**, a consumer should
+    /// receive a frame while the producer is still parked, not only after the
+    /// producer has finished and signal end-of-stream when the producer drops
+    /// its sender.
+    #[tokio::test]
+    async fn channel_body_streams_frames_incrementally() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<Frame<Bytes>, ErrorCode>>(4);
+        // Gates the producer's second frame on the consumer acknowledging the
+        // first, proving the first was delivered before the producer completed.
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let producer = tokio::spawn(async move {
+            tx.send(Ok(Frame::data(Bytes::from_static(b"first"))))
+                .await
+                .expect("send first");
+            ack_rx.await.expect("consumer ack");
+            tx.send(Ok(Frame::data(Bytes::from_static(b"second"))))
+                .await
+                .expect("send second");
+            // `tx` dropped here -> end-of-stream.
+        });
+
+        let mut body = ChannelBody {
+            rx,
+            _task: tokio_util::task::AbortOnDropHandle::new(producer),
+        };
+
+        let first = body
+            .frame()
+            .await
+            .expect("a frame")
+            .expect("ok frame")
+            .into_data()
+            .expect("data frame");
+        assert_eq!(first.as_ref(), b"first");
+
+        // The producer is now parked on `ack_rx`; releasing it lets the second
+        // frame flow. Receiving `first` before this proves incremental delivery.
+        ack_tx.send(()).expect("release producer");
+
+        let second = body
+            .frame()
+            .await
+            .expect("a frame")
+            .expect("ok frame")
+            .into_data()
+            .expect("data frame");
+        assert_eq!(second.as_ref(), b"second");
+
+        assert!(
+            body.frame().await.is_none(),
+            "stream should end when the producer drops its sender"
+        );
+    }
+
+    /// Dropping a `ChannelBody` must abort the component task (via the held
+    /// `AbortOnDropHandle`) so the guest is cancelled promptly on disconnect.
+    #[tokio::test]
+    async fn channel_body_drop_aborts_task() {
+        let (_tx, rx) = tokio::sync::mpsc::channel::<Result<Frame<Bytes>, ErrorCode>>(1);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (gone_tx, gone_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let task = tokio::spawn(async move {
+            let _gone_tx = gone_tx; // dropped (closing the channel) only when the task ends
+            let _ = started_tx.send(());
+            // Runs "forever" unless aborted.
+            std::future::pending::<()>().await;
+        });
+
+        let body = ChannelBody {
+            rx,
+            _task: tokio_util::task::AbortOnDropHandle::new(task),
+        };
+        started_rx.await.expect("task started");
+
+        drop(body);
+
+        // The task's `gone_tx` is dropped when the task is aborted, so this
+        // resolves with a recv error.
+        assert!(
+            gone_rx.await.is_err(),
+            "dropping the body should abort the task"
+        );
     }
 }


### PR DESCRIPTION
Rework the P3 wasi:http handler to stream response bodies instead of
buffering them with collect(). The component now runs in a task that owns
the store and drives run_concurrent, forwarding frames over a bounded
channel (backpressure instead of unbounded buffering). The store and
therefore the guest stays alive until the body is fully drained, and the
task is aborted via AbortOnDropHandle when the response body is dropped, so
a disconnected client cancels the guest promptly (there is no epoch/
wall-clock backstop otherwise).

into_http's finish future now reports the body-delivery outcome back to the
guest (Ok on clean delivery, ConnectionTerminated if the client goes away)
instead of signalling immediate success.

Fix a connection leak in the P3 gRPC outbound path: the between-bytes
timeout body kept its inner hyper::body::Incoming alive after surfacing
ConnectionReadTimeout, pinning the HTTP/2 stream/TCP connection until the
guest dropped its handle. The inner body is now held in an Option and
dropped eagerly on timeout, end-of-stream, or error.

Add outbound-HTTP client span instrumentation (P2 default + gRPC, P3),
recording method, url.full, server.address/port and response status, and
marking otel.status_code=ERROR on transport failures and allowed-hosts
denials. Adopt opentelemetry-semantic-conventions constants on the incoming
request span and record http.response.body.size via a body wrapper that
tallies streamed bytes.

Tests:
- TimedBody drops its inner body (and connection) on between-bytes timeout
- MeteredBody counts data-frame bytes and excludes trailers
- ChannelBody streams frames incrementally and aborts the task on drop
