### PR TITLE
fix(templates,examples): declare allowedHosts for outbound HTTP demos

### DIFF
--- a/examples/grpc-hello-world/README.md
+++ b/examples/grpc-hello-world/README.md
@@ -19,6 +19,8 @@ wash -C component-client dev
 
 Navigate to [http://localhost:8000](http://localhost:8000)
 
+Outbound HTTP from the component to `localhost:50051` is gated by the host runtime and permitted via `workload.allowedHosts` in [`component-client/.wash/config.yaml`](component-client/.wash/config.yaml).
+
 ## Component as gRPC Server
 
 Start the gRPC Server using wash dev:

--- a/examples/grpc-hello-world/component-client/.wash/config.yaml
+++ b/examples/grpc-hello-world/component-client/.wash/config.yaml
@@ -3,3 +3,10 @@ version: 2.0.0
 build:
   command: cargo build -p component-client --target wasm32-wasip2 --release --locked
   component_path: ../target/wasm32-wasip2/release/component_client.wasm
+
+# Outbound HTTP is gated by the host runtime. This component dials the
+# gRPC server on `localhost:50051`; a bare `localhost` entry matches any
+# port.
+workload:
+  allowedHosts:
+    - localhost

--- a/templates/http-client/.wash/config.yaml
+++ b/templates/http-client/.wash/config.yaml
@@ -1,3 +1,9 @@
 build:
   command: cargo build --target wasm32-wasip2 --release
   component_path: target/wasm32-wasip2/release/http_client.wasm
+
+# Outbound HTTP is gated by the host runtime. Hosts listed here are
+# allowed; add new hosts before targeting them.
+workload:
+  allowedHosts:
+    - httpbin.org

--- a/templates/http-client/README.md
+++ b/templates/http-client/README.md
@@ -49,6 +49,8 @@ The component proxies a `GET https://httpbin.org/get` and returns the upstream J
 
 Change the `UPSTREAM_URL` constant in [src/lib.rs](src/lib.rs) to point at any HTTPS endpoint. Outgoing TLS is provided by the host runtime and no additional crates are required in the component.
 
+When you change the upstream, also add its host to `workload.allowedHosts` in [.wash/config.yaml](.wash/config.yaml). Outbound HTTP is gated by the host runtime; hosts listed there are allowed. The default template ships with `httpbin.org` to match the built-in demo target.
+
 ## Build Wasm binary
 
 ```shell


### PR DESCRIPTION
On wash 2.5.x, the `templates/http-client` demo (httpbin.org) and the `examples/grpc-hello-world/component-client` (localhost:50051) both fail with HttpRequestDenied out of the box. Updates to declare their target hosts and add a README note in each.