### PR TITLE
release: v2.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bench-tools"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -7409,7 +7409,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7457,7 +7457,7 @@ dependencies = [
 
 [[package]]
 name = "wash-runtime"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9367,7 +9367,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xtask"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 [workspace.package]
 authors = ["The wasmCloud Team"]
 edition = "2024"
-version = "2.4.0"
+version = "2.5.0"
 rust-version = "1.94.0"
 
 [workspace.lints.rust]

--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: 2.5.0
 # This tracks the release-train tag rather than this file: at release time
 # `helm-publish` overrides it with the pushed `vX.Y.Z` tag. The value here is the
 # local/dev default used by `helm template` and canary builds.
-appVersion: "2.4.0"
+appVersion: "2.5.0"


### PR DESCRIPTION
Automated release-train PR for **v2.5.0**.

**Action required:** a maintainer needs to approve this PR. Once required checks pass and approval is recorded, auto-merge fires. After merge, `release-tag.yml` waits for canary builds on `main` to pass and then pushes the immutable `v2.5.0` tag, which the existing tag-triggered workflows pick up.

If CI fails: fix forward and push to this branch, or close this PR. The train does not skip — patch releases out-of-cycle can be triggered via `workflow_dispatch` on `release-train.yml`.
