### PR TITLE
feat(wash-runtime): route inbound messages to long-lived trigger services

### DIFF
--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1350,6 +1350,15 @@ impl ResolvedWorkload {
         &self.id
     }
 
+    /// The host-side handler this workload's ingress registers with (the HTTP
+    /// server / trigger-service messaging registry). Lets a host plugin (e.g.
+    /// the messaging subscriber) deliver an inbound message to a long-lived
+    /// trigger-service instance instead of instantiating a component per
+    /// message.
+    pub fn http_handler(&self) -> &Arc<dyn crate::host::http::HostHandler> {
+        &self.http_handler
+    }
+
     /// Gets the name of the workload
     pub fn name(&self) -> &str {
         &self.name

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -28,7 +28,7 @@ use std::{collections::HashMap, path::Path};
 
 use crate::engine::workload::WorkloadItem;
 use crate::{
-    engine::workload::{ResolvedWorkload, UnresolvedWorkload, WorkloadComponent},
+    engine::workload::{ResolvedWorkload, UnresolvedWorkload, WorkloadMetadata},
     wit::WitWorld,
 };
 
@@ -339,9 +339,12 @@ impl<T, Y> WorkloadTracker<T, Y> {
         }
     }
 
-    pub fn add_component(&mut self, workload_component: &WorkloadComponent, data: Y) {
-        let component_id = workload_component.id();
-        let workload_id = workload_component.workload_id();
+    /// Track an item (a component or a long-lived service) by its metadata. Both
+    /// `WorkloadComponent` and `WorkloadService` deref to `WorkloadMetadata`, so
+    /// existing `&WorkloadComponent` callers coerce unchanged.
+    pub fn add_component(&mut self, metadata: &WorkloadMetadata, data: Y) {
+        let component_id = metadata.id();
+        let workload_id = metadata.workload_id();
         let item = self
             .workloads
             .entry(workload_id.to_string())

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -9,7 +9,7 @@ use crate::wit::{WitInterface, WitWorld};
 use anyhow::Context;
 use opentelemetry::KeyValue;
 use tokio::sync::{Notify, RwLock, oneshot};
-use tracing::{Instrument, debug, instrument, warn};
+use tracing::{Instrument, debug, instrument, trace, warn};
 
 const PLUGIN_MESSAGING_MEMORY_ID: &str = "wasmcloud-messaging-memory";
 const MAX_QUEUE_SIZE: usize = 10000;
@@ -131,6 +131,28 @@ impl InMemoryMessaging {
             tracker: Arc::new(RwLock::new(WorkloadTracker::default())),
             meters: Default::default(),
         }
+    }
+
+    /// Route a message to a workload's subscribers, exactly as an inbound publish
+    /// would: it is enqueued to every component whose subscriptions match
+    /// `subject`, then processed by that component's receive loop. Lets a host or
+    /// test inject a message without a component-side `consumer.publish`.
+    pub async fn publish(
+        &self,
+        workload_id: &str,
+        subject: &str,
+        body: Vec<u8>,
+    ) -> Result<(), String> {
+        route_to_subscribers(
+            self,
+            workload_id,
+            &types::BrokerMessage {
+                subject: subject.to_string(),
+                reply_to: None,
+                body,
+            },
+        )
+        .await
     }
 }
 
@@ -308,11 +330,10 @@ impl HostPlugin for InMemoryMessaging {
                 .map(String::as_str),
         );
 
-        let WorkloadItem::Component(component_handle) = component_handle else {
-            // Only track components
-            return Ok(());
-        };
-
+        // Track a handler component OR a long-lived handler service:
+        // `WorkloadItem` derefs to the underlying metadata for both, so the
+        // subscriber loop is set up either way (and its receive loop delivers to
+        // the running service when one is registered).
         if super::exports_messaging_handler(&component_handle.world()) {
             debug!(?subscriptions, "Tracking component in in-memory messaging");
             self.tracker.write().await.add_component(
@@ -347,11 +368,20 @@ impl HostPlugin for InMemoryMessaging {
             }
         };
 
-        let instance_pre = workload.instantiate_pre(component_id).await?;
-
-        let pre = bindings::MessagingPre::new(instance_pre)
-            .map_err(anyhow::Error::from)
-            .context("failed to instantiate messaging pre")?;
+        // A long-lived handler service has no per-component instance to
+        // pre-instantiate; its receive loop delivers to the running service
+        // instead. Only components get a `MessagingPre` for per-message work.
+        let pre = match workload.instantiate_pre(component_id).await {
+            Ok(instance_pre) => Some(
+                bindings::MessagingPre::new(instance_pre)
+                    .map_err(anyhow::Error::from)
+                    .context("failed to instantiate messaging pre")?,
+            ),
+            Err(e) => {
+                trace!(component_id, error = %e, "no per-message instance (long-lived service); messages delivered to the service");
+                None
+            }
+        };
 
         let workload = workload.clone();
         let component_id = component_id.to_string();
@@ -380,6 +410,43 @@ impl HostPlugin for InMemoryMessaging {
 
                         debug!(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"), "Processing message");
 
+                        // If this workload runs a long-lived trigger service for
+                        // messaging, deliver to it (preserving its in-memory
+                        // state) rather than instantiating a component per message.
+                        if workload
+                            .http_handler()
+                            .has_trigger_service_messaging(workload.id())
+                            .await
+                        {
+                            let broker = crate::host::trigger_service::BrokerMessage {
+                                subject: msg.subject.clone(),
+                                body: msg.body.clone(),
+                                reply_to: msg.reply_to.clone(),
+                            };
+                            match workload
+                                .http_handler()
+                                .deliver_trigger_service_message(workload.id(), broker)
+                                .await
+                            {
+                                Ok(Ok(())) => debug!(subject = %msg.subject, "trigger service handled message"),
+                                Ok(Err(e)) => {
+                                    warn!(subject = %msg.subject, error = %e, "trigger service message handler returned error")
+                                }
+                                Err(e) => {
+                                    warn!(subject = %msg.subject, error = %e, "failed to deliver message to trigger service")
+                                }
+                            }
+                            continue;
+                        }
+
+                        let Some(pre) = &pre else {
+                            warn!(
+                                subject = %msg.subject,
+                                component_id = %component_id,
+                                "no trigger service registered and no per-message instance; dropping message"
+                            );
+                            continue;
+                        };
                         let mut store = match workload.new_store(&component_id).await {
                             Err(e) => {
                                 warn!("failed to create store for component {component_id}: {e}");

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -10,7 +10,7 @@ use async_nats::Subscriber;
 use futures::stream::StreamExt;
 use opentelemetry::KeyValue;
 use tokio::sync::RwLock;
-use tracing::{Instrument, debug, instrument, warn};
+use tracing::{Instrument, debug, instrument, trace, warn};
 use wasmtime::error::Context as _;
 
 const PLUGIN_MESSAGING_ID: &str = "wasmcloud-messaging";
@@ -195,16 +195,12 @@ impl HostPlugin for NatsMessaging {
             .get("subscriptions")
             .cloned();
 
-        // Only components are tracked as handlers; services just get the
-        // consumer linker wired above.
-        let WorkloadItem::Component(component_handle) = component_handle else {
-            return Ok(());
-        };
-
-        // Track this component as a subscriber when its world exports the
-        // messaging handler, mirroring the in-memory backend. This works
-        // whether or not the workload declares a `wasmcloud:messaging` host
-        // interface entry.
+        // Track a handler component OR a long-lived handler service:
+        // `WorkloadItem` derefs to the underlying metadata for both, so the
+        // subscriber loop is set up either way (and its receive loop delivers to
+        // the running service when one is registered). Works whether or not the
+        // workload declares a `wasmcloud:messaging` host interface entry, and
+        // matches the handler export version-tolerantly.
         if super::exports_messaging_handler(&component_handle.world()) {
             let raw = local_subscriptions.or(interface_subscriptions);
             let raw_subscriptions = super::parse_subscriptions(raw.as_deref());
@@ -253,11 +249,19 @@ impl HostPlugin for NatsMessaging {
             return Ok(());
         }
 
-        let instance_pre = workload.instantiate_pre(component_id).await?;
-        debug!("instantiate_pre succeeded");
-
-        let pre = bindings::MessagingPre::new(instance_pre)
-            .context("failed to instantiate messaging pre")?;
+        // A long-lived handler service has no per-component instance to
+        // pre-instantiate; its receive loop delivers to the running service
+        // instead. Only components get a `MessagingPre` for per-message work.
+        let pre = match workload.instantiate_pre(component_id).await {
+            Ok(instance_pre) => Some(
+                bindings::MessagingPre::new(instance_pre)
+                    .context("failed to instantiate messaging pre")?,
+            ),
+            Err(e) => {
+                trace!(component_id, error = %e, "no per-message instance (long-lived service); messages delivered to the service");
+                None
+            }
+        };
 
         let workload = workload.clone();
         let component_id = component_id.to_string();
@@ -324,6 +328,47 @@ impl HostPlugin for NatsMessaging {
                             }
                         };
 
+                        let subject = msg.subject.to_string();
+                        let reply_to = msg.reply.as_ref().map(|r| r.to_string());
+                        let body: Vec<u8> = msg.payload.into();
+
+                        // If this workload runs a long-lived trigger service for
+                        // messaging, deliver to it (preserving its in-memory
+                        // state) rather than instantiating a component per message.
+                        if workload
+                            .http_handler()
+                            .has_trigger_service_messaging(workload.id())
+                            .await
+                        {
+                            let broker = crate::host::trigger_service::BrokerMessage {
+                                subject: subject.clone(),
+                                body,
+                                reply_to,
+                            };
+                            match workload
+                                .http_handler()
+                                .deliver_trigger_service_message(workload.id(), broker)
+                                .await
+                            {
+                                Ok(Ok(())) => debug!(%subject, "trigger service handled message"),
+                                Ok(Err(e)) => {
+                                    warn!(%subject, error = %e, "trigger service message handler returned error")
+                                }
+                                Err(e) => {
+                                    warn!(%subject, error = %e, "failed to deliver message to trigger service")
+                                }
+                            }
+                            continue;
+                        }
+
+                        let Some(pre) = &pre else {
+                            warn!(
+                                %subject,
+                                component_id = %component_id,
+                                "no trigger service registered and no per-message instance; dropping message"
+                            );
+                            continue;
+                        };
                         let mut store = match workload.new_store(&component_id).await {
                             Err(e) => {
                                 warn!("failed to create store for component {component_id}: {e}");
@@ -338,11 +383,10 @@ impl HostPlugin for NatsMessaging {
                             }
                             Ok(p) => p,
                         };
-                        let reply_to = msg.reply.as_ref().map(|r| r.to_string());
                         let msg = types::BrokerMessage {
-                            subject: msg.subject.to_string(),
+                            subject,
                             reply_to,
-                            body: msg.payload.into(),
+                            body,
                         };
 
                         let span = tracing::span!(

--- a/crates/wash-runtime/tests/integration_trigger_service_messaging.rs
+++ b/crates/wash-runtime/tests/integration_trigger_service_messaging.rs
@@ -18,15 +18,22 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use tokio::time::timeout;
 
-use wash_runtime::host::HostApi;
+use wash_runtime::engine::Engine;
 use wash_runtime::host::http::{DevRouter, HostHandler, HttpServer};
 use wash_runtime::host::trigger_service::BrokerMessage;
+use wash_runtime::host::{HostApi, HostBuilder};
+use wash_runtime::plugin::wasmcloud_messaging::InMemoryMessaging;
+use wash_runtime::plugin::{
+    wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig, wasi_keyvalue::InMemoryKeyValue,
+    wasi_logging::TracingLogger,
+};
 use wash_runtime::types::{
     LocalResources, Service, Workload, WorkloadStartRequest, WorkloadStopRequest,
 };
+use wash_runtime::wit::WitInterface;
 
 mod common;
-use common::start_host_with_p3_handler;
+use common::{http_only_host_interfaces, start_host_with_p3_handler};
 
 const MSG_COUNTER_WASM: &[u8] = include_bytes!("wasm/msg_counter.wasm");
 
@@ -217,6 +224,119 @@ async fn test_trigger_service_restarts_and_resubscribes_on_fault() -> Result<()>
         got,
         Some("1:after".to_string()),
         "after a fault the supervisor re-subscribes on a fresh instance (count reset)"
+    );
+
+    Ok(())
+}
+
+/// The `wasmcloud:messaging/handler` host interface, so the messaging plugin
+/// binds to the service (empty config → the service subscribes to everything).
+fn messaging_handler_interface() -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "messaging".to_string(),
+        interfaces: ["handler".to_string()].into_iter().collect(),
+        version: Some(semver::Version::new(0, 2, 0)),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+fn msg_counter_e2e_request(workload_id: &str, host: &str) -> WorkloadStartRequest {
+    let mut host_interfaces = http_only_host_interfaces(host);
+    host_interfaces.push(messaging_handler_interface());
+    WorkloadStartRequest {
+        workload_id: workload_id.to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: host.to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(MSG_COUNTER_WASM),
+                local_resources: LocalResources::default(),
+                max_restarts: 0,
+            }),
+            components: vec![],
+            host_interfaces,
+            volumes: vec![],
+        },
+    }
+}
+
+/// Read the trigger service's `{"count":N}` over HTTP.
+async fn get_count(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host: &str,
+) -> Result<u64> {
+    let resp = timeout(
+        Duration::from_secs(10),
+        client
+            .get(format!("http://{addr}/count"))
+            .header("HOST", host)
+            .send(),
+    )
+    .await
+    .context("GET /count timed out")??;
+    anyhow::ensure!(resp.status().is_success(), "GET /count: {}", resp.status());
+    let body = resp.text().await?;
+    Ok(common::json_u64_field(&body, "count"))
+}
+
+/// End-to-end: a message published through the in-memory messaging backend is
+/// delivered to the long-lived trigger service (not a fresh per-message
+/// instance), so the count observed over the service's HTTP handler advances.
+#[tokio::test]
+async fn test_trigger_service_messaging_via_in_memory_backend() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let http_server =
+        Arc::new(HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?);
+    let addr = http_server.addr();
+    let messaging = Arc::new(InMemoryMessaging::new());
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(http_server.clone())
+        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
+        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
+        .with_plugin(Arc::new(TracingLogger::default()))?
+        .with_plugin(Arc::new(DynamicConfig::default()))?
+        .with_plugin(messaging.clone())?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    let workload_id = uuid::Uuid::new_v4().to_string();
+    let host_header = "msg-e2e";
+    host.workload_start(msg_counter_e2e_request(&workload_id, host_header))
+        .await
+        .context("failed to start msg-counter trigger service workload")?;
+
+    let client = reqwest::Client::new();
+    assert_eq!(
+        get_count(&client, addr, host_header).await?,
+        0,
+        "no messages handled yet"
+    );
+
+    // Publish through the in-memory backend; it routes to the subscribed trigger
+    // service, whose receive loop delivers to the co-driven instance.
+    messaging
+        .publish(&workload_id, "test.subject", b"hello".to_vec())
+        .await
+        .map_err(|e| anyhow::anyhow!("publish failed: {e}"))?;
+
+    // Delivery + handling is async; poll until the count reflects it.
+    let mut observed = 0;
+    for _ in 0..40 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        observed = get_count(&client, addr, host_header).await?;
+        if observed >= 1 {
+            break;
+        }
+    }
+    assert_eq!(
+        observed, 1,
+        "the published message was handled on the co-driven trigger service instance"
     );
 
     Ok(())


### PR DESCRIPTION
The messaging backends (in-memory and NATS) only tracked handler *components* and gave each message a fresh per-message instance. A long-lived trigger service that exports wasmcloud:messaging/handler@0.2.0 was never subscribed, so published messages never reached it. Track handler services alongside components and deliver to a running service when one is registered, so a message lands on the service's single long-lived instance (preserving its
in-memory state) instead of a throwaway one.

- Generalize WorkloadTracker::add_component to take &WorkloadMetadata; both
  WorkloadComponent and WorkloadService deref to it, so existing
  &WorkloadComponent callers coerce unchanged. Drop the WorkloadItem::Component
  guard in both backends so a handler service is set up as a subscriber too.
- A service has no per-component instance to pre-instantiate, so MessagingPre
  becomes optional: instantiate_pre failure is not fatal for a service (its
  receive loop delivers to the service); only components keep a MessagingPre
  for per-message work. A workload with neither a service nor a pre drops the
  message with a warning instead of panicking.
- In both receive loops, when has_trigger_service_messaging holds, forward the
  broker message via deliver_trigger_service_message (the API added with the
  messaging ingress) and skip per-message instantiation. This restores the
  ResolvedWorkload::http_handler() accessor as its intended consumer.
- Add InMemoryMessaging::publish so a host or test can inject a message through
  the normal subscriber routing without a component-side consumer.publish.

`test_trigger_service_messaging_via_in_memory_backend` publishes through the in-memory backend and reads the count over the service's HTTP handler, proving the message was handled on the co-driven service instance (0 -> 1) rather than a fresh instance per message.