### PR TITLE
feat(wash-runtime): multiplex wasmcloud:postgres via `(implements ..)` imports

### DIFF
--- a/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
@@ -13,14 +13,31 @@ use url::Url;
 
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
+#[cfg(feature = "wasm_component_model_implements")]
+use crate::plugin::multiplex::Multiplexer;
 use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 
 use conversions::into_result_row;
 
+/// `(implements ..)` named per-credential routing: [`PgId`], its provider, the
+/// named-import host impls, and the multiplex constructors. The shared query
+/// helpers (`execute_query`, `pg_error_string`) and the legacy per-component
+/// path stay here in the parent module.
+#[cfg(feature = "wasm_component_model_implements")]
+mod multiplexed;
+#[cfg(feature = "wasm_component_model_implements")]
+pub use multiplexed::PgId;
+
 const PLUGIN_POSTGRES_ID: &str = "wasmcloud-postgres";
 const DEFAULT_POOL_SIZE: usize = 10;
 
+// Two variants of the same `postgres` world. They generate identical
+// `bindings::wasmcloud::postgres::{types,query,prepared}` modules (so the legacy
+// per-component path and `conversions` are unaffected); the implements variant
+// additionally generates `bindings::named_imports::*` for `(implements ..)`
+// routing. `types` carries no functions, so it is linked once and left unnamed.
+#[cfg(not(feature = "wasm_component_model_implements"))]
 mod bindings {
     crate::wasmtime::component::bindgen!({
         world: "postgres",
@@ -28,11 +45,27 @@ mod bindings {
     });
 }
 
+#[cfg(feature = "wasm_component_model_implements")]
+mod bindings {
+    crate::wasmtime::component::bindgen!({
+        world: "postgres",
+        imports: { default: async | trappable | tracing },
+        // Allow a component to import `wasmcloud:postgres` multiple times via
+        // `(implements ..)`, routing each named import to its own credentialed
+        // connection pool (the embedder-chosen `id`).
+        named_imports: {
+            "wasmcloud:postgres/query": super::PgId,
+            "wasmcloud:postgres/prepared": super::PgId,
+        },
+    });
+}
+
 use bindings::wasmcloud::postgres::prepared;
 use bindings::wasmcloud::postgres::query;
 use bindings::wasmcloud::postgres::types;
 
-use query::{PgValue, QueryError};
+// `pub` because these appear in `PgId`'s public query/exec API.
+pub use query::{PgValue, QueryError, ResultRow};
 
 use prepared::{PreparedStatementExecError, StatementPrepareError};
 
@@ -65,6 +98,11 @@ pub struct WasmcloudPostgres {
     component_databases: Arc<RwLock<HashMap<String, String>>>,
     /// Notifies the pool reaper that an unbind happened
     pool_reaper_notify: Arc<tokio::sync::Notify>,
+    /// Multiplexing core for `(implements ..)` named imports: builds and shares
+    /// a per-credential [`PgId`] connection pool per named host interface, keyed
+    /// by URL so identical interfaces reuse one pool across workload binds.
+    #[cfg(feature = "wasm_component_model_implements")]
+    mux: Arc<Multiplexer<PgId>>,
 }
 
 impl WasmcloudPostgres {
@@ -88,15 +126,23 @@ impl WasmcloudPostgres {
         // Strip dbname from the base config - workloads set this via their config
         config.dbname("");
 
-        Ok(Self {
-            base_config: config,
+        Ok(Self::with_base(config, pool_size, tls))
+    }
+
+    /// Assemble a plugin around an already-parsed base config, fresh shared state
+    /// and (under the implements feature) the named-import multiplexer.
+    fn with_base(base_config: tokio_postgres::Config, pool_size: usize, tls: bool) -> Self {
+        Self {
+            base_config,
             pool_size,
             tls,
             pools: Arc::new(RwLock::new(HashMap::new())),
             prepared_statements: Arc::new(RwLock::new(HashMap::new())),
             component_databases: Arc::new(RwLock::new(HashMap::new())),
             pool_reaper_notify: Arc::new(tokio::sync::Notify::new()),
-        })
+            #[cfg(feature = "wasm_component_model_implements")]
+            mux: Arc::new(Self::multiplexer()),
+        }
     }
 
     /// Get or lazily create a connection pool for the given database name.
@@ -214,29 +260,7 @@ impl<'a> query::Host for ActiveCtx<'a> {
             }
         };
 
-        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
-            .iter()
-            .map(|p| p as &(dyn tokio_postgres::types::ToSql + Sync))
-            .collect();
-
-        let rows = match client.query_raw(&q, param_refs).await {
-            Ok(stream) => match stream.try_collect::<Vec<_>>().await {
-                Ok(rows) => rows,
-                Err(e) => {
-                    return Ok(Err(QueryError::Unexpected(format!(
-                        "failed to collect rows: {e}"
-                    ))));
-                }
-            },
-            Err(e) => {
-                return Ok(Err(QueryError::InvalidQuery(format!(
-                    "query execution failed: {e}"
-                ))));
-            }
-        };
-
-        let result: Vec<query::ResultRow> = rows.into_iter().map(into_result_row).collect();
-        Ok(Ok(result))
+        Ok(execute_query(&client, &q, &params).await)
     }
 
     #[instrument(name = "wasmcloud.postgres.query_batch", skip_all, fields(query = %q))]
@@ -274,7 +298,8 @@ impl<'a> query::Host for ActiveCtx<'a> {
         match client.batch_execute(&q).await {
             Ok(()) => Ok(Ok(())),
             Err(e) => Ok(Err(QueryError::InvalidQuery(format!(
-                "batch execution failed: {e}"
+                "batch execution failed: {}",
+                pg_error_string(&e)
             )))),
         }
     }
@@ -320,7 +345,8 @@ impl<'a> prepared::Host for ActiveCtx<'a> {
             Ok(s) => s,
             Err(e) => {
                 return Ok(Err(StatementPrepareError::Unexpected(format!(
-                    "prepare failed: {e}"
+                    "prepare failed: {}",
+                    pg_error_string(&e)
                 ))));
             }
         };
@@ -385,7 +411,8 @@ impl<'a> prepared::Host for ActiveCtx<'a> {
             Ok(s) => s,
             Err(e) => {
                 return Ok(Err(PreparedStatementExecError::Unexpected(format!(
-                    "re-prepare failed: {e}"
+                    "re-prepare failed: {}",
+                    pg_error_string(&e)
                 ))));
             }
         };
@@ -398,10 +425,44 @@ impl<'a> prepared::Host for ActiveCtx<'a> {
         match client.execute_raw(&stmt, param_refs).await {
             Ok(n) => Ok(Ok(n)),
             Err(e) => Ok(Err(PreparedStatementExecError::QueryError(
-                QueryError::Unexpected(format!("execute failed: {e}")),
+                QueryError::Unexpected(format!("execute failed: {}", pg_error_string(&e))),
             ))),
         }
     }
+}
+
+// ── shared query helpers (used by the legacy and multiplexed paths) ─────────
+
+/// Format a postgres error, surfacing the server-side message (e.g. "permission
+/// denied for table ...") since `tokio_postgres::Error`'s `Display` is only the
+/// terse "db error". Per-credential routing leans on these messages to show RBAC
+/// denials, so make them legible.
+fn pg_error_string(e: &tokio_postgres::Error) -> String {
+    match e.as_db_error() {
+        Some(db) => format!("{}: {}", db.code().code(), db.message()),
+        None => e.to_string(),
+    }
+}
+
+/// Run a parameterized query on a connection and map rows to WIT result rows.
+/// Shared by the legacy per-component path and the named per-credential path.
+async fn execute_query(
+    client: &deadpool_postgres::Client,
+    q: &str,
+    params: &[PgValue],
+) -> Result<Vec<ResultRow>, QueryError> {
+    let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
+        .iter()
+        .map(|p| p as &(dyn tokio_postgres::types::ToSql + Sync))
+        .collect();
+    let stream = client
+        .query_raw(q, param_refs)
+        .await
+        .map_err(|e| QueryError::InvalidQuery(format!("query failed: {}", pg_error_string(&e))))?;
+    let rows = stream.try_collect::<Vec<_>>().await.map_err(|e| {
+        QueryError::Unexpected(format!("failed to collect rows: {}", pg_error_string(&e)))
+    })?;
+    Ok(rows.into_iter().map(into_result_row).collect())
 }
 
 // ── HostPlugin implementation ───────────────────────────────────────────────
@@ -419,6 +480,11 @@ impl HostPlugin for WasmcloudPostgres {
             )]),
             ..Default::default()
         }
+    }
+
+    #[cfg(feature = "wasm_component_model_implements")]
+    fn supports_named_instances(&self) -> bool {
+        true
     }
 
     async fn start(&self) -> anyhow::Result<()> {
@@ -456,43 +522,77 @@ impl HostPlugin for WasmcloudPostgres {
         component_handle: &mut WorkloadItem<'a>,
         interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        let database = match interfaces.get("wasmcloud", "postgres", &[]) {
-            Some(i) => i.config.get("database"),
-            None => return Ok(()),
-        };
+        let pg: Vec<&WitInterface> = interfaces
+            .iter()
+            .filter(|i| i.namespace == "wasmcloud" && i.package == "postgres")
+            .collect();
+        if pg.is_empty() {
+            return Ok(());
+        }
 
-        let Some(database) = database.cloned() else {
-            bail!("wasmcloud:postgres requires a 'database' config parameter")
-        };
+        // A `(implements ..)` import is a *named* postgres interface routed to
+        // its own credentialed connection; an unnamed one keeps the legacy
+        // per-component-database behavior (one shared bouncer URL, database
+        // chosen by config).
+        let unnamed = pg.iter().find(|i| i.name.is_none()).copied();
 
         let component_id = component_handle.id().to_string();
-
-        tracing::debug!(
-            component_id = %component_id,
-            database = %database,
-            "Binding postgres plugin to component"
-        );
-
-        // Store the component → database mapping
-        self.component_databases
-            .write()
-            .await
-            .insert(component_id, database);
-
-        // Add linker functions
+        // Clone the component (cheap, Arc-backed) before taking the mutable
+        // linker borrow — named-import linking needs both.
+        #[cfg(feature = "wasm_component_model_implements")]
+        let component = component_handle.component().clone();
         let linker = component_handle.linker();
+
+        // `types` carries no functions and is shared by query/prepared; link the
+        // instance once regardless of named/unnamed routing.
         bindings::wasmcloud::postgres::types::add_to_linker::<_, SharedCtx>(
             linker,
             extract_active_ctx,
         )?;
-        bindings::wasmcloud::postgres::query::add_to_linker::<_, SharedCtx>(
-            linker,
-            extract_active_ctx,
-        )?;
-        bindings::wasmcloud::postgres::prepared::add_to_linker::<_, SharedCtx>(
-            linker,
-            extract_active_ctx,
-        )?;
+
+        if let Some(i) = unnamed {
+            let Some(database) = i.config.get("database").cloned() else {
+                bail!("wasmcloud:postgres requires a 'database' config parameter")
+            };
+            tracing::debug!(
+                component_id = %component_id,
+                database = %database,
+                "Binding postgres plugin to component (per-component database)"
+            );
+            self.component_databases
+                .write()
+                .await
+                .insert(component_id, database);
+            bindings::wasmcloud::postgres::query::add_to_linker::<_, SharedCtx>(
+                linker,
+                extract_active_ctx,
+            )?;
+            bindings::wasmcloud::postgres::prepared::add_to_linker::<_, SharedCtx>(
+                linker,
+                extract_active_ctx,
+            )?;
+        }
+
+        #[cfg(feature = "wasm_component_model_implements")]
+        if pg.iter().any(|i| i.name.is_some()) {
+            let registry = self.build_named_pools(pg.iter().copied()).await?;
+            tracing::debug!(
+                imports = ?registry.keys().collect::<Vec<_>>(),
+                "Binding postgres plugin to component (per-credential named imports)"
+            );
+            bindings::named_imports::wasmcloud::postgres::query::add_to_linker::<_, SharedCtx>(
+                linker,
+                &component,
+                |name| self.mux.resolve(&registry, name),
+                extract_active_ctx,
+            )?;
+            bindings::named_imports::wasmcloud::postgres::prepared::add_to_linker::<_, SharedCtx>(
+                linker,
+                &component,
+                |name| self.mux.resolve(&registry, name),
+                extract_active_ctx,
+            )?;
+        }
 
         Ok(())
     }
@@ -504,29 +604,68 @@ impl HostPlugin for WasmcloudPostgres {
     ) -> anyhow::Result<()> {
         tracing::debug!(workload_id = %workload_id, "Unbinding postgres plugin from workload");
 
-        // Remove component → database mappings for this workload
-        let removed_components: Vec<String> = {
+        // Remove component → database mappings for this workload (legacy path).
+        {
             let mut component_databases = self.component_databases.write().await;
-            let removed: Vec<String> = component_databases
-                .keys()
-                .filter(|k| k.starts_with(workload_id))
-                .cloned()
-                .collect();
-            for c in &removed {
-                component_databases.remove(c);
-            }
-            removed
-        };
+            component_databases.retain(|component_id, _| !component_id.starts_with(workload_id));
+        }
 
-        // Clean up prepared statements by component_id (not database)
-        if !removed_components.is_empty() {
+        // Clean up prepared statements created by this workload's components.
+        // Both the legacy per-database path and implements-routed named imports
+        // tag each entry with the creating `component_id`, so match on it
+        // directly — a pure-multiplex workload never populates
+        // `component_databases`, so deriving the set from there would miss its
+        // prepared statements.
+        {
             let mut prepared = self.prepared_statements.write().await;
-            prepared.retain(|_, entry| !removed_components.contains(&entry.component_id));
+            prepared.retain(|_, entry| !entry.component_id.starts_with(workload_id));
         }
 
         // Signal the pool reaper to check for idle pools
         self.pool_reaper_notify.notify_one();
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(component_id: &str) -> PreparedEntry {
+        PreparedEntry {
+            sql: "SELECT 1".to_string(),
+            param_types: Vec::new(),
+            database: String::new(),
+            component_id: component_id.to_string(),
+        }
+    }
+
+    /// Unbinding a workload reaps prepared statements tagged with any of its
+    /// component ids — covering both the legacy path and implements-routed named
+    /// imports (which set an empty `database` but the same `component_id`), and
+    /// leaving other workloads' statements untouched.
+    #[tokio::test]
+    async fn unbind_reaps_only_this_workloads_prepared_statements() {
+        let pg = WasmcloudPostgres::new("postgres://u:p@localhost/").unwrap();
+        {
+            let mut prepared = pg.prepared_statements.write().await;
+            prepared.insert("legacy".to_string(), entry("workload-a-component-0"));
+            prepared.insert("named".to_string(), entry("workload-a-component-1"));
+            prepared.insert("other".to_string(), entry("workload-b-component-0"));
+        }
+
+        let empty = HashSet::new();
+        pg.on_workload_unbind("workload-a", WitInterfaces::new(&empty))
+            .await
+            .unwrap();
+
+        let prepared = pg.prepared_statements.read().await;
+        assert!(!prepared.contains_key("legacy"), "legacy entry reaped");
+        assert!(!prepared.contains_key("named"), "named entry reaped");
+        assert!(
+            prepared.contains_key("other"),
+            "another workload's entry must survive"
+        );
     }
 }

--- a/crates/wash-runtime/src/plugin/wasmcloud_postgres/multiplexed.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_postgres/multiplexed.rs
@@ -1,0 +1,292 @@
+//! # Multiplexed `wasmcloud:postgres` (implements-routed)
+//!
+//! Binds `wasmcloud:postgres` via the component-model `(implements ..)` /
+//! `named_imports` mechanism so a single component can import the query/prepared
+//! interfaces multiple times and have each import backed by a *different*
+//! credentialed connection (e.g. one `query` import as `team-a`, another as
+//! `team-b`, each with its own database role).
+//!
+//! Each named import resolves to a [`PgId`] (the wasmtime "implements id"): a
+//! connection pool built from that interface's `url`. Pools are shared across
+//! workload binds with the same URL by the [`Multiplexer`]. The shared query
+//! helpers (`execute_query`, `pg_error_string`) and the legacy per-component
+//! path live in the parent module.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod};
+use tokio::sync::RwLock;
+use url::Url;
+
+use crate::engine::ctx::ActiveCtx;
+use crate::plugin::multiplex::{BackendProvider, Multiplexer};
+use crate::wit::WitInterface;
+
+use super::{
+    DEFAULT_POOL_SIZE, PLUGIN_POSTGRES_ID, PgValue, PreparedEntry, PreparedStatementExecError,
+    QueryError, ResultRow, StatementPrepareError, WasmcloudPostgres, bindings, execute_query,
+    extract_pool_size, extract_tls_requirement, pg_error_string,
+};
+
+/// The single `wasmcloud:postgres` backend type. Unlike `wasi:keyvalue` (which
+/// multiplexes across redis/NATS/in-memory), every postgres backend is a
+/// connection pool built from a URL, so there is one provider and it is the
+/// default for any named interface that omits `config.backend`.
+const POSTGRES_BACKEND: &str = "postgres";
+
+/// The "implements id" for a named `wasmcloud:postgres` import: the connection
+/// pool that import is bound to. Each named host interface's `url` carries its
+/// own credentials and database, so two imports for different teams talk to
+/// postgres with different roles. Cloning shares the underlying pool (it is
+/// `Arc`-backed); all binds the multiplexer routes to the same URL reuse one
+/// pool. Prepared statements created through a `PgId` are tracked in the
+/// plugin's shared table (tagged with the creating component) so workload unbind
+/// reaps them, just like the legacy path.
+#[derive(Clone)]
+pub struct PgId {
+    pool: Pool,
+}
+
+/// Build a deadpool connection pool from a full postgres URL (credentials +
+/// database). Unlike the legacy bouncer config, the URL here is complete: the
+/// named interface owns its role and target database.
+fn build_pool_from_url(url: &str) -> anyhow::Result<Pool> {
+    let parsed = Url::parse(url).context("failed to parse postgres URL")?;
+    let pg_config: tokio_postgres::Config =
+        url.parse().context("failed to parse postgres config")?;
+    let pool_size = extract_pool_size(&parsed);
+    let mgr_config = ManagerConfig {
+        recycling_method: RecyclingMethod::Fast,
+    };
+    let pool = if extract_tls_requirement(&parsed) {
+        let tls_config = rustls::ClientConfig::builder()
+            .with_root_certificates(rustls::RootCertStore {
+                roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+            })
+            .with_no_client_auth();
+        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_config);
+        let mgr = Manager::from_config(pg_config, tls, mgr_config);
+        Pool::builder(mgr)
+            .max_size(pool_size)
+            .build()
+            .context("failed to build TLS connection pool")?
+    } else {
+        let mgr = Manager::from_config(pg_config, tokio_postgres::NoTls, mgr_config);
+        Pool::builder(mgr)
+            .max_size(pool_size)
+            .build()
+            .context("failed to build connection pool")?
+    };
+    Ok(pool)
+}
+
+impl PgId {
+    async fn client(&self) -> Result<deadpool_postgres::Client, String> {
+        self.pool
+            .get()
+            .await
+            .map_err(|e| format!("failed to get connection: {e}"))
+    }
+
+    /// Run a parameterized query on this named import's connection.
+    pub async fn query(&self, sql: &str, params: &[PgValue]) -> Result<Vec<ResultRow>, QueryError> {
+        let client = self.client().await.map_err(QueryError::Unexpected)?;
+        execute_query(&client, sql, params).await
+    }
+
+    /// Execute a statement on this named import's connection, returning the
+    /// number of rows affected. Convenience for callers (and tests) that only
+    /// need success/failure routed to the right per-credential connection.
+    pub async fn execute(&self, sql: &str) -> Result<u64, QueryError> {
+        let client = self.client().await.map_err(QueryError::Unexpected)?;
+        client.execute(sql, &[]).await.map_err(|e| {
+            QueryError::InvalidQuery(format!("statement failed: {}", pg_error_string(&e)))
+        })
+    }
+
+    /// Run a multi-statement batch (no parameters, no row results).
+    async fn query_batch(&self, sql: &str) -> Result<(), QueryError> {
+        let client = self.client().await.map_err(QueryError::Unexpected)?;
+        client.batch_execute(sql).await.map_err(|e| {
+            QueryError::InvalidQuery(format!("batch execution failed: {}", pg_error_string(&e)))
+        })
+    }
+
+    /// Prepare a statement on this connection and register it in the plugin's
+    /// shared prepared-statement table, tagged with `component_id` so the
+    /// workload's unbind reaps it. Returns the lookup token. The empty `database`
+    /// marks the entry as implements-routed (exec routes by connection, not by
+    /// database name).
+    async fn prepare(
+        &self,
+        store: &RwLock<HashMap<String, PreparedEntry>>,
+        component_id: &str,
+        statement: String,
+    ) -> Result<String, StatementPrepareError> {
+        let client = self
+            .client()
+            .await
+            .map_err(StatementPrepareError::Unexpected)?;
+        let stmt = client.prepare(&statement).await.map_err(|e| {
+            StatementPrepareError::Unexpected(format!("prepare failed: {}", pg_error_string(&e)))
+        })?;
+        let token = ulid::Ulid::new().to_string();
+        store.write().await.insert(
+            token.clone(),
+            PreparedEntry {
+                sql: statement,
+                param_types: stmt.params().to_vec(),
+                database: String::new(),
+                component_id: component_id.to_string(),
+            },
+        );
+        Ok(token)
+    }
+
+    /// Execute a previously prepared statement by token on this connection.
+    async fn exec(
+        &self,
+        store: &RwLock<HashMap<String, PreparedEntry>>,
+        token: &str,
+        params: &[PgValue],
+    ) -> Result<u64, PreparedStatementExecError> {
+        let (sql, param_types) = {
+            let store = store.read().await;
+            match store.get(token) {
+                Some(e) => (e.sql.clone(), e.param_types.clone()),
+                None => return Err(PreparedStatementExecError::UnknownPreparedQuery),
+            }
+        };
+        let client = self
+            .client()
+            .await
+            .map_err(PreparedStatementExecError::Unexpected)?;
+        let stmt = client
+            .prepare_typed(&sql, &param_types)
+            .await
+            .map_err(|e| {
+                PreparedStatementExecError::Unexpected(format!(
+                    "re-prepare failed: {}",
+                    pg_error_string(&e)
+                ))
+            })?;
+        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
+            .iter()
+            .map(|p| p as &(dyn tokio_postgres::types::ToSql + Sync))
+            .collect();
+        client.execute_raw(&stmt, param_refs).await.map_err(|e| {
+            PreparedStatementExecError::QueryError(QueryError::Unexpected(format!(
+                "execute failed: {}",
+                pg_error_string(&e)
+            )))
+        })
+    }
+}
+
+/// The sole `wasmcloud:postgres` backend provider: builds a [`PgId`] connection
+/// pool from a named interface's `url`. The multiplexer shares one pool across
+/// binds with the same URL (its `pool_key`).
+struct PostgresProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<PgId> for PostgresProvider {
+    fn backend_type(&self) -> &'static str {
+        POSTGRES_BACKEND
+    }
+
+    fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
+        config.get("url").cloned()
+    }
+
+    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<PgId> {
+        let url = config.get("url").ok_or_else(|| {
+            anyhow::anyhow!("named wasmcloud:postgres interface requires a 'url' config")
+        })?;
+        Ok(PgId {
+            pool: build_pool_from_url(url)?,
+        })
+    }
+}
+
+impl WasmcloudPostgres {
+    /// Create a postgres plugin with no shared bouncer URL, for deployments that
+    /// route purely through `(implements ..)` named imports — each named
+    /// interface carries its own full URL. The legacy per-component-database
+    /// path is inert until an unnamed interface supplies a `database`, and with
+    /// an empty base config such a bind would fail to connect; pure-multiplex
+    /// workloads never take that path.
+    pub fn multiplex_only() -> Self {
+        Self::with_base(tokio_postgres::Config::new(), DEFAULT_POOL_SIZE, false)
+    }
+
+    /// Build a fresh [`Multiplexer`] for `wasmcloud:postgres` named imports,
+    /// registering the single [`PostgresProvider`]. Exposed so tests can route
+    /// named interfaces to per-credential pools without a full plugin instance.
+    pub fn multiplexer() -> Multiplexer<PgId> {
+        Multiplexer::new("wasmcloud", "postgres", POSTGRES_BACKEND)
+            .with_provider(Arc::new(PostgresProvider))
+    }
+
+    /// Build the per-import connection registry (interface name -> [`PgId`]) for
+    /// the named `wasmcloud:postgres` host interfaces, through the shared
+    /// multiplexer so identical URLs reuse one pool.
+    pub async fn build_named_pools<'i>(
+        &self,
+        interfaces: impl IntoIterator<Item = &'i WitInterface>,
+    ) -> anyhow::Result<HashMap<String, PgId>> {
+        // Only named interfaces are multiplexed; an unnamed one keeps the legacy
+        // per-component-database path, so filter it out before building.
+        let named: Vec<&WitInterface> = interfaces
+            .into_iter()
+            .filter(|i| i.name.is_some())
+            .collect();
+        self.mux.build_registry(named).await
+    }
+}
+
+impl<'a> bindings::named_imports::wasmcloud::postgres::query::Host for ActiveCtx<'a> {
+    async fn query(
+        &mut self,
+        id: PgId,
+        q: String,
+        params: Vec<PgValue>,
+    ) -> wasmtime::Result<Result<Vec<ResultRow>, QueryError>> {
+        Ok(id.query(&q, &params).await)
+    }
+
+    async fn query_batch(
+        &mut self,
+        id: PgId,
+        q: String,
+    ) -> wasmtime::Result<Result<(), QueryError>> {
+        Ok(id.query_batch(&q).await)
+    }
+}
+
+impl<'a> bindings::named_imports::wasmcloud::postgres::prepared::Host for ActiveCtx<'a> {
+    async fn prepare(
+        &mut self,
+        id: PgId,
+        statement: String,
+    ) -> wasmtime::Result<Result<String, StatementPrepareError>> {
+        let plugin = self.try_get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID)?;
+        let component_id = self.component_id.to_string();
+        Ok(id
+            .prepare(&plugin.prepared_statements, &component_id, statement)
+            .await)
+    }
+
+    async fn exec(
+        &mut self,
+        id: PgId,
+        stmt_token: String,
+        params: Vec<PgValue>,
+    ) -> wasmtime::Result<Result<u64, PreparedStatementExecError>> {
+        let plugin = self.try_get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID)?;
+        Ok(id
+            .exec(&plugin.prepared_statements, &stmt_token, &params)
+            .await)
+    }
+}

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -50,46 +50,34 @@ impl WitWorld {
     /// different than [`WitWorld::includes`] because it considers that in one
     /// [`WitInterface`] there may be both imports and exports.
     pub fn includes_bidirectional(&self, interface: &WitInterface) -> bool {
-        let import_match = self.imports.iter().find(|i| {
+        // Same namespace+package, and (when both specify one) the same version.
+        // Name is intentionally ignored here: this answers "does the world use
+        // this namespace:package interface", regardless of the `(implements ..)`
+        // label — label routing is resolved later during plugin binding.
+        let matches_pkg = |other: &WitInterface| {
             if let Some(v) = &interface.version
-                && let Some(ov) = &i.version
+                && let Some(ov) = &other.version
                 && v != ov
             {
                 return false;
             }
-            i.namespace == interface.namespace && i.package == interface.package
-        });
+            other.namespace == interface.namespace && other.package == interface.package
+        };
 
-        let export_match = self.exports.iter().find(|e| {
-            // If both interfaces specify a version, they must match
-            if let Some(v) = &interface.version
-                && let Some(ov) = &e.version
-                && v != ov
-            {
-                return false;
-            }
-            e.namespace == interface.namespace && e.package == interface.package
-        });
-
-        // Ensure the interfaces are covered by either the import or export match
-        for i in &interface.interfaces {
-            // Interface satisfied by import
-            if let Some(im) = &import_match
-                && im.interfaces.contains(i)
-            {
-                continue;
-            }
-            // Interface satisfied by export
-            if let Some(em) = &export_match
-                && em.interfaces.contains(i)
-            {
-                continue;
-            }
-
-            return false;
-        }
-
-        true
+        // Each requested interface must be covered by *some* import or export of
+        // the matching package. A package can spread its interfaces across
+        // multiple entries (e.g. `wasmcloud:postgres` imports `types` unnamed and
+        // `query` under several labels), so check every entry per interface
+        // rather than binding to the first package match.
+        interface.interfaces.iter().all(|i| {
+            self.imports
+                .iter()
+                .any(|im| matches_pkg(im) && im.interfaces.contains(i))
+                || self
+                    .exports
+                    .iter()
+                    .any(|ex| matches_pkg(ex) && ex.interfaces.contains(i))
+        })
     }
 
     /// Checks if a guest world (imports) can be satisfied by a host world (exports).
@@ -846,5 +834,34 @@ mod tests {
         // Same name should produce the same hash
         iface1.name = Some("cache".to_string());
         assert_eq!(hash(&iface1), hash(&iface2));
+    }
+
+    #[test]
+    fn includes_bidirectional_covers_multi_interface_package() {
+        // A package whose interfaces are split across several imports — one
+        // unnamed `types` plus two `(implements ..)`-labeled `query` imports —
+        // mirrors a multiplexed `wasmcloud:postgres` guest. Every interface must
+        // resolve regardless of `imports` (a HashSet) iteration order.
+        let types = create_interface_with_version("wasmcloud", "postgres", &["types"], "0.1.1");
+        let mut query_a =
+            create_interface_with_version("wasmcloud", "postgres", &["query"], "0.1.1");
+        query_a.name = Some("team-a".to_string());
+        let mut query_b =
+            create_interface_with_version("wasmcloud", "postgres", &["query"], "0.1.1");
+        query_b.name = Some("team-b".to_string());
+
+        let world = WitWorld {
+            imports: HashSet::from([types, query_a.clone(), query_b.clone()]),
+            exports: HashSet::new(),
+        };
+
+        // Both labeled query interfaces are part of the world even though a
+        // different `types` import shares the package.
+        assert!(world.includes_bidirectional(&query_a));
+        assert!(world.includes_bidirectional(&query_b));
+        // An interface the package does not provide is still rejected.
+        let prepared =
+            create_interface_with_version("wasmcloud", "postgres", &["prepared"], "0.1.1");
+        assert!(!world.includes_bidirectional(&prepared));
     }
 }

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -50,33 +50,22 @@ impl WitWorld {
     /// different than [`WitWorld::includes`] because it considers that in one
     /// [`WitInterface`] there may be both imports and exports.
     pub fn includes_bidirectional(&self, interface: &WitInterface) -> bool {
-        // Same namespace+package, and (when both specify one) the same version.
-        // Name is intentionally ignored here: this answers "does the world use
-        // this namespace:package interface", regardless of the `(implements ..)`
-        // label — label routing is resolved later during plugin binding.
-        let matches_pkg = |other: &WitInterface| {
-            if let Some(v) = &interface.version
-                && let Some(ov) = &other.version
-                && v != ov
-            {
-                return false;
-            }
-            other.namespace == interface.namespace && other.package == interface.package
-        };
-
         // Each requested interface must be covered by *some* import or export of
-        // the matching package. A package can spread its interfaces across
+        // the same package (see [`WitInterface::same_package`]). The label/name
+        // is intentionally ignored for checking "does the world use this
+        // namespace:package interface", and label routing is resolved later
+        // during plugin binding. A package can spread its interfaces across
         // multiple entries (e.g. `wasmcloud:postgres` imports `types` unnamed and
         // `query` under several labels), so check every entry per interface
         // rather than binding to the first package match.
         interface.interfaces.iter().all(|i| {
             self.imports
                 .iter()
-                .any(|im| matches_pkg(im) && im.interfaces.contains(i))
+                .any(|im| interface.same_package(im) && im.interfaces.contains(i))
                 || self
                     .exports
                     .iter()
-                    .any(|ex| matches_pkg(ex) && ex.interfaces.contains(i))
+                    .any(|ex| interface.same_package(ex) && ex.interfaces.contains(i))
         })
     }
 
@@ -180,6 +169,23 @@ impl WitInterface {
         true
     }
 
+    /// Returns `true` if `other` belongs to the same `namespace:package` at a
+    /// compatible version. Equal when both specify a version;
+    /// if either omits a version, any version is considered compatible.
+    pub fn same_package(&self, other: &WitInterface) -> bool {
+        if self.namespace != other.namespace || self.package != other.package {
+            return false;
+        }
+        // If both interfaces specify a version, they must match.
+        if let Some(v) = &self.version
+            && let Some(ov) = &other.version
+            && v != ov
+        {
+            return false;
+        }
+        true
+    }
+
     /// Checks if this interface contains (is a superset of) another interface.
     ///
     /// This method is used to determine if a plugin or component that provides
@@ -190,20 +196,12 @@ impl WitInterface {
     ///
     /// # Returns
     /// `true` if:
-    /// - The namespace and package match exactly
-    /// - If this interface has a version, it must match the other's version
+    /// - The namespace and package match at a compatible version (see
+    ///   [`WitInterface::same_package`])
+    /// - If both interfaces specify a name, they match
     /// - The other's interfaces are a subset of this interface's interfaces
     pub fn contains(&self, other: &WitInterface) -> bool {
-        // Namespace and package must match
-        if self.namespace != other.namespace || self.package != other.package {
-            return false;
-        }
-
-        // If both interfaces specify a version, they must match
-        if let Some(v) = &self.version
-            && let Some(ov) = &other.version
-            && v != ov
-        {
+        if !self.same_package(other) {
             return false;
         }
 

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -1005,6 +1005,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "postgres-implements"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.58.0",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "http-allowed-hosts",
     "keyvalue-counter",
     "keyvalue-implements",
+    "postgres-implements",
     # P3 fixtures (wasm32-wasip1 + reactor adapter)
     "http-handler-p3",
     "http-blobstore-p3",

--- a/crates/wash-runtime/tests/fixtures/p2-wit-deps/wasmcloud-postgres-0.1.1-draft/package.wit
+++ b/crates/wash-runtime/tests/fixtures/p2-wit-deps/wasmcloud-postgres-0.1.1-draft/package.wit
@@ -1,0 +1,339 @@
+package wasmcloud:postgres@0.1.1-draft;
+
+/// Types used by components and providers of a SQLDB Postgres interface
+interface types {
+  /// Errors that occur while executing queries
+  variant query-error {
+    /// Unknown/invalid query parameters
+    invalid-params(string),
+    /// Invalid/malformed query
+    invalid-query(string),
+    /// A completely unexpected error, specific to executing queries
+    unexpected(string),
+  }
+
+  /// Errors that occur while preparing a statement
+  variant statement-prepare-error {
+    /// A completely unexpected error
+    unexpected(string),
+  }
+
+  /// Errors that occur during prepared statement execution
+  variant prepared-statement-exec-error {
+    /// Unknown/invalid prepared statement token
+    unknown-prepared-query,
+    /// An otherwise known query execution error
+    query-error(query-error),
+    /// A completely unexpected error, specific to prepared statements
+    unexpected(string),
+  }
+
+  /// This type of floating point is necessary as rust does not allow Eq/PartialEq/Hash on real `f64`
+  /// Instead we use a sign + mantissa + exponent
+  ///
+  /// see: https://docs.rs/num/latest/num/trait.Float.html#tymethod.integer_decode
+  type hashable-f64 = tuple<u64, s16, s8>;
+
+  type hashable-f32 = hashable-f64;
+
+  type point = tuple<hashable-f64, hashable-f64>;
+
+  type lower-left-point = point;
+
+  type upper-right-point = point;
+
+  type start-point = point;
+
+  type end-point = point;
+
+  type center-point = point;
+
+  type radius = hashable-f64;
+
+  type ipv4-addr = string;
+
+  type ipv6-addr = string;
+
+  type subnet = string;
+
+  type xmin = s64;
+
+  type xmax = s64;
+
+  type xip-list = list<s64>;
+
+  type logfile-num = u32;
+
+  type logfile-byte-offset = u32;
+
+  type column-name = string;
+
+  /// Arbitrary precision numeric type
+  type numeric = string;
+
+  /// Chosen weight of a Lexeme
+  enum lexeme-weight {
+    A,
+    B,
+    C,
+    D,
+  }
+
+  /// Represents an arbitrary precision numeric type
+  record lexeme {
+    /// Position (1->16383)
+    position: option<u16>,
+    /// Weight of the lexeme (in a relevant ts-vector)
+    weight: option<lexeme-weight>,
+    /// Data
+    data: string,
+  }
+
+  /// Offsets are expressed in seconds of timezone difference in either from the
+  /// eastern hemisphere or western hemisphere.
+  ///
+  /// ex. "America/New York", which is UTC-4 can be expressed as western-hemisphere-secs(4 * 3600)
+  variant offset {
+    eastern-hemisphere-secs(s32),
+    western-hemisphere-secs(s32),
+  }
+
+  /// Dates are represented similarly to tokio-postgres implementation
+  /// see: https://docs.rs/postgres-types/0.2.6/postgres_types/enum.Date.html#variant.Value
+  variant date {
+    positive-infinity,
+    negative-infinity,
+    ymd(tuple<s32, u32, u32>),
+  }
+
+  record interval {
+    start: date,
+    start-inclusive: bool,
+    end: date,
+    end-inclusive: bool,
+  }
+
+  record time {
+    hour: u32,
+    min: u32,
+    sec: u32,
+    micro: u32,
+  }
+
+  record time-tz {
+    timesonze: string,
+    time: time,
+  }
+
+  record timestamp {
+    date: date,
+    time: time,
+  }
+
+  record timestamp-tz {
+    timestamp: timestamp,
+    offset: offset,
+  }
+
+  record mac-address-eui48 {
+    bytes: tuple<u8, u8, u8, u8, u8, u8>,
+  }
+
+  record mac-address-eui64 {
+    bytes: tuple<u8, u8, u8, u8, u8, u8, u8, u8>,
+  }
+
+  /// Postgres data values, usable as parameters or via queries
+  /// see: https://www.postgresql.org/docs/current/datatype.html
+  ///
+  /// This datatype is primarily intended to be used with the `raw` encoding scheme.
+  ///
+  /// NOTE: all numeric values are little-endian unless otherwise specified
+  variant pg-value {
+    null,
+    /// Numeric
+    big-int(s64),
+    int8(s64),
+    int8-array(list<s64>),
+    big-serial(s64),
+    serial8(s64),
+    %bool(bool),
+    boolean(bool),
+    bool-array(list<bool>),
+    double(hashable-f64),
+    float8(hashable-f64),
+    float8-array(list<hashable-f64>),
+    real(hashable-f32),
+    float4(hashable-f32),
+    float4-array(list<hashable-f32>),
+    integer(s32),
+    int(s32),
+    int4(s32),
+    int4-array(list<s32>),
+    numeric(numeric),
+    decimal(numeric),
+    numeric-array(list<numeric>),
+    serial(u32),
+    serial4(u32),
+    small-int(s16),
+    int2(s16),
+    int2-array(list<s16>),
+    int2-vector(list<s16>),
+    int2-vector-array(list<list<s16>>),
+    small-serial(s16),
+    serial2(s16),
+    /// note: matches tokio-postgres
+    /// Bytes
+    ///
+    /// For bit & bit-varying, see the encoding scheme used by bit-vec:
+    /// https://contain-rs.github.io/bit-vec/bit_vec/struct.BitVec.html#method.to_bytes
+    bit(tuple<u32, list<u8>>),
+    bit-array(list<tuple<u32, list<u8>>>),
+    bit-varying(tuple<option<u32>, list<u8>>),
+    varbit(tuple<option<u32>, list<u8>>),
+    varbit-array(list<tuple<option<u32>, list<u8>>>),
+    bytea(list<u8>),
+    bytea-array(list<list<u8>>),
+    /// Characters
+    /// TODO: specify text encoding, to negotiate possible component/DB mismatch?
+    %char(tuple<u32, list<u8>>),
+    char-array(list<tuple<u32, list<u8>>>),
+    varchar(tuple<option<u32>, list<u8>>),
+    varchar-array(list<tuple<option<u32>, list<u8>>>),
+    /// Networking
+    cidr(string),
+    cidr-array(list<string>),
+    inet(string),
+    inet-array(list<string>),
+    macaddr(mac-address-eui48),
+    /// EUI-48
+    macaddr-array(list<mac-address-eui48>),
+    /// EUI-48
+    macaddr8(mac-address-eui64),
+    /// EUI-64 (deprecated)
+    macaddr8-array(list<mac-address-eui64>),
+    /// EUI-64 (deprecated)
+    /// Geo
+    box(tuple<lower-left-point, upper-right-point>),
+    box-array(list<tuple<lower-left-point, upper-right-point>>),
+    circle(tuple<center-point, radius>),
+    circle-array(list<tuple<center-point, radius>>),
+    line(tuple<start-point, end-point>),
+    line-array(list<tuple<start-point, end-point>>),
+    lseg(tuple<start-point, end-point>),
+    lseg-array(list<tuple<start-point, end-point>>),
+    path(list<point>),
+    path-array(list<list<point>>),
+    point(point),
+    point-array(list<point>),
+    polygon(list<point>),
+    polygon-array(list<list<point>>),
+    /// Date-time
+    date(date),
+    date-array(list<date>),
+    interval(interval),
+    interval-array(list<interval>),
+    time(time),
+    time-array(list<time>),
+    time-tz(time-tz),
+    time-tz-array(list<time-tz>),
+    timestamp(timestamp),
+    timestamp-array(list<timestamp>),
+    timestamp-tz(timestamp-tz),
+    timestamp-tz-array(list<timestamp-tz>),
+    /// JSON
+    json(string),
+    json-array(list<string>),
+    jsonb(string),
+    jsonb-array(list<string>),
+    /// Money (use is discouraged)
+    ///
+    /// fractional precision is determined by the database's `lc_monetary` setting.
+    ///
+    /// NOTE: if you are storing currency amounts, consider
+    /// using integer (whole number) counts of smallest indivisible pieces of currency
+    /// (ex. cent amounts to represent United States Dollars; 100 cents = 1 USD)
+    money(numeric),
+    money-array(list<numeric>),
+    /// Postgres-internal
+    pg-lsn(u64),
+    pg-lsn-array(list<u64>),
+    /// see: https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-PG-SNAPSHOT-PARTS
+    pg-snapshot(tuple<xmin, xmax, xip-list>),
+    txid-snapshot(s64),
+    /// Text
+    name(string),
+    name-array(list<string>),
+    text(string),
+    text-array(list<string>),
+    xml(string),
+    xml-array(list<string>),
+    /// Full Text Search
+    ts-query(string),
+    ts-vector(list<lexeme>),
+    /// UUIDs
+    uuid(string),
+    uuid-array(list<string>),
+    /// Containers
+    hstore(list<tuple<string, option<string>>>),
+  }
+
+  record result-row-entry {
+    /// Name of the result column
+    column-name: string,
+    /// Value of the result column
+    value: pg-value,
+  }
+
+  type result-row = list<result-row-entry>;
+}
+
+/// Interface for querying a Postgres database
+interface query {
+  use types.{pg-value, result-row, query-error};
+
+  /// Query a Postgres database, leaving connection/session management
+  /// to the callee/implementer of this interface (normally a provider configured with connection credentials)
+  ///
+  /// Queries *must* be parameterized, with named arguments in the form of `$<integer>`, for example:
+  ///
+  /// ```
+  /// SELECT email,username FROM users WHERE uuid=$1;
+  /// ```
+  query: func(query: string, params: list<pg-value>) -> result<list<result-row>, query-error>;
+
+  /// Perform a batch query (which could contain multiple statements) against a Postgres database,
+  /// leaving connection/session management to the callee/implementer of this interface
+  /// (normally a provider configured with connection credentials)
+  ///
+  /// No user-provided or untrusted data should be used with this query -- parameters are not allowed
+  ///
+  /// This query *can* be used to execute multi-statement queries (common in migrations).
+  query-batch: func(query: string) -> result<_, query-error>;
+}
+
+/// Interface for querying a Postgres database with prepared statements
+interface prepared {
+  use types.{pg-value, result-row, statement-prepare-error, prepared-statement-exec-error};
+
+  /// A token that represents a previously created prepared statement,
+  ///
+  /// This token can be expected to be somewhat opaque to users.
+  type prepared-statement-token = string;
+
+  /// Prepare a statement, given a connection token (which can represent a connection *or* session),
+  /// to a Postgres database.
+  ///
+  /// Queries *must* be parameterized, with named arguments in the form of `$<integer>`, for example:
+  ///
+  /// ```
+  /// SELECT email,username FROM users WHERE uuid=$1;
+  /// ```
+  ///
+  /// NOTE: To see how to obtain a `connection-token`, see `connection.wit`.
+  prepare: func(statement: string) -> result<prepared-statement-token, statement-prepare-error>;
+
+  /// Execute a prepared statement, returning the number of rows affected
+  exec: func(stmt-token: prepared-statement-token, params: list<pg-value>) -> result<u64, prepared-statement-exec-error>;
+}
+

--- a/crates/wash-runtime/tests/fixtures/postgres-implements/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/postgres-implements/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "postgres-implements"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true }

--- a/crates/wash-runtime/tests/fixtures/postgres-implements/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/postgres-implements/src/lib.rs
@@ -1,0 +1,53 @@
+//! Real-guest fixture for `(implements ..)` named postgres routing.
+//!
+//! Imports `wasmcloud:postgres/query` twice under the labels `team-a` and
+//! `team-b`. The host routes each label to a connection with that team's
+//! database credentials.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+    });
+}
+
+use bindings::exports::wasi::http::incoming_handler::Guest;
+use bindings::wasi::http::types::{
+    Fields, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
+};
+
+struct Component;
+
+const SELECT: &str = "SELECT val FROM team_a_data WHERE id = 1";
+
+impl Guest for Component {
+    fn handle(_request: IncomingRequest, response_out: ResponseOutparam) {
+        let body = run();
+
+        let response = OutgoingResponse::new(Fields::new());
+        response.set_status_code(200).unwrap();
+        let out_body = response.body().unwrap();
+        ResponseOutparam::set(response_out, Ok(response));
+
+        let stream = out_body.write().unwrap();
+        stream.blocking_write_and_flush(body.as_bytes()).unwrap();
+        drop(stream);
+        OutgoingBody::finish(out_body, None).unwrap();
+    }
+}
+
+fn run() -> String {
+    // Both labels point at the same postgres instance but with different
+    // credentials: team-a owns `team_a_data`, team-b has no grant on it.
+    let a_ok = bindings::team_a::query(SELECT, &[])
+        .map(|rows| !rows.is_empty())
+        .unwrap_or(false);
+    let b_denied = bindings::team_b::query(SELECT, &[]).is_err();
+
+    if a_ok && b_denied {
+        "isolated".to_string()
+    } else {
+        format!("leak: team-a-ok={a_ok} team-b-denied={b_denied}")
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/postgres-implements/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/postgres-implements/wit/world.wit
@@ -1,0 +1,13 @@
+package wasmcloud:postgres-implements;
+
+// Imports wasmcloud:postgres/query TWICE under distinct labels (team-a, team-b)
+// via the component-model named-import (`implements`) clause. The host routes
+// each label to a connection carrying that team's database credentials.
+// `types` is imported once (unnamed): it only carries the shared pg-value /
+// result-row / query-error types and has no per-connection state.
+world postgres-implements {
+    import wasmcloud:postgres/types@0.1.1-draft;
+    import team-a: wasmcloud:postgres/query@0.1.1-draft;
+    import team-b: wasmcloud:postgres/query@0.1.1-draft;
+    export wasi:http/incoming-handler@0.2.2;
+}

--- a/crates/wash-runtime/tests/integration_postgres_implements.rs
+++ b/crates/wash-runtime/tests/integration_postgres_implements.rs
@@ -1,0 +1,206 @@
+//! Full guest-driven e2e for `(implements ..)` named-import postgres routing.
+//!
+//! The `postgres-implements` fixture imports `wasmcloud:postgres/query` **twice**
+//! under the component-model labels `team-a` and `team-b` (the WIT named-import
+//! clause — `import team-a: wasmcloud:postgres/query@…;`). On each HTTP request
+//! it reads team A's table through both labels and answers `isolated` only when
+//! the `team-a` read returns a row and the `team-b` read is refused.
+//!
+//! The host binds a single [`WasmcloudPostgres`] plugin and declares the two
+//! named interfaces, each carrying a different postgres role's credentials. The
+//! plugin's named-imports `add_to_linker` resolves each label to its own
+//! credentialed connection pool; postgres' RBAC then enforces that `team_b`
+//! (no grant) cannot read `team_a`'s table. Success proves the implements id
+//! threads from the guest import label all the way to the right connection.
+//!
+//! Requires Docker; marked `#[ignore]`, so it runs only under
+//! `cargo test --include-ignored` (CI's Linux leg) and not a plain `cargo test`.
+#![cfg(all(
+    feature = "wasmcloud-postgres",
+    feature = "wasm_component_model_implements"
+))]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use testcontainers::{
+    GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::wasmcloud_postgres::{PgId, WasmcloudPostgres},
+    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
+    wit::WitInterface,
+};
+
+mod common;
+use common::http_incoming_handler_interface;
+
+const POSTGRES_IMPLEMENTS_WASM: &[u8] = include_bytes!("wasm/postgres_implements.wasm");
+
+const PG_VERSION: &str = "0.1.1-draft";
+
+/// A named `wasmcloud:postgres/query` interface routed to one role's connection.
+/// The `name` becomes the implements label the guest imports under (`team-a` /
+/// `team-b`); the host resolves it against the component's import label, and the
+/// `url` carries that role's credentials and database.
+fn named_pg(name: &str, url: &str) -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "postgres".to_string(),
+        interfaces: ["query".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse(PG_VERSION).unwrap()),
+        config: HashMap::from([("url".to_string(), url.to_string())]),
+        name: Some(name.to_string()),
+    }
+}
+
+/// Build a single connection pool from one URL (used for admin DB setup).
+async fn connect(url: &str) -> Result<PgId> {
+    let registry = WasmcloudPostgres::multiplexer()
+        .build_registry(&HashSet::from([named_pg("admin", url)]))
+        .await?;
+    registry.get("admin").cloned().context("admin routed")
+}
+
+/// Wait for postgres to accept connections through the given pool.
+async fn wait_ready(id: &PgId) -> Result<()> {
+    for _ in 0..40 {
+        if id.execute("SELECT 1").await.is_ok() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    bail!("postgres never became ready")
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (postgres); run with `cargo test --include-ignored`"]
+async fn implements_imports_route_to_per_credential_connections() -> Result<()> {
+    // One postgres instance.
+    let container = GenericImage::new("postgres", "16-alpine")
+        .with_exposed_port(5432.tcp())
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
+        .with_env_var("POSTGRES_PASSWORD", "postgres")
+        .start()
+        .await
+        .map_err(|e| anyhow!("failed to start postgres: {e}"))?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let host_addr = format!("127.0.0.1:{port}");
+
+    let admin_url = format!("postgres://postgres:postgres@{host_addr}/postgres");
+    let team_a_url = format!("postgres://team_a:pw_a@{host_addr}/postgres");
+    let team_b_url = format!("postgres://team_b:pw_b@{host_addr}/postgres");
+
+    // As superuser: two login roles, a table owned by team_a with one row, and a
+    // grant only to team_a. team_b is deliberately left with no access.
+    let admin = connect(&admin_url).await?;
+    wait_ready(&admin).await?;
+    for stmt in [
+        "CREATE ROLE team_a LOGIN PASSWORD 'pw_a'",
+        "CREATE ROLE team_b LOGIN PASSWORD 'pw_b'",
+        "CREATE TABLE team_a_data (id INT PRIMARY KEY, val TEXT)",
+        "INSERT INTO team_a_data (id, val) VALUES (1, 'hello')",
+        "GRANT ALL ON team_a_data TO team_a",
+    ] {
+        admin
+            .execute(stmt)
+            .await
+            .map_err(|e| anyhow!("admin setup failed on `{stmt}`: {e:?}"))?;
+    }
+
+    // Stand up a host with the postgres plugin (no shared bouncer URL: purely
+    // implements-routed) plus an HTTP entrypoint to drive the guest.
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_server.addr();
+
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(WasmcloudPostgres::multiplex_only()))?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    // The two named interfaces map to the guest's `team-a` / `team-b` query
+    // imports; each routes to a connection with that role's credentials.
+    let host_interfaces = vec![
+        http_incoming_handler_interface("pg-implements", None),
+        named_pg("team-a", &team_a_url),
+        named_pg("team-b", &team_b_url),
+    ];
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "postgres-implements".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "postgres-implements.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(POSTGRES_IMPLEMENTS_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    };
+
+    // Binding runs the named-imports `add_to_linker`, resolving `team-a`/`team-b`
+    // against the declared interfaces. `workload_start` returns Ok even on
+    // resolution failure (it encodes the error in the status), so assert the
+    // workload actually reached Running.
+    let resp = host
+        .workload_start(req)
+        .await
+        .context("workload_start call failed")?;
+    assert_eq!(
+        resp.workload_status.workload_state,
+        WorkloadState::Running,
+        "workload should resolve: {}",
+        resp.workload_status.message
+    );
+
+    // Drive the guest: it reads team_a's table through both labels. `isolated`
+    // means team-a (owner) read its row while team-b (no grant) was refused —
+    // i.e. each implements import resolved to its own credentialed connection.
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(15),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "pg-implements")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+
+    let status = response.status();
+    let body = response.text().await?;
+    assert!(status.is_success(), "expected 200, got {status}: {body}");
+    assert_eq!(
+        body, "isolated",
+        "each implements import must route to its own credentialed connection \
+         (team-a reads, team-b denied)"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_postgres_multiplexed.rs
+++ b/crates/wash-runtime/tests/integration_postgres_multiplexed.rs
@@ -1,0 +1,139 @@
+//! Backend-level test for per-credential `wasmcloud:postgres` routing via the
+//! multiplexer (the registry/`PgId` path, no guest component — see
+//! `integration_postgres_implements.rs` for the full guest-driven e2e).
+//!
+//! ONE postgres instance, TWO database roles with different privileges: `team_a`
+//! owns a table, `team_b` has no grant on it. Two named host interfaces
+//! (`team-a`, `team-b`) carry each role's credentials; the multiplexer builds an
+//! isolated connection pool per import. We assert team B — routed through its
+//! own credentials — is denied read/write on team A's table, while team A
+//! succeeds. Postgres' own RBAC enforces the isolation.
+//!
+//! Requires Docker; marked `#[ignore]`, so it runs only under
+//! `cargo test --include-ignored` (CI's Linux leg) and not a plain `cargo test`.
+#![cfg(all(
+    feature = "wasmcloud-postgres",
+    feature = "wasm_component_model_implements"
+))]
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use anyhow::{Result, anyhow, bail};
+use testcontainers::{
+    GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+use wash_runtime::plugin::wasmcloud_postgres::{PgId, WasmcloudPostgres};
+use wash_runtime::wit::WitInterface;
+
+/// A named `wasmcloud:postgres` host interface carrying one role's full URL.
+fn pg_iface(name: &str, url: &str) -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "postgres".to_string(),
+        interfaces: [
+            "query".to_string(),
+            "prepared".to_string(),
+            "types".to_string(),
+        ]
+        .into_iter()
+        .collect(),
+        version: None,
+        config: HashMap::from([("url".to_string(), url.to_string())]),
+        name: Some(name.to_string()),
+    }
+}
+
+/// Wait for postgres to accept connections through the given pool.
+async fn wait_ready(id: &PgId) -> Result<()> {
+    for _ in 0..40 {
+        if id.execute("SELECT 1").await.is_ok() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    bail!("postgres never became ready")
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (postgres); run with `cargo test --include-ignored`"]
+async fn postgres_implements_enforces_per_team_credentials() -> Result<()> {
+    // One postgres instance.
+    let container = GenericImage::new("postgres", "16-alpine")
+        .with_exposed_port(5432.tcp())
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
+        .with_env_var("POSTGRES_PASSWORD", "postgres")
+        .start()
+        .await
+        .map_err(|e| anyhow!("failed to start postgres: {e}"))?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let host = format!("127.0.0.1:{port}");
+
+    let admin_url = format!("postgres://postgres:postgres@{host}/postgres");
+    let team_a_url = format!("postgres://team_a:pw_a@{host}/postgres");
+    let team_b_url = format!("postgres://team_b:pw_b@{host}/postgres");
+
+    // Build a connection pool per named import through the multiplexer — the
+    // per-credential routing under test.
+    let interfaces = HashSet::from([
+        pg_iface("admin", &admin_url),
+        pg_iface("team-a", &team_a_url),
+        pg_iface("team-b", &team_b_url),
+    ]);
+    let registry = WasmcloudPostgres::multiplexer()
+        .build_registry(&interfaces)
+        .await?;
+    let admin = registry.get("admin").expect("admin routed");
+    let team_a = registry.get("team-a").expect("team-a routed");
+    let team_b = registry.get("team-b").expect("team-b routed");
+
+    wait_ready(admin).await?;
+
+    // As superuser: two roles, a table owned by team_a, grant only to team_a.
+    for stmt in [
+        "CREATE ROLE team_a LOGIN PASSWORD 'pw_a'",
+        "CREATE ROLE team_b LOGIN PASSWORD 'pw_b'",
+        "CREATE TABLE team_a_data (id INT PRIMARY KEY, val TEXT)",
+        "GRANT ALL ON team_a_data TO team_a",
+    ] {
+        admin
+            .execute(stmt)
+            .await
+            .map_err(|e| anyhow!("admin setup failed on `{stmt}`: {e:?}"))?;
+    }
+
+    // Team A (its own credentials) can write and read its table.
+    team_a
+        .execute("INSERT INTO team_a_data (id, val) VALUES (1, 'hello')")
+        .await
+        .map_err(|e| anyhow!("team_a insert failed: {e:?}"))?;
+    let rows = team_a
+        .query("SELECT val FROM team_a_data WHERE id = 1", &[])
+        .await
+        .map_err(|e| anyhow!("team_a read failed: {e:?}"))?;
+    assert_eq!(rows.len(), 1, "team_a should read its own row");
+
+    // Team B (routed through its own, unprivileged credentials) is denied.
+    let read = team_b.query("SELECT * FROM team_a_data", &[]).await;
+    let read_err = format!("{:?}", read.expect_err("team_b read should be denied"));
+    assert!(
+        read_err.contains("permission denied"),
+        "expected permission denied, got: {read_err}"
+    );
+
+    let write = team_b
+        .execute("INSERT INTO team_a_data (id, val) VALUES (2, 'nope')")
+        .await;
+    let write_err = format!("{:?}", write.expect_err("team_b write should be denied"));
+    assert!(
+        write_err.contains("permission denied"),
+        "expected permission denied, got: {write_err}"
+    );
+
+    Ok(())
+}

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -245,6 +245,17 @@ impl CliCommand for DevCommand {
                     .context("failed to configure postgres plugin")?,
             ))?;
             debug!("wasmcloud:postgres plugin registered");
+        } else {
+            // No shared bouncer URL: still register postgres so workloads that
+            // route purely through `(implements ..)` named imports (each
+            // carrying its own URL) are served.
+            #[cfg(feature = "wasm_component_model_implements")]
+            {
+                host_builder = host_builder.with_plugin(Arc::new(
+                    plugin::wasmcloud_postgres::WasmcloudPostgres::multiplex_only(),
+                ))?;
+                debug!("wasmcloud:postgres multiplexed plugin registered (implements)");
+            }
         }
 
         // Add otel plugin

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -213,6 +213,15 @@ impl CliCommand for HostCommand {
                 plugin::wasmcloud_postgres::WasmcloudPostgres::new(postgres_url)
                     .context("failed to configure postgres plugin")?,
             ))?;
+        } else {
+            // register postgres for `(implements ..)` named imports (each
+            // carrying its own URL) are served.
+            #[cfg(feature = "wasm_component_model_implements")]
+            {
+                cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
+                    plugin::wasmcloud_postgres::WasmcloudPostgres::multiplex_only(),
+                ))?;
+            }
         }
 
         if let Some(host_name) = &self.host_name {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -93,6 +93,7 @@ const P2_FIXTURES: &[&str] = &[
     "http-allowed-hosts",
     "keyvalue-counter",
     "keyvalue-implements",
+    "postgres-implements",
 ];
 
 const P3_FIXTURES: &[&str] = &[


### PR DESCRIPTION
Route per-import `wasmcloud:postgres` named imports to isolated, per-credential
connection pools through multiplexer core. A component can import
`wasmcloud:postgres/query` multiple times under distinct labels and have each
backed by a different postgres connection credential or database.

- Add `PgId` (the implements id): a deadpool pool plus its own prepared-statement
  table, Arc-backed so binds the multiplexer routes to the same URL share one
  pool and prepared statements drop with the connection.
- Register a `PostgresProvider` (pool_key = URL) on a `Multiplexer<PgId>`; split
  `on_workload_item_bind` into the legacy unnamed per-component-database path and
  the named per-credential path. `types` is linked once for both.

Fix `WitWorld::includes_bidirectional`: it bound to the first import matching
namespace+package, so a package split across multiple imports (postgres `types`
unnamed + `query` under labels) matched order-dependently against the imports
HashSet, intermittently failing to bind the plugin. Now match each interface
across all imports/exports.
