### PR TITLE
fix(wash): support Windows-style paths in wash new names

### DIFF
--- a/crates/wash/src/cli/new.rs
+++ b/crates/wash/src/cli/new.rs
@@ -115,7 +115,10 @@ impl NewCommand {
 }
 
 fn last_non_empty_segment(value: &str) -> Option<&str> {
-    value.split('/').rev().find(|segment| !segment.is_empty())
+    value
+        .split(['/', '\\'])
+        .rev()
+        .find(|segment| !segment.is_empty())
 }
 
 fn load_template_new_command(project_dir: &Path) -> anyhow::Result<Option<String>> {
@@ -237,6 +240,30 @@ mod tests {
             git: "https://github.com/wasmCloud/wasmCloud.git".to_string(),
             name: None,
             subfolder: Some("templates/http-hello-world/".to_string()),
+            git_ref: None,
+        };
+
+        assert_eq!(cmd.get_project_name(), "http-hello-world");
+    }
+
+    #[test]
+    fn get_project_name_uses_last_segment_of_windows_repo_path() {
+        let cmd = NewCommand {
+            git: r"C:\src\templates\http-hello-world.git".to_string(),
+            name: None,
+            subfolder: None,
+            git_ref: None,
+        };
+
+        assert_eq!(cmd.get_project_name(), "http-hello-world");
+    }
+
+    #[test]
+    fn get_project_name_uses_last_segment_of_windows_subfolder_path() {
+        let cmd = NewCommand {
+            git: "https://github.com/wasmCloud/wasmCloud.git".to_string(),
+            name: None,
+            subfolder: Some(r"templates\http-hello-world\".to_string()),
             git_ref: None,
         };
 


### PR DESCRIPTION
This fixes a small `wash new` naming bug on Windows-ish inputs.

If the repo path or `--subfolder` uses backslashes, `wash new` was deriving the whole string as the fallback project name because `last_non_empty_segment()` only split on `/`. So `C:\src\templates\http-hello-world.git` ended up kinda cursed, not `http-hello-world`.

What changed
- split on both `/` and `\` when deriving the fallback name
- add regression tests for Windows repo paths and subfolder paths
- keep the existing trailing slash behavior covered too

Repro
1. On `main`, derive the default name from `C:\src\templates\http-hello-world.git` or `templates\http-hello-world\`.
2. Before this patch, the derived name keeps the whole backslash path.
3. With this patch, both cases resolve to `http-hello-world`.

Tested with `cargo test -p wash --lib get_project_name -- --nocapture --test-threads=1`.
