### PR TITLE
async backends

### DIFF
--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -169,6 +169,8 @@ wasmtime-wasi-http = { workspace = true, features = ["p2"] }
 gag = "1.0"
 rcgen = { version = "0.14.7", default-features = false, features = ["crypto", "aws_lc_rs", "pem"] }
 testcontainers = { workspace = true }
+# Raw redis client for the keyvalue redis interop test
+redis = { workspace = true }
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
 # Pinned to match the gungraun-runner version the bench host's Ansible
 # playbook installs (scripts/bench/ansible/provision.yml). gungraun

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/mod.rs
@@ -1,7 +1,18 @@
 mod filesystem;
 mod in_memory;
+#[cfg(feature = "wasm_component_model_implements")]
+mod multiplexed;
+#[cfg(feature = "wasm_component_model_implements")]
+mod multiplexed_async;
 mod nats;
 
 pub use filesystem::FilesystemBlobstore;
 pub use in_memory::InMemoryBlobstore;
+#[cfg(feature = "wasm_component_model_implements")]
+pub use multiplexed::{
+    BlobBackend, BlobBackendError, BlobId, BlobProvider, FilesystemBackend, FilesystemProvider,
+    InMemoryBackend, InMemoryProvider, MultiplexedBlobstore, NatsBlobBackend, NatsBlobProvider,
+};
+#[cfg(feature = "wasm_component_model_implements")]
+pub use multiplexed_async::MultiplexedAsyncBlobstore;
 pub use nats::NatsBlobstore;

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed.rs
@@ -130,7 +130,6 @@ type BlobResult<T> = Result<T, BlobBackendError>;
 #[async_trait::async_trait]
 pub trait BlobBackend: Send + Sync {
     async fn create_container(&self, name: &str) -> BlobResult<()>;
-    /// Validate that `name` exists (used by `get-container`).
     async fn get_container(&self, name: &str) -> BlobResult<()>;
     async fn delete_container(&self, name: &str) -> BlobResult<()>;
     async fn container_exists(&self, name: &str) -> BlobResult<bool>;

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed.rs
@@ -1,0 +1,851 @@
+//! # Multiplexed WASI Blobstore (implements-routed)
+//!
+//! Binds `wasi:blobstore` via the component-model `(implements ..)` /
+//! `named_imports` mechanism so a single component can import the same
+//! interface multiple times and have each import backed by a *different*
+//! backend (e.g. one `wasi:blobstore/blobstore` import backed by the filesystem
+//! and another by NATS object-store).
+//!
+//! Each named `wasi:blobstore/blobstore` import is resolved by the
+//! [`Multiplexer`] to a [`BlobBackend`] (the wasmtime "implements id") for the
+//! container-lifecycle calls. The `container` and `types` interfaces are bound
+//! *standalone* (not per-label): a guest imports them unlabeled via
+//! `blobstore`'s `use container`/`use types`, and their resource methods route
+//! through the backend stored on the resource (`BlobContainer`/`OutgoingBlob`),
+//! so they need no label of their own.
+//!
+//! The same [`BlobBackend`] trait also backs the async `wasmcloud:blobstore`
+//! surface (see [`super::multiplexed_async`]); this module owns the trait,
+//! the backends/providers, and the `wasi:blobstore` (wasi:io-based) host layer.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use wasmtime::component::Resource;
+use wasmtime_wasi::p2::{
+    InputStream, OutputStream,
+    pipe::{MemoryInputPipe, MemoryOutputPipe},
+};
+
+use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
+use crate::engine::workload::WorkloadItem;
+use crate::plugin::multiplex::{BackendProvider, Multiplexer};
+use crate::plugin::{HostPlugin, WitInterfaces};
+use crate::wit::{WitInterface, WitWorld};
+
+mod bindings {
+    wasmtime::component::bindgen!({
+        world: "blobstore",
+        imports: { default: async | trappable | tracing },
+        named_imports: {
+            "wasi:blobstore/blobstore": super::BlobId,
+            "wasi:blobstore/container": super::BlobId,
+            "wasi:blobstore/types": super::BlobId,
+        },
+        with: {
+            "wasi:io": ::wasmtime_wasi_io::bindings::wasi::io,
+            "wasi:blobstore/container.container": super::BlobContainer,
+            "wasi:blobstore/container.stream-object-names": super::ObjectNameStream,
+            "wasi:blobstore/types.incoming-value": super::IncomingBlob,
+            "wasi:blobstore/types.outgoing-value": super::OutgoingBlob,
+        },
+    });
+}
+
+use bindings::wasi::blobstore::types::{
+    ContainerMetadata, ContainerName, Error as BlobError, ObjectId, ObjectMetadata, ObjectName,
+};
+
+/// The "implements id" threaded through every blobstore host method: the backend
+/// a given named import is bound to. `Arc` so it is cheaply `Clone`d into each
+/// per-import closure, as `named_imports` requires.
+pub type BlobId = Arc<dyn BlobBackend>;
+
+/// Default ceiling on the size of a single object written through an
+/// `outgoing-value`'s `MemoryOutputPipe`. Generous but bounded so a runaway
+/// guest cannot exhaust host memory through one write.
+const DEFAULT_MAX_OBJECT_SIZE: usize = 64 * 1024 * 1024;
+
+const DEFAULT_BACKEND: &str = "in-memory";
+const MULTIPLEXED_BLOBSTORE_ID: &str = "wasi-blobstore-multiplexed";
+
+/// Backend-agnostic container metadata; converted into the per-surface bindgen
+/// types by the host layers.
+#[derive(Clone, Debug)]
+pub struct ContainerInfo {
+    pub name: String,
+    /// Seconds since the Unix epoch.
+    pub created_at: u64,
+}
+
+/// Backend-agnostic object metadata.
+#[derive(Clone, Debug)]
+pub struct ObjectInfo {
+    pub name: String,
+    pub container: String,
+    /// Seconds since the Unix epoch.
+    pub created_at: u64,
+    pub size: u64,
+}
+
+/// The unified error surface for a [`BlobBackend`]. Named cases map cleanly onto
+/// the async `wasmcloud:blobstore` `variant error`; the `wasi:blobstore` layer
+/// flattens them to its `string` error via [`Display`].
+#[derive(Clone, Debug)]
+pub enum BlobBackendError {
+    NoSuchContainer(String),
+    ContainerAlreadyExists(String),
+    NoSuchObject(String),
+    Other(String),
+}
+
+impl BlobBackendError {
+    pub fn other(e: impl std::fmt::Display) -> Self {
+        Self::Other(e.to_string())
+    }
+}
+
+impl std::fmt::Display for BlobBackendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoSuchContainer(c) => write!(f, "container '{c}' does not exist"),
+            Self::ContainerAlreadyExists(c) => write!(f, "container '{c}' already exists"),
+            Self::NoSuchObject(o) => write!(f, "object '{o}' does not exist"),
+            Self::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+type BlobResult<T> = Result<T, BlobBackendError>;
+
+/// A blobstore backend (in-memory, filesystem, NATS object-store, ...).
+///
+/// Operations are keyed by container name plus object name; the backend owns its
+/// own state/connection. Object bodies are passed as whole `Vec<u8>` buffers —
+/// the host layers buffer guest streams into memory before handing them off, so
+/// backends do not deal with streaming directly. This is the unified surface
+/// that both the `wasi:blobstore` and async `wasmcloud:blobstore` host layers
+/// dispatch onto.
+#[async_trait::async_trait]
+pub trait BlobBackend: Send + Sync {
+    async fn create_container(&self, name: &str) -> BlobResult<()>;
+    /// Validate that `name` exists (used by `get-container`).
+    async fn get_container(&self, name: &str) -> BlobResult<()>;
+    async fn delete_container(&self, name: &str) -> BlobResult<()>;
+    async fn container_exists(&self, name: &str) -> BlobResult<bool>;
+    async fn container_info(&self, name: &str) -> BlobResult<ContainerInfo>;
+    async fn clear_container(&self, name: &str) -> BlobResult<()>;
+
+    /// Read object bytes in the inclusive byte range `[start, end]`, clamped to
+    /// the object's length.
+    async fn get_data(
+        &self,
+        container: &str,
+        object: &str,
+        start: u64,
+        end: u64,
+    ) -> BlobResult<Vec<u8>>;
+    async fn write_data(&self, container: &str, object: &str, data: Vec<u8>) -> BlobResult<()>;
+    async fn list_objects(&self, container: &str) -> BlobResult<Vec<String>>;
+    async fn delete_object(&self, container: &str, object: &str) -> BlobResult<()>;
+    async fn delete_objects(&self, container: &str, objects: &[String]) -> BlobResult<()>;
+    async fn has_object(&self, container: &str, object: &str) -> BlobResult<bool>;
+    async fn object_info(&self, container: &str, object: &str) -> BlobResult<ObjectInfo>;
+    /// Copy an object. NOTE: both containers are resolved on the *same* backend.
+    /// `copy`/`move` cannot cross backends, because the WIT object ids are plain
+    /// strings carrying no backend, so a  component that maps two `(implements ..)`
+    /// labels to different backends cannot copy between them via this API.
+    async fn copy_object(
+        &self,
+        src_container: &str,
+        src_object: &str,
+        dest_container: &str,
+        dest_object: &str,
+    ) -> BlobResult<()>;
+    async fn move_object(
+        &self,
+        src_container: &str,
+        src_object: &str,
+        dest_container: &str,
+        dest_object: &str,
+    ) -> BlobResult<()> {
+        self.copy_object(src_container, src_object, dest_container, dest_object)
+            .await?;
+        self.delete_object(src_container, src_object).await
+    }
+}
+
+/// A container resource. Remembers the backend it was opened through so every
+/// subsequent operation routes to that backend, regardless of which named
+/// interface the call arrived on. Shared by the `wasi:blobstore` and async
+/// `wasmcloud:blobstore` host layers (each is a distinct WIT resource backed by
+/// this same Rust type).
+pub struct BlobContainer {
+    backend: BlobId,
+    name: String,
+}
+
+impl BlobContainer {
+    pub(crate) fn new(backend: BlobId, name: String) -> Self {
+        Self { backend, name }
+    }
+
+    pub(crate) fn backend(&self) -> &BlobId {
+        &self.backend
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// An `incoming-value` resource: the bytes read by `get-data`, buffered.
+pub type IncomingBlob = Vec<u8>;
+
+/// An `outgoing-value` resource: a memory pipe the guest writes into, plus the
+/// destination (set at `write-data`) and backend used to persist at `finish`.
+pub struct OutgoingBlob {
+    pipe: MemoryOutputPipe,
+    backend: Option<BlobId>,
+    container: Option<String>,
+    object: Option<String>,
+}
+
+/// A `stream-object-names` resource: a paged snapshot of object names.
+pub struct ObjectNameStream {
+    names: Vec<String>,
+    position: usize,
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Clamp a `[start, end]` (inclusive) request to the half-open slice bounds of a
+/// buffer of length `len`.
+fn clamp_range(start: u64, end: u64, len: usize) -> std::ops::Range<usize> {
+    let len = len as u64;
+    let start = start.min(len);
+    let end_excl = end.saturating_add(1).min(len);
+    (start as usize)..(end_excl.max(start) as usize)
+}
+
+impl<'a> bindings::named_imports::wasi::blobstore::blobstore::Host for ActiveCtx<'a> {
+    async fn create_container(
+        &mut self,
+        id: BlobId,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<Resource<BlobContainer>, BlobError>> {
+        if let Err(e) = id.create_container(&name).await {
+            return Ok(Err(e.to_string()));
+        }
+        Ok(Ok(self.table.push(BlobContainer { backend: id, name })?))
+    }
+
+    async fn get_container(
+        &mut self,
+        id: BlobId,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<Resource<BlobContainer>, BlobError>> {
+        if let Err(e) = id.get_container(&name).await {
+            return Ok(Err(e.to_string()));
+        }
+        Ok(Ok(self.table.push(BlobContainer { backend: id, name })?))
+    }
+
+    async fn delete_container(
+        &mut self,
+        id: BlobId,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<(), BlobError>> {
+        Ok(id.delete_container(&name).await.map_err(|e| e.to_string()))
+    }
+
+    async fn container_exists(
+        &mut self,
+        id: BlobId,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<bool, BlobError>> {
+        Ok(id.container_exists(&name).await.map_err(|e| e.to_string()))
+    }
+
+    async fn copy_object(
+        &mut self,
+        id: BlobId,
+        src: ObjectId,
+        dest: ObjectId,
+    ) -> wasmtime::Result<Result<(), BlobError>> {
+        Ok(id
+            .copy_object(&src.container, &src.object, &dest.container, &dest.object)
+            .await
+            .map_err(|e| e.to_string()))
+    }
+
+    async fn move_object(
+        &mut self,
+        id: BlobId,
+        src: ObjectId,
+        dest: ObjectId,
+    ) -> wasmtime::Result<Result<(), BlobError>> {
+        Ok(id
+            .move_object(&src.container, &src.object, &dest.container, &dest.object)
+            .await
+            .map_err(|e| e.to_string()))
+    }
+}
+
+impl<'a> bindings::wasi::blobstore::container::HostContainer for ActiveCtx<'a> {
+    async fn name(
+        &mut self,
+        container: Resource<BlobContainer>,
+    ) -> wasmtime::Result<Result<String, BlobError>> {
+        let c = self.table.get(&container)?;
+        Ok(Ok(c.name.clone()))
+    }
+
+    async fn info(
+        &mut self,
+        container: Resource<BlobContainer>,
+    ) -> wasmtime::Result<Result<ContainerMetadata, BlobError>> {
+        let c = self.table.get(&container)?;
+        match c.backend.container_info(&c.name).await {
+            Ok(info) => Ok(Ok(ContainerMetadata {
+                name: info.name,
+                created_at: info.created_at,
+            })),
+            Err(e) => Ok(Err(e.to_string())),
+        }
+    }
+
+    async fn get_data(
+        &mut self,
+        container: Resource<BlobContainer>,
+        name: ObjectName,
+        start: u64,
+        end: u64,
+    ) -> wasmtime::Result<Result<Resource<IncomingBlob>, BlobError>> {
+        let c = self.table.get(&container)?;
+        match c.backend.get_data(&c.name, &name, start, end).await {
+            Ok(bytes) => Ok(Ok(self.table.push(bytes)?)),
+            Err(e) => Ok(Err(e.to_string())),
+        }
+    }
+
+    async fn write_data(
+        &mut self,
+        container: Resource<BlobContainer>,
+        name: ObjectName,
+        data: Resource<OutgoingBlob>,
+    ) -> wasmtime::Result<Result<(), BlobError>> {
+        let c = self.table.get(&container)?;
+        let (backend, container_name) = (c.backend.clone(), c.name.clone());
+        let handle = self.table.get_mut(&data)?;
+        handle.backend = Some(backend);
+        handle.container = Some(container_name);
+        handle.object = Some(name);
+        Ok(Ok(()))
+    }
+
+    async fn list_objects(
+        &mut self,
+        container: Resource<BlobContainer>,
+    ) -> wasmtime::Result<Result<Resource<ObjectNameStream>, BlobError>> {
+        let c = self.table.get(&container)?;
+        match c.backend.list_objects(&c.name).await {
+            Ok(names) => Ok(Ok(self
+                .table
+                .push(ObjectNameStream { names, position: 0 })?)),
+            Err(e) => Ok(Err(e.to_string())),
+        }
+    }
+
+    async fn delete_object(
+        &mut self,
+        container: Resource<BlobContainer>,
+        name: ObjectName,
+    ) -> wasmtime::Result<Result<(), BlobError>> {
+        let c = self.table.get(&container)?;
+        Ok(c.backend
+            .delete_object(&c.name, &name)
+            .await
+            .map_err(|e| e.to_string()))
+    }
+
+    async fn delete_objects(
+        &mut self,
+        container: Resource<BlobContainer>,
+        names: Vec<ObjectName>,
+    ) -> wasmtime::Result<Result<(), BlobError>> {
+        let c = self.table.get(&container)?;
+        Ok(c.backend
+            .delete_objects(&c.name, &names)
+            .await
+            .map_err(|e| e.to_string()))
+    }
+
+    async fn has_object(
+        &mut self,
+        container: Resource<BlobContainer>,
+        name: ObjectName,
+    ) -> wasmtime::Result<Result<bool, BlobError>> {
+        let c = self.table.get(&container)?;
+        Ok(c.backend
+            .has_object(&c.name, &name)
+            .await
+            .map_err(|e| e.to_string()))
+    }
+
+    async fn object_info(
+        &mut self,
+        container: Resource<BlobContainer>,
+        name: ObjectName,
+    ) -> wasmtime::Result<Result<ObjectMetadata, BlobError>> {
+        let c = self.table.get(&container)?;
+        match c.backend.object_info(&c.name, &name).await {
+            Ok(info) => Ok(Ok(ObjectMetadata {
+                name: info.name,
+                container: info.container,
+                created_at: info.created_at,
+                size: info.size,
+            })),
+            Err(e) => Ok(Err(e.to_string())),
+        }
+    }
+
+    async fn clear(
+        &mut self,
+        container: Resource<BlobContainer>,
+    ) -> wasmtime::Result<Result<(), BlobError>> {
+        let c = self.table.get(&container)?;
+        Ok(c.backend
+            .clear_container(&c.name)
+            .await
+            .map_err(|e| e.to_string()))
+    }
+
+    async fn drop(&mut self, rep: Resource<BlobContainer>) -> wasmtime::Result<()> {
+        self.table.delete(rep)?;
+        Ok(())
+    }
+}
+
+impl<'a> bindings::wasi::blobstore::container::HostStreamObjectNames for ActiveCtx<'a> {
+    async fn read_stream_object_names(
+        &mut self,
+        stream: Resource<ObjectNameStream>,
+        len: u64,
+    ) -> wasmtime::Result<Result<(Vec<ObjectName>, bool), BlobError>> {
+        let s = self.table.get_mut(&stream)?;
+        let remaining = s.names.len().saturating_sub(s.position);
+        let to_read = (len as usize).min(remaining);
+        let page = s
+            .names
+            .get(s.position..s.position + to_read)
+            .unwrap_or_default()
+            .to_vec();
+        s.position += to_read;
+        let is_end = s.position >= s.names.len();
+        Ok(Ok((page, is_end)))
+    }
+
+    async fn skip_stream_object_names(
+        &mut self,
+        stream: Resource<ObjectNameStream>,
+        num: u64,
+    ) -> wasmtime::Result<Result<(u64, bool), BlobError>> {
+        let s = self.table.get_mut(&stream)?;
+        let remaining = s.names.len().saturating_sub(s.position);
+        let to_skip = (num as usize).min(remaining);
+        s.position += to_skip;
+        let is_end = s.position >= s.names.len();
+        Ok(Ok((to_skip as u64, is_end)))
+    }
+
+    async fn drop(&mut self, rep: Resource<ObjectNameStream>) -> wasmtime::Result<()> {
+        self.table.delete(rep)?;
+        Ok(())
+    }
+}
+
+impl<'a> bindings::wasi::blobstore::types::HostOutgoingValue for ActiveCtx<'a> {
+    async fn new_outgoing_value(&mut self) -> wasmtime::Result<Resource<OutgoingBlob>> {
+        Ok(self.table.push(OutgoingBlob {
+            pipe: MemoryOutputPipe::new(DEFAULT_MAX_OBJECT_SIZE),
+            backend: None,
+            container: None,
+            object: None,
+        })?)
+    }
+
+    async fn outgoing_value_write_body(
+        &mut self,
+        outgoing_value: Resource<OutgoingBlob>,
+    ) -> wasmtime::Result<Result<Resource<bindings::wasi::io0_2_1::streams::OutputStream>, ()>>
+    {
+        let handle = self.table.get_mut(&outgoing_value)?;
+        // The guest writes into the same pipe we read back in `finish`.
+        let boxed: Box<dyn OutputStream> = Box::new(handle.pipe.clone());
+        Ok(Ok(self.table.push(boxed)?))
+    }
+
+    async fn finish(
+        &mut self,
+        outgoing_value: Resource<OutgoingBlob>,
+    ) -> wasmtime::Result<Result<(), BlobError>> {
+        let handle = self.table.delete(outgoing_value)?;
+        let (Some(backend), Some(container), Some(object)) =
+            (handle.backend, handle.container, handle.object)
+        else {
+            // `finish` without a prior `write-data` has nothing to persist.
+            return Ok(Ok(()));
+        };
+        let data = handle.pipe.contents().to_vec();
+        Ok(backend
+            .write_data(&container, &object, data)
+            .await
+            .map_err(|e| e.to_string()))
+    }
+
+    async fn drop(&mut self, rep: Resource<OutgoingBlob>) -> wasmtime::Result<()> {
+        // Dropping flushes any pending write, matching the standalone backends.
+        self.finish(rep).await?.ok();
+        Ok(())
+    }
+}
+
+impl<'a> bindings::wasi::blobstore::types::HostIncomingValue for ActiveCtx<'a> {
+    async fn incoming_value_consume_sync(
+        &mut self,
+        incoming_value: Resource<IncomingBlob>,
+    ) -> wasmtime::Result<Result<Vec<u8>, BlobError>> {
+        let data = self.table.delete(incoming_value)?;
+        Ok(Ok(data))
+    }
+
+    async fn incoming_value_consume_async(
+        &mut self,
+        incoming_value: Resource<IncomingBlob>,
+    ) -> wasmtime::Result<
+        Result<Resource<bindings::wasi::blobstore::types::IncomingValueAsyncBody>, BlobError>,
+    > {
+        // `incoming-value-consume-async` consumes `this` (owned, per the WIT), so
+        // remove it from the table.
+        let data = self.table.delete(incoming_value)?;
+        let stream: Box<dyn InputStream> = Box::new(MemoryInputPipe::new(data));
+        Ok(Ok(self.table.push(stream)?))
+    }
+
+    async fn size(&mut self, incoming_value: Resource<IncomingBlob>) -> wasmtime::Result<u64> {
+        Ok(self.table.get(&incoming_value)?.len() as u64)
+    }
+
+    async fn drop(&mut self, rep: Resource<IncomingBlob>) -> wasmtime::Result<()> {
+        self.table.delete(rep)?;
+        Ok(())
+    }
+}
+
+// `Host` marker traits combine the resource-method traits above.
+impl<'a> bindings::wasi::blobstore::container::Host for ActiveCtx<'a> {}
+impl<'a> bindings::wasi::blobstore::types::Host for ActiveCtx<'a> {}
+
+mod filesystem;
+mod in_memory;
+mod nats;
+
+pub use filesystem::{FilesystemBackend, FilesystemProvider};
+pub use in_memory::{InMemoryBackend, InMemoryProvider};
+pub use nats::{NatsBlobBackend, NatsBlobProvider};
+
+/// A blobstore backend provider: a [`BackendProvider`] producing [`BlobId`]s.
+pub type BlobProvider = dyn BackendProvider<BlobId>;
+
+/// A blobstore [`HostPlugin`] that multiplexes `wasi:blobstore` across backends
+/// selected per `(implements ..)` import. Register the backend providers you
+/// want to support via [`MultiplexedBlobstore::with_provider`].
+pub struct MultiplexedBlobstore {
+    mux: Multiplexer<BlobId>,
+}
+
+impl Default for MultiplexedBlobstore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MultiplexedBlobstore {
+    pub fn new() -> Self {
+        Self {
+            mux: Multiplexer::new("wasi", "blobstore", DEFAULT_BACKEND),
+        }
+    }
+
+    /// Register a backend provider keyed by its `backend_type()`.
+    pub fn with_provider(mut self, provider: Arc<BlobProvider>) -> Self {
+        self.mux = self.mux.with_provider(provider);
+        self
+    }
+
+    /// Build the routing registry (host-interface name -> backend) for a
+    /// component from its matched blobstore host interfaces.
+    pub async fn build_registry<'i>(
+        &self,
+        interfaces: impl IntoIterator<Item = &'i WitInterface>,
+    ) -> anyhow::Result<HashMap<String, BlobId>> {
+        self.mux.build_registry(interfaces).await
+    }
+}
+
+#[async_trait::async_trait]
+impl HostPlugin for MultiplexedBlobstore {
+    fn id(&self) -> &'static str {
+        MULTIPLEXED_BLOBSTORE_ID
+    }
+
+    fn world(&self) -> WitWorld {
+        WitWorld {
+            imports: HashSet::from([WitInterface::from(
+                "wasi:blobstore/blobstore,container,types@0.2.0-draft",
+            )]),
+            ..Default::default()
+        }
+    }
+
+    fn supports_named_instances(&self) -> bool {
+        true
+    }
+
+    async fn on_workload_item_bind<'a>(
+        &self,
+        item: &mut WorkloadItem<'a>,
+        interfaces: WitInterfaces<'_>,
+    ) -> anyhow::Result<()> {
+        if !interfaces.contains("wasi", "blobstore", &[]) {
+            return Ok(());
+        }
+
+        let registry = self.build_registry(interfaces.iter()).await?;
+        // Clone the component (cheap, Arc-backed) so the immutable borrow ends
+        // before we take the mutable linker borrow.
+        let component = item.component().clone();
+        let linker = item.linker();
+
+        // `blobstore` (create/get container, copy/move) is routed per `(implements
+        // ..)` label so each label lands on its own backend. `container` and
+        // `types` are bound standalone: a guest imports them *unlabeled* via
+        // `blobstore`'s `use container`/`use types` (WIT forbids two interfaces
+        // sharing a label), and their methods route through the resource's stored
+        // backend (the container/outgoing-value), not a label.
+        bindings::named_imports::wasi::blobstore::blobstore::add_to_linker::<_, SharedCtx>(
+            linker,
+            &component,
+            |name| self.mux.resolve(&registry, name),
+            extract_active_ctx,
+        )?;
+        bindings::wasi::blobstore::container::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+        bindings::wasi::blobstore::types::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blob_iface(name: Option<&str>, backend: Option<&str>, root: Option<&str>) -> WitInterface {
+        let mut config = HashMap::new();
+        if let Some(b) = backend {
+            config.insert("backend".to_string(), b.to_string());
+        }
+        if let Some(r) = root {
+            config.insert("root".to_string(), r.to_string());
+        }
+        WitInterface {
+            namespace: "wasi".to_string(),
+            package: "blobstore".to_string(),
+            interfaces: ["blobstore".to_string()].into_iter().collect(),
+            version: None,
+            config,
+            name: name.map(String::from),
+        }
+    }
+
+    fn tmp_dir(tag: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "wash-fs-blob-{tag}-{}-{unique}",
+            std::process::id()
+        ))
+    }
+
+    /// A backend round-trips a write through `get-data`, and reports object
+    /// metadata/listing — the core object lifecycle, proven on in-memory.
+    async fn assert_object_lifecycle(backend: &BlobId) {
+        backend.create_container("bucket").await.unwrap();
+        assert!(backend.container_exists("bucket").await.unwrap());
+
+        backend
+            .write_data("bucket", "greeting", b"hello world".to_vec())
+            .await
+            .unwrap();
+        assert!(backend.has_object("bucket", "greeting").await.unwrap());
+        assert_eq!(
+            backend
+                .get_data("bucket", "greeting", 0, u64::MAX)
+                .await
+                .unwrap(),
+            b"hello world".to_vec()
+        );
+        // Inclusive byte range.
+        assert_eq!(
+            backend.get_data("bucket", "greeting", 0, 4).await.unwrap(),
+            b"hello".to_vec()
+        );
+        assert_eq!(
+            backend
+                .object_info("bucket", "greeting")
+                .await
+                .unwrap()
+                .size,
+            11
+        );
+        assert_eq!(
+            backend.list_objects("bucket").await.unwrap(),
+            vec!["greeting".to_string()]
+        );
+
+        backend
+            .copy_object("bucket", "greeting", "bucket", "copy")
+            .await
+            .unwrap();
+        assert_eq!(
+            backend
+                .get_data("bucket", "copy", 0, u64::MAX)
+                .await
+                .unwrap(),
+            b"hello world".to_vec()
+        );
+
+        backend.delete_object("bucket", "greeting").await.unwrap();
+        assert!(!backend.has_object("bucket", "greeting").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn in_memory_object_lifecycle() {
+        let backend: BlobId = Arc::new(InMemoryBackend::new());
+        assert_object_lifecycle(&backend).await;
+    }
+
+    #[tokio::test]
+    async fn filesystem_object_lifecycle() {
+        let dir = tmp_dir("lifecycle");
+        let backend: BlobId = Arc::new(FilesystemBackend::new(&dir));
+        assert_object_lifecycle(&backend).await;
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn in_memory_backend_instances_are_isolated() {
+        let a = InMemoryBackend::new();
+        a.create_container("bucket").await.unwrap();
+        a.write_data("bucket", "k", b"v1".to_vec()).await.unwrap();
+
+        let b = InMemoryBackend::new();
+        // `b` never saw `bucket`.
+        assert!(!b.container_exists("bucket").await.unwrap());
+    }
+
+    /// The decisive case: two named interfaces of the *same* backend type route
+    /// to independent backends, proven with in-memory.
+    #[tokio::test]
+    async fn registry_routes_named_interfaces_to_distinct_backends() {
+        let plugin = MultiplexedBlobstore::new().with_provider(Arc::new(InMemoryProvider));
+        let interfaces = HashSet::from([
+            blob_iface(Some("team-a"), Some("in-memory"), None),
+            blob_iface(Some("team-b"), Some("in-memory"), None),
+        ]);
+
+        let registry = plugin.build_registry(&interfaces).await.unwrap();
+        let a = registry.get("team-a").expect("team-a routed").clone();
+        let b = registry.get("team-b").expect("team-b routed").clone();
+
+        a.create_container("bucket").await.unwrap();
+        a.write_data("bucket", "k", b"v".to_vec()).await.unwrap();
+        assert!(
+            !b.container_exists("bucket").await.unwrap(),
+            "backends leaked"
+        );
+        assert_eq!(
+            a.get_data("bucket", "k", 0, u64::MAX).await.unwrap(),
+            b"v".to_vec()
+        );
+    }
+
+    /// The filesystem provider routes a named interface to an on-disk backend,
+    /// proving it's wired into the multiplexer and data actually hits disk.
+    #[tokio::test]
+    async fn filesystem_backend_persists_through_the_multiplexer() {
+        let dir = tmp_dir("mux");
+        let iface = blob_iface(
+            Some("team-fs"),
+            Some("filesystem"),
+            Some(&dir.to_string_lossy()),
+        );
+
+        let plugin = MultiplexedBlobstore::new().with_provider(Arc::new(FilesystemProvider));
+        let registry = plugin
+            .build_registry(&HashSet::from([iface]))
+            .await
+            .unwrap();
+        let backend = registry.get("team-fs").expect("team-fs routed").clone();
+
+        backend.create_container("bucket").await.unwrap();
+        backend
+            .write_data("bucket", "k", b"v".to_vec())
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.get_data("bucket", "k", 0, u64::MAX).await.unwrap(),
+            b"v".to_vec()
+        );
+        // It actually hit disk.
+        assert!(dir.join("bucket").join("k").exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn build_registry_errors_on_unregistered_backend() {
+        let plugin = MultiplexedBlobstore::new(); // no providers registered
+        let interfaces = HashSet::from([blob_iface(Some("x"), Some("nats"), None)]);
+        let err = plugin
+            .build_registry(&interfaces)
+            .await
+            .err()
+            .expect("expected error for unregistered backend");
+        assert!(err.to_string().contains("nats"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn create_existing_container_errors() {
+        let backend = InMemoryBackend::new();
+        backend.create_container("dup").await.unwrap();
+        assert!(matches!(
+            backend.create_container("dup").await,
+            Err(BlobBackendError::ContainerAlreadyExists(_))
+        ));
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed/filesystem.rs
@@ -60,11 +60,11 @@ impl BlobBackend for FilesystemBackend {
     }
 
     async fn get_container(&self, name: &str) -> BlobResult<()> {
-        self.container_exists(name).await.and_then(|exists| {
-            exists
-                .then_some(())
-                .ok_or_else(|| BlobBackendError::NoSuchContainer(name.to_string()))
-        })
+        match self.container_exists(name).await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(BlobBackendError::NoSuchContainer(name.to_string())),
+            Err(e) => Err(e),
+        }
     }
 
     async fn delete_container(&self, name: &str) -> BlobResult<()> {

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed/filesystem.rs
@@ -1,0 +1,265 @@
+//! Filesystem [`BlobBackend`] for the multiplexed blobstore plugin.
+//!
+//! Rooted at a directory: containers are subdirectories, objects are files
+//! (path-traversal guarded via [`lock_root`]).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use crate::plugin::lock_root;
+use crate::plugin::multiplex::BackendProvider;
+
+use super::{
+    BlobBackend, BlobBackendError, BlobId, BlobResult, ContainerInfo, ObjectInfo, clamp_range,
+};
+
+/// A filesystem [`BlobBackend`] rooted at a directory.
+pub struct FilesystemBackend {
+    root: PathBuf,
+}
+
+impl FilesystemBackend {
+    pub fn new(root: impl AsRef<Path>) -> Self {
+        Self {
+            root: root.as_ref().to_path_buf(),
+        }
+    }
+
+    fn container_path(&self, container: &str) -> BlobResult<PathBuf> {
+        lock_root(&self.root, container).map_err(|e| BlobBackendError::Other(e.to_string()))
+    }
+
+    fn object_path(&self, container: &str, object: &str) -> BlobResult<PathBuf> {
+        let dir = self.container_path(container)?;
+        lock_root(dir, object).map_err(|e| BlobBackendError::Other(e.to_string()))
+    }
+
+    async fn created_at(path: &Path) -> u64 {
+        match tokio::fs::metadata(path).await.and_then(|m| m.created()) {
+            Ok(t) => t
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+            Err(_) => 0,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl BlobBackend for FilesystemBackend {
+    async fn create_container(&self, name: &str) -> BlobResult<()> {
+        let path = self.container_path(name)?;
+        if tokio::fs::try_exists(&path).await.unwrap_or(false) {
+            return Err(BlobBackendError::ContainerAlreadyExists(name.to_string()));
+        }
+        tokio::fs::create_dir_all(&path)
+            .await
+            .map_err(BlobBackendError::other)
+    }
+
+    async fn get_container(&self, name: &str) -> BlobResult<()> {
+        self.container_exists(name).await.and_then(|exists| {
+            exists
+                .then_some(())
+                .ok_or_else(|| BlobBackendError::NoSuchContainer(name.to_string()))
+        })
+    }
+
+    async fn delete_container(&self, name: &str) -> BlobResult<()> {
+        let path = self.container_path(name)?;
+        match tokio::fs::remove_dir_all(&path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(BlobBackendError::other(e)),
+        }
+    }
+
+    async fn container_exists(&self, name: &str) -> BlobResult<bool> {
+        let path = self.container_path(name)?;
+        Ok(tokio::fs::try_exists(&path).await.unwrap_or(false))
+    }
+
+    async fn container_info(&self, name: &str) -> BlobResult<ContainerInfo> {
+        let path = self.container_path(name)?;
+        if !tokio::fs::try_exists(&path).await.unwrap_or(false) {
+            return Err(BlobBackendError::NoSuchContainer(name.to_string()));
+        }
+        Ok(ContainerInfo {
+            name: name.to_string(),
+            created_at: Self::created_at(&path).await,
+        })
+    }
+
+    async fn clear_container(&self, name: &str) -> BlobResult<()> {
+        let path = self.container_path(name)?;
+        if !tokio::fs::try_exists(&path).await.unwrap_or(false) {
+            return Err(BlobBackendError::NoSuchContainer(name.to_string()));
+        }
+        // Remove the whole tree and recreate the (now empty) container, so that
+        // objects written under nested keys (e.g. `a/b`) are cleared too.
+        tokio::fs::remove_dir_all(&path)
+            .await
+            .map_err(BlobBackendError::other)?;
+        tokio::fs::create_dir_all(&path)
+            .await
+            .map_err(BlobBackendError::other)?;
+        Ok(())
+    }
+
+    async fn get_data(
+        &self,
+        container: &str,
+        object: &str,
+        start: u64,
+        end: u64,
+    ) -> BlobResult<Vec<u8>> {
+        let path = self.object_path(container, object)?;
+        let data = match tokio::fs::read(&path).await {
+            Ok(data) => data,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(BlobBackendError::NoSuchObject(object.to_string()));
+            }
+            Err(e) => return Err(BlobBackendError::other(e)),
+        };
+        let range = clamp_range(start, end, data.len());
+        Ok(data.get(range).unwrap_or_default().to_vec())
+    }
+
+    async fn write_data(&self, container: &str, object: &str, data: Vec<u8>) -> BlobResult<()> {
+        if !self.container_exists(container).await? {
+            return Err(BlobBackendError::NoSuchContainer(container.to_string()));
+        }
+        let path = self.object_path(container, object)?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(BlobBackendError::other)?;
+        }
+        tokio::fs::write(&path, data)
+            .await
+            .map_err(BlobBackendError::other)
+    }
+
+    async fn list_objects(&self, container: &str) -> BlobResult<Vec<String>> {
+        let root = self.container_path(container)?;
+        if !tokio::fs::try_exists(&root).await.unwrap_or(false) {
+            return Err(BlobBackendError::NoSuchContainer(container.to_string()));
+        }
+        // Walk the container tree so objects written under nested keys (e.g.
+        // `a/b`, stored as a file `a/b`) are listed, matching the flat-key
+        // in-memory and NATS backends. Each name is the file's path relative to
+        // the container root, '/'-joined.
+        let mut names = Vec::new();
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            let mut entries = tokio::fs::read_dir(&dir)
+                .await
+                .map_err(BlobBackendError::other)?;
+            while let Some(entry) = entries
+                .next_entry()
+                .await
+                .map_err(BlobBackendError::other)?
+            {
+                let file_type = entry.file_type().await.map_err(BlobBackendError::other)?;
+                let entry_path = entry.path();
+                if file_type.is_dir() {
+                    stack.push(entry_path);
+                } else if file_type.is_file() {
+                    let Ok(rel) = entry_path.strip_prefix(&root) else {
+                        continue;
+                    };
+                    let name = rel
+                        .components()
+                        .map(|c| c.as_os_str().to_string_lossy())
+                        .collect::<Vec<_>>()
+                        .join("/");
+                    names.push(name);
+                }
+            }
+        }
+        Ok(names)
+    }
+
+    async fn delete_object(&self, container: &str, object: &str) -> BlobResult<()> {
+        let path = self.object_path(container, object)?;
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(BlobBackendError::other(e)),
+        }
+    }
+
+    async fn delete_objects(&self, container: &str, objects: &[String]) -> BlobResult<()> {
+        for object in objects {
+            self.delete_object(container, object).await?;
+        }
+        Ok(())
+    }
+
+    async fn has_object(&self, container: &str, object: &str) -> BlobResult<bool> {
+        let path = self.object_path(container, object)?;
+        // Only a regular file is an object. A directory here is an intermediate
+        // path component of a nested key (e.g. `a` exists because `a/b` was
+        // written) — not an object named `a`.
+        Ok(tokio::fs::metadata(&path)
+            .await
+            .map(|m| m.is_file())
+            .unwrap_or(false))
+    }
+
+    async fn object_info(&self, container: &str, object: &str) -> BlobResult<ObjectInfo> {
+        let path = self.object_path(container, object)?;
+        let meta = match tokio::fs::metadata(&path).await {
+            Ok(meta) => meta,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(BlobBackendError::NoSuchObject(object.to_string()));
+            }
+            Err(e) => return Err(BlobBackendError::other(e)),
+        };
+        // A directory (nested-key intermediate) is not an object.
+        if !meta.is_file() {
+            return Err(BlobBackendError::NoSuchObject(object.to_string()));
+        }
+        Ok(ObjectInfo {
+            name: object.to_string(),
+            container: container.to_string(),
+            created_at: Self::created_at(&path).await,
+            size: meta.len(),
+        })
+    }
+
+    async fn copy_object(
+        &self,
+        src_container: &str,
+        src_object: &str,
+        dest_container: &str,
+        dest_object: &str,
+    ) -> BlobResult<()> {
+        let data = self
+            .get_data(src_container, src_object, 0, u64::MAX)
+            .await?;
+        self.write_data(dest_container, dest_object, data).await
+    }
+}
+
+/// Provider for [`FilesystemBackend`], selected by `config.backend =
+/// "filesystem"`. Requires `config.root` (the directory under which containers
+/// live).
+#[derive(Default)]
+pub struct FilesystemProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<BlobId> for FilesystemProvider {
+    fn backend_type(&self) -> &'static str {
+        "filesystem"
+    }
+
+    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<BlobId> {
+        let root = config.get("root").ok_or_else(|| {
+            anyhow::anyhow!("filesystem blobstore backend requires a 'root' config")
+        })?;
+        Ok(Arc::new(FilesystemBackend::new(root)))
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed/in_memory.rs
@@ -4,7 +4,7 @@
 //! isolated store, so two named imports backed by two `InMemoryBackend`s do not
 //! share data.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -25,7 +25,9 @@ struct MemObject {
 #[derive(Default, Debug)]
 struct MemContainer {
     created_at: u64,
-    objects: HashMap<String, MemObject>,
+    // `BTreeMap` keeps objects ordered by (often hierarchical) name, so
+    // `list_objects` yields a stable, sorted listing.
+    objects: BTreeMap<String, MemObject>,
 }
 
 /// An in-memory [`BlobBackend`]. Each instance is an isolated store.
@@ -51,18 +53,18 @@ impl BlobBackend for InMemoryBackend {
             name.to_string(),
             MemContainer {
                 created_at: now_secs(),
-                objects: HashMap::new(),
+                objects: BTreeMap::new(),
             },
         );
         Ok(())
     }
 
     async fn get_container(&self, name: &str) -> BlobResult<()> {
-        self.container_exists(name).await.and_then(|exists| {
-            exists
-                .then_some(())
-                .ok_or_else(|| BlobBackendError::NoSuchContainer(name.to_string()))
-        })
+        match self.container_exists(name).await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(BlobBackendError::NoSuchContainer(name.to_string())),
+            Err(e) => Err(e),
+        }
     }
 
     async fn delete_container(&self, name: &str) -> BlobResult<()> {

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed/in_memory.rs
@@ -1,0 +1,227 @@
+//! In-memory [`BlobBackend`] for the multiplexed blobstore plugin.
+//!
+//! Used to prove the routing mechanism and for tests. Each instance is an
+//! isolated store, so two named imports backed by two `InMemoryBackend`s do not
+//! share data.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::plugin::multiplex::BackendProvider;
+
+use super::{
+    BlobBackend, BlobBackendError, BlobId, BlobResult, ContainerInfo, DEFAULT_BACKEND, ObjectInfo,
+    clamp_range, now_secs,
+};
+
+#[derive(Clone, Debug)]
+struct MemObject {
+    data: Vec<u8>,
+    created_at: u64,
+}
+
+#[derive(Default, Debug)]
+struct MemContainer {
+    created_at: u64,
+    objects: HashMap<String, MemObject>,
+}
+
+/// An in-memory [`BlobBackend`]. Each instance is an isolated store.
+#[derive(Default)]
+pub struct InMemoryBackend {
+    containers: RwLock<HashMap<String, MemContainer>>,
+}
+
+impl InMemoryBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl BlobBackend for InMemoryBackend {
+    async fn create_container(&self, name: &str) -> BlobResult<()> {
+        let mut containers = self.containers.write().await;
+        if containers.contains_key(name) {
+            return Err(BlobBackendError::ContainerAlreadyExists(name.to_string()));
+        }
+        containers.insert(
+            name.to_string(),
+            MemContainer {
+                created_at: now_secs(),
+                objects: HashMap::new(),
+            },
+        );
+        Ok(())
+    }
+
+    async fn get_container(&self, name: &str) -> BlobResult<()> {
+        self.container_exists(name).await.and_then(|exists| {
+            exists
+                .then_some(())
+                .ok_or_else(|| BlobBackendError::NoSuchContainer(name.to_string()))
+        })
+    }
+
+    async fn delete_container(&self, name: &str) -> BlobResult<()> {
+        self.containers.write().await.remove(name);
+        Ok(())
+    }
+
+    async fn container_exists(&self, name: &str) -> BlobResult<bool> {
+        Ok(self.containers.read().await.contains_key(name))
+    }
+
+    async fn container_info(&self, name: &str) -> BlobResult<ContainerInfo> {
+        let containers = self.containers.read().await;
+        let c = containers
+            .get(name)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(name.to_string()))?;
+        Ok(ContainerInfo {
+            name: name.to_string(),
+            created_at: c.created_at,
+        })
+    }
+
+    async fn clear_container(&self, name: &str) -> BlobResult<()> {
+        let mut containers = self.containers.write().await;
+        let c = containers
+            .get_mut(name)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(name.to_string()))?;
+        c.objects.clear();
+        Ok(())
+    }
+
+    async fn get_data(
+        &self,
+        container: &str,
+        object: &str,
+        start: u64,
+        end: u64,
+    ) -> BlobResult<Vec<u8>> {
+        let containers = self.containers.read().await;
+        let c = containers
+            .get(container)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(container.to_string()))?;
+        let o = c
+            .objects
+            .get(object)
+            .ok_or_else(|| BlobBackendError::NoSuchObject(object.to_string()))?;
+        let range = clamp_range(start, end, o.data.len());
+        Ok(o.data.get(range).unwrap_or_default().to_vec())
+    }
+
+    async fn write_data(&self, container: &str, object: &str, data: Vec<u8>) -> BlobResult<()> {
+        let mut containers = self.containers.write().await;
+        let c = containers
+            .get_mut(container)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(container.to_string()))?;
+        c.objects.insert(
+            object.to_string(),
+            MemObject {
+                data,
+                created_at: now_secs(),
+            },
+        );
+        Ok(())
+    }
+
+    async fn list_objects(&self, container: &str) -> BlobResult<Vec<String>> {
+        let containers = self.containers.read().await;
+        let c = containers
+            .get(container)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(container.to_string()))?;
+        Ok(c.objects.keys().cloned().collect())
+    }
+
+    async fn delete_object(&self, container: &str, object: &str) -> BlobResult<()> {
+        let mut containers = self.containers.write().await;
+        let c = containers
+            .get_mut(container)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(container.to_string()))?;
+        c.objects.remove(object);
+        Ok(())
+    }
+
+    async fn delete_objects(&self, container: &str, objects: &[String]) -> BlobResult<()> {
+        let mut containers = self.containers.write().await;
+        let c = containers
+            .get_mut(container)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(container.to_string()))?;
+        for object in objects {
+            c.objects.remove(object);
+        }
+        Ok(())
+    }
+
+    async fn has_object(&self, container: &str, object: &str) -> BlobResult<bool> {
+        let containers = self.containers.read().await;
+        let c = containers
+            .get(container)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(container.to_string()))?;
+        Ok(c.objects.contains_key(object))
+    }
+
+    async fn object_info(&self, container: &str, object: &str) -> BlobResult<ObjectInfo> {
+        let containers = self.containers.read().await;
+        let c = containers
+            .get(container)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(container.to_string()))?;
+        let o = c
+            .objects
+            .get(object)
+            .ok_or_else(|| BlobBackendError::NoSuchObject(object.to_string()))?;
+        Ok(ObjectInfo {
+            name: object.to_string(),
+            container: container.to_string(),
+            created_at: o.created_at,
+            size: o.data.len() as u64,
+        })
+    }
+
+    async fn copy_object(
+        &self,
+        src_container: &str,
+        src_object: &str,
+        dest_container: &str,
+        dest_object: &str,
+    ) -> BlobResult<()> {
+        let mut containers = self.containers.write().await;
+        let src = containers
+            .get(src_container)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(src_container.to_string()))?
+            .objects
+            .get(src_object)
+            .ok_or_else(|| BlobBackendError::NoSuchObject(src_object.to_string()))?
+            .data
+            .clone();
+        let dest = containers
+            .get_mut(dest_container)
+            .ok_or_else(|| BlobBackendError::NoSuchContainer(dest_container.to_string()))?;
+        dest.objects.insert(
+            dest_object.to_string(),
+            MemObject {
+                data: src,
+                created_at: now_secs(),
+            },
+        );
+        Ok(())
+    }
+}
+
+/// In-memory provider. Each named interface gets its own isolated store.
+#[derive(Default)]
+pub struct InMemoryProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<BlobId> for InMemoryProvider {
+    fn backend_type(&self) -> &'static str {
+        DEFAULT_BACKEND
+    }
+
+    async fn instantiate(&self, _config: &HashMap<String, String>) -> anyhow::Result<BlobId> {
+        Ok(Arc::new(InMemoryBackend::new()))
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed/nats.rs
@@ -1,0 +1,230 @@
+//! NATS JetStream object-store [`BlobBackend`] for the multiplexed blobstore
+//! plugin.
+//!
+//! Each container maps to a JetStream object store (bucket) within one
+//! JetStream context; the context (and thus connection) is shared across binds
+//! with the same `config.url` via the multiplexer's connection pool. Object
+//! bodies are buffered in memory — the host layers already buffer guest streams
+//! before handing them off, so the backend reads/writes whole `Vec<u8>`s.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_nats::jetstream::object_store::{self, ObjectStore};
+use futures::StreamExt;
+use tokio::io::AsyncReadExt;
+
+use crate::plugin::multiplex::BackendProvider;
+
+use super::{
+    BlobBackend, BlobBackendError, BlobId, BlobResult, ContainerInfo, ObjectInfo, clamp_range,
+};
+
+/// A NATS JetStream object-store-backed [`BlobBackend`].
+pub struct NatsBlobBackend {
+    context: Arc<async_nats::jetstream::Context>,
+}
+
+impl NatsBlobBackend {
+    fn err(e: impl std::fmt::Display) -> BlobBackendError {
+        BlobBackendError::Other(format!("NATS object-store error: {e}"))
+    }
+
+    /// Resolve a container to its object store, mapping a missing bucket to
+    /// `NoSuchContainer`.
+    async fn store(&self, container: &str) -> BlobResult<ObjectStore> {
+        self.context
+            .get_object_store(container)
+            .await
+            .map_err(|_| BlobBackendError::NoSuchContainer(container.to_string()))
+    }
+
+    /// Collect the (non-deleted) object names in a store.
+    async fn collect_names(store: &ObjectStore) -> BlobResult<Vec<String>> {
+        let mut list = store.list().await.map_err(Self::err)?;
+        let mut names = Vec::new();
+        while let Some(item) = list.next().await {
+            let info = item.map_err(Self::err)?;
+            if !info.deleted {
+                names.push(info.name);
+            }
+        }
+        Ok(names)
+    }
+
+    /// Whether `object` currently exists. NATS object-store `delete` leaves a
+    /// tombstone, and `info` still returns the deleted object's metadata with
+    /// `deleted: true`, so presence must check that flag rather than just
+    /// `info(..).is_ok()`.
+    async fn present(store: &ObjectStore, object: &str) -> bool {
+        matches!(store.info(object).await, Ok(info) if !info.deleted)
+    }
+}
+
+#[async_trait::async_trait]
+impl BlobBackend for NatsBlobBackend {
+    async fn create_container(&self, name: &str) -> BlobResult<()> {
+        if self.context.get_object_store(name).await.is_ok() {
+            return Err(BlobBackendError::ContainerAlreadyExists(name.to_string()));
+        }
+        self.context
+            .create_object_store(object_store::Config {
+                bucket: name.to_string(),
+                ..Default::default()
+            })
+            .await
+            .map_err(Self::err)?;
+        Ok(())
+    }
+
+    async fn get_container(&self, name: &str) -> BlobResult<()> {
+        self.store(name).await.map(|_| ())
+    }
+
+    async fn delete_container(&self, name: &str) -> BlobResult<()> {
+        // Idempotent: deleting a missing container is not an error.
+        if self.context.get_object_store(name).await.is_ok() {
+            self.context
+                .delete_object_store(name)
+                .await
+                .map_err(Self::err)?;
+        }
+        Ok(())
+    }
+
+    async fn container_exists(&self, name: &str) -> BlobResult<bool> {
+        Ok(self.context.get_object_store(name).await.is_ok())
+    }
+
+    async fn container_info(&self, name: &str) -> BlobResult<ContainerInfo> {
+        self.store(name).await?;
+        Ok(ContainerInfo {
+            name: name.to_string(),
+            // The object store does not expose a simple creation timestamp.
+            created_at: 0,
+        })
+    }
+
+    async fn clear_container(&self, name: &str) -> BlobResult<()> {
+        let store = self.store(name).await?;
+        for object in Self::collect_names(&store).await? {
+            store.delete(&object).await.map_err(Self::err)?;
+        }
+        Ok(())
+    }
+
+    async fn get_data(
+        &self,
+        container: &str,
+        object: &str,
+        start: u64,
+        end: u64,
+    ) -> BlobResult<Vec<u8>> {
+        let store = self.store(container).await?;
+        let mut obj = store
+            .get(object)
+            .await
+            .map_err(|_| BlobBackendError::NoSuchObject(object.to_string()))?;
+        let mut buf = Vec::new();
+        obj.read_to_end(&mut buf).await.map_err(Self::err)?;
+        let range = clamp_range(start, end, buf.len());
+        Ok(buf.get(range).unwrap_or_default().to_vec())
+    }
+
+    async fn write_data(&self, container: &str, object: &str, data: Vec<u8>) -> BlobResult<()> {
+        let store = self.store(container).await?;
+        let mut cursor = std::io::Cursor::new(data);
+        store.put(object, &mut cursor).await.map_err(Self::err)?;
+        Ok(())
+    }
+
+    async fn list_objects(&self, container: &str) -> BlobResult<Vec<String>> {
+        let store = self.store(container).await?;
+        Self::collect_names(&store).await
+    }
+
+    async fn delete_object(&self, container: &str, object: &str) -> BlobResult<()> {
+        let store = self.store(container).await?;
+        // Idempotent: deleting a missing (or already-deleted) object is not an
+        // error, and avoids re-deleting a tombstone.
+        if Self::present(&store, object).await {
+            store.delete(object).await.map_err(Self::err)?;
+        }
+        Ok(())
+    }
+
+    async fn delete_objects(&self, container: &str, objects: &[String]) -> BlobResult<()> {
+        let store = self.store(container).await?;
+        for object in objects {
+            if Self::present(&store, object).await {
+                store.delete(object).await.map_err(Self::err)?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn has_object(&self, container: &str, object: &str) -> BlobResult<bool> {
+        let store = self.store(container).await?;
+        Ok(Self::present(&store, object).await)
+    }
+
+    async fn object_info(&self, container: &str, object: &str) -> BlobResult<ObjectInfo> {
+        let store = self.store(container).await?;
+        let info = store
+            .info(object)
+            .await
+            .map_err(|_| BlobBackendError::NoSuchObject(object.to_string()))?;
+        // `info` still returns a deleted object's (tombstone) metadata; treat
+        // that as absent.
+        if info.deleted {
+            return Err(BlobBackendError::NoSuchObject(object.to_string()));
+        }
+        Ok(ObjectInfo {
+            name: info.name,
+            container: container.to_string(),
+            created_at: 0,
+            size: info.size as u64,
+        })
+    }
+
+    async fn copy_object(
+        &self,
+        src_container: &str,
+        src_object: &str,
+        dest_container: &str,
+        dest_object: &str,
+    ) -> BlobResult<()> {
+        let data = self
+            .get_data(src_container, src_object, 0, u64::MAX)
+            .await?;
+        self.write_data(dest_container, dest_object, data).await
+    }
+}
+
+/// Provider for [`NatsBlobBackend`], selected by `config.backend = "nats"`.
+/// Requires `config.url` (e.g. `nats://127.0.0.1:4222`). Pooled by url, so
+/// interfaces sharing a server share one connection.
+#[derive(Default)]
+pub struct NatsBlobProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<BlobId> for NatsBlobProvider {
+    fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
+        config.get("url").cloned()
+    }
+
+    fn backend_type(&self) -> &'static str {
+        "nats"
+    }
+
+    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<BlobId> {
+        let url = config
+            .get("url")
+            .ok_or_else(|| anyhow::anyhow!("nats blobstore backend requires a 'url' config"))?;
+        let client = async_nats::connect(url).await?;
+        let context = async_nats::jetstream::new(client);
+        Ok(Arc::new(NatsBlobBackend {
+            context: Arc::new(context),
+        }))
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed_async.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed_async.rs
@@ -1,0 +1,506 @@
+//! # Multiplexed async `wasmcloud:blobstore` (implements-routed)
+//!
+//! The async-native counterpart to [`super::multiplexed`]. Binds
+//! `wasmcloud:blobstore@0.1.0` whose object bodies are native component-model
+//! `stream<u8>` values (wasip3 style, no `wasi:io`) via the same
+//! `(implements ..)` / `named_imports` mechanism, routing each named import to a
+//! [`BlobBackend`].
+//!
+//! Because the WIT methods are `async func`s returning/consuming `stream<u8>`,
+//! the generated host traits use wasmtime's *concurrent* ABI: methods are
+//! `async fn`s taking an [`Accessor`] (rather than the `&mut ActiveCtx` style of
+//! the `wasi:blobstore` layer). `get-data`/`list-objects` build a
+//! [`StreamReader`] from a buffered `Vec` (the backend reads whole objects into
+//! memory); `write-data` drains the guest's `stream<u8>` into a `Vec` via a
+//! [`StreamConsumer`] before handing it to the backend.
+
+use std::collections::HashSet;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tokio::sync::oneshot;
+use wasmtime::StoreContextMut;
+use wasmtime::component::{Accessor, Resource, Source, StreamConsumer, StreamReader, StreamResult};
+
+use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
+use crate::engine::workload::WorkloadItem;
+use crate::plugin::multiplex::Multiplexer;
+use crate::plugin::{HostPlugin, WitInterfaces};
+use crate::wit::{WitInterface, WitWorld};
+
+use super::multiplexed::{BlobBackendError, BlobContainer, BlobId, BlobProvider};
+
+mod bindings {
+    wasmtime::component::bindgen!({
+        world: "async-blobstore",
+        imports: { default: async | trappable | tracing },
+        named_imports: {
+            "wasmcloud:blobstore/blobstore": crate::plugin::wasi_blobstore::multiplexed::BlobId,
+            "wasmcloud:blobstore/container": crate::plugin::wasi_blobstore::multiplexed::BlobId,
+        },
+        with: {
+            "wasmcloud:blobstore/container.container":
+                crate::plugin::wasi_blobstore::multiplexed::BlobContainer,
+        },
+    });
+}
+
+use bindings::wasmcloud::blobstore::types::{
+    ContainerMetadata, ContainerName, Error as AsyncError, ObjectId, ObjectMetadata, ObjectName,
+};
+
+const DEFAULT_BACKEND: &str = "in-memory";
+const MULTIPLEXED_ASYNC_BLOBSTORE_ID: &str = "wasmcloud-blobstore-multiplexed";
+
+impl From<BlobBackendError> for AsyncError {
+    fn from(e: BlobBackendError) -> Self {
+        match e {
+            BlobBackendError::NoSuchContainer(_) => AsyncError::NoSuchContainer,
+            BlobBackendError::ContainerAlreadyExists(_) => AsyncError::ContainerAlreadyExists,
+            BlobBackendError::NoSuchObject(_) => AsyncError::NoSuchObject,
+            BlobBackendError::Other(s) => AsyncError::Other(s),
+        }
+    }
+}
+
+/// Read `(backend, container-name)` out of a container resource. Kept tiny so it
+/// can run inside an [`Accessor::with`] closure without holding the store borrow
+/// across an await.
+fn container_ref<T>(
+    access: &mut wasmtime::component::Access<'_, T, SharedCtx>,
+    container: &Resource<BlobContainer>,
+) -> wasmtime::Result<(BlobId, String)> {
+    let c = access.get().table.get(container)?;
+    Ok((c.backend().clone(), c.name().to_string()))
+}
+
+impl<T: 'static + Send> bindings::named_imports::wasmcloud::blobstore::blobstore::HostWithStore<T>
+    for SharedCtx
+{
+    async fn create_container(
+        accessor: &Accessor<T, Self>,
+        id: BlobId,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<Resource<BlobContainer>, AsyncError>> {
+        if let Err(e) = id.create_container(&name).await {
+            return Ok(Err(e.into()));
+        }
+        let resource = accessor.with(|mut a| a.get().table.push(BlobContainer::new(id, name)))?;
+        Ok(Ok(resource))
+    }
+
+    async fn get_container(
+        accessor: &Accessor<T, Self>,
+        id: BlobId,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<Resource<BlobContainer>, AsyncError>> {
+        if let Err(e) = id.get_container(&name).await {
+            return Ok(Err(e.into()));
+        }
+        let resource = accessor.with(|mut a| a.get().table.push(BlobContainer::new(id, name)))?;
+        Ok(Ok(resource))
+    }
+
+    async fn delete_container(
+        _accessor: &Accessor<T, Self>,
+        id: BlobId,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<(), AsyncError>> {
+        Ok(id.delete_container(&name).await.map_err(Into::into))
+    }
+
+    async fn container_exists(
+        _accessor: &Accessor<T, Self>,
+        id: BlobId,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<bool, AsyncError>> {
+        Ok(id.container_exists(&name).await.map_err(Into::into))
+    }
+
+    async fn copy_object(
+        _accessor: &Accessor<T, Self>,
+        id: BlobId,
+        src: ObjectId,
+        dest: ObjectId,
+    ) -> wasmtime::Result<Result<(), AsyncError>> {
+        Ok(id
+            .copy_object(&src.container, &src.object, &dest.container, &dest.object)
+            .await
+            .map_err(Into::into))
+    }
+
+    async fn move_object(
+        _accessor: &Accessor<T, Self>,
+        id: BlobId,
+        src: ObjectId,
+        dest: ObjectId,
+    ) -> wasmtime::Result<Result<(), AsyncError>> {
+        Ok(id
+            .move_object(&src.container, &src.object, &dest.container, &dest.object)
+            .await
+            .map_err(Into::into))
+    }
+}
+
+impl bindings::named_imports::wasmcloud::blobstore::blobstore::Host for ActiveCtx<'_> {}
+
+// The `container` interface is bound as a *standalone* (non-implements)
+// interface rather than per-label. A `wasmcloud:blobstore/blobstore` `use
+// container.{container}` drags the `container` interface into the guest as an
+// *unlabeled* transitive import (WIT forbids two interfaces sharing one
+// `(implements ..)` label), so it cannot be routed per-label. It does not need
+// to be: every `BlobContainer` resource already carries the backend it was
+// opened through (set by `blobstore.create-container`, which *is* label-routed),
+// so the container methods route via the resource regardless of the import.
+
+impl<T: 'static + Send> bindings::wasmcloud::blobstore::container::HostContainerWithStore<T>
+    for SharedCtx
+{
+    async fn name(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<BlobContainer>,
+    ) -> wasmtime::Result<Result<String, AsyncError>> {
+        let (_backend, name) = accessor.with(|mut a| container_ref(&mut a, &self_))?;
+        Ok(Ok(name))
+    }
+
+    async fn info(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<BlobContainer>,
+    ) -> wasmtime::Result<Result<ContainerMetadata, AsyncError>> {
+        let (backend, name) = accessor.with(|mut a| container_ref(&mut a, &self_))?;
+        match backend.container_info(&name).await {
+            Ok(info) => Ok(Ok(ContainerMetadata {
+                name: info.name,
+                created_at: info.created_at,
+            })),
+            Err(e) => Ok(Err(e.into())),
+        }
+    }
+
+    async fn get_data(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<BlobContainer>,
+        name: ObjectName,
+        start: u64,
+        end: u64,
+    ) -> wasmtime::Result<Result<StreamReader<u8>, AsyncError>> {
+        let (backend, container) = accessor.with(|mut a| container_ref(&mut a, &self_))?;
+        let bytes = match backend.get_data(&container, &name, start, end).await {
+            Ok(bytes) => bytes,
+            Err(e) => return Ok(Err(e.into())),
+        };
+        let reader = accessor.with(|mut a| StreamReader::new(&mut a, bytes))?;
+        Ok(Ok(reader))
+    }
+
+    async fn write_data(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<BlobContainer>,
+        name: ObjectName,
+        data: StreamReader<u8>,
+    ) -> wasmtime::Result<Result<(), AsyncError>> {
+        let (backend, container) = accessor.with(|mut a| container_ref(&mut a, &self_))?;
+        // Drain the guest's stream into memory, then hand the whole object to the
+        // backend. `CollectConsumer` sends the collected bytes when the stream
+        // ends (it is dropped by the runtime at end-of-stream).
+        let (tx, rx) = oneshot::channel::<Vec<u8>>();
+        accessor.with(|mut a| {
+            data.pipe(
+                &mut a,
+                CollectConsumer {
+                    buf: Vec::new(),
+                    done: Some(tx),
+                },
+            )
+        })?;
+        let bytes = rx.await.unwrap_or_default();
+        Ok(backend
+            .write_data(&container, &name, bytes)
+            .await
+            .map_err(Into::into))
+    }
+
+    async fn list_objects(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<BlobContainer>,
+    ) -> wasmtime::Result<Result<StreamReader<ObjectName>, AsyncError>> {
+        let (backend, container) = accessor.with(|mut a| container_ref(&mut a, &self_))?;
+        let names = match backend.list_objects(&container).await {
+            Ok(names) => names,
+            Err(e) => return Ok(Err(e.into())),
+        };
+        let reader = accessor.with(|mut a| StreamReader::new(&mut a, names))?;
+        Ok(Ok(reader))
+    }
+
+    async fn delete_object(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<BlobContainer>,
+        name: ObjectName,
+    ) -> wasmtime::Result<Result<(), AsyncError>> {
+        let (backend, container) = accessor.with(|mut a| container_ref(&mut a, &self_))?;
+        Ok(backend
+            .delete_object(&container, &name)
+            .await
+            .map_err(Into::into))
+    }
+
+    async fn delete_objects(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<BlobContainer>,
+        names: Vec<ObjectName>,
+    ) -> wasmtime::Result<Result<(), AsyncError>> {
+        let (backend, container) = accessor.with(|mut a| container_ref(&mut a, &self_))?;
+        Ok(backend
+            .delete_objects(&container, &names)
+            .await
+            .map_err(Into::into))
+    }
+
+    async fn has_object(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<BlobContainer>,
+        name: ObjectName,
+    ) -> wasmtime::Result<Result<bool, AsyncError>> {
+        let (backend, container) = accessor.with(|mut a| container_ref(&mut a, &self_))?;
+        Ok(backend
+            .has_object(&container, &name)
+            .await
+            .map_err(Into::into))
+    }
+
+    async fn object_info(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<BlobContainer>,
+        name: ObjectName,
+    ) -> wasmtime::Result<Result<ObjectMetadata, AsyncError>> {
+        let (backend, container) = accessor.with(|mut a| container_ref(&mut a, &self_))?;
+        match backend.object_info(&container, &name).await {
+            Ok(info) => Ok(Ok(ObjectMetadata {
+                name: info.name,
+                container: info.container,
+                created_at: info.created_at,
+                size: info.size,
+            })),
+            Err(e) => Ok(Err(e.into())),
+        }
+    }
+
+    async fn clear(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<BlobContainer>,
+    ) -> wasmtime::Result<Result<(), AsyncError>> {
+        let (backend, container) = accessor.with(|mut a| container_ref(&mut a, &self_))?;
+        Ok(backend
+            .clear_container(&container)
+            .await
+            .map_err(Into::into))
+    }
+}
+
+impl bindings::wasmcloud::blobstore::container::HostContainer for ActiveCtx<'_> {
+    async fn drop(&mut self, rep: Resource<BlobContainer>) -> wasmtime::Result<()> {
+        self.table.delete(rep)?;
+        Ok(())
+    }
+}
+
+impl bindings::wasmcloud::blobstore::container::Host for ActiveCtx<'_> {}
+
+/// A [`StreamConsumer`] that accumulates every byte the guest writes and hands
+/// the buffer back once the stream ends. The runtime drops the consumer at
+/// end-of-stream, which fires [`Drop`] and delivers the bytes over `done`.
+struct CollectConsumer {
+    buf: Vec<u8>,
+    done: Option<oneshot::Sender<Vec<u8>>>,
+}
+
+impl Drop for CollectConsumer {
+    fn drop(&mut self) {
+        if let Some(tx) = self.done.take() {
+            let _ = tx.send(std::mem::take(&mut self.buf));
+        }
+    }
+}
+
+impl<D> StreamConsumer<D> for CollectConsumer {
+    type Item = u8;
+
+    fn poll_consume(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        store: StoreContextMut<D>,
+        src: Source<Self::Item>,
+        finish: bool,
+    ) -> Poll<wasmtime::Result<StreamResult>> {
+        let this = self.get_mut();
+        let mut src = src.as_direct(store);
+        let bytes = src.remaining();
+        if bytes.is_empty() {
+            // No items offered (count == 0). This is an unbounded in-memory sink,
+            // so it is always ready to accept. The actual end-of-stream is observed via `Drop`.
+            return Poll::Ready(Ok(if finish {
+                StreamResult::Cancelled
+            } else {
+                StreamResult::Completed
+            }));
+        }
+        let n = bytes.len();
+        this.buf.extend_from_slice(bytes);
+        src.mark_read(n);
+        Poll::Ready(Ok(StreamResult::Completed))
+    }
+}
+
+/// A blobstore [`HostPlugin`] that multiplexes async `wasmcloud:blobstore`
+/// across backends selected per `(implements ..)` import. Shares the
+/// [`BlobBackend`] providers with [`super::multiplexed::MultiplexedBlobstore`].
+pub struct MultiplexedAsyncBlobstore {
+    mux: Multiplexer<BlobId>,
+}
+
+impl Default for MultiplexedAsyncBlobstore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MultiplexedAsyncBlobstore {
+    pub fn new() -> Self {
+        Self {
+            mux: Multiplexer::new("wasmcloud", "blobstore", DEFAULT_BACKEND),
+        }
+    }
+
+    /// Register a backend provider keyed by its `backend_type()`.
+    pub fn with_provider(mut self, provider: Arc<BlobProvider>) -> Self {
+        self.mux = self.mux.with_provider(provider);
+        self
+    }
+
+    /// Build the routing registry (host-interface name -> backend) for a
+    /// component from its matched blobstore host interfaces.
+    pub async fn build_registry<'i>(
+        &self,
+        interfaces: impl IntoIterator<Item = &'i WitInterface>,
+    ) -> anyhow::Result<std::collections::HashMap<String, BlobId>> {
+        self.mux.build_registry(interfaces).await
+    }
+}
+
+#[async_trait::async_trait]
+impl HostPlugin for MultiplexedAsyncBlobstore {
+    fn id(&self) -> &'static str {
+        MULTIPLEXED_ASYNC_BLOBSTORE_ID
+    }
+
+    fn world(&self) -> WitWorld {
+        WitWorld {
+            imports: HashSet::from([WitInterface::from(
+                "wasmcloud:blobstore/blobstore,container,types@0.1.0",
+            )]),
+            ..Default::default()
+        }
+    }
+
+    fn supports_named_instances(&self) -> bool {
+        true
+    }
+
+    async fn on_workload_item_bind<'a>(
+        &self,
+        item: &mut WorkloadItem<'a>,
+        interfaces: WitInterfaces<'_>,
+    ) -> anyhow::Result<()> {
+        if !interfaces.contains("wasmcloud", "blobstore", &[]) {
+            return Ok(());
+        }
+
+        let registry = self.build_registry(interfaces.iter()).await?;
+        let component = item.component().clone();
+        let linker = item.linker();
+
+        // `blobstore` (create/get/delete container, copy/move) is routed per
+        // `(implements ..)` label so each label lands on its own backend.
+        bindings::named_imports::wasmcloud::blobstore::blobstore::add_to_linker::<_, SharedCtx>(
+            linker,
+            &component,
+            |name| self.mux.resolve(&registry, name),
+            extract_active_ctx,
+        )?;
+        // `container` is bound standalone (see the container host impls): a guest
+        // imports it *unlabeled* via `blobstore`'s `use container`, and its
+        // methods route through the resource's stored backend, not a label.
+        bindings::wasmcloud::blobstore::container::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::wasi_blobstore::InMemoryProvider;
+
+    fn blob_iface(name: &str) -> WitInterface {
+        WitInterface {
+            namespace: "wasmcloud".to_string(),
+            package: "blobstore".to_string(),
+            interfaces: ["blobstore".to_string()].into_iter().collect(),
+            version: None,
+            config: std::collections::HashMap::from([(
+                "backend".to_string(),
+                "in-memory".to_string(),
+            )]),
+            name: Some(name.to_string()),
+        }
+    }
+
+    /// The async blobstore plugin routes two named `wasmcloud:blobstore`
+    /// interfaces to distinct backends, proving the `("wasmcloud", "blobstore")`
+    /// multiplexer is wired and isolation holds over the shared `BlobBackend`.
+    #[tokio::test]
+    async fn registry_routes_named_interfaces_to_distinct_backends() {
+        let plugin = MultiplexedAsyncBlobstore::new().with_provider(Arc::new(InMemoryProvider));
+        let interfaces = HashSet::from([blob_iface("team-a"), blob_iface("team-b")]);
+
+        let registry = plugin.build_registry(&interfaces).await.unwrap();
+        let a = registry.get("team-a").expect("team-a routed").clone();
+        let b = registry.get("team-b").expect("team-b routed").clone();
+
+        a.create_container("bucket").await.unwrap();
+        a.write_data("bucket", "k", b"v".to_vec()).await.unwrap();
+        assert!(
+            !b.container_exists("bucket").await.unwrap(),
+            "backends leaked"
+        );
+        assert_eq!(
+            a.get_data("bucket", "k", 0, u64::MAX).await.unwrap(),
+            b"v".to_vec()
+        );
+    }
+
+    #[tokio::test]
+    async fn async_error_maps_from_backend_error() {
+        assert!(matches!(
+            AsyncError::from(BlobBackendError::NoSuchContainer("c".into())),
+            AsyncError::NoSuchContainer
+        ));
+        assert!(matches!(
+            AsyncError::from(BlobBackendError::ContainerAlreadyExists("c".into())),
+            AsyncError::ContainerAlreadyExists
+        ));
+        assert!(matches!(
+            AsyncError::from(BlobBackendError::NoSuchObject("o".into())),
+            AsyncError::NoSuchObject
+        ));
+        assert!(matches!(
+            AsyncError::from(BlobBackendError::Other("x".into())),
+            AsyncError::Other(_)
+        ));
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed_async.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed_async.rs
@@ -215,7 +215,17 @@ impl<T: 'static + Send> bindings::wasmcloud::blobstore::container::HostContainer
                 },
             )
         })?;
-        let bytes = rx.await.unwrap_or_default();
+        // The consumer always delivers on `Drop` at end-of-stream; a receive
+        // error means it was dropped without finishing, so surface that rather
+        // than silently writing a zero-length object.
+        let bytes = match rx.await {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                return Ok(Err(AsyncError::Other(
+                    "object body stream ended without delivering data".to_string(),
+                )));
+            }
+        };
         Ok(backend
             .write_data(&container, &name, bytes)
             .await

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/fs_store.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/fs_store.rs
@@ -143,4 +143,33 @@ impl FsKvStore {
             .map_err(FsKvError::Io)?;
         Ok(next)
     }
+
+    /// Signed counterpart of [`Self::increment`] for the multiplexed
+    /// `wasmcloud:keyvalue` backend, whose `atomics.increment` is `s64` (a
+    /// negative `delta` decrements). The standalone `wasi:keyvalue` plugin keeps
+    /// using the unsigned [`Self::increment`]; the two never share a store
+    /// (separate roots), so the decimal encodings don't mix.
+    #[cfg(feature = "wasm_component_model_implements")]
+    pub(crate) async fn increment_signed(
+        &self,
+        bucket: &str,
+        key: &str,
+        delta: i64,
+    ) -> Result<i64, FsKvError> {
+        let path = self.key_path(bucket, key)?;
+        let current = match tokio::fs::read_to_string(&path).await {
+            Ok(s) => s.trim().parse::<i64>().unwrap_or(0),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(e) => return Err(FsKvError::Io(e)),
+        };
+        // Report overflow as an error (consistent with Redis `HINCRBY`) rather
+        // than saturating or panicking.
+        let next = current
+            .checked_add(delta)
+            .ok_or_else(|| FsKvError::Io(std::io::Error::other("counter overflow")))?;
+        tokio::fs::write(&path, next.to_string())
+            .await
+            .map_err(FsKvError::Io)?;
+        Ok(next)
+    }
 }

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/mod.rs
@@ -3,6 +3,8 @@ mod fs_store;
 mod in_memory;
 #[cfg(feature = "wasm_component_model_implements")]
 mod multiplexed;
+#[cfg(feature = "wasm_component_model_implements")]
+mod multiplexed_async;
 mod nats;
 mod redis;
 
@@ -14,5 +16,7 @@ pub use multiplexed::{
     KvBackend, KvId, KvProvider, MultiplexedKeyValue, NatsBackend, NatsProvider, RedisBackend,
     RedisProvider, StoreError,
 };
+#[cfg(feature = "wasm_component_model_implements")]
+pub use multiplexed_async::MultiplexedAsyncKeyValue;
 pub use nats::NatsKeyValue;
 pub use redis::RedisKeyValue;

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed.rs
@@ -13,10 +13,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use bytes::{Buf, Bytes};
-use futures::stream::{FuturesOrdered, StreamExt};
-use redis::AsyncCommands;
-use tokio::sync::RwLock;
 use wasmtime::component::Resource;
 
 use crate::engine::ctx::{SharedCtx, extract_active_ctx};
@@ -56,6 +52,51 @@ pub struct KvBucket {
     name: String,
 }
 
+impl KvBucket {
+    pub(crate) fn new(backend: KvId, name: String) -> Self {
+        Self { backend, name }
+    }
+
+    pub(crate) fn backend(&self) -> &KvId {
+        &self.backend
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// A value together with its backend-native version token. The token is opaque
+/// and only equality is meaningful, but it MUST change on every write to the key
+/// (NATS revision, a per-bucket counter, ...). Never a hash of the value, or a
+/// value that returns to identical bytes (A → B → A) would reuse a version and
+/// defeat the ABA check.
+#[derive(Clone, Debug)]
+pub struct Versioned {
+    pub value: Vec<u8>,
+    pub version: String,
+}
+
+/// Preconditions for a [`KvBackend::swap`]. At least one must be set (enforced
+/// by the host layer). Every set condition must hold for the write to apply.
+#[derive(Default, Clone, Debug)]
+pub struct CasGuard {
+    /// Require the entry's current version to equal this (the ABA-safe check).
+    pub require_version: Option<String>,
+    /// Require the entry's current value to equal this (ABA-prone).
+    pub require_value: Option<Vec<u8>>,
+}
+
+/// Outcome of a [`KvBackend::swap`].
+#[derive(Clone, Debug)]
+pub enum CasOutcome {
+    /// Preconditions held; the new value was written.
+    Swapped,
+    /// A precondition failed; nothing was written. Carries the current entry
+    /// (`None` if the key is absent) so the caller can recompute and retry.
+    Stale(Option<Versioned>),
+}
+
 /// A keyvalue backend (redis, NATS, in-memory, ...). Operations are keyed by
 /// the opened bucket `name` plus the per-call key(s); the backend owns its own
 /// connection/state. This is the unified surface that the per-interface host
@@ -68,9 +109,19 @@ pub trait KvBackend: Send + Sync {
     async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError>;
     async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError>;
     async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError>;
+    /// List keys, page-by-page via an opaque `u64` cursor. NOTE: paging is
+    /// offset/scan-based, so concurrent writes between pages may cause a key to
+    /// be skipped or repeated — the WIT permits an out-of-date listing.
     async fn list_keys(&self, bucket: &str, cursor: Option<u64>)
     -> Result<KeyResponse, StoreError>;
-    async fn increment(&self, bucket: &str, key: &str, delta: u64) -> Result<u64, StoreError>;
+    /// Atomically add the signed `delta` to the counter at `key`, returning the
+    /// new value. A negative `delta` decrements (the `wasmcloud:keyvalue` counter
+    /// is signed, like Redis/DynamoDB/FoundationDB). NOTE: the counter is stored
+    /// in a backend-specific encoding (in-memory little-endian i64, NATS
+    /// big-endian i64, redis integer, filesystem decimal text), so a counter is
+    /// not portable across backends, and a value written via `set` is only a
+    /// valid counter if it matches that backend's encoding.
+    async fn increment(&self, bucket: &str, key: &str, delta: i64) -> Result<i64, StoreError>;
     #[allow(clippy::type_complexity)]
     async fn get_many(
         &self,
@@ -83,11 +134,50 @@ pub trait KvBackend: Send + Sync {
         key_values: Vec<(String, Vec<u8>)>,
     ) -> Result<(), StoreError>;
     async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError>;
+
+    /// Set `key` to `value` only if it is absent (the `set` `if-not-exists`
+    /// option). Returns `true` if the write happened, `false` if the key already
+    /// existed. Backends SHOULD make this atomic; the default is a (racy)
+    /// `exists`-then-`set` that can let two concurrent callers both win.
+    async fn put_if_absent(
+        &self,
+        bucket: &str,
+        key: &str,
+        value: Vec<u8>,
+    ) -> Result<bool, StoreError> {
+        if self.exists(bucket, key).await? {
+            return Ok(false);
+        }
+        self.set(bucket, key, value).await?;
+        Ok(true)
+    }
+
+    /// Read a key's current value and version (the `cas.current` operation), or
+    /// `None` if absent. Default: compare-and-swap is unsupported.
+    async fn current(&self, _bucket: &str, _key: &str) -> Result<Option<Versioned>, StoreError> {
+        Err(StoreError::Other(
+            "compare-and-swap is not supported by this backend".to_string(),
+        ))
+    }
+
+    /// Atomically write `value` to `key` iff every precondition in `guard` holds
+    /// (the `cas.swap` operation). MUST be a single atomic compare-and-set
+    /// against the backend, not a host-side read-then-write. Default:
+    /// compare-and-swap is unsupported.
+    async fn swap(
+        &self,
+        _bucket: &str,
+        _key: &str,
+        _value: Vec<u8>,
+        _guard: CasGuard,
+    ) -> Result<CasOutcome, StoreError> {
+        Err(StoreError::Other(
+            "compare-and-swap is not supported by this backend".to_string(),
+        ))
+    }
 }
 
 use crate::engine::ctx::ActiveCtx;
-
-// ---- store interface -------------------------------------------------------
 
 impl<'a> bindings::named_imports::wasi::keyvalue::store::Host for ActiveCtx<'a> {
     async fn open(
@@ -164,8 +254,6 @@ impl<'a> bindings::named_imports::wasi::keyvalue::store::HostBucket for ActiveCt
     }
 }
 
-// ---- atomics interface -----------------------------------------------------
-
 impl<'a> bindings::named_imports::wasi::keyvalue::atomics::Host for ActiveCtx<'a> {
     async fn increment(
         &mut self,
@@ -174,12 +262,22 @@ impl<'a> bindings::named_imports::wasi::keyvalue::atomics::Host for ActiveCtx<'a
         key: String,
         delta: u64,
     ) -> wasmtime::Result<Result<u64, StoreError>> {
+        // `wasi:keyvalue/atomics` is unsigned, but the shared `KvBackend` is
+        // signed (for `wasmcloud:keyvalue`'s `s64`). Convert at the boundary: a
+        // delta beyond `i64::MAX` or a counter that has gone negative is reported
+        // as an error rather than silently wrapping.
         let b = self.table.get(&bucket)?;
-        Ok(b.backend.increment(&b.name, &key, delta).await)
+        let Ok(delta) = i64::try_from(delta) else {
+            return Ok(Err(StoreError::Other("delta exceeds i64::MAX".to_string())));
+        };
+        Ok(b.backend
+            .increment(&b.name, &key, delta)
+            .await
+            .and_then(|v| {
+                u64::try_from(v).map_err(|_| StoreError::Other("counter is negative".to_string()))
+            }))
     }
 }
-
-// ---- batch interface -------------------------------------------------------
 
 impl<'a> bindings::named_imports::wasi::keyvalue::batch::Host for ActiveCtx<'a> {
     #[allow(clippy::type_complexity)]
@@ -214,528 +312,24 @@ impl<'a> bindings::named_imports::wasi::keyvalue::batch::Host for ActiveCtx<'a> 
     }
 }
 
-// ---- in-memory backend (reference impl; no external infra) -----------------
-
-/// An in-memory [`KvBackend`], used to prove the routing mechanism and for
-/// tests. Each instance is an isolated store, so two named imports backed by
-/// two `InMemoryBackend`s do not share data.
-#[derive(Default)]
-pub struct InMemoryBackend {
-    buckets: RwLock<HashMap<String, HashMap<String, Vec<u8>>>>,
-}
-
-impl InMemoryBackend {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    fn missing(bucket: &str) -> StoreError {
-        StoreError::Other(format!("bucket '{bucket}' does not exist"))
-    }
-}
-
-#[async_trait::async_trait]
-impl KvBackend for InMemoryBackend {
-    async fn open(&self, identifier: &str) -> Result<(), StoreError> {
-        self.buckets
-            .write()
-            .await
-            .entry(identifier.to_string())
-            .or_default();
-        Ok(())
-    }
-
-    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
-        let store = self.buckets.read().await;
-        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
-        Ok(b.get(key).cloned())
-    }
-
-    async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
-        let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
-        b.insert(key.to_string(), value);
-        Ok(())
-    }
-
-    async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
-        let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
-        b.remove(key);
-        Ok(())
-    }
-
-    async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
-        let store = self.buckets.read().await;
-        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
-        Ok(b.contains_key(key))
-    }
-
-    async fn list_keys(
-        &self,
-        bucket: &str,
-        cursor: Option<u64>,
-    ) -> Result<KeyResponse, StoreError> {
-        const PAGE_SIZE: usize = 100;
-        let store = self.buckets.read().await;
-        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
-        let mut keys: Vec<String> = b.keys().cloned().collect();
-        keys.sort();
-        let start = cursor.unwrap_or(0) as usize;
-        let end = std::cmp::min(start + PAGE_SIZE, keys.len());
-        let page = keys.get(start..end).unwrap_or_default().to_vec();
-        let next = (end < keys.len()).then_some(end as u64);
-        Ok(KeyResponse {
-            keys: page,
-            cursor: next,
-        })
-    }
-
-    async fn increment(&self, bucket: &str, key: &str, delta: u64) -> Result<u64, StoreError> {
-        let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
-        let current = match b.get(key) {
-            Some(bytes) if bytes.len() == 8 => {
-                // len checked == 8 by the guard, so copy into a fixed array
-                // without a fallible conversion (the lib denies unwrap/expect).
-                let mut arr = [0u8; 8];
-                arr.copy_from_slice(bytes);
-                u64::from_le_bytes(arr)
-            }
-            Some(bytes) => String::from_utf8_lossy(bytes).parse::<u64>().unwrap_or(0),
-            None => 0,
-        };
-        let next = current.saturating_add(delta);
-        b.insert(key.to_string(), next.to_le_bytes().to_vec());
-        Ok(next)
-    }
-
-    async fn get_many(
-        &self,
-        bucket: &str,
-        keys: Vec<String>,
-    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
-        let store = self.buckets.read().await;
-        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
-        Ok(keys
-            .into_iter()
-            .map(|k| b.get(&k).cloned().map(|v| (k, v)))
-            .collect())
-    }
-
-    async fn set_many(
-        &self,
-        bucket: &str,
-        key_values: Vec<(String, Vec<u8>)>,
-    ) -> Result<(), StoreError> {
-        let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
-        for (k, v) in key_values {
-            b.insert(k, v);
-        }
-        Ok(())
-    }
-
-    async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
-        let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
-        for k in keys {
-            b.remove(&k);
-        }
-        Ok(())
-    }
-}
-
-// ---- providers + plugin ----------------------------------------------------
-
 const DEFAULT_BACKEND: &str = "in-memory";
 const MULTIPLEXED_KEYVALUE_ID: &str = "wasi-keyvalue-multiplexed";
+
+/// Page size for `list-keys` paging against the redis / NATS backends.
+const LIST_KEYS_BATCH_SIZE: usize = 1000;
 
 /// A keyvalue backend provider: a [`BackendProvider`] producing [`KvId`]s.
 pub type KvProvider = dyn BackendProvider<KvId>;
 
-/// In-memory provider. Each named interface gets its own isolated store.
-#[derive(Default)]
-pub struct InMemoryProvider;
-
-#[async_trait::async_trait]
-impl BackendProvider<KvId> for InMemoryProvider {
-    fn backend_type(&self) -> &'static str {
-        DEFAULT_BACKEND
-    }
-
-    async fn instantiate(&self, _config: &HashMap<String, String>) -> anyhow::Result<KvId> {
-        Ok(Arc::new(InMemoryBackend::new()))
-    }
-}
-
-// ---- redis backend ---------------------------------------------------------
-
-const LIST_KEYS_BATCH_SIZE: usize = 1000;
-
-/// A redis-backed [`KvBackend`]. The bucket identifier is used as a key prefix
-/// (`{bucket}:{key}`). Holds a shared multiplexed connection (pooled per url by
-/// the provider).
-pub struct RedisBackend {
-    conn: redis::aio::MultiplexedConnection,
-}
-
-impl RedisBackend {
-    fn prefixed(bucket: &str, key: &str) -> String {
-        format!("{bucket}:{key}")
-    }
-
-    fn err(e: impl std::fmt::Display) -> StoreError {
-        StoreError::Other(format!("Redis error: {e}"))
-    }
-}
-
-#[async_trait::async_trait]
-impl KvBackend for RedisBackend {
-    async fn open(&self, _identifier: &str) -> Result<(), StoreError> {
-        // Redis namespaces by key prefix; there is no bucket to create.
-        Ok(())
-    }
-
-    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
-        let mut conn = self.conn.clone();
-        conn.get::<_, Option<Vec<u8>>>(Self::prefixed(bucket, key))
-            .await
-            .map_err(Self::err)
-    }
-
-    async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
-        let mut conn = self.conn.clone();
-        conn.set::<_, _, ()>(Self::prefixed(bucket, key), value)
-            .await
-            .map_err(Self::err)
-    }
-
-    async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
-        let mut conn = self.conn.clone();
-        conn.del::<_, ()>(Self::prefixed(bucket, key))
-            .await
-            .map_err(Self::err)
-    }
-
-    async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
-        let mut conn = self.conn.clone();
-        conn.exists::<_, bool>(Self::prefixed(bucket, key))
-            .await
-            .map_err(Self::err)
-    }
-
-    async fn list_keys(
-        &self,
-        bucket: &str,
-        cursor: Option<u64>,
-    ) -> Result<KeyResponse, StoreError> {
-        let mut conn = self.conn.clone();
-        let pattern = Self::prefixed(bucket, "*");
-        let (next, raw): (u64, Vec<String>) = redis::cmd("SCAN")
-            .arg(cursor.unwrap_or(0))
-            .arg("MATCH")
-            .arg(&pattern)
-            .arg("COUNT")
-            .arg(LIST_KEYS_BATCH_SIZE)
-            .query_async(&mut conn)
-            .await
-            .map_err(Self::err)?;
-        let prefix = pattern.strip_suffix('*').unwrap_or("");
-        let keys = raw
-            .into_iter()
-            .filter_map(|k| k.strip_prefix(prefix).map(str::to_string))
-            .collect();
-        Ok(KeyResponse {
-            keys,
-            cursor: (next != 0).then_some(next),
-        })
-    }
-
-    async fn increment(&self, bucket: &str, key: &str, delta: u64) -> Result<u64, StoreError> {
-        let mut conn = self.conn.clone();
-        let delta = i64::try_from(delta)
-            .map_err(|_| StoreError::Other(format!("delta {delta} exceeds i64::MAX")))?;
-        conn.incr::<_, _, i64>(Self::prefixed(bucket, key), delta)
-            .await
-            .map(|v| v as u64)
-            .map_err(Self::err)
-    }
-
-    async fn get_many(
-        &self,
-        bucket: &str,
-        keys: Vec<String>,
-    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
-        if keys.is_empty() {
-            return Ok(vec![]);
-        }
-        let mut conn = self.conn.clone();
-        let redis_keys: Vec<String> = keys.iter().map(|k| Self::prefixed(bucket, k)).collect();
-        let values: Vec<Option<Vec<u8>>> =
-            conn.mget(redis_keys.as_slice()).await.map_err(Self::err)?;
-        Ok(keys
-            .into_iter()
-            .zip(values)
-            .map(|(k, v)| v.map(|v| (k, v)))
-            .collect())
-    }
-
-    async fn set_many(
-        &self,
-        bucket: &str,
-        key_values: Vec<(String, Vec<u8>)>,
-    ) -> Result<(), StoreError> {
-        if key_values.is_empty() {
-            return Ok(());
-        }
-        let mut conn = self.conn.clone();
-        let pairs: Vec<(String, Vec<u8>)> = key_values
-            .into_iter()
-            .map(|(k, v)| (Self::prefixed(bucket, &k), v))
-            .collect();
-        conn.mset::<_, _, ()>(pairs.as_slice())
-            .await
-            .map_err(Self::err)
-    }
-
-    async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
-        if keys.is_empty() {
-            return Ok(());
-        }
-        let mut conn = self.conn.clone();
-        let redis_keys: Vec<String> = keys.iter().map(|k| Self::prefixed(bucket, k)).collect();
-        conn.del::<_, ()>(redis_keys.as_slice())
-            .await
-            .map_err(Self::err)
-    }
-}
-
-/// Provider for [`RedisBackend`], selected by `config.backend = "redis"`.
-/// Requires `config.url` (e.g. `redis://127.0.0.1:6379`).
-#[derive(Default)]
-pub struct RedisProvider;
-
-#[async_trait::async_trait]
-impl BackendProvider<KvId> for RedisProvider {
-    fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
-        config.get("url").cloned()
-    }
-    fn backend_type(&self) -> &'static str {
-        "redis"
-    }
-
-    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<KvId> {
-        let url = config
-            .get("url")
-            .ok_or_else(|| anyhow::anyhow!("redis keyvalue backend requires a 'url' config"))?;
-        let client = redis::Client::open(url.as_str())?;
-        let conn = client.get_multiplexed_async_connection().await?;
-        Ok(Arc::new(RedisBackend { conn }))
-    }
-}
-
-// ---- NATS JetStream backend ------------------------------------------------
-
-/// A NATS JetStream KV-backed [`KvBackend`]. Each bucket maps to a JetStream KV
-/// store (which must already exist); store handles are cached by name.
-pub struct NatsBackend {
-    context: Arc<async_nats::jetstream::Context>,
-    stores: RwLock<HashMap<String, async_nats::jetstream::kv::Store>>,
-}
-
-impl NatsBackend {
-    fn err(e: impl std::fmt::Display) -> StoreError {
-        StoreError::Other(format!("JetStream error: {e}"))
-    }
-
-    async fn store(&self, bucket: &str) -> Result<async_nats::jetstream::kv::Store, StoreError> {
-        if let Some(s) = self.stores.read().await.get(bucket) {
-            return Ok(s.clone());
-        }
-        let kv = self
-            .context
-            .get_key_value(bucket)
-            .await
-            .map_err(Self::err)?;
-        self.stores
-            .write()
-            .await
-            .insert(bucket.to_string(), kv.clone());
-        Ok(kv)
-    }
-}
-
-#[async_trait::async_trait]
-impl KvBackend for NatsBackend {
-    async fn open(&self, identifier: &str) -> Result<(), StoreError> {
-        self.store(identifier).await.map(|_| ())
-    }
-
-    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
-        let s = self.store(bucket).await?;
-        Ok(s.get(key).await.map_err(Self::err)?.map(|b| b.to_vec()))
-    }
-
-    async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
-        let s = self.store(bucket).await?;
-        s.put(key.to_string(), value.into())
-            .await
-            .map_err(Self::err)?;
-        Ok(())
-    }
-
-    async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
-        let s = self.store(bucket).await?;
-        s.delete(key).await.map_err(Self::err)?;
-        Ok(())
-    }
-
-    async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
-        let s = self.store(bucket).await?;
-        Ok(s.get(key).await.map_err(Self::err)?.is_some())
-    }
-
-    async fn list_keys(
-        &self,
-        bucket: &str,
-        cursor: Option<u64>,
-    ) -> Result<KeyResponse, StoreError> {
-        let s = self.store(bucket).await?;
-        let skip = cursor.unwrap_or(0) as usize;
-        let mut stream = s
-            .keys()
-            .await
-            .map_err(Self::err)?
-            .skip(skip)
-            .take(LIST_KEYS_BATCH_SIZE + 1)
-            .boxed();
-        let mut resp = KeyResponse {
-            keys: vec![],
-            cursor: None,
-        };
-        while let Some(Ok(key)) = stream.next().await {
-            if resp.keys.len() >= LIST_KEYS_BATCH_SIZE {
-                resp.cursor = Some(skip as u64 + LIST_KEYS_BATCH_SIZE as u64);
-                break;
-            }
-            resp.keys.push(key);
-        }
-        Ok(resp)
-    }
-
-    async fn increment(&self, bucket: &str, key: &str, delta: u64) -> Result<u64, StoreError> {
-        let s = self.store(bucket).await?;
-        // Optimistic CAS, matching the standalone NATS backend (big-endian u64).
-        let (revision, current) = match s.entry(key).await.map_err(Self::err)? {
-            // Read the counter as a big-endian u64, tolerating a malformed
-            // (non-8-byte) value as 0 rather than panicking: `Buf::get_u64`
-            // traps the guest if the value has fewer than 8 bytes.
-            Some(mut e) => {
-                let current = if e.value.len() >= 8 {
-                    e.value.get_u64()
-                } else {
-                    0
-                };
-                (Some(e.revision), current)
-            }
-            None => (None, 0),
-        };
-        // saturating, matching the in-memory/filesystem backends: a host-method
-        // panic on overflow would become a wasmtime trap.
-        let next = current.saturating_add(delta);
-        let bytes = Bytes::from(next.to_be_bytes().to_vec());
-        match revision {
-            Some(rev) => s.update(key, bytes, rev).await.map_err(Self::err)?,
-            None => s.put(key.to_string(), bytes).await.map_err(Self::err)?,
-        };
-        Ok(next)
-    }
-
-    async fn get_many(
-        &self,
-        bucket: &str,
-        keys: Vec<String>,
-    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
-        let s = self.store(bucket).await?;
-        FuturesOrdered::from_iter(keys.into_iter().map(|key| {
-            let s = s.clone();
-            async move {
-                Ok(s.get(&key)
-                    .await
-                    .map_err(Self::err)?
-                    .map(|b| (key, b.to_vec())))
-            }
-        }))
-        .collect::<Vec<_>>()
-        .await
-        .into_iter()
-        .collect()
-    }
-
-    async fn set_many(
-        &self,
-        bucket: &str,
-        key_values: Vec<(String, Vec<u8>)>,
-    ) -> Result<(), StoreError> {
-        let s = self.store(bucket).await?;
-        FuturesOrdered::from_iter(key_values.into_iter().map(|(key, value)| {
-            let s = s.clone();
-            async move {
-                s.put(key, value.into())
-                    .await
-                    .map(|_| ())
-                    .map_err(Self::err)
-            }
-        }))
-        .collect::<Vec<_>>()
-        .await
-        .into_iter()
-        .collect()
-    }
-
-    async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
-        let s = self.store(bucket).await?;
-        FuturesOrdered::from_iter(keys.into_iter().map(|key| {
-            let s = s.clone();
-            async move { s.delete(&key).await.map(|_| ()).map_err(Self::err) }
-        }))
-        .collect::<Vec<_>>()
-        .await
-        .into_iter()
-        .collect()
-    }
-}
-
-/// Provider for [`NatsBackend`], selected by `config.backend = "nats"`. Requires
-/// `config.url` (e.g. `nats://127.0.0.1:4222`).
-#[derive(Default)]
-pub struct NatsProvider;
-
-#[async_trait::async_trait]
-impl BackendProvider<KvId> for NatsProvider {
-    fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
-        config.get("url").cloned()
-    }
-    fn backend_type(&self) -> &'static str {
-        "nats"
-    }
-
-    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<KvId> {
-        let url = config
-            .get("url")
-            .ok_or_else(|| anyhow::anyhow!("nats keyvalue backend requires a 'url' config"))?;
-        let client = async_nats::connect(url).await?;
-        let context = async_nats::jetstream::new(client);
-        Ok(Arc::new(NatsBackend {
-            context: Arc::new(context),
-            stores: RwLock::new(HashMap::new()),
-        }))
-    }
-}
-
 mod filesystem;
+mod in_memory;
+mod nats;
+mod redis;
+
 pub use filesystem::{FilesystemBackend, FilesystemProvider};
+pub use in_memory::{InMemoryBackend, InMemoryProvider};
+pub use nats::{NatsBackend, NatsProvider};
+pub use redis::{RedisBackend, RedisProvider};
 
 /// A keyvalue [`HostPlugin`] that multiplexes `wasi:keyvalue` across backends
 /// selected per `(implements ..)` import. Register the backend providers you

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/filesystem.rs
@@ -76,9 +76,9 @@ impl KvBackend for FilesystemBackend {
         Ok(KeyResponse { keys, cursor })
     }
 
-    async fn increment(&self, bucket: &str, key: &str, delta: u64) -> Result<u64, StoreError> {
+    async fn increment(&self, bucket: &str, key: &str, delta: i64) -> Result<i64, StoreError> {
         self.store
-            .increment(bucket, key, delta)
+            .increment_signed(bucket, key, delta)
             .await
             .map_err(to_store_error)
     }

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/in_memory.rs
@@ -56,7 +56,7 @@ impl InMemoryBackend {
         Self::default()
     }
 
-    fn missing(bucket: &str) -> StoreError {
+    fn err_missing(bucket: &str) -> StoreError {
         StoreError::Other(format!("bucket '{bucket}' does not exist"))
     }
 }
@@ -74,27 +74,31 @@ impl KvBackend for InMemoryBackend {
 
     async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
         let store = self.buckets.read().await;
-        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store.get(bucket).ok_or_else(|| Self::err_missing(bucket))?;
         Ok(b.entries.get(key).map(|e| e.value.clone()))
     }
 
     async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
         let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store
+            .get_mut(bucket)
+            .ok_or_else(|| Self::err_missing(bucket))?;
         b.put(key, value);
         Ok(())
     }
 
     async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
         let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store
+            .get_mut(bucket)
+            .ok_or_else(|| Self::err_missing(bucket))?;
         b.entries.remove(key);
         Ok(())
     }
 
     async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
         let store = self.buckets.read().await;
-        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store.get(bucket).ok_or_else(|| Self::err_missing(bucket))?;
         Ok(b.entries.contains_key(key))
     }
 
@@ -105,7 +109,7 @@ impl KvBackend for InMemoryBackend {
     ) -> Result<KeyResponse, StoreError> {
         const PAGE_SIZE: usize = 100;
         let store = self.buckets.read().await;
-        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store.get(bucket).ok_or_else(|| Self::err_missing(bucket))?;
         let mut keys: Vec<String> = b.entries.keys().cloned().collect();
         keys.sort();
         let start = cursor.unwrap_or(0) as usize;
@@ -120,7 +124,9 @@ impl KvBackend for InMemoryBackend {
 
     async fn increment(&self, bucket: &str, key: &str, delta: i64) -> Result<i64, StoreError> {
         let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store
+            .get_mut(bucket)
+            .ok_or_else(|| Self::err_missing(bucket))?;
         let current = match b.entries.get(key) {
             Some(e) if e.value.len() == 8 => {
                 // len checked == 8 by the guard, so copy into a fixed array
@@ -149,7 +155,7 @@ impl KvBackend for InMemoryBackend {
         keys: Vec<String>,
     ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
         let store = self.buckets.read().await;
-        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store.get(bucket).ok_or_else(|| Self::err_missing(bucket))?;
         Ok(keys
             .into_iter()
             .map(|k| b.entries.get(&k).map(|e| (k, e.value.clone())))
@@ -162,7 +168,9 @@ impl KvBackend for InMemoryBackend {
         key_values: Vec<(String, Vec<u8>)>,
     ) -> Result<(), StoreError> {
         let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store
+            .get_mut(bucket)
+            .ok_or_else(|| Self::err_missing(bucket))?;
         for (k, v) in key_values {
             b.put(&k, v);
         }
@@ -171,7 +179,9 @@ impl KvBackend for InMemoryBackend {
 
     async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
         let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store
+            .get_mut(bucket)
+            .ok_or_else(|| Self::err_missing(bucket))?;
         for k in keys {
             b.entries.remove(&k);
         }
@@ -187,7 +197,9 @@ impl KvBackend for InMemoryBackend {
         // Check-and-insert under one write lock: atomic against concurrent
         // writers in-process, so two `if-not-exists` sets can't both win.
         let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store
+            .get_mut(bucket)
+            .ok_or_else(|| Self::err_missing(bucket))?;
         if b.entries.contains_key(key) {
             return Ok(false);
         }
@@ -197,7 +209,7 @@ impl KvBackend for InMemoryBackend {
 
     async fn current(&self, bucket: &str, key: &str) -> Result<Option<Versioned>, StoreError> {
         let store = self.buckets.read().await;
-        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store.get(bucket).ok_or_else(|| Self::err_missing(bucket))?;
         Ok(b.entries.get(key).map(|e| Versioned {
             value: e.value.clone(),
             version: e.version.to_string(),
@@ -214,7 +226,9 @@ impl KvBackend for InMemoryBackend {
         // The whole compare-and-set runs under one write lock, so it is atomic
         // against concurrent writers (no lost update).
         let mut store = self.buckets.write().await;
-        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let b = store
+            .get_mut(bucket)
+            .ok_or_else(|| Self::err_missing(bucket))?;
         let current = b.entries.get(key);
         let stale = || {
             CasOutcome::Stale(current.map(|e| Versioned {

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/in_memory.rs
@@ -1,0 +1,356 @@
+//! In-memory [`KvBackend`] for the multiplexed keyvalue plugin.
+//!
+//! Used to prove the routing mechanism and for tests. Each instance is an
+//! isolated store, so two named imports backed by two `InMemoryBackend`s do not
+//! share data. Every bucket carries a monotonic version counter so that
+//! compare-and-swap is ABA-safe: a value that returns to identical bytes still
+//! gets a fresh version, and `swap` does its compare-and-set under one write
+//! lock (atomic in-process), so there is no lost-update race.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::plugin::multiplex::BackendProvider;
+
+use super::{
+    CasGuard, CasOutcome, DEFAULT_BACKEND, KeyResponse, KvBackend, KvId, StoreError, Versioned,
+};
+
+/// One stored value plus the version stamped at its last write.
+#[derive(Clone)]
+struct Entry {
+    value: Vec<u8>,
+    version: u64,
+}
+
+/// A bucket: its entries plus a monotonic version source. `next_version` only
+/// ever increases (even across delete/re-create), so versions are unique within
+/// the bucket and a key's version always changes on a write.
+#[derive(Default)]
+struct Bucket {
+    entries: HashMap<String, Entry>,
+    next_version: u64,
+}
+
+impl Bucket {
+    /// Stamp `key` with `value` at a fresh version.
+    fn put(&mut self, key: &str, value: Vec<u8>) -> u64 {
+        self.next_version += 1;
+        let version = self.next_version;
+        self.entries
+            .insert(key.to_string(), Entry { value, version });
+        version
+    }
+}
+
+/// An in-memory [`KvBackend`]. Each instance is an isolated store.
+#[derive(Default)]
+pub struct InMemoryBackend {
+    buckets: RwLock<HashMap<String, Bucket>>,
+}
+
+impl InMemoryBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn missing(bucket: &str) -> StoreError {
+        StoreError::Other(format!("bucket '{bucket}' does not exist"))
+    }
+}
+
+#[async_trait::async_trait]
+impl KvBackend for InMemoryBackend {
+    async fn open(&self, identifier: &str) -> Result<(), StoreError> {
+        self.buckets
+            .write()
+            .await
+            .entry(identifier.to_string())
+            .or_default();
+        Ok(())
+    }
+
+    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        let store = self.buckets.read().await;
+        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        Ok(b.entries.get(key).map(|e| e.value.clone()))
+    }
+
+    async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        b.put(key, value);
+        Ok(())
+    }
+
+    async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        b.entries.remove(key);
+        Ok(())
+    }
+
+    async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
+        let store = self.buckets.read().await;
+        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        Ok(b.entries.contains_key(key))
+    }
+
+    async fn list_keys(
+        &self,
+        bucket: &str,
+        cursor: Option<u64>,
+    ) -> Result<KeyResponse, StoreError> {
+        const PAGE_SIZE: usize = 100;
+        let store = self.buckets.read().await;
+        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let mut keys: Vec<String> = b.entries.keys().cloned().collect();
+        keys.sort();
+        let start = cursor.unwrap_or(0) as usize;
+        let end = std::cmp::min(start + PAGE_SIZE, keys.len());
+        let page = keys.get(start..end).unwrap_or_default().to_vec();
+        let next = (end < keys.len()).then_some(end as u64);
+        Ok(KeyResponse {
+            keys: page,
+            cursor: next,
+        })
+    }
+
+    async fn increment(&self, bucket: &str, key: &str, delta: i64) -> Result<i64, StoreError> {
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let current = match b.entries.get(key) {
+            Some(e) if e.value.len() == 8 => {
+                // len checked == 8 by the guard, so copy into a fixed array
+                // without a fallible conversion (the lib denies unwrap/expect).
+                let mut arr = [0u8; 8];
+                arr.copy_from_slice(&e.value);
+                i64::from_le_bytes(arr)
+            }
+            Some(e) => String::from_utf8_lossy(&e.value)
+                .parse::<i64>()
+                .unwrap_or(0),
+            None => 0,
+        };
+        // Negative `delta` decrements. Report overflow as an error (consistent
+        // with Redis `HINCRBY`) rather than saturating or panicking.
+        let next = current
+            .checked_add(delta)
+            .ok_or_else(|| StoreError::Other("counter overflow".to_string()))?;
+        b.put(key, next.to_le_bytes().to_vec());
+        Ok(next)
+    }
+
+    async fn get_many(
+        &self,
+        bucket: &str,
+        keys: Vec<String>,
+    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
+        let store = self.buckets.read().await;
+        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        Ok(keys
+            .into_iter()
+            .map(|k| b.entries.get(&k).map(|e| (k, e.value.clone())))
+            .collect())
+    }
+
+    async fn set_many(
+        &self,
+        bucket: &str,
+        key_values: Vec<(String, Vec<u8>)>,
+    ) -> Result<(), StoreError> {
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        for (k, v) in key_values {
+            b.put(&k, v);
+        }
+        Ok(())
+    }
+
+    async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        for k in keys {
+            b.entries.remove(&k);
+        }
+        Ok(())
+    }
+
+    async fn put_if_absent(
+        &self,
+        bucket: &str,
+        key: &str,
+        value: Vec<u8>,
+    ) -> Result<bool, StoreError> {
+        // Check-and-insert under one write lock: atomic against concurrent
+        // writers in-process, so two `if-not-exists` sets can't both win.
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        if b.entries.contains_key(key) {
+            return Ok(false);
+        }
+        b.put(key, value);
+        Ok(true)
+    }
+
+    async fn current(&self, bucket: &str, key: &str) -> Result<Option<Versioned>, StoreError> {
+        let store = self.buckets.read().await;
+        let b = store.get(bucket).ok_or_else(|| Self::missing(bucket))?;
+        Ok(b.entries.get(key).map(|e| Versioned {
+            value: e.value.clone(),
+            version: e.version.to_string(),
+        }))
+    }
+
+    async fn swap(
+        &self,
+        bucket: &str,
+        key: &str,
+        value: Vec<u8>,
+        guard: CasGuard,
+    ) -> Result<CasOutcome, StoreError> {
+        // The whole compare-and-set runs under one write lock, so it is atomic
+        // against concurrent writers (no lost update).
+        let mut store = self.buckets.write().await;
+        let b = store.get_mut(bucket).ok_or_else(|| Self::missing(bucket))?;
+        let current = b.entries.get(key);
+        let stale = || {
+            CasOutcome::Stale(current.map(|e| Versioned {
+                value: e.value.clone(),
+                version: e.version.to_string(),
+            }))
+        };
+        if let Some(req) = &guard.require_version {
+            // Version moved (or key absent) → precondition fails. ABA-safe: the
+            // version is monotonic, so A → B → A does not reuse the old version.
+            if current.map(|e| e.version.to_string()).as_deref() != Some(req.as_str()) {
+                return Ok(stale());
+            }
+        }
+        if let Some(req) = &guard.require_value
+            && current.map(|e| e.value.as_slice()) != Some(req.as_slice())
+        {
+            return Ok(stale());
+        }
+        b.put(key, value);
+        Ok(CasOutcome::Swapped)
+    }
+}
+
+/// In-memory provider. Each named interface gets its own isolated store.
+#[derive(Default)]
+pub struct InMemoryProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<KvId> for InMemoryProvider {
+    fn backend_type(&self) -> &'static str {
+        DEFAULT_BACKEND
+    }
+
+    async fn instantiate(&self, _config: &HashMap<String, String>) -> anyhow::Result<KvId> {
+        Ok(Arc::new(InMemoryBackend::new()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn version(be: &InMemoryBackend, key: &str) -> String {
+        be.current("b", key).await.unwrap().unwrap().version
+    }
+
+    #[tokio::test]
+    async fn cas_swap_is_aba_safe() {
+        let be = InMemoryBackend::new();
+        be.open("b").await.unwrap();
+        be.set("b", "k", b"A".to_vec()).await.unwrap();
+        let v1 = version(&be, "k").await;
+
+        // A -> B -> A: the value returns to identical bytes, but the monotonic
+        // version has moved, so a swap pinned to the original version is stale.
+        be.set("b", "k", b"B".to_vec()).await.unwrap();
+        be.set("b", "k", b"A".to_vec()).await.unwrap();
+
+        let guard = CasGuard {
+            require_version: Some(v1),
+            require_value: None,
+        };
+        let out = be.swap("b", "k", b"C".to_vec(), guard).await.unwrap();
+        assert!(
+            matches!(out, CasOutcome::Stale(_)),
+            "ABA must be detected: stale old version, not a false swap"
+        );
+        assert_eq!(be.get("b", "k").await.unwrap(), Some(b"A".to_vec()));
+
+        // Swapping against the *current* version succeeds.
+        let guard = CasGuard {
+            require_version: Some(version(&be, "k").await),
+            require_value: None,
+        };
+        let out = be.swap("b", "k", b"C".to_vec(), guard).await.unwrap();
+        assert!(matches!(out, CasOutcome::Swapped));
+        assert_eq!(be.get("b", "k").await.unwrap(), Some(b"C".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn cas_require_value() {
+        let be = InMemoryBackend::new();
+        be.open("b").await.unwrap();
+        be.set("b", "k", b"A".to_vec()).await.unwrap();
+
+        // Mismatched expected value → stale, carrying the current entry.
+        let guard = CasGuard {
+            require_version: None,
+            require_value: Some(b"WRONG".to_vec()),
+        };
+        match be.swap("b", "k", b"C".to_vec(), guard).await.unwrap() {
+            CasOutcome::Stale(Some(v)) => assert_eq!(v.value, b"A".to_vec()),
+            other => panic!("expected stale, got {other:?}"),
+        }
+        assert_eq!(be.get("b", "k").await.unwrap(), Some(b"A".to_vec()));
+
+        // Matching expected value → swapped.
+        let guard = CasGuard {
+            require_version: None,
+            require_value: Some(b"A".to_vec()),
+        };
+        assert!(matches!(
+            be.swap("b", "k", b"C".to_vec(), guard).await.unwrap(),
+            CasOutcome::Swapped
+        ));
+    }
+
+    #[tokio::test]
+    async fn version_changes_on_every_write_including_recreate() {
+        let be = InMemoryBackend::new();
+        be.open("b").await.unwrap();
+        be.set("b", "k", b"A".to_vec()).await.unwrap();
+        let v1 = version(&be, "k").await;
+        // delete then re-create with identical bytes must NOT reuse the version.
+        be.delete("b", "k").await.unwrap();
+        be.set("b", "k", b"A".to_vec()).await.unwrap();
+        assert_ne!(
+            v1,
+            version(&be, "k").await,
+            "version must not reset on recreate"
+        );
+    }
+
+    #[tokio::test]
+    async fn increment_is_signed_and_errors_on_overflow() {
+        let be = InMemoryBackend::new();
+        be.open("b").await.unwrap();
+        // Signed: a negative delta decrements, and the counter may go below zero.
+        assert_eq!(be.increment("b", "c", 5).await.unwrap(), 5);
+        assert_eq!(be.increment("b", "c", -3).await.unwrap(), 2);
+        assert_eq!(be.increment("b", "c", -10).await.unwrap(), -8);
+        // Overflow is an error, not a silent saturate.
+        be.set("b", "max", i64::MAX.to_le_bytes().to_vec())
+            .await
+            .unwrap();
+        assert!(be.increment("b", "max", 1).await.is_err());
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/nats.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use bytes::{Buf, Bytes};
-use futures::stream::{FuturesOrdered, StreamExt};
+use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::RwLock;
 
 use crate::plugin::multiplex::BackendProvider;
@@ -45,11 +45,10 @@ impl NatsBackend {
                 // failure is a real error that must propagate so a guest can retry
                 // instead of seeing "not found".
                 KeyValueErrorKind::GetBucket => {
-                    let transport = matches!(
+                    if matches!(
                         e.source().and_then(|s| s.downcast_ref::<GetStreamError>()),
                         Some(g) if g.kind() == GetStreamErrorKind::Request
-                    );
-                    if transport {
+                    ) {
                         Self::err(e)
                     } else {
                         StoreError::NoSuchStore
@@ -177,7 +176,7 @@ impl KvBackend for NatsBackend {
         keys: Vec<String>,
     ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
         let s = self.store(bucket).await?;
-        FuturesOrdered::from_iter(keys.into_iter().map(|key| {
+        FuturesUnordered::from_iter(keys.into_iter().map(|key| {
             let s = s.clone();
             async move {
                 Ok(s.get(&key)
@@ -198,7 +197,7 @@ impl KvBackend for NatsBackend {
         key_values: Vec<(String, Vec<u8>)>,
     ) -> Result<(), StoreError> {
         let s = self.store(bucket).await?;
-        FuturesOrdered::from_iter(key_values.into_iter().map(|(key, value)| {
+        FuturesUnordered::from_iter(key_values.into_iter().map(|(key, value)| {
             let s = s.clone();
             async move {
                 s.put(key, value.into())
@@ -215,7 +214,7 @@ impl KvBackend for NatsBackend {
 
     async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
         let s = self.store(bucket).await?;
-        FuturesOrdered::from_iter(keys.into_iter().map(|key| {
+        FuturesUnordered::from_iter(keys.into_iter().map(|key| {
             let s = s.clone();
             async move { s.delete(&key).await.map(|_| ()).map_err(Self::err) }
         }))

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/nats.rs
@@ -1,0 +1,345 @@
+//! NATS JetStream KV-backed [`KvBackend`] for the multiplexed keyvalue plugin.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bytes::{Buf, Bytes};
+use futures::stream::{FuturesOrdered, StreamExt};
+use tokio::sync::RwLock;
+
+use crate::plugin::multiplex::BackendProvider;
+
+use super::{
+    CasGuard, CasOutcome, KeyResponse, KvBackend, KvId, LIST_KEYS_BATCH_SIZE, StoreError, Versioned,
+};
+
+/// A NATS JetStream KV-backed [`KvBackend`]. Each bucket maps to a JetStream KV
+/// store (which must already exist); store handles are cached by name.
+pub struct NatsBackend {
+    context: Arc<async_nats::jetstream::Context>,
+    stores: RwLock<HashMap<String, async_nats::jetstream::kv::Store>>,
+}
+
+impl NatsBackend {
+    fn err(e: impl std::fmt::Display) -> StoreError {
+        StoreError::Other(format!("JetStream error: {e}"))
+    }
+
+    async fn store(&self, bucket: &str) -> Result<async_nats::jetstream::kv::Store, StoreError> {
+        if let Some(s) = self.stores.read().await.get(bucket) {
+            return Ok(s.clone());
+        }
+        use async_nats::jetstream::context::{
+            GetStreamError, GetStreamErrorKind, KeyValueErrorKind,
+        };
+        use std::error::Error as _;
+        let kv = self
+            .context
+            .get_key_value(bucket)
+            .await
+            .map_err(|e| match e.kind() {
+                // An invalid name is never a real store.
+                KeyValueErrorKind::InvalidStoreName => StoreError::NoSuchStore,
+                // `GetBucket` wraps a `get_stream` failure: a missing/invalid
+                // stream is `no-such-store`, but a `Request` (transport/timeout)
+                // failure is a real error that must propagate so a guest can retry
+                // instead of seeing "not found".
+                KeyValueErrorKind::GetBucket => {
+                    let transport = matches!(
+                        e.source().and_then(|s| s.downcast_ref::<GetStreamError>()),
+                        Some(g) if g.kind() == GetStreamErrorKind::Request
+                    );
+                    if transport {
+                        Self::err(e)
+                    } else {
+                        StoreError::NoSuchStore
+                    }
+                }
+                // A JetStream/transport failure is a real error, not "not found".
+                KeyValueErrorKind::JetStream => Self::err(e),
+            })?;
+        self.stores
+            .write()
+            .await
+            .insert(bucket.to_string(), kv.clone());
+        Ok(kv)
+    }
+}
+
+#[async_trait::async_trait]
+impl KvBackend for NatsBackend {
+    async fn open(&self, identifier: &str) -> Result<(), StoreError> {
+        self.store(identifier).await.map(|_| ())
+    }
+
+    async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        let s = self.store(bucket).await?;
+        Ok(s.get(key).await.map_err(Self::err)?.map(|b| b.to_vec()))
+    }
+
+    async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
+        let s = self.store(bucket).await?;
+        s.put(key.to_string(), value.into())
+            .await
+            .map_err(Self::err)?;
+        Ok(())
+    }
+
+    async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
+        let s = self.store(bucket).await?;
+        s.delete(key).await.map_err(Self::err)?;
+        Ok(())
+    }
+
+    async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
+        let s = self.store(bucket).await?;
+        Ok(s.get(key).await.map_err(Self::err)?.is_some())
+    }
+
+    async fn list_keys(
+        &self,
+        bucket: &str,
+        cursor: Option<u64>,
+    ) -> Result<KeyResponse, StoreError> {
+        let s = self.store(bucket).await?;
+        let skip = cursor.unwrap_or(0) as usize;
+        let mut stream = s
+            .keys()
+            .await
+            .map_err(Self::err)?
+            .skip(skip)
+            .take(LIST_KEYS_BATCH_SIZE + 1)
+            .boxed();
+        let mut resp = KeyResponse {
+            keys: vec![],
+            cursor: None,
+        };
+        while let Some(Ok(key)) = stream.next().await {
+            if resp.keys.len() >= LIST_KEYS_BATCH_SIZE {
+                resp.cursor = Some(skip as u64 + LIST_KEYS_BATCH_SIZE as u64);
+                break;
+            }
+            resp.keys.push(key);
+        }
+        Ok(resp)
+    }
+
+    async fn increment(&self, bucket: &str, key: &str, delta: i64) -> Result<i64, StoreError> {
+        use async_nats::jetstream::kv::{CreateErrorKind, UpdateErrorKind};
+        let s = self.store(bucket).await?;
+        // Optimistic CAS retry loop (big-endian i64): read counter + revision,
+        // compute, then conditionally write. A revision/exists conflict means a
+        // concurrent writer won the race, so re-read and retry rather than
+        // erroring. `atomics.increment` is defined to be atomic, so contention
+        // must serialize, not fail.
+        loop {
+            let (revision, current) = match s.entry(key).await.map_err(Self::err)? {
+                // Read the counter as a big-endian i64, tolerating a malformed
+                // (non-8-byte) value as 0 rather than panicking: `Buf::get_i64`
+                // traps if the value has fewer than 8 bytes.
+                Some(mut e) => {
+                    let current = if e.value.len() >= 8 {
+                        e.value.get_i64()
+                    } else {
+                        0
+                    };
+                    (Some(e.revision), current)
+                }
+                None => (None, 0),
+            };
+            // Report overflow as an error (consistent with Redis `HINCRBY`)
+            // rather than saturating or panicking.
+            let next = current
+                .checked_add(delta)
+                .ok_or_else(|| StoreError::Other("counter overflow".to_string()))?;
+            let bytes = Bytes::from(next.to_be_bytes().to_vec());
+            match revision {
+                // `update` is the atomic compare-and-set on the read revision.
+                Some(rev) => match s.update(key, bytes, rev).await {
+                    Ok(_) => return Ok(next),
+                    Err(e) if e.kind() == UpdateErrorKind::WrongLastRevision => continue,
+                    Err(e) => return Err(Self::err(e)),
+                },
+                // `create` (not `put`) so a concurrent create is detected and
+                // retried instead of clobbered.
+                None => match s.create(key, bytes).await {
+                    Ok(_) => return Ok(next),
+                    Err(e) if e.kind() == CreateErrorKind::AlreadyExists => continue,
+                    Err(e) => return Err(Self::err(e)),
+                },
+            }
+        }
+    }
+
+    async fn get_many(
+        &self,
+        bucket: &str,
+        keys: Vec<String>,
+    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
+        let s = self.store(bucket).await?;
+        FuturesOrdered::from_iter(keys.into_iter().map(|key| {
+            let s = s.clone();
+            async move {
+                Ok(s.get(&key)
+                    .await
+                    .map_err(Self::err)?
+                    .map(|b| (key, b.to_vec())))
+            }
+        }))
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect()
+    }
+
+    async fn set_many(
+        &self,
+        bucket: &str,
+        key_values: Vec<(String, Vec<u8>)>,
+    ) -> Result<(), StoreError> {
+        let s = self.store(bucket).await?;
+        FuturesOrdered::from_iter(key_values.into_iter().map(|(key, value)| {
+            let s = s.clone();
+            async move {
+                s.put(key, value.into())
+                    .await
+                    .map(|_| ())
+                    .map_err(Self::err)
+            }
+        }))
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect()
+    }
+
+    async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
+        let s = self.store(bucket).await?;
+        FuturesOrdered::from_iter(keys.into_iter().map(|key| {
+            let s = s.clone();
+            async move { s.delete(&key).await.map(|_| ()).map_err(Self::err) }
+        }))
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect()
+    }
+
+    async fn put_if_absent(
+        &self,
+        bucket: &str,
+        key: &str,
+        value: Vec<u8>,
+    ) -> Result<bool, StoreError> {
+        use async_nats::jetstream::kv::CreateErrorKind;
+        let s = self.store(bucket).await?;
+        // `create` is the atomic insert-if-absent primitive.
+        match s.create(key, Bytes::from(value)).await {
+            Ok(_) => Ok(true),
+            Err(e) if e.kind() == CreateErrorKind::AlreadyExists => Ok(false),
+            Err(e) => Err(Self::err(e)),
+        }
+    }
+
+    async fn current(&self, bucket: &str, key: &str) -> Result<Option<Versioned>, StoreError> {
+        let s = self.store(bucket).await?;
+        Ok(present_entry(&s, key).await?)
+    }
+
+    async fn swap(
+        &self,
+        bucket: &str,
+        key: &str,
+        value: Vec<u8>,
+        guard: CasGuard,
+    ) -> Result<CasOutcome, StoreError> {
+        use async_nats::jetstream::kv::Operation;
+        let s = self.store(bucket).await?;
+
+        // Read the current entry (with its revision) to evaluate preconditions.
+        let entry = s.entry(key).await.map_err(Self::err)?;
+        let revision = entry.as_ref().map(|e| e.revision);
+        let current = entry
+            .filter(|e| matches!(e.operation, Operation::Put))
+            .map(|e| Versioned {
+                value: e.value.to_vec(),
+                version: e.revision.to_string(),
+            });
+
+        if let Some(req) = &guard.require_version
+            && current.as_ref().map(|v| v.version.as_str()) != Some(req.as_str())
+        {
+            return Ok(CasOutcome::Stale(current));
+        }
+        if let Some(req) = &guard.require_value
+            && current.as_ref().map(|v| v.value.as_slice()) != Some(req.as_slice())
+        {
+            return Ok(CasOutcome::Stale(current));
+        }
+
+        // A precondition can only pass for a present entry, so its revision is
+        // known here; an absent key would already have returned `Stale` above.
+        let Some(rev) = revision else {
+            return Ok(CasOutcome::Stale(None));
+        };
+        // Atomic compare-and-set on the native revision: `update` succeeds only
+        // if the revision has not moved since we read it. A `WrongLastRevision`
+        // means a concurrent writer won the race — that, and only that, is a CAS
+        // conflict, so we re-read and report the now-current entry as stale. Any
+        // other error (network, auth, store deleted, ...) is a real failure and
+        // must be propagated.
+        use async_nats::jetstream::kv::UpdateErrorKind;
+        match s.update(key, Bytes::from(value), rev).await {
+            Ok(_) => Ok(CasOutcome::Swapped),
+            Err(e) if e.kind() == UpdateErrorKind::WrongLastRevision => {
+                Ok(CasOutcome::Stale(present_entry(&s, key).await?))
+            }
+            Err(e) => Err(Self::err(e)),
+        }
+    }
+}
+
+/// Read a key's current value + revision, treating a delete/purge tombstone as
+/// absent.
+async fn present_entry(
+    store: &async_nats::jetstream::kv::Store,
+    key: &str,
+) -> Result<Option<Versioned>, StoreError> {
+    use async_nats::jetstream::kv::Operation;
+    Ok(store
+        .entry(key)
+        .await
+        .map_err(NatsBackend::err)?
+        .filter(|e| matches!(e.operation, Operation::Put))
+        .map(|e| Versioned {
+            value: e.value.to_vec(),
+            version: e.revision.to_string(),
+        }))
+}
+
+/// Provider for [`NatsBackend`], selected by `config.backend = "nats"`. Requires
+/// `config.url` (e.g. `nats://127.0.0.1:4222`).
+#[derive(Default)]
+pub struct NatsProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<KvId> for NatsProvider {
+    fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
+        config.get("url").cloned()
+    }
+    fn backend_type(&self) -> &'static str {
+        "nats"
+    }
+
+    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<KvId> {
+        let url = config
+            .get("url")
+            .ok_or_else(|| anyhow::anyhow!("nats keyvalue backend requires a 'url' config"))?;
+        let client = async_nats::connect(url).await?;
+        let context = async_nats::jetstream::new(client);
+        Ok(Arc::new(NatsBackend {
+            context: Arc::new(context),
+            stores: RwLock::new(HashMap::new()),
+        }))
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/redis.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/redis.rs
@@ -1,0 +1,229 @@
+//! Redis-backed [`KvBackend`] for the multiplexed keyvalue plugin.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use redis::AsyncCommands;
+
+use crate::plugin::multiplex::BackendProvider;
+
+use super::{KeyResponse, KvBackend, KvId, LIST_KEYS_BATCH_SIZE, StoreError};
+
+/// A redis-backed [`KvBackend`] over a **flat keyspace**, so it interoperates
+/// with a redis dataset created or managed outside this host:
+/// `get(key)` is `GET key`, `increment` is `INCRBY`, etc.
+///
+/// Isolation between logical stores is by connection/DB — the `(implements ..)`
+/// label selects the redis URL (and DB, via the url) — or an optional,
+/// operator-set [`prefix`](Self::prefix). The `open(identifier)` bucket name does
+/// NOT namespace keys, so a guest can open an externally-created keyspace simply
+/// by pointing its label at the right redis. Holds a shared multiplexed
+/// connection (pooled per url+prefix by the provider).
+pub struct RedisBackend {
+    conn: redis::aio::MultiplexedConnection,
+    /// Optional operator-configured key prefix, default none.
+    /// Lets a deployment namespace within a shared DB or match an external key
+    /// convention. It is operator-set, not guest-controlled, so a guest cannot
+    /// use it to inject `SCAN` glob metacharacters; it is escaped regardless.
+    prefix: Option<String>,
+}
+
+impl RedisBackend {
+    /// Map a logical key to its redis key (prepending the optional prefix).
+    fn key(&self, key: &str) -> String {
+        match &self.prefix {
+            Some(p) => format!("{p}{key}"),
+            None => key.to_string(),
+        }
+    }
+
+    fn err(e: impl std::fmt::Display) -> StoreError {
+        StoreError::Other(format!("Redis error: {e}"))
+    }
+
+    /// Escape redis glob metacharacters so a literal prefix matches verbatim in
+    /// `SCAN MATCH`.
+    fn glob_escape(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        for c in s.chars() {
+            if matches!(c, '*' | '?' | '[' | ']' | '\\' | '^') {
+                out.push('\\');
+            }
+            out.push(c);
+        }
+        out
+    }
+}
+
+#[async_trait::async_trait]
+impl KvBackend for RedisBackend {
+    async fn open(&self, _identifier: &str) -> Result<(), StoreError> {
+        // The bucket identifier does not namespace keys. The connection (label/url) and optional `prefix` do.
+        Ok(())
+    }
+
+    async fn get(&self, _bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        let mut conn = self.conn.clone();
+        conn.get::<_, Option<Vec<u8>>>(self.key(key))
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn set(&self, _bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
+        let mut conn = self.conn.clone();
+        conn.set::<_, _, ()>(self.key(key), value)
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn delete(&self, _bucket: &str, key: &str) -> Result<(), StoreError> {
+        let mut conn = self.conn.clone();
+        conn.del::<_, ()>(self.key(key)).await.map_err(Self::err)
+    }
+
+    async fn exists(&self, _bucket: &str, key: &str) -> Result<bool, StoreError> {
+        let mut conn = self.conn.clone();
+        conn.exists::<_, bool>(self.key(key))
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn list_keys(
+        &self,
+        _bucket: &str,
+        cursor: Option<u64>,
+    ) -> Result<KeyResponse, StoreError> {
+        let mut conn = self.conn.clone();
+        // SCAN the connection's keyspace under the (escaped) operator prefix.
+        // With no prefix the pattern is `*`. The whole DB follows
+        // flat-keyspace semantics; the guest's `list-keys` prefix is applied
+        // host-side, so it never reaches this pattern.
+        let prefix = self.prefix.as_deref().unwrap_or("");
+        let pattern = format!("{}*", Self::glob_escape(prefix));
+        let (next, raw): (u64, Vec<Vec<u8>>) = redis::cmd("SCAN")
+            .arg(cursor.unwrap_or(0))
+            .arg("MATCH")
+            .arg(&pattern)
+            .arg("COUNT")
+            .arg(LIST_KEYS_BATCH_SIZE)
+            .query_async(&mut conn)
+            .await
+            .map_err(Self::err)?;
+        let strip = prefix.as_bytes();
+        let keys = raw
+            .into_iter()
+            .map(|k| {
+                let logical = k.strip_prefix(strip).unwrap_or(&k);
+                String::from_utf8_lossy(logical).into_owned()
+            })
+            .collect();
+        Ok(KeyResponse {
+            keys,
+            cursor: (next != 0).then_some(next),
+        })
+    }
+
+    async fn increment(&self, _bucket: &str, key: &str, delta: i64) -> Result<i64, StoreError> {
+        // INCRBY is a native, signed, atomic increment (negative delta
+        // decrements); it errors on overflow, which we propagate.
+        let mut conn = self.conn.clone();
+        conn.incr(self.key(key), delta).await.map_err(Self::err)
+    }
+
+    async fn get_many(
+        &self,
+        _bucket: &str,
+        keys: Vec<String>,
+    ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
+        if keys.is_empty() {
+            return Ok(vec![]);
+        }
+        let mut conn = self.conn.clone();
+        let redis_keys: Vec<String> = keys.iter().map(|k| self.key(k)).collect();
+        // Explicit MGET: the `mget` helper downgrades to `GET` for a single key,
+        // and an absent single key then returns `nil`, which decodes to an
+        // *empty* vec. MGET always returns one slot per key (nil → `None`).
+        let values: Vec<Option<Vec<u8>>> = redis::cmd("MGET")
+            .arg(redis_keys.as_slice())
+            .query_async(&mut conn)
+            .await
+            .map_err(Self::err)?;
+        Ok(keys
+            .into_iter()
+            .zip(values)
+            .map(|(k, v)| v.map(|v| (k, v)))
+            .collect())
+    }
+
+    async fn set_many(
+        &self,
+        _bucket: &str,
+        key_values: Vec<(String, Vec<u8>)>,
+    ) -> Result<(), StoreError> {
+        if key_values.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn.clone();
+        let pairs: Vec<(String, Vec<u8>)> = key_values
+            .into_iter()
+            .map(|(k, v)| (self.key(&k), v))
+            .collect();
+        conn.mset::<_, _, ()>(pairs.as_slice())
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn delete_many(&self, _bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
+        if keys.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn.clone();
+        let redis_keys: Vec<String> = keys.iter().map(|k| self.key(k)).collect();
+        conn.del::<_, ()>(redis_keys.as_slice())
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn put_if_absent(
+        &self,
+        _bucket: &str,
+        key: &str,
+        value: Vec<u8>,
+    ) -> Result<bool, StoreError> {
+        // SETNX is an atomic insert-if-absent.
+        let mut conn = self.conn.clone();
+        conn.set_nx::<_, _, bool>(self.key(key), value)
+            .await
+            .map_err(Self::err)
+    }
+}
+
+/// Provider for [`RedisBackend`], selected by `config.backend = "redis"`.
+/// Requires `config.url` (e.g. `redis://127.0.0.1:6379`); optional `config.prefix`
+/// namespaces keys within the connection's keyspace (default none → flat).
+#[derive(Default)]
+pub struct RedisProvider;
+
+#[async_trait::async_trait]
+impl BackendProvider<KvId> for RedisProvider {
+    fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
+        // Pool by url AND prefix: two interfaces with the same url but different
+        // prefixes are different logical stores and must not share an instance.
+        let url = config.get("url")?;
+        let prefix = config.get("prefix").map(String::as_str).unwrap_or("");
+        Some(format!("{url}\u{0}{prefix}"))
+    }
+    fn backend_type(&self) -> &'static str {
+        "redis"
+    }
+
+    async fn instantiate(&self, config: &HashMap<String, String>) -> anyhow::Result<KvId> {
+        let url = config
+            .get("url")
+            .ok_or_else(|| anyhow::anyhow!("redis keyvalue backend requires a 'url' config"))?;
+        let client = redis::Client::open(url.as_str())?;
+        let conn = client.get_multiplexed_async_connection().await?;
+        let prefix = config.get("prefix").filter(|p| !p.is_empty()).cloned();
+        Ok(Arc::new(RedisBackend { conn, prefix }))
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed_async.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed_async.rs
@@ -1,0 +1,477 @@
+//! # Multiplexed async `wasmcloud:keyvalue` (implements-routed)
+//!
+//! The async-native counterpart to [`super::multiplexed`]. Binds
+//! `wasmcloud:keyvalue@0.1.0` whose every backend operation is an `async func`
+//! (no `wasi:io/poll`) via the same `(implements ..)` / `named_imports`
+//! mechanism, routing each named import to a [`KvBackend`].
+//!
+//! Because the WIT methods are `async func`s, the generated host traits use
+//! wasmtime's *concurrent* ABI: methods are `async fn`s taking an [`Accessor`].
+//! They reuse the existing [`KvBackend`] backends (in-memory / redis / NATS /
+//! filesystem); some of the richer async-only surface is mapped at this host
+//! layer over the backend's operations:
+//!
+//! * **CAS** (`cas.current` / `cas.swap`) delegates to [`KvBackend::current`] /
+//!   [`KvBackend::swap`], which perform an atomic compare-and-set against the
+//!   backend using a backend-native, write-monotonic version (NATS revision,
+//!   in-memory counter). Backends without an atomic primitive return an
+//!   unsupported error rather than a racy host-side read-modify-write.
+//! * **`set-options`**: `if-not-exists` is an `exists`-then-`set` check (racy);
+//!   `ttl-ms` is rejected with an error, since the basic backends cannot honor
+//!   expiry (the WIT requires erroring rather than silently ignoring a TTL).
+//! * **`atomics.increment`** is a direct pass-through onto the backend's signed
+//!   `increment` (the WIT delta/counter are `s64`; a negative delta decrements,
+//!   unlike `wasi:keyvalue`'s unsigned counter).
+//! * **`list-keys`** maps the opaque string cursor to the backend's `u64` cursor
+//!   and filters by `prefix` host-side.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use wasmtime::component::{Accessor, Resource};
+
+use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
+use crate::engine::workload::WorkloadItem;
+use crate::plugin::multiplex::Multiplexer;
+use crate::plugin::{HostPlugin, WitInterfaces};
+use crate::wit::{WitInterface, WitWorld};
+
+use super::multiplexed::{CasGuard, CasOutcome, KvBucket, KvId, KvProvider, StoreError, Versioned};
+
+mod bindings {
+    wasmtime::component::bindgen!({
+        world: "async-keyvalue",
+        imports: { default: async | trappable | tracing },
+        // Only `store` is routed per `(implements ..)` label; `atomics`/`cas`/
+        // `batch` are bound as standalone interfaces (they borrow the bucket,
+        // which carries its backend) — see `on_workload_item_bind`.
+        named_imports: {
+            "wasmcloud:keyvalue/store": crate::plugin::wasi_keyvalue::multiplexed::KvId,
+        },
+        with: {
+            "wasmcloud:keyvalue/types.bucket":
+                crate::plugin::wasi_keyvalue::multiplexed::KvBucket,
+        },
+    });
+}
+
+use bindings::wasmcloud::keyvalue::cas::{CasOptions, CasResult, Entry};
+use bindings::wasmcloud::keyvalue::types::{Error as AsyncKvError, KeyResponse, SetOptions};
+
+const DEFAULT_BACKEND: &str = "in-memory";
+const MULTIPLEXED_ASYNC_KEYVALUE_ID: &str = "wasmcloud-keyvalue-multiplexed";
+
+impl From<StoreError> for AsyncKvError {
+    fn from(e: StoreError) -> Self {
+        match e {
+            StoreError::NoSuchStore => AsyncKvError::NoSuchStore,
+            StoreError::AccessDenied => AsyncKvError::AccessDenied,
+            StoreError::Other(s) => AsyncKvError::Other(s),
+        }
+    }
+}
+
+/// Read `(backend, bucket-name)` out of a bucket resource without holding the
+/// store borrow across an await.
+fn bucket_ref<T>(
+    access: &mut wasmtime::component::Access<'_, T, SharedCtx>,
+    bucket: &Resource<KvBucket>,
+) -> wasmtime::Result<(KvId, String)> {
+    let b = access.get().table.get(bucket)?;
+    Ok((b.backend().clone(), b.name().to_string()))
+}
+
+// The `bucket` resource lives in the `types` interface (shared by store/atomics/
+// cas/batch), so its methods are bound standalone — the `KvBucket` carries the
+// backend it was opened through. Only `store.open` is label-routed.
+impl<T: 'static + Send> bindings::wasmcloud::keyvalue::types::HostBucketWithStore<T> for SharedCtx {
+    async fn get(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<KvBucket>,
+        key: String,
+    ) -> wasmtime::Result<Result<Option<Vec<u8>>, AsyncKvError>> {
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &self_))?;
+        Ok(backend.get(&name, &key).await.map_err(Into::into))
+    }
+
+    async fn set(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<KvBucket>,
+        key: String,
+        value: Vec<u8>,
+        options: Option<SetOptions>,
+    ) -> wasmtime::Result<Result<(), AsyncKvError>> {
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &self_))?;
+        if let Some(opts) = &options {
+            if opts.ttl_ms.is_some() {
+                return Ok(Err(AsyncKvError::Other(
+                    "ttl-ms is not supported by this backend".to_string(),
+                )));
+            }
+            if opts.if_not_exists {
+                // Atomic conditional insert (backend `put_if_absent`), not a
+                // racy host-side `exists`-then-`set` — `precondition-failed`
+                // when the key already exists.
+                return Ok(match backend.put_if_absent(&name, &key, value).await {
+                    Ok(true) => Ok(()),
+                    Ok(false) => Err(AsyncKvError::PreconditionFailed),
+                    Err(e) => Err(e.into()),
+                });
+            }
+        }
+        Ok(backend.set(&name, &key, value).await.map_err(Into::into))
+    }
+
+    async fn delete(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<KvBucket>,
+        key: String,
+    ) -> wasmtime::Result<Result<(), AsyncKvError>> {
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &self_))?;
+        Ok(backend.delete(&name, &key).await.map_err(Into::into))
+    }
+
+    async fn exists(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<KvBucket>,
+        key: String,
+    ) -> wasmtime::Result<Result<bool, AsyncKvError>> {
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &self_))?;
+        Ok(backend.exists(&name, &key).await.map_err(Into::into))
+    }
+
+    async fn list_keys(
+        accessor: &Accessor<T, Self>,
+        self_: Resource<KvBucket>,
+        prefix: Option<String>,
+        cursor: Option<String>,
+    ) -> wasmtime::Result<Result<KeyResponse, AsyncKvError>> {
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &self_))?;
+        // A malformed cursor must be rejected, not silently treated as `None`
+        // (start-from-the-beginning).
+        let cursor = match cursor.as_deref() {
+            None => None,
+            Some(c) => match c.parse::<u64>() {
+                Ok(n) => Some(n),
+                Err(_) => return Ok(Err(AsyncKvError::InvalidArgument)),
+            },
+        };
+        let resp = match backend.list_keys(&name, cursor).await {
+            Ok(resp) => resp,
+            Err(e) => return Ok(Err(e.into())),
+        };
+        let keys = match &prefix {
+            Some(p) => resp.keys.into_iter().filter(|k| k.starts_with(p)).collect(),
+            None => resp.keys,
+        };
+        Ok(Ok(KeyResponse {
+            keys,
+            cursor: resp.cursor.map(|c| c.to_string()),
+        }))
+    }
+}
+
+impl bindings::wasmcloud::keyvalue::types::HostBucket for ActiveCtx<'_> {
+    async fn drop(&mut self, rep: Resource<KvBucket>) -> wasmtime::Result<()> {
+        self.table.delete(rep)?;
+        Ok(())
+    }
+}
+
+impl bindings::wasmcloud::keyvalue::types::Host for ActiveCtx<'_> {}
+
+// `store` keeps only `open`, routed per `(implements ..)` label.
+impl<T: 'static + Send> bindings::named_imports::wasmcloud::keyvalue::store::HostWithStore<T>
+    for SharedCtx
+{
+    async fn open(
+        accessor: &Accessor<T, Self>,
+        id: KvId,
+        identifier: String,
+    ) -> wasmtime::Result<Result<Resource<KvBucket>, AsyncKvError>> {
+        if let Err(e) = id.open(&identifier).await {
+            return Ok(Err(e.into()));
+        }
+        let resource = accessor.with(|mut a| a.get().table.push(KvBucket::new(id, identifier)))?;
+        Ok(Ok(resource))
+    }
+}
+
+impl bindings::named_imports::wasmcloud::keyvalue::store::Host for ActiveCtx<'_> {}
+
+impl<T: 'static + Send> bindings::wasmcloud::keyvalue::atomics::HostWithStore<T> for SharedCtx {
+    async fn increment(
+        accessor: &Accessor<T, Self>,
+        bucket: Resource<KvBucket>,
+        key: String,
+        delta: i64,
+    ) -> wasmtime::Result<Result<i64, AsyncKvError>> {
+        // `delta` and the returned counter are signed `s64` (a negative delta
+        // decrements), so this is a direct pass-through onto the backend's signed
+        // `increment`.
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &bucket))?;
+        Ok(backend
+            .increment(&name, &key, delta)
+            .await
+            .map_err(Into::into))
+    }
+}
+
+impl bindings::wasmcloud::keyvalue::atomics::Host for ActiveCtx<'_> {}
+
+impl<T: 'static + Send> bindings::wasmcloud::keyvalue::cas::HostWithStore<T> for SharedCtx {
+    async fn current(
+        accessor: &Accessor<T, Self>,
+        bucket: Resource<KvBucket>,
+        key: String,
+    ) -> wasmtime::Result<Result<Option<Entry>, AsyncKvError>> {
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &bucket))?;
+        Ok(backend
+            .current(&name, &key)
+            .await
+            .map(|opt| opt.map(into_entry))
+            .map_err(Into::into))
+    }
+
+    async fn swap(
+        accessor: &Accessor<T, Self>,
+        bucket: Resource<KvBucket>,
+        key: String,
+        value: Vec<u8>,
+        options: CasOptions,
+    ) -> wasmtime::Result<Result<CasResult, AsyncKvError>> {
+        if options.require_version.is_none() && options.require_value.is_none() {
+            return Ok(Err(AsyncKvError::InvalidArgument));
+        }
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &bucket))?;
+        // The backend performs the compare-and-set atomically (NATS revision,
+        // in-memory under one write lock), so there is no host-side
+        // read-then-write race and the version check is ABA-safe.
+        let guard = CasGuard {
+            require_version: options.require_version,
+            require_value: options.require_value,
+        };
+        Ok(backend
+            .swap(&name, &key, value, guard)
+            .await
+            .map(|outcome| match outcome {
+                CasOutcome::Swapped => CasResult::Swapped,
+                CasOutcome::Stale(cur) => CasResult::Stale(cur.map(into_entry)),
+            })
+            .map_err(Into::into))
+    }
+}
+
+/// Convert a backend [`Versioned`] into the WIT `cas.entry`.
+fn into_entry(v: Versioned) -> Entry {
+    Entry {
+        value: v.value,
+        version: v.version,
+    }
+}
+
+impl bindings::wasmcloud::keyvalue::cas::Host for ActiveCtx<'_> {}
+
+impl<T: 'static + Send> bindings::wasmcloud::keyvalue::batch::HostWithStore<T> for SharedCtx {
+    #[allow(clippy::type_complexity)]
+    async fn get_many(
+        accessor: &Accessor<T, Self>,
+        bucket: Resource<KvBucket>,
+        keys: Vec<String>,
+    ) -> wasmtime::Result<Result<Vec<Option<(String, Vec<u8>)>>, AsyncKvError>> {
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &bucket))?;
+        Ok(backend.get_many(&name, keys).await.map_err(Into::into))
+    }
+
+    async fn set_many(
+        accessor: &Accessor<T, Self>,
+        bucket: Resource<KvBucket>,
+        key_values: Vec<(String, Vec<u8>)>,
+    ) -> wasmtime::Result<Result<(), AsyncKvError>> {
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &bucket))?;
+        Ok(backend
+            .set_many(&name, key_values)
+            .await
+            .map_err(Into::into))
+    }
+
+    async fn delete_many(
+        accessor: &Accessor<T, Self>,
+        bucket: Resource<KvBucket>,
+        keys: Vec<String>,
+    ) -> wasmtime::Result<Result<(), AsyncKvError>> {
+        let (backend, name) = accessor.with(|mut a| bucket_ref(&mut a, &bucket))?;
+        Ok(backend.delete_many(&name, keys).await.map_err(Into::into))
+    }
+}
+
+impl bindings::wasmcloud::keyvalue::batch::Host for ActiveCtx<'_> {}
+
+/// A keyvalue [`HostPlugin`] that multiplexes async `wasmcloud:keyvalue` across
+/// backends selected per `(implements ..)` import. Shares the [`KvBackend`]
+/// providers with [`super::multiplexed::MultiplexedKeyValue`].
+pub struct MultiplexedAsyncKeyValue {
+    mux: Multiplexer<KvId>,
+}
+
+impl Default for MultiplexedAsyncKeyValue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MultiplexedAsyncKeyValue {
+    pub fn new() -> Self {
+        Self {
+            mux: Multiplexer::new("wasmcloud", "keyvalue", DEFAULT_BACKEND),
+        }
+    }
+
+    /// Register a backend provider keyed by its `backend_type()`.
+    pub fn with_provider(mut self, provider: Arc<KvProvider>) -> Self {
+        self.mux = self.mux.with_provider(provider);
+        self
+    }
+
+    /// Build the routing registry (host-interface name -> backend) for a
+    /// component from its matched keyvalue host interfaces.
+    pub async fn build_registry<'i>(
+        &self,
+        interfaces: impl IntoIterator<Item = &'i WitInterface>,
+    ) -> anyhow::Result<std::collections::HashMap<String, KvId>> {
+        self.mux.build_registry(interfaces).await
+    }
+}
+
+#[async_trait::async_trait]
+impl HostPlugin for MultiplexedAsyncKeyValue {
+    fn id(&self) -> &'static str {
+        MULTIPLEXED_ASYNC_KEYVALUE_ID
+    }
+
+    fn world(&self) -> WitWorld {
+        WitWorld {
+            imports: HashSet::from([WitInterface::from(
+                "wasmcloud:keyvalue/store,atomics,cas,batch@0.1.0",
+            )]),
+            ..Default::default()
+        }
+    }
+
+    fn supports_named_instances(&self) -> bool {
+        true
+    }
+
+    async fn on_workload_item_bind<'a>(
+        &self,
+        item: &mut WorkloadItem<'a>,
+        interfaces: WitInterfaces<'_>,
+    ) -> anyhow::Result<()> {
+        if !interfaces.contains("wasmcloud", "keyvalue", &[]) {
+            return Ok(());
+        }
+
+        let registry = self.build_registry(interfaces.iter()).await?;
+        let component = item.component().clone();
+        let linker = item.linker();
+
+        // Only `store.open` is routed per `(implements ..)` label. The `bucket`
+        // resource lives in `types`, and `types`/`atomics`/`cas`/`batch` are bound
+        // standalone: a guest imports them unlabeled, and their methods operate on
+        // a `bucket` whose `KvBucket` already carries the backend it was opened
+        // through, so they route via the resource rather than a label.
+        bindings::named_imports::wasmcloud::keyvalue::store::add_to_linker::<_, SharedCtx>(
+            linker,
+            &component,
+            |name| self.mux.resolve(&registry, name),
+            extract_active_ctx,
+        )?;
+        bindings::wasmcloud::keyvalue::types::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+        bindings::wasmcloud::keyvalue::atomics::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+        bindings::wasmcloud::keyvalue::cas::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+        bindings::wasmcloud::keyvalue::batch::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::wasi_keyvalue::InMemoryProvider;
+
+    fn kv_iface(name: &str) -> WitInterface {
+        WitInterface {
+            namespace: "wasmcloud".to_string(),
+            package: "keyvalue".to_string(),
+            interfaces: ["store".to_string()].into_iter().collect(),
+            version: None,
+            config: std::collections::HashMap::from([(
+                "backend".to_string(),
+                "in-memory".to_string(),
+            )]),
+            name: Some(name.to_string()),
+        }
+    }
+
+    #[test]
+    fn store_error_maps_to_async_variant() {
+        assert!(matches!(
+            AsyncKvError::from(StoreError::NoSuchStore),
+            AsyncKvError::NoSuchStore
+        ));
+        assert!(matches!(
+            AsyncKvError::from(StoreError::AccessDenied),
+            AsyncKvError::AccessDenied
+        ));
+        assert!(matches!(
+            AsyncKvError::from(StoreError::Other("x".into())),
+            AsyncKvError::Other(_)
+        ));
+    }
+
+    /// The async keyvalue plugin routes two named `wasmcloud:keyvalue` interfaces
+    /// to distinct backends — proving the `("wasmcloud", "keyvalue")` multiplexer
+    /// is wired and isolation holds, exercising the shared `KvBackend`.
+    #[tokio::test]
+    async fn registry_routes_named_interfaces_to_distinct_backends() {
+        let plugin = MultiplexedAsyncKeyValue::new().with_provider(Arc::new(InMemoryProvider));
+        let interfaces = HashSet::from([kv_iface("team-a"), kv_iface("team-b")]);
+
+        let registry = plugin.build_registry(&interfaces).await.unwrap();
+        let a = registry.get("team-a").expect("team-a routed").clone();
+        let b = registry.get("team-b").expect("team-b routed").clone();
+
+        a.open("bucket").await.unwrap();
+        a.set("bucket", "k", b"v".to_vec()).await.unwrap();
+        b.open("bucket").await.unwrap();
+        assert_eq!(b.get("bucket", "k").await.unwrap(), None, "backends leaked");
+        assert_eq!(a.get("bucket", "k").await.unwrap(), Some(b"v".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn build_registry_errors_on_unregistered_backend() {
+        let plugin = MultiplexedAsyncKeyValue::new(); // no providers
+        let mut iface = kv_iface("x");
+        iface
+            .config
+            .insert("backend".to_string(), "redis".to_string());
+        let err = plugin
+            .build_registry(&HashSet::from([iface]))
+            .await
+            .err()
+            .expect("expected error for unregistered backend");
+        assert!(err.to_string().contains("redis"), "unexpected error: {err}");
+    }
+}

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -90,6 +90,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "blobstore-implements-p3"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.58.0",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +758,13 @@ dependencies = [
 
 [[package]]
 name = "keyvalue-implements"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.58.0",
+]
+
+[[package]]
+name = "keyvalue-implements-p3"
 version = "0.0.0"
 dependencies = [
  "wit-bindgen 0.58.0",

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -34,6 +34,8 @@ members = [
     "res-caller-p3",
     "ephemeral-callee-p3",
     "ephemeral-caller-p3",
+    "blobstore-implements-p3",
+    "keyvalue-implements-p3",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/blobstore-implements-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/blobstore-implements-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "blobstore-implements-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/blobstore-implements-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/blobstore-implements-p3/src/lib.rs
@@ -1,0 +1,80 @@
+//! Real-guest fixture for async `wasmcloud:blobstore` `(implements ..)` routing.
+//!
+//! Imports the native-stream `wasmcloud:blobstore@0.1.0` under the labels
+//! `store-a` (the `blobstore` interface) and `objects-a` (the `container`
+//! interface). On each HTTP request it creates a container, streams an object
+//! body in via `write-data(name, stream<u8>)`, reads it back out via
+//! `get-data(..) -> stream<u8>`, and returns the bytes — exercising the
+//! concurrent/stream host ABI end to end against whatever backend the host
+//! routes `store-a` to.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+    });
+}
+
+use bindings::exports::wasi::http::handler::Guest as Handler;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+
+struct Component;
+
+const CONTAINER: &str = "photos";
+const OBJECT: &str = "cat.png";
+const BODY: &[u8] = b"meow from a real p3 guest";
+
+fn internal(msg: String) -> ErrorCode {
+    ErrorCode::InternalError(Some(msg))
+}
+
+fn respond(status: u16, body_bytes: Vec<u8>) -> Result<Response, ErrorCode> {
+    let headers = Fields::new();
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
+
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body_bytes).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    response
+        .set_status_code(status)
+        .map_err(|()| internal("failed to set status".into()))?;
+    Ok(response)
+}
+
+impl Handler for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        // Create (or reuse) the container through the `store-a` implements import.
+        let container = match bindings::store_a::create_container(CONTAINER.to_string()).await {
+            Ok(c) => c,
+            Err(_) => bindings::store_a::get_container(CONTAINER.to_string())
+                .await
+                .map_err(|e| internal(format!("get_container: {e:?}")))?,
+        };
+
+        // Stream the object body in through `write-data(name, stream<u8>)`.
+        let (mut tx, rx) = bindings::wit_stream::new();
+        wit_bindgen::spawn_local(async move {
+            tx.write_all(BODY.to_vec()).await;
+            drop(tx);
+        });
+        container
+            .write_data(OBJECT.to_string(), rx)
+            .await
+            .map_err(|e| internal(format!("write_data: {e:?}")))?;
+
+        // Read it back out of the returned `stream<u8>`.
+        let stream = container
+            .get_data(OBJECT.to_string(), 0, u64::MAX)
+            .await
+            .map_err(|e| internal(format!("get_data: {e:?}")))?;
+        let data = stream.collect().await;
+
+        respond(200, data)
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/blobstore-implements-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/blobstore-implements-p3/wit/world.wit
@@ -1,0 +1,15 @@
+package wasmcloud:blobstore-implements-p3@0.1.0;
+
+// Imports the async, native-stream `wasmcloud:blobstore@0.1.0` under `(implements
+// ..)` labels. Because WIT requires one interface per label, the `blobstore`
+// interface (create/get container) and the `container` interface (the resource
+// methods, incl. the `stream<u8>` get-data/write-data) get *distinct* labels per
+// logical store. The container resource carries its host-bound backend, so its
+// methods route correctly regardless of which labeled container import they
+// arrive on.
+world blobstore-implements {
+    import store-a: wasmcloud:blobstore/blobstore@0.1.0;
+    import objects-a: wasmcloud:blobstore/container@0.1.0;
+
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/keyvalue-implements-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-implements-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "keyvalue-implements-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/keyvalue-implements-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-implements-p3/src/lib.rs
@@ -1,0 +1,190 @@
+//! Real-guest ABA test for async `wasmcloud:keyvalue` compare-and-swap.
+//!
+//! Opens a bucket through the `(implements ..)`-labeled `kv` (store) import, then
+//! drives an A → B → A sequence and a version-pinned `cas.swap` through the
+//! standalone `cas` import. Because the value returns to identical bytes, a
+//! content-hash version would let the swap wrongly succeed; a backend-native
+//! monotonic version makes it `stale`. The handler answers `aba-detected` only
+//! when the swap is correctly rejected.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+    });
+}
+
+use bindings::exports::wasi::http::handler::Guest as Handler;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::wasmcloud::keyvalue::cas::{self, CasOptions, CasResult};
+use bindings::wasmcloud::keyvalue::{atomics, batch};
+
+struct Component;
+
+const BUCKET: &str = "aba";
+const KEY: &str = "k";
+
+fn internal(msg: String) -> ErrorCode {
+    ErrorCode::InternalError(Some(msg))
+}
+
+fn respond(status: u16, body_bytes: Vec<u8>) -> Result<Response, ErrorCode> {
+    let headers = Fields::new();
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
+
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body_bytes).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    response
+        .set_status_code(status)
+        .map_err(|()| internal("failed to set status".into()))?;
+    Ok(response)
+}
+
+async fn run() -> Result<String, String> {
+    // `kv` is the labeled `store` import; `cas` is standalone but operates on the
+    // same `bucket` resource.
+    let bucket = bindings::kv::open(BUCKET.to_string())
+        .await
+        .map_err(|e| format!("open: {e:?}"))?;
+
+    bucket
+        .set(KEY.to_string(), b"A".to_vec(), None)
+        .await
+        .map_err(|e| format!("set A: {e:?}"))?;
+
+    let v1 = cas::current(&bucket, KEY.to_string())
+        .await
+        .map_err(|e| format!("current: {e:?}"))?
+        .ok_or_else(|| "key missing after set".to_string())?
+        .version;
+
+    // A -> B -> A: the value returns to identical bytes.
+    bucket
+        .set(KEY.to_string(), b"B".to_vec(), None)
+        .await
+        .map_err(|e| format!("set B: {e:?}"))?;
+    bucket
+        .set(KEY.to_string(), b"A".to_vec(), None)
+        .await
+        .map_err(|e| format!("set A again: {e:?}"))?;
+
+    // (1) A swap pinned to the original version (v1) must be reported stale.
+    // The key changed A -> B -> A, so its bytes are back to the original. With a
+    // monotonic version the version still moved, so the swap is correctly stale;
+    // a content-hash version would match again and let the swap through.
+    let aba = cas::swap(
+        &bucket,
+        KEY.to_string(),
+        b"C".to_vec(),
+        CasOptions {
+            require_version: Some(v1),
+            require_value: None,
+        },
+    )
+    .await
+    .map_err(|e| format!("aba swap: {e:?}"))?;
+    if !matches!(aba, CasResult::Stale(_)) {
+        return Ok("fail: A->B->A swap on the old version should be stale".to_string());
+    }
+
+    // (2) Swap pinned to the CURRENT version must succeed — proves CAS actually
+    // works, so the stale result above isn't just an always-stale backend.
+    let current_version = cas::current(&bucket, KEY.to_string())
+        .await
+        .map_err(|e| format!("current after aba: {e:?}"))?
+        .ok_or_else(|| "key vanished".to_string())?
+        .version;
+    let positive = cas::swap(
+        &bucket,
+        KEY.to_string(),
+        b"D".to_vec(),
+        CasOptions {
+            require_version: Some(current_version),
+            require_value: None,
+        },
+    )
+    .await
+    .map_err(|e| format!("positive swap: {e:?}"))?;
+    if !matches!(positive, CasResult::Swapped) {
+        return Ok("fail: swap on the current version should succeed".to_string());
+    }
+
+    // (3) Empty cas-options (no precondition) must be rejected with
+    // invalid-argument, not silently performed as an unconditional write.
+    let empty = cas::swap(
+        &bucket,
+        KEY.to_string(),
+        b"E".to_vec(),
+        CasOptions {
+            require_version: None,
+            require_value: None,
+        },
+    )
+    .await;
+    match empty {
+        Err(e) if format!("{e:?}").contains("InvalidArgument") => {}
+        other => return Ok(format!("fail: empty cas-options not rejected: {other:?}")),
+    }
+
+    // (4) atomics.increment through the standalone `atomics` import, on the same
+    // labeled-store bucket. Absent counter starts at 0: +5 -> 5, +3 -> 8.
+    let c1 = atomics::increment(&bucket, "counter".to_string(), 5)
+        .await
+        .map_err(|e| format!("increment 1: {e:?}"))?;
+    let c2 = atomics::increment(&bucket, "counter".to_string(), 3)
+        .await
+        .map_err(|e| format!("increment 2: {e:?}"))?;
+    if (c1, c2) != (5, 8) {
+        return Ok(format!("fail: increment expected (5,8), got ({c1},{c2})"));
+    }
+
+    // (5) batch set-many / get-many / delete-many through the standalone `batch`
+    // import. get-many must return values positionally, with `none` for a miss.
+    batch::set_many(
+        &bucket,
+        vec![
+            ("b1".to_string(), b"v1".to_vec()),
+            ("b2".to_string(), b"v2".to_vec()),
+        ],
+    )
+    .await
+    .map_err(|e| format!("set_many: {e:?}"))?;
+    let got = batch::get_many(
+        &bucket,
+        vec!["b1".to_string(), "b2".to_string(), "missing".to_string()],
+    )
+    .await
+    .map_err(|e| format!("get_many: {e:?}"))?;
+    let values: Vec<Option<Vec<u8>>> = got.into_iter().map(|kv| kv.map(|(_, v)| v)).collect();
+    if values != vec![Some(b"v1".to_vec()), Some(b"v2".to_vec()), None] {
+        return Ok(format!("fail: get_many mismatch: {values:?}"));
+    }
+    batch::delete_many(&bucket, vec!["b1".to_string()])
+        .await
+        .map_err(|e| format!("delete_many: {e:?}"))?;
+    let after = batch::get_many(&bucket, vec!["b1".to_string(), "b2".to_string()])
+        .await
+        .map_err(|e| format!("get_many after delete: {e:?}"))?;
+    if after[0].is_some() || after[1].is_none() {
+        return Ok(format!("fail: delete_many left {after:?}"));
+    }
+
+    Ok("ok".to_string())
+}
+
+impl Handler for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        let body = match run().await {
+            Ok(s) => s,
+            Err(e) => format!("error: {e}"),
+        };
+        respond(200, body.into_bytes())
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/keyvalue-implements-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-implements-p3/wit/world.wit
@@ -1,0 +1,15 @@
+package wasmcloud:keyvalue-implements-p3@0.1.0;
+
+// Imports the async `wasmcloud:keyvalue@0.1.0` `store` under an `(implements ..)`
+// label (`kv`) plus `atomics`, `cas`, and `batch` unlabeled. Those three
+// `use types.{bucket}`, so they cannot carry their own label; the host binds them
+// standalone and they operate on the `bucket` opened through the labeled `store`
+// The guest exercises all four (store/atomics/cas/batch) against one bucket.
+world keyvalue-aba {
+    import kv: wasmcloud:keyvalue/store@0.1.0;
+    import wasmcloud:keyvalue/atomics@0.1.0;
+    import wasmcloud:keyvalue/cas@0.1.0;
+    import wasmcloud:keyvalue/batch@0.1.0;
+
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasmcloud-blobstore-0.1.0/package.wit
+++ b/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasmcloud-blobstore-0.1.0/package.wit
@@ -1,0 +1,152 @@
+package wasmcloud:blobstore@0.1.0;
+
+/// Types used by blobstore.
+///
+/// Unlike `wasi:blobstore@0.2.0-draft`, this package does not depend on `wasi:io`. Object bodies
+/// are carried as native component-model `stream<u8>` values, so the `incoming-value` and
+/// `outgoing-value` wrapper resources are gone.
+interface types {
+  /// name of a container, a collection of objects.
+  /// The container name may be any valid UTF-8 string.
+  type container-name = string;
+
+  /// name of an object within a container
+  /// The object name may be any valid UTF-8 string.
+  type object-name = string;
+
+  /// nanoseconds since the Unix epoch.
+  type timestamp = u64;
+
+  /// size of an object, in bytes
+  type object-size = u64;
+
+  /// The set of errors which may be raised by functions in this package.
+  ///
+  /// Following the wasip3 convention, this enumerates specific named cases
+  /// rather than a bare `string`. It is intentionally non-exhaustive: future
+  /// versions may add cases, and generated bindings are marked non-exhaustive
+  /// accordingly, so consumers must always include a catch-all arm.
+  /// Backend-specific failures that do not map to a named case are reported
+  /// via `other`.
+  variant error {
+    /// The referenced container does not exist.
+    no-such-container,
+    /// A container with the requested name already exists (e.g. on
+    /// `create-container`).
+    container-already-exists,
+    /// The referenced object does not exist.
+    no-such-object,
+    /// The requesting component does not have access to the container or
+    /// object (which may or may not exist).
+    access-denied,
+    /// The operation did not complete within the host- or backend-imposed
+    /// time limit.
+    timeout,
+    /// The store is currently unreachable or otherwise unavailable. The
+    /// operation may succeed if retried later.
+    store-unavailable,
+    /// The operation was rejected because a storage quota or rate limit was
+    /// exceeded.
+    quota-exceeded,
+    /// Some other implementation-specific error has occurred (e.g. I/O). Used
+    /// for backend-specific failures that do not map to a named case above.
+    other(string),
+  }
+
+  /// information about a container
+  record container-metadata {
+    /// the container's name
+    name: container-name,
+    /// date and time the container was created
+    created-at: timestamp,
+  }
+
+  /// information about an object
+  record object-metadata {
+    /// the object's name
+    name: object-name,
+    /// the object's parent container
+    container: container-name,
+    /// date and time the object was created
+    created-at: timestamp,
+    /// size of the object, in bytes
+    size: object-size,
+  }
+
+  /// identifier for an object that includes its container name
+  record object-id {
+    container: container-name,
+    object: object-name,
+  }
+}
+
+/// a Container is a collection of objects
+interface container {
+  use types.{container-metadata, error, object-metadata, object-name};
+
+  /// this defines the `container` resource
+  resource container {
+    /// returns container name
+    name: async func() -> result<string, error>;
+    /// returns container metadata
+    info: async func() -> result<container-metadata, error>;
+    /// retrieves an object, or a portion of an object, as a byte stream.
+    ///
+    /// Start and end offsets are inclusive. The returned `stream<u8>` yields the object's bytes
+    /// as they become available; the caller owns the stream and drives it to completion (or drops
+    /// it early to cancel the transfer).
+    get-data: async func(name: object-name, start: u64, end: u64) -> result<stream<u8>, error>;
+    /// creates or replaces an object with the data read from the provided byte stream.
+    ///
+    /// The callee consumes the `stream<u8>`; the write completes once the stream is exhausted.
+    write-data: async func(name: object-name, data: stream<u8>) -> result<_, error>;
+    /// returns the names of the objects in the container as a stream. Order is undefined.
+    list-objects: async func() -> result<stream<object-name>, error>;
+    /// deletes an object.
+    /// does not return an error if the object did not exist.
+    delete-object: async func(name: object-name) -> result<_, error>;
+    /// deletes multiple objects in the container
+    delete-objects: async func(names: list<object-name>) -> result<_, error>;
+    /// returns true if the object exists in this container
+    has-object: async func(name: object-name) -> result<bool, error>;
+    /// returns metadata for the object
+    object-info: async func(name: object-name) -> result<object-metadata, error>;
+    /// removes all objects within the container, leaving the container empty.
+    clear: async func() -> result<_, error>;
+  }
+}
+
+/// wasmCloud blobstore service definition
+interface blobstore {
+  use container.{container};
+  use types.{error, container-name, object-id};
+
+  /// creates a new empty container
+  create-container: async func(name: container-name) -> result<container, error>;
+
+  /// retrieves a container by name
+  get-container: async func(name: container-name) -> result<container, error>;
+
+  /// deletes a container and all objects within it
+  delete-container: async func(name: container-name) -> result<_, error>;
+
+  /// returns true if the container exists
+  container-exists: async func(name: container-name) -> result<bool, error>;
+
+  /// copies (duplicates) an object, to the same or a different container.
+  /// returns an error if the target container does not exist.
+  /// overwrites the destination object if it already existed.
+  copy-object: async func(src: object-id, dest: object-id) -> result<_, error>;
+
+  /// moves or renames an object, to the same or a different container.
+  /// returns an error if the destination container does not exist.
+  /// overwrites the destination object if it already existed.
+  move-object: async func(src: object-id, dest: object-id) -> result<_, error>;
+}
+
+/// The `wasmcloud:blobstore/imports` world provides common APIs for interacting with blob stores.
+world imports {
+  import types;
+  import container;
+  import blobstore;
+}

--- a/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasmcloud-keyvalue-0.1.0/package.wit
+++ b/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasmcloud-keyvalue-0.1.0/package.wit
@@ -1,0 +1,362 @@
+package wasmcloud:keyvalue@0.1.0;
+
+/// Types shared across the keyvalue interfaces.
+///
+/// The `bucket` resource lives here (rather than in `store`) so that every
+/// interface that operates on a bucket — `store`, `atomics`, `cas`, `batch`,
+/// `watcher` — `use`s the *same* resource type. That matters for the
+/// component-model `(implements ..)` mechanism: a host can route each labeled
+/// `store` import to a different backend, and the bucket a guest opens through
+/// one label is still accepted by the (unlabeled) `atomics`/`cas`/`batch`
+/// interfaces, because they all reference this one `types.bucket`.
+interface types {
+  /// The set of errors which may be raised by functions in this package.
+  ///
+  /// Following the wasip3 convention, this enumerates specific named cases
+  /// rather than leaning on stringly-typed errors. It is intentionally
+  /// non-exhaustive: future versions may add cases, and generated bindings are
+  /// marked non-exhaustive accordingly, so consumers must always include a
+  /// catch-all arm. Backend-specific failures that do not map to a named case
+  /// are reported via `other`.
+  variant error {
+    /// The host does not recognize the store identifier requested.
+    no-such-store,
+    /// The requesting component does not have access to the specified store
+    /// (which may or may not exist).
+    access-denied,
+    /// The request was malformed or self-contradictory, e.g. a `cas.swap`
+    /// whose `cas-options` sets no precondition.
+    invalid-argument,
+    /// A conditional operation did not meet its precondition, e.g. a `set` with
+    /// `if-not-exists` against a key that already exists.
+    precondition-failed,
+    /// The operation did not complete within the host- or backend-imposed time
+    /// limit.
+    timeout,
+    /// The store is currently unreachable or otherwise unavailable. The
+    /// operation may succeed if retried later.
+    store-unavailable,
+    /// The operation was rejected because a quota or rate limit was exceeded.
+    quota-exceeded,
+    /// Some other implementation-specific error has occurred (e.g. I/O). Used
+    /// for backend-specific failures that do not map to a named case above.
+    other(string),
+  }
+
+  /// A response to a `list-keys` operation.
+  record key-response {
+    /// The list of keys returned by the query.
+    keys: list<string>,
+    /// The continuation token to use to fetch the next page of keys. If this is `none`, then
+    /// there are no more keys to fetch.
+    cursor: option<string>,
+  }
+
+  /// Options that modify the behavior of a `set` operation.
+  record set-options {
+    /// If set, the entry expires this many milliseconds after the write, after
+    /// which the host removes it. `none` stores the entry without expiry.
+    ///
+    /// Hosts whose backend cannot honor expiry MUST raise an error rather than
+    /// silently ignoring the TTL.
+    ttl-ms: option<u64>,
+    /// When true, the write succeeds only if the key does not already exist,
+    /// failing with `error::precondition-failed` otherwise. Useful for locks
+    /// and idempotent initialization.
+    if-not-exists: bool,
+  }
+
+  /// A bucket is a collection of key-value pairs. Each key-value pair is stored as an entry in the
+  /// bucket, and the bucket itself acts as a collection of all these entries.
+  ///
+  /// It is worth noting that the exact terminology for bucket in key-value stores can vary
+  /// depending on the specific implementation. For example:
+  ///
+  /// 1. Amazon DynamoDB calls a collection of key-value pairs a table
+  /// 2. Redis has hashes, sets, and sorted sets as different types of collections
+  /// 3. Cassandra calls a collection of key-value pairs a column family
+  /// 4. MongoDB calls a collection of key-value pairs a collection
+  /// 5. Riak calls a collection of key-value pairs a bucket
+  /// 6. Memcached calls a collection of key-value pairs a slab
+  /// 7. Azure Cosmos DB calls a collection of key-value pairs a container
+  ///
+  /// In this interface, we use the term `bucket` to refer to a collection of key-value pairs
+  resource bucket {
+    /// Get the value associated with the specified `key`
+    ///
+    /// The value is returned as an option. If the key-value pair exists in the
+    /// store, it returns `ok(value)`. If the key does not exist in the
+    /// store, it returns `ok(none)`.
+    ///
+    /// If any other error occurs, it returns an `err(error)`.
+    get: async func(key: string) -> result<option<list<u8>>, error>;
+    /// Set the value associated with the key in the store. If the key already
+    /// exists in the store, it overwrites the value.
+    ///
+    /// If the key does not exist in the store, it creates a new key-value pair.
+    ///
+    /// `options` controls expiry (`ttl-ms`) and conditional writes
+    /// (`if-not-exists`); pass `none` for the default overwrite-on-exists
+    /// behavior with no expiry.
+    ///
+    /// If any other error occurs, it returns an `err(error)`.
+    set: async func(key: string, value: list<u8>, options: option<set-options>) -> result<_, error>;
+    /// Delete the key-value pair associated with the key in the store.
+    ///
+    /// If the key does not exist in the store, it does nothing.
+    ///
+    /// If any other error occurs, it returns an `err(error)`.
+    delete: async func(key: string) -> result<_, error>;
+    /// Check if the key exists in the store.
+    ///
+    /// If the key exists in the store, it returns `ok(true)`. If the key does
+    /// not exist in the store, it returns `ok(false)`.
+    ///
+    /// If any other error occurs, it returns an `err(error)`.
+    exists: async func(key: string) -> result<bool, error>;
+    /// Get the keys in the store, optionally restricted to those starting with
+    /// `prefix`, with an optional cursor (for use in pagination). It returns a
+    /// list of keys. Please note that for most KeyValue implementations, this
+    /// can be a very expensive operation and so it should be used judiciously. Implementations
+    /// can return any number of keys in a single response, but they should never attempt to
+    /// send more data than is reasonable (i.e. on a small edge device, this may only be a few
+    /// KB, while on a large machine this could be several MB). Any response should also return
+    /// a cursor that can be used to fetch the next page of keys. See the `key-response` record
+    /// for more information.
+    ///
+    /// `prefix` filters the result to keys that begin with the given string; pass
+    /// `none` to list all keys. When paginating, the same `prefix` should be
+    /// supplied alongside each `cursor`.
+    ///
+    /// Note that the keys are not guaranteed to be returned in any particular order.
+    ///
+    /// If the store is empty (or no keys match `prefix`), it returns an empty list.
+    ///
+    /// MAY show an out-of-date list of keys if there are concurrent writes to the store.
+    ///
+    /// If any error occurs, it returns an `err(error)`.
+    list-keys: async func(prefix: option<string>, cursor: option<string>) -> result<key-response, error>;
+  }
+}
+
+/// A keyvalue interface that provides eventually consistent key-value operations.
+///
+/// Each of these operations acts on a single key-value pair.
+///
+/// The value in the key-value pair is defined as a `u8` byte array and the intention is that it is
+/// the common denominator for all data types defined by different key-value stores to handle data,
+/// ensuring compatibility between different key-value stores. Note: the clients will be expecting
+/// serialization/deserialization overhead to be handled by the key-value store. The value could be
+/// a serialized object from JSON, HTML or vendor-specific data types like AWS S3 objects.
+///
+/// Data consistency in a key value store refers to the guarantee that once a write operation
+/// completes, all subsequent read operations will return the value that was written.
+///
+/// Any implementation of this interface must have enough consistency to guarantee "reading your
+/// writes." In particular, this means that the client should never get a value that is older than
+/// the one it wrote, but it MAY get a newer value if one was written around the same time. These
+/// guarantees only apply to the same client (which will likely be provided by the host or an
+/// external capability of some kind). In this context a "client" is referring to the caller or
+/// guest that is consuming this interface. Once a write request is committed by a specific client,
+/// all subsequent read requests by the same client will reflect that write or any subsequent
+/// writes. Another client running in a different context may or may not immediately see the result
+/// due to the replication lag.
+///
+/// Unlike `wasi:keyvalue@0.2.0-draft`, every operation that touches a backend is an `async func`.
+/// This lets a single component issue many in-flight key-value operations concurrently without the
+/// `wasi:io/poll` ceremony required under wasip2.
+interface store {
+  use types.{bucket, error};
+
+  /// Get the bucket with the specified identifier.
+  ///
+  /// `identifier` must refer to a bucket provided by the host.
+  ///
+  /// `error::no-such-store` will be raised if the `identifier` is not recognized.
+  open: async func(identifier: string) -> result<bucket, error>;
+}
+
+/// A keyvalue interface that provides atomic operations.
+///
+/// Atomic operations are single, indivisible operations. When a fault causes an atomic operation to
+/// fail, it will appear to the invoker of the atomic operation that the action either completed
+/// successfully or did nothing at all.
+interface atomics {
+  use types.{bucket, error};
+
+  /// Atomically increment the value associated with the key in the store by the given (signed)
+  /// delta. It returns the new value.
+  ///
+  /// If the key does not exist in the store, it creates a new key-value pair with the value set
+  /// to the given delta.
+  ///
+  /// If any other error occurs, it returns an `err(error)`.
+  increment: async func(bucket: borrow<bucket>, key: string, delta: s64) -> result<s64, error>;
+}
+
+/// A keyvalue interface that provides compare-and-swap (optimistic concurrency) for a single key.
+///
+/// This is kept separate from `atomics` so a host can grant or deny it independently, and so
+/// backends that cannot perform conditional writes can decline just this capability. It is a
+/// one-shot, resource-free API: each `swap` carries its own preconditions and reports the current
+/// state back on conflict, so the read-modify-write retry loop needs no extra round trips.
+interface cas {
+  use types.{bucket, error};
+
+  /// An opaque, backend-defined version token for an entry: an etcd revision, an S3/HTTP ETag, a
+  /// Cosmos DB `_etag`, a monotonic counter, and so on. Treat it as opaque — only equality is
+  /// meaningful, and tokens are not ordered or comparable across keys or backends.
+  type version = string;
+
+  /// A key's value together with its current version.
+  record entry {
+    value: list<u8>,
+    version: version,
+  }
+
+  /// Read a key's current value and version, for use as the precondition of a later `swap`.
+  /// Returns `none` if the key does not exist.
+  ///
+  /// `store.get` deliberately omits the version; use this when you intend to do a
+  /// version-checked swap.
+  current: async func(bucket: borrow<bucket>, key: string) -> result<option<entry>, error>;
+
+  /// Preconditions for a `swap`. Every condition that is set must hold for the write to be
+  /// applied. At least one condition must be set: a `swap` with an empty `cas-options` is a
+  /// misuse and is rejected with `error::invalid-argument` (use `store.set` for an unconditional
+  /// write).
+  record cas-options {
+    /// Require the entry's current version to equal this. This is the ABA-safe check: it detects
+    /// a value that changed A -> B -> A, which a value comparison misses. Omit it if you do not
+    /// care about ABA.
+    require-version: option<version>,
+    /// Require the entry's current value to equal this. A version-free optimistic check: simpler,
+    /// but ABA-prone. Omit to skip.
+    require-value: option<list<u8>>,
+  }
+
+  /// The outcome of a `swap`.
+  variant cas-result {
+    /// The new value was written.
+    swapped,
+    /// A precondition did not hold; nothing was written. The current entry is returned (`none`
+    /// if the key is absent) so the caller can recompute and retry without a separate read.
+    stale(option<entry>),
+  }
+
+  /// Conditionally and atomically set `key` to `value` if every precondition in `options` holds.
+  ///
+  /// Returns `cas-result::swapped` on success, or `cas-result::stale` with the current entry if a
+  /// precondition fails. A lost race is the expected `stale` outcome, not an `error`. `options`
+  /// must set at least one precondition; an empty `cas-options` returns `err(error::invalid-argument)`
+  /// rather than performing an unconditional write. Other `err(error)` values are store-level
+  /// failures.
+  swap: async func(
+    bucket: borrow<bucket>,
+    key: string,
+    value: list<u8>,
+    options: cas-options,
+  ) -> result<cas-result, error>;
+}
+
+/// A keyvalue interface that provides batch operations.
+///
+/// A batch operation is an operation that operates on multiple keys at once.
+///
+/// Batch operations are useful for reducing network round-trip time. For example, if you want to
+/// get the values associated with 100 keys, you can either do 100 get operations or you can do 1
+/// batch get operation. The batch operation is faster because it only needs to make 1 network call
+/// instead of 100.
+///
+/// A batch operation does not guarantee atomicity, meaning that if the batch operation fails, some
+/// of the keys may have been modified and some may not.
+///
+/// This interface has the same consistency guarantees as the `store` interface, meaning that you
+/// should be able to "read your writes."
+interface batch {
+  use types.{bucket, error};
+
+  /// Get the key-value pairs associated with the keys in the store. It returns a list of
+  /// key-value pairs.
+  ///
+  /// If any of the keys do not exist in the store, it returns a `none` value for that pair in the
+  /// list.
+  ///
+  /// MAY show an out-of-date value if there are concurrent writes to the store.
+  ///
+  /// If any other error occurs, it returns an `err(error)`.
+  get-many: async func(bucket: borrow<bucket>, keys: list<string>) -> result<list<option<tuple<string, list<u8>>>>, error>;
+
+  /// Set the values associated with the keys in the store. If the key already exists in the
+  /// store, it overwrites the value.
+  ///
+  /// Note that the key-value pairs are not guaranteed to be set in the order they are provided.
+  ///
+  /// If any of the keys do not exist in the store, it creates a new key-value pair.
+  ///
+  /// If any other error occurs, it returns an `err(error)`. When an error occurs, it does not
+  /// rollback the key-value pairs that were already set. Thus, this batch operation does not
+  /// guarantee atomicity, implying that some key-value pairs could be set while others might
+  /// fail.
+  ///
+  /// Other concurrent operations may also be able to see the partial results.
+  set-many: async func(bucket: borrow<bucket>, key-values: list<tuple<string, list<u8>>>) -> result<_, error>;
+
+  /// Delete the key-value pairs associated with the keys in the store.
+  ///
+  /// Note that the key-value pairs are not guaranteed to be deleted in the order they are
+  /// provided.
+  ///
+  /// If any of the keys do not exist in the store, it skips the key.
+  ///
+  /// If any other error occurs, it returns an `err(error)`. When an error occurs, it does not
+  /// rollback the key-value pairs that were already deleted. Thus, this batch operation does not
+  /// guarantee atomicity, implying that some key-value pairs could be deleted while others might
+  /// fail.
+  ///
+  /// Other concurrent operations may also be able to see the partial results.
+  delete-many: async func(bucket: borrow<bucket>, keys: list<string>) -> result<_, error>;
+}
+
+/// A keyvalue interface that provides event-driven notifications of changes to a bucket.
+///
+/// This interface is exported by a component that wants to react to key-value changes, and the
+/// callbacks are delivered by the host as those changes occur.
+interface watcher {
+  use types.{bucket};
+
+  /// Handle the `set` event for the given bucket and key. It includes a handle to the `bucket`
+  /// that can be used to interact with the store.
+  on-set: async func(bucket: bucket, key: string, value: list<u8>);
+
+  /// Handle the `delete` event for the given bucket and key. It includes a handle to the
+  /// `bucket` that can be used to interact with the store.
+  on-delete: async func(bucket: bucket, key: string);
+}
+
+/// The `wasmcloud:keyvalue/imports` world provides common APIs for interacting with key-value
+/// stores. Components targeting this world will be able to do:
+///
+/// 1. CRUD (create, read, update, delete) operations on key-value stores, with optional
+///    per-entry expiry and conditional writes.
+/// 2. Atomic `increment` operations, and compare-and-swap (CAS) via the `cas` interface.
+/// 3. Batch operations that can reduce the number of round trips to the network.
+world imports {
+  import types;
+  import store;
+  import atomics;
+  import cas;
+  import batch;
+}
+
+/// The `wasmcloud:keyvalue/watch-service` world is implemented by components that want to receive
+/// change notifications for a bucket in addition to performing key-value operations themselves.
+world watch-service {
+  import types;
+  import store;
+  import atomics;
+  import cas;
+  import batch;
+
+  export watcher;
+}

--- a/crates/wash-runtime/tests/integration_blobstore_async_multiplexed.rs
+++ b/crates/wash-runtime/tests/integration_blobstore_async_multiplexed.rs
@@ -1,0 +1,141 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! End-to-end test for the multiplexed async `wasmcloud:blobstore` NATS backend,
+//! routed through `MultiplexedAsyncBlobstore`'s provider/registry path.
+//!
+//! Builds a registry from a named `wasmcloud:blobstore` host interface with
+//! `backend = nats`, then drives the *real* NATS JetStream object-store backend
+//! through the full `BlobBackend` surface (container lifecycle, object
+//! read/write, listing, copy, delete, clear), asserting the named import routed
+//! to a working object store.
+//!
+//! Requires Docker (NATS with JetStream); marked `#[ignore]`, so it runs only
+//! under `cargo test --include-ignored` (CI's Linux leg) and not a plain
+//! `cargo test`.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use testcontainers::{
+    GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+use wash_runtime::plugin::wasi_blobstore::{MultiplexedAsyncBlobstore, NatsBlobProvider};
+use wash_runtime::wit::WitInterface;
+
+/// A named `wasmcloud:blobstore` interface routed to the NATS backend.
+fn nats_blob_iface(name: &str, url: &str) -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "blobstore".to_string(),
+        interfaces: ["blobstore".to_string(), "container".to_string()]
+            .into_iter()
+            .collect(),
+        version: None,
+        config: HashMap::from([
+            ("backend".to_string(), "nats".to_string()),
+            ("url".to_string(), url.to_string()),
+        ]),
+        name: Some(name.to_string()),
+    }
+}
+
+/// `BlobBackendError` is not `std::error::Error`; stringify it for `?`/`anyhow`.
+fn err(e: impl std::fmt::Debug) -> anyhow::Error {
+    anyhow::anyhow!("blobstore backend error: {e:?}")
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (NATS JetStream); run with `cargo test --include-ignored`"]
+async fn async_multiplexed_blobstore_routes_to_nats() -> Result<()> {
+    // --- NATS container (JetStream enabled for the object store) ---
+    let nats = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
+    let nats_port = nats.get_host_port_ipv4(4222).await?;
+    let nats_url = format!("nats://127.0.0.1:{nats_port}");
+
+    // --- build the routing registry from the named host interface ---
+    let plugin = MultiplexedAsyncBlobstore::new().with_provider(Arc::new(NatsBlobProvider));
+    let registry = plugin
+        .build_registry(&[nats_blob_iface("nats-blob", &nats_url)])
+        .await
+        .context("build registry")?;
+    let be = registry.get("nats-blob").expect("nats-blob routed").clone();
+
+    // --- container lifecycle ---
+    be.create_container("photos").await.map_err(err)?;
+    assert!(be.container_exists("photos").await.map_err(err)?);
+    // Creating an existing container is an error.
+    assert!(
+        be.create_container("photos").await.is_err(),
+        "re-creating a container must error"
+    );
+
+    // --- object write / read round-trip ---
+    be.write_data("photos", "cat.png", b"meow".to_vec())
+        .await
+        .map_err(err)?;
+    assert!(be.has_object("photos", "cat.png").await.map_err(err)?);
+    assert_eq!(
+        be.get_data("photos", "cat.png", 0, u64::MAX)
+            .await
+            .map_err(err)?,
+        b"meow".to_vec()
+    );
+    // Inclusive byte range [0, 1].
+    assert_eq!(
+        be.get_data("photos", "cat.png", 0, 1).await.map_err(err)?,
+        b"me".to_vec()
+    );
+    assert_eq!(
+        be.object_info("photos", "cat.png").await.map_err(err)?.size,
+        4
+    );
+
+    // --- listing ---
+    be.write_data("photos", "dog.png", b"woof".to_vec())
+        .await
+        .map_err(err)?;
+    let mut names = be.list_objects("photos").await.map_err(err)?;
+    names.sort();
+    assert_eq!(names, vec!["cat.png".to_string(), "dog.png".to_string()]);
+
+    // --- copy ---
+    be.copy_object("photos", "cat.png", "photos", "cat-copy.png")
+        .await
+        .map_err(err)?;
+    assert_eq!(
+        be.get_data("photos", "cat-copy.png", 0, u64::MAX)
+            .await
+            .map_err(err)?,
+        b"meow".to_vec()
+    );
+
+    // --- delete + clear ---
+    be.delete_object("photos", "dog.png").await.map_err(err)?;
+    assert!(!be.has_object("photos", "dog.png").await.map_err(err)?);
+    // Deleting a missing object is idempotent.
+    be.delete_object("photos", "dog.png").await.map_err(err)?;
+
+    be.clear_container("photos").await.map_err(err)?;
+    assert!(be.list_objects("photos").await.map_err(err)?.is_empty());
+
+    // --- container deletion ---
+    be.delete_container("photos").await.map_err(err)?;
+    assert!(!be.container_exists("photos").await.map_err(err)?);
+    // Reading a deleted container surfaces an error.
+    assert!(
+        be.get_data("photos", "cat.png", 0, u64::MAX).await.is_err(),
+        "reading from a deleted container must error"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_blobstore_implements_p3.rs
+++ b/crates/wash-runtime/tests/integration_blobstore_implements_p3.rs
@@ -1,0 +1,159 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! End-to-end `(implements ..)` routing of the async, native-stream
+//! `wasmcloud:blobstore@0.1.0` through a **real P3 guest**, backed by NATS.
+//!
+//! The `blobstore-implements-p3` fixture imports the async blobstore under the
+//! labels `store-a` (the `blobstore` interface) and `objects-a` (the `container`
+//! interface). On each request it creates a container, streams an object body in
+//! via `write-data(name, stream<u8>)`, reads it back out via
+//! `get-data(..) -> stream<u8>`, and returns the bytes.
+//!
+//! The host binds a single [`MultiplexedAsyncBlobstore`] with a NATS provider and
+//! declares the two named interfaces routed to the Dockerized NATS object store.
+//! A 200 whose body echoes the written bytes proves the concurrent/stream host
+//! ABI works end to end through a guest — the producer (`get-data`), the consumer
+//! (`write-data`), and the implements id threading — against a real backend.
+//!
+//! Requires Docker (NATS JetStream); marked `#[ignore]`, so it runs only under
+//! `cargo test --include-ignored`.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use testcontainers::{
+    GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::wasi_blobstore::{MultiplexedAsyncBlobstore, NatsBlobProvider},
+    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
+    wit::WitInterface,
+};
+
+mod common;
+use common::http_incoming_handler_interface;
+
+const BLOBSTORE_IMPLEMENTS_P3_WASM: &[u8] = include_bytes!("wasm/blobstore_implements_p3.wasm");
+
+/// A named async `wasmcloud:blobstore` interface routed to the NATS backend.
+/// `name` is the `(implements ..)` label the guest imports under; `iface` is the
+/// blobstore sub-interface (`blobstore` or `container`).
+fn nats_blob_iface(name: &str, iface: &str, url: &str) -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "blobstore".to_string(),
+        interfaces: [iface.to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.1.0").unwrap()),
+        config: HashMap::from([
+            ("backend".to_string(), "nats".to_string()),
+            ("url".to_string(), url.to_string()),
+        ]),
+        name: Some(name.to_string()),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (NATS JetStream); run with `cargo test --include-ignored`"]
+async fn p3_guest_streams_blobstore_through_nats() -> Result<()> {
+    // --- NATS container (JetStream enabled for the object store) ---
+    let nats = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
+    let nats_port = nats.get_host_port_ipv4(4222).await?;
+    let nats_url = format!("nats://127.0.0.1:{nats_port}");
+
+    // --- host with the async multiplexed blobstore plugin + NATS provider ---
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_server.addr();
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(
+            MultiplexedAsyncBlobstore::new().with_provider(Arc::new(NatsBlobProvider)),
+        ))?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    // The guest's `store-a` (blobstore) and `objects-a` (container) implements
+    // imports both route to the same NATS server (pooled by url).
+    let host_interfaces = vec![
+        http_incoming_handler_interface("blob-impl", None),
+        nats_blob_iface("store-a", "blobstore", &nats_url),
+        nats_blob_iface("objects-a", "container", &nats_url),
+    ];
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "blobstore-implements-p3".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "blobstore-implements-p3.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(BLOBSTORE_IMPLEMENTS_P3_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    };
+
+    // Binding runs the named-imports `add_to_linker` for both `store-a` and
+    // `objects-a`. `workload_start` returns Ok even on resolution failure (it
+    // encodes the error in the status), so assert it actually reached Running.
+    let resp = host
+        .workload_start(req)
+        .await
+        .context("workload_start call failed")?;
+    assert_eq!(
+        resp.workload_status.workload_state,
+        WorkloadState::Running,
+        "workload should resolve: {}",
+        resp.workload_status.message
+    );
+
+    // Drive the guest: it creates a container, streams an object in, reads it
+    // back, and echoes the bytes. A matching body proves the stream ABI flowed
+    // both directions through the real NATS object store.
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(15),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "blob-impl")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+
+    let status = response.status();
+    let body = response.text().await?;
+    assert!(status.is_success(), "expected 200, got {status}: {body}");
+    assert_eq!(
+        body, "meow from a real p3 guest",
+        "the guest must round-trip the object body through the NATS-backed stream ABI"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_keyvalue_aba_implements_p3.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_aba_implements_p3.rs
@@ -1,0 +1,136 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! End-to-end ABA test for async `wasmcloud:keyvalue` compare-and-swap through a
+//! **real P3 guest**, routed via `(implements ..)`.
+//!
+//! The `keyvalue-implements-p3` fixture opens a bucket through the labeled `kv`
+//! (`store`) import, then `set k=A`, `current(k) -> v1`, `set k=B`, `set k=A`,
+//! and asserts (via `store`/`cas`/`atomics`/`batch`, all on that one bucket):
+//!
+//! - `swap(k, C, require_version=v1)` is `stale` — the value returned to
+//!   identical bytes (A → B → A), so a content-hash version would wrongly
+//!   succeed; the backend's monotonic version makes it stale (ABA detected).
+//! - a swap pinned to the *current* version succeeds — so the stale result is a
+//!   real precondition miss, not an always-stale backend.
+//! - a swap with empty `cas-options` is rejected with `invalid-argument`.
+//! - `atomics.increment` and `batch` get/set/delete-many round-trip correctly.
+//!
+//! The guest answers `ok` only when all hold.
+//!
+//! This exercises the full async/concurrent host ABI through a guest — the
+//! `store.open` label routing, the shared `types.bucket` resource, and the
+//! standalone `cas` `current`/`swap` host methods calling the backend's atomic
+//! compare-and-set — against the in-memory backend, so it needs no Docker.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::wasi_keyvalue::{InMemoryProvider, MultiplexedAsyncKeyValue},
+    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
+    wit::WitInterface,
+};
+
+mod common;
+use common::http_incoming_handler_interface;
+
+const KEYVALUE_IMPLEMENTS_P3_WASM: &[u8] = include_bytes!("wasm/keyvalue_implements_p3.wasm");
+
+/// The labeled `store` import (`kv`), routed to an in-memory backend. `cas` is
+/// bound standalone and needs no declaration — it operates on the bucket the
+/// guest opens through this label.
+fn kv_store_iface(name: &str) -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: ["store".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.1.0").unwrap()),
+        config: HashMap::from([("backend".to_string(), "in-memory".to_string())]),
+        name: Some(name.to_string()),
+    }
+}
+
+#[tokio::test]
+async fn p3_guest_cas_swap_detects_aba() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_server.addr();
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(
+            MultiplexedAsyncKeyValue::new().with_provider(Arc::new(InMemoryProvider)),
+        ))?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    let host_interfaces = vec![
+        http_incoming_handler_interface("kv-impl", None),
+        kv_store_iface("kv"),
+    ];
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "keyvalue-implements-p3".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "keyvalue-implements-p3.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(KEYVALUE_IMPLEMENTS_P3_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    };
+
+    // Binding runs `add_to_linker` for the named `store` plus standalone
+    // `types`/`cas`. Assert the workload actually reached Running (a labeled
+    // store + cas guest is exactly the case the WIT restructure enables).
+    let resp = host
+        .workload_start(req)
+        .await
+        .context("workload_start call failed")?;
+    assert_eq!(
+        resp.workload_status.workload_state,
+        WorkloadState::Running,
+        "workload should resolve (labeled store + standalone cas): {}",
+        resp.workload_status.message
+    );
+
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(15),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "kv-impl")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+
+    let status = response.status();
+    let body = response.text().await?;
+    assert!(status.is_success(), "expected 200, got {status}: {body}");
+    assert_eq!(
+        body, "ok",
+        "guest must observe: ABA swap stale, current-version swap succeeds, empty cas-options rejected"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_keyvalue_async_coexistence.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_async_coexistence.rs
@@ -1,0 +1,202 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! Coexistence of the standalone, sync-multiplexed, and **async-multiplexed**
+//! keyvalue plugins on a single host.
+//!
+//! The production host (see `wash`'s `host`/`dev`) registers all three on one
+//! builder:
+//!   * [`InMemoryKeyValue`] — standalone `wasi:keyvalue`, serves unnamed imports;
+//!   * [`MultiplexedKeyValue`] — `(implements ..)` `wasi:keyvalue`, serves named;
+//!   * [`MultiplexedAsyncKeyValue`] — `(implements ..)` async `wasmcloud:keyvalue`.
+//!
+//! Existing tests cover the standalone + sync-multiplexed pair. This adds the
+//! async plugin to the mix and runs two workloads on the one host:
+//!   * a sync `wasi:keyvalue` guest (`keyvalue-counter`) — unnamed (→ standalone)
+//!     plus a named interface (→ sync multiplexed);
+//!   * the async `wasmcloud:keyvalue` guest (`keyvalue-implements-p3`) —
+//!     labeled `store` plus standalone `atomics`/`cas`/`batch`.
+//!
+//! Both reaching `Running` is the coexistence proof: the three plugins'
+//! `add_to_linker` registrations don't conflict on one host. The async guest is
+//! then driven over HTTP (store/cas/atomics/batch → `ok`) to confirm the async
+//! path works alongside the sync plugins. (The `DevRouter` is single-component,
+//! so it can't HTTP-route both workloads; the sync counter's standalone routing
+//! is covered by `integration_keyvalue_coexistence`.) In-memory, so no Docker.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::wasi_keyvalue::{
+        InMemoryKeyValue, InMemoryProvider, MultiplexedAsyncKeyValue, MultiplexedKeyValue,
+    },
+    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
+    wit::WitInterface,
+};
+
+mod common;
+use common::http_incoming_handler_interface;
+
+const KEYVALUE_COUNTER_WASM: &[u8] = include_bytes!("wasm/keyvalue_counter.wasm");
+const KEYVALUE_IMPLEMENTS_P3_WASM: &[u8] = include_bytes!("wasm/keyvalue_implements_p3.wasm");
+
+/// A `wasi:keyvalue@0.2.0-draft` interface (store+atomics). `name = None` is the
+/// unnamed import (→ standalone); a name routes to the sync multiplexed plugin.
+fn wasi_kv_iface(name: Option<&str>) -> WitInterface {
+    let mut config = HashMap::new();
+    if name.is_some() {
+        config.insert("backend".to_string(), "in-memory".to_string());
+    }
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: ["store".to_string(), "atomics".to_string()]
+            .into_iter()
+            .collect(),
+        version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+        config,
+        name: name.map(String::from),
+    }
+}
+
+/// The labeled async `wasmcloud:keyvalue/store` import (→ async multiplexed).
+fn wasmcloud_kv_store(name: &str) -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: ["store".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.1.0").unwrap()),
+        config: HashMap::from([("backend".to_string(), "in-memory".to_string())]),
+        name: Some(name.to_string()),
+    }
+}
+
+fn workload(
+    name: &str,
+    component: &str,
+    wasm: &'static [u8],
+    host_interfaces: Vec<WitInterface>,
+) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: name.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: component.to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(wasm),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    }
+}
+
+#[tokio::test]
+async fn standalone_sync_and_async_keyvalue_coexist() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_server.addr();
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
+        .with_plugin(Arc::new(
+            MultiplexedKeyValue::new().with_provider(Arc::new(InMemoryProvider)),
+        ))?
+        .with_plugin(Arc::new(
+            MultiplexedAsyncKeyValue::new().with_provider(Arc::new(InMemoryProvider)),
+        ))?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    // Sync wasi:keyvalue workload: unnamed (→ standalone) + named (→ sync mux).
+    let sync = workload(
+        "kv-sync",
+        "keyvalue-counter.wasm",
+        KEYVALUE_COUNTER_WASM,
+        vec![
+            http_incoming_handler_interface("kv-sync", None),
+            wasi_kv_iface(None),
+            wasi_kv_iface(Some("cache")),
+        ],
+    );
+    let resp = host
+        .workload_start(sync)
+        .await
+        .context("sync keyvalue workload_start failed")?;
+    assert_eq!(
+        resp.workload_status.workload_state,
+        WorkloadState::Running,
+        "standalone + sync-multiplexed keyvalue should run: {}",
+        resp.workload_status.message
+    );
+
+    // Async wasmcloud:keyvalue workload on the SAME host.
+    let async_ = workload(
+        "kv-async",
+        "keyvalue-implements-p3.wasm",
+        KEYVALUE_IMPLEMENTS_P3_WASM,
+        vec![
+            http_incoming_handler_interface("kv-async", None),
+            wasmcloud_kv_store("kv"),
+        ],
+    );
+    let resp = host
+        .workload_start(async_)
+        .await
+        .context("async keyvalue workload_start failed")?;
+    assert_eq!(
+        resp.workload_status.workload_state,
+        WorkloadState::Running,
+        "async-multiplexed keyvalue should run alongside the sync plugins: {}",
+        resp.workload_status.message
+    );
+
+    // Both workloads reaching `Running` above is the coexistence proof: the
+    // standalone, sync-multiplexed, and async-multiplexed plugins all ran their
+    // `add_to_linker` on this one host without conflict. The sync counter's
+    // standalone routing is covered by `integration_keyvalue_coexistence`; here
+    // the `DevRouter` is single-component (it can't route two HTTP workloads by
+    // HOST header), so we drive the async guest — last-started, so it is the one
+    // served — to confirm the async path works end-to-end alongside the sync
+    // plugins.
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(15),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "kv-async")
+            .send(),
+    )
+    .await
+    .context("async request timed out")?
+    .context("async request failed")?;
+    let status = response.status();
+    let body = response.text().await?;
+    assert!(
+        status.is_success(),
+        "async expected 200, got {status}: {body}"
+    );
+    assert_eq!(
+        body, "ok",
+        "async wasmcloud:keyvalue guest (store/cas/atomics/batch) must work alongside the sync plugins"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_keyvalue_redis_interop.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_redis_interop.rs
@@ -1,0 +1,161 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! Interop test for the multiplexed redis [`KvBackend`]: it speaks a **flat
+//! redis keyspace** (like the v1 wasmCloud redis provider), so it can read and
+//! write keys created/managed by any other redis client and not a private
+//! per-bucket layout.
+//!
+//! Drives a real redis container directly through the backend (no host/guest):
+//!   1. a raw redis client `SET`s a plain key; the backend `get`s it back;
+//!   2. the backend `set`s a key; a raw redis client `GET`s it back;
+//!   3. a raw client seeds a counter; the backend `increment`s it (signed),
+//!      and the raw client sees the new value — proving `INCRBY` semantics.
+//!
+//! Requires Docker (redis); marked `#[ignore]`, so it runs only under
+//! `cargo test --include-ignored`.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use redis::AsyncCommands;
+use testcontainers::{
+    GenericImage,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+use wash_runtime::plugin::multiplex::BackendProvider;
+use wash_runtime::plugin::wasi_keyvalue::RedisProvider;
+
+// The flat backend ignores the bucket identifier for key naming (the connection
+// is the keyspace), so any value works here.
+const BUCKET: &str = "ignored";
+
+#[tokio::test]
+#[ignore = "requires Docker (redis); run with `cargo test --include-ignored`"]
+async fn redis_backend_interops_with_a_raw_keyspace() -> Result<()> {
+    let redis = GenericImage::new("redis", "7-alpine")
+        .with_exposed_port(6379.tcp())
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start redis: {e}"))?;
+    let url = format!(
+        "redis://127.0.0.1:{}",
+        redis.get_host_port_ipv4(6379).await?
+    );
+
+    // A raw redis client, standing in for "someone else" managing the keyspace.
+    let raw_client = redis::Client::open(url.as_str())?;
+    let mut raw = raw_client.get_multiplexed_async_connection().await?;
+
+    // The multiplexed backend pointed at the same redis (no prefix => flat).
+    let backend: wash_runtime::plugin::wasi_keyvalue::KvId = RedisProvider
+        .instantiate(&HashMap::from([
+            ("backend".to_string(), "redis".to_string()),
+            ("url".to_string(), url.clone()),
+        ]))
+        .await
+        .context("failed to instantiate redis backend")?;
+
+    // 1. Raw client writes a plain key; the backend reads it back.
+    raw.set::<_, _, ()>("external-key", b"hello from raw redis".to_vec())
+        .await?;
+    let got = backend
+        .get(BUCKET, "external-key")
+        .await
+        .map_err(|e| anyhow::anyhow!("backend.get failed: {e:?}"))?;
+    assert_eq!(
+        got.as_deref(),
+        Some(b"hello from raw redis".as_slice()),
+        "backend must read a key created by a raw redis client"
+    );
+
+    // 2. Backend writes a key; the raw client reads it back (plain, no wrapping).
+    backend
+        .set(BUCKET, "from-backend", b"hello from backend".to_vec())
+        .await
+        .map_err(|e| anyhow::anyhow!("backend.set failed: {e:?}"))?;
+    let raw_value: Option<Vec<u8>> = raw.get("from-backend").await?;
+    assert_eq!(
+        raw_value.as_deref(),
+        Some(b"hello from backend".as_slice()),
+        "a raw redis client must see the backend's write as a plain key"
+    );
+
+    // 3. Signed increment interops with a raw INCRBY counter.
+    raw.set::<_, _, ()>("counter", "10").await?;
+    let incremented = backend
+        .increment(BUCKET, "counter", 5)
+        .await
+        .map_err(|e| anyhow::anyhow!("backend.increment failed: {e:?}"))?;
+    assert_eq!(
+        incremented, 15,
+        "increment must build on the raw counter value"
+    );
+    let raw_counter: i64 = raw.get("counter").await?;
+    assert_eq!(
+        raw_counter, 15,
+        "a raw redis client must see the incremented counter"
+    );
+
+    // 4. The optional `prefix` namespaces keys within the same DB. A prefixed
+    // backend maps logical key `k` to redis key `app1:k`, and isolates from the
+    // flat keys written above.
+    let prefixed: wash_runtime::plugin::wasi_keyvalue::KvId = RedisProvider
+        .instantiate(&HashMap::from([
+            ("backend".to_string(), "redis".to_string()),
+            ("url".to_string(), url.clone()),
+            ("prefix".to_string(), "app1:".to_string()),
+        ]))
+        .await
+        .context("failed to instantiate prefixed redis backend")?;
+
+    // A prefixed write lands under the prefix in the raw keyspace...
+    prefixed
+        .set(BUCKET, "k", b"v".to_vec())
+        .await
+        .map_err(|e| anyhow::anyhow!("prefixed set failed: {e:?}"))?;
+    let raw_prefixed: Option<Vec<u8>> = raw.get("app1:k").await?;
+    assert_eq!(
+        raw_prefixed.as_deref(),
+        Some(b"v".as_slice()),
+        "a prefixed backend must write to `{{prefix}}{{key}}` in the raw keyspace"
+    );
+
+    // ...and a raw key under the prefix is read back by its logical name.
+    raw.set::<_, _, ()>("app1:external", b"x".to_vec()).await?;
+    let via_prefixed = prefixed
+        .get(BUCKET, "external")
+        .await
+        .map_err(|e| anyhow::anyhow!("prefixed get failed: {e:?}"))?;
+    assert_eq!(
+        via_prefixed.as_deref(),
+        Some(b"x".as_slice()),
+        "a prefixed backend must read `{{prefix}}{{key}}` by its logical key"
+    );
+
+    // Isolation: the unprefixed backend does not see the prefixed key, and the
+    // prefixed `list-keys` returns logical (stripped) names, not the flat keys.
+    let flat_view = backend
+        .get(BUCKET, "external")
+        .await
+        .map_err(|e| anyhow::anyhow!("unprefixed get failed: {e:?}"))?;
+    assert!(
+        flat_view.is_none(),
+        "the unprefixed backend must not see a prefixed key"
+    );
+    let mut listed = prefixed
+        .list_keys(BUCKET, None)
+        .await
+        .map_err(|e| anyhow::anyhow!("prefixed list_keys failed: {e:?}"))?
+        .keys;
+    listed.sort();
+    assert_eq!(
+        listed,
+        vec!["external".to_string(), "k".to_string()],
+        "prefixed list-keys must return logical keys (prefix stripped), isolated from flat keys"
+    );
+
+    Ok(())
+}

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -248,14 +248,14 @@ impl CliCommand for DevCommand {
                     .with_provider(Arc::new(plugin::wasi_blobstore::FilesystemProvider))
                     .with_provider(Arc::new(plugin::wasi_blobstore::NatsBlobProvider)),
             ))?;
-            debug!("WASI Blobstore multiplexed plugin registered (implements)");
+            debug!("wasi:blobstore multiplexed plugin registered (implements)");
             host_builder = host_builder.with_plugin(Arc::new(
                 plugin::wasi_blobstore::MultiplexedAsyncBlobstore::new()
                     .with_provider(Arc::new(plugin::wasi_blobstore::InMemoryProvider))
                     .with_provider(Arc::new(plugin::wasi_blobstore::FilesystemProvider))
                     .with_provider(Arc::new(plugin::wasi_blobstore::NatsBlobProvider)),
             ))?;
-            debug!("wasmcloud Blobstore async multiplexed plugin registered (implements)");
+            debug!("wasmcloud:blobstore async multiplexed plugin registered (implements)");
             host_builder = host_builder.with_plugin(Arc::new(
                 plugin::wasi_keyvalue::MultiplexedAsyncKeyValue::new()
                     .with_provider(Arc::new(plugin::wasi_keyvalue::InMemoryProvider))
@@ -263,7 +263,7 @@ impl CliCommand for DevCommand {
                     .with_provider(Arc::new(plugin::wasi_keyvalue::NatsProvider))
                     .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
             ))?;
-            debug!("wasmcloud KeyValue async multiplexed plugin registered (implements)");
+            debug!("wasmcloud:keyvalue async multiplexed plugin registered (implements)");
         }
 
         // Add postgres plugin if configured

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -242,6 +242,28 @@ impl CliCommand for DevCommand {
                     .with_provider(Arc::new(plugin::wasmcloud_messaging::NatsMsgProvider)),
             ))?;
             debug!("wasmcloud:messaging multiplexed plugin registered (implements)");
+            host_builder = host_builder.with_plugin(Arc::new(
+                plugin::wasi_blobstore::MultiplexedBlobstore::new()
+                    .with_provider(Arc::new(plugin::wasi_blobstore::InMemoryProvider))
+                    .with_provider(Arc::new(plugin::wasi_blobstore::FilesystemProvider))
+                    .with_provider(Arc::new(plugin::wasi_blobstore::NatsBlobProvider)),
+            ))?;
+            debug!("WASI Blobstore multiplexed plugin registered (implements)");
+            host_builder = host_builder.with_plugin(Arc::new(
+                plugin::wasi_blobstore::MultiplexedAsyncBlobstore::new()
+                    .with_provider(Arc::new(plugin::wasi_blobstore::InMemoryProvider))
+                    .with_provider(Arc::new(plugin::wasi_blobstore::FilesystemProvider))
+                    .with_provider(Arc::new(plugin::wasi_blobstore::NatsBlobProvider)),
+            ))?;
+            debug!("wasmcloud Blobstore async multiplexed plugin registered (implements)");
+            host_builder = host_builder.with_plugin(Arc::new(
+                plugin::wasi_keyvalue::MultiplexedAsyncKeyValue::new()
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::InMemoryProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::RedisProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::NatsProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
+            ))?;
+            debug!("wasmcloud KeyValue async multiplexed plugin registered (implements)");
         }
 
         // Add postgres plugin if configured

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -211,6 +211,25 @@ impl CliCommand for HostCommand {
                     .with_provider(Arc::new(plugin::wasmcloud_messaging::InMemoryMsgProvider))
                     .with_provider(Arc::new(plugin::wasmcloud_messaging::NatsMsgProvider)),
             ))?;
+            cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
+                plugin::wasi_blobstore::MultiplexedBlobstore::new()
+                    .with_provider(Arc::new(plugin::wasi_blobstore::InMemoryProvider))
+                    .with_provider(Arc::new(plugin::wasi_blobstore::FilesystemProvider))
+                    .with_provider(Arc::new(plugin::wasi_blobstore::NatsBlobProvider)),
+            ))?;
+            cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
+                plugin::wasi_blobstore::MultiplexedAsyncBlobstore::new()
+                    .with_provider(Arc::new(plugin::wasi_blobstore::InMemoryProvider))
+                    .with_provider(Arc::new(plugin::wasi_blobstore::FilesystemProvider))
+                    .with_provider(Arc::new(plugin::wasi_blobstore::NatsBlobProvider)),
+            ))?;
+            cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
+                plugin::wasi_keyvalue::MultiplexedAsyncKeyValue::new()
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::InMemoryProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::RedisProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::NatsProvider))
+                    .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
+            ))?;
         }
 
         if let Some(postgres_url) = &self.postgres_url {

--- a/wit/keyvalue/wit/atomics.wit
+++ b/wit/keyvalue/wit/atomics.wit
@@ -9,7 +9,8 @@ interface atomics {
   use types.{bucket, error};
 
   /// Atomically increment the value associated with the key in the store by the given (signed)
-  /// delta. It returns the new value.
+  /// delta, returning the new value. A negative delta decrements, where decrement is just a
+  /// negative increment, rather than `wasi:keyvalue`'s unsigned-only counter.
   ///
   /// If the key does not exist in the store, it creates a new key-value pair with the value set
   /// to the given delta.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -112,6 +112,8 @@ const P3_FIXTURES: &[&str] = &[
     "res-caller-p3",
     "ephemeral-callee-p3",
     "ephemeral-caller-p3",
+    "blobstore-implements-p3",
+    "keyvalue-implements-p3",
 ];
 
 // Fixtures with local-only WIT worlds (no wasi imports). Copying shared


### PR DESCRIPTION
## Multiplex async `wasmcloud:keyvalue` and `wasmcloud:blobstore`

Adds `(implements ..)` routing so one component can import these interfaces multiple times, each backed by a different backend (in-memory / redis / NATS / filesystem). `store.open` / `blobstore` are routed per label; the bucket/container resource and the extension interfaces (`atomics`/`cas`/`batch`, `container`) bind standalone and route via the backend the resource was opened through.

- **Compare-and-swap** is pushed into the backend with a write-monotonic, ABA-safe version (in-memory counter, NATS `revision`); redis/filesystem decline.
- **`if-not-exists`** is an atomic `put_if_absent` (in-memory lock / redis `SETNX` / NATS `create`).
- **`atomics.increment`** is signed (`s64`, decrement via negative), matching Redis/DynamoDB/etc.; overflow errors on every backend.
- **Redis** uses a flat keyspace, so it interoperates with an externally-managed redis dataset (like the v1 provider), with an optional `prefix` config.
- **Async blobstore** streams object bodies as native `stream<u8>` (wasip3).

New test fixtures with P3 guests: a keyvalue guest exercising store/cas/atomics/batch (incl. an ABA-safety check) and verified non-labeled are able to coexist with multiplexed plugin backends. Added e2e redis interop and blobstore-over-NATS.