### PR TITLE
ci(release): chart and app in lockstep

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,15 +1,17 @@
 # chart-testing (ct) configuration — consumed by the `lint` job in
-# .github/workflows/charts.yml.
+# .github/workflows/charts.yml. ct runs `helm lint` plus a yamllint pass over
+# Chart.yaml / values.yaml (see `lint-conf`).
 #
-# The point of this file is `check-version-increment`: when a PR changes any
-# file under a chart, ct compares the chart against `target-branch` and FAILS
-# unless Chart.yaml `version` was bumped. That is the guard against shipping a
-# chart edit without a version bump.
+# The chart `version` is release-driven: the release-train workflow sets it
+# equal to `appVersion` on every release, so it moves in one place only. We
+# therefore do NOT require a per-PR version bump — chart-only PRs don't need to
+# touch Chart.yaml at all. `target-branch` is still used to detect which charts
+# changed so ct only lints those.
 target-branch: main
 chart-dirs:
   - charts
-# Core guard: require a Chart.yaml `version` bump for any chart change.
-check-version-increment: true
+# Chart version is bumped by the release train, not per PR; don't require a bump.
+check-version-increment: false
 # Chart.yaml carries no `maintainers` list; don't require one.
 validate-maintainers: false
 # Lint Chart.yaml / values.yaml with a project-appropriate yamllint config.

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -48,25 +48,25 @@ jobs:
       - name: Render
         run: make helm-render
 
-  # Fails a PR that changes any file under a chart without bumping that chart's
-  # Chart.yaml `version`. Also runs `helm lint` + yamllint on the chart.
+  # Runs `helm lint` + yamllint on the chart. The chart `version` is
+  # release-driven (see .github/ct.yaml), so this does not enforce a version bump.
   lint:
     needs:
       - changes
     if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true')
-    name: ct lint (chart version bump)
+    name: ct lint (helm + yaml)
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # ct diffs the chart against `target-branch` to decide whether the
-          # version was bumped, so it needs full history, not a shallow clone.
+          # ct diffs against `target-branch` to detect which charts changed so
+          # it only lints those, so it needs full history, not a shallow clone.
           fetch-depth: 0
           persist-credentials: false
       - uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
-      - name: Lint charts and enforce version bump
+      - name: Lint charts
         run: ct lint --config .github/ct.yaml
 
   # Schema-validates the rendered manifests against the Kubernetes API.

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -205,10 +205,17 @@ jobs:
             echo "failed to bump workspace version in Cargo.toml" >&2
             exit 1
           fi
-          # Helm chart appVersion tracks the workspace version.
-          sed -i -E "s/^appVersion: \".*\"$/appVersion: \"${NEW}\"/" charts/runtime-operator/Chart.yaml
-          if ! grep -qE "^appVersion: \"${NEW}\"$" charts/runtime-operator/Chart.yaml; then
-            echo "failed to bump appVersion in Chart.yaml" >&2
+          # The Helm chart is release-driven: both `appVersion` and the chart
+          # `version` track the workspace version and always match. This is the
+          # only place the chart version changes — ct's per-PR version-bump guard
+          # is disabled (see .github/ct.yaml) precisely so chart-only PRs don't
+          # have to touch it.
+          CHART_YAML=charts/runtime-operator/Chart.yaml
+          sed -i -E "s/^appVersion: \".*\"$/appVersion: \"${NEW}\"/" "${CHART_YAML}"
+          sed -i -E "s/^version: .*/version: ${NEW}/" "${CHART_YAML}"
+          if ! grep -qE "^appVersion: \"${NEW}\"$" "${CHART_YAML}" \
+            || ! grep -qE "^version: ${NEW}$" "${CHART_YAML}"; then
+            echo "failed to set chart version/appVersion to ${NEW} in ${CHART_YAML}" >&2
             exit 1
           fi
           # Refresh Cargo.lock — `--workspace` only updates workspace member

--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -12,10 +12,12 @@ description: A Helm chart for Kubernetes
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# The chart version. This is what gets published: `helm-publish` packages the
-# chart with this value, so it MUST be bumped whenever anything under this chart
-# changes. CI enforces the bump with `ct lint --check-version-increment`.
-version: 2.5.2
+# The chart version. This is what `helm-publish` packages the chart with. It is
+# release-driven: the release-train workflow sets it equal to `appVersion` on
+# every release, so the two always match. Don't bump it in feature PRs — chart
+# changes ride out with the next release. (ct does not enforce a per-PR bump;
+# see .github/ct.yaml.)
+version: 2.5.1
 
 # The version of the application being deployed (the operator image tag default).
 # This tracks the release-train tag rather than this file: at release time


### PR DESCRIPTION
Doing this the helm purist way is painful. This makes it simple (one version ftw).
