### PR TITLE
feat(wash-runtime): trigger service

### DIFF
--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -315,6 +315,18 @@ impl WorkloadService {
         Ok(command)
     }
 
+    /// Pre-instantiate the raw component, leaving binding-view construction
+    /// (e.g. both cli `Command` and http `Service`) to the caller. Used when a
+    /// p3 service also serves HTTP and must drive both exports on one instance.
+    pub fn pre_instantiate_raw(
+        &self,
+    ) -> anyhow::Result<wasmtime::component::InstancePre<SharedCtx>> {
+        Ok(self
+            .metadata
+            .linker
+            .instantiate_pre(&self.metadata.component)?)
+    }
+
     /// Whether or not the service is currently running.
     pub fn is_running(&self) -> bool {
         self.handle.is_some()
@@ -535,6 +547,26 @@ impl std::fmt::Debug for ResolvedWorkload {
     }
 }
 
+/// Build a trigger service's host-invoked ingresses, returning them alongside the
+/// paired senders to register with the host-side ingresses. Called once per
+/// incarnation (start and each restart) so a restarted service gets fresh
+/// channels whose senders replace the stale registrations.
+#[allow(clippy::type_complexity)]
+fn build_trigger_ingresses(
+    serves_http: bool,
+) -> (
+    Vec<crate::host::trigger_service::Ingress>,
+    Option<tokio::sync::mpsc::Sender<crate::host::http::ServiceHttpJob>>,
+) {
+    let mut ingresses = Vec::new();
+    let http_tx = serves_http.then(|| {
+        let (tx, rx) = tokio::sync::mpsc::channel(256);
+        ingresses.push(crate::host::trigger_service::Ingress::Http(rx));
+        tx
+    });
+    (ingresses, http_tx)
+}
+
 impl ResolvedWorkload {
     /// Executes the service, if present, and returns whether it was run.
     #[instrument(name="execute_service", skip_all, fields(workload.id = self.id.as_ref(), workload.name = self.name.as_ref(), workload.namespace = self.namespace.as_ref()))]
@@ -544,6 +576,16 @@ impl ResolvedWorkload {
             .as_ref()
             .is_some_and(|s| s.metadata.targets_p3())
         {
+            // A p3 service that also exports a host-invoked handler (today
+            // `wasi:http/handler`) co-drives it with `cli/run` on one instance
+            // (see the `trigger service` module).
+            if self
+                .service
+                .as_ref()
+                .is_some_and(|s| crate::engine::exports_wasi_http(&s.metadata.component))
+            {
+                return self.execute_trigger_service().await;
+            }
             return self.execute_service_p3().await;
         }
 
@@ -645,6 +687,94 @@ impl ResolvedWorkload {
         } else {
             Ok(None)
         }
+    }
+
+    /// Execute a p3 service that also exports a host-invoked handler (today
+    /// `wasi:http/handler`): one instance co-drives `cli/run` and the handler
+    /// under a single `run_concurrent` (see [`crate::host::trigger_service`]).
+    /// The service runs in its own long-lived store.
+    /// `is_service = true` lets the `cli/run` side bind its loopback socket.
+    async fn execute_trigger_service(&mut self) -> anyhow::Result<Option<Arc<JoinHandle<()>>>> {
+        let Some(service) = self.service.as_ref() else {
+            return Ok(None);
+        };
+        let pre = service.pre_instantiate_raw()?;
+        let (serves_http, max_restarts) = (
+            crate::engine::exports_wasi_http(&service.metadata.component),
+            service.max_restarts,
+        );
+        self.resolve_service_volume_mounts().await?;
+
+        let mut store = {
+            let Some(service) = self.service.as_ref() else {
+                bail!("service unexpectedly missing during execution");
+            };
+            self.new_store_from_metadata(&service.metadata, true)
+                .await?
+        };
+        let http_handler = self.http_handler.clone();
+        let workload_id: Arc<str> = Arc::from(self.id());
+
+        // Build the first incarnation's host-invoked ingresses. Each paired sender
+        // is registered with its host-side ingress (the HTTP server), which then
+        // delivers to this live instance instead of instantiating a component per
+        // request. The first registration is synchronous (before the driver
+        // spawns) so a delivery immediately after start finds the handler;
+        // restarts re-register from inside the supervisor.
+        let (ingresses, http_tx) = build_trigger_ingresses(serves_http);
+        if let Some(http_tx) = http_tx {
+            self.http_handler
+                .on_service_http_resolved(self.id(), http_tx)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to register service HTTP handler: {e:#}"))?;
+        }
+
+        // Supervise the driver: on a fault (e.g. a guest trap in `cli/run` or a
+        // handler), re-instantiate into the same store, rebuild the ingresses, and
+        // re-register their handlers (swapping the stale senders) until the restart
+        // budget is exhausted. A clean exit (every channel closed) stops it.
+        let handle = tokio::spawn(async move {
+            let mut first = Some(ingresses);
+            let mut restarts = max_restarts;
+            loop {
+                let ingresses = match first.take() {
+                    Some(ingresses) => ingresses,
+                    None => {
+                        let (ingresses, http_tx) = build_trigger_ingresses(serves_http);
+                        if let Some(http_tx) = http_tx
+                            && let Err(e) = http_handler
+                                .on_service_http_resolved(&workload_id, http_tx)
+                                .await
+                        {
+                            error!(err = %e, "failed to re-register service HTTP handler on restart");
+                        }
+                        ingresses
+                    }
+                };
+                match crate::host::trigger_service::run_trigger_driver(&mut store, &pre, ingresses)
+                    .await
+                {
+                    Ok(()) => {
+                        info!("trigger service exited");
+                        break;
+                    }
+                    Err(e) if restarts == 0 => {
+                        error!(err = %e, "trigger service faulted; max restarts reached");
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(err = %e, retries = restarts, "trigger service faulted; restarting");
+                        restarts = restarts.saturating_sub(1);
+                    }
+                }
+            }
+        });
+
+        let handle = Arc::new(handle);
+        if let Some(s) = self.service.as_mut() {
+            s.handle = Some(Arc::clone(&handle));
+        }
+        Ok(Some(handle))
     }
 
     /// Aborts the running service [`JoinHandle`] if it exists.
@@ -1295,6 +1425,15 @@ impl ResolvedWorkload {
                     "failed to notify HTTP handler of workload",
                 )?;
             }
+        }
+
+        // A trigger service registered its HTTP handler at start
+        // (`execute_trigger_service`); drop that registration on stop so it no
+        // longer receives host-invoked deliveries on a torn-down instance.
+        if self.service.is_some()
+            && let Err(e) = self.http_handler.on_service_http_unbind(self.id()).await
+        {
+            tracing::error!(workload.id = %self.id(), err = %e, "failed to unbind service HTTP handler, continuing");
         }
 
         Ok(())

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -137,6 +137,13 @@ pub trait Router: Send + Sync + 'static {
     /// Unregister a workload that is being stopped
     async fn on_workload_unbind(&self, workload_id: &str) -> anyhow::Result<()>;
 
+    /// Register a workload whose long-lived service handles HTTP ingress (the
+    /// service exports `wasi:http/handler`). Routers that key off a component
+    /// can use this to map the workload for routing. Default: no-op.
+    async fn on_service_http_resolved(&self, _workload_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Determine if the outgoing request is allowed
     fn allow_outgoing_request(
         &self,
@@ -409,6 +416,17 @@ impl Router for DevRouter {
         Ok(())
     }
 
+    async fn on_service_http_resolved(&self, workload_id: &str) -> anyhow::Result<()> {
+        // A service-handled workload routes the same way as a component one:
+        // DevRouter sends all requests to the most-recently resolved workload.
+        let mut lock = self
+            .last_workload_id
+            .write()
+            .map_err(|e| anyhow::anyhow!("DevRouter write lock poisoned: {e}"))?;
+        lock.replace(workload_id.to_string());
+        Ok(())
+    }
+
     fn allow_outgoing_request(
         &self,
         _workload_id: &str,
@@ -462,6 +480,22 @@ pub trait HostHandler: Send + Sync + 'static {
     ) -> anyhow::Result<()>;
     /// Unregister a workload
     async fn on_workload_unbind(&self, workload_id: &str) -> anyhow::Result<()>;
+
+    /// Register a long-lived service instance that serves HTTP ingress: inbound
+    /// requests for `workload_id` are delivered over `sender` instead of
+    /// instantiating a component per request. Default: no-op (the workload
+    /// keeps the per-request path).
+    async fn on_service_http_resolved(
+        &self,
+        _workload_id: &str,
+        _sender: tokio::sync::mpsc::Sender<ServiceHttpJob>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+    /// Unregister a service HTTP instance. Default: no-op.
+    async fn on_service_http_unbind(&self, _workload_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
 
     /// Handle an outgoing HTTP request from a workload
     fn outgoing_request(
@@ -574,6 +608,17 @@ impl HostHandler for NullServer {
 pub type WorkloadHandles =
     Arc<RwLock<HashMap<String, (ResolvedWorkload, InstancePre<SharedCtx>, String)>>>;
 
+/// An inbound HTTP request routed to a long-lived service instance, paired with
+/// a oneshot for its response.
+pub type ServiceHttpJob = (
+    hyper::Request<hyper::body::Incoming>,
+    tokio::sync::oneshot::Sender<anyhow::Result<hyper::Response<HyperOutgoingBody>>>,
+);
+
+/// A map from workload id to the channel of its HTTP-serving service instance.
+/// Empty unless a workload's service opts into HTTP ingress (a p3 feature).
+pub type ServiceHandlers = Arc<RwLock<HashMap<String, tokio::sync::mpsc::Sender<ServiceHttpJob>>>>;
+
 /// HTTP server plugin that handles incoming HTTP requests for WebAssembly components.
 ///
 /// This plugin implements the `wasi:http/incoming-handler` interface and routes
@@ -594,6 +639,8 @@ pub struct HttpServer<T: Router, O: OutgoingHandler = DefaultOutgoingHandler> {
     outgoing_handler: O,
     addr: SocketAddr,
     workload_handles: WorkloadHandles,
+    /// Workloads whose long-lived service serves HTTP ingress directly.
+    service_handlers: ServiceHandlers,
     shutdown_tx: Arc<RwLock<Option<mpsc::Sender<()>>>>,
     tls_acceptor: Option<TlsAcceptor>,
     listener: Arc<tokio::sync::Mutex<Option<TcpListener>>>,
@@ -713,6 +760,7 @@ impl<T: Router, O: OutgoingHandler> HttpServerBuilder<T, O> {
             outgoing_handler: self.outgoing_handler,
             addr,
             workload_handles: Arc::default(),
+            service_handlers: Arc::default(),
             shutdown_tx: Arc::new(RwLock::new(None)),
             tls_acceptor,
             listener: Arc::new(tokio::sync::Mutex::new(Some(listener))),
@@ -756,6 +804,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
         let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
         let shutdown_tx_clone = self.shutdown_tx.clone();
         let workload_handles = self.workload_handles.clone();
+        let service_handlers = self.service_handlers.clone();
         let tls_acceptor = self.tls_acceptor.clone();
 
         // Store the shutdown sender
@@ -782,6 +831,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
                 listener,
                 handler,
                 workload_handles,
+                service_handlers,
                 &mut shutdown_rx,
                 tls_acceptor,
                 fuel_meter,
@@ -837,7 +887,32 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
         self.router.on_workload_unbind(workload_id).await?;
 
         self.workload_handles.write().await.remove(workload_id);
+        self.service_handlers.write().await.remove(workload_id);
 
+        Ok(())
+    }
+
+    async fn on_service_http_resolved(
+        &self,
+        workload_id: &str,
+        sender: tokio::sync::mpsc::Sender<ServiceHttpJob>,
+    ) -> anyhow::Result<()> {
+        self.router.on_service_http_resolved(workload_id).await?;
+        // A re-resolve without an intervening unbind is expected: the trigger
+        // service supervisor re-registers a fresh sender on every restart (see
+        // `execute_trigger_service`) to swap in the new incarnation. Overwriting
+        // is correct there — the replaced mapping belonged to the faulted
+        // incarnation whose receiver is already dropped, so nothing live is
+        // orphaned. Stop is the only path that unbinds.
+        self.service_handlers
+            .write()
+            .await
+            .insert(workload_id.to_string(), sender);
+        Ok(())
+    }
+
+    async fn on_service_http_unbind(&self, workload_id: &str) -> anyhow::Result<()> {
+        self.service_handlers.write().await.remove(workload_id);
         Ok(())
     }
 
@@ -917,6 +992,7 @@ async fn run_http_server<T: Router>(
     listener: TcpListener,
     handler: Arc<T>,
     workload_handles: WorkloadHandles,
+    service_handlers: ServiceHandlers,
     shutdown_rx: &mut mpsc::Receiver<()>,
     tls_acceptor: Option<TlsAcceptor>,
     fuel_meter: FuelConsumptionMeter,
@@ -935,12 +1011,14 @@ async fn run_http_server<T: Router>(
                         debug!(addr = ?client_addr, "new HTTP client connection");
 
                         let handles_clone = workload_handles.clone();
+                        let service_handlers_clone = service_handlers.clone();
                         let tls_acceptor_clone = tls_acceptor.clone();
                         let handler_clone = handler.clone();
                         let fuel_meter = fuel_meter.clone();
                         tokio::spawn(async move {
                             let service = hyper::service::service_fn(move |req| {
                                 let handles = handles_clone.clone();
+                                let service_handlers = service_handlers_clone.clone();
                                 let handler = handler_clone.clone();
                                 let fuel_meter = fuel_meter.clone();
                                 async move {
@@ -948,7 +1026,7 @@ async fn run_http_server<T: Router>(
                                     let remote_context =
                                         opentelemetry::global::get_text_map_propagator(|propagator| propagator.extract(&extractor));
 
-                                    handle_http_request(handler, req, handles, fuel_meter).with_context(remote_context).await
+                                    handle_http_request(handler, req, handles, service_handlers, fuel_meter).with_context(remote_context).await
                                 }
                             });
 
@@ -1040,6 +1118,7 @@ async fn handle_http_request<T: Router>(
     handler: Arc<T>,
     req: hyper::Request<hyper::body::Incoming>,
     workload_handles: WorkloadHandles,
+    service_handlers: ServiceHandlers,
     fuel_meter: FuelConsumptionMeter,
 ) -> Result<hyper::Response<HyperOutgoingBody>, hyper::Error> {
     let method = req.method().clone();
@@ -1067,6 +1146,31 @@ async fn handle_http_request<T: Router>(
         host = %workload_id,
         "HTTP request received"
     );
+
+    // If this workload's long-lived service serves HTTP, deliver the request to
+    // it (preserving its in-memory state) instead of the per-request path.
+    let service_sender = service_handlers.read().await.get(&workload_id).cloned();
+    if let Some(sender) = service_sender {
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+        let response = if sender.send((req, resp_tx)).await.is_err() {
+            error!(host = %workload_id, "service HTTP instance is not running");
+            error_response(503)
+        } else {
+            match resp_rx.await {
+                Ok(Ok(resp)) => resp,
+                Ok(Err(e)) => {
+                    error!(err = ?e, "service HTTP handler failed");
+                    error_response(500)
+                }
+                Err(_) => {
+                    error!("service HTTP instance dropped the response");
+                    error_response(500)
+                }
+            }
+        };
+        record_response_status(&response);
+        return Ok(response);
+    }
 
     // NOTE(lxf): Separate HTTP / GRPC handling
 

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -65,6 +65,7 @@ use sysinfo::SystemMonitor;
 pub mod allowed_hosts;
 pub mod http;
 pub mod http_p3;
+pub mod trigger_service;
 
 /// The API for interacting with a wasmcloud host.
 ///

--- a/crates/wash-runtime/src/host/trigger_service/http.rs
+++ b/crates/wash-runtime/src/host/trigger_service/http.rs
@@ -1,0 +1,219 @@
+//! The [`Ingress::Http`] path: `wasi:http/handler@0.3` requests served on the
+//! shared service instance, streaming responses back to the HTTP server.
+//!
+//! [`Ingress::Http`]: super::Ingress::Http
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use http_body_util::BodyExt;
+use wasmtime::component::{Accessor, AccessorTask};
+use wasmtime_wasi_http::p2::bindings::http::types::ErrorCode as P2ErrorCode;
+use wasmtime_wasi_http::p2::body::HyperOutgoingBody;
+use wasmtime_wasi_http::p3::bindings::Service;
+use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
+
+use crate::engine::ctx::SharedCtx;
+
+/// Response body that yields frames forwarded from the [`HttpTask`] over a
+/// bounded channel, so a service response streams to the client incrementally
+/// instead of being buffered. End-of-stream is signalled when the task drops the
+/// sender (body complete, or the task aborted because the client disconnected).
+struct ChannelBody {
+    rx: tokio::sync::mpsc::Receiver<Result<hyper::body::Frame<bytes::Bytes>, P2ErrorCode>>,
+}
+
+impl hyper::body::Body for ChannelBody {
+    type Data = bytes::Bytes;
+    type Error = P2ErrorCode;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
+/// Handles one inbound HTTP request on the shared service instance.
+pub(super) struct HttpTask {
+    pub(super) service: Arc<Service>,
+    pub(super) req: hyper::Request<hyper::body::Incoming>,
+    pub(super) resp_tx:
+        tokio::sync::oneshot::Sender<anyhow::Result<hyper::Response<HyperOutgoingBody>>>,
+}
+
+impl AccessorTask<SharedCtx> for HttpTask {
+    async fn run(self, accessor: &Accessor<SharedCtx>) -> wasmtime::Result<()> {
+        let HttpTask {
+            service,
+            req,
+            resp_tx,
+        } = self;
+
+        let (parts, body) = req.into_parts();
+        let body = body
+            .map_err(|e| ErrorCode::InternalError(Some(e.to_string())))
+            .boxed_unsync();
+        let req = hyper::Request::from_parts(parts, body);
+        let (wasi_req, req_io) = wasmtime_wasi_http::p3::Request::from_http(req);
+
+        // Bounded channel for response-body frames: the head is delivered to the
+        // HTTP server as soon as the handler returns it, while the body keeps
+        // streaming. The small capacity back-pressures the guest so frames don't
+        // accumulate without bound.
+        let (frame_tx, frame_rx) =
+            tokio::sync::mpsc::channel::<Result<hyper::body::Frame<bytes::Bytes>, P2ErrorCode>>(4);
+        let mut resp_tx = Some(resp_tx);
+
+        let handler_fut = async move {
+            let response = match service.handle(accessor, wasi_req).await {
+                Ok(Ok(response)) => response,
+                Ok(Err(error_code)) => {
+                    tracing::error!(?error_code, "service HTTP handler returned error");
+                    if let Some(tx) = resp_tx.take() {
+                        let resp = hyper::Response::builder()
+                            .status(500)
+                            .body(HyperOutgoingBody::default())
+                            .map_err(anyhow::Error::from);
+                        let _ = tx.send(resp);
+                    }
+                    return Ok(());
+                }
+                Err(e) => {
+                    if let Some(tx) = resp_tx.take() {
+                        let _ =
+                            tx.send(Err(anyhow::anyhow!(e).context("service HTTP handler trap")));
+                    }
+                    return Ok(());
+                }
+            };
+
+            // `into_http`'s future reports the body-delivery outcome back to the
+            // guest; resolve it once the body has been fully forwarded.
+            let (finish_tx, finish_rx) = tokio::sync::oneshot::channel::<Result<(), ErrorCode>>();
+            let http_response = match accessor
+                .with(|s| response.into_http(s, async move { finish_rx.await.unwrap_or(Ok(())) }))
+            {
+                Ok(http_response) => http_response,
+                Err(e) => {
+                    if let Some(tx) = resp_tx.take() {
+                        let _ = tx.send(Err(anyhow::anyhow!(e)
+                            .context("failed to convert service response to http")));
+                    }
+                    return Ok(());
+                }
+            };
+            let (head, mut body) = http_response.into_parts();
+
+            // Deliver the head + streaming body to the HTTP server now.
+            if let Some(tx) = resp_tx.take() {
+                let stream_body =
+                    HyperOutgoingBody::new(ChannelBody { rx: frame_rx }.boxed_unsync());
+                if tx
+                    .send(Ok(hyper::Response::from_parts(head, stream_body)))
+                    .is_err()
+                {
+                    // Caller dropped the receiver; report the failed delivery.
+                    let _ = finish_tx.send(Err(ErrorCode::ConnectionTerminated));
+                    return Ok(());
+                }
+            }
+
+            // Forward body frames incrementally; stop if the client disconnects.
+            let mut delivery = Ok(());
+            while let Some(frame) = body.frame().await {
+                // Frames carry the p3 `ErrorCode`; the server body wants the p2 one.
+                let frame = frame.map_err(|e| P2ErrorCode::InternalError(Some(format!("{e:?}"))));
+                if frame_tx.send(frame).await.is_err() {
+                    delivery = Err(ErrorCode::ConnectionTerminated);
+                    break;
+                }
+            }
+            let _ = finish_tx.send(delivery);
+            Ok::<(), anyhow::Error>(())
+        };
+        let io_fut = async move {
+            let _ = req_io.await;
+        };
+
+        // Bound the whole exchange so a stalled client (connected but not reading)
+        // can't park this task on `frame_tx.send` for the life of the connection.
+        // A response still streaming past this bound is truncated.
+        match tokio::time::timeout(
+            crate::timeouts::http_response(),
+            futures::future::join(handler_fut, io_fut),
+        )
+        .await
+        {
+            Ok((handler_result, ())) => {
+                if let Err(e) = handler_result {
+                    tracing::error!(err = ?e, "service HTTP response streaming failed");
+                }
+            }
+            Err(_) => tracing::error!("service HTTP response timed out"),
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use hyper::body::Frame;
+
+    /// [`ChannelBody`] must forward frames **incrementally** — a consumer
+    /// receives a frame while the producer is still parked — so a service
+    /// response streams to the client rather than being buffered whole. Also
+    /// checks that end-of-stream is signalled when the producer drops its sender.
+    #[tokio::test]
+    async fn channel_body_streams_frames_incrementally() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<Frame<Bytes>, P2ErrorCode>>(4);
+        // Gates the producer's second frame on the consumer acknowledging the
+        // first, proving the first was delivered before the producer completed.
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let producer = tokio::spawn(async move {
+            tx.send(Ok(Frame::data(Bytes::from_static(b"first"))))
+                .await
+                .expect("send first");
+            ack_rx.await.expect("consumer ack");
+            tx.send(Ok(Frame::data(Bytes::from_static(b"second"))))
+                .await
+                .expect("send second");
+            // `tx` dropped here -> end-of-stream.
+        });
+
+        let mut body = ChannelBody { rx };
+
+        let first = body
+            .frame()
+            .await
+            .expect("a frame")
+            .expect("ok frame")
+            .into_data()
+            .expect("data frame");
+        assert_eq!(first.as_ref(), b"first");
+
+        // Receiving `first` while the producer is still parked on `ack_rx` proves
+        // incremental (non-buffered) delivery. Release the producer for the rest.
+        ack_tx.send(()).expect("release producer");
+
+        let second = body
+            .frame()
+            .await
+            .expect("a frame")
+            .expect("ok frame")
+            .into_data()
+            .expect("data frame");
+        assert_eq!(second.as_ref(), b"second");
+
+        assert!(
+            body.frame().await.is_none(),
+            "stream should end when the producer drops its sender"
+        );
+        producer.await.expect("producer task");
+    }
+}

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -1,0 +1,183 @@
+//! TriggerService: a long-lived service instance that co-drives `wasi:cli/run`
+//! alongside one or more host-invoked handler exports on a single instance.
+//!
+//! A wasmCloud service is a long-lived `wasi:cli/run` component. When that same
+//! component also exports a host-invoked handler (today `wasi:http/handler@0.3`),
+//! the TriggerService runs BOTH on one instance under a single [`Store::run_concurrent`]:
+//!
+//! - the `cli/run` export drives the service's own long-running work (e.g. a
+//!   connection pooler listening on a loopback socket), and
+//! - each host-invoked export is served as concurrent per-invocation tasks on
+//!   the same instance, so the long-running work and the handlers share the
+//!   instance's in-memory state.
+//!
+//! Each host-invoked export is an [`Ingress`]: the host-side plugin (the HTTP
+//! server, ...) pushes invocations into the ingress's channel and the TriggerService
+//! serves them via [`Accessor::spawn`]. Adding another host-invoked interface
+//! (e.g. a messaging handler) is a new [`Ingress`] variant plus a serve arm —
+//! the `cli/run` driving and the single-instance `run_concurrent` are reused.
+//! Each ingress kind lives in its own submodule ([`http`]); this module holds
+//! the shared [`Ingress`] enum, the `prepare`/`serve` dispatch, and the
+//! [`run_trigger_driver`] loop.
+
+use std::sync::Arc;
+
+use wasmtime::Store;
+use wasmtime::component::{Accessor, AccessorTask, Instance, InstancePre};
+use wasmtime::error::Context as _;
+use wasmtime_wasi::p3::bindings::Command;
+use wasmtime_wasi_http::p3::bindings::Service;
+
+use crate::engine::ctx::SharedCtx;
+use crate::host::http::ServiceHttpJob;
+
+mod http;
+
+use http::HttpTask;
+
+/// A host-invoked handler export the TriggerService serves, carrying the receiver end
+/// of its delivery channel. The paired sender is handed to the host-side ingress
+/// (the HTTP server, ...) so it can deliver invocations to this live instance.
+#[non_exhaustive]
+pub enum Ingress {
+    /// `wasi:http/handler@0.3` — the HTTP server delivers requests here.
+    Http(tokio::sync::mpsc::Receiver<ServiceHttpJob>),
+}
+
+impl Ingress {
+    /// Build this ingress's binding view over the shared instance. Done before
+    /// `run_concurrent` (which needs `&mut store`), mirroring the `cli` view.
+    fn prepare(
+        self,
+        store: &mut Store<SharedCtx>,
+        instance: &Instance,
+    ) -> anyhow::Result<PreparedIngress> {
+        match self {
+            Ingress::Http(rx) => {
+                let service = Service::new(store, instance)
+                    .map_err(|e| e.context("service is missing wasi:http/handler export"))?;
+                Ok(PreparedIngress::Http {
+                    service: Arc::new(service),
+                    rx,
+                })
+            }
+        }
+    }
+}
+
+/// An [`Ingress`] with its binding view built, ready to serve invocations under
+/// `run_concurrent`.
+enum PreparedIngress {
+    Http {
+        service: Arc<Service>,
+        rx: tokio::sync::mpsc::Receiver<ServiceHttpJob>,
+    },
+}
+
+impl PreparedIngress {
+    /// Serve inbound invocations, spawning one concurrent task per invocation on
+    /// the shared instance, until the delivery channel closes (the workload is
+    /// stopping).
+    async fn serve(&mut self, accessor: &Accessor<SharedCtx>) {
+        match self {
+            PreparedIngress::Http { service, rx } => {
+                while let Some((req, resp_tx)) = rx.recv().await {
+                    accessor.spawn(HttpTask {
+                        service: Arc::clone(service),
+                        req,
+                        resp_tx,
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// A running service instance co-driving `cli/run` and its host-invoked handler
+/// exports on one instance.
+pub struct TriggerService {
+    /// The driver task: instantiates once and runs cli/run + every ingress
+    /// concurrently.
+    pub driver: tokio::task::JoinHandle<()>,
+}
+
+impl TriggerService {
+    /// Instantiate the service once and start driving its `cli/run` export plus
+    /// every `ingress` on the same instance under one `run_concurrent`.
+    pub fn spawn(
+        mut store: Store<SharedCtx>,
+        pre: InstancePre<SharedCtx>,
+        ingresses: Vec<Ingress>,
+    ) -> Self {
+        let driver = tokio::spawn(async move {
+            if let Err(e) = run_trigger_driver(&mut store, &pre, ingresses).await {
+                tracing::error!(err = %e, "trigger service driver faulted");
+            }
+        });
+
+        TriggerService { driver }
+    }
+}
+
+/// Drive a trigger service on `store` to completion: instantiate `pre`, then
+/// co-drive `cli/run` (optional) with every ingress under `run_concurrent`,
+/// serving until each ingress channel closes (clean exit, `Ok`) or the store
+/// faults (`Err`, e.g. a guest trap). Reusable across restarts — a supervisor
+/// re-instantiates into the same store and re-runs this.
+pub(crate) async fn run_trigger_driver(
+    store: &mut Store<SharedCtx>,
+    pre: &InstancePre<SharedCtx>,
+    ingresses: Vec<Ingress>,
+) -> anyhow::Result<()> {
+    let instance = pre
+        .instantiate_async(&mut *store)
+        .await
+        .context("failed to instantiate trigger service")?;
+    // `cli/run` is optional: a service exports it (its long-running work), but a
+    // handler-only instance need not — in which case there is simply no run loop
+    // to co-drive.
+    let mut command = match Command::new(&mut *store, &instance) {
+        Ok(c) => Some(c),
+        Err(e) => {
+            tracing::debug!(err = %e, "no wasi:cli/run export to co-drive");
+            None
+        }
+    };
+    // Build each ingress's binding view before entering run_concurrent.
+    let mut prepared = Vec::with_capacity(ingresses.len());
+    for ingress in ingresses {
+        prepared.push(
+            ingress
+                .prepare(&mut *store, &instance)
+                .map_err(|e| e.context("failed to prepare trigger service ingress"))?,
+        );
+    }
+
+    store
+        .run_concurrent(async |accessor| {
+            // Spawn the cli/run co-driver.
+            if let Some(command) = command.take() {
+                accessor.spawn(RunTask { command });
+            }
+            futures::future::join_all(prepared.iter_mut().map(|p| p.serve(accessor))).await;
+        })
+        .await
+        .context("trigger service driver exited")?;
+    Ok(())
+}
+
+/// Drives the service's `wasi:cli/run` export (its long-running work).
+struct RunTask {
+    command: Command,
+}
+
+impl AccessorTask<SharedCtx> for RunTask {
+    async fn run(self, accessor: &Accessor<SharedCtx>) -> wasmtime::Result<()> {
+        match self.command.wasi_cli_run().call_run(accessor).await {
+            Ok(Ok(())) => tracing::info!("service cli/run exited successfully"),
+            Ok(Err(())) => tracing::error!("service cli/run exited with error"),
+            Err(e) => tracing::error!(err = %e, "service cli/run trapped"),
+        }
+        Ok(())
+    }
+}

--- a/crates/wash-runtime/src/lib.rs
+++ b/crates/wash-runtime/src/lib.rs
@@ -5,6 +5,7 @@ pub mod host;
 pub mod observability;
 pub mod plugin;
 pub mod sockets;
+mod timeouts;
 pub mod types;
 pub mod wit;
 

--- a/crates/wash-runtime/src/timeouts.rs
+++ b/crates/wash-runtime/src/timeouts.rs
@@ -1,0 +1,58 @@
+//! Runtime-tunable timeouts for the cross-store call and trigger-service paths.
+//!
+//! Every timeout is declared in the single [`declare_timeouts!`] invocation
+//! below and read through a generated accessor. Add a new timeout by adding one
+//! line there.
+
+use std::sync::LazyLock;
+use std::time::Duration;
+
+/// Parse `var` as whole seconds, falling back to `default_secs` if it is unset.
+/// A set-but-unparseable value also falls back, with a warning — silently
+/// ignoring it would leave an operator's typo undetected.
+fn env_secs(var: &str, default_secs: u64) -> Duration {
+    let secs = match std::env::var(var) {
+        Ok(v) => match v.parse::<u64>() {
+            Ok(secs) => secs,
+            Err(_) => {
+                tracing::warn!(
+                    var,
+                    value = %v,
+                    default_secs,
+                    "ignoring unparseable timeout override (want whole seconds)"
+                );
+                default_secs
+            }
+        },
+        Err(_) => default_secs,
+    };
+    Duration::from_secs(secs)
+}
+
+/// Declare the runtime-tunable timeouts, one `name = ("ENV_VAR", default_secs)`
+/// entry per line (separated by `;`). Each entry generates a
+/// `pub(crate) fn name() -> Duration` accessor: on first call it reads the named
+/// env var as a whole number of seconds (via [`env_secs`]), falling back to the
+/// compile-time default if the var is unset or unparseable, and caches the
+/// result for the process lifetime with a [`LazyLock`] — so an override must be
+/// set before the runtime starts. Per-entry attributes (doc comments,
+/// `#[cfg(...)]`) are forwarded to the generated fn.
+macro_rules! declare_timeouts {
+    ($(
+        $(#[$attr:meta])*
+        $name:ident = ($var:literal, $default:literal)
+    );* $(;)?) => {
+        $(
+            $(#[$attr])*
+            pub(crate) fn $name() -> Duration {
+                static VALUE: LazyLock<Duration> = LazyLock::new(|| env_secs($var, $default));
+                *VALUE
+            }
+        )*
+    };
+}
+
+declare_timeouts! {
+    /// Max wall-clock for a trigger service to produce an HTTP response.
+    http_response = ("WASH_HTTP_RESPONSE_TIMEOUT_SECS", 600);
+}

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -253,7 +253,9 @@ pub async fn start_host_with_tls(
 
 /// Start a host with `wasip3` enabled on the engine, a `DevRouter` backed
 /// HTTP server, and the standard plugin set.
-pub async fn start_host_with_p3(addr: &str) -> Result<(std::net::SocketAddr, impl HostApi)> {
+pub async fn start_host_with_p3_http_handler(
+    addr: &str,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
     let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
     let bound_addr = http_server.addr();
@@ -265,6 +267,19 @@ pub async fn start_host_with_p3(addr: &str) -> Result<(std::net::SocketAddr, imp
     .build()?;
     let host = host.start().await.context("Failed to start host")?;
     Ok((bound_addr, host))
+}
+
+/// Extract the numeric value of `"name":N` from a flat JSON body without
+/// pulling in a JSON dependency. Panics (failing the test) if the field is
+/// missing or non-numeric.
+pub fn json_u64_field(body: &str, name: &str) -> u64 {
+    let key = format!("\"{name}\":");
+    let start = body.find(&key).expect("field present in body") + key.len();
+    let rest = &body[start..];
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    rest[..end].parse().expect("numeric field")
 }
 
 /// GET `http://{addr}/` with the given `HOST` header and a 10s timeout.

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -1313,6 +1313,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "svc-counter"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "keyvalue-implements-p3",
     "keyvalue-default-p3",
     "postgres-stream-p3",
+    "svc-counter",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/svc-counter/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/svc-counter/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "svc-counter"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/svc-counter/src/bindings.rs
+++ b/crates/wash-runtime/tests/fixtures/svc-counter/src/bindings.rs
@@ -1,0 +1,2 @@
+#![allow(unsafe_code)]
+wit_bindgen::generate!({ world: "svc-counter", generate_all });

--- a/crates/wash-runtime/tests/fixtures/svc-counter/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/svc-counter/src/lib.rs
@@ -1,0 +1,57 @@
+//! A p3 service that co-drives `cli/run` and `http/handler` on one instance.
+//!
+//! `cli/run` increments a process-global `CLI_TICKS` on a fixed clock interval.
+//! `http/handler` returns the live `cli_ticks` plus a per-call `http_calls`
+//! count. Because both run on the same instance sharing the same statics, an
+//! HTTP response observing `cli_ticks > 0` (and growing between requests) proves
+//! the host co-drives the run loop concurrently with serving HTTP.
+
+mod bindings;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use bindings::exports::wasi::cli::run::Guest as RunGuest;
+use bindings::exports::wasi::http::handler::Guest as HttpGuest;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+
+static CLI_TICKS: AtomicU64 = AtomicU64::new(0);
+static HTTP_CALLS: AtomicU64 = AtomicU64::new(0);
+
+struct Component;
+
+impl RunGuest for Component {
+    async fn run() -> Result<(), ()> {
+        use bindings::wasi::clocks::monotonic_clock;
+        loop {
+            // 10ms tick — fast enough that any HTTP request arrives after >0.
+            monotonic_clock::wait_for(10_000_000).await;
+            CLI_TICKS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+}
+
+impl HttpGuest for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        let http_calls = HTTP_CALLS.fetch_add(1, Ordering::SeqCst) + 1;
+        let cli_ticks = CLI_TICKS.load(Ordering::SeqCst);
+        let body = format!("{{\"cli_ticks\":{cli_ticks},\"http_calls\":{http_calls}}}");
+        Ok(make_response(200, body.into_bytes()))
+    }
+}
+
+fn make_response(status: u16, body: Vec<u8>) -> Response {
+    let headers = Fields::new();
+    let _ = headers.set(&"content-type".to_string(), &[b"application/json".to_vec()]);
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    let _ = response.set_status_code(status);
+    response
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/svc-counter/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/svc-counter/wit/world.wit
@@ -1,0 +1,12 @@
+package wasmcloud:test-p3@0.1.0;
+
+/// A p3 service that exports BOTH cli/run (a tick loop) and http/handler (a
+/// counter). Exercises the host's service co-driver: one instance runs cli/run
+/// concurrently with serving HTTP, sharing in-memory state.
+world svc-counter {
+    import wasi:http/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:clocks/monotonic-clock@0.3.0;
+    export wasi:cli/run@0.3.0;
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/integration_p2_p3_matrix.rs
+++ b/crates/wash-runtime/tests/integration_p2_p3_matrix.rs
@@ -25,7 +25,7 @@ mod common;
 use common::{
     http_blobstore_host_interfaces as p3_http_blobstore_host_interfaces,
     http_counter_host_interfaces, http_only_host_interfaces as p3_http_host_interfaces,
-    start_host_with_p3 as start_p3_host,
+    start_host_with_p3_http_handler as start_p3_host,
 };
 
 // P3 fixtures

--- a/crates/wash-runtime/tests/integration_p3_ephemeral.rs
+++ b/crates/wash-runtime/tests/integration_p3_ephemeral.rs
@@ -31,7 +31,7 @@ use wash_runtime::{
 };
 
 mod common;
-use common::{http_only_host_interfaces, start_host_with_p3};
+use common::{http_only_host_interfaces, start_host_with_p3_http_handler};
 
 const EPHEMERAL_CALLER_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_caller_p3.wasm");
 const EPHEMERAL_CALLEE_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_callee_p3.wasm");
@@ -42,7 +42,7 @@ async fn test_p3_plain_value_async_call_uses_ephemeral_store() -> Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init();
 
-    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
 
     let req = WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),

--- a/crates/wash-runtime/tests/integration_p3_resources.rs
+++ b/crates/wash-runtime/tests/integration_p3_resources.rs
@@ -36,7 +36,7 @@ use wash_runtime::{
 };
 
 mod common;
-use common::{http_only_host_interfaces, start_host_with_p3};
+use common::{http_only_host_interfaces, start_host_with_p3_http_handler};
 
 const RES_CALLER_P3_WASM: &[u8] = include_bytes!("wasm/res_caller_p3.wasm");
 const RES_PRODUCER_P3_WASM: &[u8] = include_bytes!("wasm/res_producer_p3.wasm");
@@ -55,7 +55,7 @@ fn component(name: &str, bytes: &'static [u8]) -> Component {
 
 #[tokio::test]
 async fn test_p3_resource_handle_crosses_linker() -> Result<()> {
-    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
 
     let req = WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),

--- a/crates/wash-runtime/tests/integration_p3_streams.rs
+++ b/crates/wash-runtime/tests/integration_p3_streams.rs
@@ -40,7 +40,7 @@ use wash_runtime::{
 };
 
 mod common;
-use common::{http_only_host_interfaces, start_host_with_p3};
+use common::{http_only_host_interfaces, start_host_with_p3_http_handler};
 
 const STREAM_PRODUCER_P3_WASM: &[u8] = include_bytes!("wasm/stream_producer_p3.wasm");
 const STREAM_CONSUMER_P3_WASM: &[u8] = include_bytes!("wasm/stream_consumer_p3.wasm");
@@ -48,7 +48,7 @@ const STREAM_PACER_P3_WASM: &[u8] = include_bytes!("wasm/stream_pacer_p3.wasm");
 
 #[tokio::test]
 async fn test_p3_cross_component_stream_to_http() -> Result<()> {
-    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
 
     // The consumer exports wasi:http/handler and is the workload's incoming
     // entrypoint; the producer is linked in and supplies the byte stream.
@@ -130,7 +130,7 @@ async fn test_p3_cross_component_stream_to_http() -> Result<()> {
 /// streaming path. Margins are deliberately loose to stay CI-stable.
 #[tokio::test]
 async fn test_p3_incoming_handler_streams_incrementally() -> Result<()> {
-    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
 
     let req = WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),
@@ -244,7 +244,7 @@ async fn test_p3_incoming_handler_streams_incrementally() -> Result<()> {
 /// which only asserts the final bytes and so passes even on a buffered path.
 #[tokio::test]
 async fn test_p3_cross_component_stream_streams_incrementally() -> Result<()> {
-    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
 
     // Same two-component workload as the byte-for-byte test; here we measure
     // *when* the producer's bytes arrive, not just that they all do.

--- a/crates/wash-runtime/tests/integration_service_http.rs
+++ b/crates/wash-runtime/tests/integration_service_http.rs
@@ -1,0 +1,127 @@
+//! Integration tests for the p3 service HTTP ingress co-driver.
+//!
+//! A p3 service that exports BOTH `wasi:cli/run@0.3` and
+//! `wasi:http/handler@0.3` is co-driven on a single instance: the host keeps
+//! `cli/run` running while delivering inbound HTTP to the same instance's
+//! `http/handler`. The `svc-counter` fixture proves this by incrementing a
+//! process-global counter from its `cli/run` loop and reporting it from each
+//! HTTP response — a response observing `cli_ticks > 0` that grows across
+//! requests can only happen if the run loop is co-driven concurrently.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{collections::HashMap, time::Duration};
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::host::HostApi;
+use wash_runtime::types::{LocalResources, Service, Workload, WorkloadStartRequest};
+
+mod common;
+use common::{http_only_host_interfaces, json_u64_field, start_host_with_p3_http_handler};
+
+const SVC_COUNTER_WASM: &[u8] = include_bytes!("wasm/svc_counter.wasm");
+
+/// Parse `{"cli_ticks":N,"http_calls":M}` without pulling in a JSON dep.
+fn parse_counter(body: &str) -> (u64, u64) {
+    (
+        json_u64_field(body, "cli_ticks"),
+        json_u64_field(body, "http_calls"),
+    )
+}
+
+fn svc_counter_request(host: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: host.to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(SVC_COUNTER_WASM),
+                local_resources: LocalResources::default(),
+                max_restarts: 0,
+            }),
+            components: vec![],
+            host_interfaces: http_only_host_interfaces(host),
+            volumes: vec![],
+        },
+    }
+}
+
+/// The service co-drives `cli/run` (ticking a counter) while serving HTTP on the
+/// same instance: the HTTP response sees a non-zero, growing `cli_ticks`.
+#[tokio::test]
+async fn test_service_http_co_drives_cli_run() -> Result<()> {
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+
+    host.workload_start(svc_counter_request("svc-counter"))
+        .await
+        .context("failed to start p3 service-http workload")?;
+
+    // No connection pooling: a GET retried on a stale pooled connection would
+    // land twice on the instance and break the exactly-once http_calls counts.
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()?;
+
+    let get = || async {
+        let resp = timeout(
+            Duration::from_secs(10),
+            client
+                .get(format!("http://{addr}/"))
+                .header("HOST", "svc-counter")
+                .send(),
+        )
+        .await??;
+        anyhow::ensure!(
+            resp.status().is_success(),
+            "service should serve requests, got {}",
+            resp.status()
+        );
+        let (cli_ticks, http_calls) = parse_counter(&resp.text().await?);
+        Ok::<_, anyhow::Error>((cli_ticks, http_calls))
+    };
+
+    // Request once to confirm the service instance serves HTTP at all. The very
+    // first request can race the 10ms run-loop tick, so cli_ticks may still be 0
+    // here — that's expected.
+    let (_ticks1, calls1) = get().await?;
+    assert_eq!(calls1, 1, "first request is http_calls=1");
+
+    // Poll over a window: cli/run is co-driven on the same instance, so its tick
+    // counter must climb past zero while we keep serving HTTP. Each response also
+    // increments http_calls on the SAME instance (shared in-memory state, not a
+    // fresh per-request instance).
+    let mut last_ticks = 0;
+    let mut last_calls = calls1;
+    let mut saw_growth = false;
+    for _ in 0..40 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let (ticks, calls) = get().await?;
+        assert_eq!(
+            calls,
+            last_calls + 1,
+            "each request lands on the same long-lived instance (expected http_calls={}, got {calls})",
+            last_calls + 1
+        );
+        last_calls = calls;
+        if ticks > last_ticks && last_ticks > 0 {
+            // cli/run advanced between two HTTP requests → co-driven concurrently.
+            saw_growth = true;
+            break;
+        }
+        if ticks > 0 {
+            last_ticks = ticks;
+        }
+    }
+
+    assert!(
+        saw_growth,
+        "cli/run should be co-driven concurrently with HTTP serving — cli_ticks never grew between requests"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_wasip3.rs
+++ b/crates/wash-runtime/tests/integration_wasip3.rs
@@ -17,7 +17,7 @@ use wash_runtime::{
 };
 
 mod common;
-use common::{http_counter_host_interfaces, start_host_with_p3};
+use common::{http_counter_host_interfaces, start_host_with_p3_http_handler};
 
 const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
 
@@ -117,7 +117,7 @@ fn test_targets_wasip3_ignores_non_wasi() {
 
 #[tokio::test]
 async fn test_p2_http_component_works_with_p3_enabled() -> Result<()> {
-    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
 
     let req = WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),
@@ -180,7 +180,7 @@ async fn test_p2_http_component_works_with_p3_enabled() -> Result<()> {
 
 #[tokio::test]
 async fn test_p2_concurrent_requests_with_p3_enabled() -> Result<()> {
-    let (addr, host) = start_host_with_p3("127.0.0.1:0").await?;
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
 
     let req = WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -117,6 +117,7 @@ const P3_FIXTURES: &[&str] = &[
     "keyvalue-implements-p3",
     "keyvalue-default-p3",
     "postgres-stream-p3",
+    "svc-counter",
 ];
 
 // Fixtures with local-only WIT worlds (no wasi imports). Copying shared


### PR DESCRIPTION
A p3 service that exports both wasi:cli/run@0.3 and wasi:http/handler@0.3 is now driven on a single instance under one Store::run_concurrent: cli/run runs as a background task while each inbound HTTP request is served as a concurrent per-invocation task on the same instance. This allows the long-running work and the handlers to share in-memory state, instead of the host instantiating a component per request.

The TriggerService is deliberately general: each host-invoked export is an Ingress carrying the receiver of its delivery channel, prepared into a binding view before `run_concurrent` and served by spawning one task per invocation. Adding another host-invoked interface later is a new Ingress variant plus a serve arm.

The HTTP server keeps a ServiceHandlers registry (workload id -> delivery channel): a resolved trigger-service workload registers its sender (HostHandler::on_service_http_resolved), inbound requests for it are delivered to the live instance, and stop/unbind drops the registration. Responses stream incrementally, the head is delivered as soon as the handler returns it, body frames follow through a small bounded channel that back-pressures the guest, with a configurable overall timeout backstop (WASH_HTTP_RESPONSE_TIMEOUT_SECS, the first entry in the new env-tunable timeouts module).

Supervision: on a fault (e.g. a guest trap in cli/run) the driver re-instantiates into the same store with fresh ingress channels, re-registering their senders, within the service's existing max_restarts budget.

The svc-counter fixture exports both cli/run (a tick loop) and http/handler (a counter); the integration test proves one instance co-drives both: cli_ticks grows across requests while http_calls increments exactly once per request on
the same instance.

This is the first in a series of stacked PRs.