### PR TITLE
feat(wash-runtime): multiplex wasmcloud:messaging/consumer

### DIFF
--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
@@ -1,7 +1,14 @@
 mod in_memory;
+#[cfg(feature = "wasm_component_model_implements")]
+mod multiplexed;
 mod nats;
 
 pub use in_memory::InMemoryMessaging;
+#[cfg(feature = "wasm_component_model_implements")]
+pub use multiplexed::{
+    BrokerMessage, InMemoryMsgBackend, InMemoryMsgProvider, MsgBackend, MsgId, MsgProvider,
+    MultiplexedMessaging, NatsMsgBackend, NatsMsgProvider,
+};
 pub use nats::NatsMessaging;
 
 /// Parses a comma-separated `subscriptions` config value into trimmed,

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/multiplexed.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/multiplexed.rs
@@ -1,0 +1,241 @@
+//! # Multiplexed wasmcloud:messaging consumer (implements-routed)
+//!
+//! Binds the `wasmcloud:messaging/consumer` interface via the component-model
+//! `(implements ..)` / `named_imports` mechanism so a single component can
+//! import the consumer interface multiple times and route each import's
+//! outbound `publish`/`request` to a *different* backend (e.g. one import
+//! publishing to NATS cluster A and another to cluster B).
+//!
+//! The handler (subscription) side is an *export* and is unaffected by import
+//! multiplexing; it is served by the standalone messaging plugins.
+//!
+//! Each backend lives in its own submodule: [`nats`] (NATS clusters) and
+//! [`in_memory`] (a reference loopback).
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tracing::instrument;
+
+use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
+use crate::engine::workload::WorkloadItem;
+use crate::plugin::multiplex::{BackendProvider, Multiplexer};
+use crate::plugin::{HostPlugin, WitInterfaces};
+use crate::wit::{WitInterface, WitWorld};
+
+mod in_memory;
+mod nats;
+
+pub use in_memory::{InMemoryMsgBackend, InMemoryMsgProvider};
+pub use nats::{NatsMsgBackend, NatsMsgProvider};
+
+mod bindings {
+    crate::wasmtime::component::bindgen!({
+        world: "messaging",
+        imports: { default: async | trappable | tracing },
+        exports: { default: async | tracing },
+        named_imports: {
+            "wasmcloud:messaging/consumer": super::MsgId,
+        },
+    });
+}
+
+pub use bindings::wasmcloud::messaging::types::BrokerMessage;
+
+/// The "implements id" threaded through every consumer host method: the backend
+/// a given named import is bound to. `Arc` so it is cheaply `Clone`d into each
+/// per-import closure, as `named_imports` requires.
+pub type MsgId = Arc<dyn MsgBackend>;
+
+/// A messaging backend (a NATS cluster, an in-memory loopback, ...). The
+/// unified surface the named consumer host impl dispatches onto. Errors are the
+/// WIT `error` (a `string`).
+#[async_trait::async_trait]
+pub trait MsgBackend: Send + Sync {
+    async fn request(
+        &self,
+        subject: String,
+        body: Vec<u8>,
+        timeout_ms: u32,
+    ) -> Result<BrokerMessage, String>;
+    async fn publish(&self, msg: BrokerMessage) -> Result<(), String>;
+}
+
+impl<'a> bindings::named_imports::wasmcloud::messaging::consumer::Host for ActiveCtx<'a> {
+    #[instrument(name = "wasmcloud.messaging.request", skip_all, fields(subject = %subject, timeout_ms = timeout_ms))]
+    async fn request(
+        &mut self,
+        id: MsgId,
+        subject: String,
+        body: Vec<u8>,
+        timeout_ms: u32,
+    ) -> wasmtime::Result<Result<BrokerMessage, String>> {
+        Ok(id.request(subject, body, timeout_ms).await)
+    }
+
+    #[instrument(name = "wasmcloud.messaging.publish", skip_all, fields(subject = %msg.subject))]
+    async fn publish(
+        &mut self,
+        id: MsgId,
+        msg: BrokerMessage,
+    ) -> wasmtime::Result<Result<(), String>> {
+        Ok(id.publish(msg).await)
+    }
+}
+
+// `types` has no host functions or resources, so it is bound via the regular
+// (non-named) path; only `consumer` is multiplexed per import.
+impl<'a> bindings::wasmcloud::messaging::types::Host for ActiveCtx<'a> {}
+
+const DEFAULT_BACKEND: &str = "in-memory";
+const MULTIPLEXED_MESSAGING_ID: &str = "wasmcloud-messaging-multiplexed";
+
+/// A messaging backend provider: a [`BackendProvider`] producing [`MsgId`]s.
+pub type MsgProvider = dyn BackendProvider<MsgId>;
+
+/// A messaging [`HostPlugin`] that multiplexes `wasmcloud:messaging/consumer`
+/// across backends selected per `(implements ..)` import. Register the backend
+/// providers you want via [`MultiplexedMessaging::with_provider`].
+pub struct MultiplexedMessaging {
+    mux: Multiplexer<MsgId>,
+}
+
+impl Default for MultiplexedMessaging {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MultiplexedMessaging {
+    pub fn new() -> Self {
+        Self {
+            mux: Multiplexer::new("wasmcloud", "messaging", DEFAULT_BACKEND),
+        }
+    }
+
+    pub fn with_provider(mut self, provider: Arc<MsgProvider>) -> Self {
+        self.mux = self.mux.with_provider(provider);
+        self
+    }
+
+    /// Build the routing registry (host-interface name -> backend) from a
+    /// component's matched messaging host interfaces.
+    pub async fn build_registry<'i>(
+        &self,
+        interfaces: impl IntoIterator<Item = &'i WitInterface>,
+    ) -> anyhow::Result<HashMap<String, MsgId>> {
+        self.mux.build_registry(interfaces).await
+    }
+}
+
+#[async_trait::async_trait]
+impl HostPlugin for MultiplexedMessaging {
+    fn id(&self) -> &'static str {
+        MULTIPLEXED_MESSAGING_ID
+    }
+
+    fn world(&self) -> WitWorld {
+        WitWorld {
+            imports: HashSet::from([WitInterface::from(
+                "wasmcloud:messaging/consumer,types@0.2.0",
+            )]),
+            ..Default::default()
+        }
+    }
+
+    fn supports_named_instances(&self) -> bool {
+        true
+    }
+
+    async fn on_workload_item_bind<'a>(
+        &self,
+        item: &mut WorkloadItem<'a>,
+        interfaces: WitInterfaces<'_>,
+    ) -> anyhow::Result<()> {
+        if !interfaces.contains("wasmcloud", "messaging", &[]) {
+            return Ok(());
+        }
+
+        let registry = self.build_registry(interfaces.iter()).await?;
+        let component = item.component().clone();
+        let linker = item.linker();
+
+        // `types` carries only record definitions; bind it via the regular
+        // path (no per-import routing needed).
+        bindings::wasmcloud::messaging::types::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+        bindings::named_imports::wasmcloud::messaging::consumer::add_to_linker::<_, SharedCtx>(
+            linker,
+            &component,
+            |name| self.mux.resolve(&registry, name),
+            extract_active_ctx,
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg_iface(name: Option<&str>, backend: Option<&str>) -> WitInterface {
+        let mut config = HashMap::new();
+        if let Some(b) = backend {
+            config.insert("backend".to_string(), b.to_string());
+        }
+        WitInterface {
+            namespace: "wasmcloud".to_string(),
+            package: "messaging".to_string(),
+            interfaces: ["consumer".to_string()].into_iter().collect(),
+            version: None,
+            config,
+            name: name.map(String::from),
+        }
+    }
+
+    fn brokered(subject: &str, body: &[u8]) -> BrokerMessage {
+        BrokerMessage {
+            subject: subject.to_string(),
+            reply_to: None,
+            body: body.to_vec(),
+        }
+    }
+
+    /// The decisive case: two named interfaces of the same backend type route to
+    /// independent backends, so a publish on one is not seen by the other.
+    #[tokio::test]
+    async fn registry_routes_named_interfaces_to_distinct_backends() {
+        let plugin = MultiplexedMessaging::new().with_provider(Arc::new(InMemoryMsgProvider));
+        let interfaces = HashSet::from([
+            msg_iface(Some("cluster-a"), Some("in-memory")),
+            msg_iface(Some("cluster-b"), Some("in-memory")),
+        ]);
+
+        let registry = plugin.build_registry(&interfaces).await.unwrap();
+        let a = registry.get("cluster-a").expect("a routed").clone();
+        let b = registry.get("cluster-b").expect("b routed").clone();
+
+        a.publish(brokered("tasks", b"hi")).await.unwrap();
+
+        // The registry hands back the same backend for a given name, and the two
+        // names resolve to independent instances (the in-memory provider never
+        // pools, so each named import is isolated).
+        assert!(Arc::ptr_eq(&a, &registry.get("cluster-a").unwrap().clone()));
+        assert!(!Arc::ptr_eq(&a, &b), "routes must be distinct backends");
+    }
+
+    #[tokio::test]
+    async fn build_registry_errors_on_unregistered_backend() {
+        let plugin = MultiplexedMessaging::new(); // no providers
+        let interfaces = HashSet::from([msg_iface(Some("x"), Some("nats"))]);
+        let err = plugin
+            .build_registry(&interfaces)
+            .await
+            .err()
+            .expect("expected error for unregistered backend");
+        assert!(err.to_string().contains("nats"), "unexpected error: {err}");
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/multiplexed/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/multiplexed/in_memory.rs
@@ -1,0 +1,100 @@
+//! In-memory loopback backend for the multiplexed `wasmcloud:messaging` plugin.
+//!
+//! A reference [`MsgBackend`] needing no external infra: it records published
+//! messages and answers `request` by echoing it back as its own reply. Used to
+//! prove routing and for tests; each instance is isolated, so two named imports
+//! backed by two `InMemoryMsgBackend`s do not share published messages.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::plugin::multiplex::BackendProvider;
+
+use super::{BrokerMessage, MsgBackend, MsgId};
+
+/// An in-memory [`MsgBackend`] that records published messages and answers
+/// `request` by echoing it back as its own reply. Each instance is isolated.
+#[derive(Default)]
+pub struct InMemoryMsgBackend {
+    published: RwLock<Vec<BrokerMessage>>,
+}
+
+impl InMemoryMsgBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Messages published through this backend, in order.
+    pub async fn published(&self) -> Vec<BrokerMessage> {
+        self.published.read().await.clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl MsgBackend for InMemoryMsgBackend {
+    async fn request(
+        &self,
+        subject: String,
+        body: Vec<u8>,
+        _timeout_ms: u32,
+    ) -> Result<BrokerMessage, String> {
+        // Loopback: echo the request back as its own reply.
+        self.published.write().await.push(BrokerMessage {
+            subject: subject.clone(),
+            reply_to: None,
+            body: body.clone(),
+        });
+        Ok(BrokerMessage {
+            subject,
+            reply_to: None,
+            body,
+        })
+    }
+
+    async fn publish(&self, msg: BrokerMessage) -> Result<(), String> {
+        self.published.write().await.push(msg);
+        Ok(())
+    }
+}
+
+/// In-memory provider, the default backend type. Each named interface gets its
+/// own isolated loopback (it never pools).
+#[derive(Default)]
+pub struct InMemoryMsgProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<MsgId> for InMemoryMsgProvider {
+    fn backend_type(&self) -> &'static str {
+        super::DEFAULT_BACKEND
+    }
+
+    async fn instantiate(&self, _config: &HashMap<String, String>) -> anyhow::Result<MsgId> {
+        Ok(Arc::new(InMemoryMsgBackend::new()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn brokered(subject: &str, body: &[u8]) -> BrokerMessage {
+        BrokerMessage {
+            subject: subject.to_string(),
+            reply_to: None,
+            body: body.to_vec(),
+        }
+    }
+
+    #[tokio::test]
+    async fn in_memory_backend_records_publishes() {
+        let b = InMemoryMsgBackend::new();
+        b.publish(brokered("a", b"1")).await.unwrap();
+        b.publish(brokered("b", b"2")).await.unwrap();
+        let published = b.published().await;
+        assert_eq!(published.len(), 2);
+        assert_eq!(published[0].subject, "a");
+        assert_eq!(published[1].subject, "b");
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/multiplexed/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/multiplexed/nats.rs
@@ -1,0 +1,79 @@
+//! NATS backend for the multiplexed `wasmcloud:messaging` plugin.
+//!
+//! A [`MsgBackend`]/[`BackendProvider`] pair backed by an `async_nats` client,
+//! serving the outbound (consumer) `publish`/`request` path — the same surface
+//! the standalone `NatsMessaging` plugin uses.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::plugin::multiplex::BackendProvider;
+
+use super::{BrokerMessage, MsgBackend, MsgId};
+
+/// A NATS-backed [`MsgBackend`]. The provider pools clients by `url`
+/// ([`NatsMsgProvider::pool_key`]), so named imports pointing at the same
+/// cluster share one connection while imports with distinct urls get
+/// independent clients.
+pub struct NatsMsgBackend {
+    client: Arc<async_nats::Client>,
+}
+
+#[async_trait::async_trait]
+impl MsgBackend for NatsMsgBackend {
+    async fn request(
+        &self,
+        subject: String,
+        body: Vec<u8>,
+        timeout_ms: u32,
+    ) -> Result<BrokerMessage, String> {
+        let timeout = std::time::Duration::from_millis(timeout_ms as u64);
+        let resp =
+            match tokio::time::timeout(timeout, self.client.request(subject, body.into())).await {
+                Ok(Ok(msg)) => msg,
+                Ok(Err(e)) => return Err(format!("failed to send request: {e}")),
+                Err(_) => return Err(format!("request timed out after {timeout_ms}ms")),
+            };
+        Ok(BrokerMessage {
+            subject: resp.subject.to_string(),
+            reply_to: resp.reply.as_ref().map(|r| r.to_string()),
+            body: resp.payload.into(),
+        })
+    }
+
+    async fn publish(&self, msg: BrokerMessage) -> Result<(), String> {
+        let result = if let Some(reply_to) = msg.reply_to {
+            self.client
+                .publish_with_reply(msg.subject, reply_to, msg.body.into())
+                .await
+        } else {
+            self.client.publish(msg.subject, msg.body.into()).await
+        };
+        result.map_err(|e| format!("failed to send message: {e}"))
+    }
+}
+
+/// NATS provider, selected by `config.backend = "nats"`. Requires `config.url`
+/// (e.g. `nats://127.0.0.1:4222`).
+#[derive(Default)]
+pub struct NatsMsgProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<MsgId> for NatsMsgProvider {
+    fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
+        config.get("url").cloned()
+    }
+    fn backend_type(&self) -> &'static str {
+        "nats"
+    }
+
+    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<MsgId> {
+        let url = config
+            .get("url")
+            .ok_or_else(|| anyhow::anyhow!("nats messaging backend requires a 'url' config"))?;
+        let client = async_nats::connect(url).await?;
+        Ok(Arc::new(NatsMsgBackend {
+            client: Arc::new(client),
+        }))
+    }
+}

--- a/crates/wash-runtime/tests/integration_messaging_multiplexed.rs
+++ b/crates/wash-runtime/tests/integration_messaging_multiplexed.rs
@@ -1,0 +1,181 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! End-to-end test for multiplexed `wasmcloud:messaging/consumer` routing via
+//! `(implements ..)` across TWO independent NATS clusters. `team-a` resolves to
+//! cluster A and `team-b` to cluster B. Both verification clients subscribe to
+//! the *same* subject, so only the routing differs: a publish through `team-a`
+//! lands on cluster A and never on cluster B (and vice versa), and a `request`
+//! through `team-a` round-trips against a responder on cluster A. This proves
+//! each named import is bound to its own backend, not merely its own subject.
+//!
+//! Requires Docker (NATS); marked `#[ignore]`, so it runs only under
+//! `cargo test --include-ignored` (CI's Linux leg) and not a plain `cargo test`.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use testcontainers::{
+    ContainerAsync, GenericImage,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+use wash_runtime::plugin::wasmcloud_messaging::{
+    BrokerMessage, MultiplexedMessaging, NatsMsgProvider,
+};
+use wash_runtime::wit::WitInterface;
+
+fn msg_iface(name: &str, url: &str) -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "messaging".to_string(),
+        interfaces: ["consumer".to_string(), "types".to_string()]
+            .into_iter()
+            .collect(),
+        version: None,
+        config: HashMap::from([
+            ("backend".to_string(), "nats".to_string()),
+            ("url".to_string(), url.to_string()),
+        ]),
+        name: Some(name.to_string()),
+    }
+}
+
+fn err(e: impl std::fmt::Debug) -> anyhow::Error {
+    anyhow::anyhow!("messaging backend error: {e:?}")
+}
+
+/// Start a fresh single-node NATS cluster in a container, returning the guard
+/// (kept alive for the test's duration) and its `nats://` url.
+async fn start_nats() -> Result<(ContainerAsync<GenericImage>, String)> {
+    let container = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start NATS: {e}"))?;
+    let port = container.get_host_port_ipv4(4222).await?;
+    Ok((container, format!("nats://127.0.0.1:{port}")))
+}
+
+/// Force a server-side round-trip so every subscription queued earlier on
+/// `client` is registered before we publish. `flush()` only flushes the local
+/// TCP buffer; NATS processes commands per-connection in order, so once our
+/// sentinel comes back, the earlier SUBs are active too.
+async fn sync(client: &async_nats::Client) -> Result<()> {
+    let inbox = client.new_inbox();
+    let mut sentinel = client.subscribe(inbox.clone()).await?;
+    client
+        .publish(inbox, bytes::Bytes::from_static(&[0]))
+        .await?;
+    client.flush().await?;
+    tokio::time::timeout(Duration::from_secs(5), sentinel.next())
+        .await
+        .context("sync round-trip timed out")?
+        .context("sync inbox closed")?;
+    Ok(())
+}
+
+/// Await the next message on `sub`, failing if none arrives in time.
+async fn next_msg(sub: &mut async_nats::Subscriber) -> Result<async_nats::Message> {
+    tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .context("timed out waiting for message")?
+        .context("subscription closed")
+}
+
+/// Assert no message arrives on `sub` within a short window — the cross-cluster
+/// isolation check (the other cluster must never see this import's publish).
+async fn expect_silent(sub: &mut async_nats::Subscriber) -> Result<()> {
+    match tokio::time::timeout(Duration::from_secs(1), sub.next()).await {
+        Err(_) => Ok(()),   // timed out: silent, as required
+        Ok(None) => Ok(()), // subscription closed: no message
+        Ok(Some(m)) => Err(anyhow::anyhow!(
+            "unexpected message on the isolated cluster (subject {})",
+            m.subject
+        )),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn multiplexed_messaging_routes_each_import_to_its_cluster() -> Result<()> {
+    // Two independent clusters; team-a -> A, team-b -> B.
+    let (_nats_a, url_a) = start_nats().await?;
+    let (_nats_b, url_b) = start_nats().await?;
+
+    let plugin = MultiplexedMessaging::new().with_provider(Arc::new(NatsMsgProvider));
+    let interfaces = HashSet::from([msg_iface("team-a", &url_a), msg_iface("team-b", &url_b)]);
+    let registry = plugin.build_registry(&interfaces).await?;
+    let team_a = registry.get("team-a").expect("team-a routed").clone();
+    let team_b = registry.get("team-b").expect("team-b routed").clone();
+
+    // A verification client on each cluster, both subscribed to the SAME subject
+    // so only the routing (which cluster) distinguishes them.
+    let verify_a = async_nats::connect(&url_a)
+        .await
+        .context("verify-a connect")?;
+    let verify_b = async_nats::connect(&url_b)
+        .await
+        .context("verify-b connect")?;
+    let subject = "team.events";
+    let mut sub_a = verify_a.subscribe(subject).await?;
+    let mut sub_b = verify_b.subscribe(subject).await?;
+    sync(&verify_a).await?;
+    sync(&verify_b).await?;
+
+    // team-a's publish lands on cluster A only.
+    team_a
+        .publish(BrokerMessage {
+            subject: subject.to_string(),
+            reply_to: None,
+            body: b"from-a".to_vec(),
+        })
+        .await
+        .map_err(err)?;
+    assert_eq!(next_msg(&mut sub_a).await?.payload.as_ref(), b"from-a");
+    expect_silent(&mut sub_b)
+        .await
+        .context("cluster B must not see team-a's publish")?;
+
+    // team-b's publish lands on cluster B only.
+    team_b
+        .publish(BrokerMessage {
+            subject: subject.to_string(),
+            reply_to: None,
+            body: b"from-b".to_vec(),
+        })
+        .await
+        .map_err(err)?;
+    assert_eq!(next_msg(&mut sub_b).await?.payload.as_ref(), b"from-b");
+    expect_silent(&mut sub_a)
+        .await
+        .context("cluster A must not see team-b's publish")?;
+
+    // `request` routed through team-a reaches a responder on cluster A and
+    // returns its reply.
+    let responder = async_nats::connect(&url_a)
+        .await
+        .context("responder connect")?;
+    let mut requests = responder.subscribe("team-a.rpc").await?;
+    sync(&responder).await?;
+    let responder_handle = tokio::spawn(async move {
+        if let Some(msg) = requests.next().await
+            && let Some(reply) = msg.reply
+        {
+            let _ = responder.publish(reply, b"pong".to_vec().into()).await;
+            let _ = responder.flush().await;
+        }
+    });
+
+    let reply = team_a
+        .request("team-a.rpc".to_string(), b"ping".to_vec(), 5000)
+        .await
+        .map_err(err)?;
+    assert_eq!(reply.body, b"pong".to_vec());
+    responder_handle.abort();
+
+    Ok(())
+}

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -236,6 +236,12 @@ impl CliCommand for DevCommand {
                     .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
             ))?;
             debug!("WASI KeyValue multiplexed plugin registered (implements)");
+            host_builder = host_builder.with_plugin(Arc::new(
+                plugin::wasmcloud_messaging::MultiplexedMessaging::new()
+                    .with_provider(Arc::new(plugin::wasmcloud_messaging::InMemoryMsgProvider))
+                    .with_provider(Arc::new(plugin::wasmcloud_messaging::NatsMsgProvider)),
+            ))?;
+            debug!("wasmcloud:messaging multiplexed plugin registered (implements)");
         }
 
         // Add postgres plugin if configured

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -206,6 +206,11 @@ impl CliCommand for HostCommand {
                     .with_provider(Arc::new(plugin::wasi_keyvalue::NatsProvider))
                     .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
             ))?;
+            cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
+                plugin::wasmcloud_messaging::MultiplexedMessaging::new()
+                    .with_provider(Arc::new(plugin::wasmcloud_messaging::InMemoryMsgProvider))
+                    .with_provider(Arc::new(plugin::wasmcloud_messaging::NatsMsgProvider)),
+            ))?;
         }
 
         if let Some(postgres_url) = &self.postgres_url {


### PR DESCRIPTION
Bind `wasmcloud:messaging/consumer` through the component-model
`(implements ..)` / `named_imports` mechanism so a single component can
import the consumer interface multiple times and route each import's
outbound `publish`/`request` to a different backend (e.g. one import
publishing to NATS cluster A and another to cluster B). The consumer
interface has no resources, so the resolved backend (`MsgBackend`) is
threaded directly into each host method; `types` is record-only and bound
via the regular path. The `handler` export is unaffected by import
multiplexing and stays served by the standalone messaging plugins.

- crates/wash-runtime: add `wasmcloud_messaging::multiplexed`
- crates/wash host/dev: register `MultiplexedMessaging`
- integration test against 2 nats clusters to show tenant isolation
