### PR TITLE
feat(wash-runtime): multiplex wasi:keyvalue via `(implements ..)` imports

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: "Install Zig and cargo-zigbuild for cross-compilation"
     required: false
     default: "false"
+  wasm-component-ld-version:
+    description: "Version of standalone wasm-component-ld to install"
+    required: false
+    default: "0.5.24"
 
 runs:
   using: "composite"
@@ -107,9 +111,54 @@ runs:
     - name: Install cargo-zigbuild
       if: ${{ inputs.install-zigbuild == 'true' }}
       uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+      env:
+        # Authenticate the action's GitHub API calls so they aren't throttled
+        # by the 60/hr anonymous per-IP limit shared across hosted runners.
+        GITHUB_TOKEN: ${{ github.token }}
       with:
         tool: cargo-zigbuild
 
     - name: Install wash CLI
       if: ${{ inputs.install-wash == 'true' }}
       uses: wasmcloud/setup-wash-action@47756fa211cc82f392c57e39504f43ef46fc0b3e # v2.1.0
+
+    # The wasm32-wasip2 linker. The toolchain bundles one, but it lags the
+    # standalone crate and is too old to decode the component-model
+    # `(implements ..)` imports that wit-bindgen now emits — linking such a
+    # component fails with "decoding custom section ... invalid leading byte".
+    # Drop once a Rust release bundles wasm-component-ld >= 0.5.23.
+    - name: Install cargo-binstall
+      uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+      env:
+        # Authenticate the action's GitHub API calls so they aren't throttled
+        # by the 60/hr anonymous per-IP limit shared across hosted runners.
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        tool: cargo-binstall
+    - name: Install wasm-component-ld
+      shell: bash
+      env:
+        VERSION: ${{ inputs.wasm-component-ld-version }}
+        # Authenticate cargo-binstall's GitHub API calls. Unauthenticated
+        # requests share a 60/hr per-IP limit that hosted runners blow through,
+        # returning 403. binstall then falls back to a source `cargo install`,
+        # which rejects the `--install-path` below and fails the job. The token
+        # raises the limit so the prebuilt release asset is used. `github.token`
+        # (not `secrets`) is the only token context available in a composite
+        # action; read-only access is sufficient for release-asset lookups.
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        # rustc resolves `wasm-component-ld` from the active toolchain's own
+        # sysroot (lib/rustlib/<host>/bin), NOT from PATH, so binstalling into
+        # ~/.cargo/bin would leave the build linking with the stale bundled
+        # copy. Install directly over the bundled binary instead. `rustc` is
+        # resolved from the repo root, so a checked-in rust-toolchain.toml pins
+        # the same toolchain the build below uses. Targeting the native sysroot
+        # dir keeps this working on Windows, where passing a bash-style linker
+        # path to cargo would not.
+        bindir="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's/^host: //p')/bin"
+        cargo binstall --no-confirm --force \
+          --install-path "${bindir}" \
+          "wasm-component-ld@${VERSION}"
+        "${bindir}/wasm-component-ld" --version

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -59,6 +59,10 @@ jobs:
           persist-credentials: false
       - name: Install cargo-audit
         uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        env:
+          # Authenticate the action's GitHub API calls so they aren't throttled
+          # by the 60/hr anonymous per-IP limit shared across hosted runners.
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: cargo-audit
       - name: Run cargo audit

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -116,13 +116,26 @@ jobs:
       - name: Test
         env:
           RUST_BACKTRACE: "1"
-          OCI_INTEGRATION_TESTS: ${{ matrix.os == 'ubuntu-latest' && '1' || '' }}
-          NATS_INTEGRATION_TESTS: ${{ matrix.os == 'ubuntu-latest' && '1' || '' }}
         run: |
           cargo test --workspace
-      - name: Test with wasi-tls
+      - name: Test with wasi-tls + wasm_component_model_implements
+        env:
+          RUST_BACKTRACE: "1"
         run: |
-          cargo test -p wash-runtime --features wasi-tls
+          cargo test -p wash-runtime --features wasi-tls,wasm_component_model_implements
+      # Docker/registry-backed `#[ignore]` integration tests, Linux only: the
+      # macOS/Windows hosted runners have no Docker daemon (and macOS can't get
+      # one — no nested virtualization). `-- --ignored` runs ONLY the ignored
+      # tests, once. Scoped to the crates we gate this way (wash-runtime + wash's
+      # OCI suite) so it doesn't pull in the pre-existing network-only wit tests
+      # in `crates/wash/tests/integration_wit.rs`.
+      - name: Integration tests (Docker/registry, Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          RUST_BACKTRACE: "1"
+        run: |
+          cargo test -p wash-runtime --features wasm_component_model_implements,wasi-tls -- --ignored
+          cargo test -p wash --test integration_oci -- --ignored
       - name: Build benchmarks
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -155,6 +168,10 @@ jobs:
           rust-components: rustfmt
       - name: Install cargo-machete
         uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        env:
+          # Authenticate the action's GitHub API calls so they aren't throttled
+          # by the 60/hr anonymous per-IP limit shared across hosted runners.
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: cargo-machete@0.8.0
       - name: Format
@@ -162,7 +179,7 @@ jobs:
           cargo +nightly fmt -- --check
       - name: Lint
         run: |
-          cargo clippy --workspace --features wasi-tls
+          cargo clippy --workspace --features wasm_component_model_implements,wasi-tls
       - name: Lint anyhow context message casing
         run: |
           # anyhow `.context()` / `.with_context()` strings are error messages,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,7 +2099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2926,7 +2926,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3208,7 +3207,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3289,6 +3288,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,6 +3375,22 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -3993,7 +4038,7 @@ dependencies = [
  "oci-spec 0.7.1",
  "olpc-cjson",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4005,24 +4050,25 @@ dependencies = [
 
 [[package]]
 name = "oci-client"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
+checksum = "5261a7fb43d9c53b8e63e6d5e86860719dad253d015d022066c72d585125aed8"
 dependencies = [
  "bytes",
  "chrono",
  "futures-util",
+ "hex",
  "http",
  "http-auth",
- "jwt",
+ "jsonwebtoken",
  "lazy_static 1.5.0",
- "oci-spec 0.8.4",
+ "oci-spec 0.9.0",
  "olpc-cjson",
  "regex",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4047,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
 dependencies = [
  "const_format",
  "derive_builder",
@@ -4081,18 +4127,18 @@ dependencies = [
 
 [[package]]
 name = "oci-wasm"
-version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/rust-oci-wasm?rev=5ee16fa1#5ee16fa174522e3f9d0dba033cbafe05f7693e27"
+version = "0.4.0"
+source = "git+https://github.com/bytecodealliance/rust-oci-wasm?rev=e7b5865f99503acce599cf083d59e42a4f05030e#e7b5865f99503acce599cf083d59e42a4f05030e"
 dependencies = [
  "anyhow",
  "chrono",
- "oci-client 0.15.0",
+ "oci-client 0.17.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "tokio",
- "wit-component 0.244.0",
- "wit-parser 0.244.0",
+ "wit-component 0.251.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -4873,7 +4919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -4893,8 +4939,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4928,7 +4974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5074,6 +5120,7 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -5398,7 +5445,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5413,9 +5459,50 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -5510,7 +5597,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5560,6 +5647,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -5987,6 +6101,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6265,7 +6395,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7176,7 +7306,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "ptree",
- "reqwest",
+ "reqwest 0.12.28",
  "secrecy",
  "semver",
  "serde",
@@ -7302,7 +7432,7 @@ dependencies = [
  "libc",
  "pbjson-build 0.8.0",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "scopeguard",
  "semver",
  "serde",
@@ -7322,7 +7452,7 @@ dependencies = [
  "wasm-pkg-client",
  "wasm-pkg-core",
  "wat",
- "wit-component 0.248.0",
+ "wit-component 0.252.0",
 ]
 
 [[package]]
@@ -7355,8 +7485,8 @@ dependencies = [
  "io-lifetimes",
  "moka",
  "names",
- "oci-client 0.15.0",
- "oci-wasm 0.3.0",
+ "oci-client 0.17.0",
+ "oci-wasm 0.4.0",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-http",
@@ -7371,7 +7501,7 @@ dependencies = [
  "prost 0.14.4",
  "rcgen",
  "redis",
- "reqwest",
+ "reqwest 0.12.28",
  "rustix",
  "rustls",
  "semver",
@@ -7404,7 +7534,7 @@ dependencies = [
  "wasmtime-wasi-tls",
  "wat",
  "webpki-roots 0.26.11",
- "wit-component 0.248.0",
+ "wit-component 0.252.0",
 ]
 
 [[package]]
@@ -7687,6 +7817,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-metadata"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f998ccc6e012f7b86865eb2a106c8a0422017a1a88977ce01a69f2244be2e57"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b7e08e02a3cd55bf778009d4cd6faae50da011f293644daf78a531a32d6d142"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
+]
+
+[[package]]
 name = "wasm-pkg-client"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7731,7 +7885,7 @@ dependencies = [
  "etcetera 0.8.0",
  "futures-util",
  "http",
- "reqwest",
+ "reqwest 0.12.28",
  "semver",
  "serde",
  "serde_json",
@@ -7771,6 +7925,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -7846,6 +8013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
 ]
@@ -8242,6 +8410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8465,7 +8642,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9004,9 +9181,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.248.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0012379f0ff47e1d44dd312e76cfa42de2589251f093fb105e9de9db90c89221"
+checksum = "83a5e60173c413659c689f0581b0cf5d1a2404077568f9ffdce748a9eb2fc913"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -9015,10 +9192,29 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.248.0",
- "wasm-metadata 0.248.0",
- "wasmparser 0.248.0",
- "wit-parser 0.248.0",
+ "wasm-encoder 0.251.0",
+ "wasm-metadata 0.251.0",
+ "wasmparser 0.251.0",
+ "wit-parser 0.251.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76db0662b590f45d33d0e363fa13539a5a1eecd35d5a12fe208c335461c1053d"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.252.0",
+ "wasm-metadata 0.252.0",
+ "wasmparser 0.252.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
@@ -9059,25 +9255,6 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
-dependencies = [
- "anyhow",
- "hashbrown 0.17.1",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.248.0",
-]
-
-[[package]]
-name = "wit-parser"
 version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
@@ -9093,6 +9270,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.251.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-ident",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -9176,7 +9372,7 @@ dependencies = [
  "anyhow",
  "clap",
  "wasi-preview1-component-adapter-provider",
- "wit-component 0.248.0",
+ "wit-component 0.252.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,8 @@ kube = { version = "1", default-features = false }
 kube-derive = { version = "1", default-features = false }
 notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
 moka = { version = "0.12", default-features = false }
-oci-client = { version = "0.15.0", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots"]}
-oci-wasm = { version = "0.3.0", default-features = false, features = ["rustls-tls"] }
+oci-client = { version = "0.17.0", default-features = false, features = ["rustls-tls"] }
+oci-wasm = { version = "0.4.0", default-features = false, features = ["rustls-tls"] }
 opentelemetry = { version = "0.31", default-features = false }
 opentelemetry-appender-tracing = { version = "0.31", default-features = false }
 opentelemetry-otlp = { version = "0.31", default-features = false }
@@ -133,7 +133,7 @@ wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7
 wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wasmtime-wasi-http = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
 wasmtime-wasi-tls = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
-wit-component = { version = "0.248.0", default-features = false }
+wit-component = { version = "0.252.0", default-features = false }
 wash-runtime = { path = "crates/wash-runtime", default-features = false }
 wat = { version = "1.248.0", default-features = false }
 
@@ -168,8 +168,12 @@ ignored = [
 ]
 
 [patch.crates-io]
-# Pinned for async component support (fixes #187). Remove after https://github.com/bytecodealliance/rust-oci-wasm/issues/28
-oci-wasm = { git = "https://github.com/bytecodealliance/rust-oci-wasm", rev = "5ee16fa1" }
+# Pinned to main for two reasons: async component support (fixes #187, not yet
+# in a release — see https://github.com/bytecodealliance/rust-oci-wasm/issues/28)
+# and a wit-component (0.251) new enough to decode `(implements ..)` named
+# imports when building the OCI config. Switch back to a crates.io version once
+# a release carries both.
+oci-wasm = { git = "https://github.com/bytecodealliance/rust-oci-wasm", rev = "e7b5865f99503acce599cf083d59e42a4f05030e" }
 
 # The wasi-gfx deps (behind the `wasi-webgpu` feature) depend on wasmtime 46
 # from crates.io, while the rest of the workspace uses the forked git wasmtime

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -118,7 +118,7 @@ opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_ex
 
 # OCI dependencies (optional, behind 'oci' feature)
 docker_credential = { workspace = true, optional = true }
-oci-client = { workspace = true, optional = true, features = ["rustls-tls", "rustls-tls-native-roots"] }
+oci-client = { workspace = true, optional = true, features = ["rustls-tls"] }
 oci-wasm = { workspace = true, optional = true, features = ["rustls-tls"] }
 sha2 = { workspace = true, optional = true }
 wit-component = { workspace = true, optional = true }
@@ -157,7 +157,10 @@ pbjson-build = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-reqwest = { workspace = true }
+# `stream` (bytes_stream / Body::wrap_stream) is used by the blobstore
+# integration tests; enable it explicitly rather than relying on another dep
+# transitively turning it on (oci-client 0.17 no longer does).
+reqwest = { workspace = true, features = ["stream"] }
 wat = { workspace = true, features = ["component-model"] }
 bytes = { workspace = true }
 http-body-util = { workspace = true }

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -182,8 +182,21 @@ impl WorkloadMetadata {
             .component_type()
             .imports(self.component.engine())
         {
-            if let ComponentItem::ComponentInstance(_) = import_item.ty {
-                let interface = WitInterface::from(import_name);
+            if let ComponentItem::ComponentInstance(_) = &import_item.ty {
+                // An `(implements <id>)` import carries the real interface
+                // identity in its `implements` annotation; the import name is
+                // the multiplex label (e.g. `team-a`). Build the interface from
+                // the annotation and record the label as the routing `name` so
+                // it lines up with a named host interface. A plain import uses
+                // its name as the identity directly.
+                let interface = match import_item.implements {
+                    Some(implements_id) => {
+                        let mut iface = WitInterface::from(implements_id);
+                        iface.name = Some(import_name.to_string());
+                        iface
+                    }
+                    None => WitInterface::from(import_name),
+                };
                 let k = interface.instance();
                 imports
                     .entry(k)

--- a/crates/wash-runtime/src/oci.rs
+++ b/crates/wash-runtime/src/oci.rs
@@ -742,14 +742,10 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // Integration test with real registry - only run when OCI_INTEGRATION_TESTS env var is set
+    // Integration test with real registry - marked `#[ignore]`, run with `cargo test --include-ignored`
     #[tokio::test]
+    #[ignore = "hits a real OCI registry (network); run with `cargo test --include-ignored`"]
     async fn test_pull_and_validate_ghcr_component() {
-        // Skip this test unless integration tests are explicitly enabled
-        if std::env::var("OCI_INTEGRATION_TESTS").is_err() {
-            return;
-        }
-
         // Use public OCI references for testing
         let references = vec![
             // wasmCloud hello world component

--- a/crates/wash-runtime/src/oci.rs
+++ b/crates/wash-runtime/src/oci.rs
@@ -467,7 +467,8 @@ pub async fn pull_component(
             .with_context(|| "failed to cache component")?;
     }
 
-    Ok((component_data, digest))
+    // oci-client 0.17 hands back layer data as `Bytes`; callers expect `Vec<u8>`.
+    Ok((component_data.to_vec(), digest))
 }
 
 /// Push a WebAssembly component to an OCI registry
@@ -566,6 +567,7 @@ pub async fn push_component(
             size: config_obj.data.len() as i64,
             urls: None,
             annotations: None,
+            artifact_type: None,
         };
 
         let layer_descriptors: Vec<OciDescriptor> = layers
@@ -576,6 +578,7 @@ pub async fn push_component(
                 size: layer.data.len() as i64,
                 urls: None,
                 annotations: None,
+                artifact_type: None,
             })
             .collect();
 

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -52,6 +52,10 @@ pub mod wasi_otel;
 
 pub mod wasmcloud_messaging;
 
+/// Shared `(implements ..)` multiplexing core
+#[cfg(feature = "wasm_component_model_implements")]
+pub mod multiplex;
+
 #[cfg(all(
     feature = "wasi-webgpu",
     not(target_os = "windows"),

--- a/crates/wash-runtime/src/plugin/multiplex.rs
+++ b/crates/wash-runtime/src/plugin/multiplex.rs
@@ -1,0 +1,611 @@
+//! # Generic multiplexing core for `(implements ..)` routing
+//!
+//! The per-builtin multiplexed plugins all share the same set of
+//! [`BackendProvider`]s keyed by a `config.backend` discriminator, a registry
+//! mapping each host-interface name (the implements id) to a backend, and a
+//! [`Multiplexer::resolve`] call that resolves a component import name to its
+//! backend.
+//!
+//! ## Connection pool
+//!
+//! Backends whose provider supplies a [`BackendProvider::pool_key`] (redis,
+//! NATS) are cached and shared across workload binds with the same
+//! configuration, so identical interfaces reuse one connection. The pool is
+//! self-managing: a single-flight cell collapses concurrent binds for the same
+//! key into one `instantiate`, an idle entry is reaped after
+//! [`Multiplexer::with_idle_ttl`], and the number of cached connections is
+//! capped by [`Multiplexer::with_max_connections`] (least-recently-used
+//! eviction). The cap bounds *cached* connections; a connection still held by a
+//! live bind keeps working after eviction. Eviction only means a future bind
+//! re-instantiates it.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use tokio::sync::{Mutex, OnceCell};
+
+use crate::wit::WitInterface;
+
+/// `config` key naming the backend type for a named host interface (e.g.
+/// `redis`, `nats`, `filesystem`). Shared by every multiplexed builtin.
+pub const BACKEND_CONFIG_KEY: &str = "backend";
+
+/// Default ceiling on pooled (cached) connections, *per backend type* per
+/// multiplexer — so e.g. redis and NATS are capped independently (a multiplexer
+/// can hold up to this many of each). Counts distinct backend endpoints kept
+/// warm, not concurrent operations.
+const DEFAULT_MAX_CONNECTIONS: usize = 64;
+
+/// Default idle period after which a pooled connection is reaped.
+const DEFAULT_IDLE_TTL: Duration = Duration::from_secs(300);
+
+/// A factory for backends of one backend type, parameterized by the builtin's
+/// id type `Id` (an `Arc<dyn …Backend>`). Selected by a named host interface's
+/// `config.backend`; `instantiate` builds a backend from that interface's
+/// `config` (credentials, url, root, …), so two interfaces of the same type but
+/// different config get independent backends.
+#[async_trait::async_trait]
+pub trait BackendProvider<Id>: Send + Sync {
+    /// The `config.backend` discriminator this provider handles.
+    fn backend_type(&self) -> &'static str;
+    /// Build a backend from a named host interface's config.
+    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<Id>;
+    /// A pool key for connection reuse, or `None` to never pool.
+    ///
+    /// Providers backed by a shared external connection (redis, NATS) return
+    /// `Some(key)` derived from the connection config (typically the `url`), so
+    /// interfaces with the same configuration share one backend and thus one
+    /// connection, instead of opening a fresh one per workload bind. Isolated
+    /// providers (in-memory) return `None` and always produce a fresh backend.
+    fn pool_key(&self, _config: &HashMap<String, String>) -> Option<String> {
+        None
+    }
+}
+
+/// One slot in the connection pool.
+struct PoolEntry<Id> {
+    /// Single-flight init cell: concurrent binds for the same key await one
+    /// `instantiate`; on error the cell stays empty so the next bind retries
+    /// (a failed connection is never cached).
+    cell: Arc<OnceCell<Id>>,
+    /// Wall-clock of the most recent resolve, for idle reaping and LRU eviction.
+    last_used: Instant,
+}
+
+/// The reusable multiplexing core: a provider registry, a self-managing
+/// connection pool, plus the registry-building and import-resolution logic
+/// shared by every multiplexed builtin. Construct one per builtin with its
+/// namespace/package and default backend type, register providers, then
+/// `build_registry` / `resolve`.
+pub struct Multiplexer<Id> {
+    namespace: &'static str,
+    package: &'static str,
+    default_backend_type: &'static str,
+    providers: HashMap<&'static str, Arc<dyn BackendProvider<Id>>>,
+    /// Connection pool: backends shared across workload binds, keyed by
+    /// `backend_type` + the provider's `pool_key`. Reaped when idle and capped
+    /// per backend type, so it does not grow without bound.
+    pool: Arc<Mutex<HashMap<String, PoolEntry<Id>>>>,
+    /// Default ceiling on pooled (cached) connections *per backend type*; LRU
+    /// eviction within a backend's group past this.
+    max_connections: usize,
+    /// Per-backend-type overrides of `max_connections` (e.g. `redis` -> 32).
+    max_connections_by_backend: HashMap<&'static str, usize>,
+    /// Idle period after which a pooled connection is reaped.
+    idle_ttl: Duration,
+    /// Whether the background idle-reaper task has been spawned yet (spawned
+    /// lazily on the first pooled bind, when a tokio runtime is guaranteed).
+    reaper_started: AtomicBool,
+}
+
+impl<Id: Clone + Send + Sync + 'static> Multiplexer<Id> {
+    /// Create a multiplexer for `namespace:package`, defaulting interfaces with
+    /// no `config.backend` to `default_backend_type`.
+    pub fn new(
+        namespace: &'static str,
+        package: &'static str,
+        default_backend_type: &'static str,
+    ) -> Self {
+        Self {
+            namespace,
+            package,
+            default_backend_type,
+            providers: HashMap::new(),
+            pool: Arc::new(Mutex::new(HashMap::new())),
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+            max_connections_by_backend: HashMap::new(),
+            idle_ttl: DEFAULT_IDLE_TTL,
+            reaper_started: AtomicBool::new(false),
+        }
+    }
+
+    /// Register a backend provider keyed by its `backend_type()`.
+    pub fn with_provider(mut self, provider: Arc<dyn BackendProvider<Id>>) -> Self {
+        self.providers.insert(provider.backend_type(), provider);
+        self
+    }
+
+    /// Override the default pooled-connection ceiling *per backend type*
+    /// (default [`DEFAULT_MAX_CONNECTIONS`]). Once a backend type's pooled
+    /// connections would exceed this, its least-recently-used one is evicted;
+    /// each backend type is capped independently. Clamped to at least 1. Use
+    /// [`with_max_connections_for`](Self::with_max_connections_for) to override
+    /// a single type.
+    pub fn with_max_connections(mut self, max: usize) -> Self {
+        self.max_connections = max.max(1);
+        self
+    }
+
+    /// Override the pooled-connection ceiling for one backend type (e.g.
+    /// `("redis", 32)`), taking precedence over
+    /// [`with_max_connections`](Self::with_max_connections) for that type.
+    /// Clamped to at least 1.
+    pub fn with_max_connections_for(mut self, backend_type: &'static str, max: usize) -> Self {
+        self.max_connections_by_backend
+            .insert(backend_type, max.max(1));
+        self
+    }
+
+    /// Override the idle period after which a pooled connection is reaped
+    /// (default [`DEFAULT_IDLE_TTL`]).
+    pub fn with_idle_ttl(mut self, ttl: Duration) -> Self {
+        self.idle_ttl = ttl;
+        self
+    }
+
+    /// Instantiate the backend for a single interface: the provider chosen by
+    /// `config.backend` (or the default backend type) builds it from the
+    /// interface's config. Backends whose provider supplies a `pool_key` are
+    /// shared across binds for the same configuration. Exposed so callers can
+    /// post-process (e.g. wrap with a decorator) before inserting into a
+    /// registry.
+    pub async fn instantiate(&self, iface: &WitInterface) -> anyhow::Result<Id> {
+        let backend_type = iface
+            .config
+            .get(BACKEND_CONFIG_KEY)
+            .map(String::as_str)
+            .unwrap_or(self.default_backend_type);
+        let provider = self.providers.get(backend_type).ok_or_else(|| {
+            anyhow::anyhow!(
+                "no {}:{} provider registered for backend '{backend_type}'",
+                self.namespace,
+                self.package
+            )
+        })?;
+
+        // Unpooled providers (in-memory, filesystem) always build a fresh,
+        // isolated backend — nothing to share or reap.
+        let Some(pool_key) = provider.pool_key(&iface.config) else {
+            return provider.instantiate(&iface.config).await;
+        };
+        // `backend_type` is a fixed `&'static str` from a closed set with no
+        // null byte, so the `\u{0}` separator makes cross-type collisions
+        // impossible.
+        let key = format!("{backend_type}\u{0}{pool_key}");
+
+        self.ensure_reaper_running();
+
+        // Grab (or create) this key's single-flight cell, holding the pool lock
+        // only long enough to touch the map. Never across the instantiate await
+        // below, so one slow/hung connect can't block other binds.
+        let cell = {
+            let mut pool = self.pool.lock().await;
+            reap_idle(&mut pool, self.idle_ttl);
+            let entry = pool.entry(key.clone()).or_insert_with(|| PoolEntry {
+                cell: Arc::new(OnceCell::new()),
+                last_used: Instant::now(),
+            });
+            entry.last_used = Instant::now();
+            entry.cell.clone()
+        };
+
+        // Single instantiate shared across concurrent binds for this key: the
+        // first to arrive runs the connect, the rest await its result. On error
+        // the cell is left empty, so a later bind retries rather than caching a
+        // failed connection.
+        let backend = cell
+            .get_or_try_init(|| provider.instantiate(&iface.config))
+            .await?
+            .clone();
+
+        // Now that the slot is populated, enforce this backend type's ceiling.
+        // Eviction is least-recently-used within the backend's group and never
+        // touches the entry we just resolved.
+        {
+            let max = self
+                .max_connections_by_backend
+                .get(backend_type)
+                .copied()
+                .unwrap_or(self.max_connections);
+            let mut pool = self.pool.lock().await;
+            enforce_limit(&mut pool, backend_type, max, &key);
+        }
+        Ok(backend)
+    }
+
+    /// Build the routing registry (host-interface name -> backend) from a
+    /// component's matched host interfaces. Unnamed interfaces are keyed by the
+    /// empty string and act as the default route. Interfaces for other
+    /// packages are ignored.
+    pub async fn build_registry<'i>(
+        &self,
+        interfaces: impl IntoIterator<Item = &'i WitInterface>,
+    ) -> anyhow::Result<HashMap<String, Id>> {
+        self.build_registry_with(interfaces, |_, backend| backend)
+            .await
+    }
+
+    /// Like [`build_registry`](Self::build_registry), but applies `decorate` to
+    /// each freshly-instantiated backend before inserting it.
+    /// This keeps the namespace/package filtering and name-keying in one
+    /// place so builtins that need post-processing don't reimplement the loop.
+    pub async fn build_registry_with<'i, F>(
+        &self,
+        interfaces: impl IntoIterator<Item = &'i WitInterface>,
+        mut decorate: F,
+    ) -> anyhow::Result<HashMap<String, Id>>
+    where
+        F: FnMut(&WitInterface, Id) -> Id + Send,
+    {
+        // Collect up front so no input iterator is held across the `await`s
+        // below (keeps the returned future `Send`).
+        let interfaces: Vec<&WitInterface> = interfaces.into_iter().collect();
+        let mut registry = HashMap::new();
+        for iface in interfaces {
+            if iface.namespace != self.namespace || iface.package != self.package {
+                continue;
+            }
+            let backend = self.instantiate(iface).await?;
+            let backend = decorate(iface, backend);
+            registry.insert(iface.name.clone().unwrap_or_default(), backend);
+        }
+        Ok(registry)
+    }
+
+    /// Resolve a component import name (the implements id) to a backend, given a
+    /// registry from [`Multiplexer::build_registry`]. The import name is matched
+    /// directly against the host-interface name; unnamed imports fall through to
+    /// the default (`""`) route.
+    pub fn resolve(
+        &self,
+        registry: &HashMap<String, Id>,
+        import_name: &str,
+    ) -> wasmtime::Result<Id> {
+        registry
+            .get(import_name)
+            .or_else(|| registry.get(""))
+            .cloned()
+            .ok_or_else(|| {
+                wasmtime::format_err!(
+                    "no {}:{} backend bound for import '{import_name}'",
+                    self.namespace,
+                    self.package
+                )
+            })
+    }
+
+    /// Spawn the background idle-reaper once, on the first pooled bind (where a
+    /// tokio runtime is guaranteed). The task holds only a `Weak` to the pool,
+    /// so it self-terminates when the multiplexer is dropped.
+    fn ensure_reaper_running(&self) {
+        if self.reaper_started.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let pool = Arc::downgrade(&self.pool);
+        let ttl = self.idle_ttl;
+        // Tick at half the TTL so an idle entry is reaped within ~1.5×TTL even
+        // if the host goes quiet (opportunistic reaping in `instantiate` only
+        // fires when there is bind activity).
+        let interval = (ttl / 2).max(Duration::from_secs(1));
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            loop {
+                ticker.tick().await;
+                let Some(pool) = pool.upgrade() else {
+                    return; // multiplexer dropped
+                };
+                reap_idle(&mut *pool.lock().await, ttl);
+            }
+        });
+    }
+
+    /// Test-only view of the current pool size.
+    #[cfg(test)]
+    async fn pool_len(&self) -> usize {
+        self.pool.lock().await.len()
+    }
+
+    /// Test-only count of pooled connections for one backend type.
+    #[cfg(test)]
+    async fn pool_count_for(&self, backend_type: &str) -> usize {
+        let prefix = format!("{backend_type}\u{0}");
+        self.pool
+            .lock()
+            .await
+            .keys()
+            .filter(|k| k.starts_with(&prefix))
+            .count()
+    }
+}
+
+/// Drop initialized pool entries idle longer than `ttl`. In-flight entries
+/// (cell not yet initialized) are always kept — they are being connected right
+/// now. Dropping an entry releases the pool's reference to the backend; a
+/// connection still held by a live bind stays open until that bind drops it.
+fn reap_idle<Id>(pool: &mut HashMap<String, PoolEntry<Id>>, ttl: Duration) {
+    let now = Instant::now();
+    pool.retain(|_, e| !e.cell.initialized() || now.duration_since(e.last_used) < ttl);
+}
+
+/// Evict least-recently-used entries of one backend type until that backend's
+/// pooled-connection count is within `max`, never evicting `keep` (the entry
+/// just resolved). Only the named backend type's group (keys prefixed
+/// `{backend_type}\0`) is considered, so each backend type is capped
+/// independently.
+fn enforce_limit<Id>(
+    pool: &mut HashMap<String, PoolEntry<Id>>,
+    backend_type: &str,
+    max: usize,
+    keep: &str,
+) {
+    let prefix = format!("{backend_type}\u{0}");
+    loop {
+        let in_group = pool.keys().filter(|k| k.starts_with(&prefix)).count();
+        if in_group <= max {
+            break;
+        }
+        let victim = pool
+            .iter()
+            .filter(|(k, _)| k.starts_with(&prefix) && k.as_str() != keep)
+            .min_by_key(|(_, e)| e.last_used)
+            .map(|(k, _)| k.clone());
+        match victim {
+            Some(k) => {
+                pool.remove(&k);
+            }
+            None => break, // only `keep` remains in this backend's group
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering::SeqCst;
+
+    fn registry(entries: &[(&str, i32)]) -> HashMap<String, i32> {
+        entries.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+    }
+
+    fn mux() -> Multiplexer<i32> {
+        Multiplexer::new("wasi", "keyvalue", "in-memory")
+    }
+
+    #[test]
+    fn resolve_routes_by_import_name_with_default_fallback() {
+        let reg = registry(&[("team-a", 1), ("", 99)]);
+        let mux = mux();
+        assert_eq!(mux.resolve(&reg, "team-a").unwrap(), 1);
+        // Unknown import name falls through to the default ("") route.
+        assert_eq!(mux.resolve(&reg, "other").unwrap(), 99);
+    }
+
+    #[test]
+    fn resolve_errors_without_match_or_default() {
+        let reg = registry(&[("team-a", 1)]);
+        let err = mux().resolve(&reg, "nope").unwrap_err();
+        assert!(
+            err.to_string().contains("wasi:keyvalue"),
+            "error should name the package: {err}"
+        );
+    }
+
+    // A provider that counts `instantiate` calls and pools (by `url`) when
+    // constructed with `pooled = true`. `Id = Arc<usize>` so backend identity
+    // is observable via `Arc::ptr_eq`. `delay` widens the instantiate window so
+    // concurrent binds genuinely overlap in the single-flight test.
+    struct CountingProvider {
+        backend: &'static str,
+        count: AtomicUsize,
+        pooled: bool,
+        delay: Duration,
+    }
+
+    impl CountingProvider {
+        fn new(pooled: bool) -> Arc<Self> {
+            Self::typed("test", pooled, Duration::ZERO)
+        }
+        fn with_delay(pooled: bool, delay: Duration) -> Arc<Self> {
+            Self::typed("test", pooled, delay)
+        }
+        fn typed(backend: &'static str, pooled: bool, delay: Duration) -> Arc<Self> {
+            Arc::new(Self {
+                backend,
+                count: AtomicUsize::new(0),
+                pooled,
+                delay,
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl BackendProvider<Arc<usize>> for CountingProvider {
+        fn backend_type(&self) -> &'static str {
+            self.backend
+        }
+        async fn instantiate(&self, _: &HashMap<String, String>) -> anyhow::Result<Arc<usize>> {
+            if !self.delay.is_zero() {
+                tokio::time::sleep(self.delay).await;
+            }
+            Ok(Arc::new(self.count.fetch_add(1, SeqCst)))
+        }
+        fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
+            self.pooled.then(|| config.get("url").cloned()).flatten()
+        }
+    }
+
+    fn iface(backend: &str, url: &str) -> WitInterface {
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "keyvalue".to_string(),
+            interfaces: ["store".to_string()].into_iter().collect(),
+            version: None,
+            config: HashMap::from([
+                ("backend".to_string(), backend.to_string()),
+                ("url".to_string(), url.to_string()),
+            ]),
+            name: None,
+        }
+    }
+
+    fn url_iface(url: &str) -> WitInterface {
+        iface("test", url)
+    }
+
+    #[tokio::test]
+    async fn pooled_provider_shares_backend_for_same_config() {
+        let provider = CountingProvider::new(true);
+        let mux = Multiplexer::new("wasi", "keyvalue", "test").with_provider(provider.clone());
+
+        let a = mux.instantiate(&url_iface("redis://x")).await.unwrap();
+        let b = mux.instantiate(&url_iface("redis://x")).await.unwrap();
+        assert!(Arc::ptr_eq(&a, &b), "same config should share one backend");
+        assert_eq!(
+            provider.count.load(SeqCst),
+            1,
+            "instantiate should run once for a pooled config"
+        );
+
+        // A different url is a different connection.
+        let c = mux.instantiate(&url_iface("redis://y")).await.unwrap();
+        assert!(!Arc::ptr_eq(&a, &c), "different config = different backend");
+    }
+
+    #[tokio::test]
+    async fn unpooled_provider_makes_fresh_backends() {
+        let provider = CountingProvider::new(false);
+        let mux = Multiplexer::new("wasi", "keyvalue", "test").with_provider(provider.clone());
+        let a = mux.instantiate(&url_iface("redis://x")).await.unwrap();
+        let b = mux.instantiate(&url_iface("redis://x")).await.unwrap();
+        assert!(
+            !Arc::ptr_eq(&a, &b),
+            "no pool key = fresh backend each time"
+        );
+        assert_eq!(provider.count.load(SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn pooled_instantiate_is_single_flight() {
+        // Many concurrent binds for the same key must trigger exactly one
+        // connect (the thundering-herd guard), and all share one backend.
+        let provider = CountingProvider::with_delay(true, Duration::from_millis(50));
+        let mux =
+            Arc::new(Multiplexer::new("wasi", "keyvalue", "test").with_provider(provider.clone()));
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let mux = mux.clone();
+            handles.push(tokio::spawn(async move {
+                mux.instantiate(&url_iface("redis://x")).await.unwrap()
+            }));
+        }
+        let mut backends = Vec::new();
+        for h in handles {
+            backends.push(h.await.unwrap());
+        }
+        for b in &backends {
+            assert!(Arc::ptr_eq(b, &backends[0]), "all binds share one backend");
+        }
+        assert_eq!(
+            provider.count.load(SeqCst),
+            1,
+            "concurrent binds for one key must instantiate exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn pool_evicts_lru_over_connection_limit() {
+        let provider = CountingProvider::new(true);
+        let mux = Multiplexer::new("wasi", "keyvalue", "test")
+            .with_provider(provider.clone())
+            .with_max_connections(2);
+
+        let _a = mux.instantiate(&url_iface("redis://a")).await.unwrap();
+        let _b = mux.instantiate(&url_iface("redis://b")).await.unwrap();
+        // Third distinct connection evicts the LRU entry — `a`, the oldest.
+        let _c = mux.instantiate(&url_iface("redis://c")).await.unwrap();
+        assert_eq!(mux.pool_len().await, 2, "pool must stay within the limit");
+        assert_eq!(
+            provider.count.load(SeqCst),
+            3,
+            "three distinct backends so far"
+        );
+
+        // `b` and `c` survived (only the LRU `a` was evicted): re-resolving them
+        // is a cache hit, so it does NOT re-instantiate.
+        let _b2 = mux.instantiate(&url_iface("redis://b")).await.unwrap();
+        let _c2 = mux.instantiate(&url_iface("redis://c")).await.unwrap();
+        assert_eq!(
+            provider.count.load(SeqCst),
+            3,
+            "b and c are cache hits, not re-instantiated — so a was the evicted one"
+        );
+
+        // `a` was the evicted entry, so re-resolving it instantiates afresh.
+        let _a2 = mux.instantiate(&url_iface("redis://a")).await.unwrap();
+        assert_eq!(
+            provider.count.load(SeqCst),
+            4,
+            "evicted 'a' re-instantiates"
+        );
+    }
+
+    #[tokio::test]
+    async fn pool_limits_are_per_backend_type() {
+        // Two backend types share one multiplexer; "test" is capped at 1 while
+        // "other" uses the default. Each type's pool is bounded independently.
+        let mux = Multiplexer::new("wasi", "keyvalue", "test")
+            .with_provider(CountingProvider::typed("test", true, Duration::ZERO))
+            .with_provider(CountingProvider::typed("other", true, Duration::ZERO))
+            .with_max_connections(10)
+            .with_max_connections_for("test", 1);
+
+        // Two distinct "test" connections -> capped at 1 (LRU evicts the first).
+        let _ta = mux.instantiate(&iface("test", "redis://a")).await.unwrap();
+        let _tb = mux.instantiate(&iface("test", "redis://b")).await.unwrap();
+        // Two "other" connections -> not affected by the "test" cap.
+        let _oa = mux.instantiate(&iface("other", "nats://a")).await.unwrap();
+        let _ob = mux.instantiate(&iface("other", "nats://b")).await.unwrap();
+
+        assert_eq!(
+            mux.pool_count_for("test").await,
+            1,
+            "'test' backend capped at 1"
+        );
+        assert_eq!(
+            mux.pool_count_for("other").await,
+            2,
+            "'other' backend uses the default cap, unaffected by the 'test' override"
+        );
+    }
+
+    #[tokio::test]
+    async fn pool_reaps_idle_entries() {
+        let provider = CountingProvider::new(true);
+        let mux = Multiplexer::new("wasi", "keyvalue", "test")
+            .with_provider(provider.clone())
+            .with_idle_ttl(Duration::from_millis(20));
+
+        let _a = mux.instantiate(&url_iface("redis://a")).await.unwrap();
+        assert_eq!(mux.pool_len().await, 1);
+
+        // After the TTL the idle entry is reaped — by the background reaper
+        // and/or opportunistically on the next bind.
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        let _b = mux.instantiate(&url_iface("redis://b")).await.unwrap();
+        assert_eq!(mux.pool_len().await, 1, "idle 'a' should have been reaped");
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
@@ -1,19 +1,21 @@
 #![deny(clippy::all)]
-//! # WASI KeyValue Memory Plugin
+//! # WASI KeyValue Filesystem Plugin
 //!
-//! This module implements `wasi:keyvalue@0.2.0-draft` interfaces using
-//! Filesystem  as the backend storage.
+//! Implements `wasi:keyvalue@0.2.0-draft` over the local filesystem. The actual
+//! storage lives in the shared [`FsKvStore`](super::fs_store::FsKvStore) — this
+//! module is the host-binding adapter (the unnamed/default `wasi:keyvalue`
+//! instance); the multiplexed `FilesystemBackend` is the other adapter.
 
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 const PLUGIN_KEYVALUE_ID: &str = "wasi-keyvalue";
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
-use crate::plugin::{HostPlugin, WitInterfaces, lock_root};
+use crate::plugin::wasi_keyvalue::fs_store::{FsKvError, FsKvStore};
+use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
-use futures::StreamExt;
 use tracing::instrument;
 use wasmtime::component::Resource;
 
@@ -31,15 +33,26 @@ mod bindings {
 
 use bindings::wasi::keyvalue::store::{Error as StoreError, KeyResponse};
 
-/// Resource representation for a bucket (key-value store)
-pub struct BucketHandle {
-    root: PathBuf,
+/// Map a shared-store error to the WIT `store::Error`.
+fn to_store_error(e: FsKvError) -> StoreError {
+    match e {
+        FsKvError::InvalidIdentifier => {
+            StoreError::Other("invalid keyvalue identifier".to_string())
+        }
+        FsKvError::Io(e) => StoreError::Other(format!("Filesystem error: {e}")),
+    }
 }
 
-/// Filesystem-based keyvalue plugin
+/// Resource representation for a bucket: its identifier (a subdirectory of the
+/// store root, resolved per-op by [`FsKvStore`]).
+pub struct BucketHandle {
+    id: String,
+}
+
+/// Filesystem-based keyvalue plugin.
 #[derive(Clone)]
 pub struct FilesystemKeyValue {
-    root: PathBuf,
+    store: FsKvStore,
     metrics: Arc<WasiKeyvalueMetrics>,
 }
 
@@ -62,7 +75,7 @@ impl FilesystemKeyValue {
         let meter = opentelemetry::global::meter("wasi-keyvalue");
         let metrics = WasiKeyvalueMetrics::new(&meter);
         Self {
-            root: root.as_ref().to_path_buf(),
+            store: FsKvStore::new(root),
             metrics: Arc::new(metrics),
         }
     }
@@ -84,24 +97,13 @@ impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
         identifier: String,
     ) -> wasmtime::Result<Result<Resource<BucketHandle>, StoreError>> {
         let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
-
         plugin.record_operation("open");
 
-        let Ok(path) = lock_root(&plugin.root, &identifier) else {
-            return Ok(Err(StoreError::Other(
-                "invalid bucket identifier".to_string(),
-            )));
-        };
-
-        if std::fs::create_dir_all(&path).is_err() {
-            return Ok(Err(StoreError::Other(
-                "failed to create bucket directory".to_string(),
-            )));
+        if let Err(e) = plugin.store.create_bucket(&identifier).await {
+            return Ok(Err(to_store_error(e)));
         }
 
-        let bucket = BucketHandle { root: path };
-
-        let resource = self.table.push(bucket)?;
+        let resource = self.table.push(BucketHandle { id: identifier })?;
         Ok(Ok(resource))
     }
 }
@@ -115,23 +117,10 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         key: String,
     ) -> wasmtime::Result<Result<Option<Vec<u8>>, StoreError>> {
         let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
-
         plugin.record_operation("get");
 
-        let bucket_handle = self.table.get(&bucket)?;
-        let Ok(path) = lock_root(&bucket_handle.root, &key) else {
-            return Ok(Err(StoreError::Other("invalid key identifier".to_string())));
-        };
-
-        let entry = match tokio::fs::read(path).await {
-            Ok(entry) => Some(entry.to_vec()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
-            Err(e) => {
-                return Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))));
-            }
-        };
-
-        Ok(Ok(entry))
+        let id = self.table.get(&bucket)?.id.clone();
+        Ok(plugin.store.get(&id, &key).await.map_err(to_store_error))
     }
 
     #[instrument(name = "wasi.keyvalue.set", skip(self, bucket, value))]
@@ -142,22 +131,14 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         value: Vec<u8>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
         let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
-
         plugin.record_operation("set");
 
-        let bucket_handle = self.table.get(&bucket)?;
-
-        let Ok(path) = lock_root(&bucket_handle.root, &key) else {
-            return Ok(Err(StoreError::Other("invalid key identifier".to_string())));
-        };
-
-        match tokio::fs::write(path, value).await {
-            Ok(_) => Ok(Ok(())),
-            Err(e) => {
-                tracing::error!("Filesystem error setting key: {}", e);
-                Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))))
-            }
-        }
+        let id = self.table.get(&bucket)?.id.clone();
+        Ok(plugin
+            .store
+            .set(&id, &key, &value)
+            .await
+            .map_err(to_store_error))
     }
 
     #[instrument(name = "wasi.keyvalue.delete", skip(self, bucket))]
@@ -167,21 +148,10 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         key: String,
     ) -> wasmtime::Result<Result<(), StoreError>> {
         let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
-
         plugin.record_operation("delete");
 
-        let bucket_handle = self.table.get(&bucket)?;
-        let Ok(path) = lock_root(&bucket_handle.root, &key) else {
-            return Ok(Err(StoreError::Other("invalid key identifier".to_string())));
-        };
-
-        match tokio::fs::remove_file(path).await {
-            Ok(_) => Ok(Ok(())),
-            Err(e) => {
-                tracing::error!("Filesystem error deleting key: {}", e);
-                Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))))
-            }
-        }
+        let id = self.table.get(&bucket)?.id.clone();
+        Ok(plugin.store.delete(&id, &key).await.map_err(to_store_error))
     }
 
     #[instrument(name = "wasi.keyvalue.exists", skip(self, bucket))]
@@ -191,21 +161,10 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         key: String,
     ) -> wasmtime::Result<Result<bool, StoreError>> {
         let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
-
         plugin.record_operation("exists");
 
-        let bucket_handle = self.table.get(&bucket)?;
-
-        let Ok(path) = lock_root(&bucket_handle.root, &key) else {
-            return Ok(Err(StoreError::Other("invalid key identifier".to_string())));
-        };
-
-        // directories are not valid keys
-        if path.is_dir() {
-            return Ok(Ok(false));
-        }
-
-        Ok(Ok(path.exists()))
+        let id = self.table.get(&bucket)?.id.clone();
+        Ok(plugin.store.exists(&id, &key).await.map_err(to_store_error))
     }
 
     #[instrument(name = "wasi.keyvalue.list_keys", skip(self, bucket))]
@@ -215,45 +174,17 @@ impl<'a> bindings::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
         cursor: Option<u64>,
     ) -> wasmtime::Result<Result<KeyResponse, StoreError>> {
         let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
-
         plugin.record_operation("list_keys");
 
-        let bucket_handle = self.table.get(&bucket)?;
-
-        let mut keys_iter = match tokio::fs::read_dir(&bucket_handle.root).await {
-            Ok(i) => i,
-            Err(e) => {
-                tracing::error!("Filesystem error getting key: {}", e);
-                return Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))));
-            }
-        };
-
-        let mut resp = KeyResponse {
-            keys: vec![],
-            cursor: None,
-        };
-
-        let cursor_skip = cursor.unwrap_or(0) as usize;
-        let mut cursor_done = cursor_skip;
-
-        while let Ok(Some(key)) = keys_iter.next_entry().await {
-            // skip keys until we reach the cursor
-            if cursor_done != 0 {
-                cursor_done -= 1;
-                continue;
-            }
-
-            // if we have reached the batch size, set the cursor and break
-            if resp.keys.len() >= LIST_KEYS_BATCH_SIZE {
-                resp.cursor = Some(cursor_skip as u64 + LIST_KEYS_BATCH_SIZE as u64);
-                break;
-            }
-
-            resp.keys
-                .push(key.file_name().to_string_lossy().to_string());
+        let id = self.table.get(&bucket)?.id.clone();
+        match plugin
+            .store
+            .list_keys(&id, cursor, LIST_KEYS_BATCH_SIZE)
+            .await
+        {
+            Ok((keys, cursor)) => Ok(Ok(KeyResponse { keys, cursor })),
+            Err(e) => Ok(Err(to_store_error(e))),
         }
-
-        Ok(Ok(resp))
     }
 
     async fn drop(&mut self, rep: Resource<BucketHandle>) -> wasmtime::Result<()> {
@@ -277,32 +208,14 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
         delta: u64,
     ) -> wasmtime::Result<Result<u64, StoreError>> {
         let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
-
         plugin.record_operation("increment");
 
-        let bucket_handle = self.table.get(&bucket)?;
-        let Ok(path) = lock_root(&bucket_handle.root, &key) else {
-            return Ok(Err(StoreError::Other("invalid key identifier".to_string())));
-        };
-
-        let current_value = match tokio::fs::read_to_string(&path).await {
-            Ok(entry) => entry.trim().parse::<u64>().unwrap_or(0),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
-            Err(e) => {
-                tracing::error!("Filesystem error getting key entry: {}", e);
-                return Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))));
-            }
-        };
-
-        let new_value = current_value + delta;
-
-        match tokio::fs::write(&path, new_value.to_string()).await {
-            Ok(_) => Ok(Ok(new_value)),
-            Err(e) => {
-                tracing::error!("Filesystem error putting key: {}", e);
-                Ok(Err(StoreError::Other(format!("Filesystem error: {e}"))))
-            }
-        }
+        let id = self.table.get(&bucket)?.id.clone();
+        Ok(plugin
+            .store
+            .increment(&id, &key, delta)
+            .await
+            .map_err(to_store_error))
     }
 }
 
@@ -316,36 +229,16 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         keys: Vec<String>,
     ) -> wasmtime::Result<Result<Vec<Option<(String, Vec<u8>)>>, StoreError>> {
         let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
-
         plugin.record_operation("get_many");
 
-        let bucket_handle = self.table.get(&bucket)?;
-
-        let values = futures::stream::FuturesOrdered::from_iter(keys.iter().map(|key| async {
-            let Ok(path) = lock_root(&bucket_handle.root, key) else {
-                return Err(StoreError::Other("invalid key identifier".to_string()));
-            };
-            match tokio::fs::read(path).await {
-                Ok(entry) => Ok(Some((key.clone(), entry.to_vec()))),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-                Err(e) => {
-                    tracing::error!("JetStream error getting key: {}", e);
-                    Err(StoreError::Other(format!("JetStream error: {e}")))
-                }
-            }
-        }))
-        .collect::<Vec<_>>()
-        .await;
-
-        // Remove the outer Result, propagate the first error if any
-        let mut result = Vec::with_capacity(values.len());
-        for entry in values {
-            match entry {
-                Ok(v) => result.push(v),
-                Err(e) => return Ok(Err(e)),
+        let id = self.table.get(&bucket)?.id.clone();
+        let mut result = Vec::with_capacity(keys.len());
+        for key in keys {
+            match plugin.store.get(&id, &key).await {
+                Ok(value) => result.push(value.map(|v| (key, v))),
+                Err(e) => return Ok(Err(to_store_error(e))),
             }
         }
-
         Ok(Ok(result))
     }
 
@@ -356,35 +249,14 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         key_values: Vec<(String, Vec<u8>)>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
         let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
-
         plugin.record_operation("set_many");
 
-        let bucket_handle = self.table.get(&bucket)?;
-
-        let values = futures::stream::FuturesOrdered::from_iter(key_values.iter().map(
-            |(key, value)| async {
-                let Ok(path) = lock_root(&bucket_handle.root, key) else {
-                    return Err(StoreError::Other("invalid key identifier".to_string()));
-                };
-                match tokio::fs::write(path, value.to_vec()).await {
-                    Ok(_) => Ok(()),
-                    Err(e) => {
-                        tracing::error!("JetStream error putting key: {}", e);
-                        Err(StoreError::Other(format!("JetStream error: {e}")))
-                    }
-                }
-            },
-        ))
-        .collect::<Vec<_>>()
-        .await;
-
-        // Remove the outer Result, propagate the first error if any
-        for entry in values {
-            if let Err(e) = entry {
-                return Ok(Err(e));
+        let id = self.table.get(&bucket)?.id.clone();
+        for (key, value) in key_values {
+            if let Err(e) = plugin.store.set(&id, &key, &value).await {
+                return Ok(Err(to_store_error(e)));
             }
         }
-
         Ok(Ok(()))
     }
 
@@ -395,33 +267,14 @@ impl<'a> bindings::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
         keys: Vec<String>,
     ) -> wasmtime::Result<Result<(), StoreError>> {
         let plugin = self.try_get_plugin::<FilesystemKeyValue>(PLUGIN_KEYVALUE_ID)?;
-
         plugin.record_operation("delete_many");
 
-        let bucket_handle = self.table.get(&bucket)?;
-
-        let values = futures::stream::FuturesOrdered::from_iter(keys.iter().map(|key| async {
-            let Ok(path) = lock_root(&bucket_handle.root, key) else {
-                return Err(StoreError::Other("invalid key identifier".to_string()));
-            };
-            match tokio::fs::remove_file(path).await {
-                Ok(_) => Ok(()),
-                Err(e) => {
-                    tracing::error!("JetStream error deleting key: {}", e);
-                    Err(StoreError::Other(format!("JetStream error: {e}")))
-                }
-            }
-        }))
-        .collect::<Vec<_>>()
-        .await;
-
-        // Remove the outer Result, propagate the first error if any
-        for entry in values {
-            if let Err(e) = entry {
-                return Ok(Err(e));
+        let id = self.table.get(&bucket)?.id.clone();
+        for key in keys {
+            if let Err(e) = plugin.store.delete(&id, &key).await {
+                return Ok(Err(to_store_error(e)));
             }
         }
-
         Ok(Ok(()))
     }
 }

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/fs_store.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/fs_store.rs
@@ -1,0 +1,146 @@
+//! Shared filesystem-backed key-value storage.
+//!
+//! Buckets are subdirectories of a `root`; keys are files within them.
+//! Path traversal is guarded by [`crate::plugin::lock_root`]. This is the single
+//! storage implementation used by both the standalone [`FilesystemKeyValue`]
+//! plugin (the unnamed/default `wasi:keyvalue` instance) and the multiplexed
+//! [`FilesystemBackend`] (an `(implements ..)` named route) — each is a thin
+//! adapter that maps [`FsKvError`] to its own interface error type.
+//!
+//! [`FilesystemKeyValue`]: super::filesystem::FilesystemKeyValue
+//! [`FilesystemBackend`]: super::multiplexed::FilesystemBackend
+
+use std::path::{Path, PathBuf};
+
+use crate::plugin::lock_root;
+
+/// An error from the shared filesystem key-value store. Adapters map this to
+/// their own (`wasi:keyvalue/store`) error type.
+pub(crate) enum FsKvError {
+    /// A bucket or key identifier failed path-traversal validation.
+    InvalidIdentifier,
+    /// An underlying filesystem I/O error.
+    Io(std::io::Error),
+}
+
+/// Filesystem key-value storage rooted at a directory.
+#[derive(Clone)]
+pub(crate) struct FsKvStore {
+    root: PathBuf,
+}
+
+impl FsKvStore {
+    pub(crate) fn new(root: impl AsRef<Path>) -> Self {
+        Self {
+            root: root.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Resolve (and traversal-check) a bucket's directory under `root`.
+    fn bucket_root(&self, bucket: &str) -> Result<PathBuf, FsKvError> {
+        lock_root(&self.root, bucket).map_err(|_| FsKvError::InvalidIdentifier)
+    }
+
+    /// Resolve (and traversal-check) a key's file under its bucket directory.
+    fn key_path(&self, bucket: &str, key: &str) -> Result<PathBuf, FsKvError> {
+        lock_root(self.bucket_root(bucket)?, key).map_err(|_| FsKvError::InvalidIdentifier)
+    }
+
+    /// Create the bucket directory (idempotent); also validates the identifier.
+    pub(crate) async fn create_bucket(&self, bucket: &str) -> Result<(), FsKvError> {
+        let root = self.bucket_root(bucket)?;
+        tokio::fs::create_dir_all(&root)
+            .await
+            .map_err(FsKvError::Io)
+    }
+
+    pub(crate) async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, FsKvError> {
+        let path = self.key_path(bucket, key)?;
+        match tokio::fs::read(path).await {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(FsKvError::Io(e)),
+        }
+    }
+
+    pub(crate) async fn set(&self, bucket: &str, key: &str, value: &[u8]) -> Result<(), FsKvError> {
+        let path = self.key_path(bucket, key)?;
+        tokio::fs::write(path, value).await.map_err(FsKvError::Io)
+    }
+
+    /// Delete a key. A missing key is a no-op (success).
+    pub(crate) async fn delete(&self, bucket: &str, key: &str) -> Result<(), FsKvError> {
+        let path = self.key_path(bucket, key)?;
+        match tokio::fs::remove_file(path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(FsKvError::Io(e)),
+        }
+    }
+
+    pub(crate) async fn exists(&self, bucket: &str, key: &str) -> Result<bool, FsKvError> {
+        let path = self.key_path(bucket, key)?;
+        match tokio::fs::metadata(&path).await {
+            // Directories are buckets, not keys.
+            Ok(meta) => Ok(!meta.is_dir()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(FsKvError::Io(e)),
+        }
+    }
+
+    /// List up to `batch` key names starting at `cursor`, returning the names
+    /// and the next cursor (`Some` if more remain). A missing bucket directory
+    /// yields an empty page.
+    pub(crate) async fn list_keys(
+        &self,
+        bucket: &str,
+        cursor: Option<u64>,
+        batch: usize,
+    ) -> Result<(Vec<String>, Option<u64>), FsKvError> {
+        let root = self.bucket_root(bucket)?;
+        let mut entries = match tokio::fs::read_dir(&root).await {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok((vec![], None)),
+            Err(e) => return Err(FsKvError::Io(e)),
+        };
+
+        let skip = cursor.unwrap_or(0) as usize;
+        let mut remaining_skip = skip;
+        let mut keys = Vec::new();
+        let mut next_cursor = None;
+        while let Some(entry) = entries.next_entry().await.map_err(FsKvError::Io)? {
+            if remaining_skip != 0 {
+                remaining_skip -= 1;
+                continue;
+            }
+            if keys.len() >= batch {
+                next_cursor = Some(skip as u64 + batch as u64);
+                break;
+            }
+            keys.push(entry.file_name().to_string_lossy().to_string());
+        }
+        Ok((keys, next_cursor))
+    }
+
+    /// Atomically-ish increment a decimal counter stored as a string. A missing
+    /// or unparseable value is treated as 0; the result is saturating so an
+    /// overflow can't panic-trap a guest.
+    pub(crate) async fn increment(
+        &self,
+        bucket: &str,
+        key: &str,
+        delta: u64,
+    ) -> Result<u64, FsKvError> {
+        let path = self.key_path(bucket, key)?;
+        let current = match tokio::fs::read_to_string(&path).await {
+            Ok(s) => s.trim().parse::<u64>().unwrap_or(0),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(e) => return Err(FsKvError::Io(e)),
+        };
+        let next = current.saturating_add(delta);
+        tokio::fs::write(&path, next.to_string())
+            .await
+            .map_err(FsKvError::Io)?;
+        Ok(next)
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/mod.rs
@@ -1,9 +1,18 @@
 mod filesystem;
+mod fs_store;
 mod in_memory;
+#[cfg(feature = "wasm_component_model_implements")]
+mod multiplexed;
 mod nats;
 mod redis;
 
 pub use filesystem::FilesystemKeyValue;
 pub use in_memory::InMemoryKeyValue;
+#[cfg(feature = "wasm_component_model_implements")]
+pub use multiplexed::{
+    FilesystemBackend, FilesystemProvider, InMemoryBackend, InMemoryProvider, KeyResponse,
+    KvBackend, KvId, KvProvider, MultiplexedKeyValue, NatsBackend, NatsProvider, RedisBackend,
+    RedisProvider, StoreError,
+};
 pub use nats::NatsKeyValue;
 pub use redis::RedisKeyValue;

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed.rs
@@ -1,0 +1,940 @@
+//! # Multiplexed WASI KeyValue (implements-routed)
+//!
+//! Binds `wasi:keyvalue` via the component-model `(implements ..)` /
+//! `named_imports` mechanism so a single component can import the same
+//! interface multiple times and have each import backed by a *different*
+//! backend (e.g. one `wasi:keyvalue/store` import backed by redis and another
+//! by NATS).
+//!
+//! Each named import is resolved by a `lookup` closure to a [`KvBackend`]
+//! (the wasmtime "implements id"); the embedder-chosen id is threaded into
+//! every host method, including the `bucket` resource methods.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use bytes::{Buf, Bytes};
+use futures::stream::{FuturesOrdered, StreamExt};
+use redis::AsyncCommands;
+use tokio::sync::RwLock;
+use wasmtime::component::Resource;
+
+use crate::engine::ctx::{SharedCtx, extract_active_ctx};
+use crate::engine::workload::WorkloadItem;
+use crate::plugin::multiplex::{BackendProvider, Multiplexer};
+use crate::plugin::{HostPlugin, WitInterfaces};
+use crate::wit::{WitInterface, WitWorld};
+
+mod bindings {
+    wasmtime::component::bindgen!({
+        world: "keyvalue",
+        imports: { default: async | trappable | tracing },
+        named_imports: {
+            "wasi:keyvalue/store": super::KvId,
+            "wasi:keyvalue/atomics": super::KvId,
+            "wasi:keyvalue/batch": super::KvId,
+        },
+        with: {
+            "wasi:keyvalue/store.bucket": super::KvBucket,
+        },
+    });
+}
+
+pub use bindings::wasi::keyvalue::store::{Error as StoreError, KeyResponse};
+
+/// The "implements id" threaded through every keyvalue host method: the backend
+/// a given named import is bound to. `Arc` so it is cheaply `Clone`d into each
+/// per-import closure, as `named_imports` requires.
+pub type KvId = Arc<dyn KvBackend>;
+
+/// A bucket resource. It remembers which backend it was opened through so that
+/// every subsequent operation (get/set/atomics/batch) routes to that backend,
+/// regardless of which interface the call arrived on.
+pub struct KvBucket {
+    backend: KvId,
+    /// The bucket identifier passed to `store.open`.
+    name: String,
+}
+
+/// A keyvalue backend (redis, NATS, in-memory, ...). Operations are keyed by
+/// the opened bucket `name` plus the per-call key(s); the backend owns its own
+/// connection/state. This is the unified surface that the per-interface host
+/// trait impls below dispatch onto.
+#[async_trait::async_trait]
+pub trait KvBackend: Send + Sync {
+    /// Validate/create the bucket named `identifier`. Called from `store.open`.
+    async fn open(&self, identifier: &str) -> Result<(), StoreError>;
+    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError>;
+    async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError>;
+    async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError>;
+    async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError>;
+    async fn list_keys(&self, bucket: &str, cursor: Option<u64>)
+    -> Result<KeyResponse, StoreError>;
+    async fn increment(&self, bucket: &str, key: &str, delta: u64) -> Result<u64, StoreError>;
+    #[allow(clippy::type_complexity)]
+    async fn get_many(
+        &self,
+        bucket: &str,
+        keys: Vec<String>,
+    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError>;
+    async fn set_many(
+        &self,
+        bucket: &str,
+        key_values: Vec<(String, Vec<u8>)>,
+    ) -> Result<(), StoreError>;
+    async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError>;
+}
+
+use crate::engine::ctx::ActiveCtx;
+
+// ---- store interface -------------------------------------------------------
+
+impl<'a> bindings::named_imports::wasi::keyvalue::store::Host for ActiveCtx<'a> {
+    async fn open(
+        &mut self,
+        id: KvId,
+        identifier: String,
+    ) -> wasmtime::Result<Result<Resource<KvBucket>, StoreError>> {
+        if let Err(e) = id.open(&identifier).await {
+            return Ok(Err(e));
+        }
+        let bucket = KvBucket {
+            backend: id,
+            name: identifier,
+        };
+        Ok(Ok(self.table.push(bucket)?))
+    }
+}
+
+impl<'a> bindings::named_imports::wasi::keyvalue::store::HostBucket for ActiveCtx<'a> {
+    async fn get(
+        &mut self,
+        _id: KvId,
+        bucket: Resource<KvBucket>,
+        key: String,
+    ) -> wasmtime::Result<Result<Option<Vec<u8>>, StoreError>> {
+        let b = self.table.get(&bucket)?;
+        Ok(b.backend.get(&b.name, &key).await)
+    }
+
+    async fn set(
+        &mut self,
+        _id: KvId,
+        bucket: Resource<KvBucket>,
+        key: String,
+        value: Vec<u8>,
+    ) -> wasmtime::Result<Result<(), StoreError>> {
+        let b = self.table.get(&bucket)?;
+        Ok(b.backend.set(&b.name, &key, value).await)
+    }
+
+    async fn delete(
+        &mut self,
+        _id: KvId,
+        bucket: Resource<KvBucket>,
+        key: String,
+    ) -> wasmtime::Result<Result<(), StoreError>> {
+        let b = self.table.get(&bucket)?;
+        Ok(b.backend.delete(&b.name, &key).await)
+    }
+
+    async fn exists(
+        &mut self,
+        _id: KvId,
+        bucket: Resource<KvBucket>,
+        key: String,
+    ) -> wasmtime::Result<Result<bool, StoreError>> {
+        let b = self.table.get(&bucket)?;
+        Ok(b.backend.exists(&b.name, &key).await)
+    }
+
+    async fn list_keys(
+        &mut self,
+        _id: KvId,
+        bucket: Resource<KvBucket>,
+        cursor: Option<u64>,
+    ) -> wasmtime::Result<Result<KeyResponse, StoreError>> {
+        let b = self.table.get(&bucket)?;
+        Ok(b.backend.list_keys(&b.name, cursor).await)
+    }
+
+    async fn drop(&mut self, _id: KvId, rep: Resource<KvBucket>) -> wasmtime::Result<()> {
+        self.table.delete(rep)?;
+        Ok(())
+    }
+}
+
+// ---- atomics interface -----------------------------------------------------
+
+impl<'a> bindings::named_imports::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
+    async fn increment(
+        &mut self,
+        _id: KvId,
+        bucket: Resource<KvBucket>,
+        key: String,
+        delta: u64,
+    ) -> wasmtime::Result<Result<u64, StoreError>> {
+        let b = self.table.get(&bucket)?;
+        Ok(b.backend.increment(&b.name, &key, delta).await)
+    }
+}
+
+// ---- batch interface -------------------------------------------------------
+
+impl<'a> bindings::named_imports::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
+    #[allow(clippy::type_complexity)]
+    async fn get_many(
+        &mut self,
+        _id: KvId,
+        bucket: Resource<KvBucket>,
+        keys: Vec<String>,
+    ) -> wasmtime::Result<Result<Vec<Option<(String, Vec<u8>)>>, StoreError>> {
+        let b = self.table.get(&bucket)?;
+        Ok(b.backend.get_many(&b.name, keys).await)
+    }
+
+    async fn set_many(
+        &mut self,
+        _id: KvId,
+        bucket: Resource<KvBucket>,
+        key_values: Vec<(String, Vec<u8>)>,
+    ) -> wasmtime::Result<Result<(), StoreError>> {
+        let b = self.table.get(&bucket)?;
+        Ok(b.backend.set_many(&b.name, key_values).await)
+    }
+
+    async fn delete_many(
+        &mut self,
+        _id: KvId,
+        bucket: Resource<KvBucket>,
+        keys: Vec<String>,
+    ) -> wasmtime::Result<Result<(), StoreError>> {
+        let b = self.table.get(&bucket)?;
+        Ok(b.backend.delete_many(&b.name, keys).await)
+    }
+}
+
+// ---- in-memory backend (reference impl; no external infra) -----------------
+
+/// An in-memory [`KvBackend`], used to prove the routing mechanism and for
+/// tests. Each instance is an isolated store, so two named imports backed by
+/// two `InMemoryBackend`s do not share data.
+#[derive(Default)]
+pub struct InMemoryBackend {
+    buckets: RwLock<HashMap<String, HashMap<String, Vec<u8>>>>,
+}
+
+impl InMemoryBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn missing(bucket: &str) -> StoreError {
+        StoreError::Other(format!("bucket '{bucket}' does not exist"))
+    }
+}
+
+#[async_trait::async_trait]
+impl KvBackend for InMemoryBackend {
+    async fn open(&self, identifier: &str) -> Result<(), StoreError> {
+        self.buckets
+            .write()
+            .await
+            .entry(identifier.to_string())
+            .or_default();
+        Ok(())
+    }
+
+    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        let store = self.buckets.read().await;
+        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        Ok(b.get(key).cloned())
+    }
+
+    async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        b.insert(key.to_string(), value);
+        Ok(())
+    }
+
+    async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        b.remove(key);
+        Ok(())
+    }
+
+    async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
+        let store = self.buckets.read().await;
+        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        Ok(b.contains_key(key))
+    }
+
+    async fn list_keys(
+        &self,
+        bucket: &str,
+        cursor: Option<u64>,
+    ) -> Result<KeyResponse, StoreError> {
+        const PAGE_SIZE: usize = 100;
+        let store = self.buckets.read().await;
+        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let mut keys: Vec<String> = b.keys().cloned().collect();
+        keys.sort();
+        let start = cursor.unwrap_or(0) as usize;
+        let end = std::cmp::min(start + PAGE_SIZE, keys.len());
+        let page = keys.get(start..end).unwrap_or_default().to_vec();
+        let next = (end < keys.len()).then_some(end as u64);
+        Ok(KeyResponse {
+            keys: page,
+            cursor: next,
+        })
+    }
+
+    async fn increment(&self, bucket: &str, key: &str, delta: u64) -> Result<u64, StoreError> {
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let current = match b.get(key) {
+            Some(bytes) if bytes.len() == 8 => {
+                // len checked == 8 by the guard, so copy into a fixed array
+                // without a fallible conversion (the lib denies unwrap/expect).
+                let mut arr = [0u8; 8];
+                arr.copy_from_slice(bytes);
+                u64::from_le_bytes(arr)
+            }
+            Some(bytes) => String::from_utf8_lossy(bytes).parse::<u64>().unwrap_or(0),
+            None => 0,
+        };
+        let next = current.saturating_add(delta);
+        b.insert(key.to_string(), next.to_le_bytes().to_vec());
+        Ok(next)
+    }
+
+    async fn get_many(
+        &self,
+        bucket: &str,
+        keys: Vec<String>,
+    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
+        let store = self.buckets.read().await;
+        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        Ok(keys
+            .into_iter()
+            .map(|k| b.get(&k).cloned().map(|v| (k, v)))
+            .collect())
+    }
+
+    async fn set_many(
+        &self,
+        bucket: &str,
+        key_values: Vec<(String, Vec<u8>)>,
+    ) -> Result<(), StoreError> {
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        for (k, v) in key_values {
+            b.insert(k, v);
+        }
+        Ok(())
+    }
+
+    async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        for k in keys {
+            b.remove(&k);
+        }
+        Ok(())
+    }
+}
+
+// ---- providers + plugin ----------------------------------------------------
+
+const DEFAULT_BACKEND: &str = "in-memory";
+const MULTIPLEXED_KEYVALUE_ID: &str = "wasi-keyvalue-multiplexed";
+
+/// A keyvalue backend provider: a [`BackendProvider`] producing [`KvId`]s.
+pub type KvProvider = dyn BackendProvider<KvId>;
+
+/// In-memory provider. Each named interface gets its own isolated store.
+#[derive(Default)]
+pub struct InMemoryProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<KvId> for InMemoryProvider {
+    fn backend_type(&self) -> &'static str {
+        DEFAULT_BACKEND
+    }
+
+    async fn instantiate(&self, _config: &HashMap<String, String>) -> anyhow::Result<KvId> {
+        Ok(Arc::new(InMemoryBackend::new()))
+    }
+}
+
+// ---- redis backend ---------------------------------------------------------
+
+const LIST_KEYS_BATCH_SIZE: usize = 1000;
+
+/// A redis-backed [`KvBackend`]. The bucket identifier is used as a key prefix
+/// (`{bucket}:{key}`). Holds a shared multiplexed connection (pooled per url by
+/// the provider).
+pub struct RedisBackend {
+    conn: redis::aio::MultiplexedConnection,
+}
+
+impl RedisBackend {
+    fn prefixed(bucket: &str, key: &str) -> String {
+        format!("{bucket}:{key}")
+    }
+
+    fn err(e: impl std::fmt::Display) -> StoreError {
+        StoreError::Other(format!("Redis error: {e}"))
+    }
+}
+
+#[async_trait::async_trait]
+impl KvBackend for RedisBackend {
+    async fn open(&self, _identifier: &str) -> Result<(), StoreError> {
+        // Redis namespaces by key prefix; there is no bucket to create.
+        Ok(())
+    }
+
+    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        let mut conn = self.conn.clone();
+        conn.get::<_, Option<Vec<u8>>>(Self::prefixed(bucket, key))
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
+        let mut conn = self.conn.clone();
+        conn.set::<_, _, ()>(Self::prefixed(bucket, key), value)
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
+        let mut conn = self.conn.clone();
+        conn.del::<_, ()>(Self::prefixed(bucket, key))
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
+        let mut conn = self.conn.clone();
+        conn.exists::<_, bool>(Self::prefixed(bucket, key))
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn list_keys(
+        &self,
+        bucket: &str,
+        cursor: Option<u64>,
+    ) -> Result<KeyResponse, StoreError> {
+        let mut conn = self.conn.clone();
+        let pattern = Self::prefixed(bucket, "*");
+        let (next, raw): (u64, Vec<String>) = redis::cmd("SCAN")
+            .arg(cursor.unwrap_or(0))
+            .arg("MATCH")
+            .arg(&pattern)
+            .arg("COUNT")
+            .arg(LIST_KEYS_BATCH_SIZE)
+            .query_async(&mut conn)
+            .await
+            .map_err(Self::err)?;
+        let prefix = pattern.strip_suffix('*').unwrap_or("");
+        let keys = raw
+            .into_iter()
+            .filter_map(|k| k.strip_prefix(prefix).map(str::to_string))
+            .collect();
+        Ok(KeyResponse {
+            keys,
+            cursor: (next != 0).then_some(next),
+        })
+    }
+
+    async fn increment(&self, bucket: &str, key: &str, delta: u64) -> Result<u64, StoreError> {
+        let mut conn = self.conn.clone();
+        let delta = i64::try_from(delta)
+            .map_err(|_| StoreError::Other(format!("delta {delta} exceeds i64::MAX")))?;
+        conn.incr::<_, _, i64>(Self::prefixed(bucket, key), delta)
+            .await
+            .map(|v| v as u64)
+            .map_err(Self::err)
+    }
+
+    async fn get_many(
+        &self,
+        bucket: &str,
+        keys: Vec<String>,
+    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
+        if keys.is_empty() {
+            return Ok(vec![]);
+        }
+        let mut conn = self.conn.clone();
+        let redis_keys: Vec<String> = keys.iter().map(|k| Self::prefixed(bucket, k)).collect();
+        let values: Vec<Option<Vec<u8>>> =
+            conn.mget(redis_keys.as_slice()).await.map_err(Self::err)?;
+        Ok(keys
+            .into_iter()
+            .zip(values)
+            .map(|(k, v)| v.map(|v| (k, v)))
+            .collect())
+    }
+
+    async fn set_many(
+        &self,
+        bucket: &str,
+        key_values: Vec<(String, Vec<u8>)>,
+    ) -> Result<(), StoreError> {
+        if key_values.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn.clone();
+        let pairs: Vec<(String, Vec<u8>)> = key_values
+            .into_iter()
+            .map(|(k, v)| (Self::prefixed(bucket, &k), v))
+            .collect();
+        conn.mset::<_, _, ()>(pairs.as_slice())
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
+        if keys.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn.clone();
+        let redis_keys: Vec<String> = keys.iter().map(|k| Self::prefixed(bucket, k)).collect();
+        conn.del::<_, ()>(redis_keys.as_slice())
+            .await
+            .map_err(Self::err)
+    }
+}
+
+/// Provider for [`RedisBackend`], selected by `config.backend = "redis"`.
+/// Requires `config.url` (e.g. `redis://127.0.0.1:6379`).
+#[derive(Default)]
+pub struct RedisProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<KvId> for RedisProvider {
+    fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
+        config.get("url").cloned()
+    }
+    fn backend_type(&self) -> &'static str {
+        "redis"
+    }
+
+    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<KvId> {
+        let url = config
+            .get("url")
+            .ok_or_else(|| anyhow::anyhow!("redis keyvalue backend requires a 'url' config"))?;
+        let client = redis::Client::open(url.as_str())?;
+        let conn = client.get_multiplexed_async_connection().await?;
+        Ok(Arc::new(RedisBackend { conn }))
+    }
+}
+
+// ---- NATS JetStream backend ------------------------------------------------
+
+/// A NATS JetStream KV-backed [`KvBackend`]. Each bucket maps to a JetStream KV
+/// store (which must already exist); store handles are cached by name.
+pub struct NatsBackend {
+    context: Arc<async_nats::jetstream::Context>,
+    stores: RwLock<HashMap<String, async_nats::jetstream::kv::Store>>,
+}
+
+impl NatsBackend {
+    fn err(e: impl std::fmt::Display) -> StoreError {
+        StoreError::Other(format!("JetStream error: {e}"))
+    }
+
+    async fn store(&self, bucket: &str) -> Result<async_nats::jetstream::kv::Store, StoreError> {
+        if let Some(s) = self.stores.read().await.get(bucket) {
+            return Ok(s.clone());
+        }
+        let kv = self
+            .context
+            .get_key_value(bucket)
+            .await
+            .map_err(Self::err)?;
+        self.stores
+            .write()
+            .await
+            .insert(bucket.to_string(), kv.clone());
+        Ok(kv)
+    }
+}
+
+#[async_trait::async_trait]
+impl KvBackend for NatsBackend {
+    async fn open(&self, identifier: &str) -> Result<(), StoreError> {
+        self.store(identifier).await.map(|_| ())
+    }
+
+    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        let s = self.store(bucket).await?;
+        Ok(s.get(key).await.map_err(Self::err)?.map(|b| b.to_vec()))
+    }
+
+    async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
+        let s = self.store(bucket).await?;
+        s.put(key.to_string(), value.into())
+            .await
+            .map_err(Self::err)?;
+        Ok(())
+    }
+
+    async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
+        let s = self.store(bucket).await?;
+        s.delete(key).await.map_err(Self::err)?;
+        Ok(())
+    }
+
+    async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
+        let s = self.store(bucket).await?;
+        Ok(s.get(key).await.map_err(Self::err)?.is_some())
+    }
+
+    async fn list_keys(
+        &self,
+        bucket: &str,
+        cursor: Option<u64>,
+    ) -> Result<KeyResponse, StoreError> {
+        let s = self.store(bucket).await?;
+        let skip = cursor.unwrap_or(0) as usize;
+        let mut stream = s
+            .keys()
+            .await
+            .map_err(Self::err)?
+            .skip(skip)
+            .take(LIST_KEYS_BATCH_SIZE + 1)
+            .boxed();
+        let mut resp = KeyResponse {
+            keys: vec![],
+            cursor: None,
+        };
+        while let Some(Ok(key)) = stream.next().await {
+            if resp.keys.len() >= LIST_KEYS_BATCH_SIZE {
+                resp.cursor = Some(skip as u64 + LIST_KEYS_BATCH_SIZE as u64);
+                break;
+            }
+            resp.keys.push(key);
+        }
+        Ok(resp)
+    }
+
+    async fn increment(&self, bucket: &str, key: &str, delta: u64) -> Result<u64, StoreError> {
+        let s = self.store(bucket).await?;
+        // Optimistic CAS, matching the standalone NATS backend (big-endian u64).
+        let (revision, current) = match s.entry(key).await.map_err(Self::err)? {
+            // Read the counter as a big-endian u64, tolerating a malformed
+            // (non-8-byte) value as 0 rather than panicking: `Buf::get_u64`
+            // traps the guest if the value has fewer than 8 bytes.
+            Some(mut e) => {
+                let current = if e.value.len() >= 8 {
+                    e.value.get_u64()
+                } else {
+                    0
+                };
+                (Some(e.revision), current)
+            }
+            None => (None, 0),
+        };
+        // saturating, matching the in-memory/filesystem backends: a host-method
+        // panic on overflow would become a wasmtime trap.
+        let next = current.saturating_add(delta);
+        let bytes = Bytes::from(next.to_be_bytes().to_vec());
+        match revision {
+            Some(rev) => s.update(key, bytes, rev).await.map_err(Self::err)?,
+            None => s.put(key.to_string(), bytes).await.map_err(Self::err)?,
+        };
+        Ok(next)
+    }
+
+    async fn get_many(
+        &self,
+        bucket: &str,
+        keys: Vec<String>,
+    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
+        let s = self.store(bucket).await?;
+        FuturesOrdered::from_iter(keys.into_iter().map(|key| {
+            let s = s.clone();
+            async move {
+                Ok(s.get(&key)
+                    .await
+                    .map_err(Self::err)?
+                    .map(|b| (key, b.to_vec())))
+            }
+        }))
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect()
+    }
+
+    async fn set_many(
+        &self,
+        bucket: &str,
+        key_values: Vec<(String, Vec<u8>)>,
+    ) -> Result<(), StoreError> {
+        let s = self.store(bucket).await?;
+        FuturesOrdered::from_iter(key_values.into_iter().map(|(key, value)| {
+            let s = s.clone();
+            async move {
+                s.put(key, value.into())
+                    .await
+                    .map(|_| ())
+                    .map_err(Self::err)
+            }
+        }))
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect()
+    }
+
+    async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
+        let s = self.store(bucket).await?;
+        FuturesOrdered::from_iter(keys.into_iter().map(|key| {
+            let s = s.clone();
+            async move { s.delete(&key).await.map(|_| ()).map_err(Self::err) }
+        }))
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect()
+    }
+}
+
+/// Provider for [`NatsBackend`], selected by `config.backend = "nats"`. Requires
+/// `config.url` (e.g. `nats://127.0.0.1:4222`).
+#[derive(Default)]
+pub struct NatsProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<KvId> for NatsProvider {
+    fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
+        config.get("url").cloned()
+    }
+    fn backend_type(&self) -> &'static str {
+        "nats"
+    }
+
+    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<KvId> {
+        let url = config
+            .get("url")
+            .ok_or_else(|| anyhow::anyhow!("nats keyvalue backend requires a 'url' config"))?;
+        let client = async_nats::connect(url).await?;
+        let context = async_nats::jetstream::new(client);
+        Ok(Arc::new(NatsBackend {
+            context: Arc::new(context),
+            stores: RwLock::new(HashMap::new()),
+        }))
+    }
+}
+
+mod filesystem;
+pub use filesystem::{FilesystemBackend, FilesystemProvider};
+
+/// A keyvalue [`HostPlugin`] that multiplexes `wasi:keyvalue` across backends
+/// selected per `(implements ..)` import. Register the backend providers you
+/// want to support via [`MultiplexedKeyValue::with_provider`].
+pub struct MultiplexedKeyValue {
+    mux: Multiplexer<KvId>,
+}
+
+impl Default for MultiplexedKeyValue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MultiplexedKeyValue {
+    pub fn new() -> Self {
+        Self {
+            mux: Multiplexer::new("wasi", "keyvalue", DEFAULT_BACKEND),
+        }
+    }
+
+    /// Register a backend provider keyed by its `backend_type()`.
+    pub fn with_provider(mut self, provider: Arc<KvProvider>) -> Self {
+        self.mux = self.mux.with_provider(provider);
+        self
+    }
+
+    /// Build the routing registry (host-interface name -> backend) for a
+    /// component from its matched keyvalue host interfaces.
+    pub async fn build_registry<'i>(
+        &self,
+        interfaces: impl IntoIterator<Item = &'i WitInterface>,
+    ) -> anyhow::Result<HashMap<String, KvId>> {
+        self.mux.build_registry(interfaces).await
+    }
+}
+
+#[async_trait::async_trait]
+impl HostPlugin for MultiplexedKeyValue {
+    fn id(&self) -> &'static str {
+        MULTIPLEXED_KEYVALUE_ID
+    }
+
+    fn world(&self) -> WitWorld {
+        WitWorld {
+            imports: HashSet::from([WitInterface::from(
+                "wasi:keyvalue/store,atomics,batch@0.2.0-draft",
+            )]),
+            ..Default::default()
+        }
+    }
+
+    fn supports_named_instances(&self) -> bool {
+        true
+    }
+
+    async fn on_workload_item_bind<'a>(
+        &self,
+        item: &mut WorkloadItem<'a>,
+        interfaces: WitInterfaces<'_>,
+    ) -> anyhow::Result<()> {
+        if !interfaces.contains("wasi", "keyvalue", &[]) {
+            return Ok(());
+        }
+
+        let registry = self.build_registry(interfaces.iter()).await?;
+        // Clone the component (cheap, Arc-backed) so the immutable borrow ends
+        // before we take the mutable linker borrow.
+        let component = item.component().clone();
+        let linker = item.linker();
+
+        bindings::named_imports::wasi::keyvalue::store::add_to_linker::<_, SharedCtx>(
+            linker,
+            &component,
+            |name| self.mux.resolve(&registry, name),
+            extract_active_ctx,
+        )?;
+        bindings::named_imports::wasi::keyvalue::atomics::add_to_linker::<_, SharedCtx>(
+            linker,
+            &component,
+            |name| self.mux.resolve(&registry, name),
+            extract_active_ctx,
+        )?;
+        bindings::named_imports::wasi::keyvalue::batch::add_to_linker::<_, SharedCtx>(
+            linker,
+            &component,
+            |name| self.mux.resolve(&registry, name),
+            extract_active_ctx,
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kv_iface(name: Option<&str>, backend: Option<&str>) -> WitInterface {
+        let mut config = HashMap::new();
+        if let Some(b) = backend {
+            config.insert("backend".to_string(), b.to_string());
+        }
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "keyvalue".to_string(),
+            interfaces: ["store".to_string()].into_iter().collect(),
+            version: None,
+            config,
+            name: name.map(String::from),
+        }
+    }
+
+    #[tokio::test]
+    async fn in_memory_backend_instances_are_isolated() {
+        let a = InMemoryBackend::new();
+        a.open("bucket").await.unwrap();
+        a.set("bucket", "k", b"v1".to_vec()).await.unwrap();
+        assert_eq!(a.get("bucket", "k").await.unwrap(), Some(b"v1".to_vec()));
+
+        let b = InMemoryBackend::new();
+        b.open("bucket").await.unwrap();
+        assert_eq!(b.get("bucket", "k").await.unwrap(), None);
+    }
+
+    /// The decisive case: two named interfaces of the *same* backend type route
+    /// to independent backends (postgres-per-team shape, proven with in-memory).
+    #[tokio::test]
+    async fn registry_routes_named_interfaces_to_distinct_backends() {
+        let plugin = MultiplexedKeyValue::new().with_provider(Arc::new(InMemoryProvider));
+        let interfaces = HashSet::from([
+            kv_iface(Some("team-a"), Some("in-memory")),
+            kv_iface(Some("team-b"), Some("in-memory")),
+        ]);
+
+        let registry = plugin.build_registry(&interfaces).await.unwrap();
+        let a = registry.get("team-a").expect("team-a routed").clone();
+        let b = registry.get("team-b").expect("team-b routed").clone();
+
+        a.open("bucket").await.unwrap();
+        a.set("bucket", "k", b"v".to_vec()).await.unwrap();
+        b.open("bucket").await.unwrap();
+        assert_eq!(b.get("bucket", "k").await.unwrap(), None, "backends leaked");
+        assert_eq!(a.get("bucket", "k").await.unwrap(), Some(b"v".to_vec()));
+    }
+
+    /// The filesystem provider routes a named interface to an on-disk backend
+    /// (the shared `FsKvStore`), proving it's wired into the multiplexer and the
+    /// shared storage works through the `(implements ..)` path.
+    #[tokio::test]
+    async fn filesystem_backend_persists_through_the_multiplexer() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("wash-fs-kv-{}-{unique}", std::process::id()));
+
+        let iface = WitInterface {
+            namespace: "wasi".to_string(),
+            package: "keyvalue".to_string(),
+            interfaces: ["store".to_string()].into_iter().collect(),
+            version: None,
+            config: HashMap::from([
+                ("backend".to_string(), "filesystem".to_string()),
+                ("root".to_string(), dir.to_string_lossy().to_string()),
+            ]),
+            name: Some("team-fs".to_string()),
+        };
+
+        let plugin = MultiplexedKeyValue::new().with_provider(Arc::new(FilesystemProvider));
+        let registry = plugin
+            .build_registry(&HashSet::from([iface]))
+            .await
+            .unwrap();
+        let backend = registry.get("team-fs").expect("team-fs routed").clone();
+
+        backend.open("bucket").await.unwrap();
+        backend.set("bucket", "k", b"v".to_vec()).await.unwrap();
+        assert_eq!(
+            backend.get("bucket", "k").await.unwrap(),
+            Some(b"v".to_vec())
+        );
+        assert_eq!(backend.increment("bucket", "ctr", 5).await.unwrap(), 5);
+        assert_eq!(backend.increment("bucket", "ctr", 3).await.unwrap(), 8);
+
+        // It actually hit disk via the shared store.
+        assert!(dir.join("bucket").join("k").exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn build_registry_errors_on_unregistered_backend() {
+        let plugin = MultiplexedKeyValue::new(); // no providers registered
+        let interfaces = HashSet::from([kv_iface(Some("x"), Some("redis"))]);
+        let err = plugin
+            .build_registry(&interfaces)
+            .await
+            .err()
+            .expect("expected error for unregistered backend");
+        assert!(err.to_string().contains("redis"), "unexpected error: {err}");
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/filesystem.rs
@@ -1,0 +1,135 @@
+//! Filesystem backend for the multiplexed `wasi:keyvalue` plugin.
+//!
+//! A thin [`KvBackend`] adapter over the shared [`FsKvStore`] — the same
+//! storage the standalone `FilesystemKeyValue` plugin uses.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::plugin::multiplex::BackendProvider;
+use crate::plugin::wasi_keyvalue::fs_store::{FsKvError, FsKvStore};
+
+use super::{KeyResponse, KvBackend, KvId, LIST_KEYS_BATCH_SIZE, StoreError};
+
+/// A filesystem [`KvBackend`] rooted at a directory: buckets are subdirectories,
+/// keys are files (path-traversal guarded). Backed by the shared [`FsKvStore`].
+pub struct FilesystemBackend {
+    store: FsKvStore,
+}
+
+impl FilesystemBackend {
+    pub fn new(root: impl AsRef<Path>) -> Self {
+        Self {
+            store: FsKvStore::new(root),
+        }
+    }
+}
+
+fn to_store_error(e: FsKvError) -> StoreError {
+    match e {
+        FsKvError::InvalidIdentifier => {
+            StoreError::Other("invalid keyvalue identifier".to_string())
+        }
+        FsKvError::Io(e) => StoreError::Other(format!("Filesystem error: {e}")),
+    }
+}
+
+#[async_trait::async_trait]
+impl KvBackend for FilesystemBackend {
+    async fn open(&self, identifier: &str) -> Result<(), StoreError> {
+        self.store
+            .create_bucket(identifier)
+            .await
+            .map_err(to_store_error)
+    }
+
+    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        self.store.get(bucket, key).await.map_err(to_store_error)
+    }
+
+    async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
+        self.store
+            .set(bucket, key, &value)
+            .await
+            .map_err(to_store_error)
+    }
+
+    async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
+        self.store.delete(bucket, key).await.map_err(to_store_error)
+    }
+
+    async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
+        self.store.exists(bucket, key).await.map_err(to_store_error)
+    }
+
+    async fn list_keys(
+        &self,
+        bucket: &str,
+        cursor: Option<u64>,
+    ) -> Result<KeyResponse, StoreError> {
+        let (keys, cursor) = self
+            .store
+            .list_keys(bucket, cursor, LIST_KEYS_BATCH_SIZE)
+            .await
+            .map_err(to_store_error)?;
+        Ok(KeyResponse { keys, cursor })
+    }
+
+    async fn increment(&self, bucket: &str, key: &str, delta: u64) -> Result<u64, StoreError> {
+        self.store
+            .increment(bucket, key, delta)
+            .await
+            .map_err(to_store_error)
+    }
+
+    async fn get_many(
+        &self,
+        bucket: &str,
+        keys: Vec<String>,
+    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
+        let mut out = Vec::with_capacity(keys.len());
+        for key in keys {
+            out.push(self.get(bucket, &key).await?.map(|v| (key, v)));
+        }
+        Ok(out)
+    }
+
+    async fn set_many(
+        &self,
+        bucket: &str,
+        key_values: Vec<(String, Vec<u8>)>,
+    ) -> Result<(), StoreError> {
+        for (key, value) in key_values {
+            self.set(bucket, &key, value).await?;
+        }
+        Ok(())
+    }
+
+    async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
+        for key in keys {
+            self.delete(bucket, &key).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Provider for [`FilesystemBackend`], selected by `config.backend =
+/// "filesystem"`. Requires `config.root` (the directory under which buckets
+/// live).
+#[derive(Default)]
+pub struct FilesystemProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<KvId> for FilesystemProvider {
+    fn backend_type(&self) -> &'static str {
+        "filesystem"
+    }
+
+    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<KvId> {
+        let root = config.get("root").ok_or_else(|| {
+            anyhow::anyhow!("filesystem keyvalue backend requires a 'root' config")
+        })?;
+        Ok(Arc::new(FilesystemBackend::new(root)))
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
@@ -305,7 +305,14 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
         let (entry_revision, entry_value) = match bucket_handle.kv.entry(&key).await {
             Ok(Some(mut e)) => {
                 let revision = Some(e.revision);
-                let value = e.value.get_u64();
+                // Tolerate a malformed (non-8-byte) value as 0 rather than
+                // panicking: `Buf::get_u64` traps the guest if the value has
+                // fewer than 8 bytes.
+                let value = if e.value.len() >= 8 {
+                    e.value.get_u64()
+                } else {
+                    0
+                };
                 (revision, value)
             }
             Ok(None) => (None, 0),
@@ -315,7 +322,8 @@ impl<'a> bindings::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
             }
         };
 
-        let new_value = entry_value + delta;
+        // saturating, so an overflowing increment can't panic-trap the guest.
+        let new_value = entry_value.saturating_add(delta);
         let entry_bytes = Bytes::from((new_value).to_be_bytes().to_vec());
 
         // Here's were CAS happens
@@ -530,7 +538,8 @@ mod tests {
     //! These live here (rather than under `tests/`) because they exercise a
     //! private method directly; the repo's `tests/integration_nats_*` files can
     //! only reach the public host API. They spin up a real JetStream via
-    //! testcontainers. Requires Docker. Gated behind `NATS_INTEGRATION_TESTS=1`.
+    //! testcontainers. Requires Docker; marked `#[ignore]`, run with
+    //! `cargo test --include-ignored`.
 
     use super::*;
     use testcontainers::{
@@ -561,26 +570,13 @@ mod tests {
         Ok((container, client))
     }
 
-    fn skip_if_disabled() -> bool {
-        if std::env::var("NATS_INTEGRATION_TESTS").unwrap_or_default() != "1" {
-            eprintln!(
-                "Skipping NATS keyvalue integration test (set NATS_INTEGRATION_TESTS=1 to enable)"
-            );
-            return true;
-        }
-        false
-    }
-
     /// `get_or_create_bucket` is implemented as an idempotent `create_key_value`.
     /// This verifies the property that makes that safe: re-opening an existing,
     /// populated bucket returns the same store with its entries intact — the
     /// duplicate create does not reset or wipe the bucket.
     #[tokio::test]
+    #[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
     async fn test_reopening_bucket_preserves_entries() -> anyhow::Result<()> {
-        if skip_if_disabled() {
-            return Ok(());
-        }
-
         tracing_subscriber::fmt()
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .try_init()

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 name = "cli-service-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -216,14 +216,14 @@ version = "0.1.0"
 dependencies = [
  "sysinfo",
  "tokio",
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "cron-component"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ name = "cron-service"
 version = "0.1.0"
 dependencies = [
  "tokio",
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -526,18 +526,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hassle-rs"
@@ -594,7 +588,7 @@ dependencies = [
 name = "http-blobstore-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -625,21 +619,21 @@ name = "http-counter"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "http-handler-p2"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "http-handler-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -684,35 +678,35 @@ dependencies = [
 name = "inter-component-call-callee"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "inter-component-call-caller"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "inter-component-call-middleware"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "inter-component-call-p3-callee"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "inter-component-call-p3-caller"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -731,6 +725,21 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyvalue-counter"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "wit-bindgen 0.58.0",
+]
+
+[[package]]
+name = "keyvalue-implements"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -804,6 +813,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "macro-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,14 +842,14 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "messaging-echo"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
 name = "messaging-handler"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -1158,7 +1178,7 @@ name = "socket-test-p3"
 version = "0.0.0"
 dependencies = [
  "futures",
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -1263,7 +1283,7 @@ dependencies = [
 name = "tls-echo-client-p3"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.54.0",
+ "wit-bindgen 0.58.0",
 ]
 
 [[package]]
@@ -1425,12 +1445,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.245.1"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.245.1",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -1463,14 +1483,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.245.1"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da55e60097e8b37b475a0fa35c3420dd71d9eb7bd66109978ab55faf56a57efb"
+checksum = "5f998ccc6e012f7b86865eb2a106c8a0422017a1a88977ce01a69f2244be2e57"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -1516,12 +1536,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.245.1"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
  "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
 ]
@@ -1901,22 +1921,22 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb00254d5051d69730ee32580b7373592f10ad786757c372f0f2c7b61f86a2c"
-dependencies = [
- "bitflags 2.11.1",
- "futures",
- "wit-bindgen-rust-macro 0.54.0",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a43552cfa071f246cfd99e5dbb23710dfe7336b3259e09339818483359470749"
+dependencies = [
+ "bitflags 2.11.1",
+ "futures",
+ "wit-bindgen-rust-macro 0.58.0",
 ]
 
 [[package]]
@@ -1943,13 +1963,13 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.54.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cdef5ccf0b0e9bf30868d6f9c5ed116c84ae95f84ba29d2216d3e922de3963"
+checksum = "4738d1c9a78e97bc7f664bfafd5d8e67d7bb26faa5c41e6d628e8bbdad3ec351"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser 0.245.1",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -2015,18 +2035,18 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.54.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e76541e2f37ac1729db85765729daa0f3c2b5975d66699114d107525f6d6c8d5"
+checksum = "1130ce1f531bc9f9a75922244aa773bf5e2117fda1ef4a86b9f98d6b8135eb46"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
- "wasm-metadata 0.245.1",
- "wit-bindgen-core 0.54.0",
- "wit-component 0.245.1",
+ "wasm-metadata 0.251.0",
+ "wit-bindgen-core 0.58.0",
+ "wit-component 0.251.0",
 ]
 
 [[package]]
@@ -2061,17 +2081,18 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.54.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a284e17b2bc808c72ba008f6694626fa76bcac608b3d1ed0880f9add3f558f8e"
+checksum = "07296369e4d598e7e79b64eef66f724d83324ea671bcf677d78fc5cf92604ae5"
 dependencies = [
  "anyhow",
+ "macro-string",
  "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wit-bindgen-core 0.54.0",
- "wit-bindgen-rust 0.54.0",
+ "wit-bindgen-core 0.58.0",
+ "wit-bindgen-rust 0.58.0",
 ]
 
 [[package]]
@@ -2114,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.245.1"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4894f10d2d5cbc17c77e91f86a1e48e191a788da4425293b55c98b44ba3fcac9"
+checksum = "83a5e60173c413659c689f0581b0cf5d1a2404077568f9ffdce748a9eb2fc913"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -2125,10 +2146,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.245.1",
- "wasm-metadata 0.245.1",
- "wasmparser 0.245.1",
- "wit-parser 0.245.1",
+ "wasm-encoder 0.251.0",
+ "wasm-metadata 0.251.0",
+ "wasmparser 0.251.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -2169,12 +2190,12 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.245.1"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
+checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "id-arena",
  "indexmap",
  "log",
@@ -2183,7 +2204,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.245.1",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -15,6 +15,8 @@ members = [
     "inter-component-call-callee",
     "inter-component-call-middleware",
     "http-allowed-hosts",
+    "keyvalue-counter",
+    "keyvalue-implements",
     # P3 fixtures (wasm32-wasip1 + reactor adapter)
     "http-handler-p3",
     "http-blobstore-p3",
@@ -35,4 +37,4 @@ tokio = { version = "1", default-features = false, features = ["sync", "macros",
 wstd = "0.6"
 wasmcloud-component = "0.2.0"
 wgpu = { git = "https://github.com/wasi-gfx/wgpu.git", rev = "898122bf2cace048e63f065181a86459edb28205", default-features = false, features = ["wasi", "wgsl"] }
-wit-bindgen = "0.54.0"
+wit-bindgen = "0.58.0"

--- a/crates/wash-runtime/tests/fixtures/cli-service-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/cli-service-p3/src/lib.rs
@@ -13,7 +13,7 @@ impl Guest for Component {
         let msg = b"p3 service running\n".to_vec();
         let (mut tx, rx) = bindings::wit_stream::new();
 
-        wit_bindgen::spawn(async move {
+        wit_bindgen::spawn_local(async move {
             tx.write_all(msg).await;
             drop(tx);
         });

--- a/crates/wash-runtime/tests/fixtures/http-blobstore-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/http-blobstore-p3/src/lib.rs
@@ -18,7 +18,7 @@ fn respond(status: u16, body_bytes: Vec<u8>) -> Result<Response, ErrorCode> {
     let (mut tx, rx) = bindings::wit_stream::new();
     let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
 
-    wit_bindgen::spawn(async move {
+    wit_bindgen::spawn_local(async move {
         tx.write_all(body_bytes).await;
         drop(tx);
         let _ = trailers_tx.write(Ok(None)).await;

--- a/crates/wash-runtime/tests/fixtures/http-handler-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/http-handler-p3/src/lib.rs
@@ -17,7 +17,7 @@ impl Handler for Component {
         let (mut tx, rx) = bindings::wit_stream::new();
         let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
 
-        wit_bindgen::spawn(async move {
+        wit_bindgen::spawn_local(async move {
             tx.write_all(body_bytes).await;
             drop(tx);
             let _ = trailers_tx.write(Ok(None)).await;

--- a/crates/wash-runtime/tests/fixtures/inter-component-call-p3-caller/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/inter-component-call-p3-caller/src/lib.rs
@@ -24,7 +24,7 @@ impl Handler for Component {
         let (mut tx, rx) = bindings::wit_stream::new();
         let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
 
-        wit_bindgen::spawn(async move {
+        wit_bindgen::spawn_local(async move {
             tx.write_all(body_bytes).await;
             drop(tx);
             let _ = trailers_tx.write(Ok(None)).await;

--- a/crates/wash-runtime/tests/fixtures/keyvalue-counter/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-counter/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "keyvalue-counter"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/wash-runtime/tests/fixtures/keyvalue-counter/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-counter/src/lib.rs
@@ -1,0 +1,59 @@
+//! Minimal keyvalue fixture.
+//!
+//! Imports `wasi:keyvalue` once (unnamed/default instance) and exports an HTTP
+//! handler. Each request increments a counter in the default keyvalue store and
+//! returns the new value as the response body, so the test can observe that the
+//! unnamed import still routes to (and persists in) the standalone backend even
+//! when a multiplexed `(implements ..)` keyvalue plugin is also registered.
+
+use anyhow::{Context, Result};
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+    });
+}
+
+use bindings::{
+    exports::wasi::http::incoming_handler::Guest,
+    wasi::{
+        http::types::{
+            Fields, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
+        },
+        keyvalue::{atomics::increment, store::open},
+    },
+};
+
+struct Component;
+
+const BUCKET: &str = "counter";
+const KEY: &str = "n";
+
+impl Guest for Component {
+    fn handle(_request: IncomingRequest, response_out: ResponseOutparam) {
+        let (status, body_text) = match handle_request() {
+            Ok(count) => (200, count.to_string()),
+            Err(e) => (500, format!("error: {e:#}")),
+        };
+
+        let response = OutgoingResponse::new(Fields::new());
+        response.set_status_code(status).unwrap();
+        let body = response.body().unwrap();
+        ResponseOutparam::set(response_out, Ok(response));
+
+        let stream = body.write().unwrap();
+        stream.blocking_write_and_flush(body_text.as_bytes()).unwrap();
+        drop(stream);
+        OutgoingBody::finish(body, None).unwrap();
+    }
+}
+
+fn handle_request() -> Result<u64> {
+    // Unnamed `open` -> the default keyvalue instance, served by the standalone
+    // plugin even when a multiplexed plugin is registered for named imports.
+    let bucket = open(BUCKET).context("open default keyvalue bucket")?;
+    let count = increment(&bucket, KEY, 1).context("increment counter")?;
+    Ok(count)
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/keyvalue-counter/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-counter/wit/world.wit
@@ -1,0 +1,13 @@
+package wasmcloud:keyvalue-counter;
+
+// Imports wasi:keyvalue ONCE, unnamed (the default instance). The coexistence
+// test registers a standalone keyvalue plugin (which serves this unnamed
+// import) alongside a multiplexed `(implements ..)` plugin (which serves named
+// imports) to prove the two `add_to_linker` flavors share one linker without
+// conflict. The named side is declared host-side here; for a guest that emits
+// `(implements ..)` imports itself, see the `keyvalue-implements` fixture.
+world keyvalue-counter {
+    import wasi:keyvalue/store@0.2.0-draft;
+    import wasi:keyvalue/atomics@0.2.0-draft;
+    export wasi:http/incoming-handler@0.2.2;
+}

--- a/crates/wash-runtime/tests/fixtures/keyvalue-implements/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-implements/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "keyvalue-implements"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true }

--- a/crates/wash-runtime/tests/fixtures/keyvalue-implements/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-implements/src/lib.rs
@@ -1,0 +1,62 @@
+//! Real-guest fixture for `(implements ..)` named keyvalue routing.
+//!
+//! Imports `wasi:keyvalue/store` twice under the labels `team-a` and `team-b`
+//! (the WIT `implements` clause). On each HTTP request it writes a distinct
+//! value to the same key through each named import and reads both back; the host
+//! routes the two labels to separate backends, so the values must stay isolated.
+//! Responds `isolated` on success, `leak: …` otherwise.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+    });
+}
+
+use bindings::exports::wasi::http::incoming_handler::Guest;
+use bindings::wasi::http::types::{
+    Fields, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
+};
+
+struct Component;
+
+const KEY: &str = "k";
+
+impl Guest for Component {
+    fn handle(_request: IncomingRequest, response_out: ResponseOutparam) {
+        let body = match run() {
+            Ok(s) => s,
+            Err(e) => format!("error: {e}"),
+        };
+
+        let response = OutgoingResponse::new(Fields::new());
+        response.set_status_code(200).unwrap();
+        let out_body = response.body().unwrap();
+        ResponseOutparam::set(response_out, Ok(response));
+
+        let stream = out_body.write().unwrap();
+        stream.blocking_write_and_flush(body.as_bytes()).unwrap();
+        drop(stream);
+        OutgoingBody::finish(out_body, None).unwrap();
+    }
+}
+
+fn run() -> Result<String, String> {
+    // `team-a` and `team-b` are two independent `(implements ..)` imports of
+    // wasi:keyvalue/store, routed by the host to separate backends.
+    let a = bindings::team_a::open("bucket").map_err(|e| format!("open team-a: {e:?}"))?;
+    let b = bindings::team_b::open("bucket").map_err(|e| format!("open team-b: {e:?}"))?;
+
+    a.set(KEY, b"from-a").map_err(|e| format!("set team-a: {e:?}"))?;
+    b.set(KEY, b"from-b").map_err(|e| format!("set team-b: {e:?}"))?;
+
+    let va = a.get(KEY).map_err(|e| format!("get team-a: {e:?}"))?;
+    let vb = b.get(KEY).map_err(|e| format!("get team-b: {e:?}"))?;
+
+    if va.as_deref() == Some(b"from-a".as_slice()) && vb.as_deref() == Some(b"from-b".as_slice()) {
+        Ok("isolated".to_string())
+    } else {
+        Ok(format!("leak: team-a={va:?} team-b={vb:?}"))
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/keyvalue-implements/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-implements/wit/world.wit
@@ -1,0 +1,9 @@
+package wasmcloud:keyvalue-implements;
+
+// Imports wasi:keyvalue/store TWICE under distinct labels via the component-model
+// `implements` clause (`import <label>: <iface>;`).
+world keyvalue-implements {
+    import team-a: wasi:keyvalue/store@0.2.0-draft;
+    import team-b: wasi:keyvalue/store@0.2.0-draft;
+    export wasi:http/incoming-handler@0.2.2;
+}

--- a/crates/wash-runtime/tests/integration_keyvalue_coexistence.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_coexistence.rs
@@ -1,0 +1,145 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! Coexistence of a standalone keyvalue plugin and a multiplexed
+//! `(implements ..)` keyvalue plugin on one linker, exercised through a *real*
+//! instantiated component.
+//!
+//! The component (`keyvalue-counter`) imports `wasi:keyvalue` once, unnamed,
+//! and increments a counter per request. The host registers BOTH:
+//!   * [`InMemoryKeyValue`] — the standalone plugin, whose default-instance
+//!     `add_to_linker` serves the component's unnamed import; and
+//!   * [`MultiplexedKeyValue`] — the multiplexed plugin, whose named-imports
+//!     `add_to_linker` serves `(implements ..)` named imports.
+//!
+//! The workload declares the unnamed interface (routed to the standalone) plus
+//! two *named* interfaces, `cache` and `sessions` (routed to the multiplexed
+//! plugin). Both plugins therefore run their `add_to_linker` on the same linker
+//! at instantiate time — the exact path that could collide if the default and
+//! named instance registrations conflicted. `workload_start` succeeding proves
+//! they coexist; the HTTP round-trip proves the unnamed import still routes to
+//! (and persists in) the standalone backend.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::wasi_keyvalue::{InMemoryKeyValue, InMemoryProvider, MultiplexedKeyValue},
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+    wit::WitInterface,
+};
+
+mod common;
+use common::http_incoming_handler_interface;
+
+const KEYVALUE_COUNTER_WASM: &[u8] = include_bytes!("wasm/keyvalue_counter.wasm");
+
+const KV_VERSION: &str = "0.2.0-draft";
+
+fn kv_interface(name: Option<&str>, backend: Option<&str>) -> WitInterface {
+    let mut config = HashMap::new();
+    if let Some(backend) = backend {
+        config.insert("backend".to_string(), backend.to_string());
+    }
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: ["store".to_string(), "atomics".to_string()]
+            .into_iter()
+            .collect(),
+        version: Some(semver::Version::parse(KV_VERSION).unwrap()),
+        config,
+        name: name.map(String::from),
+    }
+}
+
+#[tokio::test]
+async fn standalone_and_multiplexed_keyvalue_coexist() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_server.addr();
+
+    // Both plugins on one host: the standalone serves the unnamed import, the
+    // multiplexed serves the named ones. The multiplexed plugin defaults named
+    // interfaces to an isolated in-memory backend via `InMemoryProvider`.
+    let multiplexed = MultiplexedKeyValue::new().with_provider(Arc::new(InMemoryProvider));
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
+        .with_plugin(Arc::new(multiplexed))?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    // Unnamed kv (-> standalone) + two named kv interfaces (-> multiplexed). The
+    // named entries force the multiplexed plugin to bind and run its named
+    // `add_to_linker` alongside the standalone's default-instance one.
+    let host_interfaces = vec![
+        http_incoming_handler_interface("kv-coexist", None),
+        kv_interface(None, None),
+        kv_interface(Some("cache"), Some("in-memory")),
+        kv_interface(Some("sessions"), Some("in-memory")),
+    ];
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "keyvalue-coexist".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "keyvalue-counter.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(KEYVALUE_COUNTER_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    };
+
+    // Instantiation runs BOTH plugins' `add_to_linker` on the same linker.
+    // Success here is the core coexistence assertion: the default-instance and
+    // named-instance registrations don't conflict.
+    host.workload_start(req)
+        .await
+        .context("standalone + multiplexed keyvalue plugins should bind together")?;
+
+    // The unnamed import must route to the standalone backend and persist there
+    // across requests (the counter increments 1 -> 2), unaffected by the
+    // multiplexed plugin sharing the linker.
+    let client = reqwest::Client::new();
+    for expected in ["1", "2"] {
+        let response = timeout(
+            Duration::from_secs(10),
+            client
+                .get(format!("http://{addr}/"))
+                .header("HOST", "kv-coexist")
+                .send(),
+        )
+        .await
+        .context("request timed out")?
+        .context("request failed")?;
+
+        let status = response.status();
+        let body = response.text().await?;
+        assert!(status.is_success(), "expected 200, got {status}: {body}");
+        assert_eq!(
+            body, expected,
+            "unnamed keyvalue import should route to the standalone backend and persist"
+        );
+    }
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_keyvalue_implements.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_implements.rs
@@ -1,0 +1,149 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! End-to-end `(implements ..)` named-import routing through a *real* guest.
+//!
+//! The `keyvalue-implements` fixture imports `wasi:keyvalue/store` **twice**
+//! under the component-model labels `team-a` and `team-b` (the WIT `implements`
+//! clause — `import team-a: wasi:keyvalue/store@…;`). On each request it opens a
+//! bucket through each label, writes a distinct value to the same key, and reads
+//! both back; it answers `isolated` only if neither write is visible through the
+//! other label.
+//!
+//! The host binds a single [`MultiplexedKeyValue`] plugin. The workload declares
+//! the two named interfaces `team-a` and `team-b`, each routed to an isolated
+//! in-memory backend. The plugin's named-imports `add_to_linker` resolves each
+//! label to its own backend, so the two stores must stay disjoint — proving the
+//! implements id threads through `open` *and* the bucket resource methods
+//! (`set`/`get`) to the correct backend.
+//!
+//! Unlike `integration_keyvalue_coexistence.rs` (where the named side is
+//! declared host-side because the guest imported unnamed), here the *guest
+//! itself* emits the `(implements ..)` imports.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::wasi_keyvalue::{InMemoryProvider, MultiplexedKeyValue},
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+    wit::WitInterface,
+};
+
+mod common;
+use common::http_incoming_handler_interface;
+
+const KEYVALUE_IMPLEMENTS_WASM: &[u8] = include_bytes!("wasm/keyvalue_implements.wasm");
+
+const KV_VERSION: &str = "0.2.0-draft";
+
+/// A named `wasi:keyvalue/store` interface routed to an in-memory backend. The
+/// `name` becomes the implements label the guest imports under (`team-a` /
+/// `team-b`); `resolve` matches it against the component's import label.
+fn named_store(name: &str) -> WitInterface {
+    let mut config = HashMap::new();
+    config.insert("backend".to_string(), "in-memory".to_string());
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: ["store".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse(KV_VERSION).unwrap()),
+        config,
+        name: Some(name.to_string()),
+    }
+}
+
+#[tokio::test]
+async fn implements_imports_route_to_isolated_backends() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_server.addr();
+
+    // One multiplexed plugin serves both labeled imports; each named interface
+    // defaults to its own isolated in-memory backend via `InMemoryProvider`.
+    let multiplexed = MultiplexedKeyValue::new().with_provider(Arc::new(InMemoryProvider));
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(multiplexed))?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    // The two named interfaces map to the guest's `team-a` / `team-b` implements
+    // imports; each routes to a distinct in-memory backend.
+    let host_interfaces = vec![
+        http_incoming_handler_interface("kv-implements", None),
+        named_store("team-a"),
+        named_store("team-b"),
+    ];
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "keyvalue-implements".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "keyvalue-implements.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(KEYVALUE_IMPLEMENTS_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    };
+
+    // Binding runs the named-imports `add_to_linker`, resolving `team-a`/`team-b`
+    // against the declared interfaces. Success proves both labeled imports of the
+    // same external interface bound on one linker. `workload_start` returns Ok
+    // even on resolution failure (it encodes the error in the status), so assert
+    // the workload actually reached Running.
+    let resp = host
+        .workload_start(req)
+        .await
+        .context("workload_start call failed")?;
+    assert_eq!(
+        resp.workload_status.workload_state,
+        wash_runtime::types::WorkloadState::Running,
+        "workload should resolve: {}",
+        resp.workload_status.message
+    );
+
+    // The guest writes `from-a` via team-a and `from-b` via team-b to the same
+    // key, then reads both back. `isolated` means neither write leaked across the
+    // label boundary — i.e. the implements id routed `open` and the bucket
+    // resource methods to the correct backend.
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "kv-implements")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+
+    let status = response.status();
+    let body = response.text().await?;
+    assert!(status.is_success(), "expected 200, got {status}: {body}");
+    assert_eq!(
+        body, "isolated",
+        "each implements import must route to its own backend (no cross-label leak)"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_keyvalue_multiplexed.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_multiplexed.rs
@@ -1,0 +1,164 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! End-to-end test for the multiplexed keyvalue backends (redis + NATS
+//! JetStream) routed through `MultiplexedKeyValue`'s provider/registry path.
+//!
+//! Builds a registry from two named host interfaces, one `redis`, one `nats`,
+//! each with its own connection `url`.
+//! Drives *real* backends against containers, asserting each named import routes to
+//! the correct server and that the two are isolated.
+//!
+//! Requires Docker (redis + NATS); marked `#[ignore]`, so it runs only under
+//! `cargo test --include-ignored` (CI's Linux leg) and not a plain `cargo test`
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use testcontainers::{
+    GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+use wash_runtime::plugin::wasi_keyvalue::{MultiplexedKeyValue, NatsProvider, RedisProvider};
+use wash_runtime::wit::WitInterface;
+
+fn kv_iface(name: &str, backend: &str, url: &str) -> WitInterface {
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: [
+            "store".to_string(),
+            "atomics".to_string(),
+            "batch".to_string(),
+        ]
+        .into_iter()
+        .collect(),
+        version: None,
+        config: HashMap::from([
+            ("backend".to_string(), backend.to_string()),
+            ("url".to_string(), url.to_string()),
+        ]),
+        name: Some(name.to_string()),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (redis + NATS); run with `cargo test --include-ignored`"]
+async fn multiplexed_routes_to_redis_and_nats() -> Result<()> {
+    // --- redis container ---
+    let redis = GenericImage::new("redis", "7-alpine")
+        .with_exposed_port(6379.tcp())
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start redis: {e}"))?;
+    let redis_port = redis.get_host_port_ipv4(6379).await?;
+    let redis_url = format!("redis://127.0.0.1:{redis_port}");
+
+    // --- NATS container (JetStream enabled for KV) ---
+    let nats = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
+    let nats_port = nats.get_host_port_ipv4(4222).await?;
+    let nats_url = format!("nats://127.0.0.1:{nats_port}");
+
+    // The NATS backend opens existing KV stores, so create the bucket first.
+    let nats_client = async_nats::connect(&nats_url)
+        .await
+        .context("connect to nats")?;
+    async_nats::jetstream::new(nats_client)
+        .create_key_value(async_nats::jetstream::kv::Config {
+            bucket: "shared".to_string(),
+            ..Default::default()
+        })
+        .await
+        .context("create nats kv bucket")?;
+
+    // --- build the routing registry from two named host interfaces ---
+    let plugin = MultiplexedKeyValue::new()
+        .with_provider(Arc::new(RedisProvider))
+        .with_provider(Arc::new(NatsProvider));
+    let interfaces = HashSet::from([
+        kv_iface("redis-kv", "redis", &redis_url),
+        kv_iface("nats-kv", "nats", &nats_url),
+    ]);
+    let registry = plugin.build_registry(&interfaces).await?;
+    let redis_be = registry.get("redis-kv").expect("redis-kv routed").clone();
+    let nats_be = registry.get("nats-kv").expect("nats-kv routed").clone();
+
+    // --- each named import lands on its own server ---
+    redis_be.open("bucket").await.map_err(err)?;
+    redis_be
+        .set("bucket", "k", b"from-redis".to_vec())
+        .await
+        .map_err(err)?;
+    nats_be.open("shared").await.map_err(err)?;
+    nats_be
+        .set("shared", "k", b"from-nats".to_vec())
+        .await
+        .map_err(err)?;
+
+    assert_eq!(
+        redis_be.get("bucket", "k").await.map_err(err)?,
+        Some(b"from-redis".to_vec())
+    );
+    assert_eq!(
+        nats_be.get("shared", "k").await.map_err(err)?,
+        Some(b"from-nats".to_vec())
+    );
+    // Isolation: the redis backend never sees the NATS-only key (different server).
+    assert_eq!(
+        redis_be.get("bucket", "nats-only").await.map_err(err)?,
+        None
+    );
+
+    // --- exercise the rest of the surface against the real redis backend ---
+    redis_be
+        .set_many(
+            "bucket",
+            vec![("a".into(), b"1".to_vec()), ("b".into(), b"2".to_vec())],
+        )
+        .await
+        .map_err(err)?;
+    assert_eq!(
+        redis_be
+            .get_many("bucket", vec!["a".into(), "b".into(), "missing".into()])
+            .await
+            .map_err(err)?,
+        vec![
+            Some(("a".to_string(), b"1".to_vec())),
+            Some(("b".to_string(), b"2".to_vec())),
+            None,
+        ]
+    );
+    assert!(redis_be.exists("bucket", "a").await.map_err(err)?);
+    redis_be.delete("bucket", "a").await.map_err(err)?;
+    assert!(!redis_be.exists("bucket", "a").await.map_err(err)?);
+    assert_eq!(
+        redis_be.increment("bucket", "ctr", 5).await.map_err(err)?,
+        5
+    );
+    assert_eq!(
+        redis_be.increment("bucket", "ctr", 3).await.map_err(err)?,
+        8
+    );
+
+    // --- and the real NATS backend ---
+    assert_eq!(nats_be.increment("shared", "ctr", 7).await.map_err(err)?, 7);
+    let mut keys = nats_be.list_keys("shared", None).await.map_err(err)?.keys;
+    keys.sort();
+    assert_eq!(keys, vec!["ctr".to_string(), "k".to_string()]);
+
+    Ok(())
+}
+
+/// The `KvBackend` ops return a WIT `store::Error` which isn't `std::error::Error`;
+/// stringify it for `?`/`anyhow`.
+fn err(e: impl std::fmt::Debug) -> anyhow::Error {
+    anyhow::anyhow!("keyvalue backend error: {e:?}")
+}

--- a/crates/wash-runtime/tests/integration_nats_blobstore.rs
+++ b/crates/wash-runtime/tests/integration_nats_blobstore.rs
@@ -1,6 +1,6 @@
 //! Integration test for HTTP + NatsBlobstore round-trip
 //!
-//! Requires Docker. Gated behind `NATS_INTEGRATION_TESTS=1` so CI can opt in.
+//! Requires Docker (NATS); marked `#[ignore]`, run with `cargo test --include-ignored`.
 //!
 //! Uses testcontainers to spin up a NATS server with JetStream, then validates
 //! that the http-blobstore fixture component can write data through NatsBlobstore
@@ -155,12 +155,8 @@ impl TestHarness {
 }
 
 #[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
 async fn test_nats_blobstore_roundtrip() -> Result<()> {
-    if std::env::var("NATS_INTEGRATION_TESTS").unwrap_or_default() != "1" {
-        eprintln!("Skipping NATS integration test (set NATS_INTEGRATION_TESTS=1 to enable)");
-        return Ok(());
-    }
-
     let harness = setup().await?;
 
     let test_data = "Hello from NATS blobstore integration test!";

--- a/crates/wash-runtime/tests/integration_nats_messaging.rs
+++ b/crates/wash-runtime/tests/integration_nats_messaging.rs
@@ -7,7 +7,7 @@
 //! or the spawn loop that silently break subscription delivery will fail this
 //! test.
 //!
-//! Requires Docker. Gated behind `NATS_INTEGRATION_TESTS=1` so CI can opt in.
+//! Requires Docker (NATS); marked `#[ignore]`, run with `cargo test --include-ignored`.
 
 use anyhow::{Context, Result};
 use std::{collections::HashMap, sync::Arc, time::Duration};
@@ -148,12 +148,8 @@ async fn setup() -> Result<TestHarness> {
 }
 
 #[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
 async fn test_nats_messaging_handler_subscription_round_trip() -> Result<()> {
-    if std::env::var("NATS_INTEGRATION_TESTS").unwrap_or_default() != "1" {
-        eprintln!("Skipping NATS integration test (set NATS_INTEGRATION_TESTS=1 to enable)");
-        return Ok(());
-    }
-
     let harness = setup().await?;
 
     // Give the plugin a moment to flush its SUB to the server. The handler
@@ -190,12 +186,8 @@ async fn test_nats_messaging_handler_subscription_round_trip() -> Result<()> {
 /// timing-dependent on slow runners; with the flush, it must be true by the
 /// time `workload_start` returns.
 #[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
 async fn test_nats_messaging_subscription_registered_on_server() -> Result<()> {
-    if std::env::var("NATS_INTEGRATION_TESTS").unwrap_or_default() != "1" {
-        eprintln!("Skipping NATS integration test (set NATS_INTEGRATION_TESTS=1 to enable)");
-        return Ok(());
-    }
-
     let harness = setup().await?;
 
     // Poll briefly to absorb the small lag between connect and the server's

--- a/crates/wash-runtime/tests/integration_nats_messaging_fault.rs
+++ b/crates/wash-runtime/tests/integration_nats_messaging_fault.rs
@@ -17,7 +17,7 @@
 //! protocol is line-based ASCII so substring matches on the buffer are
 //! sufficient: `SUB <subject> <sid>\r\n`, `UNSUB <sid>\r\n`).
 //!
-//! Requires Docker. Gated behind `NATS_INTEGRATION_TESTS=1`.
+//! Requires Docker (NATS); marked `#[ignore]`, run with `cargo test --include-ignored`.
 
 use anyhow::{Context, Result};
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
@@ -257,14 +257,6 @@ async fn setup(latency: Duration) -> Result<TestHarness> {
     })
 }
 
-fn skip_if_disabled() -> bool {
-    if std::env::var("NATS_INTEGRATION_TESTS").unwrap_or_default() != "1" {
-        eprintln!("Skipping NATS fault-injection test (set NATS_INTEGRATION_TESTS=1 to enable)");
-        return true;
-    }
-    false
-}
-
 // ---------------------------------------------------------------------------
 // Fault injection: invariant must hold even with NATS-side latency
 // ---------------------------------------------------------------------------
@@ -281,11 +273,8 @@ fn skip_if_disabled() -> bool {
 /// resolve says "ok", the subscription is *on the server*. The latency
 /// makes the window wide enough to be deterministic on every machine.
 #[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
 async fn subscription_registers_under_upstream_latency() -> Result<()> {
-    if skip_if_disabled() {
-        return Ok(());
-    }
-
     let harness = setup(Duration::from_millis(100)).await?;
 
     let connz_url = format!("{}/connz?subs=true", harness.monitoring_url);
@@ -321,11 +310,8 @@ async fn subscription_registers_under_upstream_latency() -> Result<()> {
 ///
 /// NATS protocol subscribe message format: `SUB <subject> <sid>\r\n`.
 #[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
 async fn sub_protocol_message_sent_before_resolve_returns() -> Result<()> {
-    if skip_if_disabled() {
-        return Ok(());
-    }
-
     let harness = setup(Duration::from_millis(0)).await?;
 
     // Poll briefly for the SUB to land in the capture buffer. Even with the
@@ -365,11 +351,8 @@ async fn sub_protocol_message_sent_before_resolve_returns() -> Result<()> {
 /// `SUB <subject> <sid>` line for our subject and assert no `UNSUB <sid>`
 /// follows it.
 #[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
 async fn no_unsubscribe_during_steady_state() -> Result<()> {
-    if skip_if_disabled() {
-        return Ok(());
-    }
-
     let harness = setup(Duration::from_millis(0)).await?;
     // Give the subscriber loop a moment to be polled; if it were going to
     // exit immediately and drop its Subscribers, the UNSUB would land here.

--- a/crates/wash/tests/integration_oci.rs
+++ b/crates/wash/tests/integration_oci.rs
@@ -1,7 +1,6 @@
 //! Integration tests for `wash oci push` / `wash oci pull` round-trip.
 //!
-//! Requires Docker and the `OCI_INTEGRATION_TESTS` env var to be set.
-//! Skips gracefully otherwise.
+//! Requires Docker/registry; marked `#[ignore]`, run with `cargo test --include-ignored`.
 
 use std::time::Duration;
 
@@ -33,16 +32,8 @@ async fn start_registry() -> Result<(ContainerAsync<GenericImage>, u16)> {
 }
 
 #[tokio::test]
+#[ignore = "requires Docker/registry; run with `cargo test --include-ignored`"]
 async fn oci_push_pull_round_trip() -> Result<()> {
-    // Gate on env var — matches pattern from wash-runtime OCI tests
-    if std::env::var("OCI_INTEGRATION_TESTS")
-        .unwrap_or_default()
-        .is_empty()
-    {
-        eprintln!("Skipping OCI integration test (set OCI_INTEGRATION_TESTS=1 to enable)");
-        return Ok(());
-    }
-
     // Start local registry
     let (_container, port) = start_registry().await?;
     let reference = format!("localhost:{port}/test/wash-e2e:v1");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -91,6 +91,8 @@ const P2_FIXTURES: &[&str] = &[
     "inter-component-call-callee",
     "inter-component-call-middleware",
     "http-allowed-hosts",
+    "keyvalue-counter",
+    "keyvalue-implements",
 ];
 
 const P3_FIXTURES: &[&str] = &[
@@ -267,6 +269,11 @@ fn componentize(core_module: &[u8], adapter: &[u8]) -> Result<Vec<u8>> {
 /// of a single bundled `package.wit`.
 fn copy_shared_wit_deps(shared_wit_dir: &Path, fixture_dir: &Path) -> Result<()> {
     let deps_dir = fixture_dir.join("wit/deps");
+    // Clear stale deps before re-staging
+    if deps_dir.exists() {
+        fs::remove_dir_all(&deps_dir)
+            .with_context(|| format!("failed to clear stale {}", deps_dir.display()))?;
+    }
     fs::create_dir_all(&deps_dir)?;
 
     for entry in fs::read_dir(shared_wit_dir)


### PR DESCRIPTION
Let a component import the same interface multiple times under distinct
labels and route each to its own backend. A component that imports
`wasi:keyvalue/store` twice (e.g. `import team-a: …; import team-b: …;`)
gets each label bound to a separate backend (in-memory/filesystem/redis/
nats), and the per-import id routes every call.

Core pieces:
- plugin/multiplex.rs: generic `Multiplexer<Id>` + `BackendProvider<Id>`
  with a connection pool (single-flight via OnceCell, LRU eviction, and
  per-backend-type caps) and a background idle reaper.
- wasi_keyvalue/multiplexed{.rs,/}: the multiplexed keyvalue plugin
  (wasmtime `named_imports` bindgen) threading the backend id through
  store/atomics/batch and the bucket resource.
- wasi_keyvalue/fs_store.rs: shared `FsKvStore` so the standalone
  `FilesystemKeyValue` and the multiplexed filesystem backend share one
  implementation (also fixes blocking IO on async paths and increment
  overflow).
- engine/workload.rs: surface `(implements ..)` imports as named
  `WitInterface`s — identity from the `implements` annotation, label as
  the routing name — so the plugin dispatcher binds them. Without this the
  multiplexed plugin was never bound for real-guest implements imports.

Testing & toolchain:
- keyvalue-implements fixture: a real guest emitting labeled external
  `wasi:keyvalue/store` imports, with an end-to-end isolation test; plus
  coexistence (standalone + multiplexed on one linker) and a redis/nats
  multiplexed test. Bump fixtures wit-bindgen to 0.58.
- setup-rust now installs a newer standalone `wasm-component-ld` (via
  cargo-binstall): the toolchain-bundled linker lags the crate and can't
  encode `(implements ..)` imports.
- Gate Docker-backed integration tests (nats/oci) behind `#[ignore]`,
  run in a Linux-only CI leg.
