### PR TITLE
fix: support multiline world declarations in wash wit add

### DIFF
--- a/crates/wash/src/cli/wit.rs
+++ b/crates/wash/src/cli/wit.rs
@@ -281,6 +281,83 @@ async fn find_world_wit_file(wit_dir: &std::path::Path) -> Result<std::path::Pat
     )
 }
 
+fn insert_import_into_world(content: &str, import_line: &str) -> Result<String> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut new_lines = Vec::new();
+    let mut inserted = false;
+    let mut pending_world = false;
+    let mut world_indent = String::new();
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("world ") {
+            pending_world = true;
+            if trimmed.contains('{') {
+                pending_world = false;
+                let next_indent = lines
+                    .get(i + 1)
+                    .map(|next_line| next_line.len() - next_line.trim_start().len())
+                    .unwrap_or(4);
+                world_indent = " ".repeat(next_indent.max(4));
+            }
+        } else if pending_world && trimmed.starts_with('{') {
+            pending_world = false;
+            let next_indent = lines
+                .get(i + 1)
+                .map(|next_line| next_line.len() - next_line.trim_start().len())
+                .unwrap_or(4);
+            world_indent = " ".repeat(next_indent.max(4));
+        } else if pending_world && !trimmed.is_empty() && !trimmed.starts_with("//") {
+            pending_world = false;
+        }
+
+        new_lines.push((*line).to_string());
+
+        if inserted || world_indent.is_empty() {
+            continue;
+        }
+
+        if trimmed.starts_with("import ") {
+            let remaining_lines = lines.get(i + 1..).unwrap_or_default();
+            let has_more_imports = remaining_lines
+                .iter()
+                .take_while(|l| !l.trim().starts_with('}'))
+                .any(|l| l.trim().starts_with("import "));
+
+            if !has_more_imports {
+                new_lines.push(format!("{world_indent}{import_line}"));
+                inserted = true;
+            }
+        } else if trimmed.starts_with('{')
+            || (trimmed.starts_with("world ") && trimmed.ends_with('{'))
+        {
+            let has_imports = lines
+                .get(i + 1..)
+                .unwrap_or_default()
+                .iter()
+                .take_while(|l| !l.trim().starts_with('}'))
+                .any(|l| l.trim().starts_with("import "));
+
+            if !has_imports {
+                new_lines.push(format!("{world_indent}{import_line}"));
+                inserted = true;
+            }
+        }
+    }
+
+    if !inserted {
+        bail!("Could not find a world block in world.wit to add the import");
+    }
+
+    let mut new_content = new_lines.join("\n");
+    if content.ends_with('\n') {
+        new_content.push('\n');
+    }
+
+    Ok(new_content)
+}
+
 /// Handle `wash wit fetch`
 #[instrument(level = "debug", skip(ctx))]
 async fn handle_fetch(ctx: &CliContext, config: &Config, clean: bool) -> Result<CommandOutput> {
@@ -521,84 +598,10 @@ async fn handle_add(ctx: &CliContext, package: &str, config: &Config) -> Result<
         ));
     }
 
-    // Add the import inside the world block
-    let lines: Vec<&str> = content.lines().collect();
-    let mut new_lines = Vec::new();
-    let mut inserted = false;
-    let mut in_world = false;
-    let mut world_indent = String::new();
-
-    for (i, line) in lines.iter().enumerate() {
-        let trimmed = line.trim();
-
-        // Detect when we enter a world block
-        if trimmed.starts_with("world ") && trimmed.contains('{') {
-            in_world = true;
-            // Detect indentation level by looking at next non-empty line
-            if let Some(next_line) = lines.get(i + 1) {
-                let next_trimmed = next_line.trim_start();
-                let indent_len = next_line.len() - next_trimmed.len();
-                world_indent = " ".repeat(indent_len.max(4)); // Default to 4 spaces if no indent detected
-            } else {
-                world_indent = "    ".to_string(); // Default 4 spaces
-            }
-        }
-
-        new_lines.push(line.to_string());
-
-        // Insert the import inside the world block
-        if in_world && !inserted {
-            // Check if this line is an import statement inside the world
-            if trimmed.starts_with("import ") {
-                // Check if this is the last import in the world block
-                let remaining_lines = lines.get(i + 1..).unwrap_or_default();
-                let has_more_imports = remaining_lines
-                    .iter()
-                    .take_while(|l| !l.trim().starts_with('}')) // Stop at closing brace
-                    .any(|l| l.trim().starts_with("import "));
-
-                if !has_more_imports {
-                    // Insert after the last import
-                    new_lines.push(format!("{world_indent}{import_line}"));
-                    inserted = true;
-                }
-            } else if trimmed.starts_with("world ") && trimmed.ends_with('{') {
-                // World block just opened, and there are no imports yet
-                // Check if there are any existing imports in the world
-                let has_imports = lines
-                    .get(i + 1..)
-                    .unwrap_or_default()
-                    .iter()
-                    .take_while(|l| !l.trim().starts_with('}'))
-                    .any(|l| l.trim().starts_with("import "));
-
-                if !has_imports {
-                    // No imports yet, insert as first line in world block
-                    new_lines.push(format!("{world_indent}{import_line}"));
-                    inserted = true;
-                }
-            }
-        }
-
-        // Detect when we exit the world block
-        if in_world && trimmed == "}" {
-            in_world = false;
-        }
-    }
-
-    // If we still haven't inserted, there might not be a world block
-    if !inserted {
-        return Ok(CommandOutput::error(
-            "Could not find a world block in world.wit to add the import".to_string(),
-            None,
-        ));
-    }
-
-    let mut new_content = new_lines.join("\n");
-    // Preserve trailing newline if original content had one
-    if content.ends_with('\n') {
-        new_content.push('\n');
-    }
+    let new_content = match insert_import_into_world(&content, &import_line) {
+        Ok(content) => content,
+        Err(e) => return Ok(CommandOutput::error(e.to_string(), None)),
+    };
 
     // Write the updated content
     tokio::fs::write(&world_wit_path, &new_content)
@@ -1021,6 +1024,55 @@ world example {
         assert!(
             found_import_inside,
             "Import should be inside the world block"
+        );
+    }
+
+    #[test]
+    fn test_insert_import_into_world_with_same_line_open_brace() {
+        let content = r#"package test:component@0.1.0;
+
+world example {
+}
+"#;
+
+        let updated = insert_import_into_world(content, "import wasi:http@0.2.0;")
+            .expect("insert should succeed");
+
+        assert!(updated.contains("    import wasi:http@0.2.0;"));
+    }
+
+    #[test]
+    fn test_insert_import_into_world_with_next_line_open_brace() {
+        let content = r#"package test:component@0.1.0;
+
+world example
+{
+}
+"#;
+
+        let updated = insert_import_into_world(content, "import wasi:http@0.2.0;")
+            .expect("insert should succeed");
+
+        assert!(updated.contains("{\n    import wasi:http@0.2.0;\n}"));
+    }
+
+    #[test]
+    fn test_insert_import_into_world_with_next_line_open_brace_and_existing_imports() {
+        let content = r#"package test:component@0.1.0;
+
+world example
+{
+    import wasi:config/store@0.2.0-draft;
+}
+"#;
+
+        let updated = insert_import_into_world(content, "import wasi:http@0.2.0;")
+            .expect("insert should succeed");
+
+        assert!(
+            updated.contains(
+                "    import wasi:config/store@0.2.0-draft;\n    import wasi:http@0.2.0;\n}"
+            )
         );
     }
 

--- a/crates/wash/tests/integration_wit.rs
+++ b/crates/wash/tests/integration_wit.rs
@@ -107,6 +107,40 @@ async fn test_add_fetch_clean_workflow() -> Result<()> {
     Ok(())
 }
 
+/// Test 1b: Add dependency when the world opening brace is on the next line
+/// Verifies `wash wit add` handles valid multi-line world declarations
+#[tokio::test]
+#[ignore] // Requires network access
+async fn test_add_with_next_line_world_brace() -> Result<()> {
+    let (temp, wit_dir) =
+        setup_test_project_with_world("package test:component@0.1.0;\n\nworld example\n{\n}\n")
+            .await?;
+
+    let ctx = CliContext::builder()
+        .non_interactive(true)
+        .project_dir(temp.path().to_path_buf())
+        .build()
+        .await
+        .context("failed to create CLI context")?;
+
+    let add_cmd = WitCommand::Add {
+        package: "wasi:logging/logging@0.1.0-draft".to_string(),
+    };
+    let result = timeout(Duration::from_secs(60), add_cmd.handle(&ctx))
+        .await
+        .context("add command timed out after 60s")?
+        .context("add command failed")?;
+    assert!(result.is_success(), "add command should succeed");
+
+    let content = fs::read_to_string(wit_dir.join("world.wit"))?;
+    assert!(
+        content.contains("world example\n{\n    import wasi:logging/logging@0.1.0-draft;\n}"),
+        "world.wit should contain the import inside the multi-line world block"
+    );
+
+    Ok(())
+}
+
 /// Test 2: Update workflow (selective and full)
 /// Tests that update modifies lock file correctly
 #[tokio::test]


### PR DESCRIPTION
No linked issue, couldnt find a direct match.

`wash wit add` fails on valid `world.wit` files when the `world` opening brace is on the next line. It bails with `Could not find a world block in world.wit to add the import`, kinda rough.

This makes the import insertion logic handle both brace styles, keeps new imports after the last existing import, and adds regression tests for the helper plus the real command path.

Repro:
1. Create `wit/world.wit` with:
```wit
package test:component@0.1.0;

world example
{
}
```
2. Run `wash wit add wasi:logging/logging@0.1.0-draft`
3. Before this fix it errors with `Could not find a world block in world.wit to add the import`
4. With this fix the import is added inside the `world` block and the command keeps going