### PR TITLE
surface wasm proposals to cli and chart

### DIFF
--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -114,6 +114,9 @@ spec:
             {{- if and (.wasip3) (.wasip3.enabled) }}
             - "--wasip3"
             {{- end }}
+            {{- range .wasmProposals }}
+            - "--wasm-proposal={{ . }}"
+            {{- end }}
             {{- /* Chart-wide runtime.extraArgs applies to every host group; per-host-group
                    .extraArgs is appended after it. */}}
             {{- with $top.Values.runtime.extraArgs }}

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -212,6 +212,11 @@ runtime:
         enabled: false
       wasip3:
         enabled: false
+      # -- Additional wasm proposals to enable on this host group's engine,
+      # rendered as `--wasm-proposal=<name>` args. Accepted names:
+      # component-model-async, gc, exception-handling, wide-arithmetic,
+      # threads, tail-call.
+      wasmProposals: []
       http:
         enabled: true
         port: 9191

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -637,6 +637,42 @@ impl WasmProposal {
     }
 }
 
+/// Error returned when a string cannot be parsed into a [`WasmProposal`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParseWasmProposalError(String);
+
+impl std::fmt::Display for ParseWasmProposalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "unknown wasm proposal {:?}; expected one of: component-model-async, gc, \
+             exception-handling, wide-arithmetic, threads, tail-call",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for ParseWasmProposalError {}
+
+impl FromStr for WasmProposal {
+    type Err = ParseWasmProposalError;
+
+    /// Parse a proposal from its kebab-case name. Matching is case-insensitive
+    /// and treats `_` and `-` interchangeably, so `gc`, `GC`,
+    /// `exception_handling`, and `exception-handling` all parse.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().replace('_', "-").as_str() {
+            "component-model-async" => Ok(Self::ComponentModelAsync),
+            "gc" => Ok(Self::Gc),
+            "exception-handling" => Ok(Self::ExceptionHandling),
+            "wide-arithmetic" => Ok(Self::WideArithmetic),
+            "threads" => Ok(Self::Threads),
+            "tail-call" => Ok(Self::TailCall),
+            _ => Err(ParseWasmProposalError(s.to_string())),
+        }
+    }
+}
+
 /// Builder for constructing an [`Engine`] with custom configuration.
 ///
 /// The builder pattern allows for flexible configuration of the engine
@@ -1038,5 +1074,23 @@ mod tests {
             .with_pooling_config(pool)
             .build()
             .expect("external pooling config should build");
+    }
+
+    // Proposal names parse case-insensitively and accept `_`/`-` interchangeably;
+    // unknown names are rejected.
+    #[test]
+    fn wasm_proposal_from_str() {
+        assert_eq!("gc".parse(), Ok(WasmProposal::Gc));
+        assert_eq!("GC".parse(), Ok(WasmProposal::Gc));
+        assert_eq!(" threads ".parse(), Ok(WasmProposal::Threads));
+        assert_eq!(
+            "exception_handling".parse(),
+            Ok(WasmProposal::ExceptionHandling)
+        );
+        assert_eq!(
+            "component-model-async".parse(),
+            Ok(WasmProposal::ComponentModelAsync)
+        );
+        assert!("nonsense".parse::<WasmProposal>().is_err());
     }
 }

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -737,6 +737,13 @@ impl EngineBuilder {
     /// [`with_wasm_proposal`](Self::with_wasm_proposal) rather than being
     /// mutually exclusive with them.
     ///
+    /// Unlike the default-config path, the pooling allocator is *not* enabled
+    /// by default on top of a custom config. A base config's allocation
+    /// strategy is preserved unless pooling is explicitly requested via
+    /// [`with_pooling_allocator`](Self::with_pooling_allocator),
+    /// [`with_pooling_config`](Self::with_pooling_config), or the
+    /// `WASMTIME_POOLING` environment variable.
+    ///
     /// # Arguments
     /// * `config` - A wasmtime `Config` object with custom settings
     ///
@@ -793,12 +800,18 @@ impl EngineBuilder {
 
         // Start from the caller-supplied base config (or wasmtime's default) and
         // layer the builder-managed settings on top of it.
+        let has_custom_config = self.config.is_some();
         let mut config = self.config.take().unwrap_or_default();
 
+        // Default the pooling allocator on only when starting from wasmtime's
+        // default config. With a caller-supplied base config, leave its
+        // allocation strategy untouched unless pooling was explicitly requested
+        // (via with_pooling_allocator/with_pooling_config or WASMTIME_POOLING),
+        // so a custom strategy is not silently overridden.
         let use_pooling_allocator = self
             .use_pooling_allocator
             .or_else(|| getenv::<bool>("WASMTIME_POOLING"))
-            .unwrap_or(true);
+            .unwrap_or(!has_custom_config);
 
         // The pooling allocator can be more efficient for workloads with many short-lived instances
         if use_pooling_allocator && let Ok(true) = is_pooling_allocator_supported() {

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -10,7 +10,7 @@ use clap::Args;
 use tokio::{select, sync::mpsc};
 use tracing::{debug, info, instrument, warn};
 use wash_runtime::{
-    engine::Engine,
+    engine::{Engine, WasmProposal},
     host::{Host, HostApi},
     observability::Meters,
     plugin::{self},
@@ -63,10 +63,16 @@ impl CliCommand for DevCommand {
             .clone()
             .unwrap_or_else(|| "0.0.0.0:8000".to_string());
 
-        let engine = Engine::builder()
+        let mut engine_builder = Engine::builder()
             .with_pooling_allocator(true)
-            .with_fuel_consumption(ctx.enable_meters())
-            .build()?;
+            .with_fuel_consumption(ctx.enable_meters());
+        for name in &dev_config.wasm_proposals {
+            let proposal: WasmProposal = name
+                .parse()
+                .with_context(|| format!("invalid dev.wasm_proposals entry {name:?}"))?;
+            engine_builder = engine_builder.with_wasm_proposal(proposal);
+        }
+        let engine = engine_builder.build()?;
 
         let mut host_builder = Host::builder()
             .with_engine(engine)

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 use clap::Args;
 use tracing::info;
 use wash_runtime::{
-    engine::Engine,
+    engine::{Engine, WasmProposal},
     observability::Meters,
     plugin::{self},
 };
@@ -115,6 +115,17 @@ pub struct HostCommand {
     /// Enable WASI OpenTelemetry plugin
     #[arg(long = "wasi-otel", default_value_t = false)]
     pub wasi_otel: bool,
+
+    /// Enable additional wasm proposals on the engine. Accepts a comma-separated
+    /// list and/or repeated flags, e.g. `--wasm-proposal gc,threads`. Accepted
+    /// names: component-model-async, gc, exception-handling, wide-arithmetic,
+    /// threads, tail-call.
+    #[arg(
+        long = "wasm-proposal",
+        env = "WASH_WASM_PROPOSALS",
+        value_delimiter = ','
+    )]
+    pub wasm_proposals: Vec<WasmProposal>,
 }
 
 impl CliCommand for HostCommand {
@@ -156,10 +167,13 @@ impl CliCommand for HostCommand {
             oci_cache_dir: self.oci_cache_dir.clone(),
         };
 
-        let engine = Engine::builder()
+        let mut engine_builder = Engine::builder()
             .with_pooling_allocator(true)
-            .with_fuel_consumption(ctx.enable_meters())
-            .build()?;
+            .with_fuel_consumption(ctx.enable_meters());
+        for proposal in &self.wasm_proposals {
+            engine_builder = engine_builder.with_wasm_proposal(*proposal);
+        }
+        let engine = engine_builder.build()?;
 
         let mut cluster_host_builder = wash_runtime::washlet::ClusterHostBuilder::default()
             .with_engine(engine)

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -460,6 +460,12 @@ pub struct DevConfig {
     /// Enable WASI OpenTelemetry support
     #[serde(default)]
     pub wasi_otel: bool,
+
+    /// Additional wasm proposals to enable on the engine, by name. Accepted
+    /// names match `wash_runtime`'s `WasmProposal`: component-model-async, gc,
+    /// exception-handling, wide-arithmetic, threads, tail-call.
+    #[serde(default)]
+    pub wasm_proposals: Vec<String>,
 }
 
 impl DevConfig {
@@ -517,6 +523,12 @@ impl DevConfig {
         }
         if cfg!(target_arch = "s390x") && self.wasi_webgpu {
             errors.push("dev.wasi_webgpu is not supported on s390x".to_string());
+        }
+
+        for proposal in &self.wasm_proposals {
+            if let Err(err) = proposal.parse::<wash_runtime::engine::WasmProposal>() {
+                errors.push(format!("dev.wasm_proposals: {err}"));
+            }
         }
 
         for comp in &self.components {


### PR DESCRIPTION
Follow-up to #5254 (which added the composable WasmProposal API) and #5023. That PR made proposals configurable in the EngineBuilder library API; this PR surfaces them to the wash host/wash dev CLI and the runtime-operator host-pod spec.
- Add FromStr/ParseWasmProposalError for WasmProposal
- wash host: --wasm-proposal flag (comma-separated and/or repeatable, WASH_WASM_PROPOSALS env), wired into the engine builder.
- wash dev: dev.wasm_proposals config field, parsed at engine build and validated at config load.
- runtime-operator chart: render per-host-group wasmProposals as --wasm-proposal=<name> args; bump chart 0.5.0 → 0.6.0.

One additional fix to allow folks to override the pooling allocator config.
- The pooling allocator was enabled by default on top of a base config passed to with_config(), silently overriding any allocation strategy set there.
- Default-on pooling now applies only when starting from wasmtime's default config; a custom base config's allocator is left untouched unless pooling is explicitly requested via with_pooling_allocator/with_pooling_config or WASMTIME_POOLING.

## CLI

```bash
wash host --wasm-proposal gc,threads
wash host --wasm-proposal gc --wasm-proposal threads
WASH_WASM_PROPOSALS=gc,threads wash host
```

## wash dev config (.wash/config.yaml)

```yaml
dev:
  wasm_proposals: [gc, threads]
```

## runtime-operator values.yaml

```yaml
runtime:
  hostGroups:
    - name: gc-enabled
      wasmProposals: [gc, threads]
```