### PR TITLE
ci: set CARGO_NET_RETRY

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -592,6 +592,10 @@ jobs:
           echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "${GITHUB_ENV}"
 
       - name: Build binary (${{ matrix.target }})
+        env:
+          # Retry transient crates.io download failures (e.g. SSL eof) more
+          # aggressively than cargo's default of 3.
+          CARGO_NET_RETRY: "10"
         run: |
           ${{ matrix.buildCommand }} --release --target ${{ matrix.buildTarget || matrix.target }}
           cp target/${{ matrix.target }}/release/${{ matrix.bin }} ${{ matrix.artifact }}


### PR DESCRIPTION
Set `CARGO_NET_RETRY`: "10" env on the build step, which directly targets the transient crates.io download failure

The default is 2 retries (so 3 total attempts). Some sources cite different defaults across Cargo versions. Each retry uses backoff, and only requests that Cargo classifies as transient, (network/spurious HTTP errors like 5xx, 429, connection resets) are retried. A genuine "crate doesn't exist" (404) won't be retried, so you don't waste time on real errors.