### PR TITLE
ci(wit): publish to namespaced OCI path so packages resolve

### DIFF
--- a/.github/scripts/build-wit-matrix.mjs
+++ b/.github/scripts/build-wit-matrix.mjs
@@ -5,8 +5,15 @@
 // `package <ns>:<name>@<ver>;` header in canonical form. That's the
 // source of truth for what to publish and where. Each artifact becomes
 // one matrix entry:
-//   { name, version, ref: ghcr.io/wasmcloud/interfaces/<name>:<version>,
+//   { name, version,
+//     ref: ghcr.io/wasmcloud/interfaces/<ns>/<name>:<version>,
+//     subject: ghcr.io/wasmcloud/interfaces/<ns>/<name>,
 //     artifact: <basename of wasm file> }
+//
+// The OCI path MUST include the `<ns>` segment: the wasmcloud.com registry
+// maps `wasmcloud:<name>` to `<namespacePrefix><ns>/<name>` (namespacePrefix
+// is `wasmcloud/interfaces/`). Publishing to `…/interfaces/<name>` (no `<ns>`)
+// succeeds but lands at a path nothing resolves via `wkg`/`wasmcloud:<name>`.
 //
 // Outputs (to $GITHUB_OUTPUT):
 //   matrix=<JSON object with `include` array>
@@ -64,7 +71,11 @@ for (const file of wasms) {
   items.push({
     name,
     version,
-    ref: `${REGISTRY_PATH}/${name}:${version}`,
+    // Include `<namespace>` in the OCI path so it matches the wasmcloud.com
+    // registry's `namespacePrefix` mapping (`wasmcloud/interfaces/<ns>/<name>`).
+    ref: `${REGISTRY_PATH}/${namespace}/${name}:${version}`,
+    // Same path without the tag, for the build-provenance attestation subject.
+    subject: `${REGISTRY_PATH}/${namespace}/${name}`,
     artifact: basename(path),
   });
 }

--- a/.github/workflows/wit.yml
+++ b/.github/workflows/wit.yml
@@ -5,8 +5,10 @@ name: wit
 # OCI tag is the version declared in its `package <ns>:<name>@<ver>;`
 # header — independent of the monorepo's `vX.Y.Z` release cadence.
 #
-# Destination: ghcr.io/wasmcloud/interfaces/<name>:<version>
-# (the matrix builder enforces `<ns>` == `wasmcloud`).
+# Destination: ghcr.io/wasmcloud/interfaces/<ns>/<name>:<version>
+# (the matrix builder enforces `<ns>` == `wasmcloud`; the `<ns>` path
+# segment is required by the wasmcloud.com registry's `namespacePrefix`
+# mapping, so `wkg`/`wasmcloud:<name>` resolves the pushed package).
 #
 # Pipeline:
 #   validate  for each wit/<pkg>/: round-trips the WIT through
@@ -317,7 +319,7 @@ jobs:
         if: steps.push.outputs.skipped == 'false'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-name: ghcr.io/wasmcloud/interfaces/${{ matrix.name }}
+          subject-name: ${{ matrix.subject }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 


### PR DESCRIPTION
The publish matrix built each ref as
`ghcr.io/wasmcloud/interfaces/<name>:<version>`, dropping the
`<namespace>` segment. The wasmcloud.com registry resolves
`wasmcloud:<name>` via its well-known `namespacePrefix`
(`wasmcloud/interfaces/`) to `…/interfaces/wasmcloud/<name>`, so packages
pushed without the `wasmcloud/` segment land at a path nothing resolves:
`wkg`/`wasmcloud:<name>` 404s on them

This silently shipped wasmcloud:blobstore@0.1.0 and wasmcloud:keyvalue@0.1.0
to `…/interfaces/{blobstore,keyvalue}` — present in ghcr, unresolvable by
name. (wasmcloud:postgres, published by the older flow, lives only at the
correct `…/interfaces/wasmcloud/postgres` path, confirming the canonical
layout.)

Include `<namespace>` in the OCI path:
  ref: ghcr.io/wasmcloud/interfaces/<ns>/<name>:<version>
Add a `subject` matrix field (the namespaced path, no tag) and point the
build-provenance attestation `subject-name` at it. The immutability check
now inspects the corrected ref, so blobstore/keyvalue publish to the
namespaced path on the next main run while already-correct packages
(messaging, secrets) immutable-skip.

Signed-off-by: Bailey Hayes <bailey@cosmonic.com>
