### PR TITLE
feat(wash-runtime): messaging ingress for trigger services

### DIFF
--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -916,6 +916,16 @@ pub fn exports_wasi_http(component: &Component) -> bool {
         .any(|(export, _item)| export.starts_with("wasi:http"))
 }
 
+/// Whether a component exports the `wasmcloud:messaging/handler` interface (the
+/// inbound message handler the host invokes).
+pub fn exports_messaging_handler(component: &Component) -> bool {
+    let ty: wasmtime::component::types::Component = component.component_type();
+    let engine = component.engine();
+
+    ty.exports(engine)
+        .any(|(export, _item)| export.starts_with("wasmcloud:messaging/handler"))
+}
+
 pub fn imports_wasi_http(component: &Component) -> bool {
     let ty: wasmtime::component::types::Component = component.component_type();
     let engine = component.engine();

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -547,16 +547,47 @@ impl std::fmt::Debug for ResolvedWorkload {
     }
 }
 
+/// Everything needed to rebuild a p3 service's store (plain `cli/run` or
+/// trigger service), captured by its supervisor so each incarnation gets a
+/// FRESH store: after a guest trap the old store can no longer enter ANY
+/// component instance ("cannot enter component instance"), so reusing it would
+/// leave every restarted incarnation permanently broken.
+struct ServiceStoreRecipe {
+    engine: wasmtime::Engine,
+    http_handler: Arc<dyn crate::host::http::HostHandler>,
+    active_template: ComponentCtxTemplate,
+    linked_templates: Vec<ComponentCtxTemplate>,
+    linked_instances: Vec<(Arc<str>, wasmtime::component::InstancePre<SharedCtx>)>,
+}
+
+impl ServiceStoreRecipe {
+    /// Build a fresh service store (`is_service = true` so `cli/run` may bind
+    /// its loopback socket).
+    async fn build(&self) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
+        new_store_from_templates(
+            &self.engine,
+            self.http_handler.clone(),
+            &self.active_template,
+            &self.linked_templates,
+            &self.linked_instances,
+            true,
+        )
+        .await
+    }
+}
+
 /// Build a trigger service's host-invoked ingresses, returning them alongside the
-/// paired senders to register with the host-side ingresses. Called once per
-/// incarnation (start and each restart) so a restarted service gets fresh
+/// paired senders to register with the host-side HTTP/messaging ingresses. Called
+/// once per incarnation (start and each restart) so a restarted service gets fresh
 /// channels whose senders replace the stale registrations.
 #[allow(clippy::type_complexity)]
 fn build_trigger_ingresses(
     serves_http: bool,
+    serves_messaging: bool,
 ) -> (
     Vec<crate::host::trigger_service::Ingress>,
     Option<tokio::sync::mpsc::Sender<crate::host::http::ServiceHttpJob>>,
+    Option<tokio::sync::mpsc::Sender<crate::host::trigger_service::MessagingJob>>,
 ) {
     let mut ingresses = Vec::new();
     let http_tx = serves_http.then(|| {
@@ -564,7 +595,12 @@ fn build_trigger_ingresses(
         ingresses.push(crate::host::trigger_service::Ingress::Http(rx));
         tx
     });
-    (ingresses, http_tx)
+    let messaging_tx = serves_messaging.then(|| {
+        let (tx, rx) = tokio::sync::mpsc::channel(256);
+        ingresses.push(crate::host::trigger_service::Ingress::Messaging(rx));
+        tx
+    });
+    (ingresses, http_tx, messaging_tx)
 }
 
 impl ResolvedWorkload {
@@ -579,11 +615,10 @@ impl ResolvedWorkload {
             // A p3 service that also exports a host-invoked handler (today
             // `wasi:http/handler`) co-drives it with `cli/run` on one instance
             // (see the `trigger service` module).
-            if self
-                .service
-                .as_ref()
-                .is_some_and(|s| crate::engine::exports_wasi_http(&s.metadata.component))
-            {
+            if self.service.as_ref().is_some_and(|s| {
+                crate::engine::exports_wasi_http(&s.metadata.component)
+                    || crate::engine::exports_messaging_handler(&s.metadata.component)
+            }) {
                 return self.execute_trigger_service().await;
             }
             return self.execute_service_p3().await;
@@ -635,12 +670,18 @@ impl ResolvedWorkload {
 
         if let Some((Ok(pre), mut max_restarts)) = service {
             self.resolve_service_volume_mounts().await?;
-            let mut store = if let Some(service) = self.service.as_ref() {
-                self.new_store_from_metadata(&service.metadata, true)
-                    .await?
-            } else {
-                bail!("service unexpectedly missing during execution");
+            // Capture the store recipe so each restarted incarnation gets a
+            // FRESH store: a trapped store cannot re-enter any component
+            // instance, so reuse after a fault would leave every restart
+            // permanently broken (and even a clean restart would accumulate
+            // stale instances in a reused store).
+            let recipe = {
+                let Some(service) = self.service.as_ref() else {
+                    bail!("service unexpectedly missing during execution");
+                };
+                self.service_store_recipe(&service.metadata).await?
             };
+            let mut store = recipe.build().await?;
             let handle = tokio::spawn(async move {
                 loop {
                     let instance = match pre.instantiate_async(&mut store).await {
@@ -676,6 +717,13 @@ impl ResolvedWorkload {
                         }
                     }
                     max_restarts = max_restarts.saturating_sub(1);
+                    match recipe.build().await {
+                        Ok(fresh) => store = fresh,
+                        Err(e) => {
+                            error!(err = %e, "failed to rebuild P3 service store; giving up");
+                            break;
+                        }
+                    }
                 }
             });
 
@@ -690,43 +738,57 @@ impl ResolvedWorkload {
     }
 
     /// Execute a p3 service that also exports a host-invoked handler (today
-    /// `wasi:http/handler`): one instance co-drives `cli/run` and the handler
-    /// under a single `run_concurrent` (see [`crate::host::trigger_service`]).
-    /// The service runs in its own long-lived store.
+    /// `wasi:http/handler` and `wasmcloud:messaging`): one instance co-drives
+    /// `cli/run` and the handler under a single `run_concurrent` (see
+    /// [`crate::host::trigger_service`]). The service runs in its own
+    /// long-lived store.
     /// `is_service = true` lets the `cli/run` side bind its loopback socket.
     async fn execute_trigger_service(&mut self) -> anyhow::Result<Option<Arc<JoinHandle<()>>>> {
         let Some(service) = self.service.as_ref() else {
             return Ok(None);
         };
         let pre = service.pre_instantiate_raw()?;
-        let (serves_http, max_restarts) = (
+        let (serves_http, serves_messaging, max_restarts) = (
             crate::engine::exports_wasi_http(&service.metadata.component),
+            crate::engine::exports_messaging_handler(&service.metadata.component),
             service.max_restarts,
         );
         self.resolve_service_volume_mounts().await?;
 
-        let mut store = {
+        // Capture the store recipe so the supervisor below can rebuild a FRESH
+        // store per incarnation: a trapped store cannot re-enter any component
+        // instance, so a restart must never reuse it.
+        let recipe = {
             let Some(service) = self.service.as_ref() else {
                 bail!("service unexpectedly missing during execution");
             };
-            self.new_store_from_metadata(&service.metadata, true)
-                .await?
+            self.service_store_recipe(&service.metadata).await?
         };
+        let mut store = recipe.build().await?;
         let http_handler = self.http_handler.clone();
         let workload_id: Arc<str> = Arc::from(self.id());
 
         // Build the first incarnation's host-invoked ingresses. Each paired sender
-        // is registered with its host-side ingress (the HTTP server), which then
-        // delivers to this live instance instead of instantiating a component per
-        // request. The first registration is synchronous (before the driver
-        // spawns) so a delivery immediately after start finds the handler;
-        // restarts re-register from inside the supervisor.
-        let (ingresses, http_tx) = build_trigger_ingresses(serves_http);
+        // is registered with its host-side ingress (the HTTP server, the messaging
+        // subscriber), which then delivers to this live instance instead of
+        // instantiating a component per request/message. The first registration is
+        // synchronous (before the driver spawns) so a delivery immediately after
+        // start finds the handler; restarts re-register from inside the supervisor.
+        let (ingresses, http_tx, messaging_tx) =
+            build_trigger_ingresses(serves_http, serves_messaging);
         if let Some(http_tx) = http_tx {
             self.http_handler
                 .on_service_http_resolved(self.id(), http_tx)
                 .await
                 .map_err(|e| anyhow::anyhow!("failed to register service HTTP handler: {e:#}"))?;
+        }
+        if let Some(messaging_tx) = messaging_tx {
+            self.http_handler
+                .on_trigger_service_messaging_resolved(self.id(), messaging_tx)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("failed to register trigger service messaging handler: {e:#}")
+                })?;
         }
 
         // Supervise the driver: on a fault (e.g. a guest trap in `cli/run` or a
@@ -740,13 +802,21 @@ impl ResolvedWorkload {
                 let ingresses = match first.take() {
                     Some(ingresses) => ingresses,
                     None => {
-                        let (ingresses, http_tx) = build_trigger_ingresses(serves_http);
+                        let (ingresses, http_tx, messaging_tx) =
+                            build_trigger_ingresses(serves_http, serves_messaging);
                         if let Some(http_tx) = http_tx
                             && let Err(e) = http_handler
                                 .on_service_http_resolved(&workload_id, http_tx)
                                 .await
                         {
                             error!(err = %e, "failed to re-register service HTTP handler on restart");
+                        }
+                        if let Some(messaging_tx) = messaging_tx
+                            && let Err(e) = http_handler
+                                .on_trigger_service_messaging_resolved(&workload_id, messaging_tx)
+                                .await
+                        {
+                            error!(err = %e, "failed to re-register trigger service messaging handler on restart");
                         }
                         ingresses
                     }
@@ -765,6 +835,15 @@ impl ResolvedWorkload {
                     Err(e) => {
                         warn!(err = %e, retries = restarts, "trigger service faulted; restarting");
                         restarts = restarts.saturating_sub(1);
+                        // The faulted store cannot re-enter any component
+                        // instance; the next incarnation needs a fresh one.
+                        match recipe.build().await {
+                            Ok(fresh) => store = fresh,
+                            Err(e) => {
+                                error!(err = %e, "failed to rebuild trigger service store; giving up");
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -1311,6 +1390,25 @@ impl ResolvedWorkload {
         metadata: &WorkloadMetadata,
         is_service: bool,
     ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
+        let recipe = self.service_store_recipe(metadata).await?;
+        new_store_from_templates(
+            &recipe.engine,
+            recipe.http_handler.clone(),
+            &recipe.active_template,
+            &recipe.linked_templates,
+            &recipe.linked_instances,
+            is_service,
+        )
+        .await
+    }
+
+    /// Capture everything needed to (re)build this service's store, so the
+    /// trigger-service supervisor can construct a fresh store per incarnation
+    /// without borrowing `self`.
+    async fn service_store_recipe(
+        &self,
+        metadata: &WorkloadMetadata,
+    ) -> anyhow::Result<ServiceStoreRecipe> {
         let linked_component_ids = metadata
             .linked_components
             .iter()
@@ -1343,15 +1441,13 @@ impl ResolvedWorkload {
             ));
         }
 
-        new_store_from_templates(
-            metadata.engine(),
-            self.http_handler.clone(),
-            &active_template,
-            &linked_templates,
-            &linked_instances,
-            is_service,
-        )
-        .await
+        Ok(ServiceStoreRecipe {
+            engine: metadata.engine().clone(),
+            http_handler: self.http_handler.clone(),
+            active_template,
+            linked_templates,
+            linked_instances,
+        })
     }
 
     pub async fn instantiate_pre(
@@ -1427,13 +1523,20 @@ impl ResolvedWorkload {
             }
         }
 
-        // A trigger service registered its HTTP handler at start
-        // (`execute_trigger_service`); drop that registration on stop so it no
+        // A trigger service registered its HTTP/messaging handlers at start
+        // (`execute_trigger_service`); drop those registrations on stop so it no
         // longer receives host-invoked deliveries on a torn-down instance.
-        if self.service.is_some()
-            && let Err(e) = self.http_handler.on_service_http_unbind(self.id()).await
-        {
-            tracing::error!(workload.id = %self.id(), err = %e, "failed to unbind service HTTP handler, continuing");
+        if self.service.is_some() {
+            if let Err(e) = self.http_handler.on_service_http_unbind(self.id()).await {
+                tracing::error!(workload.id = %self.id(), err = %e, "failed to unbind service HTTP handler, continuing");
+            }
+            if let Err(e) = self
+                .http_handler
+                .on_trigger_service_messaging_unbind(self.id())
+                .await
+            {
+                tracing::error!(workload.id = %self.id(), err = %e, "failed to unbind trigger service messaging handler, continuing");
+            }
         }
 
         Ok(())

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -27,6 +27,7 @@ use std::{
 };
 
 use crate::host::allowed_hosts::AllowedHost;
+use crate::host::trigger_service::{BrokerMessage, MessagingJob};
 use crate::{engine::ctx::SharedCtx, observability::Meters};
 use crate::{engine::workload::ResolvedWorkload, observability::FuelConsumptionMeter};
 use anyhow::{Context, ensure};
@@ -497,6 +498,36 @@ pub trait HostHandler: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Register a long-lived trigger service instance that handles inbound messages:
+    /// messages for `workload_id` are delivered over `sender` instead of
+    /// instantiating a component per message. Default: no-op.
+    async fn on_trigger_service_messaging_resolved(
+        &self,
+        _workload_id: &str,
+        _sender: tokio::sync::mpsc::Sender<MessagingJob>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+    /// Unregister a trigger service messaging instance. Default: no-op.
+    async fn on_trigger_service_messaging_unbind(&self, _workload_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    /// Deliver a message to a workload's registered messaging trigger service, returning
+    /// the handler's `result<_, string>`. Default: no messaging support.
+    async fn deliver_trigger_service_message(
+        &self,
+        _workload_id: &str,
+        _msg: BrokerMessage,
+    ) -> anyhow::Result<Result<(), String>> {
+        anyhow::bail!("this host does not support trigger service messaging delivery")
+    }
+    /// Whether a long-lived trigger service is registered to handle messages for
+    /// `workload_id` (so a host ingress can deliver to it instead of
+    /// instantiating per message). Default: false.
+    async fn has_trigger_service_messaging(&self, _workload_id: &str) -> bool {
+        false
+    }
+
     /// Handle an outgoing HTTP request from a workload
     fn outgoing_request(
         &self,
@@ -619,6 +650,10 @@ pub type ServiceHttpJob = (
 /// Empty unless a workload's service opts into HTTP ingress (a p3 feature).
 pub type ServiceHandlers = Arc<RwLock<HashMap<String, tokio::sync::mpsc::Sender<ServiceHttpJob>>>>;
 
+/// A map from workload id to the channel of a trigger service's messaging handler
+/// instance. Empty unless a workload's service exports a messaging handler.
+pub type MessagingHandlers = Arc<RwLock<HashMap<String, tokio::sync::mpsc::Sender<MessagingJob>>>>;
+
 /// HTTP server plugin that handles incoming HTTP requests for WebAssembly components.
 ///
 /// This plugin implements the `wasi:http/incoming-handler` interface and routes
@@ -641,6 +676,8 @@ pub struct HttpServer<T: Router, O: OutgoingHandler = DefaultOutgoingHandler> {
     workload_handles: WorkloadHandles,
     /// Workloads whose long-lived service serves HTTP ingress directly.
     service_handlers: ServiceHandlers,
+    /// Workloads whose long-lived trigger service serves messaging ingress directly.
+    messaging_handlers: MessagingHandlers,
     shutdown_tx: Arc<RwLock<Option<mpsc::Sender<()>>>>,
     tls_acceptor: Option<TlsAcceptor>,
     listener: Arc<tokio::sync::Mutex<Option<TcpListener>>>,
@@ -761,6 +798,7 @@ impl<T: Router, O: OutgoingHandler> HttpServerBuilder<T, O> {
             addr,
             workload_handles: Arc::default(),
             service_handlers: Arc::default(),
+            messaging_handlers: Arc::default(),
             shutdown_tx: Arc::new(RwLock::new(None)),
             tls_acceptor,
             listener: Arc::new(tokio::sync::Mutex::new(Some(listener))),
@@ -888,6 +926,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
 
         self.workload_handles.write().await.remove(workload_id);
         self.service_handlers.write().await.remove(workload_id);
+        self.messaging_handlers.write().await.remove(workload_id);
 
         Ok(())
     }
@@ -914,6 +953,59 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
     async fn on_service_http_unbind(&self, workload_id: &str) -> anyhow::Result<()> {
         self.service_handlers.write().await.remove(workload_id);
         Ok(())
+    }
+
+    async fn on_trigger_service_messaging_resolved(
+        &self,
+        workload_id: &str,
+        sender: tokio::sync::mpsc::Sender<MessagingJob>,
+    ) -> anyhow::Result<()> {
+        // As with the HTTP handler: a re-resolve without unbind is the expected
+        // restart path (the supervisor swaps in the new incarnation's sender),
+        // and the replaced mapping belonged to a faulted incarnation whose
+        // receiver is already gone. Stop is the only path that unbinds.
+        self.messaging_handlers
+            .write()
+            .await
+            .insert(workload_id.to_string(), sender);
+        Ok(())
+    }
+
+    async fn on_trigger_service_messaging_unbind(&self, workload_id: &str) -> anyhow::Result<()> {
+        self.messaging_handlers.write().await.remove(workload_id);
+        Ok(())
+    }
+
+    async fn deliver_trigger_service_message(
+        &self,
+        workload_id: &str,
+        msg: BrokerMessage,
+    ) -> anyhow::Result<Result<(), String>> {
+        let sender = self
+            .messaging_handlers
+            .read()
+            .await
+            .get(workload_id)
+            .cloned()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no messaging trigger service registered for workload {workload_id}"
+                )
+            })?;
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        sender
+            .send((msg, tx))
+            .await
+            .map_err(|_| anyhow::anyhow!("trigger service messaging instance is not running"))?;
+        rx.await
+            .map_err(|_| anyhow::anyhow!("trigger service dropped the message response"))
+    }
+
+    async fn has_trigger_service_messaging(&self, workload_id: &str) -> bool {
+        self.messaging_handlers
+            .read()
+            .await
+            .contains_key(workload_id)
     }
 
     fn outgoing_request(

--- a/crates/wash-runtime/src/host/trigger_service/messaging.rs
+++ b/crates/wash-runtime/src/host/trigger_service/messaging.rs
@@ -1,0 +1,103 @@
+//! The [`Ingress::Messaging`] path: `wasmcloud:messaging/handler@0.2.0`
+//! invocations served on the shared service instance.
+//!
+//! [`Ingress::Messaging`]: super::Ingress::Messaging
+
+use wasmtime::component::{Accessor, AccessorTask, ComponentExportIndex, Instance, Val};
+
+use crate::engine::ctx::SharedCtx;
+
+/// An inbound message delivered to the service's `wasmcloud:messaging/handler`
+/// export. Mirrors the `broker-message` record.
+pub struct BrokerMessage {
+    pub subject: String,
+    pub body: Vec<u8>,
+    pub reply_to: Option<String>,
+}
+
+/// A messaging invocation: the message plus a oneshot carrying the handler's
+/// `result<_, string>` outcome back to the host-side ingress (to ack/log).
+pub type MessagingJob = (
+    BrokerMessage,
+    tokio::sync::oneshot::Sender<Result<(), String>>,
+);
+
+/// Interface + function names for the messaging handler export.
+pub(super) const MESSAGING_HANDLER: &str = "wasmcloud:messaging/handler@0.2.0";
+pub(super) const HANDLE_MESSAGE: &str = "handle-message";
+
+/// Handles one inbound message on the shared service instance by invoking the
+/// p2 `handle-message` export via the dynamic concurrent path (there is no
+/// accessor-driven p3 messaging binding), and reports its `result<_, string>`.
+///
+/// A handler `Err(string)` is an ordinary application outcome, reported on
+/// `result_tx` only. A guest *trap*, however, leaves the shared instance
+/// unenterable for every later message, so after reporting it the task returns
+/// the error — faulting `run_concurrent` so the driver exits and the service
+/// supervisor restarts (and re-registers) a fresh instance.
+pub(super) struct MessagingTask {
+    pub(super) instance: Instance,
+    pub(super) func_idx: ComponentExportIndex,
+    pub(super) msg: BrokerMessage,
+    pub(super) result_tx: tokio::sync::oneshot::Sender<Result<(), String>>,
+}
+
+impl AccessorTask<SharedCtx> for MessagingTask {
+    async fn run(self, accessor: &Accessor<SharedCtx>) -> wasmtime::Result<()> {
+        let MessagingTask {
+            instance,
+            func_idx,
+            msg,
+            result_tx,
+        } = self;
+
+        let func = match accessor.with(|mut store| instance.get_func(&mut store, func_idx)) {
+            Some(func) => func,
+            None => {
+                let _ = result_tx.send(Err("handle-message export not found".to_string()));
+                return Ok(());
+            }
+        };
+
+        // Lower the `broker-message` record to a `Val`.
+        let message = Val::Record(vec![
+            ("subject".to_string(), Val::String(msg.subject)),
+            (
+                "body".to_string(),
+                Val::List(msg.body.into_iter().map(Val::U8).collect()),
+            ),
+            (
+                "reply-to".to_string(),
+                Val::Option(msg.reply_to.map(|s| Box::new(Val::String(s)))),
+            ),
+        ]);
+
+        let mut results = vec![Val::Bool(false)];
+        let outcome = match func
+            .call_concurrent(accessor, &[message], &mut results)
+            .await
+        {
+            Ok(()) => lift_result_string(results.first()),
+            Err(e) => {
+                let _ = result_tx.send(Err(format!("handle-message trapped: {e:#}")));
+                return Err(e.context("messaging handler trapped; restarting the trigger service"));
+            }
+        };
+        let _ = result_tx.send(outcome);
+        Ok(())
+    }
+}
+
+/// Lift a `result<_, string>` value into a Rust `Result`, mapping the `err` case
+/// to its string (empty when the payload is absent).
+fn lift_result_string(v: Option<&Val>) -> Result<(), String> {
+    match v {
+        Some(Val::Result(Ok(_))) => Ok(()),
+        Some(Val::Result(Err(Some(boxed)))) => match &**boxed {
+            Val::String(s) => Err(s.clone()),
+            other => Err(format!("{other:?}")),
+        },
+        Some(Val::Result(Err(None))) => Err(String::new()),
+        other => Err(format!("unexpected result value: {other:?}")),
+    }
+}

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -12,18 +12,18 @@
 //!   instance's in-memory state.
 //!
 //! Each host-invoked export is an [`Ingress`]: the host-side plugin (the HTTP
-//! server, ...) pushes invocations into the ingress's channel and the TriggerService
-//! serves them via [`Accessor::spawn`]. Adding another host-invoked interface
-//! (e.g. a messaging handler) is a new [`Ingress`] variant plus a serve arm —
-//! the `cli/run` driving and the single-instance `run_concurrent` are reused.
-//! Each ingress kind lives in its own submodule ([`http`]); this module holds
-//! the shared [`Ingress`] enum, the `prepare`/`serve` dispatch, and the
-//! [`run_trigger_driver`] loop.
+//! server, the messaging subscriber, ...) pushes invocations into the ingress's
+//! channel and the TriggerService serves them via [`Accessor::spawn`]. Adding
+//! another host-invoked interface is a new [`Ingress`] variant plus a serve arm
+//! — the `cli/run` driving and the single-instance `run_concurrent` are reused.
+//! Each ingress kind lives in its own submodule ([`http`], [`messaging`]); this
+//! module holds the shared [`Ingress`] enum, the `prepare`/`serve` dispatch,
+//! and the [`run_trigger_driver`] loop.
 
 use std::sync::Arc;
 
 use wasmtime::Store;
-use wasmtime::component::{Accessor, AccessorTask, Instance, InstancePre};
+use wasmtime::component::{Accessor, AccessorTask, ComponentExportIndex, Instance, InstancePre};
 use wasmtime::error::Context as _;
 use wasmtime_wasi::p3::bindings::Command;
 use wasmtime_wasi_http::p3::bindings::Service;
@@ -32,16 +32,24 @@ use crate::engine::ctx::SharedCtx;
 use crate::host::http::ServiceHttpJob;
 
 mod http;
+mod messaging;
+
+pub use messaging::{BrokerMessage, MessagingJob};
 
 use http::HttpTask;
+use messaging::{HANDLE_MESSAGE, MESSAGING_HANDLER, MessagingTask};
 
 /// A host-invoked handler export the TriggerService serves, carrying the receiver end
 /// of its delivery channel. The paired sender is handed to the host-side ingress
-/// (the HTTP server, ...) so it can deliver invocations to this live instance.
+/// (the HTTP server, the messaging subscriber, ...) so it can deliver
+/// invocations to this live instance.
 #[non_exhaustive]
 pub enum Ingress {
     /// `wasi:http/handler@0.3` — the HTTP server delivers requests here.
     Http(tokio::sync::mpsc::Receiver<ServiceHttpJob>),
+    /// `wasmcloud:messaging/handler@0.2.0` — the messaging subscriber delivers
+    /// received messages here.
+    Messaging(tokio::sync::mpsc::Receiver<MessagingJob>),
 }
 
 impl Ingress {
@@ -61,6 +69,23 @@ impl Ingress {
                     rx,
                 })
             }
+            Ingress::Messaging(rx) => {
+                // Look up the p2 `handle-message` export up front; it's invoked
+                // dynamically (there is no accessor-driven p3 messaging binding).
+                let iface = instance
+                    .get_export(&mut *store, None, MESSAGING_HANDLER)
+                    .with_context(|| format!("service is missing {MESSAGING_HANDLER} export"))?
+                    .1;
+                let func_idx = instance
+                    .get_export(&mut *store, Some(&iface), HANDLE_MESSAGE)
+                    .with_context(|| format!("{MESSAGING_HANDLER} is missing {HANDLE_MESSAGE}"))?
+                    .1;
+                Ok(PreparedIngress::Messaging {
+                    instance: *instance,
+                    func_idx,
+                    rx,
+                })
+            }
         }
     }
 }
@@ -71,6 +96,11 @@ enum PreparedIngress {
     Http {
         service: Arc<Service>,
         rx: tokio::sync::mpsc::Receiver<ServiceHttpJob>,
+    },
+    Messaging {
+        instance: Instance,
+        func_idx: ComponentExportIndex,
+        rx: tokio::sync::mpsc::Receiver<MessagingJob>,
     },
 }
 
@@ -86,6 +116,20 @@ impl PreparedIngress {
                         service: Arc::clone(service),
                         req,
                         resp_tx,
+                    });
+                }
+            }
+            PreparedIngress::Messaging {
+                instance,
+                func_idx,
+                rx,
+            } => {
+                while let Some((msg, result_tx)) = rx.recv().await {
+                    accessor.spawn(MessagingTask {
+                        instance: *instance,
+                        func_idx: *func_idx,
+                        msg,
+                        result_tx,
                     });
                 }
             }

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -269,6 +269,29 @@ pub async fn start_host_with_p3_http_handler(
     Ok((bound_addr, host))
 }
 
+/// Like [`start_host_with_p3_http_handler`] but also returns the [`HttpServer`], so a test can
+/// drive host-side ingress hooks directly (e.g. deliver a message to a trigger service's
+/// messaging handler via `deliver_trigger_service_message`).
+pub async fn start_host_with_p3_handler(
+    addr: &str,
+) -> Result<(
+    std::net::SocketAddr,
+    impl HostApi,
+    Arc<HttpServer<DevRouter>>,
+)> {
+    let engine = Engine::builder().build()?;
+    let http_server = Arc::new(HttpServer::new(DevRouter::default(), addr.parse()?).await?);
+    let bound_addr = http_server.addr();
+    let host = with_standard_plugins(
+        HostBuilder::new()
+            .with_engine(engine)
+            .with_http_handler(http_server.clone()),
+    )?
+    .build()?;
+    let host = host.start().await.context("Failed to start host")?;
+    Ok((bound_addr, host, http_server))
+}
+
 /// Extract the numeric value of `"name":N` from a flat JSON body without
 /// pulling in a JSON dependency. Panics (failing the test) if the field is
 /// missing or non-numeric.

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -910,6 +910,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "msg-counter"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
 name = "naga"
 version = "0.19.0"
 source = "git+https://github.com/wasi-gfx/wgpu.git?rev=898122bf2cace048e63f065181a86459edb28205#898122bf2cace048e63f065181a86459edb28205"

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "keyvalue-default-p3",
     "postgres-stream-p3",
     "svc-counter",
+    "msg-counter",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/msg-counter/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/msg-counter/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "msg-counter"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/msg-counter/src/bindings.rs
+++ b/crates/wash-runtime/tests/fixtures/msg-counter/src/bindings.rs
@@ -1,0 +1,2 @@
+#![allow(unsafe_code)]
+wit_bindgen::generate!({ world: "msg-counter", generate_all });

--- a/crates/wash-runtime/tests/fixtures/msg-counter/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/msg-counter/src/lib.rs
@@ -1,0 +1,74 @@
+//! A p3 service co-driving `wasi:cli/run@0.3` (a p3 async tick loop), the p2
+//! `wasmcloud:messaging/handler@0.2.0`, and `wasi:http/handler@0.3` on one
+//! long-lived instance.
+//!
+//! `handle-message` increments a process-global `MSG_COUNT` and echoes
+//! `"{count}:{subject}"` as its error result (observed directly by the trigger service
+//! spike). The http handler reports the live `MSG_COUNT` as `{"count":N}`, so an
+//! end-to-end test can publish a message through a messaging backend and read
+//! the count over HTTP — proving the message reached the handler on the SAME
+//! long-lived instance the trigger service co-drives, not a fresh one per message.
+
+mod bindings;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use bindings::exports::wasi::cli::run::Guest as RunGuest;
+use bindings::exports::wasi::http::handler::Guest as HttpGuest;
+use bindings::exports::wasmcloud::messaging::handler::Guest as MsgGuest;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::wasmcloud::messaging::types::BrokerMessage;
+
+static MSG_COUNT: AtomicU64 = AtomicU64::new(0);
+
+struct Component;
+
+impl RunGuest for Component {
+    async fn run() -> Result<(), ()> {
+        use bindings::wasi::clocks::monotonic_clock;
+        // Keep the service alive; the trigger service co-drives this concurrently with
+        // message and HTTP handling.
+        loop {
+            monotonic_clock::wait_for(1_000_000).await;
+        }
+    }
+}
+
+impl MsgGuest for Component {
+    fn handle_message(msg: BrokerMessage) -> Result<(), String> {
+        // A `boom` subject traps the handler, faulting the co-driven instance —
+        // the restart-behavior test uses this to force a supervised restart.
+        if msg.subject == "boom" {
+            panic!("msg-counter boom: deliberate handler trap for the restart test");
+        }
+        let n = MSG_COUNT.fetch_add(1, Ordering::SeqCst) + 1;
+        // Echo the running count + subject so the trigger service spike can observe
+        // delivery and that the instance is long-lived.
+        Err(format!("{n}:{}", msg.subject))
+    }
+}
+
+impl HttpGuest for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        let count = MSG_COUNT.load(Ordering::SeqCst);
+        let body = format!("{{\"count\":{count}}}");
+        Ok(make_response(200, body.into_bytes()))
+    }
+}
+
+fn make_response(status: u16, body: Vec<u8>) -> Response {
+    let headers = Fields::new();
+    let _ = headers.set(&"content-type".to_string(), &[b"application/json".to_vec()]);
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    let _ = response.set_status_code(status);
+    response
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/msg-counter/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/msg-counter/wit/world.wit
@@ -1,0 +1,15 @@
+package wasmcloud:test-msg@0.1.0;
+
+/// A p3 service that exports cli/run (a p3 tick loop), the p2
+/// `wasmcloud:messaging/handler`, AND `wasi:http/handler` (reporting the message
+/// count). Exercises the TriggerService co-driving a p2 sync message handler and a p3
+/// http handler alongside a p3 async cli/run on one long-lived instance; the
+/// http endpoint makes the message count observable end-to-end.
+world msg-counter {
+    import wasi:clocks/types@0.3.0;
+    import wasi:clocks/monotonic-clock@0.3.0;
+    import wasi:http/types@0.3.0;
+    export wasi:cli/run@0.3.0;
+    export wasi:http/handler@0.3.0;
+    export wasmcloud:messaging/handler@0.2.0;
+}

--- a/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasmcloud-messaging-0.2.0/package.wit
+++ b/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasmcloud-messaging-0.2.0/package.wit
@@ -1,0 +1,29 @@
+package wasmcloud:messaging@0.2.0;
+
+/// Types common to message broker interactions
+interface types {
+  /// A message sent to or received from a broker
+  record broker-message {
+    subject: string,
+    body: list<u8>,
+    reply-to: option<string>,
+  }
+}
+
+interface handler {
+  use types.{broker-message};
+
+  /// Callback handled to invoke a function when a message is received from a subscription
+  handle-message: func(msg: broker-message) -> result<_, string>;
+}
+
+interface consumer {
+  use types.{broker-message};
+
+  /// Perform a request operation on a subject
+  request: func(subject: string, body: list<u8>, timeout-ms: u32) -> result<broker-message, string>;
+
+  /// Publish a message to a subject without awaiting a response
+  publish: func(msg: broker-message) -> result<_, string>;
+}
+

--- a/crates/wash-runtime/tests/integration_trigger_service_messaging.rs
+++ b/crates/wash-runtime/tests/integration_trigger_service_messaging.rs
@@ -1,0 +1,223 @@
+//! Spike: the TriggerService co-drives a p2 `wasmcloud:messaging/handler` alongside a
+//! p3 `wasi:cli/run` on one long-lived instance.
+//!
+//! The `msg-counter` fixture exports BOTH `wasi:cli/run@0.3` and the p2
+//! `wasmcloud:messaging/handler@0.2.0`. Its `handle-message` increments a
+//! process-global counter and echoes `"{count}:{subject}"`. Delivering two
+//! messages and observing the count climb (1, then 2) proves the p2 handler runs
+//! on the SAME long-lived instance the trigger service co-drives — invoked via the
+//! dynamic `call_concurrent` path under `run_concurrent` — rather than a fresh
+//! instance per message.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::host::HostApi;
+use wash_runtime::host::http::{DevRouter, HostHandler, HttpServer};
+use wash_runtime::host::trigger_service::BrokerMessage;
+use wash_runtime::types::{
+    LocalResources, Service, Workload, WorkloadStartRequest, WorkloadStopRequest,
+};
+
+mod common;
+use common::start_host_with_p3_handler;
+
+const MSG_COUNTER_WASM: &[u8] = include_bytes!("wasm/msg_counter.wasm");
+
+fn msg_counter_request(workload_id: &str, max_restarts: u64) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: workload_id.to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "msg-counter".to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(MSG_COUNTER_WASM),
+                local_resources: LocalResources::default(),
+                max_restarts,
+            }),
+            components: vec![],
+            host_interfaces: vec![],
+            volumes: vec![],
+        },
+    }
+}
+
+async fn deliver(
+    http_server: &Arc<HttpServer<DevRouter>>,
+    workload_id: &str,
+    subject: &str,
+) -> Result<Result<(), String>> {
+    let msg = BrokerMessage {
+        subject: subject.to_string(),
+        body: b"hi".to_vec(),
+        reply_to: None,
+    };
+    timeout(
+        Duration::from_secs(10),
+        http_server.deliver_trigger_service_message(workload_id, msg),
+    )
+    .await
+    .context("deliver_trigger_service_message timed out")?
+}
+
+#[tokio::test]
+async fn test_trigger_service_co_drives_messaging_handler() -> Result<()> {
+    let workload_id = uuid::Uuid::new_v4().to_string();
+    let (addr, host, http_server) = start_host_with_p3_handler("127.0.0.1:0").await?;
+
+    host.workload_start(msg_counter_request(&workload_id, 0))
+        .await
+        .context("failed to start msg-counter trigger service workload")?;
+
+    // Two messages land on the SAME long-lived instance, so the handler's
+    // process-global count climbs 1 -> 2 (a fresh instance per message would
+    // return 1 both times).
+    let r1 = deliver(&http_server, &workload_id, "first").await?;
+    assert_eq!(
+        r1,
+        Err("1:first".to_string()),
+        "first message handled on the co-driven instance"
+    );
+
+    let r2 = deliver(&http_server, &workload_id, "second").await?;
+    assert_eq!(
+        r2,
+        Err("2:second".to_string()),
+        "second message hits the same long-lived instance (count persists)"
+    );
+
+    // Multi-ingress: the same instance also serves HTTP (`wasi:http/handler`
+    // is a second co-driven ingress), and its response reads the SAME
+    // process-global count the messaging handler advanced — proving both
+    // ingresses share one live instance.
+    let client = reqwest::Client::new();
+    let resp = timeout(
+        Duration::from_secs(10),
+        client.get(format!("http://{addr}/")).send(),
+    )
+    .await
+    .context("HTTP request to the co-driven instance timed out")??;
+    anyhow::ensure!(
+        resp.status().is_success(),
+        "the co-driven instance should serve HTTP, got {}",
+        resp.status()
+    );
+    let body = resp.text().await?;
+    assert_eq!(
+        common::json_u64_field(&body, "count"),
+        2,
+        "the HTTP ingress must observe the messaging ingress's state (one shared \
+         instance), got {body}"
+    );
+
+    Ok(())
+}
+
+/// Teardown: a stopped trigger service drops its messaging subscription, so a
+/// message published afterward is not delivered. Guards the unbind wiring — a
+/// stopped service must deregister its handler, not keep receiving deliveries on
+/// a torn-down instance.
+#[tokio::test]
+async fn test_trigger_service_stop_drops_messaging_subscription() -> Result<()> {
+    let workload_id = uuid::Uuid::new_v4().to_string();
+    let (_addr, host, http_server) = start_host_with_p3_handler("127.0.0.1:0").await?;
+
+    host.workload_start(msg_counter_request(&workload_id, 0))
+        .await
+        .context("failed to start msg-counter trigger service workload")?;
+
+    // Delivery works while running.
+    let live = deliver(&http_server, &workload_id, "live").await?;
+    assert_eq!(
+        live,
+        Err("1:live".to_string()),
+        "message handled while running"
+    );
+
+    host.workload_stop(WorkloadStopRequest {
+        workload_id: workload_id.clone(),
+    })
+    .await
+    .context("failed to stop trigger service workload")?;
+
+    // Stop must DEREGISTER the handler, not merely tear down the instance: the
+    // registration is gone, so delivery fails at lookup rather than reaching a
+    // torn-down channel.
+    assert!(
+        !http_server
+            .has_trigger_service_messaging(&workload_id)
+            .await,
+        "stop must drop the messaging subscription"
+    );
+    let after = deliver(&http_server, &workload_id, "after").await;
+    assert!(
+        after.is_err(),
+        "a message published after stop must not be delivered, got {after:?}"
+    );
+
+    Ok(())
+}
+
+/// Restart: a handler trap faults the co-driven instance; the supervisor restarts
+/// it within `max_restarts` and re-registers the messaging handler, so delivery
+/// resumes on a FRESH instance (its per-instance count reset to 1, not 2).
+///
+/// A trap leaves the shared instance unenterable for every later message, so
+/// [`MessagingTask`] reports it and then faults the driver out of
+/// `run_concurrent`, letting the workload supervisor re-instantiate and
+/// re-register. An ordinary handler `Err(string)` outcome does NOT fault the
+/// driver — the co-drive test above proves consecutive deliveries keep the
+/// instance.
+///
+/// [`MessagingTask`]: wash_runtime::host::trigger_service
+#[tokio::test]
+async fn test_trigger_service_restarts_and_resubscribes_on_fault() -> Result<()> {
+    let workload_id = uuid::Uuid::new_v4().to_string();
+    let (_addr, host, http_server) = start_host_with_p3_handler("127.0.0.1:0").await?;
+    host.workload_start(msg_counter_request(&workload_id, 3))
+        .await
+        .context("failed to start msg-counter trigger service workload")?;
+
+    // Prime the count on the initial instance.
+    let r1 = deliver(&http_server, &workload_id, "first").await?;
+    assert_eq!(
+        r1,
+        Err("1:first".to_string()),
+        "handled on the initial instance"
+    );
+
+    // `boom` traps the handler, faulting the instance; the supervisor restarts it.
+    let _ = deliver(&http_server, &workload_id, "boom").await;
+
+    // After the restart, delivery resumes (re-subscribed) on a fresh instance
+    // whose per-instance count starts over at 1. The restart is async, so poll
+    // until a delivery is HANDLED again — a `{count}:{subject}` echo. A delivery
+    // that races the teardown of the poisoned incarnation surfaces a trap error
+    // string instead ("cannot enter component instance"); keep polling through
+    // those rather than mistaking them for a handled message.
+    let mut got = None;
+    for _ in 0..100 {
+        if let Ok(Err(s)) = deliver(&http_server, &workload_id, "after").await
+            && s.ends_with(":after")
+        {
+            got = Some(s);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        got,
+        Some("1:after".to_string()),
+        "after a fault the supervisor re-subscribes on a fresh instance (count reset)"
+    );
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -118,11 +118,17 @@ const P3_FIXTURES: &[&str] = &[
     "keyvalue-default-p3",
     "postgres-stream-p3",
     "svc-counter",
+    "msg-counter",
 ];
 
 // Fixtures with local-only WIT worlds (no wasi imports). Copying shared
 // deps into these would pollute their wit resolution with unneeded packages.
 const P2_SKIP_SHARED_WIT: &[&str] = &["cron-service", "cron-component"];
+
+// P3 fixtures that vendor their own `wit/deps` (a custom contract plus the
+// wasi packages they reference). Copying the shared p3-wit-deps over them
+// would pull every wasi package into their `generate_all` surface.
+const P3_SKIP_SHARED_WIT: &[&str] = &[];
 
 fn build_fixtures(workspace: &Path) -> Result<()> {
     let fixtures_dir = workspace.join("crates/wash-runtime/tests/fixtures");
@@ -141,7 +147,13 @@ fn build_fixtures(workspace: &Path) -> Result<()> {
         P2_FIXTURES,
         P2_SKIP_SHARED_WIT,
     )?;
-    build_kind(&fixtures_dir, &wasm_dir, FixtureKind::P3, P3_FIXTURES, &[])?;
+    build_kind(
+        &fixtures_dir,
+        &wasm_dir,
+        FixtureKind::P3,
+        P3_FIXTURES,
+        P3_SKIP_SHARED_WIT,
+    )?;
 
     println!(
         "staged {} fixtures into {}",


### PR DESCRIPTION
Adds wasmcloud:messaging/handler@0.2.0 as a second TriggerService ingress: a p3 service exporting the p2 handle-message alongside cli/run (and optionally wasi:http/handler) has messages delivered to its ONE long-lived instance, invoked via the dynamic call_concurrent path instead of a fresh instance per message. The host keeps a MessagingHandlers registry mirroring the HTTP one (register on resolve, swap on restart, drop on stop/unbind), with deliver_trigger_service_message / has_trigger_service_messaging as the delivery API for host-side messaging ingresses.

Trap handling: a handler Err(string) is an ordinary application outcome, reported to the deliverer only. A guest TRAP, however, leaves the shared instance unenterable for every later invocation, so MessagingTask reports it and then faults the driver out of run_concurrent. The service supervisor restarts within max_restarts and now rebuilds a FRESH store per incarnation (via a captured ServiceStoreRecipe): a trapped store can never re-enter any component instance, so reusing it would leave every restarted incarnation permanently broken. The plain p3 cli/run restart loop (execute_service_p3) had the same latent same-store-reuse pattern and now rebuilds from the same recipe on every restart, which also stops stale instances accumulating in a reused store across clean restarts.

The msg-counter fixture co-exports cli/run + http/handler + the messaging handler; tests cover count persistence across deliveries on one instance, the HTTP ingress observing the messaging ingress's state (multi-ingress on one instance), deregistration on stop, and trap -> restart -> re-subscribe with the per-instance count reset to prove the incarnation is fresh.

Second PR in series of stacked PRs and builds on #5332