### PR TITLE
Add endpointslices/restricted virtual resource to RBAC

### DIFF
--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # The chart version. This is what gets published: `helm-publish` packages the
 # chart with this value, so it MUST be bumped whenever anything under this chart
 # changes. CI enforces the bump with `ct lint --check-version-increment`.
-version: 2.5.0
+version: 2.5.1
 
 # The version of the application being deployed (the operator image tag default).
 # This tracks the release-train tag rather than this file: at release time

--- a/charts/runtime-operator/templates/operator/clusterrole.yaml
+++ b/charts/runtime-operator/templates/operator/clusterrole.yaml
@@ -104,4 +104,19 @@ rules:
     - patch
     - update
     - watch
+  # endpointslices/restricted is a virtual resource that has no impact to non-OpenShift clusters.
+  # The operator needs this permission to create EndpointSlices in OpenShift clusters that have
+  #the restricted API enabled.
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices/restricted
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints/restricted
+    verbs:
+    - create
 {{- end }}

--- a/charts/runtime-operator/templates/operator/clusterrole.yaml
+++ b/charts/runtime-operator/templates/operator/clusterrole.yaml
@@ -106,7 +106,7 @@ rules:
     - watch
   # endpointslices/restricted is a virtual resource that has no impact to non-OpenShift clusters.
   # The operator needs this permission to create EndpointSlices in OpenShift clusters that have
-  #the restricted API enabled.
+  # the restricted API enabled.
   - apiGroups:
     - discovery.k8s.io
     resources:

--- a/charts/runtime-operator/templates/operator/endpointslice-role.yaml
+++ b/charts/runtime-operator/templates/operator/endpointslice-role.yaml
@@ -26,6 +26,21 @@ rules:
     - patch
     - update
     - watch
+  # endpointslices/restricted is a virtual resource that has no impact to non-OpenShift clusters.
+  # The operator needs this permission to create EndpointSlices in OpenShift clusters that have
+  # the restricted API enabled.
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices/restricted
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints/restricted
+    verbs:
+    - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
### Description
OpenShift and other Kubernetes cluster can have the `RestrictedEndpointAdmission` webhook enabled, which prevents the runtime operator from being able to manage endpointslices for a Kubernetes service. 

When the operator tries to manage the endpointslice, you will get an error stating:
```
endpointslices.discovery.k8s.io \"workload-xyz\" is forbidden: endpoint address <ip address> is not allowed
```

This change adds the create permission to the `endpointslices/restricted` and `endpoints/restricted` which will then allow for the operator to pass the `RestrictedEndpointAdmission` webhook and successfully register the ip addresses of the host for the endpointslice.

### Testing
Tested with an open shift cluster by manually creating the RBAC role. The operator was able to reconcile the Workload's service without any error.


Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
