### PR TITLE
fix(runtime): add missing wasi:http/types,handler@0.3.0 to fn wit_world

### DIFF
--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -483,6 +483,7 @@ impl Host {
             "wasi:filesystem/preopens,types@0.2.0".into(),
             "wasi:random/insecure-seed,insecure,random@0.2.0".into(),
             "wasi:sockets/instance-network,ip-name-lookup,network,tcp-create-socket,tcp,udp-create-socket,udp@0.2.0".into(),
+            "wasi:http/types,handler@0.3.0".into(),
             #[cfg(feature = "wasi-tls")]
             "wasi:tls/client,types@0.3.0-draft".into(),
         ]);


### PR DESCRIPTION
## Description

This change does not have an associated issue. It is a straightforward fix to align the hardcoded `exports` list in `wit_world()` with the runtime's existing capabilities.

The `wasi:http/types,handler@0.3.0` interface is already supported by the underlying runtime, but the hardcoded list of exports was missing it. This PR adds it to ensure the host accurately advertises all available WASI HTTP 0.3.0 exports (specifically the `handler` interface) to guest components during capability negotiation.

Previously, the runtime fn log_interfaces logs all available host interfaces to the tracing system, but missing the handler@0.3.0 in the advertised exports, which could affect logging, discovery, or tooling that relies on this metadata. This change fixes.

## Changes

- Added `"wasi:http/types,handler@0.3.0".into()` to the `exports` HashSet in `wit_world()`


---

### Checklist

- [x] I have signed the [DCO](https://developercertificate.org/) using `git commit -s`.
- [x] My changes follow the project's [coding conventions](https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [development process](https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md).
- [x] I have ensured all communication follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).