### PR TITLE
feat: backport implements to wasmtime 46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cranelift-assembler-x64-meta 0.133.0",
 ]
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64-meta"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cranelift-srcgen 0.133.0",
 ]
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cranelift-entity 0.133.0",
  "wasmtime-internal-core 46.0.0",
@@ -1379,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bitset"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64 0.133.0",
@@ -1460,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cranelift-assembler-x64-meta 0.133.0",
  "cranelift-codegen-shared 0.133.0",
@@ -1478,7 +1478,7 @@ checksum = "78fdb83ab012d0ee6a44ced7ca8788a444f17cf821c62f95d6ef87c9f0262518"
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 
 [[package]]
 name = "cranelift-control"
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "cranelift-control"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "arbitrary",
 ]
@@ -1512,7 +1512,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cranelift-bitset 0.133.0",
  "serde",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cranelift-codegen 0.133.0",
  "hashbrown 0.17.1",
@@ -1553,7 +1553,7 @@ checksum = "94eaf429c32a12715429c7c6ddfdd43c170f4cdd7e97bfa507bd68a652091087"
 [[package]]
 name = "cranelift-isle"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 
 [[package]]
 name = "cranelift-native"
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cranelift-codegen 0.133.0",
  "libc",
@@ -1585,7 +1585,7 @@ checksum = "cba7c0ff5941842c36653da155580ce41e675c204a67ac1b4e1c478a9347bbb7"
 [[package]]
 name = "cranelift-srcgen"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 
 [[package]]
 name = "crc32fast"
@@ -5024,7 +5024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -5044,8 +5044,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5079,7 +5079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -5193,7 +5193,7 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cranelift-bitset 0.133.0",
  "log",
@@ -5215,7 +5215,7 @@ dependencies = [
 [[package]]
 name = "pulley-macros"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -8251,7 +8251,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-macro"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8271,7 +8271,7 @@ checksum = "9d2eeb9b53222859e6f5dc73d2ccfb33254d672469cac11b693a71912e2f3817"
 [[package]]
 name = "wasmtime-internal-component-util"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 
 [[package]]
 name = "wasmtime-internal-core"
@@ -8288,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-core"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cranelift"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cfg-if",
  "cranelift-codegen 0.133.0",
@@ -8367,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-fiber"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cc",
  "cfg-if",
@@ -8393,7 +8393,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-debug"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros 46.0.0",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cfg-if",
  "libc",
@@ -8438,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-unwinder"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "cfg-if",
  "cranelift-codegen 0.133.0",
@@ -8461,7 +8461,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8501,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -8543,7 +8543,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -8570,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8606,7 +8606,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-io"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-tls"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#4000b93ad8f2ab07980763c8e5f2901525a3c4cf"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -8921,7 +8921,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,10 @@ wasmcloud = { path = "crates/wasmcloud", default-features = false }
 # wasmtime 46 is not yet released to crates.io; pin to the release-46.0.0
 # branch HEAD. Bump the rev together when picking up release-branch fixes,
 # and switch back to a crates.io `version` once 46.0.0 ships.
+# The resource-implements feature (bytecodealliance/wasmtime#13666) merged to
+# `main` and will ship in wasmtime 47 — it is NOT on the 46 release branch. To
+# run it on 46 we maintain a backport and pull it in via the
+# `[patch."https://github.com/bytecodealliance/wasmtime"]` section below.
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
@@ -165,3 +169,22 @@ ignored = [
 [patch.crates-io]
 # Pinned for async component support (fixes #187). Remove after https://github.com/bytecodealliance/rust-oci-wasm/issues/28
 oci-wasm = { git = "https://github.com/bytecodealliance/rust-oci-wasm", rev = "5ee16fa1" }
+
+# Redirect upstream wasmtime to a 46 backport carrying the resource-implements
+# feature (bytecodealliance/wasmtime#13666). The feature merged to `main` (47.0.0)
+# but is not on the 46 release branch, and wasmtime does not backport features to
+# release branches — so to ship it on 46 we maintain `release-46.0.0-implements`
+# on the fork: `release-46.0.0` + the cherry-picked implements commits. Cargo
+# requires the patch source to be version-compatible with the upstream dep, so the
+# branch MUST stay based on release-46.0.0 (46.0.0) to match the rev pinned above
+# — a main-based (47.0.0) branch will fail to apply.
+#
+# Re-cherry-pick onto a newer release-46.0.x base when bumping the rev above.
+# Retire this whole block (and the fork branch) once the workspace moves to
+# wasmtime 47, where the feature ships in the stock release.
+[patch."https://github.com/bytecodealliance/wasmtime"]
+wasmtime = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi-io = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi-http = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi-tls = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }

--- a/crates/wash-runtime/src/sockets/host_udp_create_socket.rs
+++ b/crates/wash-runtime/src/sockets/host_udp_create_socket.rs
@@ -11,7 +11,11 @@ impl udp_create_socket::Host for WasiSocketsCtxView<'_> {
         &mut self,
         address_family: IpAddressFamily,
     ) -> SocketResult<Resource<UpstreamUdpSocket>> {
-        let socket = UdpSocket::new(self.ctx, address_family.into())
+        let address_family = match address_family {
+            IpAddressFamily::Ipv4 => cap_net_ext::AddressFamily::Ipv4,
+            IpAddressFamily::Ipv6 => cap_net_ext::AddressFamily::Ipv6,
+        };
+        let socket = UdpSocket::new(self.ctx, address_family)
             .map_err(super::network::socket_error_from_util)?;
         let socket = self.table.push(socket)?;
         Ok(Resource::new_own(socket.rep()))

--- a/crates/wash-runtime/tests/integration_nats_blobstore.rs
+++ b/crates/wash-runtime/tests/integration_nats_blobstore.rs
@@ -117,9 +117,9 @@ async fn setup() -> Result<TestHarness> {
                     ]
                     .into_iter()
                     .collect(),
-                    version: Some(
-                        semver::Version::parse("0.2.0-draft").expect("valid semver version"),
-                    ),
+                    version: Some(semver::Version::parse("0.2.0-draft").map_err(|e| {
+                        anyhow::anyhow!("invalid blobstore interface version: {e}")
+                    })?),
                     config: {
                         let mut config = HashMap::new();
                         config.insert("buckets".to_string(), "my-container-real".to_string());


### PR DESCRIPTION
I pushed a remote fork of wasmtime release-46.0.0 with implements resource support.
This points us to that fork.

Additionally fixes a clippy lint in integration test, and adjust to api changes.
