### PR TITLE
fix: default backends for wasmcloud:{keyvalue,blobstore}

### DIFF
--- a/crates/wash-runtime/src/plugin/multiplex.rs
+++ b/crates/wash-runtime/src/plugin/multiplex.rs
@@ -98,6 +98,12 @@ pub struct Multiplexer<Id> {
     /// Whether the background idle-reaper task has been spawned yet (spawned
     /// lazily on the first pooled bind, when a tokio runtime is guaranteed).
     reaper_started: AtomicBool,
+    /// Per-workload default backend (the unnamed `""` route), recorded at bind so
+    /// a plugin's *standard* (non-`(implements)`) binding can serve a **plain**
+    /// (unlabeled) import — the shared mechanism that lets every multiplexed
+    /// plugin default without requiring a label. A `std::sync::Mutex` because the
+    /// critical section is a tiny map touch with no `await` held across it.
+    defaults: Arc<std::sync::Mutex<HashMap<Arc<str>, Id>>>,
 }
 
 impl<Id: Clone + Send + Sync + 'static> Multiplexer<Id> {
@@ -118,7 +124,30 @@ impl<Id: Clone + Send + Sync + 'static> Multiplexer<Id> {
             max_connections_by_backend: HashMap::new(),
             idle_ttl: DEFAULT_IDLE_TTL,
             reaper_started: AtomicBool::new(false),
+            defaults: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Record the workload's default (unnamed `""`) backend from a built
+    /// registry, so a plugin's standard binding can serve a plain import for this
+    /// workload. No-op if the workload declared no default (`""`) route.
+    pub fn set_default(&self, workload_id: impl Into<Arc<str>>, registry: &HashMap<String, Id>) {
+        if let Some(default) = registry.get("") {
+            self.defaults
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .insert(workload_id.into(), default.clone());
+        }
+    }
+
+    /// The default backend a plain (unnamed) import should route to for this
+    /// workload, if one was recorded at bind via [`Multiplexer::set_default`].
+    pub fn default_for(&self, workload_id: &str) -> Option<Id> {
+        self.defaults
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(workload_id)
+            .cloned()
     }
 
     /// Register a backend provider keyed by its `backend_type()`.
@@ -266,24 +295,24 @@ impl<Id: Clone + Send + Sync + 'static> Multiplexer<Id> {
 
     /// Resolve a component import name (the implements id) to a backend, given a
     /// registry from [`Multiplexer::build_registry`]. The import name is matched
-    /// directly against the host-interface name; unnamed imports fall through to
-    /// the default (`""`) route.
+    /// directly against the host-interface name. The unnamed default is keyed
+    /// `""`, so an unnamed import matches it directly.
+    ///
+    /// A named label that matches no configured interface is an error: silently
+    /// falling back to the default would route that import's traffic to a backend
+    /// (and credentials) it never asked for.
     pub fn resolve(
         &self,
         registry: &HashMap<String, Id>,
         import_name: &str,
     ) -> wasmtime::Result<Id> {
-        registry
-            .get(import_name)
-            .or_else(|| registry.get(""))
-            .cloned()
-            .ok_or_else(|| {
-                wasmtime::format_err!(
-                    "no {}:{} backend bound for import '{import_name}'",
-                    self.namespace,
-                    self.package
-                )
-            })
+        registry.get(import_name).cloned().ok_or_else(|| {
+            wasmtime::format_err!(
+                "no {}:{} backend bound for import '{import_name}'",
+                self.namespace,
+                self.package
+            )
+        })
     }
 
     /// Spawn the background idle-reaper once, on the first pooled bind (where a
@@ -385,12 +414,34 @@ mod tests {
     }
 
     #[test]
-    fn resolve_routes_by_import_name_with_default_fallback() {
+    fn resolve_matches_by_import_name_including_the_unnamed_default() {
         let reg = registry(&[("team-a", 1), ("", 99)]);
         let mux = mux();
         assert_eq!(mux.resolve(&reg, "team-a").unwrap(), 1);
-        // Unknown import name falls through to the default ("") route.
-        assert_eq!(mux.resolve(&reg, "other").unwrap(), 99);
+        // The unnamed default is keyed "" and matched directly.
+        assert_eq!(mux.resolve(&reg, "").unwrap(), 99);
+        // An unmatched named label is an error, not a silent fallback to the
+        // default — routing it there would use the wrong backend/credentials.
+        let err = mux.resolve(&reg, "other").unwrap_err();
+        assert!(
+            err.to_string().contains("other"),
+            "error should name the unmatched import: {err}"
+        );
+    }
+
+    #[test]
+    fn set_default_records_the_unnamed_route_per_workload() {
+        let mux = mux();
+        // A workload whose registry carries an unnamed (`""`) route gets that
+        // backend recorded as its default; a plain import looks it up here.
+        mux.set_default("wl-1", &registry(&[("team-a", 1), ("", 99)]));
+        assert_eq!(mux.default_for("wl-1"), Some(99));
+        // Defaults are per-workload: an unknown workload has none.
+        assert_eq!(mux.default_for("wl-unknown"), None);
+        // A registry with no unnamed route records nothing (a labeled-only
+        // workload has no plain-import default to fall back to).
+        mux.set_default("wl-2", &registry(&[("team-a", 1)]));
+        assert_eq!(mux.default_for("wl-2"), None);
     }
 
     #[test]

--- a/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed_async.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore/multiplexed_async.rs
@@ -145,6 +145,113 @@ impl<T: 'static + Send> bindings::named_imports::wasmcloud::blobstore::blobstore
 
 impl bindings::named_imports::wasmcloud::blobstore::blobstore::Host for ActiveCtx<'_> {}
 
+/// Look up the per-workload default backend for a PLAIN (unlabeled) import,
+/// populated at bind from the `""` route. `None` if the workload has no default
+/// blobstore route (e.g. it only imports labeled instances).
+async fn default_backend<T: 'static + Send>(
+    accessor: &Accessor<T, SharedCtx>,
+) -> wasmtime::Result<Option<BlobId>> {
+    let (plugin, workload_id) = accessor.with(|mut a| {
+        let ctx = a.get();
+        (
+            ctx.try_get_plugin::<MultiplexedAsyncBlobstore>(MULTIPLEXED_ASYNC_BLOBSTORE_ID),
+            ctx.workload_id.clone(),
+        )
+    });
+    let plugin = plugin?;
+    Ok(plugin.mux.default_for(&workload_id))
+}
+
+fn no_default_backend<T2>() -> wasmtime::Result<Result<T2, AsyncError>> {
+    Ok(Err(AsyncError::Other(
+        "no default wasmcloud:blobstore backend is bound for this component".to_string(),
+    )))
+}
+
+// Standard (non-`(implements)`) binding for a PLAIN `wasmcloud:blobstore/blobstore`
+// import: every call routes to the workload's single default backend. The
+// returned `container` resource carries that backend, so the standalone
+// `container` methods (read/write/list/…) work unchanged.
+impl<T: 'static + Send> bindings::wasmcloud::blobstore::blobstore::HostWithStore<T> for SharedCtx {
+    async fn create_container(
+        accessor: &Accessor<T, Self>,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<Resource<BlobContainer>, AsyncError>> {
+        let Some(id) = default_backend(accessor).await? else {
+            return no_default_backend();
+        };
+        if let Err(e) = id.create_container(&name).await {
+            return Ok(Err(e.into()));
+        }
+        let resource = accessor.with(|mut a| a.get().table.push(BlobContainer::new(id, name)))?;
+        Ok(Ok(resource))
+    }
+
+    async fn get_container(
+        accessor: &Accessor<T, Self>,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<Resource<BlobContainer>, AsyncError>> {
+        let Some(id) = default_backend(accessor).await? else {
+            return no_default_backend();
+        };
+        if let Err(e) = id.get_container(&name).await {
+            return Ok(Err(e.into()));
+        }
+        let resource = accessor.with(|mut a| a.get().table.push(BlobContainer::new(id, name)))?;
+        Ok(Ok(resource))
+    }
+
+    async fn delete_container(
+        accessor: &Accessor<T, Self>,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<(), AsyncError>> {
+        let Some(id) = default_backend(accessor).await? else {
+            return no_default_backend();
+        };
+        Ok(id.delete_container(&name).await.map_err(Into::into))
+    }
+
+    async fn container_exists(
+        accessor: &Accessor<T, Self>,
+        name: ContainerName,
+    ) -> wasmtime::Result<Result<bool, AsyncError>> {
+        let Some(id) = default_backend(accessor).await? else {
+            return no_default_backend();
+        };
+        Ok(id.container_exists(&name).await.map_err(Into::into))
+    }
+
+    async fn copy_object(
+        accessor: &Accessor<T, Self>,
+        src: ObjectId,
+        dest: ObjectId,
+    ) -> wasmtime::Result<Result<(), AsyncError>> {
+        let Some(id) = default_backend(accessor).await? else {
+            return no_default_backend();
+        };
+        Ok(id
+            .copy_object(&src.container, &src.object, &dest.container, &dest.object)
+            .await
+            .map_err(Into::into))
+    }
+
+    async fn move_object(
+        accessor: &Accessor<T, Self>,
+        src: ObjectId,
+        dest: ObjectId,
+    ) -> wasmtime::Result<Result<(), AsyncError>> {
+        let Some(id) = default_backend(accessor).await? else {
+            return no_default_backend();
+        };
+        Ok(id
+            .move_object(&src.container, &src.object, &dest.container, &dest.object)
+            .await
+            .map_err(Into::into))
+    }
+}
+
+impl bindings::wasmcloud::blobstore::blobstore::Host for ActiveCtx<'_> {}
+
 // The `container` interface is bound as a *standalone* (non-implements)
 // interface rather than per-label. A `wasmcloud:blobstore/blobstore` `use
 // container.{container}` drags the `container` interface into the guest as an
@@ -429,20 +536,48 @@ impl HostPlugin for MultiplexedAsyncBlobstore {
         }
 
         let registry = self.build_registry(interfaces.iter()).await?;
+
+        // Does the component import blobstore with an `(implements ..)` label, or
+        // plainly (unlabeled), or both? Bind only what's needed so a plain-only
+        // component doesn't also get the labeled instance (and vice versa).
+        let has_labeled = interfaces
+            .iter()
+            .any(|i| i.namespace == "wasmcloud" && i.package == "blobstore" && i.name.is_some());
+        let has_plain = interfaces
+            .iter()
+            .any(|i| i.namespace == "wasmcloud" && i.package == "blobstore" && i.name.is_none());
+
+        // A plain import routes to the workload's default backend (the `""` route
+        // from the registry), stashed on the multiplexer so the standard host impl
+        // can find it — the shared mechanism every multiplexed plugin uses.
+        if has_plain {
+            self.mux.set_default(item.workload_id(), &registry);
+        }
+
         let component = item.component().clone();
         let linker = item.linker();
 
-        // `blobstore` (create/get/delete container, copy/move) is routed per
+        // `blobstore` (create/get/delete container, copy/move) routed per
         // `(implements ..)` label so each label lands on its own backend.
-        bindings::named_imports::wasmcloud::blobstore::blobstore::add_to_linker::<_, SharedCtx>(
-            linker,
-            &component,
-            |name| self.mux.resolve(&registry, name),
-            extract_active_ctx,
-        )?;
-        // `container` is bound standalone (see the container host impls): a guest
-        // imports it *unlabeled* via `blobstore`'s `use container`, and its
-        // methods route through the resource's stored backend, not a label.
+        if has_labeled {
+            bindings::named_imports::wasmcloud::blobstore::blobstore::add_to_linker::<_, SharedCtx>(
+                linker,
+                &component,
+                |name| self.mux.resolve(&registry, name),
+                extract_active_ctx,
+            )?;
+        }
+        // A plain (unlabeled) `blobstore` import: bind the standard interface to
+        // the workload's default backend — no label required.
+        if has_plain {
+            bindings::wasmcloud::blobstore::blobstore::add_to_linker::<_, SharedCtx>(
+                linker,
+                extract_active_ctx,
+            )?;
+        }
+        // `container` is bound standalone regardless: a guest imports it
+        // *unlabeled* via `blobstore`'s `use container`, and its methods route
+        // through the resource's stored backend, not a label.
         bindings::wasmcloud::blobstore::container::add_to_linker::<_, SharedCtx>(
             linker,
             extract_active_ctx,

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed_async.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed_async.rs
@@ -199,6 +199,54 @@ impl<T: 'static + Send> bindings::named_imports::wasmcloud::keyvalue::store::Hos
 
 impl bindings::named_imports::wasmcloud::keyvalue::store::Host for ActiveCtx<'_> {}
 
+/// A plain (unlabeled) `store.open`: route to the workload's default backend
+/// (recorded on the multiplexer at bind) so a component that imports
+/// `wasmcloud:keyvalue/store` *without* an `(implements ..)` label still gets a
+/// working backend — no label required. The label-routed `open` above is
+/// identical but for taking its `KvId` from the label instead of the default.
+impl<T: 'static + Send> bindings::wasmcloud::keyvalue::store::HostWithStore<T> for SharedCtx {
+    async fn open(
+        accessor: &Accessor<T, Self>,
+        identifier: String,
+    ) -> wasmtime::Result<Result<Resource<KvBucket>, AsyncKvError>> {
+        let Some(id) = default_backend(accessor).await? else {
+            return no_default_backend();
+        };
+        if let Err(e) = id.open(&identifier).await {
+            return Ok(Err(e.into()));
+        }
+        let resource = accessor.with(|mut a| a.get().table.push(KvBucket::new(id, identifier)))?;
+        Ok(Ok(resource))
+    }
+}
+
+impl bindings::wasmcloud::keyvalue::store::Host for ActiveCtx<'_> {}
+
+/// The workload's default `wasmcloud:keyvalue` backend for a PLAIN (unlabeled)
+/// import, recorded on the multiplexer at bind. `None` when the workload
+/// declared no default (`""`) route.
+async fn default_backend<T: 'static + Send>(
+    accessor: &Accessor<T, SharedCtx>,
+) -> wasmtime::Result<Option<KvId>> {
+    let (plugin, workload_id) = accessor.with(|mut a| {
+        let ctx = a.get();
+        (
+            ctx.try_get_plugin::<MultiplexedAsyncKeyValue>(MULTIPLEXED_ASYNC_KEYVALUE_ID),
+            ctx.workload_id.clone(),
+        )
+    });
+    let plugin = plugin?;
+    Ok(plugin.mux.default_for(&workload_id))
+}
+
+/// The error a plain `store.open` returns when the workload bound no default
+/// backend — the component imported keyvalue plainly but nothing provides it.
+fn no_default_backend<T2>() -> wasmtime::Result<Result<T2, AsyncKvError>> {
+    Ok(Err(AsyncKvError::Other(
+        "no default wasmcloud:keyvalue backend is bound for this component".to_string(),
+    )))
+}
+
 impl<T: 'static + Send> bindings::wasmcloud::keyvalue::atomics::HostWithStore<T> for SharedCtx {
     async fn increment(
         accessor: &Accessor<T, Self>,
@@ -372,6 +420,25 @@ impl HostPlugin for MultiplexedAsyncKeyValue {
         }
 
         let registry = self.build_registry(interfaces.iter()).await?;
+
+        // Does the component import keyvalue with an `(implements ..)` label, or
+        // plainly (unlabeled), or both? Bind only the matching `store` binding so a
+        // plain-only component doesn't also get the labeled instance (and vice
+        // versa) — `types`/`atomics`/`cas`/`batch` are bound standalone regardless.
+        let has_labeled = interfaces
+            .iter()
+            .any(|i| i.namespace == "wasmcloud" && i.package == "keyvalue" && i.name.is_some());
+        let has_plain = interfaces
+            .iter()
+            .any(|i| i.namespace == "wasmcloud" && i.package == "keyvalue" && i.name.is_none());
+
+        // A plain import routes to the workload's default backend (the `""` route
+        // from the registry), stashed on the multiplexer so the standard host impl
+        // can find it — the shared mechanism every multiplexed plugin uses.
+        if has_plain {
+            self.mux.set_default(item.workload_id(), &registry);
+        }
+
         let component = item.component().clone();
         let linker = item.linker();
 
@@ -380,12 +447,22 @@ impl HostPlugin for MultiplexedAsyncKeyValue {
         // standalone: a guest imports them unlabeled, and their methods operate on
         // a `bucket` whose `KvBucket` already carries the backend it was opened
         // through, so they route via the resource rather than a label.
-        bindings::named_imports::wasmcloud::keyvalue::store::add_to_linker::<_, SharedCtx>(
-            linker,
-            &component,
-            |name| self.mux.resolve(&registry, name),
-            extract_active_ctx,
-        )?;
+        if has_labeled {
+            bindings::named_imports::wasmcloud::keyvalue::store::add_to_linker::<_, SharedCtx>(
+                linker,
+                &component,
+                |name| self.mux.resolve(&registry, name),
+                extract_active_ctx,
+            )?;
+        }
+        // A plain (unlabeled) `store` import: bind the standard interface to the
+        // workload's default backend — no label required.
+        if has_plain {
+            bindings::wasmcloud::keyvalue::store::add_to_linker::<_, SharedCtx>(
+                linker,
+                extract_active_ctx,
+            )?;
+        }
         bindings::wasmcloud::keyvalue::types::add_to_linker::<_, SharedCtx>(
             linker,
             extract_active_ctx,

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -90,6 +90,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "blobstore-default-p3"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.58.0",
+]
+
+[[package]]
 name = "blobstore-implements-p3"
 version = "0.0.0"
 dependencies = [
@@ -753,6 +760,13 @@ name = "keyvalue-counter"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "wit-bindgen 0.58.0",
+]
+
+[[package]]
+name = "keyvalue-default-p3"
+version = "0.0.0"
+dependencies = [
  "wit-bindgen 0.58.0",
 ]
 

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -35,7 +35,9 @@ members = [
     "ephemeral-callee-p3",
     "ephemeral-caller-p3",
     "blobstore-implements-p3",
+    "blobstore-default-p3",
     "keyvalue-implements-p3",
+    "keyvalue-default-p3",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/blobstore-default-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/blobstore-default-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "blobstore-default-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/blobstore-default-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/blobstore-default-p3/src/lib.rs
@@ -1,0 +1,80 @@
+//! Real-guest fixture for a PLAIN (unlabeled) async `wasmcloud:blobstore` import.
+//!
+//! Unlike `blobstore-implements-p3`, this imports `wasmcloud:blobstore@0.1.0`
+//! *without* an `(implements ..)` label. On each HTTP request it creates a
+//! container, streams an object body in via `write-data(name, stream<u8>)`,
+//! reads it back out via `get-data(..) -> stream<u8>`, and returns the bytes —
+//! proving the host binds a default backend for a plain import (no label needed).
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+    });
+}
+
+use bindings::exports::wasi::http::handler::Guest as Handler;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::wasmcloud::blobstore::blobstore;
+
+struct Component;
+
+const CONTAINER: &str = "photos";
+const OBJECT: &str = "cat.png";
+const BODY: &[u8] = b"woof from a plain p3 guest";
+
+fn internal(msg: String) -> ErrorCode {
+    ErrorCode::InternalError(Some(msg))
+}
+
+fn respond(status: u16, body_bytes: Vec<u8>) -> Result<Response, ErrorCode> {
+    let headers = Fields::new();
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
+
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body_bytes).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    response
+        .set_status_code(status)
+        .map_err(|()| internal("failed to set status".into()))?;
+    Ok(response)
+}
+
+impl Handler for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        // Create (or reuse) the container through the PLAIN blobstore import —
+        // no label, so the host must route it to a default backend.
+        let container = match blobstore::create_container(CONTAINER.to_string()).await {
+            Ok(c) => c,
+            Err(_) => blobstore::get_container(CONTAINER.to_string())
+                .await
+                .map_err(|e| internal(format!("get_container: {e:?}")))?,
+        };
+
+        // Stream the object body in through `write-data(name, stream<u8>)`.
+        let (mut tx, rx) = bindings::wit_stream::new();
+        wit_bindgen::spawn_local(async move {
+            tx.write_all(BODY.to_vec()).await;
+            drop(tx);
+        });
+        container
+            .write_data(OBJECT.to_string(), rx)
+            .await
+            .map_err(|e| internal(format!("write_data: {e:?}")))?;
+
+        // Read it back out of the returned `stream<u8>`.
+        let stream = container
+            .get_data(OBJECT.to_string(), 0, u64::MAX)
+            .await
+            .map_err(|e| internal(format!("get_data: {e:?}")))?;
+        let data = stream.collect().await;
+
+        respond(200, data)
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/blobstore-default-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/blobstore-default-p3/wit/world.wit
@@ -1,0 +1,12 @@
+package wasmcloud:blobstore-default-p3@0.1.0;
+
+// Imports the async, native-stream `wasmcloud:blobstore@0.1.0` *plainly* — no
+// `(implements ..)` label. A component should get a working default backend from
+// the host without labeling the import, which is what this fixture exercises.
+world blobstore-default {
+    import wasmcloud:blobstore/blobstore@0.1.0;
+    import wasmcloud:blobstore/container@0.1.0;
+    import wasmcloud:blobstore/types@0.1.0;
+
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/keyvalue-default-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-default-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "keyvalue-default-p3"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/keyvalue-default-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-default-p3/src/lib.rs
@@ -1,0 +1,83 @@
+//! Real-guest fixture for a PLAIN (unlabeled) async `wasmcloud:keyvalue` import.
+//!
+//! Unlike `keyvalue-implements-p3`, this opens a bucket through
+//! `wasmcloud:keyvalue/store` *without* an `(implements ..)` label. On each HTTP
+//! request it opens a bucket, sets a key, increments a counter through the
+//! standalone `atomics` import, reads the value back, and returns it — proving
+//! the host binds a default backend for a plain `store` import (no label needed).
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+    });
+}
+
+use bindings::exports::wasi::http::handler::Guest as Handler;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::wasmcloud::keyvalue::{atomics, store};
+
+struct Component;
+
+const BUCKET: &str = "default-kv";
+const KEY: &str = "greeting";
+const COUNTER: &str = "hits";
+const BODY: &[u8] = b"woof from a plain p3 keyvalue guest";
+
+fn internal(msg: String) -> ErrorCode {
+    ErrorCode::InternalError(Some(msg))
+}
+
+fn respond(status: u16, body_bytes: Vec<u8>) -> Result<Response, ErrorCode> {
+    let headers = Fields::new();
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| todo!());
+
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body_bytes).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    response
+        .set_status_code(status)
+        .map_err(|()| internal("failed to set status".into()))?;
+    Ok(response)
+}
+
+async fn run() -> Result<Vec<u8>, String> {
+    // Open a bucket through the PLAIN `store` import — no label, so the host must
+    // route it to a default backend.
+    let bucket = store::open(BUCKET.to_string())
+        .await
+        .map_err(|e| format!("open: {e:?}"))?;
+
+    bucket
+        .set(KEY.to_string(), BODY.to_vec(), None)
+        .await
+        .map_err(|e| format!("set: {e:?}"))?;
+
+    // The standalone `atomics` import operates on the plainly-opened bucket,
+    // exercising the resource-routed path alongside the default `store` binding.
+    atomics::increment(&bucket, COUNTER.to_string(), 1)
+        .await
+        .map_err(|e| format!("increment: {e:?}"))?;
+
+    let value = bucket
+        .get(KEY.to_string())
+        .await
+        .map_err(|e| format!("get: {e:?}"))?
+        .ok_or_else(|| "key missing after set".to_string())?;
+    Ok(value)
+}
+
+impl Handler for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        match run().await {
+            Ok(value) => respond(200, value),
+            Err(e) => respond(500, format!("error: {e}").into_bytes()),
+        }
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/keyvalue-default-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/keyvalue-default-p3/wit/world.wit
@@ -1,0 +1,12 @@
+package wasmcloud:keyvalue-default-p3@0.1.0;
+
+// Imports the async `wasmcloud:keyvalue@0.1.0` `store` *plainly* — no
+// `(implements ..)` label. A component should get a working default backend from
+// the host without labeling the import, which is what this fixture exercises.
+// `atomics` is imported unlabeled too and operates on the plainly-opened bucket.
+world keyvalue-default {
+    import wasmcloud:keyvalue/store@0.1.0;
+    import wasmcloud:keyvalue/atomics@0.1.0;
+
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/integration_blobstore_default_p3.rs
+++ b/crates/wash-runtime/tests/integration_blobstore_default_p3.rs
@@ -1,0 +1,143 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! A **plain** (unlabeled) async `wasmcloud:blobstore@0.1.0` import, served by a
+//! default backend through a **real P3 guest** — no `(implements ..)` label.
+//!
+//! The `blobstore-default-p3` fixture imports `wasmcloud:blobstore/blobstore`
+//! plainly. On each request it creates a container, streams an object body in via
+//! `write-data(name, stream<u8>)`, reads it back via `get-data(..) -> stream<u8>`,
+//! and returns the bytes.
+//!
+//! The host binds a single [`MultiplexedAsyncBlobstore`] with the in-memory
+//! provider and declares an **unnamed** blobstore interface (the default route).
+//! A 200 whose body echoes the written bytes proves that a component gets a
+//! working backend from a plain import — no label needed — exercising the
+//! standard (non-`(implements)`) binding to the workload's default backend.
+//!
+//! Unlike the NATS-backed blobstore integration tests, this uses the in-memory
+//! backend, so it needs no Docker and is not `#[ignore]`d.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::wasi_blobstore::{InMemoryProvider, MultiplexedAsyncBlobstore},
+    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
+    wit::WitInterface,
+};
+
+mod common;
+use common::http_incoming_handler_interface;
+
+const BLOBSTORE_DEFAULT_P3_WASM: &[u8] = include_bytes!("wasm/blobstore_default_p3.wasm");
+
+/// An UNNAMED async `wasmcloud:blobstore` interface — no `(implements ..)` label,
+/// no backend override, so it is the workload's default route and falls back to
+/// the in-memory backend.
+fn default_blob_iface() -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "blobstore".to_string(),
+        interfaces: [
+            "blobstore".to_string(),
+            "container".to_string(),
+            "types".to_string(),
+        ]
+        .into_iter()
+        .collect(),
+        version: Some(semver::Version::parse("0.1.0").unwrap()),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+#[tokio::test]
+async fn p3_guest_plain_blobstore_uses_default_backend() -> Result<()> {
+    // --- host with the async multiplexed blobstore plugin + in-memory provider ---
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_server.addr();
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(
+            MultiplexedAsyncBlobstore::new().with_provider(Arc::new(InMemoryProvider)),
+        ))?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    // The guest imports blobstore *plainly* (no label); the unnamed interface is
+    // the default route, which the plugin binds via the standard host interface.
+    let host_interfaces = vec![
+        http_incoming_handler_interface("blob-default", None),
+        default_blob_iface(),
+    ];
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "blobstore-default-p3".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "blobstore-default-p3.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(BLOBSTORE_DEFAULT_P3_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    };
+
+    // Binding runs the *standard* `blobstore::add_to_linker` (not the named one)
+    // for the plain import. `workload_start` returns Ok even on resolution
+    // failure (it encodes the error in the status), so assert it reached Running.
+    let resp = host
+        .workload_start(req)
+        .await
+        .context("workload_start call failed")?;
+    assert_eq!(
+        resp.workload_status.workload_state,
+        WorkloadState::Running,
+        "a plain (unlabeled) blobstore import should resolve to a default backend: {}",
+        resp.workload_status.message
+    );
+
+    // Drive the guest: create a container, stream an object in, read it back, and
+    // echo the bytes. A matching body proves the plain import reached a working
+    // default backend through the stream ABI — with no label.
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(15),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "blob-default")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+
+    let status = response.status();
+    let body = response.text().await?;
+    assert!(status.is_success(), "expected 200, got {status}: {body}");
+    assert_eq!(
+        body, "woof from a plain p3 guest",
+        "the guest must round-trip the object body through the default (unlabeled) backend"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_keyvalue_default_p3.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_default_p3.rs
@@ -1,0 +1,136 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! A **plain** (unlabeled) async `wasmcloud:keyvalue@0.1.0` `store` import, served
+//! by a default backend through a **real P3 guest** — no `(implements ..)` label.
+//!
+//! The `keyvalue-default-p3` fixture opens a bucket via `wasmcloud:keyvalue/store`
+//! plainly. On each request it sets a key, increments a counter through the
+//! standalone `atomics` import, reads the value back, and returns it.
+//!
+//! The host binds a single [`MultiplexedAsyncKeyValue`] with the in-memory
+//! provider and declares an **unnamed** keyvalue interface (the default route). A
+//! 200 whose body echoes the written value proves that a component gets a working
+//! backend from a plain `store` import — no label needed — exercising the standard
+//! (non-`(implements)`) binding to the workload's default backend.
+//!
+//! Like the blobstore-default counterpart, this uses the in-memory backend, so it
+//! needs no external services and is not `#[ignore]`d.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    plugin::wasi_keyvalue::{InMemoryProvider, MultiplexedAsyncKeyValue},
+    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
+    wit::WitInterface,
+};
+
+mod common;
+use common::http_incoming_handler_interface;
+
+const KEYVALUE_DEFAULT_P3_WASM: &[u8] = include_bytes!("wasm/keyvalue_default_p3.wasm");
+
+/// An UNNAMED async `wasmcloud:keyvalue` interface — no `(implements ..)` label,
+/// no backend override, so it is the workload's default route and falls back to
+/// the in-memory backend.
+fn default_kv_iface() -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: ["store".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.1.0").unwrap()),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+#[tokio::test]
+async fn p3_guest_plain_keyvalue_uses_default_backend() -> Result<()> {
+    // --- host with the async multiplexed keyvalue plugin + in-memory provider ---
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_server.addr();
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(
+            MultiplexedAsyncKeyValue::new().with_provider(Arc::new(InMemoryProvider)),
+        ))?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    // The guest imports `store` *plainly* (no label); the unnamed interface is the
+    // default route, which the plugin binds via the standard host interface.
+    let host_interfaces = vec![
+        http_incoming_handler_interface("kv-default", None),
+        default_kv_iface(),
+    ];
+
+    let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "keyvalue-default-p3".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "keyvalue-default-p3.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(KEYVALUE_DEFAULT_P3_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 100,
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    };
+
+    // Binding runs the *standard* `store::add_to_linker` (not the named one) for
+    // the plain import. `workload_start` returns Ok even on resolution failure (it
+    // encodes the error in the status), so assert it reached Running.
+    let resp = host
+        .workload_start(req)
+        .await
+        .context("workload_start call failed")?;
+    assert_eq!(
+        resp.workload_status.workload_state,
+        WorkloadState::Running,
+        "a plain (unlabeled) keyvalue import should resolve to a default backend: {}",
+        resp.workload_status.message
+    );
+
+    // Drive the guest: open a bucket, set a key, increment a counter, read the
+    // value back, and echo it. A matching body proves the plain import reached a
+    // working default backend — with no label.
+    let client = reqwest::Client::new();
+    let response = timeout(
+        Duration::from_secs(15),
+        client
+            .get(format!("http://{addr}/"))
+            .header("HOST", "kv-default")
+            .send(),
+    )
+    .await
+    .context("request timed out")?
+    .context("request failed")?;
+
+    let status = response.status();
+    let body = response.text().await?;
+    assert!(status.is_success(), "expected 200, got {status}: {body}");
+    assert_eq!(
+        body, "woof from a plain p3 keyvalue guest",
+        "the guest must round-trip the value through the default (unlabeled) backend"
+    );
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -113,7 +113,9 @@ const P3_FIXTURES: &[&str] = &[
     "ephemeral-callee-p3",
     "ephemeral-caller-p3",
     "blobstore-implements-p3",
+    "blobstore-default-p3",
     "keyvalue-implements-p3",
+    "keyvalue-default-p3",
 ];
 
 // Fixtures with local-only WIT worlds (no wasi imports). Copying shared


### PR DESCRIPTION
Adds support for default backends for wasmcloud:{keyvalue,blobstore}.
Multiplexed capability plugins previously required an `(implements ..)`
label on an import to bind a backend; a plain (unlabeled) import of
`wasmcloud:blobstore` or `wasmcloud:keyvalue/store` had no backend and
failed to instantiate. Now any multiplexed plugin serves a plain import
from the workload's default (the unnamed `""`) route.

- multiplex: add `defaults` map + `set_default`/`default_for` (+ unit test)
- wasi_blobstore: move the local default map onto the shared `Multiplexer`
- wasi_keyvalue: add the standard `store` binding + labeled/plain gating
- add `blobstore-default-p3` / `keyvalue-default-p3` real-guest fixtures and
  in-memory P3 integration tests proving a plain import round-trips through
  a default backend with no label