### PR TITLE
ci: run jobs when their workflow file is modified

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -31,6 +31,7 @@ jobs:
           filters: |
             relevant:
               - 'charts/**'
+              - '.github/workflows/charts.yml'
 
   test:
     needs:

--- a/.github/workflows/runtime-gateway.yml
+++ b/.github/workflows/runtime-gateway.yml
@@ -33,6 +33,7 @@ jobs:
               - 'runtime-gateway/**'
               - 'runtime-operator/**'
               - 'go.work'
+              - '.github/workflows/runtime-gateway.yml'
 
   lint:
     needs:

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -39,6 +39,7 @@ jobs:
       pull-requests: read
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
+      workflow: ${{ steps.filter.outputs.workflow }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -59,6 +60,8 @@ jobs:
               - 'runtime-operator/test/e2e/**'
               - 'charts/runtime-operator/**'
               - 'deploy/kind/kind-config.yaml'
+            workflow:
+              - '.github/workflows/wash.yml'
 
   check:
     needs:
@@ -469,17 +472,22 @@ jobs:
   # release-tag.yml can promote the exact bytes that the canary CI tested
   # instead of rebuilding on tag.
   canary-binaries:
-    # Fires on every main push and on `workflow_dispatch`. `always()`
-    # breaks the skipped-`changes` propagation; the explicit per-need
-    # success gates restore the default `success()` check.
+    # Fires on every main push and on `workflow_dispatch`, plus on PRs that
+    # edit this workflow so a newly added build target is validated before
+    # merge rather than only after it lands on main. `always()` breaks the
+    # skipped-`changes` propagation; the explicit per-need success gates
+    # restore the default `success()` check.
     if: |
       always() &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-      github.ref == 'refs/heads/main' &&
       needs.check.result == 'success' &&
       needs.lint.result == 'success' &&
-      needs.runtime-operator-e2e.result == 'success'
+      needs.runtime-operator-e2e.result == 'success' &&
+      (
+        ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main') ||
+        (github.event_name == 'pull_request' && needs.changes.outputs.workflow == 'true')
+      )
     needs:
+      - changes
       - check
       - lint
       - runtime-operator-e2e


### PR DESCRIPTION
The wash.yml canary-binaries job builds the per-target release matrix gated to main pushes only, so a new target added in a PR was never built until after merge — where it could break the gate or have to be reverted (e.g. the s390x add/remove churn). The PR that introduced it went green without ever exercising the new binary.

Fixed two other workflows not triggering on modifications to their own file:
- charts.yml: add .github/workflows/charts.yml
- runtime-gateway.yml: add .github/workflows/runtime-gateway.yml
