### PR TITLE
test(runtime-operator): cover host controller reconcile paths

### DIFF
--- a/runtime-operator/go.mod
+++ b/runtime-operator/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.6.0+incompatible
+	github.com/go-logr/logr v1.4.3
 	github.com/goccy/go-yaml v1.19.2
 	github.com/google/go-cmp v0.7.0
 	github.com/nats-io/nats-server/v2 v2.14.2
@@ -52,7 +53,6 @@ require (
 	github.com/flowerinthenight/kubepfm v1.7.3 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/runtime-operator/internal/controller/runtime/host_controller.go
+++ b/runtime-operator/internal/controller/runtime/host_controller.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-logr/logr"
 	"google.golang.org/protobuf/encoding/protojson"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,6 +125,22 @@ func (r *HostReconciler) finalize(ctx context.Context, host *runtimev1alpha1.Hos
 	return nil
 }
 
+// deleteUnresponsiveHost is the reconcile post-hook: a Host whose Ready
+// condition has resolved to a definite not-ready (neither True nor Unknown)
+// is deleted, and its finalizer cleans up assigned workloads. While Ready is
+// still Unknown the host is left in place so a recovering host is not deleted
+// out from under in-flight heartbeats.
+func (r *HostReconciler) deleteUnresponsiveHost(ctx context.Context, host *runtimev1alpha1.Host) error {
+	if host.Status.AllTrue(condition.TypeReady) {
+		return nil
+	}
+	if host.Status.AnyUnknown(condition.TypeReady) {
+		return nil
+	}
+	// Delete unresponsive host; the finalizer will clean up assigned workloads.
+	return r.Delete(ctx, host)
+}
+
 // SetupWithManager sets up the controller with the Manager.
 // +kubebuilder:rbac:groups=runtime.wasmcloud.dev,resources=hosts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=runtime.wasmcloud.dev,resources=hosts/status,verbs=get;update;patch
@@ -140,16 +157,7 @@ func (r *HostReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	reconciler.SetCondition(runtimev1alpha1.HostConditionReporting, r.reconcileReporting)
 	reconciler.SetCondition(condition.TypeReady, r.reconcileReady)
 
-	reconciler.AddPostHook(func(ctx context.Context, host *runtimev1alpha1.Host) error {
-		if host.Status.AllTrue(condition.TypeReady) {
-			return nil
-		}
-		if host.Status.AnyUnknown(condition.TypeReady) {
-			return nil
-		}
-		// Delete unresponsive host; the finalizer will clean up assigned workloads.
-		return r.Delete(ctx, host)
-	})
+	reconciler.AddPostHook(r.deleteUnresponsiveHost)
 
 	r.reconciler = reconciler
 
@@ -202,69 +210,77 @@ func (h *hostStatusUpdater) Start(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx).WithName("host-status-updater")
 
 	subscription.Handle(func(msg *wasmbus.Message) {
-		var req runtimev2.HostHeartbeat
-		if err := protojson.Unmarshal(msg.Data, &req); err != nil {
-			log.Error(err, "failed to decode heartbeat message")
-			return
-		}
-
-		// Every Host object lives in the operator's own namespace. Tenant
-		// attribution is recorded on the Host's Environment field,
-		// populated verbatim from req.Environment — the heartbeat is the
-		// source of truth and is not validated against cluster state.
-		//
-		// Upsert spec and metadata with Server-Side Apply in case the object was
-		// updated by another process, and the cache is stale.
-		host := &runtimev1alpha1.Host{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: runtimev1alpha1.GroupVersion.String(),
-				Kind:       "Host",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      req.FriendlyName,
-				Namespace: h.operatorNamespace,
-				Labels:    req.GetLabels(),
-			},
-			HostID:      req.Id,
-			Hostname:    req.Hostname,
-			HTTPPort:    req.HttpPort,
-			Environment: req.GetEnvironment(),
-		}
-		// Read the current state from the cache to see if the values in the heartbeat changed.
-		existing := &runtimev1alpha1.Host{}
-		getErr := h.client.Get(ctx,
-			types.NamespacedName{Name: req.FriendlyName, Namespace: h.operatorNamespace},
-			existing)
-		if getErr != nil && !apierrors.IsNotFound(getErr) {
-			log.Error(getErr, "failed to read Host resource", "host", req.FriendlyName, "hostID", req.Id)
-			return
-		}
-
-		if apierrors.IsNotFound(getErr) || hostSpecChanged(existing, host) {
-			// adding a nolint check to allow for client.apply, as the Host CRD
-			// would need to have an ApplyConfiguration generated for it, and thus a
-			// new CRD version would be required.
-			if err := h.client.Patch(ctx, host, client.Apply, //nolint:staticcheck
-				client.FieldOwner("host-status-updater"), client.ForceOwnership); err != nil {
-				log.Error(err, "failed to apply Host resource", "host", req.FriendlyName, "hostID", req.Id)
-				return
-			}
-		}
-
-		// Patching the status subresource to update the LastSeen timestamp in case
-		// the other fields reported are not yet available (such as system/OS information).
-		statusPatch, err := hostStatusPatch(&host.Status)
-		if err != nil {
-			log.Error(err, "failed to build Host status patch", "host", req.FriendlyName, "hostID", req.Id)
-			return
-		}
-		if err := h.client.Status().Patch(ctx, host, client.RawPatch(types.MergePatchType, statusPatch)); err != nil {
-			log.Error(err, "failed to update Host status", "host", req.FriendlyName, "hostID", req.Id)
-		}
+		h.handleHeartbeat(ctx, log, msg.Data)
 	})
 
 	<-ctx.Done()
 	return subscription.Drain()
+}
+
+// handleHeartbeat decodes a single heartbeat payload and reconciles the
+// corresponding Host: it applies spec/metadata via Server-Side Apply only when
+// the heartbeat differs from the stored object, then always refreshes the
+// status subresource so LastSeen advances even when the spec is unchanged.
+func (h *hostStatusUpdater) handleHeartbeat(ctx context.Context, log logr.Logger, data []byte) {
+	var req runtimev2.HostHeartbeat
+	if err := protojson.Unmarshal(data, &req); err != nil {
+		log.Error(err, "failed to decode heartbeat message")
+		return
+	}
+
+	// Every Host object lives in the operator's own namespace. Tenant
+	// attribution is recorded on the Host's Environment field,
+	// populated verbatim from req.Environment — the heartbeat is the
+	// source of truth and is not validated against cluster state.
+	//
+	// Upsert spec and metadata with Server-Side Apply in case the object was
+	// updated by another process, and the cache is stale.
+	host := &runtimev1alpha1.Host{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: runtimev1alpha1.GroupVersion.String(),
+			Kind:       "Host",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.FriendlyName,
+			Namespace: h.operatorNamespace,
+			Labels:    req.GetLabels(),
+		},
+		HostID:      req.Id,
+		Hostname:    req.Hostname,
+		HTTPPort:    req.HttpPort,
+		Environment: req.GetEnvironment(),
+	}
+	// Read the current state from the cache to see if the values in the heartbeat changed.
+	existing := &runtimev1alpha1.Host{}
+	getErr := h.client.Get(ctx,
+		types.NamespacedName{Name: req.FriendlyName, Namespace: h.operatorNamespace},
+		existing)
+	if getErr != nil && !apierrors.IsNotFound(getErr) {
+		log.Error(getErr, "failed to read Host resource", "host", req.FriendlyName, "hostID", req.Id)
+		return
+	}
+
+	if apierrors.IsNotFound(getErr) || hostSpecChanged(existing, host) {
+		// adding a nolint check to allow for client.apply, as the Host CRD
+		// would need to have an ApplyConfiguration generated for it, and thus a
+		// new CRD version would be required.
+		if err := h.client.Patch(ctx, host, client.Apply, //nolint:staticcheck
+			client.FieldOwner("host-status-updater"), client.ForceOwnership); err != nil {
+			log.Error(err, "failed to apply Host resource", "host", req.FriendlyName, "hostID", req.Id)
+			return
+		}
+	}
+
+	// Patching the status subresource to update the LastSeen timestamp in case
+	// the other fields reported are not yet available (such as system/OS information).
+	statusPatch, err := hostStatusPatch(&host.Status)
+	if err != nil {
+		log.Error(err, "failed to build Host status patch", "host", req.FriendlyName, "hostID", req.Id)
+		return
+	}
+	if err := h.client.Status().Patch(ctx, host, client.RawPatch(types.MergePatchType, statusPatch)); err != nil {
+		log.Error(err, "failed to update Host status", "host", req.FriendlyName, "hostID", req.Id)
+	}
 }
 
 // hostSpecChanged returns true if any of the stored metadata

--- a/runtime-operator/internal/controller/runtime/host_controller_test.go
+++ b/runtime-operator/internal/controller/runtime/host_controller_test.go
@@ -3,18 +3,35 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
+	"google.golang.org/protobuf/encoding/protojson"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
+	runtimev2 "go.wasmcloud.dev/runtime-operator/v2/pkg/rpc/wasmcloud/runtime/v2"
+	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus"
+)
+
+// Shared test fixtures for host OS arch and version, factored out so repeated
+// literals stay consistent across the suite.
+const (
+	testOSArch  = "arm64"
+	testVersion = "1.2.3"
 )
 
 // requiredHostStatusKeys are the status fields the Host CRD marks as required.
@@ -68,9 +85,9 @@ func TestHostStatusPatch_EmptyStatusInjectsRequiredKeys(t *testing.T) {
 // written by reconcileReporting — only lastSeen is refreshed.
 func TestHostStatusPatch_ReportedFieldsPreserved(t *testing.T) {
 	keys := patchStatusKeys(t, &runtimev1alpha1.HostStatus{
-		Version:           "1.2.3",
+		Version:           testVersion,
 		OSName:            "linux",
-		OSArch:            "arm64",
+		OSArch:            testOSArch,
 		OSKernel:          "6.1.0",
 		SystemCPUUsage:    "0.5",
 		SystemMemoryTotal: 16000,
@@ -168,8 +185,8 @@ func TestHostStatusPatch_SatisfiesCRDRequired(t *testing.T) {
 
 	// A second patch after the host has reported real values must preserve them
 	// (only lastSeen changes), mirroring steady-state heartbeats.
-	got.Status.OSArch = "arm64"
-	got.Status.Version = "1.2.3"
+	got.Status.OSArch = testOSArch
+	got.Status.Version = testVersion
 	if err := c.Status().Update(ctx, got); err != nil {
 		t.Fatalf("seed reported status: %v", err)
 	}
@@ -184,7 +201,7 @@ func TestHostStatusPatch_SatisfiesCRDRequired(t *testing.T) {
 	if err := c.Get(ctx, client.ObjectKeyFromObject(host), after); err != nil {
 		t.Fatalf("get host after second patch: %v", err)
 	}
-	if after.Status.OSArch != "arm64" || after.Status.Version != "1.2.3" {
+	if after.Status.OSArch != testOSArch || after.Status.Version != testVersion {
 		t.Errorf("reported values clobbered by heartbeat patch: %+v", after.Status)
 	}
 }
@@ -252,5 +269,399 @@ func TestHostApply_UpsertIsIdempotent(t *testing.T) {
 	}
 	if updated.UID != created.UID {
 		t.Errorf("update replaced the object (UID changed) instead of patching in place")
+	}
+}
+
+// hostWith builds a Host carrying only the metadata spec fields that
+// hostSpecChanged compares, so the heartbeat handler can skip a redundant
+// Server-Side Apply when nothing changed.
+func hostWith(hostID, hostname string, httpPort uint32, env string, labels map[string]string) *runtimev1alpha1.Host {
+	return &runtimev1alpha1.Host{
+		ObjectMeta:  metav1.ObjectMeta{Labels: labels},
+		HostID:      hostID,
+		Hostname:    hostname,
+		HTTPPort:    httpPort,
+		Environment: env,
+	}
+}
+
+// TestHostSpecChanged covers every field the heartbeat handler diffs before
+// deciding whether to re-apply the Host spec, including the nil-vs-empty label
+// case that must not register as a change.
+func TestHostSpecChanged(t *testing.T) {
+	base := func() *runtimev1alpha1.Host {
+		return hostWith("host-id-1", "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "default"})
+	}
+
+	tests := []struct {
+		name string
+		next *runtimev1alpha1.Host
+		want bool
+	}{
+		{"identical", base(), false},
+		{"hostID changed", hostWith("host-id-2", "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "default"}), true},
+		{"hostname changed", hostWith("host-id-1", "node-b", 8080, "tenant-a", map[string]string{"hostgroup": "default"}), true},
+		{"httpPort changed", hostWith("host-id-1", "node-a", 9090, "tenant-a", map[string]string{"hostgroup": "default"}), true},
+		{"environment changed", hostWith("host-id-1", "node-a", 8080, "tenant-b", map[string]string{"hostgroup": "default"}), true},
+		{"label value changed", hostWith("host-id-1", "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "other"}), true},
+		{"label added", hostWith("host-id-1", "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "default", "extra": "x"}), true},
+		{"label removed", hostWith("host-id-1", "node-a", 8080, "tenant-a", nil), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hostSpecChanged(base(), tt.next); got != tt.want {
+				t.Errorf("hostSpecChanged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	// A nil label map and an empty one are equivalent and must not be reported
+	// as a change: req.GetLabels() yields nil when the heartbeat carries none.
+	t.Run("nil vs empty labels", func(t *testing.T) {
+		existing := hostWith("host-id-1", "node-a", 8080, "tenant-a", nil)
+		next := hostWith("host-id-1", "node-a", 8080, "tenant-a", map[string]string{})
+		if hostSpecChanged(existing, next) {
+			t.Errorf("nil and empty label maps must compare equal")
+		}
+	})
+}
+
+// mockBus is a wasmbus.Bus that answers Request with a canned reply (or error),
+// recording the subject the host client addressed. Only Request is exercised by
+// the heartbeat round-trip; the remaining methods satisfy the interface.
+type mockBus struct {
+	reply      *wasmbus.Message
+	err        error
+	gotSubject string
+}
+
+func (m *mockBus) Request(_ context.Context, msg *wasmbus.Message) (*wasmbus.Message, error) {
+	m.gotSubject = msg.Subject
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.reply, nil
+}
+
+func (m *mockBus) Subscribe(string, int) (wasmbus.Subscription, error)              { return nil, nil }
+func (m *mockBus) QueueSubscribe(string, string, int) (wasmbus.Subscription, error) { return nil, nil }
+func (m *mockBus) Publish(*wasmbus.Message) error                                   { return nil }
+
+// TestReconcileReporting verifies the heartbeat response is mapped onto Host
+// status, including the float32->string CPU formatting and the unsigned->signed
+// memory/count casts, and that the host's heartbeat subject is addressed.
+func TestReconcileReporting(t *testing.T) {
+	hb := &runtimev2.HostHeartbeat{
+		SystemCpuUsage:    0.5, // exactly representable, so FormatFloat yields "0.5"
+		SystemMemoryTotal: 16000,
+		SystemMemoryFree:  8000,
+		ComponentCount:    3,
+		WorkloadCount:     2,
+		OsName:            "linux",
+		OsArch:            testOSArch,
+		OsKernel:          "6.1.0",
+		Version:           testVersion,
+	}
+	data, err := protojson.Marshal(hb)
+	if err != nil {
+		t.Fatalf("marshal heartbeat: %v", err)
+	}
+
+	bus := &mockBus{reply: &wasmbus.Message{Data: data}}
+	r := &HostReconciler{Bus: bus}
+	host := &runtimev1alpha1.Host{HostID: "host-id-1"}
+
+	if err := r.reconcileReporting(context.Background(), host); err != nil {
+		t.Fatalf("reconcileReporting: %v", err)
+	}
+
+	if want := "runtime.host.host-id-1.heartbeat"; bus.gotSubject != want {
+		t.Errorf("heartbeat subject = %q, want %q", bus.gotSubject, want)
+	}
+	if host.Status.SystemCPUUsage != "0.5" {
+		t.Errorf("SystemCPUUsage = %q, want %q", host.Status.SystemCPUUsage, "0.5")
+	}
+	if host.Status.SystemMemoryTotal != 16000 {
+		t.Errorf("SystemMemoryTotal = %d, want 16000", host.Status.SystemMemoryTotal)
+	}
+	if host.Status.SystemMemoryFree != 8000 {
+		t.Errorf("SystemMemoryFree = %d, want 8000", host.Status.SystemMemoryFree)
+	}
+	if host.Status.ComponentCount != 3 || host.Status.WorkloadCount != 2 {
+		t.Errorf("counts = (%d,%d), want (3,2)", host.Status.ComponentCount, host.Status.WorkloadCount)
+	}
+	if host.Status.OSName != "linux" || host.Status.OSArch != testOSArch ||
+		host.Status.OSKernel != "6.1.0" || host.Status.Version != testVersion {
+		t.Errorf("OS/version fields not mapped: %+v", host.Status)
+	}
+	if host.Status.LastSeen.IsZero() {
+		t.Errorf("LastSeen must be set after a successful heartbeat")
+	}
+}
+
+// TestReconcileReporting_Error verifies a transport error from the bus is
+// surfaced and no status fields are written.
+func TestReconcileReporting_Error(t *testing.T) {
+	bus := &mockBus{err: errors.New("bus down")}
+	r := &HostReconciler{Bus: bus}
+	host := &runtimev1alpha1.Host{HostID: "host-id-1"}
+
+	if err := r.reconcileReporting(context.Background(), host); err == nil {
+		t.Fatalf("expected error when the heartbeat request fails")
+	}
+	if !host.Status.LastSeen.IsZero() {
+		t.Errorf("LastSeen must not be written when the heartbeat fails")
+	}
+}
+
+// TestReconcileReady covers the three readiness branches: reporting-true is
+// ready, a recent-but-not-reporting host is Unknown (still within the
+// unreachable window), and a long-silent host is a definite failure.
+func TestReconcileReady(t *testing.T) {
+	const timeout = time.Hour
+
+	t.Run("reporting true is ready", func(t *testing.T) {
+		r := &HostReconciler{UnreachableTimeout: timeout}
+		host := &runtimev1alpha1.Host{}
+		host.Status.SetConditions(condition.ReadyCondition(runtimev1alpha1.HostConditionReporting))
+		if err := r.reconcileReady(context.Background(), host); err != nil {
+			t.Errorf("expected nil error when Reporting is true, got %v", err)
+		}
+	})
+
+	t.Run("recently seen but not reporting is unknown", func(t *testing.T) {
+		r := &HostReconciler{UnreachableTimeout: timeout}
+		host := &runtimev1alpha1.Host{}
+		host.Status.LastSeen = metav1.Now()
+		err := r.reconcileReady(context.Background(), host)
+		if err == nil {
+			t.Fatalf("expected an error while not reporting")
+		}
+		if !condition.IsStatusUnknown(err) {
+			t.Errorf("within the unreachable window the error must be ErrStatusUnknown, got %v", err)
+		}
+	})
+
+	t.Run("silent past the unreachable window is failed", func(t *testing.T) {
+		r := &HostReconciler{UnreachableTimeout: timeout}
+		host := &runtimev1alpha1.Host{}
+		host.Status.LastSeen = metav1.NewTime(time.Now().Add(-2 * timeout))
+		err := r.reconcileReady(context.Background(), host)
+		if err == nil {
+			t.Fatalf("expected an error for a long-silent host")
+		}
+		if condition.IsStatusUnknown(err) {
+			t.Errorf("past the unreachable window the error must be a definite failure, not Unknown: %v", err)
+		}
+	})
+}
+
+// newHostFinalizeClient builds a fake client wired with the same Status.HostID
+// index finalize relies on in production, seeded with the given objects.
+func newHostFinalizeClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := runtimev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add runtime v1alpha1: %v", err)
+	}
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithIndex(&runtimev1alpha1.Workload{}, workloadByHostIDIndex,
+			func(obj client.Object) []string {
+				workload, ok := obj.(*runtimev1alpha1.Workload)
+				if !ok || workload.Status.HostID == "" {
+					return nil
+				}
+				return []string{workload.Status.HostID}
+			}).
+		Build()
+}
+
+func workloadForHost(name, hostID string) *runtimev1alpha1.Workload {
+	w := &runtimev1alpha1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "tenant-a"},
+	}
+	w.Status.HostID = hostID
+	return w
+}
+
+// TestFinalize verifies the host finalizer deletes exactly the live workloads
+// assigned to it: workloads on other hosts are untouched, and a workload
+// already being deleted is left alone rather than re-deleted.
+func TestFinalize(t *testing.T) {
+	assigned := workloadForHost("assigned", "host-id-1")
+
+	deleting := workloadForHost("deleting", "host-id-1")
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+	// A fake-client object carrying a DeletionTimestamp must also carry a
+	// finalizer, otherwise the builder rejects it; the finalizer also keeps it
+	// present so we can assert finalize skipped it.
+	deleting.Finalizers = []string{"runtime.wasmcloud.dev/test-hold"}
+
+	otherHost := workloadForHost("other-host", "host-id-2")
+
+	c := newHostFinalizeClient(t, assigned, deleting, otherHost)
+	r := &HostReconciler{Client: c}
+	host := &runtimev1alpha1.Host{HostID: "host-id-1"}
+
+	if err := r.finalize(context.Background(), host); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(assigned), &runtimev1alpha1.Workload{}); !apierrors.IsNotFound(err) {
+		t.Errorf("assigned workload should have been deleted, got err=%v", err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(deleting), &runtimev1alpha1.Workload{}); err != nil {
+		t.Errorf("already-deleting workload must be left in place, got err=%v", err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(otherHost), &runtimev1alpha1.Workload{}); err != nil {
+		t.Errorf("workload on another host must be untouched, got err=%v", err)
+	}
+}
+
+// newHostDeleteClient builds a fake client seeded with a single Host (no
+// finalizer, so a Delete fully removes it and the assertion is unambiguous).
+func newHostDeleteClient(t *testing.T, host *runtimev1alpha1.Host) (client.Client, *runtimev1alpha1.Host) {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := runtimev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add runtime v1alpha1: %v", err)
+	}
+	host.Name = "host-a"
+	host.Namespace = "wasmcloud-system"
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(host).Build()
+	return c, host
+}
+
+// TestDeleteUnresponsiveHost pins the post-hook contract: a Ready host and a
+// host whose Ready is still Unknown are both kept, while a host whose Ready has
+// resolved to a definite failure is deleted so the finalizer can run.
+func TestDeleteUnresponsiveHost(t *testing.T) {
+	t.Run("ready host is kept", func(t *testing.T) {
+		host := &runtimev1alpha1.Host{}
+		host.Status.SetConditions(condition.ReadyCondition(condition.TypeReady))
+		c, h := newHostDeleteClient(t, host)
+		r := &HostReconciler{Client: c}
+		if err := r.deleteUnresponsiveHost(context.Background(), h); err != nil {
+			t.Fatalf("deleteUnresponsiveHost: %v", err)
+		}
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(h), &runtimev1alpha1.Host{}); err != nil {
+			t.Errorf("ready host must not be deleted, got err=%v", err)
+		}
+	})
+
+	t.Run("unknown host is kept", func(t *testing.T) {
+		host := &runtimev1alpha1.Host{}
+		host.Status.SetConditions(condition.UnknownCondition(condition.TypeReady, condition.ReasonUnavailable, "not reporting"))
+		c, h := newHostDeleteClient(t, host)
+		r := &HostReconciler{Client: c}
+		if err := r.deleteUnresponsiveHost(context.Background(), h); err != nil {
+			t.Fatalf("deleteUnresponsiveHost: %v", err)
+		}
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(h), &runtimev1alpha1.Host{}); err != nil {
+			t.Errorf("host with Unknown Ready must not be deleted, got err=%v", err)
+		}
+	})
+
+	t.Run("failed host is deleted", func(t *testing.T) {
+		host := &runtimev1alpha1.Host{}
+		host.Status.SetConditions(condition.ErrorCondition(condition.TypeReady, condition.ReasonUnavailable, errors.New("host down")))
+		c, h := newHostDeleteClient(t, host)
+		r := &HostReconciler{Client: c}
+		if err := r.deleteUnresponsiveHost(context.Background(), h); err != nil {
+			t.Fatalf("deleteUnresponsiveHost: %v", err)
+		}
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(h), &runtimev1alpha1.Host{}); !apierrors.IsNotFound(err) {
+			t.Errorf("definitely-not-ready host must be deleted, got err=%v", err)
+		}
+	})
+}
+
+// applyCountingClient wraps a client.Client and counts Server-Side Apply
+// patches (the spec upsert), so a test can assert whether the heartbeat handler
+// performed or skipped the apply. Status subresource patches go through
+// Status() and are not counted.
+type applyCountingClient struct {
+	client.Client
+	applies atomic.Int64
+}
+
+func (c *applyCountingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if patch.Type() == types.ApplyPatchType {
+		c.applies.Add(1)
+	}
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
+func heartbeatBytes(t *testing.T, name, hostID, hostname string) []byte {
+	t.Helper()
+	data, err := protojson.Marshal(&runtimev2.HostHeartbeat{
+		FriendlyName: name,
+		Id:           hostID,
+		Hostname:     hostname,
+	})
+	if err != nil {
+		t.Fatalf("marshal heartbeat: %v", err)
+	}
+	return data
+}
+
+// TestHeartbeatHandler_SkipsRedundantApply exercises the full handler path
+// against a real API server: the first heartbeat creates the Host (one apply),
+// an identical heartbeat is skipped (no apply), and a changed heartbeat applies
+// again. LastSeen is refreshed on every heartbeat regardless of the skip.
+func TestHeartbeatHandler_SkipsRedundantApply(t *testing.T) {
+	c, ctx := startHostEnvtest(t)
+	ns := createTestNamespace(t, ctx, c, "host-heartbeat-skip")
+
+	counter := &applyCountingClient{Client: c}
+	updater := &hostStatusUpdater{client: counter, operatorNamespace: ns}
+	log := logr.Discard()
+
+	const name = "hb-host"
+
+	// First heartbeat: object does not exist -> create via SSA.
+	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, "host-id-1", "node-a"))
+	if got := counter.applies.Load(); got != 1 {
+		t.Fatalf("first heartbeat: applies = %d, want 1", got)
+	}
+	created := &runtimev1alpha1.Host{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, created); err != nil {
+		t.Fatalf("get after first heartbeat: %v", err)
+	}
+	if created.Hostname != "node-a" {
+		t.Errorf("hostname = %q, want node-a", created.Hostname)
+	}
+	if created.Status.LastSeen.IsZero() {
+		t.Errorf("LastSeen must be set after the first heartbeat")
+	}
+
+	// Identical heartbeat: spec unchanged -> no apply, but LastSeen still refreshes.
+	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, "host-id-1", "node-a"))
+	if got := counter.applies.Load(); got != 1 {
+		t.Fatalf("redundant heartbeat must not re-apply: applies = %d, want 1", got)
+	}
+	afterRedundant := &runtimev1alpha1.Host{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, afterRedundant); err != nil {
+		t.Fatalf("get after redundant heartbeat: %v", err)
+	}
+	if afterRedundant.Status.LastSeen.IsZero() {
+		t.Errorf("LastSeen must remain set after a redundant heartbeat")
+	}
+
+	// Changed heartbeat: hostname differs -> apply again.
+	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, "host-id-1", "node-b"))
+	if got := counter.applies.Load(); got != 2 {
+		t.Fatalf("changed heartbeat must re-apply: applies = %d, want 2", got)
+	}
+	updated := &runtimev1alpha1.Host{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, updated); err != nil {
+		t.Fatalf("get after changed heartbeat: %v", err)
+	}
+	if updated.Hostname != "node-b" {
+		t.Errorf("hostname = %q, want node-b after change", updated.Hostname)
 	}
 }


### PR DESCRIPTION
Add unit and envtest coverage for the host controller logic that was
previously untested:

- reconcileReady: the three readiness branches (reporting-true, recent
  but not reporting -> Unknown, silent past the unreachable window ->
  failed)
- reconcileReporting: heartbeat-to-status field mapping, including the
  float32 CPU formatting and unsigned->signed memory/count casts, plus
  the transport-error path
- finalize: fan-out delete of live workloads assigned to the host,
  skipping already-deleting workloads and leaving other hosts untouched
- deleteUnresponsiveHost: keep Ready and Unknown hosts, delete a host
  whose Ready has resolved to a definite failure
- heartbeat handler: end-to-end envtest that the redundant-apply skip
  (#5298) holds — identical heartbeat performs no Server-Side Apply
  while LastSeen still refreshes, and a changed heartbeat re-applies

To make the skip logic and post-hook directly testable, extract the
heartbeat subscription callback into hostStatusUpdater.handleHeartbeat
and the reconcile post-hook into HostReconciler.deleteUnresponsiveHost.
No behavior change.