### PR TITLE
feat(wash-runtime): cross-store streams and futures

### DIFF
--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -19,7 +19,6 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio::sync::RwLock;
 use tokio::time::timeout;
@@ -35,6 +34,8 @@ use wasmtime_wasi::WasiCtxBuilder;
 #[cfg(feature = "wasi-tls")]
 use crate::engine::ctx::SharedTlsProvider;
 use crate::engine::ctx::{AccessorActiveCtxGuard, Ctx, SharedCtx, StoreActiveCtxGuard};
+use crate::engine::store::relocate::{self, Relocated, bridgeable_element_type};
+use crate::engine::store::stream_pump::Done;
 use crate::engine::value::{carries_cross_store_handle, lift_results, lower_params};
 use crate::engine::volumes::{ResolvedVolumeMount, resolve_component_volume_mounts_in_map};
 use crate::engine::workload::{WorkloadComponent, WorkloadMetadata};
@@ -141,6 +142,23 @@ pub(crate) struct EphemeralLinkedCall {
     pub(crate) linked_component_ids: Vec<Arc<str>>,
     #[cfg(feature = "wasi-tls")]
     pub(crate) tls_provider: Option<SharedTlsProvider>,
+    /// How this call moves its args/results across the store boundary.
+    pub(crate) mode: EphemeralCallMode,
+}
+
+/// How an ephemeral linked call transfers its args/results across the store
+/// boundary, decided by the signature classification at link time.
+#[derive(Clone)]
+pub(crate) enum EphemeralCallMode {
+    /// Handle-free call: params/results are copied directly.
+    PlainValue,
+    /// The signature carries a bridgeable `stream<T>` or `future<T>`, so
+    /// args/results are relocated across the boundary (see [`relocate`]), driven
+    /// by these param/result types.
+    Relocated {
+        param_tys: Arc<[Type]>,
+        result_tys: Arc<[Type]>,
+    },
 }
 
 fn type_is_ephemeral_safe(ty: &Type) -> bool {
@@ -150,6 +168,50 @@ fn type_is_ephemeral_safe(ty: &Type) -> bool {
 pub(crate) fn func_is_ephemeral_safe(func_ty: &ComponentFunc) -> bool {
     func_ty.params().all(|(_, ty)| type_is_ephemeral_safe(&ty))
         && func_ty.results().all(|ty| type_is_ephemeral_safe(&ty))
+}
+
+/// Whether a type can cross an ephemeral-store boundary via [`relocate`].
+///
+/// True when the type is either:
+/// - handle-free, or
+/// - carrying only `stream<T>`/`future<T>` handles whose element type is
+///   relocatable (nested anywhere in aggregates).
+///
+/// `resource` (`own`/`borrow`) and `error-context` handles are not relocatable
+/// between two ephemeral-call stores, so a type carrying either is not
+/// bridge-safe. (A `resource` crosses only the host-component-plugin bridge,
+/// where a plugin-side registry exists — see
+/// [`crate::engine::store::resource_bridge`].)
+fn type_is_bridge_safe(ty: &Type) -> bool {
+    if !carries_cross_store_handle(ty) {
+        return true;
+    }
+    match ty {
+        Type::Stream(st) => st.ty().is_some_and(|e| bridgeable_element_type(&e)),
+        Type::Future(ft) => ft.ty().is_some_and(|e| bridgeable_element_type(&e)),
+        Type::List(t) => type_is_bridge_safe(&t.ty()),
+        Type::Option(t) => type_is_bridge_safe(&t.ty()),
+        Type::Tuple(t) => t.types().all(|t| type_is_bridge_safe(&t)),
+        Type::Record(t) => t.fields().all(|f| type_is_bridge_safe(&f.ty)),
+        Type::Variant(t) => t
+            .cases()
+            .all(|c| c.ty.is_none_or(|t| type_is_bridge_safe(&t))),
+        Type::Result(t) => {
+            t.ok().is_none_or(|t| type_is_bridge_safe(&t))
+                && t.err().is_none_or(|t| type_is_bridge_safe(&t))
+        }
+        Type::Map(t) => type_is_bridge_safe(&t.key()) && type_is_bridge_safe(&t.value()),
+        // resource (own/borrow) / error-context: not relocatable here.
+        _ => false,
+    }
+}
+
+/// Whether every param/result of `func_ty` is [`type_is_bridge_safe`], so a call
+/// carrying a `stream<T>`/`future<T>` can still run in an ephemeral store (with
+/// relocation) instead of being pinned to the shared store.
+pub(crate) fn func_is_bridge_safe(func_ty: &ComponentFunc) -> bool {
+    func_ty.params().all(|(_, ty)| type_is_bridge_safe(&ty))
+        && func_ty.results().all(|ty| type_is_bridge_safe(&ty))
 }
 
 async fn build_ctx_from_template(
@@ -379,7 +441,7 @@ pub(crate) async fn invoke_linked_async_export(
     inv: &LinkedExportInvocation,
 ) -> wasmtime::Result<()> {
     if let Some(ephemeral_call) = &inv.ephemeral_call {
-        invoke_ephemeral_linked_export(params, results, inv, ephemeral_call).await
+        invoke_ephemeral_linked_export(accessor, params, results, inv, ephemeral_call).await
     } else {
         invoke_shared_store_linked_export(accessor, params, results, inv).await
     }
@@ -397,9 +459,214 @@ impl<T> Drop for AbortOnDrop<T> {
     }
 }
 
+/// Dispatch an ephemeral linked call to either the plain-value copy path or the
+/// `stream`-relocating path, by the signature classification recorded at link
+/// time.
+async fn invoke_ephemeral_linked_export(
+    accessor: &Accessor<SharedCtx>,
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+    ephemeral_call: &Arc<EphemeralLinkedCall>,
+) -> wasmtime::Result<()> {
+    match &ephemeral_call.mode {
+        EphemeralCallMode::Relocated {
+            param_tys,
+            result_tys,
+        } => {
+            invoke_ephemeral_relocated(
+                accessor,
+                params,
+                results,
+                inv,
+                ephemeral_call,
+                Arc::clone(param_tys),
+                Arc::clone(result_tys),
+            )
+            .await
+        }
+        EphemeralCallMode::PlainValue => {
+            invoke_ephemeral_plain(params, results, inv, ephemeral_call).await
+        }
+    }
+}
+
+/// Run a `stream`-carrying async linked call in an ephemeral store, relocating
+/// args/results across the boundary (see [`relocate`]).
+///
+/// Args are extracted in the caller store, so each source stream begins pumping
+/// under the caller's long-lived runtime; the call then runs in a throwaway
+/// store, where result streams are extracted before the store is torn down. The
+/// store-driving task is **detached** (leaked after initial [`AbortOnDrop`]
+/// wrapping): it must outlive
+/// this call to keep producing into result streams while the caller consumes
+/// them. It self-terminates when a result stream's consumer is dropped — which
+/// closes the pump channel — so caller cancellation still reclaims the store.
+async fn invoke_ephemeral_relocated(
+    accessor: &Accessor<SharedCtx>,
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+    ephemeral_call: &Arc<EphemeralLinkedCall>,
+    param_tys: Arc<[Type]>,
+    result_tys: Arc<[Type]>,
+) -> wasmtime::Result<()> {
+    // Extract args in the caller store: source-stream pumps run under the
+    // caller's (long-lived) runtime, so their drain signals are dropped here.
+    let args = accessor.with(|mut access| -> wasmtime::Result<Vec<Relocated>> {
+        let mut dones: Vec<Done> = Vec::new();
+        let mut out = Vec::with_capacity(params.len());
+        for (v, t) in params.iter().zip(param_tys.iter()) {
+            out.push(relocate::extract(
+                access.as_context_mut(),
+                v,
+                t,
+                &mut dones,
+            )?);
+        }
+        Ok(out)
+    })?;
+
+    let (ready_tx, ready_rx) =
+        futures::channel::oneshot::channel::<wasmtime::Result<Vec<Relocated>>>();
+    let ephemeral_call = Arc::clone(ephemeral_call);
+    let callee_pre = inv.pre.clone();
+    let func_idx = inv.func_idx;
+    let import_name = inv.import_name.clone();
+    let export_name = inv.export_name.clone();
+
+    trace!(
+        name = %inv.import_name,
+        fn_name = %inv.export_name,
+        "invoking relocated ephemeral dynamic export"
+    );
+
+    // Guard the store-driving task so a caller cancelled BEFORE results are ready
+    // (e.g. a client disconnect) aborts the in-flight call and reclaims the
+    // ephemeral store's core-instance slots, rather than leaving it to run to its
+    // timeout. Once results are handed back the task must outlive this call to
+    // drain result streams, so the guard is forgotten (detached) on success.
+    let task = AbortOnDrop(tokio::task::spawn(async move {
+        let mut store = match new_ephemeral_store(&ephemeral_call).await {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = ready_tx.send(Err(wasmtime::format_err!("{e:#}")));
+                return;
+            }
+        };
+        let instance = match callee_pre.instantiate_async(&mut store).await {
+            Ok(i) => i,
+            Err(e) => {
+                let _ = ready_tx.send(Err(e));
+                return;
+            }
+        };
+        let _ = store
+            .run_concurrent(async move |accessor| {
+                let ready = async {
+                    // get_func + arg injection inside run_concurrent: the store is
+                    // in async-required mode after instantiate.
+                    let (func, arg_vals) = accessor.with(|mut access| -> wasmtime::Result<_> {
+                        let func = instance.get_func(&mut access, func_idx).with_context(|| {
+                            format!(
+                                "function not found for linked import {import_name}.{export_name}"
+                            )
+                        })?;
+                        let mut arg_vals = Vec::with_capacity(args.len());
+                        for a in args {
+                            arg_vals.push(relocate::inject(access.as_context_mut(), a)?);
+                        }
+                        Ok((func, arg_vals))
+                    })?;
+                    let mut results_buf = vec![Val::Bool(false); result_tys.len()];
+                    let call_timeout = crate::timeouts::ephemeral_call();
+                    timeout(
+                        call_timeout,
+                        func.call_concurrent(accessor, &arg_vals, &mut results_buf),
+                    )
+                    .await
+                    .map_err(|e| {
+                        wasmtime::format_err!("function call timed out after {call_timeout:?}: {e}")
+                    })??;
+                    // Extract result streams in THIS store before it is dropped.
+                    accessor.with(
+                        |mut access| -> wasmtime::Result<(Vec<Relocated>, Vec<Done>)> {
+                            let mut dones: Vec<Done> = Vec::new();
+                            let mut out = Vec::with_capacity(results_buf.len());
+                            for (r, t) in results_buf.iter().zip(result_tys.iter()) {
+                                out.push(relocate::extract(
+                                    access.as_context_mut(),
+                                    r,
+                                    t,
+                                    &mut dones,
+                                )?);
+                            }
+                            Ok((out, dones))
+                        },
+                    )
+                }
+                .await;
+
+                match ready {
+                    Ok((relocated, dones)) => {
+                        let _ = ready_tx.send(Ok(relocated));
+                        // Keep the store alive until result streams drain, but bound
+                        // it: a consumer that never reads (or never drops) its result
+                        // stream would otherwise pin this ephemeral store — and its
+                        // core-instance slots — indefinitely. A transfer still making
+                        // progress past this bound is truncated when the store drops.
+                        let drain = async {
+                            for done in dones {
+                                let _ = done.await;
+                            }
+                        };
+                        if timeout(crate::timeouts::stream_drain(), drain)
+                            .await
+                            .is_err()
+                        {
+                            trace!("relocated ephemeral store drain timed out; dropping store");
+                        }
+                    }
+                    Err(e) => {
+                        let _ = ready_tx.send(Err(e));
+                    }
+                }
+                Ok::<(), wasmtime::Error>(())
+            })
+            .await;
+    }));
+
+    let relocated = ready_rx
+        .await
+        .map_err(|_| wasmtime::format_err!("ephemeral store dropped before producing results"))??;
+
+    // Results are in hand; the task must keep running to feed any result streams,
+    // so detach it (cancellation past this point is handled by the result-stream
+    // consumers closing their pump channels).
+    std::mem::forget(task);
+
+    // Inject results into the caller store; result-stream producers pull from
+    // the still-draining ephemeral store.
+    accessor.with(|mut access| -> wasmtime::Result<()> {
+        for (i, r) in relocated.into_iter().enumerate() {
+            let v = relocate::inject(access.as_context_mut(), r)?;
+            *results.get_mut(i).context("result index out of bounds")? = v;
+        }
+        Ok(())
+    })?;
+
+    trace!(
+        name = %inv.import_name,
+        fn_name = %inv.export_name,
+        "successfully invoked relocated ephemeral dynamic export"
+    );
+
+    Ok(())
+}
+
 /// Run a plain-value async linked call in a short-lived store that is dropped
 /// (reclaiming its core-instance slots) as soon as the call returns.
-async fn invoke_ephemeral_linked_export(
+async fn invoke_ephemeral_plain(
     params: &[Val],
     results: &mut [Val],
     inv: &LinkedExportInvocation,
@@ -413,7 +680,7 @@ async fn invoke_ephemeral_linked_export(
     let mut results_buf = vec![Val::Bool(false); results.len()];
     let call_import_name = inv.import_name.clone();
     let call_export_name = inv.export_name.clone();
-    let call_pre = inv.pre.clone();
+    let callee_pre = inv.pre.clone();
     let func_idx = inv.func_idx;
 
     trace!(
@@ -424,7 +691,7 @@ async fn invoke_ephemeral_linked_export(
     );
 
     let mut task = AbortOnDrop(tokio::task::spawn(async move {
-        let instance = call_pre.instantiate_async(&mut store).await?;
+        let instance = callee_pre.instantiate_async(&mut store).await?;
         store
             .run_concurrent(async move |accessor| {
                 let func = accessor.with(|mut access| -> wasmtime::Result<_> {
@@ -434,14 +701,14 @@ async fn invoke_ephemeral_linked_export(
                         )
                     })
                 })?;
-                const CALL_TIMEOUT: Duration = Duration::from_secs(600);
+                let call_timeout = crate::timeouts::ephemeral_call();
                 timeout(
-                    CALL_TIMEOUT,
+                    call_timeout,
                     func.call_concurrent(accessor, &params_buf, &mut results_buf),
                 )
                 .await
                 .map_err(|e| {
-                    wasmtime::format_err!("function call timed out after 600 seconds: {e}")
+                    wasmtime::format_err!("function call timed out after {call_timeout:?}: {e}")
                 })??;
                 Ok::<Vec<Val>, wasmtime::Error>(results_buf)
             })
@@ -560,13 +827,15 @@ pub(crate) async fn invoke_linked_sync_export(
 
         let mut results_buf = vec![Val::Bool(false); results.len()];
 
-        const CALL_TIMEOUT: Duration = Duration::from_secs(30);
+        let call_timeout = crate::timeouts::shared_store_call();
         timeout(
-            CALL_TIMEOUT,
+            call_timeout,
             func.call_async(&mut store, &params_buf, &mut results_buf),
         )
         .await
-        .map_err(|e| wasmtime::format_err!("function call timed out after 30 seconds: {e}"))??;
+        .map_err(|e| {
+            wasmtime::format_err!("function call timed out after {call_timeout:?}: {e}")
+        })??;
 
         lift_results(store, results_buf, results)?;
         trace!(name = %inv.import_name, fn_name = %inv.export_name, "invoked dynamic export");

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -219,6 +219,7 @@ pub fn targets_wasip3_http(component: &Component) -> bool {
 
 pub mod ctx;
 mod linked_call;
+pub(crate) mod store;
 mod value;
 mod volumes;
 pub mod workload;

--- a/crates/wash-runtime/src/engine/store.rs
+++ b/crates/wash-runtime/src/engine/store.rs
@@ -1,0 +1,10 @@
+//! Cross-store value interop: moving argument/result `Val` trees — and the
+//! `stream`/`future` handles they carry — between wasmtime stores for linked
+//! calls that don't co-locate caller and callee.
+//!
+//! - [`relocate`] extracts a `Val` tree in one store and injects it into another.
+//! - [`stream_pump`] bridges a `stream<T>`/`future<T>` across the boundary as a
+//!   live, no-buffering pump.
+
+pub(crate) mod relocate;
+pub(crate) mod stream_pump;

--- a/crates/wash-runtime/src/engine/store/relocate.rs
+++ b/crates/wash-runtime/src/engine/store/relocate.rs
@@ -1,0 +1,422 @@
+//! Relocating `Val` trees across the store boundary for cross-store linked
+//! calls.
+//!
+//! A linked call whose signature carries only **bridgeable** handles (p3
+//! `stream<T>` of a supported element type, nested anywhere in aggregates) can
+//! run in an ephemeral store even though a handle crosses the boundary: instead
+//! of co-locating caller and callee in one store, we [`extract`] each argument
+//! in the caller store into a [`Relocated`] tree and [`inject`] it into the
+//! callee store. Handle-free values/subtrees are copied wholesale; each
+//! `stream<T>` becomes a live, no-buffering channel pump (see [`stream_pump`])
+//! so the body streams incrementally with backpressure rather than being
+//! buffered at the boundary.
+//!
+//! `future<T>` relocates the same way as a stream (a one-shot pump). A
+//! `resource` handle is not relocatable here: it is a capability into one
+//! store's table with no meaning elsewhere, so a signature carrying one stays
+//! on the shared-store path.
+//!
+//! `error-context` is rejected here, and cannot be relocated with wasmtime's
+//! current public API: its `Val` carries a store-scoped table index (a `rep`
+//! into the origin store's error-context tables) that is meaningless in another
+//! store, and wasmtime exposes no host-side way to read an error-context's debug
+//! message or mint a fresh one in the destination store (`ErrorContext` offers
+//! only `from_val`/`into_val`, which round-trip the opaque index). Since an
+//! error-context conveys only a debug string, a signature can carry that across
+//! the boundary as a plain `result<_, string>` instead.
+
+use wasmtime::component::{
+    FutureAny, FutureReader, Lift, Lower, StreamAny, StreamReader, Type, Val,
+};
+use wasmtime::{AsContextMut as _, StoreContextMut};
+
+use crate::engine::ctx::SharedCtx;
+use crate::engine::store::stream_pump::{self, Done};
+
+/// A value prepared to cross the store boundary: a copyable `Val`, or a
+/// `stream<T>` carried as its producer (the source was `pipe`d in the origin
+/// store). Aggregates recurse so streams nested anywhere are handled.
+pub enum Relocated {
+    Val(Val),
+    /// A `stream<T>`, carried as a closure that builds the destination stream
+    /// (it captures the typed producer; inject just calls it).
+    Stream(ValFactory),
+    /// A `future<T>`, carried the same way as a stream — a closure that builds
+    /// the destination future from the paired receiver.
+    Future(ValFactory),
+    List(Vec<Relocated>),
+    Tuple(Vec<Relocated>),
+    Record(Vec<(String, Relocated)>),
+    Variant(String, Box<Relocated>),
+    Option(Box<Relocated>),
+    Result(Result<Box<Relocated>, Box<Relocated>>),
+    Map(Vec<(Relocated, Relocated)>),
+}
+
+/// Builds a `stream<T>`/`future<T>` value in the destination store from a
+/// pre-wired producer (it captures the source side's pump endpoint).
+type ValFactory = Box<dyn FnOnce(StoreContextMut<SharedCtx>) -> wasmtime::Result<Val> + Send>;
+
+/// Set up a no-buffering pump for a `stream<T>`: `pipe` the source reader (in
+/// `src`) into a channel, and return a factory that builds the destination
+/// stream from the channel's producer, plus the pump's drain signal.
+fn bridge_stream<T>(
+    mut src: StoreContextMut<SharedCtx>,
+    any: StreamAny,
+) -> wasmtime::Result<(ValFactory, Done)>
+where
+    T: Lift + Lower + Send + Sync + 'static,
+{
+    let reader = StreamReader::<T>::try_from_stream_any(any)?;
+    let (consumer, producer, done) = stream_pump::channel::<T>(stream_pump::DEFAULT_CAPACITY);
+    reader.pipe(src.as_context_mut(), consumer)?;
+    let factory: ValFactory = Box::new(move |mut dst: StoreContextMut<SharedCtx>| {
+        let reader = StreamReader::new(dst.as_context_mut(), producer)?;
+        let any = reader.try_into_stream_any(dst)?;
+        Ok(Val::Stream(any))
+    });
+    Ok((factory, done))
+}
+
+/// Set up a one-shot pump for a `future<T>`: `pipe` the source future (in `src`)
+/// into a [`stream_pump::FutureSink`], and return a factory that builds the
+/// destination future from the paired receiver, plus the pump's completion
+/// signal.
+fn bridge_future<T>(
+    mut src: StoreContextMut<SharedCtx>,
+    any: FutureAny,
+) -> wasmtime::Result<(ValFactory, Done)>
+where
+    T: Lift + Lower + Send + Sync + 'static,
+{
+    let reader = FutureReader::<T>::try_from_future_any(any)?;
+    let (sink, rx, done) = stream_pump::future_channel::<T>();
+    reader.pipe(src.as_context_mut(), sink)?;
+    let factory: ValFactory = Box::new(move |mut dst: StoreContextMut<SharedCtx>| {
+        let reader = FutureReader::new(dst.as_context_mut(), async move {
+            rx.await
+                .map_err(|_| wasmtime::format_err!("future bridge: source dropped before value"))
+        })?;
+        let any = reader.try_into_future_any(dst)?;
+        Ok(Val::Future(any))
+    });
+    Ok((factory, done))
+}
+
+/// Defines the pump-supported `stream<T>`/`future<T>` element types — the
+/// scalar types and `string` — in one place, generating the classification
+/// ([`bridgeable_element_type`]) and both typed dispatches ([`stream_factory`],
+/// [`future_factory`]) from the same list.
+macro_rules! bridgeable_elements {
+    ($($variant:ident => $t:ty),* $(,)?) => {
+        /// Whether a `stream<T>`/`future<T>` of this element type can be
+        /// relocated across stores.
+        pub fn bridgeable_element_type(ty: &Type) -> bool {
+            matches!(ty, $(Type::$variant)|*)
+        }
+
+        /// Dispatch a `stream<T>` to a typed pump by its element type.
+        fn stream_factory(
+            src: StoreContextMut<SharedCtx>,
+            any: StreamAny,
+            payload: &Type,
+        ) -> wasmtime::Result<(ValFactory, Done)> {
+            match payload {
+                $(Type::$variant => bridge_stream::<$t>(src, any),)*
+                other => wasmtime::bail!(
+                    "cross-store bridge: unsupported stream element type {other:?}"
+                ),
+            }
+        }
+
+        /// Dispatch a `future<T>` to a typed pump by its element type.
+        fn future_factory(
+            src: StoreContextMut<SharedCtx>,
+            any: FutureAny,
+            payload: &Type,
+        ) -> wasmtime::Result<(ValFactory, Done)> {
+            match payload {
+                $(Type::$variant => bridge_future::<$t>(src, any),)*
+                other => wasmtime::bail!(
+                    "cross-store bridge: unsupported future element type {other:?}"
+                ),
+            }
+        }
+    };
+}
+
+bridgeable_elements!(
+    Bool => bool, S8 => i8, U8 => u8, S16 => i16, U16 => u16,
+    S32 => i32, U32 => u32, S64 => i64, U64 => u64,
+    Float32 => f32, Float64 => f64, Char => char, String => String,
+);
+
+/// Whether `val` contains a store-bound handle (`stream`/`future`/`resource`/
+/// `error-context`) anywhere, so we know whether structural relocation is
+/// needed or the value can be copied wholesale.
+fn contains_handle(val: &Val) -> bool {
+    match val {
+        Val::Stream(_) | Val::Future(_) | Val::Resource(_) | Val::ErrorContext(_) => true,
+        Val::List(vs) | Val::Tuple(vs) => vs.iter().any(contains_handle),
+        Val::Record(fs) => fs.iter().any(|(_, v)| contains_handle(v)),
+        Val::Variant(_, Some(v)) | Val::Option(Some(v)) => contains_handle(v),
+        Val::Result(Ok(Some(v))) | Val::Result(Err(Some(v))) => contains_handle(v),
+        Val::Map(es) => es
+            .iter()
+            .any(|(k, v)| contains_handle(k) || contains_handle(v)),
+        _ => false,
+    }
+}
+
+/// Extract a value from `store` (its origin), setting up a live channel pump for
+/// each `stream<T>` (`reader.pipe` → no buffering) and pushing the pump's drain
+/// signal into `dones`. Handle-free values/subtrees are copied wholesale.
+pub fn extract(
+    mut store: StoreContextMut<SharedCtx>,
+    val: &Val,
+    ty: &Type,
+    dones: &mut Vec<Done>,
+) -> wasmtime::Result<Relocated> {
+    if !contains_handle(val) {
+        return Ok(Relocated::Val(val.clone()));
+    }
+    match (val, ty) {
+        (Val::Stream(any), Type::Stream(st)) => {
+            let payload = st
+                .ty()
+                .ok_or_else(|| wasmtime::format_err!("stream is missing its element type"))?;
+            let (factory, done) = stream_factory(store, any.clone(), &payload)?;
+            dones.push(done);
+            Ok(Relocated::Stream(factory))
+        }
+        (Val::Future(any), Type::Future(ft)) => {
+            let payload = ft
+                .ty()
+                .ok_or_else(|| wasmtime::format_err!("future is missing its element type"))?;
+            let (factory, done) = future_factory(store, any.clone(), &payload)?;
+            dones.push(done);
+            Ok(Relocated::Future(factory))
+        }
+        // A `resource` handle is a capability into its origin store's table;
+        // there is no way to rebuild it elsewhere, so it cannot cross. The
+        // bridge-safety classification keeps such signatures off this path.
+        (Val::Resource(_), _) => {
+            wasmtime::bail!("cross-store bridge does not transfer `resource` handles")
+        }
+        // An error-context's `Val` is a store-scoped table index with no
+        // host-side API to read its message or rebuild it in another store, so it
+        // cannot cross the boundary; steer callers to a plain error type carrying
+        // the same debug string. See the module docs.
+        (Val::ErrorContext(_), _) => {
+            wasmtime::bail!(
+                "cross-store bridge does not transfer `error-context` values; return a plain \
+                 error type (e.g. `result<_, string>`) across a component-host-plugin boundary"
+            )
+        }
+        (Val::List(vs), Type::List(lt)) => {
+            let et = lt.ty();
+            let mut out = Vec::with_capacity(vs.len());
+            for v in vs {
+                out.push(extract(store.as_context_mut(), v, &et, dones)?);
+            }
+            Ok(Relocated::List(out))
+        }
+        (Val::Tuple(vs), Type::Tuple(tt)) => {
+            let tys: Vec<Type> = tt.types().collect();
+            let mut out = Vec::with_capacity(vs.len());
+            for (v, t) in vs.iter().zip(tys.iter()) {
+                out.push(extract(store.as_context_mut(), v, t, dones)?);
+            }
+            Ok(Relocated::Tuple(out))
+        }
+        (Val::Record(vs), Type::Record(rt)) => {
+            let ftys: Vec<Type> = rt.fields().map(|f| f.ty).collect();
+            let mut out = Vec::with_capacity(vs.len());
+            for ((n, v), t) in vs.iter().zip(ftys.iter()) {
+                out.push((n.clone(), extract(store.as_context_mut(), v, t, dones)?));
+            }
+            Ok(Relocated::Record(out))
+        }
+        (Val::Option(Some(v)), Type::Option(ot)) => Ok(Relocated::Option(Box::new(extract(
+            store.as_context_mut(),
+            v,
+            &ot.ty(),
+            dones,
+        )?))),
+        (Val::Result(Ok(Some(v))), Type::Result(rt)) => {
+            let it = rt
+                .ok()
+                .ok_or_else(|| wasmtime::format_err!("result `ok` is missing its type"))?;
+            Ok(Relocated::Result(Ok(Box::new(extract(
+                store.as_context_mut(),
+                v,
+                &it,
+                dones,
+            )?))))
+        }
+        (Val::Result(Err(Some(v))), Type::Result(rt)) => {
+            let it = rt
+                .err()
+                .ok_or_else(|| wasmtime::format_err!("result `err` is missing its type"))?;
+            Ok(Relocated::Result(Err(Box::new(extract(
+                store.as_context_mut(),
+                v,
+                &it,
+                dones,
+            )?))))
+        }
+        (Val::Variant(case, Some(v)), Type::Variant(vt)) => {
+            let case_ty = vt
+                .cases()
+                .find(|c| c.name == case)
+                .and_then(|c| c.ty)
+                .ok_or_else(|| {
+                    wasmtime::format_err!("variant case `{case}` has no payload type")
+                })?;
+            Ok(Relocated::Variant(
+                case.clone(),
+                Box::new(extract(store.as_context_mut(), v, &case_ty, dones)?),
+            ))
+        }
+        (Val::Map(es), Type::Map(mt)) => {
+            let kt = mt.key();
+            let vt = mt.value();
+            let mut out = Vec::with_capacity(es.len());
+            for (k, v) in es {
+                let k = extract(store.as_context_mut(), k, &kt, dones)?;
+                let v = extract(store.as_context_mut(), v, &vt, dones)?;
+                out.push((k, v));
+            }
+            Ok(Relocated::Map(out))
+        }
+        // A handle in a value/type mismatch (shouldn't happen for valid calls).
+        _ => wasmtime::bail!("cross-store bridge: handle in an unexpected value/type position"),
+    }
+}
+
+/// Inject a relocated value into `store` (its destination), creating a fresh
+/// `stream<T>` from each producer.
+pub fn inject(mut store: StoreContextMut<SharedCtx>, r: Relocated) -> wasmtime::Result<Val> {
+    match r {
+        Relocated::Val(v) => Ok(v),
+        Relocated::Stream(factory) | Relocated::Future(factory) => factory(store),
+        Relocated::List(rs) => {
+            let mut out = Vec::with_capacity(rs.len());
+            for r in rs {
+                out.push(inject(store.as_context_mut(), r)?);
+            }
+            Ok(Val::List(out))
+        }
+        Relocated::Tuple(rs) => {
+            let mut out = Vec::with_capacity(rs.len());
+            for r in rs {
+                out.push(inject(store.as_context_mut(), r)?);
+            }
+            Ok(Val::Tuple(out))
+        }
+        Relocated::Record(fs) => {
+            let mut out = Vec::with_capacity(fs.len());
+            for (n, r) in fs {
+                out.push((n, inject(store.as_context_mut(), r)?));
+            }
+            Ok(Val::Record(out))
+        }
+        Relocated::Variant(case, r) => Ok(Val::Variant(
+            case,
+            Some(Box::new(inject(store.as_context_mut(), *r)?)),
+        )),
+        Relocated::Option(r) => Ok(Val::Option(Some(Box::new(inject(
+            store.as_context_mut(),
+            *r,
+        )?)))),
+        Relocated::Result(Ok(r)) => Ok(Val::Result(Ok(Some(Box::new(inject(
+            store.as_context_mut(),
+            *r,
+        )?))))),
+        Relocated::Result(Err(r)) => Ok(Val::Result(Err(Some(Box::new(inject(
+            store.as_context_mut(),
+            *r,
+        )?))))),
+        Relocated::Map(es) => {
+            let mut out = Vec::with_capacity(es.len());
+            for (k, v) in es {
+                let k = inject(store.as_context_mut(), k)?;
+                let v = inject(store.as_context_mut(), v)?;
+                out.push((k, v));
+            }
+            Ok(Val::Map(out))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contains_handle;
+    use wasmtime::component::Val;
+
+    // `contains_handle` decides the relocation fast path (copy wholesale) vs.
+    // structural descent. Its `true` arms (`stream`/`future`/`resource`/
+    // `error-context`) require a live store to construct and are covered by the
+    // integration tests; here we pin the negative path and the recursion so a
+    // handle-free value is never needlessly decomposed and a nested handle is
+    // never missed structurally.
+
+    #[test]
+    fn primitives_have_no_handle() {
+        for v in [
+            Val::Bool(true),
+            Val::S8(-1),
+            Val::U8(1),
+            Val::U32(7),
+            Val::U64(9),
+            Val::Float64(1.5),
+            Val::Char('z'),
+            Val::String("hi".into()),
+            Val::Enum("a".into()),
+            Val::Flags(vec!["x".into()]),
+        ] {
+            assert!(!contains_handle(&v), "{v:?} should have no handle");
+        }
+    }
+
+    #[test]
+    fn primitive_aggregates_have_no_handle() {
+        let rec = Val::Record(vec![
+            ("a".into(), Val::U32(1)),
+            ("b".into(), Val::String("x".into())),
+        ]);
+        assert!(!contains_handle(&rec));
+        assert!(!contains_handle(&Val::List(vec![Val::U8(1), Val::U8(2)])));
+        assert!(!contains_handle(&Val::Tuple(vec![
+            Val::Bool(true),
+            rec.clone()
+        ])));
+        assert!(!contains_handle(&Val::Option(Some(Box::new(Val::U32(1))))));
+        assert!(!contains_handle(&Val::Option(None)));
+        assert!(!contains_handle(&Val::Result(Ok(Some(Box::new(
+            rec.clone()
+        ))))));
+        assert!(!contains_handle(&Val::Result(Err(None))));
+        assert!(!contains_handle(&Val::Variant(
+            "c".into(),
+            Some(Box::new(Val::U32(1)))
+        )));
+        assert!(!contains_handle(&Val::Variant("c".into(), None)));
+        assert!(!contains_handle(&Val::Map(vec![(
+            Val::String("k".into()),
+            Val::U32(1)
+        )])));
+    }
+
+    #[test]
+    fn deeply_nested_primitives_have_no_handle() {
+        let deep = Val::List(vec![Val::Record(vec![(
+            "x".into(),
+            Val::Option(Some(Box::new(Val::Tuple(vec![
+                Val::U32(1),
+                Val::Map(vec![(Val::String("k".into()), Val::List(vec![Val::U8(0)]))]),
+            ])))),
+        )])]);
+        assert!(!contains_handle(&deep));
+    }
+}

--- a/crates/wash-runtime/src/engine/store/stream_pump.rs
+++ b/crates/wash-runtime/src/engine/store/stream_pump.rs
@@ -1,0 +1,221 @@
+//! Live, **no-buffering** stream pump across the store boundary, generic over
+//! the element type.
+//!
+//! A `stream<T>` is relayed through a **bounded** `futures::channel::mpsc`
+//! channel of `Vec<T>` chunks:
+//!
+//! - Source store: [`ChannelConsumer`] is `pipe`d the source `StreamReader<T>`;
+//!   each `poll_consume` waits for channel room (`Sender::poll_ready` —
+//!   backpressure) then forwards the available items.
+//! - Destination store: [`ChannelProducer`] backs a fresh `StreamReader<T>`;
+//!   each `poll_produce` pulls the next chunk from the channel.
+//!
+//! The bounded channel caps in-flight data and back-pressures the source, so the
+//! stream is never fully buffered. The element type is chosen by the caller via
+//! the func signature (see [`super::relocate::stream_factory`]).
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::StreamExt as _;
+use wasmtime::StoreContextMut;
+use wasmtime::component::{
+    Destination, FutureConsumer, Lift, Lower, Source, StreamConsumer, StreamProducer, StreamResult,
+    VecBuffer,
+};
+
+/// Default in-flight chunk capacity of the cross-store channel (backpressure).
+pub const DEFAULT_CAPACITY: usize = 8;
+
+/// Destination side: yields chunks pulled from the channel.
+pub struct ChannelProducer<T> {
+    rx: futures::channel::mpsc::Receiver<Vec<T>>,
+}
+
+impl<T, D> StreamProducer<D> for ChannelProducer<T>
+where
+    T: Lower + Send + Sync + 'static,
+{
+    type Item = T;
+    type Buffer = VecBuffer<T>;
+
+    fn poll_produce<'a>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        _store: StoreContextMut<'a, D>,
+        mut dst: Destination<'a, Self::Item, Self::Buffer>,
+        _finish: bool,
+    ) -> Poll<wasmtime::Result<StreamResult>> {
+        match self.get_mut().rx.poll_next_unpin(cx) {
+            Poll::Ready(Some(chunk)) => {
+                dst.set_buffer(VecBuffer::from(chunk));
+                Poll::Ready(Ok(StreamResult::Completed))
+            }
+            Poll::Ready(None) => Poll::Ready(Ok(StreamResult::Dropped)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Source side: forwards source items into the channel, back-pressuring when
+/// full. Fires `done` once the source ends, so a caller can know the pump has
+/// drained (e.g. an ephemeral store that must outlive a result stream).
+pub struct ChannelConsumer<T> {
+    tx: futures::channel::mpsc::Sender<Vec<T>>,
+    done: Option<futures::channel::oneshot::Sender<()>>,
+}
+
+impl<T> ChannelConsumer<T> {
+    fn finish(&mut self) {
+        if let Some(done) = self.done.take() {
+            let _ = done.send(());
+        }
+    }
+}
+
+impl<T, D: 'static> StreamConsumer<D> for ChannelConsumer<T>
+where
+    T: Lift + Send + Sync + 'static,
+{
+    type Item = T;
+
+    fn poll_consume(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        mut store: StoreContextMut<D>,
+        mut source: Source<'_, Self::Item>,
+        _finish: bool,
+    ) -> Poll<wasmtime::Result<StreamResult>> {
+        let this = self.get_mut();
+        match this.tx.poll_ready(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(_)) => {
+                this.finish();
+                return Poll::Ready(Ok(StreamResult::Dropped));
+            }
+            Poll::Pending => return Poll::Pending,
+        }
+        let available = source.remaining(&mut store);
+        if available == 0 {
+            return Poll::Ready(Ok(StreamResult::Completed));
+        }
+        let mut buf: Vec<T> = Vec::with_capacity(available);
+        source.read(&mut store, &mut buf)?;
+        if buf.is_empty() {
+            return Poll::Ready(Ok(StreamResult::Completed));
+        }
+        // `poll_ready` reserved a slot above, so this only fails if the receiver
+        // disconnected in between; report the drop instead of losing the chunk
+        // silently.
+        if this.tx.start_send(buf).is_err() {
+            this.finish();
+            return Poll::Ready(Ok(StreamResult::Dropped));
+        }
+        Poll::Ready(Ok(StreamResult::Completed))
+    }
+}
+
+impl<T> Drop for ChannelConsumer<T> {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+/// A pump's completion signal: resolves once the source stream has fully drained
+/// into the channel.
+pub type Done = futures::channel::oneshot::Receiver<()>;
+
+/// Create a connected consumer/producer pair over a bounded channel, plus a
+/// [`Done`] that fires when the source drains.
+pub fn channel<T>(capacity: usize) -> (ChannelConsumer<T>, ChannelProducer<T>, Done) {
+    let (tx, rx) = futures::channel::mpsc::channel(capacity);
+    let (done_tx, done_rx) = futures::channel::oneshot::channel();
+    (
+        ChannelConsumer {
+            tx,
+            done: Some(done_tx),
+        },
+        ChannelProducer { rx },
+        done_rx,
+    )
+}
+
+/// Source side of a `future<T>` pump: forwards the source future's single value
+/// over a oneshot, then fires `done`. The destination future is built from the
+/// paired receiver (an `async move { rx.await }` is a [`wasmtime::component::FutureProducer`]
+/// via the blanket impl), so no producer struct is needed.
+pub struct FutureSink<T> {
+    tx: Option<futures::channel::oneshot::Sender<T>>,
+    done: Option<futures::channel::oneshot::Sender<()>>,
+}
+
+impl<T> FutureSink<T> {
+    fn finish(&mut self) {
+        if let Some(done) = self.done.take() {
+            let _ = done.send(());
+        }
+    }
+}
+
+impl<T, D: 'static> FutureConsumer<D> for FutureSink<T>
+where
+    T: Lift + Send + Sync + 'static,
+{
+    type Item = T;
+
+    fn poll_consume(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        mut store: StoreContextMut<D>,
+        mut source: Source<'_, Self::Item>,
+        finish: bool,
+    ) -> Poll<wasmtime::Result<()>> {
+        let this = self.get_mut();
+        if source.remaining(&mut store) == 0 {
+            // `finish` means the read was cancelled before a value arrived.
+            if finish {
+                this.finish();
+                return Poll::Ready(Ok(()));
+            }
+            // A future write always presents its single value when the consumer
+            // is polled (`remaining() >= 1`), so this branch is unreachable.
+            // Returning a bare `Poll::Pending` here would register no waker and
+            // hang the guest's write; fail loudly instead if that ever changes.
+            this.finish();
+            return Poll::Ready(Err(wasmtime::format_err!(
+                "future bridge: consumer polled with no value available"
+            )));
+        }
+        let mut buf: Vec<T> = Vec::with_capacity(1);
+        source.read(&mut store, &mut buf)?;
+        if let Some(v) = buf.into_iter().next()
+            && let Some(tx) = this.tx.take()
+        {
+            let _ = tx.send(v);
+        }
+        this.finish();
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<T> Drop for FutureSink<T> {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+/// Create a [`FutureSink`] (source side) paired with the receiver the
+/// destination future awaits, plus a [`Done`] that fires once the value has been
+/// forwarded (or the sink is dropped).
+pub fn future_channel<T>() -> (FutureSink<T>, futures::channel::oneshot::Receiver<T>, Done) {
+    let (tx, rx) = futures::channel::oneshot::channel();
+    let (done_tx, done_rx) = futures::channel::oneshot::channel();
+    (
+        FutureSink {
+            tx: Some(tx),
+            done: Some(done_tx),
+        },
+        rx,
+        done_rx,
+    )
+}

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -23,9 +23,9 @@ use crate::{
     engine::{
         ctx::SharedCtx,
         linked_call::{
-            ComponentCtxTemplate, EphemeralLinkedCall, LinkedExportInvocation,
-            func_is_ephemeral_safe, invoke_linked_async_export, invoke_linked_sync_export,
-            new_store_from_templates,
+            ComponentCtxTemplate, EphemeralCallMode, EphemeralLinkedCall, LinkedExportInvocation,
+            func_is_bridge_safe, func_is_ephemeral_safe, invoke_linked_async_export,
+            invoke_linked_sync_export, new_store_from_templates,
         },
         volumes::{ResolvedVolumeMount, resolve_component_volume_mounts_in_map},
     },
@@ -1092,6 +1092,15 @@ impl ResolvedWorkload {
         let mut linked_components = HashSet::new();
         let ty = component.component_type();
         let imports: Vec<_> = ty.imports(component.engine()).collect();
+        // The cross-store stream bridge engages only for a p3-service workload:
+        // there a long-lived service store must never be pinned/frozen by a
+        // stream-carrying backend call, so such calls run ephemerally (relocated)
+        // instead of on the shared store. In service-less / per-request workloads
+        // stream-carrying calls stay on the shared store.
+        let is_service_workload = self
+            .service
+            .as_ref()
+            .is_some_and(|s| s.metadata.targets_p3());
 
         for (import_name, import_item) in imports.into_iter() {
             match import_item.ty {
@@ -1201,9 +1210,27 @@ impl ResolvedWorkload {
                                     "linking function import"
                                 );
                                 let export_is_async = func_ty.async_();
-                                let ephemeral_call = if export_is_async
-                                    && func_is_ephemeral_safe(&func_ty)
+                                // Plain-value async calls always run ephemerally
+                                // (params copied). In a p3-service workload, a call
+                                // carrying only relocatable `stream<T>` handles also
+                                // runs ephemerally — its args/results are relocated
+                                // (see `relocate`) rather than copied — so a
+                                // stream-carrying backend call can't pin or freeze
+                                // the service store.
+                                let plain_safe = func_is_ephemeral_safe(&func_ty);
+                                let relocate = !plain_safe
+                                    && is_service_workload
+                                    && func_is_bridge_safe(&func_ty);
+                                let ephemeral_call = if export_is_async && (plain_safe || relocate)
                                 {
+                                    let mode = if relocate {
+                                        EphemeralCallMode::Relocated {
+                                            param_tys: func_ty.params().map(|(_, ty)| ty).collect(),
+                                            result_tys: func_ty.results().collect(),
+                                        }
+                                    } else {
+                                        EphemeralCallMode::PlainValue
+                                    };
                                     Some(Arc::new(EphemeralLinkedCall {
                                         engine: plugin_engine.clone(),
                                         http_handler: self.http_handler.clone(),
@@ -1212,6 +1239,7 @@ impl ResolvedWorkload {
                                         linked_component_ids: nested_linked_component_ids.clone(),
                                         #[cfg(feature = "wasi-tls")]
                                         tls_provider: self.tls_provider.clone(),
+                                        mode,
                                     }))
                                 } else {
                                     None

--- a/crates/wash-runtime/src/timeouts.rs
+++ b/crates/wash-runtime/src/timeouts.rs
@@ -53,6 +53,13 @@ macro_rules! declare_timeouts {
 }
 
 declare_timeouts! {
+    /// Max wall-clock for a single ephemeral cross-store linked call.
+    ephemeral_call = ("WASH_EPHEMERAL_CALL_TIMEOUT_SECS", 600);
+    /// Max wall-clock to drain an ephemeral call's result streams before its
+    /// throwaway store is torn down.
+    stream_drain = ("WASH_STREAM_DRAIN_TIMEOUT_SECS", 600);
+    /// Max wall-clock for a single shared-store dynamic linked call.
+    shared_store_call = ("WASH_SHARED_STORE_CALL_TIMEOUT_SECS", 30);
     /// Max wall-clock for a trigger service to produce an HTTP response.
     http_response = ("WASH_HTTP_RESPONSE_TIMEOUT_SECS", 600);
 }

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -110,6 +110,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "bridge-backend"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
+name = "bridge-service"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -41,6 +41,8 @@ members = [
     "postgres-stream-p3",
     "svc-counter",
     "msg-counter",
+    "bridge-backend",
+    "bridge-service",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/bridge-backend/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/bridge-backend/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bridge-backend"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/bridge-backend/src/bindings.rs
+++ b/crates/wash-runtime/tests/fixtures/bridge-backend/src/bindings.rs
@@ -1,0 +1,2 @@
+#![allow(unsafe_code)]
+wit_bindgen::generate!({ world: "backend", generate_all });

--- a/crates/wash-runtime/tests/fixtures/bridge-backend/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/bridge-backend/src/lib.rs
@@ -1,0 +1,110 @@
+//! Stateless backend exporting `wasmcloud:bridge/ops`. A fresh instance handles
+//! each call (instantiated in its own ephemeral store by the host bridge), so
+//! the process-global `BUMPS` counter never survives past a single call —
+//! `bump()` always returns 1.
+
+mod bindings;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use bindings::exports::wasmcloud::bridge::ops::{Chunked, Guest};
+use wit_bindgen::{FutureReader, StreamReader, StreamResult};
+
+static BUMPS: AtomicU64 = AtomicU64::new(0);
+
+struct Component;
+
+impl Guest for Component {
+    async fn add(a: u64, b: u64) -> u64 {
+        a + b
+    }
+
+    async fn bump() -> u64 {
+        BUMPS.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    async fn block(iterations: u64) -> u64 {
+        // Tight CPU spin with no `.await` — monopolizes this instance's store
+        // executor for the duration. `black_box` keeps the loop from being
+        // optimized away.
+        let mut acc: u64 = 0;
+        let mut i: u64 = 0;
+        while i < iterations {
+            acc = std::hint::black_box(acc.wrapping_mul(31).wrapping_add(i));
+            i += 1;
+        }
+        acc
+    }
+
+    async fn consume(mut data: StreamReader<u8>) -> u64 {
+        let mut total: u64 = 0;
+        loop {
+            let (result, chunk) = data.read(Vec::with_capacity(4096)).await;
+            total += chunk.len() as u64;
+            if matches!(result, StreamResult::Dropped) {
+                break;
+            }
+        }
+        total
+    }
+
+    async fn produce(count: u64) -> StreamReader<u8> {
+        let (mut tx, rx) = bindings::wit_stream::new();
+        wit_bindgen::spawn_local(async move {
+            let chunk = vec![b'x'; 256];
+            let mut written: u64 = 0;
+            while written < count {
+                let n = ((count - written) as usize).min(chunk.len());
+                tx.write_all(chunk[..n].to_vec()).await;
+                written += n as u64;
+            }
+            drop(tx);
+        });
+        rx
+    }
+
+    async fn sum(mut data: StreamReader<u32>) -> u64 {
+        let mut total: u64 = 0;
+        loop {
+            let (result, chunk) = data.read(Vec::with_capacity(1024)).await;
+            for v in &chunk {
+                total += *v as u64;
+            }
+            if matches!(result, StreamResult::Dropped) {
+                break;
+            }
+        }
+        total
+    }
+
+    async fn delayed(value: u64) -> FutureReader<u64> {
+        let (tx, rx) = bindings::wit_future::new(|| 0u64);
+        wit_bindgen::spawn_local(async move {
+            let _ = tx.write(value).await;
+        });
+        rx
+    }
+
+    async fn relay(m: Chunked) -> u64 {
+        match m {
+            Chunked::None => 0,
+            Chunked::Data(mut s) => {
+                let mut total: u64 = 0;
+                loop {
+                    let (result, chunk) = s.read(Vec::with_capacity(4096)).await;
+                    total += chunk.len() as u64;
+                    if matches!(result, StreamResult::Dropped) {
+                        break;
+                    }
+                }
+                total
+            }
+        }
+    }
+}
+
+mod export {
+    #![allow(unsafe_code)]
+    use super::{bindings, Component};
+    bindings::export!(Component with_types_in bindings);
+}

--- a/crates/wash-runtime/tests/fixtures/bridge-backend/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/bridge-backend/wit/world.wit
@@ -1,0 +1,7 @@
+package wasmcloud:backend@0.1.0;
+
+/// Stateless backend reached across the host bridge. A fresh instance handles
+/// every call, then is dropped.
+world backend {
+    export wasmcloud:bridge/ops@0.1.0;
+}

--- a/crates/wash-runtime/tests/fixtures/bridge-service/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/bridge-service/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bridge-service"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/bridge-service/src/bindings.rs
+++ b/crates/wash-runtime/tests/fixtures/bridge-service/src/bindings.rs
@@ -1,0 +1,2 @@
+#![allow(unsafe_code)]
+wit_bindgen::generate!({ world: "service", generate_all });

--- a/crates/wash-runtime/tests/fixtures/bridge-service/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/bridge-service/src/lib.rs
@@ -1,0 +1,187 @@
+//! Long-lived p3 service: HTTP ingress + co-driven cli/run. Each request calls
+//! the stateless `wasmcloud:bridge/ops` backend across the host bridge and
+//! returns the result as JSON. Path selects the operation:
+//!
+//! - `/add`     -> `ops.add(40, 2)`            handle-free call (fast path)
+//! - `/bump`    -> `ops.bump()`                always 1 (backend is stateless)
+//! - `/consume` -> `ops.consume(stream<u8>)`   service -> component stream
+//! - `/produce` -> `ops.produce(n)`            component -> service stream
+//! - `/sum`     -> `ops.sum(stream<u32>)`      non-u8 element type
+//! - `/relay`   -> `ops.relay(variant data(stream<u8>))`  nested-in-variant
+//! - `/delayed` -> `ops.delayed(v)`            component -> service `future<u64>`
+//!
+//! Edge shapes: `/consume-empty` (arg stream closed with zero bytes),
+//! `/produce-empty` (zero-byte result stream), `/relay-none` (the variant case
+//! with no payload through a relocatable signature). Unknown paths are 404.
+
+mod bindings;
+
+use bindings::exports::wasi::cli::run::Guest as RunGuest;
+use bindings::exports::wasi::http::handler::Guest as HttpGuest;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::wasmcloud::bridge::ops;
+
+struct Component;
+
+impl HttpGuest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        let path = request
+            .get_path_with_query()
+            .unwrap_or_else(|| "/".to_string());
+
+        let body = if path.starts_with("/add") {
+            let v = ops::add(40, 2).await;
+            format!("{{\"result\":{v},\"expected\":42}}")
+        } else if path.starts_with("/bump") {
+            let v = ops::bump().await;
+            format!("{{\"result\":{v},\"expected\":1}}")
+        } else if path.starts_with("/block") {
+            // Calls a backend that busy-spins (monopolizing its own store). The
+            // await yields the service's HTTP task, so the service stays free to
+            // serve other requests concurrently — unless the backend shared the
+            // service's store, in which case the spin would freeze it.
+            let _acc = ops::block(300_000_000).await;
+            "{\"result\":1,\"expected\":1}".to_string()
+        } else if path.starts_with("/produce-empty") {
+            // Zero-byte result stream: the backend drops its writer without
+            // writing, so the relocated stream must close cleanly with 0 bytes.
+            let mut rx = ops::produce(0).await;
+            let mut total: u64 = 0;
+            loop {
+                let (result, chunk) = rx.read(Vec::with_capacity(64)).await;
+                total += chunk.len() as u64;
+                if matches!(result, wit_bindgen::StreamResult::Dropped) {
+                    break;
+                }
+            }
+            format!("{{\"result\":{total},\"expected\":0}}")
+        } else if path.starts_with("/produce-drop-early") {
+            // Read only the first chunk of a large component-produced stream,
+            // then drop the reader. The backend's writer side must unwind
+            // cleanly (no trap) when its consumer goes away.
+            let full: u64 = 70_000;
+            let mut rx = ops::produce(full).await;
+            let (_result, chunk) = rx.read(Vec::with_capacity(1024)).await;
+            let read = chunk.len() as u64;
+            drop(rx);
+            format!("{{\"result\":{read},\"expected\":{full}}}")
+        } else if path.starts_with("/produce") {
+            let expected: u64 = 70_000;
+            let mut rx = ops::produce(expected).await;
+            let mut total: u64 = 0;
+            loop {
+                let (result, chunk) = rx.read(Vec::with_capacity(4096)).await;
+                total += chunk.len() as u64;
+                if matches!(result, wit_bindgen::StreamResult::Dropped) {
+                    break;
+                }
+            }
+            format!("{{\"result\":{total},\"expected\":{expected}}}")
+        } else if path.starts_with("/sum") {
+            let (mut tx, rx) = bindings::wit_stream::new();
+            wit_bindgen::spawn_local(async move {
+                for i in 0..1000u32 {
+                    tx.write_all(vec![i]).await;
+                }
+                drop(tx);
+            });
+            let v = ops::sum(rx).await;
+            format!("{{\"result\":{v},\"expected\":499500}}")
+        } else if path.starts_with("/delayed") {
+            // The backend returns a `future<u64>`; the bridge relocates it across
+            // the store boundary and the service awaits its resolved value.
+            let expected: u64 = 12345;
+            let reader = ops::delayed(expected).await;
+            let v = reader.await;
+            format!("{{\"result\":{v},\"expected\":{expected}}}")
+        } else if path.starts_with("/relay-none") {
+            // The payload-less variant case through a stream-relocatable
+            // signature: no handle to pump, but the value still crosses the
+            // relocation path structurally.
+            let v = ops::relay(ops::Chunked::None).await;
+            format!("{{\"result\":{v},\"expected\":0}}")
+        } else if path.starts_with("/relay") {
+            let (mut tx, rx) = bindings::wit_stream::new();
+            wit_bindgen::spawn_local(async move {
+                for _ in 0..1000 {
+                    tx.write_all(vec![b'z'; 50]).await;
+                }
+                drop(tx);
+            });
+            let v = ops::relay(ops::Chunked::Data(rx)).await;
+            format!("{{\"result\":{v},\"expected\":50000}}")
+        } else if path.starts_with("/consume-empty") {
+            // Zero-byte argument stream: the writer drops before writing, so the
+            // backend's read must observe a clean immediate close (total 0).
+            let (tx, rx) = bindings::wit_stream::new();
+            drop(tx);
+            let v = ops::consume(rx).await;
+            format!("{{\"result\":{v},\"expected\":0}}")
+        } else if path.starts_with("/consume-large") {
+            // ~4 MiB through the bounded relocation channel (capacity is a
+            // handful of chunks): must complete without buffering the whole
+            // stream — the channel back-pressures the writer.
+            const CHUNK_LEN: usize = 1024;
+            const CHUNKS: u64 = 4096; // 4 MiB
+            let expected = CHUNK_LEN as u64 * CHUNKS;
+            let (mut tx, rx) = bindings::wit_stream::new();
+            wit_bindgen::spawn_local(async move {
+                let chunk = vec![b'q'; CHUNK_LEN];
+                for _ in 0..CHUNKS {
+                    tx.write_all(chunk.clone()).await;
+                }
+                drop(tx);
+            });
+            let v = ops::consume(rx).await;
+            format!("{{\"result\":{v},\"expected\":{expected}}}")
+        } else if path.starts_with("/consume") {
+            const CHUNK: &[u8] = b"hello world from the service........0123456789AB\n"; // 49 bytes
+            const CHUNKS: usize = 1234;
+            let (mut tx, rx) = bindings::wit_stream::new();
+            wit_bindgen::spawn_local(async move {
+                for _ in 0..CHUNKS {
+                    tx.write_all(CHUNK.to_vec()).await;
+                }
+                drop(tx);
+            });
+            let v = ops::consume(rx).await;
+            let expected = (CHUNK.len() * CHUNKS) as u64;
+            format!("{{\"result\":{v},\"expected\":{expected}}}")
+        } else {
+            return Ok(make_response(404, Vec::new()));
+        };
+
+        Ok(make_response(200, body.into_bytes()))
+    }
+}
+
+impl RunGuest for Component {
+    async fn run() -> Result<(), ()> {
+        use bindings::wasi::clocks::monotonic_clock;
+        // Keep the service alive; the co-driver runs this concurrently with HTTP.
+        loop {
+            monotonic_clock::wait_for(1_000_000).await;
+        }
+    }
+}
+
+fn make_response(status: u16, body: Vec<u8>) -> Response {
+    let headers = Fields::new();
+    let _ = headers.set(&"content-type".to_string(), &[b"application/json".to_vec()]);
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    let _ = response.set_status_code(status);
+    response
+}
+
+mod export {
+    #![allow(unsafe_code)]
+    use super::{bindings, Component};
+    bindings::export!(Component with_types_in bindings);
+}

--- a/crates/wash-runtime/tests/fixtures/bridge-service/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/bridge-service/wit/world.wit
@@ -1,0 +1,10 @@
+package wasmcloud:bridgesvc@0.1.0;
+
+/// Long-lived p3 service: HTTP ingress router (http/handler) + co-driven
+/// cli/run, calling the stateless backend across the host bridge.
+world service {
+    import wasi:clocks/monotonic-clock@0.3.0;
+    import wasmcloud:bridge/ops@0.1.0;
+    export wasi:cli/run@0.3.0;
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasmcloud-bridge/ops.wit
+++ b/crates/wash-runtime/tests/fixtures/p3-wit-deps/wasmcloud-bridge/ops.wit
@@ -1,0 +1,47 @@
+package wasmcloud:bridge@0.1.0;
+
+/// Contract linking the bridge-service (importer) to the bridge-backend
+/// (exporter) across the two-store boundary. Covers the relocation cases the
+/// cross-store bridge must handle: handle-free primitives (the fast path),
+/// process-global state (to prove statelessness), and typed streams in both
+/// directions plus a nested-in-variant case.
+interface ops {
+    /// Handle-free async call — exercises `func_new_concurrent` linking and the
+    /// no-handle relocation fast path.
+    add: async func(a: u64, b: u64) -> u64;
+
+    /// Increments a process-global counter and returns the new value. Because a
+    /// fresh ephemeral instance handles every call, this always returns 1 —
+    /// proving backends are stateless while the service is long-lived.
+    bump: async func() -> u64;
+
+    /// Busy-spins for `iterations` without yielding, monopolizing this instance's
+    /// store executor. With the two-store split this runs in the backend's own
+    /// ephemeral store and cannot stall the long-lived service; if the backend
+    /// shared the service's store it would freeze the service's HTTP ingress and
+    /// cli/run. Returns an opaque accumulator (prevents the spin being optimized
+    /// away).
+    block: async func(iterations: u64) -> u64;
+
+    /// `stream<u8>` service -> component.
+    consume: async func(data: stream<u8>) -> u64;
+
+    /// `stream<u8>` component -> service (result direction); the ephemeral store
+    /// must outlive the call until the returned stream drains.
+    produce: async func(count: u64) -> stream<u8>;
+
+    /// `stream<u32>` (non-`u8` element type) -> exercises `stream_factory` dispatch.
+    sum: async func(data: stream<u32>) -> u64;
+
+    /// A `stream<u8>` nested inside a variant payload.
+    variant chunked {
+        none,
+        data(stream<u8>),
+    }
+    relay: async func(m: chunked) -> u64;
+
+    /// `future<u64>` component -> service: the backend returns a future that
+    /// resolves to a value, exercising the one-shot future pump (result
+    /// direction — the ephemeral store must outlive the call until it resolves).
+    delayed: async func(value: u64) -> future<u64>;
+}

--- a/crates/wash-runtime/tests/integration_cross_store_bridge.rs
+++ b/crates/wash-runtime/tests/integration_cross_store_bridge.rs
@@ -1,0 +1,316 @@
+//! Integration tests for the cross-store host bridge: a long-lived p3 service
+//! (HTTP ingress + cli/run) calling a stateless `wasmcloud:bridge/ops` backend
+//! that runs in a separate store, instantiated fresh per call.
+//!
+//! Exercises three cross-store behaviors:
+//!   - async inter-component linking via `func_new_concurrent` — `/add`
+//!   - stateless backends: a fresh instance per call — `/bump`
+//!   - stream relocation across the store boundary (both directions, varied
+//!     element types, nested) — the remaining endpoints
+//!
+//! Each endpoint returns `{"result":N,"expected":M}`; the test asserts the
+//! backend's computed result reached the service through the bridge unchanged.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{collections::HashMap, time::Duration};
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::host::HostApi;
+use wash_runtime::types::{Component, LocalResources, Service, Workload, WorkloadStartRequest};
+
+mod common;
+use common::{http_only_host_interfaces, json_u64_field, start_host_with_p3_http_handler};
+
+const BRIDGE_SERVICE_WASM: &[u8] = include_bytes!("wasm/bridge_service.wasm");
+const BRIDGE_BACKEND_WASM: &[u8] = include_bytes!("wasm/bridge_backend.wasm");
+
+fn bridge_workload(host: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: host.to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(BRIDGE_SERVICE_WASM),
+                local_resources: LocalResources::default(),
+                max_restarts: 0,
+            }),
+            // The backend is a stateless component linked to the service by its
+            // `wasmcloud:bridge/ops` export; the host instantiates it fresh per
+            // call in its own store.
+            components: vec![Component {
+                name: "bridge-backend".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(BRIDGE_BACKEND_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 1000,
+            }],
+            host_interfaces: http_only_host_interfaces(host),
+            volumes: vec![],
+        },
+    }
+}
+
+/// GET `path` and return the parsed `(result, expected)` pair from the JSON body.
+async fn call(
+    client: &reqwest::Client,
+    addr: &std::net::SocketAddr,
+    host: &str,
+    path: &str,
+) -> Result<(u64, u64)> {
+    let resp = timeout(
+        Duration::from_secs(15),
+        client
+            .get(format!("http://{addr}{path}"))
+            .header("HOST", host)
+            .send(),
+    )
+    .await
+    .context("request timed out")??;
+    anyhow::ensure!(
+        resp.status().is_success(),
+        "{path} should succeed, got {}",
+        resp.status()
+    );
+    let body = resp.text().await?;
+    Ok((
+        json_u64_field(&body, "result"),
+        json_u64_field(&body, "expected"),
+    ))
+}
+
+/// #2: a handle-free `async func` import is linked via `func_new_concurrent` and
+/// called across the bridge, returning the backend's computed result.
+#[tokio::test]
+async fn test_bridge_async_call_primitives() -> Result<()> {
+    let host = "bridge-add";
+    let (addr, h) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    h.workload_start(bridge_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    let (result, expected) = call(&client, &addr, host, "/add").await?;
+    assert_eq!(
+        result, expected,
+        "ops.add(40,2) should reach the service as 42"
+    );
+    assert_eq!(result, 42);
+    Ok(())
+}
+
+/// A `future<u64>` returned by the backend is relocated across the store
+/// boundary (result direction) and resolves to the backend's value in the
+/// service store — the ephemeral store is kept alive until the future resolves.
+#[tokio::test]
+async fn test_bridge_future_relocation() -> Result<()> {
+    let host = "bridge-future";
+    let (addr, h) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    h.workload_start(bridge_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    let (result, expected) = call(&client, &addr, host, "/delayed").await?;
+    assert_eq!(
+        result, expected,
+        "backend future<u64> should reach the service"
+    );
+    assert_eq!(result, 12345);
+    Ok(())
+}
+
+/// The service stays responsive after a client cancels a request mid-flight
+/// (drops the connection while a streaming backend call is in progress).
+/// Exercises the service_http disconnect path — the response `oneshot` failing
+/// and the frame-forward loop breaking — without wedging the shared service
+/// instance or leaking it into later requests.
+#[tokio::test]
+async fn test_service_survives_client_cancellation() -> Result<()> {
+    let host = "bridge-cancel";
+    let (addr, h) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    h.workload_start(bridge_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    // Warm up first so the workload is resolved and serving — otherwise the
+    // abort below can land before the request ever reaches the service, and the
+    // disconnect path silently goes unexercised.
+    let (result, _) = call(&client, &addr, host, "/add").await?;
+    assert_eq!(result, 42, "service should be serving before the cancel");
+
+    // Fire a slow streaming request (4 MiB through the bounded bridge channel
+    // takes well past this abort), then abort it mid-flight.
+    let cancelled = tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        client
+            .get(format!("http://{addr}/consume-large"))
+            .header("HOST", host)
+            .send()
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    cancelled.abort();
+    let _ = cancelled.await;
+
+    // The service must still serve subsequent requests.
+    let (result, _) = call(&client, &addr, host, "/add").await?;
+    assert_eq!(
+        result, 42,
+        "service stays responsive after a client cancels a request mid-flight"
+    );
+    Ok(())
+}
+
+/// #3: every call instantiates a fresh backend in its own store, so the
+/// backend's process-global counter never persists — `bump()` is always 1, even
+/// across repeated calls, while the service instance itself stays long-lived.
+#[tokio::test]
+async fn test_bridge_backend_is_stateless() -> Result<()> {
+    let host = "bridge-bump";
+    let (addr, h) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    h.workload_start(bridge_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    for _ in 0..4 {
+        let (result, _) = call(&client, &addr, host, "/bump").await?;
+        assert_eq!(
+            result, 1,
+            "a fresh stateless backend instance handles each call, so bump() is always 1"
+        );
+    }
+    Ok(())
+}
+
+/// #5: stream relocation across the store boundary in every shape — service ->
+/// component (`/consume`), component -> service (`/produce`), a non-`u8` element
+/// type (`/sum`), and a stream nested inside a variant payload (`/relay`).
+#[tokio::test]
+async fn test_bridge_stream_relocation() -> Result<()> {
+    let host = "bridge-stream";
+    let (addr, h) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    h.workload_start(bridge_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    for path in ["/consume", "/produce", "/sum", "/relay"] {
+        let (result, expected) = call(&client, &addr, host, path).await?;
+        assert_eq!(
+            result, expected,
+            "{path}: stream should relocate across the store boundary intact (got {result}, want {expected})"
+        );
+    }
+    Ok(())
+}
+
+/// #5 edge shapes: a zero-byte stream in each direction (writer dropped without
+/// writing) closes cleanly through the relocation pump, and the payload-less
+/// variant case crosses a stream-relocatable signature intact.
+#[tokio::test]
+async fn test_bridge_stream_empty_shapes() -> Result<()> {
+    let host = "bridge-empty";
+    let (addr, h) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    h.workload_start(bridge_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    for path in ["/consume-empty", "/produce-empty", "/relay-none"] {
+        let (result, expected) = call(&client, &addr, host, path).await?;
+        assert_eq!(expected, 0, "{path} is a zero-byte / payload-less shape");
+        assert_eq!(
+            result, expected,
+            "{path}: an empty shape must cross the bridge cleanly (got {result})"
+        );
+    }
+    Ok(())
+}
+
+/// #3: while a backend call busy-spins (monopolizing its own ephemeral store),
+/// the long-lived service keeps serving other HTTP requests. If the backend
+/// shared the service's store, the spin would freeze the service's HTTP ingress
+/// and no concurrent request could complete until the spin finished — this test
+/// would then observe zero requests served during the block.
+///
+/// Needs a multi-threaded runtime: a single worker thread would be consumed by
+/// the spin regardless of the store split, masking the property under test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_bridge_isolation_under_blocking_backend() -> Result<()> {
+    let host = "bridge-block";
+    let (addr, h) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    h.workload_start(bridge_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    // Kick off a long blocking backend call in the background.
+    let block = tokio::spawn({
+        let client = client.clone();
+        let host = host.to_string();
+        async move { call(&client, &addr, &host, "/block").await }
+    });
+
+    // While that call spins in the backend's store, the service must remain
+    // responsive. Count `/add` requests that complete before the block returns.
+    let mut served_during_block = 0u32;
+    while !block.is_finished() && served_during_block < 5 {
+        match call(&client, &addr, host, "/add").await {
+            Ok((42, _)) => served_during_block += 1,
+            Ok((other, _)) => anyhow::bail!("unexpected /add result {other}"),
+            Err(_) => break,
+        }
+    }
+
+    let block_result = timeout(Duration::from_secs(30), block).await???;
+    assert_eq!(block_result.0, 1, "/block should complete cleanly");
+    // Require MORE than one: a frozen service could still let exactly one
+    // queued request complete the instant the block resolves, which `>= 1`
+    // would wrongly accept. Several completing mid-block proves the backend
+    // spin never touched the service's store.
+    assert!(
+        served_during_block >= 2,
+        "the service must serve requests while a backend call blocks its own \
+         store (served {served_during_block}); a shared store would freeze ingress"
+    );
+    Ok(())
+}
+
+/// #5 backpressure: ~4 MiB streamed through the bounded relocation channel (only
+/// a handful of chunks of capacity) must complete with the exact byte count —
+/// proving the stream is pumped incrementally with the channel back-pressuring
+/// the writer, not buffered whole.
+#[tokio::test]
+async fn test_bridge_stream_backpressure_large() -> Result<()> {
+    let host = "bridge-large";
+    let (addr, h) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    h.workload_start(bridge_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    let (result, expected) = call(&client, &addr, host, "/consume-large").await?;
+    assert_eq!(expected, 4 * 1024 * 1024, "fixture streams 4 MiB");
+    assert_eq!(
+        result, expected,
+        "every byte of the large stream must arrive"
+    );
+    Ok(())
+}
+
+/// #5 early close: the service reads only the first chunk of a large
+/// component-produced stream and drops its reader. The backend's writer side
+/// must unwind cleanly — the request completes (no trap) having delivered a
+/// partial, non-empty prefix.
+#[tokio::test]
+async fn test_bridge_reader_drops_early() -> Result<()> {
+    let host = "bridge-drop";
+    let (addr, h) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    h.workload_start(bridge_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    // A 200 with a parseable body already proves no trap on early reader drop.
+    let (read, full) = call(&client, &addr, host, "/produce-drop-early").await?;
+    assert!(
+        read > 0,
+        "should have read a non-empty prefix before dropping"
+    );
+    assert!(
+        read < full,
+        "should have stopped early (read {read} of {full}), not drained the whole stream"
+    );
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -119,15 +119,18 @@ const P3_FIXTURES: &[&str] = &[
     "postgres-stream-p3",
     "svc-counter",
     "msg-counter",
+    "bridge-backend",
+    "bridge-service",
 ];
 
 // Fixtures with local-only WIT worlds (no wasi imports). Copying shared
 // deps into these would pollute their wit resolution with unneeded packages.
 const P2_SKIP_SHARED_WIT: &[&str] = &["cron-service", "cron-component"];
 
-// P3 fixtures that vendor their own `wit/deps` (a custom contract plus the
-// wasi packages they reference). Copying the shared p3-wit-deps over them
-// would pull every wasi package into their `generate_all` surface.
+// No P3 fixture vendors its own `wit/deps`: every dep, including the bespoke
+// test contracts (e.g. `wasmcloud:bridge`), lives once in the shared
+// `p3-wit-deps/` and is staged in at build time. Kept as a (currently empty)
+// list for symmetry with `P2_SKIP_SHARED_WIT`.
 const P3_SKIP_SHARED_WIT: &[&str] = &[];
 
 fn build_fixtures(workspace: &Path) -> Result<()> {


### PR DESCRIPTION
Extends the ephemeral linked-call path so a call whose signature carries p3 stream<T>/future<T> handles (nested anywhere in aggregates) can still run in a throwaway store instead of being pinned to the caller's shared store: each argument is extracted in the caller store into a store-agnostic Relocated tree and injected into the callee store, and results come back the same way. Handle-free values/subtrees are copied wholesale; each stream/future becomes a
live, no-buffering pump (a bounded channel that back-pressures the source), so a body streams incrementally rather than buffering at the boundary. `resource` and `error-context` handles are not relocatable between ephemeral stores; a signature carrying either stays on the shared-store path.

Classification happens at link time (func_is_bridge_safe) and only for a p3-service workload, where it matters: a long-lived service store must never be pinned or frozen by a stream-carrying backend call. The ephemeral store driving a relocated call is detached once results are in hand so it can keep feeding result streams while the caller drains them (bounded by a drain timeout), and it self-terminates if the caller drops its readers. Call timeouts move to the env-tunable timeouts module and error messages report the actual configured duration.

The bridge-backend/bridge-service fixtures and integration suite cover: handle-free calls, backend statelessness, streams in both directions, a non-u8 element type, a stream nested in a variant, futures, empty streams both directions and the payload-less variant case, ~4 MiB through the bounded channel (backpressure), early reader drop, client cancellation mid-call, and service responsiveness while a backend busy-spins in its own store.

Third PR in a series of stacked PRs for the work towards Host Component Plugins.