### PR TITLE
Fix quickstart: Update wasi:http/incoming-handler version

### DIFF
--- a/templates/http-hello-world/wit/world.wit
+++ b/templates/http-hello-world/wit/world.wit
@@ -1,5 +1,5 @@
 package wasmcloud:hello;
 
 world hello {
-   export wasi:http/incoming-handler@0.2.2;
+   export wasi:http/incoming-handler@0.2.9;
 }


### PR DESCRIPTION
The Rust quickstart requires version 0.2.9 of the `wasi:http/incoming-handler`. See https://github.com/wasmCloud/wasmcloud.com/pull/1203 for more details.