### PR TITLE
implements e2e operator

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -245,6 +245,12 @@ jobs:
         with:
           context: .
           outputs: type=docker,dest=/tmp/wash-image.tar,name=localhost/wasmcloud-wash:e2e
+          # Build the e2e host with `(implements ..)` multiplexing enabled so the
+          # implements spec's named keyvalue imports resolve. Only this e2e
+          # tarball gets the feature; the published canary build below stays on
+          # default features.
+          build-args: |
+            CARGO_FEATURES=wasm_component_model_implements
           # head_ref on PRs (the source branch, shared across re-pushes
           # and across PRs from the same branch); falls back to ref_name
           # on main pushes ("main"). Always falls back to the main scope
@@ -344,6 +350,7 @@ jobs:
           # Exercise the messaging spec — this is the regression test for
           # #5074 and is the whole reason the gate exists.
           MESSAGING_E2E_IMAGE: ghcr.io/wasmcloud/components/messaging-echo-rust:0.1.0
+          IMPLEMENTS_E2E_IMAGE: ghcr.io/wasmcloud/components/keyvalue-implements:0.1.0
           PROMETHEUS_INSTALL_SKIP: "true"
           CERT_MANAGER_INSTALL_SKIP: "true"
           KIND_CLUSTER_NAME: wasmcloud-e2e

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -14,6 +14,11 @@ version.workspace = true
 [features]
 default = ["wasi-webgpu"]
 wasi-tls = ["wash-runtime/wasi-tls"]
+# Route component-model `(implements ..)` named imports to per-import backends.
+# When enabled, `wash host`/`wash dev` additionally register the multiplexed
+# keyvalue plugin (the unnamed/default import keeps its standalone backend, so
+# normal workloads are unaffected). Needs a wasmtime build with resource-implements.
+wasm_component_model_implements = ["wash-runtime/wasm_component_model_implements"]
 # On by default. Pulls in git-only wasi-gfx deps (no crates.io release);
 # disable with `--no-default-features` for a build without the git sources.
 wasi-webgpu = ["wash-runtime/wasi-webgpu"]

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -226,6 +226,18 @@ impl CliCommand for DevCommand {
             debug!("WASI KeyValue plugin registered with in-memory backend");
         }
 
+        #[cfg(feature = "wasm_component_model_implements")]
+        {
+            host_builder = host_builder.with_plugin(Arc::new(
+                plugin::wasi_keyvalue::MultiplexedKeyValue::new()
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::InMemoryProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::RedisProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::NatsProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
+            ))?;
+            debug!("WASI KeyValue multiplexed plugin registered (implements)");
+        }
+
         // Add postgres plugin if configured
         if let Some(postgres_url) = &dev_config.postgres_url {
             host_builder = host_builder.with_plugin(Arc::new(

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -197,6 +197,17 @@ impl CliCommand for HostCommand {
             )))?
             .with_meters(Meters::new(ctx.enable_meters()));
 
+        #[cfg(feature = "wasm_component_model_implements")]
+        {
+            cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
+                plugin::wasi_keyvalue::MultiplexedKeyValue::new()
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::InMemoryProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::RedisProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::NatsProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
+            ))?;
+        }
+
         if let Some(postgres_url) = &self.postgres_url {
             cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
                 plugin::wasmcloud_postgres::WasmcloudPostgres::new(postgres_url)

--- a/runtime-operator/api/runtime/v1alpha1/workload_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_types.go
@@ -1,6 +1,9 @@
 package v1alpha1
 
 import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
 	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -144,21 +147,27 @@ type HostInterface struct {
 	ConfigLayer `json:",inline"`
 
 	// Name uniquely identifies this interface instance when multiple entries
-	// share the same namespace+package. Components use this name as the
-	// identifier parameter in resource-opening functions (e.g., store::open(name)).
+	// share the same namespace+package. It is the `(implements <name>)` id the
+	// host uses to route a component's named import to this interface's backend,
+	// so two imports of the same namespace:package can resolve to different
+	// backends.
 	// Required when multiple entries of the same namespace:package exist.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9-]*$`
+	// +kubebuilder:validation:MaxLength=64
 	Name string `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=128
 	Namespace string `json:"namespace"`
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=128
 	Package string `json:"package"`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
 	Interfaces []string `json:"interfaces,omitempty"`
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxLength=64
 	Version string `json:"version,omitempty"`
 }
 
@@ -220,7 +229,21 @@ type WorkloadSpec struct {
 
 	// +kubebuilder:validation:Optional
 	Components []WorkloadComponent `json:"components,omitempty"`
+
+	// HostInterfaces declares the host-provided interfaces this workload needs.
+	// Two routing invariants are enforced at admission, complementing the
+	// host-side checks:
+	//   1. No two entries may be exact duplicates (same namespace, package,
+	//      name, and version).
+	//   2. At most one entry of a given namespace:package may be unnamed — the
+	//      unnamed entry is the default route and cannot be shared. Declare
+	//      distinct `name`s to route multiple imports of the same package to
+	//      different backends. Semver-incompatible versions of the same package
+	//      may coexist (they are distinct interfaces).
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, y.__namespace__ == x.__namespace__ && y.__package__ == x.__package__ && (has(y.name) ? y.name : '') == (has(x.name) ? x.name : '') && (has(y.version) ? y.version : '') == (has(x.version) ? x.version : '')))",message="hostInterfaces must not contain duplicate entries with the same namespace, package, name, and version"
+	// +kubebuilder:validation:XValidation:rule="self.all(x, (has(x.name) && x.name != '') || self.filter(y, y.__namespace__ == x.__namespace__ && y.__package__ == x.__package__ && !(has(y.name) && y.name != '')).size() == 1)",message="at most one unnamed hostInterface is allowed per namespace:package; set a unique name to disambiguate multiple imports of the same package"
 	HostInterfaces []HostInterface `json:"hostInterfaces,omitempty"`
 	// +kubebuilder:validation:Optional
 	Service *WorkloadService `json:"service,omitempty"`
@@ -235,7 +258,17 @@ type WorkloadSpec struct {
 
 func (s *WorkloadSpec) EnsureHostInterface(iface HostInterface) {
 	for i, existing := range s.HostInterfaces {
-		if existing.Namespace == iface.Namespace && existing.Package == iface.Package && existing.Name == iface.Name {
+		// Merge only entries that share a routing identity (namespace, package,
+		// name) AND a semver-compatible version. Following the component-model
+		// canonical-version rules (and wit-parser's merge-imports-by-semver),
+		// only compatible versions collapse: e.g. 0.2.1 and 0.2.6 (canonical
+		// "0.2") merge keeping the higher, while 0.2 and 0.3 stay distinct.
+		// Name is part of the identity, so differently-named interfaces of the
+		// same package never merge.
+		if existing.Namespace == iface.Namespace &&
+			existing.Package == iface.Package &&
+			existing.Name == iface.Name &&
+			canonVersion(existing.Version) == canonVersion(iface.Version) {
 			existing.EnsureInterfaces(iface.Interfaces...)
 			if iface.Config != nil && existing.Config == nil {
 				existing.Config = make(map[string]string)
@@ -244,12 +277,67 @@ func (s *WorkloadSpec) EnsureHostInterface(iface HostInterface) {
 			for k, v := range iface.Config {
 				existing.Config[k] = v
 			}
+			// Settle a compatible merge on the newer version.
+			existing.Version = maxVersion(existing.Version, iface.Version)
 			s.HostInterfaces[i] = existing
 
 			return
 		}
 	}
 	s.HostInterfaces = append(s.HostInterfaces, iface)
+}
+
+// canonVersion returns the canonical version prefix that determines whether two
+// interface versions are compatible for deduplication, per the component-model
+// `canonversion` rules:
+//   - major > 0            -> "<major>"                 (1.2.3      -> "1")
+//   - major == 0, minor>0  -> "<major>.<minor>"         (0.2.6-rc.1 -> "0.2")
+//   - otherwise            -> "<major>.<minor>.<patch>" (0.0.1      -> "0.0.1")
+//
+// Compatible versions share a canonical prefix and so link by trivial string
+// equality. An empty version canonicalizes to "" (unversioned); a version that
+// does not parse as semver is returned verbatim, so it only matches an
+// identical string rather than silently merging.
+func canonVersion(v string) string {
+	if v == "" {
+		return ""
+	}
+	parsed, err := semver.NewVersion(v)
+	if err != nil {
+		return v
+	}
+	switch {
+	case parsed.Major() > 0:
+		return fmt.Sprintf("%d", parsed.Major())
+	case parsed.Minor() > 0:
+		return fmt.Sprintf("%d.%d", parsed.Major(), parsed.Minor())
+	default:
+		return fmt.Sprintf("%d.%d.%d", parsed.Major(), parsed.Minor(), parsed.Patch())
+	}
+}
+
+// maxVersion returns the semver-greater of two compatible versions so a merge
+// settles on the newer one. Unparseable versions sort below parseable ones; if
+// both are unparseable the non-empty one (else a) is kept.
+func maxVersion(a, b string) string {
+	av, aerr := semver.NewVersion(a)
+	bv, berr := semver.NewVersion(b)
+	switch {
+	case aerr != nil && berr != nil:
+		if a == "" {
+			return b
+		}
+		return a
+	case aerr != nil:
+		return b
+	case berr != nil:
+		return a
+	default:
+		if av.LessThan(bv) {
+			return b
+		}
+		return a
+	}
 }
 
 // WorkloadStatus defines the observed state of Workload.

--- a/runtime-operator/api/runtime/v1alpha1/workload_types_test.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_types_test.go
@@ -139,3 +139,89 @@ func TestEnsureHostInterface_NamedAndUnnamedAreDistinct(t *testing.T) {
 		t.Fatalf("expected 2 host interfaces (named vs unnamed), got %d", len(spec.HostInterfaces))
 	}
 }
+
+func TestEnsureHostInterface_CompatibleVersionsMergeKeepingMax(t *testing.T) {
+	spec := &WorkloadSpec{}
+
+	spec.EnsureHostInterface(HostInterface{
+		Name:       "cache",
+		Namespace:  "wasi",
+		Package:    "keyvalue",
+		Version:    "0.2.1",
+		Interfaces: []string{"store"},
+	})
+	// Same name + semver-compatible version (canonical "0.2") => merge, keep the
+	// higher version.
+	spec.EnsureHostInterface(HostInterface{
+		Name:       "cache",
+		Namespace:  "wasi",
+		Package:    "keyvalue",
+		Version:    "0.2.6",
+		Interfaces: []string{"atomics"},
+	})
+
+	if len(spec.HostInterfaces) != 1 {
+		t.Fatalf("expected 1 host interface (compatible merge), got %d", len(spec.HostInterfaces))
+	}
+	if got := spec.HostInterfaces[0].Version; got != "0.2.6" {
+		t.Errorf("expected merged version 0.2.6 (max), got %q", got)
+	}
+	if !spec.HostInterfaces[0].HasInterface("store") || !spec.HostInterfaces[0].HasInterface("atomics") {
+		t.Errorf("expected merged interfaces to include store+atomics, got %v", spec.HostInterfaces[0].Interfaces)
+	}
+}
+
+func TestEnsureHostInterface_IncompatibleVersionsStayDistinct(t *testing.T) {
+	spec := &WorkloadSpec{}
+
+	spec.EnsureHostInterface(HostInterface{
+		Name:       "cache",
+		Namespace:  "wasi",
+		Package:    "keyvalue",
+		Version:    "0.2.0",
+		Interfaces: []string{"store"},
+	})
+	// Same name but semver-incompatible (canonical "0.2" vs "0.3") => distinct.
+	spec.EnsureHostInterface(HostInterface{
+		Name:       "cache",
+		Namespace:  "wasi",
+		Package:    "keyvalue",
+		Version:    "0.3.0",
+		Interfaces: []string{"store"},
+	})
+
+	if len(spec.HostInterfaces) != 2 {
+		t.Fatalf("expected 2 host interfaces (incompatible versions stay distinct), got %d", len(spec.HostInterfaces))
+	}
+}
+
+func TestCanonVersion(t *testing.T) {
+	cases := map[string]string{
+		"":            "",
+		"1.2.3":       "1",
+		"0.2.6-rc.1":  "0.2",
+		"0.2.0-draft": "0.2",
+		"0.0.1-alpha": "0.0.1",
+		"not-semver":  "not-semver",
+	}
+	for in, want := range cases {
+		if got := canonVersion(in); got != want {
+			t.Errorf("canonVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestMaxVersion(t *testing.T) {
+	cases := []struct{ a, b, want string }{
+		{"0.2.1", "0.2.6", "0.2.6"},
+		{"0.2.10", "0.2.9", "0.2.10"},
+		{"0.3.0", "0.2.9", "0.3.0"},
+		{"", "0.2.0", "0.2.0"},
+		{"0.2.0", "", "0.2.0"},
+	}
+	for _, c := range cases {
+		if got := maxVersion(c.a, c.b); got != c.want {
+			t.Errorf("maxVersion(%q, %q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloaddeployments.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloaddeployments.yaml
@@ -283,6 +283,17 @@ spec:
                       hostId:
                         type: string
                       hostInterfaces:
+                        description: |-
+                          HostInterfaces declares the host-provided interfaces this workload needs.
+                          Two routing invariants are enforced at admission, complementing the
+                          host-side checks:
+                            1. No two entries may be exact duplicates (same namespace, package,
+                               name, and version).
+                            2. At most one entry of a given namespace:package may be unnamed — the
+                               unnamed entry is the default route and cannot be shared. Declare
+                               distinct `name`s to route multiple imports of the same package to
+                               different backends. Semver-incompatible versions of the same package
+                               may coexist (they are distinct interfaces).
                         items:
                           properties:
                             config:
@@ -319,14 +330,19 @@ spec:
                             name:
                               description: |-
                                 Name uniquely identifies this interface instance when multiple entries
-                                share the same namespace+package. Components use this name as the
-                                identifier parameter in resource-opening functions (e.g., store::open(name)).
+                                share the same namespace+package. It is the `(implements <name>)` id the
+                                host uses to route a component's named import to this interface's backend,
+                                so two imports of the same namespace:package can resolve to different
+                                backends.
                                 Required when multiple entries of the same namespace:package exist.
+                              maxLength: 64
                               pattern: ^[a-z0-9][a-z0-9-]*$
                               type: string
                             namespace:
+                              maxLength: 128
                               type: string
                             package:
+                              maxLength: 128
                               type: string
                             secretFrom:
                               description: |-
@@ -351,13 +367,29 @@ spec:
                                 x-kubernetes-map-type: atomic
                               type: array
                             version:
+                              maxLength: 64
                               type: string
                           required:
                           - interfaces
                           - namespace
                           - package
                           type: object
+                        maxItems: 64
                         type: array
+                        x-kubernetes-validations:
+                        - message: hostInterfaces must not contain duplicate entries
+                            with the same namespace, package, name, and version
+                          rule: 'self.all(x, self.exists_one(y, y.__namespace__ ==
+                            x.__namespace__ && y.__package__ == x.__package__ && (has(y.name)
+                            ? y.name : '''') == (has(x.name) ? x.name : '''') && (has(y.version)
+                            ? y.version : '''') == (has(x.version) ? x.version : '''')))'
+                        - message: at most one unnamed hostInterface is allowed per
+                            namespace:package; set a unique name to disambiguate multiple
+                            imports of the same package
+                          rule: self.all(x, (has(x.name) && x.name != '') || self.filter(y,
+                            y.__namespace__ == x.__namespace__ && y.__package__ ==
+                            x.__package__ && !(has(y.name) && y.name != '')).size()
+                            == 1)
                       hostSelector:
                         additionalProperties:
                           type: string

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloadreplicasets.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloadreplicasets.yaml
@@ -232,6 +232,17 @@ spec:
                       hostId:
                         type: string
                       hostInterfaces:
+                        description: |-
+                          HostInterfaces declares the host-provided interfaces this workload needs.
+                          Two routing invariants are enforced at admission, complementing the
+                          host-side checks:
+                            1. No two entries may be exact duplicates (same namespace, package,
+                               name, and version).
+                            2. At most one entry of a given namespace:package may be unnamed — the
+                               unnamed entry is the default route and cannot be shared. Declare
+                               distinct `name`s to route multiple imports of the same package to
+                               different backends. Semver-incompatible versions of the same package
+                               may coexist (they are distinct interfaces).
                         items:
                           properties:
                             config:
@@ -268,14 +279,19 @@ spec:
                             name:
                               description: |-
                                 Name uniquely identifies this interface instance when multiple entries
-                                share the same namespace+package. Components use this name as the
-                                identifier parameter in resource-opening functions (e.g., store::open(name)).
+                                share the same namespace+package. It is the `(implements <name>)` id the
+                                host uses to route a component's named import to this interface's backend,
+                                so two imports of the same namespace:package can resolve to different
+                                backends.
                                 Required when multiple entries of the same namespace:package exist.
+                              maxLength: 64
                               pattern: ^[a-z0-9][a-z0-9-]*$
                               type: string
                             namespace:
+                              maxLength: 128
                               type: string
                             package:
+                              maxLength: 128
                               type: string
                             secretFrom:
                               description: |-
@@ -300,13 +316,29 @@ spec:
                                 x-kubernetes-map-type: atomic
                               type: array
                             version:
+                              maxLength: 64
                               type: string
                           required:
                           - interfaces
                           - namespace
                           - package
                           type: object
+                        maxItems: 64
                         type: array
+                        x-kubernetes-validations:
+                        - message: hostInterfaces must not contain duplicate entries
+                            with the same namespace, package, name, and version
+                          rule: 'self.all(x, self.exists_one(y, y.__namespace__ ==
+                            x.__namespace__ && y.__package__ == x.__package__ && (has(y.name)
+                            ? y.name : '''') == (has(x.name) ? x.name : '''') && (has(y.version)
+                            ? y.version : '''') == (has(x.version) ? x.version : '''')))'
+                        - message: at most one unnamed hostInterface is allowed per
+                            namespace:package; set a unique name to disambiguate multiple
+                            imports of the same package
+                          rule: self.all(x, (has(x.name) && x.name != '') || self.filter(y,
+                            y.__namespace__ == x.__namespace__ && y.__package__ ==
+                            x.__package__ && !(has(y.name) && y.name != '')).size()
+                            == 1)
                       hostSelector:
                         additionalProperties:
                           type: string

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloads.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloads.yaml
@@ -221,6 +221,17 @@ spec:
               hostId:
                 type: string
               hostInterfaces:
+                description: |-
+                  HostInterfaces declares the host-provided interfaces this workload needs.
+                  Two routing invariants are enforced at admission, complementing the
+                  host-side checks:
+                    1. No two entries may be exact duplicates (same namespace, package,
+                       name, and version).
+                    2. At most one entry of a given namespace:package may be unnamed — the
+                       unnamed entry is the default route and cannot be shared. Declare
+                       distinct `name`s to route multiple imports of the same package to
+                       different backends. Semver-incompatible versions of the same package
+                       may coexist (they are distinct interfaces).
                 items:
                   properties:
                     config:
@@ -257,14 +268,19 @@ spec:
                     name:
                       description: |-
                         Name uniquely identifies this interface instance when multiple entries
-                        share the same namespace+package. Components use this name as the
-                        identifier parameter in resource-opening functions (e.g., store::open(name)).
+                        share the same namespace+package. It is the `(implements <name>)` id the
+                        host uses to route a component's named import to this interface's backend,
+                        so two imports of the same namespace:package can resolve to different
+                        backends.
                         Required when multiple entries of the same namespace:package exist.
+                      maxLength: 64
                       pattern: ^[a-z0-9][a-z0-9-]*$
                       type: string
                     namespace:
+                      maxLength: 128
                       type: string
                     package:
+                      maxLength: 128
                       type: string
                     secretFrom:
                       description: |-
@@ -289,13 +305,28 @@ spec:
                         x-kubernetes-map-type: atomic
                       type: array
                     version:
+                      maxLength: 64
                       type: string
                   required:
                   - interfaces
                   - namespace
                   - package
                   type: object
+                maxItems: 64
                 type: array
+                x-kubernetes-validations:
+                - message: hostInterfaces must not contain duplicate entries with
+                    the same namespace, package, name, and version
+                  rule: 'self.all(x, self.exists_one(y, y.__namespace__ == x.__namespace__
+                    && y.__package__ == x.__package__ && (has(y.name) ? y.name : '''')
+                    == (has(x.name) ? x.name : '''') && (has(y.version) ? y.version
+                    : '''') == (has(x.version) ? x.version : '''')))'
+                - message: at most one unnamed hostInterface is allowed per namespace:package;
+                    set a unique name to disambiguate multiple imports of the same
+                    package
+                  rule: self.all(x, (has(x.name) && x.name != '') || self.filter(y,
+                    y.__namespace__ == x.__namespace__ && y.__package__ == x.__package__
+                    && !(has(y.name) && y.name != '')).size() == 1)
               hostSelector:
                 additionalProperties:
                   type: string

--- a/runtime-operator/go.mod
+++ b/runtime-operator/go.mod
@@ -10,6 +10,7 @@ tool (
 
 require (
 	connectrpc.com/connect v1.20.0
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.5.3+incompatible
 	github.com/goccy/go-yaml v1.19.2
@@ -29,7 +30,6 @@ require (
 require (
 	cel.dev/expr v0.25.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/air-verse/air v1.65.2 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/antithesishq/antithesis-sdk-go v0.7.0-default-no-op // indirect

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -106,8 +106,11 @@ var _ = BeforeSuite(func() {
 		runtimeImageRef := fmt.Sprintf("%s:%s", runtimeImageRepo, operatorImageTag)
 		if !skipRuntimeBuild {
 			By("building the wash-runtime image from the local tree")
-			// Repo root sits one level above runtime-operator/.
-			cmd := exec.Command("docker", "build", "-t", runtimeImageRef, "..")
+			// Repo root sits one level above runtime-operator/. Build wash with
+			// `(implements ..)` multiplexing enabled.
+			cmd := exec.Command("docker", "build",
+				"--build-arg", "CARGO_FEATURES=wasm_component_model_implements",
+				"-t", runtimeImageRef, "..")
 			_, err := utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the wash-runtime image")
 		}

--- a/runtime-operator/test/e2e/implements_test.go
+++ b/runtime-operator/test/e2e/implements_test.go
@@ -1,0 +1,197 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.wasmcloud.dev/runtime-operator/v2/test/utils"
+)
+
+// End-to-end coverage for `(implements ..)` named host interfaces: a single
+// WorkloadDeployment that declares the *same* namespace:package (wasi:keyvalue)
+// twice under distinct names (`team-a`, `team-b`), each routed to its own
+// backend. Reaching Ready exercises the whole stack end-to-end:
+//
+//   - admission: the CEL XValidation rules on WorkloadSpec.hostInterfaces accept
+//     two same-package entries because they carry distinct names (and still
+//     reject true duplicates / a second unnamed entry);
+//   - reconcile/dedup: EnsureHostInterface keeps the two named entries DISTINCT
+//     on the derived Workload CR (different names never merge); and
+//   - host: the multiplexed keyvalue plugin (registered in `wash host` under the
+//     `wasm_component_model_implements` feature) binds the component's `team-a`
+//     and `team-b` `(implements ..)` imports to separate backends — without it
+//     the WorkloadDeployment can't instantiate and never reaches Ready.
+//
+// The byte-level isolation check (write `from-a` via team-a, `from-b` via
+// team-b, read back `isolated`) is covered in-process by
+// crates/wash-runtime/tests/integration_keyvalue_implements.rs; this spec proves
+// the operator and host wire that routing up in a real cluster. The
+// merge/canon-version logic has direct unit tests in
+// api/runtime/v1alpha1/workload_types_test.go, and envtest (`make test`)
+// validates the CEL rules against a live apiserver.
+//
+// To run this spec, set IMPLEMENTS_E2E_IMAGE to an OCI ref the cluster can pull
+// for a component that exports wasi:http/incoming-handler and imports
+// wasi:keyvalue/store twice under the labels `team-a` and `team-b` (build from
+// crates/wash-runtime/tests/fixtures/keyvalue-implements). Excluded from
+// `make test` (which skips ./test/e2e); runs in the dedicated `make test-e2e`
+// job, which sets IMPLEMENTS_E2E_IMAGE, and skips when that's unset.
+var _ = Describe("Implements Named Host Interfaces", Ordered, func() {
+	const workloadName = "keyvalue-implements"
+
+	var componentImage string
+
+	BeforeAll(func() {
+		componentImage = os.Getenv("IMPLEMENTS_E2E_IMAGE")
+		if componentImage == "" {
+			Skip("IMPLEMENTS_E2E_IMAGE not set; skipping implements e2e " +
+				"(see runtime-operator/test/e2e/implements_test.go for setup)")
+		}
+
+		// Scale a hostgroup pod up and wait for a Host CR so workload placement
+		// is independent of spec ordering (see messaging_test.go for the
+		// rationale on why pod-Ready alone isn't enough).
+		By("ensuring at least one hostgroup pod is running")
+		cmd := exec.Command("kubectl", "scale", "deployment/hostgroup-default",
+			"--replicas=1", "-n", namespace)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to scale hostgroup")
+
+		cmd = exec.Command("kubectl", "rollout", "status",
+			"-n", namespace, "deployment/hostgroup-default", "--timeout=2m")
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "hostgroup rollout did not complete")
+
+		By("waiting for a Host CR to be registered")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "hosts.runtime.wasmcloud.dev",
+				"-n", namespace, "-o", "jsonpath={.items}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).NotTo(Equal("[]"), "no Host CR registered yet")
+		}).WithTimeout(2 * time.Minute).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		if !CurrentSpecReport().Failed() {
+			return
+		}
+		dump := func(label string, args ...string) {
+			out, err := utils.Run(exec.Command("kubectl", args...))
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== %s ===\n%s\n", label, out)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== %s (FAILED: %s) ===\n", label, err)
+			}
+		}
+		// Reaching Ready requires the host to pull the component, decode its
+		// `(implements ..)` imports, and bind team-a/team-b — so the hostgroup
+		// pod logs + pod state are the most direct evidence of where it broke
+		// (image pull, decode, or plugin bind). The WorkloadDeployment/Workload
+		// status conditions show whether placement vs sync vs health failed.
+		dump("Pods", "get", "pods", "-n", namespace, "-o", "wide")
+		dump("Events", "get", "events", "-n", namespace,
+			"--sort-by=.lastTimestamp")
+		dump("Hostgroup logs", "logs", "-n", namespace,
+			"-l", "wasmcloud.com/name=hostgroup", "--tail=600", "--prefix=true")
+		dump("WorkloadDeployment", "get", "workloaddeployment", workloadName,
+			"-n", namespace, "-o", "yaml")
+		dump("WorkloadReplicaSets", "get", "workloadreplicasets.runtime.wasmcloud.dev",
+			"-n", namespace, "-o", "yaml")
+		dump("Workload CRs", "get", "workloads.runtime.wasmcloud.dev",
+			"-n", namespace, "-o", "yaml")
+		dump("Operator logs", "logs", "-n", namespace,
+			"-l", "wasmcloud.com/name=runtime-operator", "--tail=200")
+	})
+
+	AfterAll(func() {
+		if componentImage == "" {
+			return
+		}
+		_ = exec.Command("kubectl", "delete", "workloaddeployment", workloadName,
+			"-n", namespace, "--ignore-not-found=true").Run()
+	})
+
+	It("admits two named entries of the same package and keeps them distinct", func() {
+		By("applying a WorkloadDeployment with team-a and team-b keyvalue imports")
+		// Two entries of wasi:keyvalue under distinct names route to separate
+		// backends; the unnamed http interface is the default route. Admission
+		// must accept this (same package, distinct names) — the pre-feature
+		// rules rejected duplicate namespace:package outright.
+		manifest := fmt.Sprintf(`apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          version: "0.2.2"
+          interfaces:
+            - incoming-handler
+          config:
+            host: keyvalue-implements
+        - namespace: wasi
+          package: keyvalue
+          name: team-a
+          version: "0.2.0-draft"
+          interfaces:
+            - store
+          config:
+            backend: in-memory
+        - namespace: wasi
+          package: keyvalue
+          name: team-b
+          version: "0.2.0-draft"
+          interfaces:
+            - store
+          config:
+            backend: in-memory
+      components:
+        - name: keyvalue-implements
+          image: %s
+`, workloadName, namespace, componentImage)
+
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(manifest)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(),
+			"admission should accept two distinctly-named entries of wasi:keyvalue")
+
+		By("waiting for the WorkloadDeployment to become Ready")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "workloaddeployment", workloadName,
+				"-n", namespace,
+				"-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].status}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("True"))
+		}).WithTimeout(3 * time.Minute).Should(Succeed())
+
+		By("verifying both named interfaces survive onto the derived Workload CR")
+		// The operator's EnsureHostInterface merges only entries sharing a
+		// routing identity (namespace, package, name) and a compatible version.
+		// team-a and team-b differ only by name, so they must NOT merge — both
+		// names must be present on the materialized Workload.
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "workloads.runtime.wasmcloud.dev",
+				"-n", namespace,
+				"-o", "jsonpath={.items[*].spec.hostInterfaces[*].name}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			names := strings.Fields(output)
+			g.Expect(names).To(ContainElement("team-a"))
+			g.Expect(names).To(ContainElement("team-b"))
+		}).WithTimeout(2 * time.Minute).Should(Succeed())
+	})
+})


### PR DESCRIPTION
Depends on #5279 (the multiplexed `wasi:keyvalue` plugin) and the
oci-client/oci-wasm bump (which lets wash push/pull `(implements ..)` components).

Makes component-model `(implements ..)` named host interfaces usable end-to-end
on the platform: the runtime-operator can **declare** them on a
`WorkloadDeployment`, and a deployed `wash host` actually **serves** them by
registering the multiplexed keyvalue plugin. A `WorkloadDeployment` can import
the same `namespace:package` more than once under distinct `name`s, so two
imports of one interface route to different backends (e.g. `team-a` → redis,
`team-b` → nats). The `name` is the `(implements <name>)` id the host routes by.

## Operator: named host interfaces (Go/CRD)

- `HostInterface.Name` documented as the routing id; `MaxLength` bounds added on
  name/namespace/package/version.
- `WorkloadSpec.hostInterfaces` CEL `XValidation` at admission: reject exact
  duplicates (ns + pkg + name + version), and allow at most one **unnamed** entry
  per `namespace:package` (the default route can't be shared).
- `EnsureHostInterface` merges only entries sharing a routing identity
  (namespace, package, name) **and** a semver-compatible version, per the
  component-model canonical-version rules (`0.2.1`/`0.2.6` collapse to the higher;
  `0.2`/`0.3` stay distinct). This matches how the host/wit-parser treats versions.
- CRDs regenerated; `Masterminds/semver/v3` promoted to a direct dependency.

## wash: register the multiplexed keyvalue plugin in host/dev

- `wash host` and `wash dev` register `MultiplexedKeyValue` (all provider kinds,
  backend selected per-interface via config) behind the
  `wasm_component_model_implements` feature. It claims only `(implements ..)`
  named imports. This is keyvalue-only, with blobstore/messaging/etc in future prs.

## e2e

- New gated `runtime-operator/test/e2e/implements_test.go`: deploys a
  `WorkloadDeployment` with `team-a`/`team-b` keyvalue imports and asserts
  admission accepts them, the WD reaches `Ready` (which requires the host plugin
  to bind both named imports), and both names survive distinctly onto the derived
  Workload. The byte-level isolation check (write/read `isolated`) is covered
  in-process by `crates/wash-runtime/tests/integration_keyvalue_implements.rs`.
- The e2e host image is built with the feature (CI tarball + local `make
  test-e2e`); the published **canary stays on default features**.

## Testing

- `make test` in `runtime-operator/` — envtest validates the CEL rules against a
  live apiserver; the dedup/canon-version unit tests pass.
- `cargo build` + `cargo clippy -p wash --features wasm_component_model_implements` clean.
- e2e: `IMPLEMENTS_E2E_IMAGE=ghcr.io/wasmcloud/components/keyvalue-implements:0.1.0 make test-e2e`.
