### PR TITLE
feat(wash-runtime): implements feature flag

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -351,7 +351,6 @@ jobs:
       - check
       - lint
       - wash-image
-      - wash-image-wasip3
       - runtime-operator-e2e
       - canary-publish
       - canary-binaries
@@ -466,33 +465,6 @@ jobs:
           docker buildx imagetools inspect "ghcr.io/wasmcloud/wash:${STEPS_META_OUTPUTS_VERSION}"
         env:
           STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
-
-  # wasip3 image variant. Builds wash with the `wasip3,wasi-tls` features
-  # (WASI Preview 3 compiled in) and publishes it as `canary-wasip3` /
-  # `sha-<full-sha>-wasip3`.
-  wash-image-wasip3:
-    needs:
-      - changes
-      - runtime-operator-e2e
-    if: |
-      always() &&
-      (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true') &&
-      (((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main')) &&
-      needs.runtime-operator-e2e.result == 'success'
-    permissions:
-      contents: write
-      packages: write
-    uses: ./.github/workflows/docker-build-push.yml
-    with:
-      image: ghcr.io/wasmcloud/wash
-      build-args: |
-        CARGO_FEATURES=wasip3,wasi-tls
-      # Push (and the manifest merge) only on main; PRs build to validate.
-      push: ${{ github.event_name != 'pull_request' }}
-      push-by-digest: ${{ github.event_name != 'pull_request' }}
-      tags: |
-        type=raw,value=canary-wasip3
-        type=sha,format=long,prefix=sha-,suffix=-wasip3
 
   # Canary matrix binary build. Runs on every push to main so each commit
   # exercises the full per-target matrix (including the s390x/musl cross

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -123,7 +123,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-assembler-x64-meta 0.133.0",
 ]
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64-meta"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-srcgen 0.133.0",
 ]
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-entity 0.133.0",
  "wasmtime-internal-core 46.0.0",
@@ -1379,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bitset"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64 0.133.0",
@@ -1460,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-assembler-x64-meta 0.133.0",
  "cranelift-codegen-shared 0.133.0",
@@ -1478,7 +1478,7 @@ checksum = "78fdb83ab012d0ee6a44ced7ca8788a444f17cf821c62f95d6ef87c9f0262518"
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 
 [[package]]
 name = "cranelift-control"
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "cranelift-control"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "arbitrary",
 ]
@@ -1512,7 +1512,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-bitset 0.133.0",
  "serde",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-codegen 0.133.0",
  "hashbrown 0.17.1",
@@ -1553,7 +1553,7 @@ checksum = "94eaf429c32a12715429c7c6ddfdd43c170f4cdd7e97bfa507bd68a652091087"
 [[package]]
 name = "cranelift-isle"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 
 [[package]]
 name = "cranelift-native"
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-codegen 0.133.0",
  "libc",
@@ -1585,7 +1585,7 @@ checksum = "cba7c0ff5941842c36653da155580ce41e675c204a67ac1b4e1c478a9347bbb7"
 [[package]]
 name = "cranelift-srcgen"
 version = "0.133.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 
 [[package]]
 name = "crc32fast"
@@ -2241,7 +2241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3140,7 +3140,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -3350,7 +3350,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3952,7 +3952,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5024,7 +5024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -5044,8 +5044,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5079,7 +5079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -5193,7 +5193,7 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cranelift-bitset 0.133.0",
  "log",
@@ -5215,7 +5215,7 @@ dependencies = [
 [[package]]
 name = "pulley-macros"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5684,7 +5684,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6207,7 +6207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6439,7 +6439,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6458,7 +6458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7110,7 +7110,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -8186,7 +8186,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -8251,7 +8251,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-macro"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8271,7 +8271,7 @@ checksum = "9d2eeb9b53222859e6f5dc73d2ccfb33254d672469cac11b693a71912e2f3817"
 [[package]]
 name = "wasmtime-internal-component-util"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 
 [[package]]
 name = "wasmtime-internal-core"
@@ -8288,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-core"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cranelift"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen 0.133.0",
@@ -8367,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-fiber"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cc",
  "cfg-if",
@@ -8393,7 +8393,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-debug"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros 46.0.0",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -8438,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-unwinder"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen 0.133.0",
@@ -8461,7 +8461,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8501,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -8543,7 +8543,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -8570,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8606,7 +8606,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-io"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-tls"
 version = "46.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=7535c0255b2b84f6ae4de6034649ba2eeda84173#7535c0255b2b84f6ae4de6034649ba2eeda84173"
+source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -8921,7 +8921,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,10 @@ wasmcloud = { path = "crates/wasmcloud", default-features = false }
 # wasmtime 46 is not yet released to crates.io; pin to the release-46.0.0
 # branch HEAD. Bump the rev together when picking up release-branch fixes,
 # and switch back to a crates.io `version` once 46.0.0 ships.
+# The resource-implements feature (bytecodealliance/wasmtime#13666) merged to
+# `main` and will ship in wasmtime 47 — it is NOT on the 46 release branch. To
+# run it on 46 we maintain a backport and pull it in via the
+# `[patch."https://github.com/bytecodealliance/wasmtime"]` section below.
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
@@ -165,3 +169,22 @@ ignored = [
 [patch.crates-io]
 # Pinned for async component support (fixes #187). Remove after https://github.com/bytecodealliance/rust-oci-wasm/issues/28
 oci-wasm = { git = "https://github.com/bytecodealliance/rust-oci-wasm", rev = "5ee16fa1" }
+
+# Redirect upstream wasmtime to a 46 backport carrying the resource-implements
+# feature (bytecodealliance/wasmtime#13666). The feature merged to `main` (47.0.0)
+# but is not on the 46 release branch, and wasmtime does not backport features to
+# release branches — so to ship it on 46 we maintain `release-46.0.0-implements`
+# on the fork: `release-46.0.0` + the cherry-picked implements commits. Cargo
+# requires the patch source to be version-compatible with the upstream dep, so the
+# branch MUST stay based on release-46.0.0 (46.0.0) to match the rev pinned above
+# — a main-based (47.0.0) branch will fail to apply.
+#
+# Re-cherry-pick onto a newer release-46.0.x base when bumping the rev above.
+# Retire this whole block (and the fork branch) once the workspace moves to
+# wasmtime 47, where the feature ships in the stock release.
+[patch."https://github.com/bytecodealliance/wasmtime"]
+wasmtime = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi-io = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi-http = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
+wasmtime-wasi-tls = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ USER nonroot
 # copy source code
 COPY --chown=nonroot:nonroot . .
 
-# Optional comma-separated cargo feature list (e.g. "wasip3,wasi-tls").
-# Empty by default so the standard image stays on WASI Preview 2.
+# Optional comma-separated cargo feature list for opt-in extras (e.g.
+# "wasi-tls", "wasi-webgpu"). WASI Preview 3 is already compiled into the
+# default wash build, so it needs no feature flag here.
 ARG CARGO_FEATURES=""
 
 # build static binary

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -45,6 +45,8 @@ wasi-config = []
 wasi-logging = []
 wasi-blobstore = []
 wasi-keyvalue = []
+# Component-model `(implements ..)` / `named_imports` multiplexing
+wasm_component_model_implements = []
 wasi-webgpu = ["dep:wasi-webgpu-wasmtime", "dep:wasi-graphics-context-wasmtime"]
 wasmcloud-postgres = [
     "dep:tokio-postgres", "dep:tokio-postgres-rustls",

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -625,6 +625,14 @@ pub enum WasmProposal {
     /// Component model async ABI (`stream`/`future`/`error-context` types).
     /// Enables `wasm_component_model_async`. Required for WASIP3.
     ComponentModelAsync,
+    /// Component model `(implements ..)` named imports, letting a component
+    /// import the same interface multiple times under distinct names so host
+    /// plugins can route each independently. Enables
+    /// `wasm_component_model_implements`. Requires the backported wasmtime
+    /// support, so it is only available with the `wasm_component_model_implements`
+    /// crate feature.
+    #[cfg(feature = "wasm_component_model_implements")]
+    WasmComponentModelImplements,
     /// Garbage collection. Enables `wasm_function_references` (a prerequisite)
     /// and `wasm_gc`.
     Gc,
@@ -644,6 +652,10 @@ impl WasmProposal {
         match self {
             WasmProposal::ComponentModelAsync => {
                 cfg.wasm_component_model_async(true);
+            }
+            #[cfg(feature = "wasm_component_model_implements")]
+            WasmProposal::WasmComponentModelImplements => {
+                cfg.wasm_component_model_implements(true);
             }
             WasmProposal::Gc => {
                 // GC builds on the function-references proposal.
@@ -866,6 +878,16 @@ impl EngineBuilder {
         if self.wasip3 {
             self.proposals.insert(WasmProposal::ComponentModelAsync);
         }
+
+        // Accept components that import an interface multiple times via the
+        // component-model `(implements ..)` annotation, so host plugins can
+        // route each named import (e.g. two `wasi:keyvalue/store` imports
+        // backed by redis vs NATS) independently. Only available with the
+        // backported wasmtime support behind the
+        // `wasm_component_model_implements` feature.
+        #[cfg(feature = "wasm_component_model_implements")]
+        self.proposals
+            .insert(WasmProposal::WasmComponentModelImplements);
 
         for proposal in &self.proposals {
             proposal.apply(&mut config);

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -106,6 +106,11 @@ impl WorkloadMetadata {
         &mut self.linker
     }
 
+    /// Returns a reference to the wasmtime [`Component`].
+    pub fn component(&self) -> &Component {
+        &self.component
+    }
+
     /// Returns a reference to component local resources.
     pub fn local_resources(&self) -> &LocalResources {
         &self.local_resources
@@ -1484,6 +1489,18 @@ impl UnresolvedWorkload {
                 for wit_interface in required_interfaces.iter() {
                     // Check if plugin supports this interface
                     if plugin_interfaces.includes_bidirectional(wit_interface) {
+                        // an `(implements ..)` named interface is served only
+                        // by a plugin that supports named instances.
+                        let defer_to_other = if wit_interface.name.is_some() {
+                            !p.supports_named_instances()
+                                && other_plugin_serves(plugins, plugin_id, wit_interface, true)
+                        } else {
+                            p.supports_named_instances()
+                                && other_plugin_serves(plugins, plugin_id, wit_interface, false)
+                        };
+                        if defer_to_other {
+                            continue;
+                        }
                         matching_interfaces.insert(wit_interface.clone());
                     }
                 }
@@ -1876,6 +1893,23 @@ fn build_export_map(
     }
 
     (interface_map, ambiguous)
+}
+
+/// Returns whether some *other* registered plugin (not `self_id`) with
+/// `supports_named_instances() == want_named` can serve `iface`.
+/// Used to determine whether a plugin can defer an `(implements ..)`
+///  interface to a named-capable one, and vice versa).
+fn other_plugin_serves(
+    plugins: &HashMap<&'static str, Arc<dyn HostPlugin + 'static>>,
+    self_id: &str,
+    iface: &WitInterface,
+    want_named: bool,
+) -> bool {
+    plugins.iter().any(|(id, q)| {
+        *id != self_id
+            && q.supports_named_instances() == want_named
+            && q.world().includes_bidirectional(iface)
+    })
 }
 
 fn topological_sort_components(
@@ -2962,6 +2996,57 @@ mod tests {
         if let Err(e) = result {
             panic!("Single named entry should not require named instance support: {e}");
         }
+    }
+
+    /// Coexistence: a regular (standalone) plugin and a named-capable
+    /// (multiplexed) plugin both matching the same package bind together, with
+    /// the unnamed interface routed to the regular plugin and the `(implements
+    /// ..)` named interfaces routed to the named-capable one. Without the
+    /// name-aware dispatch this errors (the regular plugin would claim the two
+    /// named entries it cannot serve).
+    #[tokio::test]
+    async fn test_named_and_regular_plugins_coexist() {
+        let regular = Arc::new(MockPlugin::new(
+            "kv-standalone",
+            vec![],
+            vec![keyvalue_interface(None)],
+        ));
+        let multiplexed = Arc::new(
+            MockPlugin::new("kv-multiplexed", vec![], vec![keyvalue_interface(None)])
+                .with_named_instance_support(),
+        );
+
+        let mut plugins = HashMap::new();
+        plugins.insert(regular.id(), regular.clone() as Arc<dyn HostPlugin>);
+        plugins.insert(multiplexed.id(), multiplexed.clone() as Arc<dyn HostPlugin>);
+
+        let mut workload = UnresolvedWorkload::new(
+            "test-workload-id".to_string(),
+            "test-workload".to_string(),
+            "test-namespace".to_string(),
+            None,
+            vec![create_test_component("component1")],
+            vec![
+                keyvalue_interface(None),
+                keyvalue_interface(Some("cache")),
+                keyvalue_interface(Some("sessions")),
+            ],
+        );
+
+        let bound = workload
+            .bind_plugins(&plugins)
+            .await
+            .expect("standalone + multiplexed plugins should bind together");
+        let bound_ids: std::collections::HashSet<&str> =
+            bound.iter().map(|(p, _)| p.id()).collect();
+        assert!(
+            bound_ids.contains("kv-standalone"),
+            "regular plugin must bind the unnamed interface"
+        );
+        assert!(
+            bound_ids.contains("kv-multiplexed"),
+            "named-capable plugin must bind the named interfaces"
+        );
     }
 
     /// Existing unnamed entries -> no change in behavior

--- a/crates/wash-runtime/src/sockets/host_udp_create_socket.rs
+++ b/crates/wash-runtime/src/sockets/host_udp_create_socket.rs
@@ -11,7 +11,11 @@ impl udp_create_socket::Host for WasiSocketsCtxView<'_> {
         &mut self,
         address_family: IpAddressFamily,
     ) -> SocketResult<Resource<UpstreamUdpSocket>> {
-        let socket = UdpSocket::new(self.ctx, address_family.into())
+        let address_family = match address_family {
+            IpAddressFamily::Ipv4 => cap_net_ext::AddressFamily::Ipv4,
+            IpAddressFamily::Ipv6 => cap_net_ext::AddressFamily::Ipv6,
+        };
+        let socket = UdpSocket::new(self.ctx, address_family)
             .map_err(super::network::socket_error_from_util)?;
         let socket = self.table.push(socket)?;
         Ok(Resource::new_own(socket.rep()))

--- a/crates/wash-runtime/tests/integration_nats_blobstore.rs
+++ b/crates/wash-runtime/tests/integration_nats_blobstore.rs
@@ -117,9 +117,9 @@ async fn setup() -> Result<TestHarness> {
                     ]
                     .into_iter()
                     .collect(),
-                    version: Some(
-                        semver::Version::parse("0.2.0-draft").expect("valid semver version"),
-                    ),
+                    version: Some(semver::Version::parse("0.2.0-draft").map_err(|e| {
+                        anyhow::anyhow!("invalid blobstore interface version: {e}")
+                    })?),
                     config: {
                         let mut config = HashMap::new();
                         config.insert("buckets".to_string(), "my-container-real".to_string());


### PR DESCRIPTION
Add the host-side routing that lets a standalone plugin and a multiplexed
(named-instance) plugin serve the same package without conflict..

An unnamed import is served by the regular plugin's default instance, while a named (implements ..) import is served by a plugin advertising
supports_named_instances(). This is so that we can keep implements behind a
feature flag.

Behavior is unchanged when only one kind of plugin is present.
