### PR TITLE
chore(codeowners): only req example maintainers for new example

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,3 +46,8 @@
 # Examples and project templates
 /examples/              @wasmCloud/examples-maintainers
 /templates/             @wasmCloud/examples-maintainers
+
+# Adding an example registers it in the examples CI matrix, so example
+# maintainers own that workflow to keep new examples reviewable by them
+# alone. This override comes after /.github/ so it takes precedence.
+/.github/workflows/examples.yml         @wasmCloud/examples-maintainers @wasmCloud/ci-maintainers


### PR DESCRIPTION
Give ownership of examples workflow to example-maintainers.

So when example.yml changes, it will request review from both example and ci maintainers, but only requires one of them to approve.