### PR TITLE
fix(wash-runtime): recognize P3 wasi:http/handler as host-served HTTP

### DIFF
--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1416,8 +1416,11 @@ impl UnresolvedWorkload {
         // This tracks which interfaces each component still needs to be bound
         let mut unmatched_interfaces: HashMap<IdFlavor, HashSet<WitInterface>> = HashMap::new();
         let host_interfaces = {
-            // filter out Plugins fulfilled by host
-            let http_iface = WitInterface::from("wasi:http/incoming-handler,outgoing-handler");
+            // filter out Plugins fulfilled by host. `handler` is the unified
+            // WASI P3 http interface (covers both incoming and outgoing);
+            // `incoming-handler`/`outgoing-handler` are its P2 equivalents.
+            let http_iface =
+                WitInterface::from("wasi:http/incoming-handler,outgoing-handler,handler");
             self.host_interfaces
                 .iter()
                 .filter(|wit_interface| !http_iface.contains(wit_interface))
@@ -1723,11 +1726,10 @@ impl UnresolvedWorkload {
         };
 
         let incoming_http_component = {
-            let http_iface = WitInterface::from("wasi:http/incoming-handler");
             match self
                 .host_interfaces
                 .iter()
-                .any(|hi| hi.contains(&http_iface))
+                .any(|hi| hi.is_incoming_http_handler())
             {
                 // http was not part of the requested interfaces
                 false => None,
@@ -2520,6 +2522,56 @@ mod tests {
 
         // The test verifies the error path exists and works correctly
         // In practice, this would fail if a component imports blobstore but no plugin provides it
+    }
+
+    /// A component exporting the unified WASI P3 `wasi:http/handler` interface
+    /// must bind with no HTTP plugin present, exactly like a P2
+    /// `incoming-handler` component: HTTP is served by the host, so the
+    /// requested interface must not fall through to plugin matching.
+    #[tokio::test]
+    async fn test_p3_http_handler_served_by_host() {
+        let engine = wasmtime::Engine::default();
+        let wasm = wat::parse_str(
+            r#"(component
+                (component $empty)
+                (instance $i (instantiate $empty))
+                (export "wasi:http/handler@0.3.0" (instance $i))
+            )"#,
+        )
+        .unwrap();
+        let component = Component::new(&engine, &wasm).unwrap();
+        let workload_component = WorkloadComponent::new(
+            "workload-p3-http".to_string(),
+            "test-workload-p3-http".to_string(),
+            "test-namespace".to_string(),
+            "test-component".to_string(),
+            component,
+            Linker::new(&engine),
+            Vec::new(),
+            LocalResources::default(),
+            Arc::default(),
+        );
+
+        let mut http_interface = WitInterface::from("wasi:http/handler");
+        http_interface
+            .config
+            .insert("host".to_string(), "localhost".to_string());
+        assert!(http_interface.is_incoming_http_handler());
+
+        let mut workload = UnresolvedWorkload::new(
+            "test-workload-id".to_string(),
+            "test-workload".to_string(),
+            "test-namespace".to_string(),
+            None,
+            vec![workload_component],
+            vec![http_interface],
+        );
+
+        let bound_plugins = workload.bind_plugins(&HashMap::new()).await.unwrap();
+        assert!(
+            bound_plugins.is_empty(),
+            "host-served wasi:http/handler must not require a plugin"
+        );
     }
 
     /// Tests that plugin callbacks are invoked in the correct order:

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -27,7 +27,6 @@ use std::{
 };
 
 use crate::host::allowed_hosts::AllowedHost;
-use crate::wit::WitInterface;
 use crate::{engine::ctx::SharedCtx, observability::Meters};
 use crate::{engine::workload::ResolvedWorkload, observability::FuelConsumptionMeter};
 use anyhow::{Context, ensure};
@@ -186,13 +185,14 @@ impl Router for DynamicRouter {
         resolved_handle: &ResolvedWorkload,
         _component_id: &str,
     ) -> anyhow::Result<()> {
-        let incoming_handler_interface = WitInterface::from("wasi:http/incoming-handler");
         let Some(http_iface) = resolved_handle
             .host_interfaces()
             .iter()
-            .find(|iface| iface.contains(&incoming_handler_interface))
+            .find(|iface| iface.is_incoming_http_handler())
         else {
-            anyhow::bail!("workload did not request wasi:http/incoming-handler interface");
+            anyhow::bail!(
+                "workload did not request wasi:http/incoming-handler or wasi:http/handler interface"
+            );
         };
 
         let primary_host = http_iface

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -215,6 +215,17 @@ impl WitInterface {
 
         self.interfaces.is_superset(&other.interfaces)
     }
+
+    /// Returns `true` if this interface is an incoming `wasi:http` handler.
+    ///
+    /// This recognises both the WASI P2 `incoming-handler` interface and the
+    /// unified WASI P3 `handler` interface, so HTTP entrypoints are detected
+    /// regardless of which WASI version a component targets.
+    pub fn is_incoming_http_handler(&self) -> bool {
+        self.namespace == "wasi"
+            && self.package == "http"
+            && (self.interfaces.contains("incoming-handler") || self.interfaces.contains("handler"))
+    }
 }
 
 impl Display for WitInterface {
@@ -449,6 +460,29 @@ mod tests {
         assert!(interface_a.contains(&interface_b));
         // Different versions should not match
         assert!(!interface_a.contains(&interface_c));
+    }
+
+    #[test]
+    fn test_is_incoming_http_handler() {
+        // P2 incoming handler
+        let p2 = WitInterface::from("wasi:http/incoming-handler");
+        assert!(p2.is_incoming_http_handler());
+
+        // Unified P3 handler, with and without version
+        let p3 = WitInterface::from("wasi:http/handler");
+        assert!(p3.is_incoming_http_handler());
+        let p3_versioned = WitInterface::from("wasi:http/handler@0.3.0");
+        assert!(p3_versioned.is_incoming_http_handler());
+
+        // Outgoing-only is not an incoming handler
+        let outgoing = WitInterface::from("wasi:http/outgoing-handler");
+        assert!(!outgoing.is_incoming_http_handler());
+
+        // Same interface name in a different package does not match
+        let messaging = WitInterface::from("wasmcloud:messaging/handler");
+        assert!(!messaging.is_incoming_http_handler());
+        let other_ns = WitInterface::from("wasi:messaging/incoming-handler");
+        assert!(!other_ns.is_incoming_http_handler());
     }
 
     #[test]


### PR DESCRIPTION
A workload declaring the unified WASI P3 `wasi:http/handler` interface
failed to deploy: bind_plugins only stripped the P2 `incoming-handler`/
`outgoing-handler` names from the host-served set, so `handler` fell
through to plugin matching and failed with "no plugins found for
requested interfaces".

Add WitInterface::is_incoming_http_handler(), covering both the P2
incoming-handler and the unified P3 handler names, and use it in the
listener gate and DynamicRouter; include `handler` in the bind-time
host-served filter. Request dispatch was already export-driven via
targets_wasip3_http(), so only the binding/routing gates were stale.
