### PR TITLE
release: v2.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,7 +579,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bench-tools"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7355,7 +7355,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7403,7 +7403,7 @@ dependencies = [
 
 [[package]]
 name = "wash-runtime"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -9178,7 +9178,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xtask"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 [workspace.package]
 authors = ["The wasmCloud Team"]
 edition = "2024"
-version = "2.5.0"
+version = "2.5.1"
 rust-version = "1.94.0"
 
 [workspace.lints.rust]

--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: 2.5.1
 # This tracks the release-train tag rather than this file: at release time
 # `helm-publish` overrides it with the pushed `vX.Y.Z` tag. The value here is the
 # local/dev default used by `helm template` and canary builds.
-appVersion: "2.5.0"
+appVersion: "2.5.1"

--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # The chart version. This is what gets published: `helm-publish` packages the
 # chart with this value, so it MUST be bumped whenever anything under this chart
 # changes. CI enforces the bump with `ct lint --check-version-increment`.
-version: 2.5.1
+version: 2.5.2
 
 # The version of the application being deployed (the operator image tag default).
 # This tracks the release-train tag rather than this file: at release time


### PR DESCRIPTION
Automated release-train PR for **v2.5.1**.

**Action required:** a maintainer needs to approve this PR. Once required checks pass and approval is recorded, auto-merge fires. After merge, `release-tag.yml` waits for canary builds on `main` to pass and then pushes the immutable `v2.5.1` tag, which the existing tag-triggered workflows pick up.

If CI fails: fix forward and push to this branch, or close this PR. The train does not skip — patch releases out-of-cycle can be triggered via `workflow_dispatch` on `release-train.yml`.
