### PR TITLE
P3 host plugin loader

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -121,6 +121,7 @@ jobs:
           RUST_BACKTRACE: "1"
         run: |
           cargo test -p wash-runtime --features wasi-tls,wasm_component_model_implements,host-component-plugins
+          cargo test -p wash --lib --features host-component-plugins
       # Docker/registry-backed `#[ignore]` integration tests, Linux only: the
       # macOS/Windows hosted runners have no Docker daemon (and macOS can't get
       # one — no nested virtualization). `-- --ignored` runs ONLY the ignored

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -133,6 +133,11 @@ spec:
             {{- range .wasmProposals }}
             - "--wasm-proposal={{ . }}"
             {{- end }}
+            {{- /* Host component plugins: one --host-plugin flag per entry, each
+                   rendered into the CLI's `key=value` grammar. */}}
+            {{- range .hostPlugins }}
+            - "--host-plugin=id={{ .id }}{{ if .image }},image={{ .image }}{{ if .pullPolicy }},pull={{ .pullPolicy }}{{ end }}{{ if .digest }},digest={{ .digest }}{{ end }}{{ else if .file }},file={{ .file }}{{ end }}{{ if .maxRestarts }},max-restarts={{ .maxRestarts }}{{ end }}"
+            {{- end }}
             {{- /* Chart-wide runtime.extraArgs applies to every host group; per-host-group
                    .extraArgs is appended after it. */}}
             {{- with $top.Values.runtime.extraArgs }}

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -355,6 +355,28 @@ runtime:
       # component-model-async, gc, exception-handling, wide-arithmetic,
       # threads, tail-call.
       wasmProposals: []
+      # -- Host component plugins for this host group: WebAssembly components
+      # that provide a host capability, each served from its own supervised
+      # store to every workload that imports its interface. Rendered as
+      # `--host-plugin=...` args.
+      #
+      # Requires a wash image built with the `host-component-plugins` feature
+      # (not enabled in release images yet); a host handed a plugin it cannot
+      # build fails to start.
+      #
+      # Each entry needs an `id` plus exactly one of `image` (OCI reference) or
+      # `file` (path in the container). Optional: `pullPolicy`
+      # (always | ifNotPresent | never, image only), `maxRestarts`, `digest`
+      # (image only).
+      #
+      # Example:
+      #
+      #   hostPlugins:
+      #     - id: acme-kv
+      #       image: ghcr.io/acme/kv-host:1.0.0
+      #       pullPolicy: ifNotPresent
+      #       maxRestarts: 3
+      hostPlugins: []
       http:
         enabled: true
         port: 9191

--- a/crates/wash-runtime/src/oci.rs
+++ b/crates/wash-runtime/src/oci.rs
@@ -331,6 +331,21 @@ pub enum OciPullPolicy {
     Never,
 }
 
+impl std::str::FromStr for OciPullPolicy {
+    type Err = anyhow::Error;
+
+    /// Parse a pull policy name: `always`, `ifNotPresent`, or `never`
+    /// (case- and separator-insensitive).
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_ascii_lowercase().replace(['-', '_'], "").as_str() {
+            "always" => Ok(Self::Always),
+            "ifnotpresent" => Ok(Self::IfNotPresent),
+            "never" => Ok(Self::Never),
+            other => bail!("invalid pull policy {other:?}; expected always|ifNotPresent|never"),
+        }
+    }
+}
+
 /// Pull a WebAssembly component from an OCI registry
 ///
 /// This function pulls a WebAssembly component from an OCI-compliant registry,

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -60,6 +60,8 @@ use crate::host::job_registry::JobRegistry;
 use crate::host::trigger_service::{
     CapabilityCall, CapabilityFunc, CapabilityJob, Ingress, TriggerService,
 };
+use crate::oci::{self, OciConfig};
+use crate::plugin::component_plugin_spec::{ComponentPluginSpec, PluginSource};
 use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 
@@ -201,6 +203,70 @@ impl ComponentHostPlugin {
         self.max_restarts = max_restarts;
         self
     }
+}
+
+/// Resolve a [`ComponentPluginSpec`] into a ready-to-register plugin: fetch its
+/// wasm (OCI pull or local file), verify an optional digest pin, and build the
+/// [`ComponentHostPlugin`]. The caller registers the result with
+/// `HostBuilder::with_plugin` before `Host::start`; this does not start it.
+pub async fn load_component_plugin(
+    spec: &ComponentPluginSpec,
+    engine: &Engine,
+    oci_config: OciConfig,
+) -> anyhow::Result<Arc<ComponentHostPlugin>> {
+    let (bytes, digest) = match &spec.source {
+        PluginSource::Oci { image, pull_policy } => {
+            oci::pull_component(image, oci_config, pull_policy.clone())
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to pull host component plugin '{}' from {image}",
+                        spec.id
+                    )
+                })?
+        }
+        PluginSource::File(path) => {
+            anyhow::ensure!(
+                spec.expected_digest.is_none(),
+                "host component plugin '{}': digest pinning applies only to `image=` sources",
+                spec.id
+            );
+            let bytes = tokio::fs::read(path).await.with_context(|| {
+                format!(
+                    "failed to read host component plugin '{}' from {}",
+                    spec.id,
+                    path.display()
+                )
+            })?;
+            (bytes, String::new())
+        }
+    };
+
+    if let Some(expected) = &spec.expected_digest {
+        anyhow::ensure!(
+            &digest == expected,
+            "host component plugin '{}' digest mismatch: pulled {digest}, expected {expected}",
+            spec.id
+        );
+    }
+
+    let id = intern_plugin_id(&spec.id);
+    let mut plugin = ComponentHostPlugin::new(id, &bytes, engine.clone())
+        .with_context(|| format!("failed to build host component plugin '{}'", spec.id))?;
+    if let Some(max_restarts) = spec.max_restarts {
+        plugin = plugin.with_max_restarts(max_restarts);
+    }
+    Ok(Arc::new(plugin))
+}
+
+/// Intern a config-supplied plugin id as `&'static str`, which is what a
+/// [`HostPlugin`] id must be. Host component plugins load once at host start
+/// from a bounded config and live for the whole process, so leaking these few
+/// ids is acceptable and bounded. If plugins ever load dynamically on a running
+/// host, the id must instead become an owned `Arc<str>` on the plugin so this
+/// does not grow without bound.
+fn intern_plugin_id(id: &str) -> &'static str {
+    Box::leak(id.to_owned().into_boxed_str())
 }
 
 #[async_trait]

--- a/crates/wash-runtime/src/plugin/component_plugin_spec.rs
+++ b/crates/wash-runtime/src/plugin/component_plugin_spec.rs
@@ -1,0 +1,195 @@
+//! Declarative spec for a host component plugin: a host-unique id plus where to
+//! fetch its wasm from.
+//!
+//! A spec is produced from a `wash host --host-plugin` flag string (via
+//! [`FromStr`]) or converted from a `wash dev` config entry, then resolved to a
+//! running plugin by [`super::component_host::load_component_plugin`]. That
+//! loader is gated on the `host-component-plugins` feature; this spec type is
+//! always compiled so the CLI can accept a plugin declaration and fail with a
+//! clear error on a build that lacks the feature, rather than silently dropping
+//! it.
+
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use anyhow::{Context as _, anyhow, bail, ensure};
+
+use crate::oci::OciPullPolicy;
+
+/// Where a host component plugin's wasm bytes come from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluginSource {
+    /// Pulled from an OCI registry by image reference.
+    Oci {
+        image: String,
+        pull_policy: OciPullPolicy,
+    },
+    /// Read from a local file path.
+    File(PathBuf),
+}
+
+/// A host component plugin to load: a host-unique id, a source for its wasm, and
+/// optional supervision/integrity settings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentPluginSpec {
+    /// Host-unique plugin id. Collides loudly with an existing plugin's id at
+    /// registration time (`HostBuilder::with_plugin` dedupes).
+    pub id: String,
+    pub source: PluginSource,
+    /// Supervised driver restarts before the plugin is declared dead. `None`
+    /// uses the loader default.
+    pub max_restarts: Option<u32>,
+    /// Optional OCI digest to pin for supply-chain integrity. Only meaningful
+    /// for [`PluginSource::Oci`]; the loader rejects it on a file source.
+    pub expected_digest: Option<String>,
+}
+
+impl ComponentPluginSpec {
+    /// Build a spec from an id and source with default supervision/integrity
+    /// settings (no restart-cap override, no digest pin).
+    pub fn from_plugin_source(id: impl Into<String>, source: PluginSource) -> Self {
+        Self {
+            id: id.into(),
+            source,
+            max_restarts: None,
+            expected_digest: None,
+        }
+    }
+}
+
+/// Parse a `wash host --host-plugin` value: a comma-separated list of
+/// `key=value` fields. Required: `id`, and exactly one of `image` / `file`.
+/// Optional: `pull` (image only), `max-restarts`, `digest` (image only).
+///
+/// ```text
+/// id=acme-kv,image=ghcr.io/acme/kv-host:1.0.0,pull=ifNotPresent,max-restarts=3
+/// id=acme-kv,file=./build/kv_plugin.wasm
+/// ```
+impl FromStr for ComponentPluginSpec {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut id = None;
+        let mut image = None;
+        let mut file = None;
+        let mut pull = None;
+        let mut max_restarts = None;
+        let mut digest = None;
+
+        for field in s.split(',') {
+            let field = field.trim();
+            if field.is_empty() {
+                continue;
+            }
+            let (key, value) = field
+                .split_once('=')
+                .ok_or_else(|| anyhow!("host plugin field {field:?} is not `key=value`"))?;
+            let value = value.trim().to_string();
+            ensure!(
+                !value.is_empty(),
+                "host plugin field {:?} has an empty value",
+                key.trim()
+            );
+            match key.trim() {
+                "id" => id = Some(value),
+                "image" => image = Some(value),
+                "file" => file = Some(PathBuf::from(value)),
+                "pull" | "pull-policy" => pull = Some(value.parse()?),
+                "max-restarts" => {
+                    max_restarts = Some(value.parse().with_context(|| {
+                        format!("max-restarts must be a non-negative integer, got {value:?}")
+                    })?)
+                }
+                "digest" => digest = Some(value),
+                other => bail!(
+                    "unknown host plugin field {other:?}; expected id|image|file|pull|max-restarts|digest"
+                ),
+            }
+        }
+
+        let id = id.context("host plugin spec is missing required `id=`")?;
+        let source = match (image, file) {
+            (Some(image), None) => PluginSource::Oci {
+                image,
+                pull_policy: pull.unwrap_or(OciPullPolicy::IfNotPresent),
+            },
+            (None, Some(file)) => {
+                ensure!(
+                    pull.is_none(),
+                    "host plugin '{id}': `pull=` applies only to `image=` sources"
+                );
+                PluginSource::File(file)
+            }
+            (Some(_), Some(_)) => {
+                bail!("host plugin '{id}' sets both `image=` and `file=`; use exactly one")
+            }
+            (None, None) => bail!("host plugin '{id}' needs an `image=` or `file=` source"),
+        };
+
+        Ok(Self {
+            id,
+            source,
+            max_restarts,
+            expected_digest: digest,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_oci_spec_with_all_fields() {
+        let spec: ComponentPluginSpec =
+            "id=acme-kv,image=ghcr.io/acme/kv:1.0.0,pull=always,max-restarts=5,digest=sha256:abc"
+                .parse()
+                .unwrap();
+        assert_eq!(spec.id, "acme-kv");
+        assert_eq!(
+            spec.source,
+            PluginSource::Oci {
+                image: "ghcr.io/acme/kv:1.0.0".into(),
+                pull_policy: OciPullPolicy::Always,
+            }
+        );
+        assert_eq!(spec.max_restarts, Some(5));
+        assert_eq!(spec.expected_digest.as_deref(), Some("sha256:abc"));
+    }
+
+    #[test]
+    fn parses_file_spec_and_defaults_pull_policy_for_oci() {
+        let file: ComponentPluginSpec = "id=kv,file=./kv.wasm".parse().unwrap();
+        assert_eq!(file.source, PluginSource::File("./kv.wasm".into()));
+
+        let oci: ComponentPluginSpec = "id=kv,image=ghcr.io/acme/kv:1".parse().unwrap();
+        assert_eq!(
+            oci.source,
+            PluginSource::Oci {
+                image: "ghcr.io/acme/kv:1".into(),
+                pull_policy: OciPullPolicy::IfNotPresent,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_missing_id_both_sources_and_neither_source() {
+        assert!("image=ghcr.io/x:1".parse::<ComponentPluginSpec>().is_err());
+        assert!(
+            "id=x,image=ghcr.io/x:1,file=./x.wasm"
+                .parse::<ComponentPluginSpec>()
+                .is_err()
+        );
+        assert!("id=x".parse::<ComponentPluginSpec>().is_err());
+        assert!(
+            "id=x,file=./x.wasm,pull=always"
+                .parse::<ComponentPluginSpec>()
+                .is_err()
+        );
+        assert!(
+            "id=x,image=ghcr.io/x:1,bogus=1"
+                .parse::<ComponentPluginSpec>()
+                .is_err()
+        );
+    }
+}

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -57,6 +57,13 @@ pub mod wasmcloud_messaging;
 #[cfg(feature = "host-component-plugins")]
 pub mod component_host;
 
+/// Declarative spec for a host component plugin (id + wasm source). Always
+/// compiled so front-ends can accept a plugin declaration and fail clearly when
+/// built without the `host-component-plugins` feature; the loader that consumes
+/// it lives in [`component_host`].
+pub mod component_plugin_spec;
+pub use component_plugin_spec::{ComponentPluginSpec, PluginSource};
+
 /// Shared `(implements ..)` multiplexing core
 #[cfg(feature = "wasm_component_model_implements")]
 pub mod multiplex;

--- a/crates/wash-runtime/tests/integration_host_plugin_loader.rs
+++ b/crates/wash-runtime/tests/integration_host_plugin_loader.rs
@@ -1,0 +1,127 @@
+//! Tests for [`wash_runtime::plugin::component_host::load_component_plugin`] —
+//! the production loader that resolves a [`ComponentPluginSpec`] (from a
+//! `wash host --host-plugin` flag or a `wash dev` config entry) to a
+//! ready-to-register plugin. The file source is exercised unconditionally; the
+//! OCI source runs opt-in against a live registry via `HOST_PLUGIN_OCI_REF`.
+#![cfg(feature = "host-component-plugins")]
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use wash_runtime::engine::Engine;
+use wash_runtime::oci::{OciConfig, OciPullPolicy};
+use wash_runtime::plugin::component_host::load_component_plugin;
+use wash_runtime::plugin::{ComponentPluginSpec, HostPlugin as _, PluginSource};
+
+fn kv_plugin_path() -> PathBuf {
+    PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/wasm/kv_plugin.wasm"
+    ))
+}
+
+#[tokio::test]
+async fn loads_component_plugin_from_file() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let spec = ComponentPluginSpec::from_plugin_source(
+        "acme-kv-plugin",
+        PluginSource::File(kv_plugin_path()),
+    );
+
+    let plugin = load_component_plugin(&spec, &engine, OciConfig::default()).await?;
+
+    assert_eq!(plugin.id(), "acme-kv-plugin");
+    let world = plugin.world();
+    assert!(
+        world
+            .imports
+            .iter()
+            .any(|i| i.namespace == "acme" && i.package == "kv"),
+        "expected the plugin's derived world to advertise acme:kv, got {world:?}"
+    );
+    Ok(())
+}
+
+/// Opt-in OCI-source loading against a live registry. Set `HOST_PLUGIN_OCI_REF`
+/// to a pushed plugin (skips when unset, so CI is unaffected). To run locally:
+///
+/// ```text
+/// docker run -d -p 5001:5000 registry:2
+/// wash oci push --insecure localhost:5001/kv-plugin:test \
+///     crates/wash-runtime/tests/wasm/kv_plugin.wasm
+/// HOST_PLUGIN_OCI_REF=localhost:5001/kv-plugin:test \
+///     cargo test -p wash-runtime --features host-component-plugins \
+///     --test integration_host_plugin_loader loads_component_plugin_from_oci
+/// ```
+#[tokio::test]
+async fn loads_component_plugin_from_oci() -> Result<()> {
+    let Ok(reference) = std::env::var("HOST_PLUGIN_OCI_REF") else {
+        eprintln!("HOST_PLUGIN_OCI_REF unset; skipping OCI loader test");
+        return Ok(());
+    };
+
+    let engine = Engine::builder().build()?;
+    let spec = ComponentPluginSpec::from_plugin_source(
+        "acme-kv-plugin",
+        PluginSource::Oci {
+            image: reference.clone(),
+            pull_policy: OciPullPolicy::Always,
+        },
+    );
+    // Local registries speak plain HTTP.
+    let oci_config = OciConfig {
+        insecure: true,
+        ..OciConfig::default()
+    };
+
+    let plugin = load_component_plugin(&spec, &engine, oci_config).await?;
+
+    assert_eq!(plugin.id(), "acme-kv-plugin");
+    assert!(
+        plugin
+            .world()
+            .imports
+            .iter()
+            .any(|i| i.namespace == "acme" && i.package == "kv"),
+        "expected acme:kv in the OCI-pulled plugin's world"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn rejects_digest_pin_on_file_source() {
+    let engine = Engine::builder().build().unwrap();
+    let mut spec = ComponentPluginSpec::from_plugin_source(
+        "acme-kv-plugin",
+        PluginSource::File(kv_plugin_path()),
+    );
+    spec.expected_digest = Some("sha256:deadbeef".into());
+
+    let err = load_component_plugin(&spec, &engine, OciConfig::default())
+        .await
+        .err()
+        .expect("digest pin on a file source should fail to load");
+    assert!(
+        format!("{err:#}").contains("digest pinning"),
+        "expected a digest-pinning error, got: {err:#}"
+    );
+}
+
+#[tokio::test]
+async fn missing_file_errors_with_id_and_context() {
+    let engine = Engine::builder().build().unwrap();
+    let spec = ComponentPluginSpec::from_plugin_source(
+        "ghost",
+        PluginSource::File("/nonexistent/does-not-exist.wasm".into()),
+    );
+
+    let err = load_component_plugin(&spec, &engine, OciConfig::default())
+        .await
+        .err()
+        .expect("a missing file should fail to load");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("ghost") && msg.contains("failed to read"),
+        "expected the error to name the plugin and the read failure, got: {msg}"
+    );
+}

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -75,7 +75,7 @@ impl CliCommand for DevCommand {
         let engine = engine_builder.build()?;
 
         let mut host_builder = Host::builder()
-            .with_engine(engine)
+            .with_engine(engine.clone())
             .with_meters(Meters::new(ctx.enable_meters()));
 
         // Enable wasi config. `copy_environment = true` surfaces each
@@ -137,6 +137,28 @@ impl CliCommand for DevCommand {
             ))?;
             debug!("WASI Blobstore plugin registered with in-memory backend");
         }
+
+        // Host component plugins: WebAssembly components that provide host
+        // capabilities, each in its own supervised store. Fetched (local file or
+        // OCI) and registered before the host starts.
+        #[cfg(feature = "host-component-plugins")]
+        for hp in &dev_config.host_plugins {
+            let spec = hp.to_spec()?;
+            let plugin = wash_runtime::plugin::component_host::load_component_plugin(
+                &spec,
+                &engine,
+                wash_runtime::oci::OciConfig::default(),
+            )
+            .await
+            .with_context(|| format!("failed to load host component plugin '{}'", spec.id))?;
+            host_builder = host_builder.with_plugin(plugin)?;
+            debug!(id = %spec.id, "host component plugin registered");
+        }
+        #[cfg(not(feature = "host-component-plugins"))]
+        ensure!(
+            dev_config.host_plugins.is_empty(),
+            "dev.host_plugins requires a wash build with the `host-component-plugins` feature"
+        );
 
         let http_handler = wash_runtime::host::http::DevRouter::default();
         // TODO(#19): Only spawn the server if the component exports wasi:http

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -126,6 +126,74 @@ pub struct HostCommand {
         value_delimiter = ','
     )]
     pub wasm_proposals: Vec<WasmProposal>,
+
+    /// Load a host component plugin providing a host capability from its own supervised store.
+    ///
+    /// A WebAssembly component served to every workload that imports its
+    /// interface. Repeatable; separate multiple with `;` or repeat the flag.
+    /// Requires a wash build with the `host-component-plugins` feature. Each
+    /// value is comma-separated `key=value` fields — required `id` and exactly
+    /// one of `image`/`file`:
+    ///   id=<name>,image=<oci-ref>[,pull=always|ifNotPresent|never][,max-restarts=N][,digest=sha256:..]
+    ///   id=<name>,file=<path>[,max-restarts=N]
+    #[arg(
+        long = "host-plugin",
+        env = "WASH_HOST_PLUGINS",
+        value_delimiter = ';',
+        value_parser = parse_host_plugin_spec
+    )]
+    pub host_plugins: Vec<wash_runtime::plugin::ComponentPluginSpec>,
+
+    /// Username for authenticating to the registry when pulling host component
+    /// plugins. Pair with `--host-plugin-registry-password`. Read from the
+    /// environment so the credential never appears in a `--host-plugin` arg or
+    /// the pod spec — in Kubernetes, source it from a Secret via `secretKeyRef`
+    /// on the host container. When unset, plugin pulls fall back to the ambient
+    /// docker credential helper (e.g. a mounted imagePullSecret) and then
+    /// anonymous access. Applies to host-component-plugin pulls only; workload
+    /// components authenticate with their own per-workload image pull secret.
+    #[cfg(feature = "host-component-plugins")]
+    #[arg(
+        long = "host-plugin-registry-user",
+        env = "WASH_HOST_PLUGIN_REGISTRY_USER",
+        hide_env_values = true,
+        requires = "host_plugin_registry_password"
+    )]
+    pub host_plugin_registry_user: Option<String>,
+
+    /// Password paired with `--host-plugin-registry-user` /
+    /// `WASH_HOST_PLUGIN_REGISTRY_USER`. Both are required together.
+    #[cfg(feature = "host-component-plugins")]
+    #[arg(
+        long = "host-plugin-registry-password",
+        env = "WASH_HOST_PLUGIN_REGISTRY_PASSWORD",
+        hide_env_values = true,
+        requires = "host_plugin_registry_user"
+    )]
+    pub host_plugin_registry_password: Option<String>,
+}
+
+/// clap value parser for `--host-plugin`: parse one spec, flattening the
+/// `anyhow` error chain into the `String` clap wants.
+fn parse_host_plugin_spec(s: &str) -> Result<wash_runtime::plugin::ComponentPluginSpec, String> {
+    s.parse().map_err(|e: anyhow::Error| format!("{e:#}"))
+}
+
+/// Resolve explicit registry credentials for host-component-plugin pulls from
+/// the CLI/env `(user, password)` pair. The two are required together (clap
+/// `requires`); a lone half — reachable only defensively — is treated as no
+/// credentials, leaving the pull to fall back to the docker credential helper
+/// and then anonymous.
+#[cfg(feature = "host-component-plugins")]
+fn host_plugin_registry_credentials(
+    user: Option<&str>,
+    password: Option<&str>,
+) -> Option<(String, String)> {
+    match (user, password) {
+        (Some(user), Some(password)) => Some((user.to_string(), password.to_string())),
+        (None, None) => None,
+        (Some(_), None) | (None, Some(_)) => None,
+    }
 }
 
 impl CliCommand for HostCommand {
@@ -176,7 +244,7 @@ impl CliCommand for HostCommand {
         let engine = engine_builder.build()?;
 
         let mut cluster_host_builder = wash_runtime::washlet::ClusterHostBuilder::default()
-            .with_engine(engine)
+            .with_engine(engine.clone())
             .with_host_config(host_config)
             .with_nats_client(Arc::new(scheduler_nats_client))
             .with_host_group(self.host_group.clone())
@@ -290,6 +358,44 @@ impl CliCommand for HostCommand {
                 .with_plugin(Arc::new(plugin::wasi_webgpu::WebGpu::default()))?;
         }
 
+        // Host component plugins: fetch each declared plugin's wasm and register
+        // it before the host starts. Host-operator controlled only — nothing in a
+        // workload request can register a host-global capability provider.
+        #[cfg(feature = "host-component-plugins")]
+        {
+            // Explicit registry credentials for plugin pulls, taken from the
+            // environment so the secret never appears in a --host-plugin arg or
+            // the pod spec. When unset, resolution falls back to the ambient
+            // docker credential helper (e.g. a mounted imagePullSecret) and then
+            // anonymous access.
+            let plugin_oci_config = wash_runtime::oci::OciConfig {
+                credentials: host_plugin_registry_credentials(
+                    self.host_plugin_registry_user.as_deref(),
+                    self.host_plugin_registry_password.as_deref(),
+                ),
+                insecure: self.allow_insecure_registries,
+                cache_dir: self.oci_cache_dir.clone(),
+                timeout: Some(self.registry_pull_timeout),
+            };
+            for spec in &self.host_plugins {
+                let plugin = wash_runtime::plugin::component_host::load_component_plugin(
+                    spec,
+                    &engine,
+                    plugin_oci_config.clone(),
+                )
+                .await
+                .with_context(|| format!("failed to load host component plugin '{}'", spec.id))?;
+                cluster_host_builder = cluster_host_builder.with_plugin(plugin)?;
+                info!(id = %spec.id, "loaded host component plugin");
+            }
+        }
+        #[cfg(not(feature = "host-component-plugins"))]
+        anyhow::ensure!(
+            self.host_plugins.is_empty(),
+            "--host-plugin/WASH_HOST_PLUGINS requires a wash build with the \
+             `host-component-plugins` feature"
+        );
+
         let cluster_host = cluster_host_builder
             .build()
             .context("failed to build cluster host")?;
@@ -309,5 +415,31 @@ impl CliCommand for HostCommand {
             "Host exited successfully".to_string(),
             None,
         ))
+    }
+}
+
+#[cfg(all(test, feature = "host-component-plugins"))]
+mod tests {
+    use super::host_plugin_registry_credentials;
+
+    #[test]
+    fn both_halves_yield_credentials() {
+        assert_eq!(
+            host_plugin_registry_credentials(Some("user"), Some("pass")),
+            Some(("user".to_string(), "pass".to_string())),
+        );
+    }
+
+    #[test]
+    fn neither_half_yields_no_credentials() {
+        assert_eq!(host_plugin_registry_credentials(None, None), None);
+    }
+
+    #[test]
+    fn a_half_pair_is_ignored_not_half_applied() {
+        // Only a username, or only a password, must resolve to no explicit
+        // credentials — never a basic auth with an empty half.
+        assert_eq!(host_plugin_registry_credentials(Some("user"), None), None);
+        assert_eq!(host_plugin_registry_credentials(None, Some("pass")), None);
     }
 }

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -367,6 +367,91 @@ impl DevComponent {
     }
 }
 
+/// A host component plugin to load into the `wash dev` host: a WebAssembly
+/// component that provides a host capability, served to every workload that
+/// imports its interface. Provide exactly one of `file` (local path) or `image`
+/// (OCI reference). Requires a wash build with the `host-component-plugins`
+/// feature.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostPluginConfig {
+    /// Host-unique plugin id.
+    pub id: String,
+    /// Local wasm file path. Mutually exclusive with `image`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<PathBuf>,
+    /// OCI image reference. Mutually exclusive with `file`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    /// Pull policy for `image` sources: `always`, `ifNotPresent`, or `never`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_policy: Option<String>,
+    /// Supervised driver restarts before the plugin is declared dead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_restarts: Option<u32>,
+    /// OCI digest to pin (`image` sources only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_digest: Option<String>,
+}
+
+impl HostPluginConfig {
+    /// Convert to a runtime [`wash_runtime::plugin::ComponentPluginSpec`],
+    /// validating that exactly one source is set and that `pullPolicy`/
+    /// `expectedDigest` are used only with an `image` source.
+    pub fn to_spec(&self) -> Result<wash_runtime::plugin::ComponentPluginSpec> {
+        use wash_runtime::plugin::{ComponentPluginSpec, PluginSource};
+
+        if self.id.is_empty() {
+            bail!("dev.host_plugins entry is missing a non-empty `id`");
+        }
+        let source = match (&self.file, &self.image) {
+            (Some(file), None) => {
+                if self.pull_policy.is_some() {
+                    bail!(
+                        "dev.host_plugins '{}': pullPolicy applies only to image sources",
+                        self.id
+                    );
+                }
+                if self.expected_digest.is_some() {
+                    bail!(
+                        "dev.host_plugins '{}': expectedDigest applies only to image sources",
+                        self.id
+                    );
+                }
+                PluginSource::File(file.clone())
+            }
+            (None, Some(image)) => {
+                let pull_policy = match &self.pull_policy {
+                    Some(p) => p
+                        .parse::<wash_runtime::oci::OciPullPolicy>()
+                        .with_context(|| format!("dev.host_plugins '{}'", self.id))?,
+                    None => wash_runtime::oci::OciPullPolicy::IfNotPresent,
+                };
+                PluginSource::Oci {
+                    image: image.clone(),
+                    pull_policy,
+                }
+            }
+            (Some(_), Some(_)) => {
+                bail!(
+                    "dev.host_plugins '{}' sets both `file` and `image`; use exactly one",
+                    self.id
+                )
+            }
+            (None, None) => bail!(
+                "dev.host_plugins '{}' needs a `file` or `image` source",
+                self.id
+            ),
+        };
+        Ok(ComponentPluginSpec {
+            id: self.id.clone(),
+            source,
+            max_restarts: self.max_restarts,
+            expected_digest: self.expected_digest.clone(),
+        })
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DevConfig {
     /// Command to run the component in dev mode
@@ -394,6 +479,12 @@ pub struct DevConfig {
     /// Additional components to load alongside the main component
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub components: Vec<DevComponent>,
+
+    /// Host component plugins to load into the dev host: WebAssembly components
+    /// that provide host capabilities. Requires a wash build with the
+    /// `host-component-plugins` feature.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub host_plugins: Vec<HostPluginConfig>,
 
     /// Volumes to mount into the dev environment
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1165,6 +1256,72 @@ dev:
         assert!(component.environment.is_none());
         assert!(component.config.is_empty());
         assert!(component.allowed_hosts.is_none());
+    }
+
+    #[test]
+    fn dev_host_plugins_parse_from_yaml_and_convert_to_spec() {
+        use wash_runtime::plugin::PluginSource;
+        // The `dev.host_plugins` key follows DevConfig's snake_case; each entry's
+        // fields follow the camelCase used by other nested dev structs.
+        let yaml = r#"
+dev:
+  host_plugins:
+    - id: acme-kv
+      file: ./build/kv_plugin.wasm
+      maxRestarts: 3
+    - id: acme-widgets
+      image: ghcr.io/acme/widgets:1.2.0
+      pullPolicy: ifNotPresent
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let dev = config.dev();
+        assert_eq!(dev.host_plugins.len(), 2);
+
+        let kv = dev.host_plugins[0].to_spec().unwrap();
+        assert_eq!(kv.id, "acme-kv");
+        assert_eq!(
+            kv.source,
+            PluginSource::File("./build/kv_plugin.wasm".into())
+        );
+        assert_eq!(kv.max_restarts, Some(3));
+
+        let widgets = dev.host_plugins[1].to_spec().unwrap();
+        assert!(matches!(widgets.source, PluginSource::Oci { .. }));
+    }
+
+    #[test]
+    fn host_plugin_config_validation_rejects_ambiguous_specs() {
+        // Both sources set.
+        let both = HostPluginConfig {
+            id: "x".into(),
+            file: Some("a.wasm".into()),
+            image: Some("ghcr.io/x:1".into()),
+            ..Default::default()
+        };
+        assert!(both.to_spec().is_err());
+
+        // No source.
+        let neither = HostPluginConfig {
+            id: "x".into(),
+            ..Default::default()
+        };
+        assert!(neither.to_spec().is_err());
+
+        // pullPolicy with a file source.
+        let pull_on_file = HostPluginConfig {
+            id: "x".into(),
+            file: Some("a.wasm".into()),
+            pull_policy: Some("always".into()),
+            ..Default::default()
+        };
+        assert!(pull_on_file.to_spec().is_err());
+
+        // Empty id.
+        let empty_id = HostPluginConfig {
+            file: Some("a.wasm".into()),
+            ..Default::default()
+        };
+        assert!(empty_id.to_spec().is_err());
     }
 
     #[test]

--- a/runtime-gateway/reconciler.go
+++ b/runtime-gateway/reconciler.go
@@ -92,10 +92,21 @@ func (a *WorkloadReconciler) deregisterWorkload(ctx context.Context, workload *r
 
 func workloadHostname(workload *runtimev1alpha1.Workload) string {
 	for _, iface := range workload.Spec.HostInterfaces {
-		if iface.Namespace == "wasi" && iface.Package == "http" && slices.Contains(iface.Interfaces, "incoming-handler") {
-			if h, ok := iface.Config["host"]; ok {
-				return h
-			}
+		if iface.Namespace != "wasi" || iface.Package != "http" {
+			continue
+		}
+		// A component's HTTP entrypoint is advertised as either the p2
+		// `incoming-handler` or the p3 `handler` interface; the host serves both
+		// (wash-runtime's is_incoming_http_handler accepts either), so the gateway
+		// must register a route for either. Without the p3 case, a workload that
+		// exports only wasi:http/handler@0.3.0 reaches Ready but has no gateway
+		// route and every request to it 503s.
+		if !slices.Contains(iface.Interfaces, "incoming-handler") &&
+			!slices.Contains(iface.Interfaces, "handler") {
+			continue
+		}
+		if h, ok := iface.Config["host"]; ok {
+			return h
 		}
 	}
 	return ""

--- a/runtime-gateway/reconciler_test.go
+++ b/runtime-gateway/reconciler_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
+)
+
+// httpInterface builds a wasi:http host interface advertising the given handler
+// interface, optionally with a routing `host` config.
+func httpInterface(iface, host string) runtimev1alpha1.HostInterface {
+	hi := runtimev1alpha1.HostInterface{
+		Namespace:  "wasi",
+		Package:    "http",
+		Interfaces: []string{iface},
+	}
+	if host != "" {
+		hi.Config = map[string]string{"host": host}
+	}
+	return hi
+}
+
+func TestWorkloadHostname(t *testing.T) {
+	tests := []struct {
+		name   string
+		ifaces []runtimev1alpha1.HostInterface
+		want   string
+	}{
+		{
+			// p2 handler entrypoint.
+			name:   "incoming-handler is routed",
+			ifaces: []runtimev1alpha1.HostInterface{httpInterface("incoming-handler", "a.localhost.direct")},
+			want:   "a.localhost.direct",
+		},
+		{
+			// p3 handler entrypoint — the case the gateway previously dropped, so
+			// a p3 handler workload reached Ready but every request to it 503'd.
+			name:   "handler is routed",
+			ifaces: []runtimev1alpha1.HostInterface{httpInterface("handler", "b.localhost.direct")},
+			want:   "b.localhost.direct",
+		},
+		{
+			name:   "handler without a host config yields no route",
+			ifaces: []runtimev1alpha1.HostInterface{httpInterface("handler", "")},
+			want:   "",
+		},
+		{
+			name: "non-http interface is ignored",
+			ifaces: []runtimev1alpha1.HostInterface{{
+				Namespace:   "acme",
+				Package:     "kv",
+				Interfaces:  []string{"store"},
+				ConfigLayer: runtimev1alpha1.ConfigLayer{Config: map[string]string{"host": "ignored"}},
+			}},
+			want: "",
+		},
+		{
+			name:   "no interfaces yields no route",
+			ifaces: nil,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &runtimev1alpha1.Workload{}
+			w.Spec.HostInterfaces = tt.ifaces
+			if got := workloadHostname(w); got != tt.want {
+				t.Errorf("workloadHostname() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -63,6 +63,15 @@ var (
 	runtimeImageRepo  = "localhost/wasmcloud-wash"
 	buildRuntimeImage = os.Getenv("BUILD_RUNTIME_IMAGE") == envBoolTrue
 	skipRuntimeBuild  = os.Getenv("SKIP_RUNTIME_BUILD") == envBoolTrue
+	// gatewayImageRepo / gatewayImageTag identify the locally-built
+	// runtime-gateway image. When buildRuntimeImage is set, the e2e builds the
+	// gateway from the local tree — so branch changes to it (e.g. routing a p3
+	// wasi:http/handler workload) are actually exercised — instead of pulling the
+	// published canary. SKIP_GATEWAY_BUILD=true reuses a previously-built local
+	// image for fast iteration on non-gateway test code.
+	gatewayImageRepo = "localhost/runtime-gateway"
+	gatewayImageTag  = "e2e"
+	skipGatewayBuild = os.Getenv("SKIP_GATEWAY_BUILD") == envBoolTrue
 	// defaultHostImageTag is the wash-runtime image tag the default (fixture)
 	// hostgroup runs. The wash.yml legs set E2E_RUNTIME_IMAGE_TAG to the release
 	// or all-features build; unset (local) uses the locally-built operatorImageTag.
@@ -146,13 +155,16 @@ var _ = BeforeSuite(func() {
 	if buildRuntimeImage {
 		if !skipRuntimeBuild {
 			By("building the wash-runtime image from the local tree")
-			// Repo root sits one level above runtime-operator/. Build wash with
-			// `(implements ..)` multiplexing enabled. A local run builds a single
-			// feature image tagged defaultHostImageTag, which both the default and
-			// registry hostgroups use.
+			// Repo root sits one level above runtime-operator/. Build the
+			// all-features host — `(implements ..)` multiplexing and host
+			// component plugins — so the implements and host-plugin specs can run
+			// locally (both features are off in release builds). Matches the
+			// all-features wash-image build in wash.yml. A local run builds a
+			// single feature image tagged defaultHostImageTag, which both the
+			// default and registry hostgroups use.
 			ref := fmt.Sprintf("%s:%s", runtimeImageRepo, defaultHostImageTag)
 			cmd := exec.Command("docker", "build",
-				"--build-arg", "CARGO_FEATURES=wasm_component_model_implements",
+				"--build-arg", "CARGO_FEATURES=wasm_component_model_implements,host-component-plugins",
 				"-t", ref, "..")
 			_, err := utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the wash-runtime image")
@@ -167,6 +179,22 @@ var _ = BeforeSuite(func() {
 			err := utils.LoadImageToKindClusterWithName(fmt.Sprintf("%s:%s", runtimeImageRepo, tag))
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the wash-runtime image into Kind")
 		}
+
+		// Build the runtime-gateway from the local tree too, so branch changes to
+		// it are exercised rather than the published canary. buildBaseHelmSets
+		// points gateway.image at this when buildRuntimeImage is set.
+		gatewayRef := fmt.Sprintf("%s:%s", gatewayImageRepo, gatewayImageTag)
+		if !skipGatewayBuild {
+			By("building the runtime-gateway image from the local tree")
+			// runtime-gateway/ sits one level above runtime-operator/; its
+			// Dockerfile resolves the operator API module from its own go.mod.
+			cmd := exec.Command("docker", "build", "-t", gatewayRef, "../runtime-gateway")
+			_, err := utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the runtime-gateway image")
+		}
+		By("loading the runtime-gateway image into Kind")
+		err = utils.LoadImageToKindClusterWithName(gatewayRef)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the runtime-gateway image into Kind")
 	}
 
 	By("installing the runtime-operator via Helm")
@@ -276,7 +304,6 @@ func buildBaseHelmSets() []string {
 		fmt.Sprintf("operator.image.repository=%s", operatorImageRepo),
 		fmt.Sprintf("operator.image.tag=%s", operatorImageTag),
 		"operator.image.pull_policy=Never",
-		"gateway.image.tag=canary",
 		"gateway.service.type=NodePort",
 		"gateway.service.nodePort=30950",
 		"runtime.hostGroups[0].name=default",
@@ -338,13 +365,18 @@ func buildBaseHelmSets() []string {
 		}
 	}
 	if buildRuntimeImage {
-		// Point at the locally-built image and disable pull so kubelet
-		// uses the kind-loaded copy.
+		// Point at the locally-built images and disable pull so kubelet uses the
+		// kind-loaded copies — for both the host and the gateway (built from the
+		// local tree in BeforeSuite).
 		sets = append(sets,
 			"runtime.image.registry=",
 			fmt.Sprintf("runtime.image.repository=%s", runtimeImageRepo),
 			fmt.Sprintf("runtime.image.tag=%s", defaultHostImageTag),
 			"runtime.image.pull_policy=Never",
+			"gateway.image.registry=",
+			fmt.Sprintf("gateway.image.repository=%s", gatewayImageRepo),
+			fmt.Sprintf("gateway.image.tag=%s", gatewayImageTag),
+			"gateway.image.pull_policy=Never",
 		)
 	} else {
 		// Use IfNotPresent so kubelet prefers a locally-loaded image
@@ -355,6 +387,7 @@ func buildBaseHelmSets() []string {
 		sets = append(sets,
 			fmt.Sprintf("runtime.image.tag=%s", runtimeImageTag),
 			"runtime.image.pull_policy=IfNotPresent",
+			"gateway.image.tag=canary",
 		)
 	}
 	return sets

--- a/runtime-operator/test/e2e/host_plugin_test.go
+++ b/runtime-operator/test/e2e/host_plugin_test.go
@@ -1,0 +1,236 @@
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.wasmcloud.dev/runtime-operator/v2/test/utils"
+)
+
+// End-to-end coverage for host component plugins: a WebAssembly component loaded
+// as a host capability provider (`wash host --host-plugin`, surfaced by the
+// chart as `runtime.hostGroups[].hostPlugins`). It proves the whole path in a
+// real cluster:
+//
+//   - chart: a hostGroup `hostPlugins` entry renders to a `--host-plugin` arg;
+//   - host: `wash host` fetches the plugin image, builds it into its own
+//     supervised store, and registers it before serving workloads;
+//   - bind: a workload that imports the plugin's bespoke `acme:kv/store`
+//     interface resolves against the component plugin (not a Rust plugin), and
+//     the call hops across the store boundary; and
+//   - roundtrip: a value written via `/set` reads back via `/get`, i.e. it
+//     survived in the plugin's persistent store between two separate requests.
+//
+// The store-boundary mechanics (streams/futures/resources, per-caller
+// partitioning, restart-on-trap) are covered in-process by
+// crates/wash-runtime/tests/integration_component_host_plugin.rs; this spec
+// proves the CLI/chart loading path and cross-store binding wire up in a real
+// cluster.
+//
+// The plugin (kv-plugin, exporting acme:kv/store) and its caller
+// (kv-plugin-caller, importing it and exposing it over HTTP) are P3 fixtures
+// built and served from the in-cluster registry (make e2e-images), like every
+// other e2e fixture. Unlike the workload-pull specs, a plugin is loaded at host
+// STARTUP — so it can't be baked into the hostgroup the suite installs before
+// the registry is serving. BeforeAll rolls the default hostgroup with the plugin
+// via `helm upgrade` (the registry is up by then) and AfterAll restores a
+// plugin-free host, keeping the spec independent of ordering.
+//
+// The host-component-plugins feature is not in release builds, so — like the
+// implements spec — this runs only when the registry flow is on AND the fixture
+// host is an all-features build (the all-features leg); it self-skips otherwise.
+// Excluded from `make test`; runs in the dedicated `make test-e2e` job.
+var _ = Describe("Host Component Plugin", Ordered, func() {
+	const (
+		pluginID     = "acme-kv"
+		workloadName = "kv-plugin-caller"
+		// Gateway routes by Host header to the component's HTTP export; matches
+		// the `host` config on the workload's wasi:http interface below.
+		workloadHost = "kv-plugin-caller.localhost.direct"
+	)
+
+	var pluginImage, callerImage string
+
+	BeforeAll(func() {
+		// Host component plugins need the host-component-plugins feature (not in
+		// release builds) AND the in-cluster registry to fetch from — the same
+		// gating as the implements spec. Off elsewhere, so self-skip.
+		if !inClusterRegistry || !defaultHostAllFeatures {
+			Skip("skipping host component plugin e2e (needs the in-cluster " +
+				"registry and an all-features fixture host)")
+		}
+		pluginImage = registryRef("kv-plugin")
+		callerImage = registryRef("kv-plugin-caller")
+
+		// Load the plugin onto the default hostgroup by re-rendering its
+		// Deployment with a `--host-plugin` arg and rolling the pod, so the host
+		// fetches and registers the plugin at startup. AfterAll restores a
+		// plugin-free host so this stays independent of spec ordering.
+		// buildBaseHelmSets already makes the default hostgroup insecure (it
+		// pulls fixtures from the plain-HTTP in-cluster registry), so the same
+		// path fetches the plugin.
+		By("configuring the default hostGroup with a host component plugin")
+		sets := append(buildBaseHelmSets(),
+			"runtime.hostGroups[0].hostPlugins[0].id="+pluginID,
+			fmt.Sprintf("runtime.hostGroups[0].hostPlugins[0].image=%s", pluginImage),
+		)
+		Expect(helmUpgradeWait(sets)).To(Succeed(),
+			"failed to load the host component plugin onto the default hostGroup")
+
+		By("waiting for the hostgroup to roll out with the plugin")
+		cmd := exec.Command("kubectl", "rollout", "status",
+			"-n", namespace, "deployment/hostgroup-default", "--timeout=3m")
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(),
+			"hostgroup did not become ready with the plugin loaded — "+
+				"a host that cannot fetch/build a configured plugin fails to start")
+
+		By("waiting for a Host CR to be registered")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "hosts.runtime.wasmcloud.dev",
+				"-n", namespace, "-o", "jsonpath={.items}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).NotTo(Equal("[]"), "no Host CR registered yet")
+		}).WithTimeout(2 * time.Minute).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		if !CurrentSpecReport().Failed() {
+			return
+		}
+		dump := func(label string, args ...string) {
+			out, err := utils.Run(exec.Command("kubectl", args...))
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== %s ===\n%s\n", label, out)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== %s (FAILED: %s) ===\n", label, err)
+			}
+		}
+		// The hostgroup logs are the most direct evidence of where it broke:
+		// plugin image pull, plugin build (exports no capability), or the
+		// workload's cross-store bind.
+		dump("Pods", "get", "pods", "-n", namespace, "-o", "wide")
+		dump("Events", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
+		dump("Hostgroup logs", "logs", "-n", namespace,
+			"-l", "wasmcloud.com/name=hostgroup", "--tail=600", "--prefix=true")
+		dump("WorkloadDeployment", "get", "workloaddeployment", workloadName,
+			"-n", namespace, "-o", "yaml")
+		dump("Workload CRs", "get", "workloads.runtime.wasmcloud.dev",
+			"-n", namespace, "-o", "yaml")
+	})
+
+	AfterAll(func() {
+		if pluginImage == "" {
+			return
+		}
+		_ = exec.Command("kubectl", "delete", "workloaddeployment", workloadName,
+			"-n", namespace, "--ignore-not-found=true").Run()
+		// Restore a plugin-free host so later specs see a clean default hostgroup
+		// regardless of ordering (dropping the hostPlugins `--set` removes the arg).
+		By("restoring a plugin-free hostGroup")
+		if err := helmUpgradeWait(buildBaseHelmSets()); err != nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: failed to restore hostGroup: %s\n", err)
+			return
+		}
+		_, _ = utils.Run(exec.Command("kubectl", "rollout", "status",
+			"-n", namespace, "deployment/hostgroup-default", "--timeout=3m"))
+	})
+
+	It("serves a workload's imported capability from the component plugin", func() {
+		By("deploying a workload that imports acme:kv/store")
+		// The host satisfies the `acme:kv/store` import with the registered
+		// component plugin; the wasi:http interface declares this component's real
+		// P3 `handler@0.3.0` export, which the host serves and the runtime-gateway
+		// now routes by Host header (the gateway was taught to register routes for
+		// p3 `handler`, not just p2 `incoming-handler`).
+		manifest := fmt.Sprintf(`apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replicas: 1
+  template:
+    spec:
+      # Pin to the default hostgroup — the one carrying the plugin, and insecure
+      # so it can pull the caller from the in-cluster (plain-HTTP) registry. The
+      # registry hostgroup stays on HTTPS and has no plugin.
+      hostSelector:
+        hostgroup: default
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          version: "0.3.0"
+          interfaces:
+            - handler
+          config:
+            host: %s
+        - namespace: acme
+          package: kv
+          version: "0.1.0"
+          interfaces:
+            - store
+      components:
+        - name: %s
+          image: %s
+`, workloadName, namespace, workloadHost, workloadName, callerImage)
+
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(manifest)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "failed to apply the caller WorkloadDeployment")
+
+		By("waiting for the WorkloadDeployment to become Ready")
+		// Ready proves the host bound the component's acme:kv import to the
+		// plugin — without a matching provider the workload never instantiates.
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "workloaddeployment", workloadName,
+				"-n", namespace,
+				"-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].status}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("True"))
+		}).WithTimeout(3 * time.Minute).Should(Succeed())
+
+		By("writing a key through the plugin (/set)")
+		Eventually(func(g Gomega) {
+			out, err := utils.Run(exec.Command("curl", "-s", "-o", "/dev/null",
+				"-w", "%{http_code}", "-H", "Host: "+workloadHost,
+				"http://localhost:80/set?key=greeting&value=hello"))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("200"), "/set should route through the plugin")
+		}).WithTimeout(2 * time.Minute).Should(Succeed())
+
+		By("reading it back (/get) — the value survived in the plugin's store")
+		Eventually(func(g Gomega) {
+			out, err := utils.Run(exec.Command("curl", "-s", "-H", "Host: "+workloadHost,
+				"http://localhost:80/get?key=greeting"))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal("hello"),
+				"the value must round-trip through the component plugin's persistent store")
+		}).WithTimeout(1 * time.Minute).Should(Succeed())
+	})
+})
+
+// helmUpgradeWait runs `helm upgrade --install --reset-values` for the
+// operator-e2e release with the given `--set` values and waits for it to
+// converge. --reset-values renders purely from buildBaseHelmSets (plus what's
+// passed), discarding any prior spec's upgrade --sets — so loading and then
+// dropping the `--host-plugin` arg on the default hostGroup is independent of
+// test ordering.
+func helmUpgradeWait(sets []string) error {
+	helmArgs := make([]string, 0, 6+2*len(sets)+3)
+	helmArgs = append(helmArgs, "upgrade", "--install", "--reset-values", "-n", namespace)
+	for _, s := range sets {
+		helmArgs = append(helmArgs, "--set", s)
+	}
+	helmArgs = append(helmArgs, "--wait", "--timeout=5m", "operator-e2e", helmChartPath)
+	_, err := utils.Run(exec.Command("helm", helmArgs...))
+	return err
+}

--- a/xtask/src/e2e_images.rs
+++ b/xtask/src/e2e_images.rs
@@ -33,11 +33,23 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 
+use crate::FixtureKind;
+
 /// The fixture directories (under crates/wash-runtime/tests/fixtures) to build
-/// and push. Each is a wasm32-wasip2 cdylib served at
-/// <registry>/fixtures/<name>:e2e. To add a fixture: drop a wash-buildable dir,
-/// add a row here, and reference `registryRef("<name>")` in a spec.
-const FIXTURES: &[&str] = &["messaging-echo", "keyvalue-implements", "http-handler-p2"];
+/// and push, each paired with its component-model preview — `FixtureKind` drives
+/// the build target triple (and thus where `wash build` leaves the component).
+/// Served at <registry>/fixtures/<name>:e2e. To add a fixture: drop a
+/// wash-buildable dir, add a row here, and reference `registryRef("<name>")` in a
+/// spec.
+const FIXTURES: &[(&str, FixtureKind)] = &[
+    ("messaging-echo", FixtureKind::P2),
+    ("keyvalue-implements", FixtureKind::P2),
+    ("http-handler-p2", FixtureKind::P2),
+    // Host component plugin fixtures (P3 async): kv-plugin serves acme:kv/store
+    // from its own supervised store; kv-plugin-caller imports it over HTTP.
+    ("kv-plugin", FixtureKind::P3),
+    ("kv-plugin-caller", FixtureKind::P3),
+];
 
 /// Fixed so it always matches the pull side (registryImageTag in
 /// e2e_suite_test.go) — the two have no shared source, so this isn't a knob.
@@ -115,12 +127,12 @@ fn build_phase(
         fs::copy(&wash, out.join("wash")).context("staging wash")?;
     }
 
-    for fixture in FIXTURES {
+    for &(fixture, kind) in FIXTURES {
         eprintln!(">>> e2e-images: wash build {fixture}");
         wash_build(&wash, &fixtures_dir.join(fixture))
             .with_context(|| format!("wash build {fixture}"))?;
         if let Some(out) = fixtures_out {
-            let built = built_component(fixtures_dir, fixture)?;
+            let built = built_component(fixtures_dir, fixture, kind)?;
             fs::copy(&built, out.join(component_name(fixture)))
                 .with_context(|| format!("staging {fixture}"))?;
         }
@@ -170,10 +182,10 @@ fn push_phase(
     let _pf = PortForward::start(&kubeconfig, namespace)?;
     wait_for_registry()?;
 
-    for fixture in FIXTURES {
+    for &(fixture, kind) in FIXTURES {
         let component = match (mode, fixtures_out) {
             (Mode::Push, Some(out)) => out.join(component_name(fixture)),
-            _ => built_component(fixtures_dir, fixture)?,
+            _ => built_component(fixtures_dir, fixture, kind)?,
         };
         let reference = format!("{PUSH_ADDR}/fixtures/{fixture}:{TAG}");
         eprintln!(">>> e2e-images: wash oci push {reference}");
@@ -248,15 +260,17 @@ fn wash_build(wash: &Path, fixture_dir: &Path) -> Result<()> {
     )
 }
 
-/// The built component filename: the wasm32-wasip2 cdylib underscore name.
+/// The built component filename: the fixture crate's underscore name.
 fn component_name(fixture: &str) -> String {
     format!("{}.wasm", fixture.replace('-', "_"))
 }
 
-/// The built component path for a fixture (all e2e fixtures are wasm32-wasip2).
-fn built_component(fixtures_dir: &Path, fixture: &str) -> Result<PathBuf> {
+/// The built component path for a fixture. `wash build` leaves the component in
+/// place under the release dir of the kind's target triple — a component
+/// directly for P2, the reactor-wrapped core module for P3.
+fn built_component(fixtures_dir: &Path, fixture: &str, kind: FixtureKind) -> Result<PathBuf> {
     let path = fixtures_dir
-        .join("target/wasm32-wasip2/release")
+        .join(format!("target/{}/release", kind.target()))
         .join(component_name(fixture));
     if !path.exists() {
         bail!("no wasm artifact for {fixture} at {}", path.display());

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -62,13 +62,13 @@ fn workspace_dir() -> Result<PathBuf> {
 /// directly, `P3` builds a core module that we wrap with the WASI reactor
 /// adapter to produce a component.
 #[derive(Copy, Clone)]
-enum FixtureKind {
+pub(crate) enum FixtureKind {
     P2,
     P3,
 }
 
 impl FixtureKind {
-    fn target(self) -> &'static str {
+    pub(crate) fn target(self) -> &'static str {
         match self {
             FixtureKind::P2 => "wasm32-wasip2",
             FixtureKind::P3 => "wasm32-wasip1",


### PR DESCRIPTION
#5335 added the `ComponentHostPlugin` adapter, a WebAssembly component that provides a host capability from its own supervised store but nothing could actually *load* one outside of tests. This PR adds the production loading path across all three host front-ends, plus an end-to-end test.

A host component plugin is loaded exactly like a built-in Rust plugin (`HostBuilder::with_plugin`, started at `Host::start`); the only new work is turning a **declaration** (an id + a place to fetch the wasm) into a registered plugin.

**Runtime primitive** (`wash-runtime`)
- `ComponentPluginSpec` / `PluginSource` — a plain, always-compiled declaration (id + OCI-image-or-file source + optional `max_restarts` / digest pin), with a `FromStr` for the CLI grammar.
- `load_component_plugin` (gated on `host-component-plugins`) — fetches the wasm (`oci::pull_component` or `tokio::fs::read`), verifies an optional digest pin, and builds the `ComponentHostPlugin`. The caller registers it with `with_plugin` before `Host::start`.

**`wash host`** (cluster / operator path)
- `--host-plugin` / `WASH_HOST_PLUGINS` (repeatable). Comma-separated `key=value`: `id=<name>,image=<ref>[,pull=…][,max-restarts=N][,digest=…]` or `id=<name>,file=<path>`.

**`wash dev`** (local path)
- `dev.host_plugins` config entries (`file` or `image` source).

**Chart** (operator path)
- Per-host-group `runtime.hostGroups[].hostPlugins` values, rendered into `--host-plugin` args on the host Deployment.

```yaml
# wash dev — .wash/config.yaml
dev:
  host_plugins:
    - id: acme-kv
      file: ./build/kv_plugin.wasm
      maxRestarts: 3

# chart — values.yaml
runtime:
  hostGroups:
    - name: default
      hostPlugins:
        - id: acme-kv
          image: ghcr.io/acme/kv-host:1.0.0
          pullPolicy: ifNotPresent
```

## Design decisions

- **Host-operator controlled only.** A host component plugin runs with the host's capability surface and serves *every* workload that imports its interface — a privileged install. So it's declared in host config; **nothing in a `WorkloadStartRequest` can register a host-global provider.**
- **Static at host start.** There is no dynamic-plugin API (`HostApi` is only heartbeat/workload_start/status/stop) and the registry is fixed after `build()`. Loading resolves once at boot. Dynamic load/unload on a running host is noted as future work (needs a mutable registry, workload re-bind, and an `Arc<str>` id).
- **All-features-only, and it fails loud.** The loader is gated on `host-component-plugins` (not in release builds). The spec/flag/config types are *always* compiled, so a plugin declared against a release host produces a clear "requires the feature" error rather than a silent drop — important for the operator/env path.
- **`Host` CRD is status-only.** It's created from the host's heartbeat (`HostPodReconciler` only bridges pod↔Host lifecycle); host pods are Helm-templated per host-group. So the declarative host-config seam is the host-group values, which is where `hostPlugins` lives.
- **`&'static str` id** is interned via a bounded `Box::leak` (plugins load once at startup and live for the process); flagged to revisit if dynamic loading lands.

## Testing

- Unit: `ComponentPluginSpec` grammar parsing (valid/invalid).
- Integration: `load_component_plugin` from a file builds a plugin with the right id/world; digest-pin-on-file and missing-file error paths; and an opt-in OCI-source test (`HOST_PLUGIN_OCI_REF`, self-skips in CI).
- Config: `HostPluginConfig::to_spec` validation + `dev.host_plugins` YAML round-trip.
- **e2e** (`runtime-operator/test/e2e/host_plugin_test.go`): a ginkgo/kind spec that loads a plugin onto a hostGroup via `hostPlugins`, deploys a workload importing the plugin's `acme:kv/store`, and asserts a value written via `/set` reads back via `/get` — proving the CLI/chart loading path and cross-store bind work in a real cluster.

**Verified end-to-end locally in kind** against a `registry:2` on the kind network: built the all-features host image, pushed the two fixtures with `wash oci push`, and ran the ginkgo spec — the host pulled the plugin from OCI, loaded it, an `acme:kv` workload scheduled and reached Ready, and `/set`→`/get` round-tripped a value through the plugin's store. `SUCCESS! -- 1 Passed`. The gated OCI-source `load_component_plugin` test and a direct `wash host --host-plugin …` run were also verified against the same registry. In CI this stays gated on the two fixtures being published (`HOST_PLUGIN_E2E_IMAGE`, `HOST_PLUGIN_CALLER_E2E_IMAGE`).

## Follow-up to activate the e2e

The e2e **self-skips until two fixtures are published** (same bootstrap the implements/messaging specs used), because host plugins load at host startup. A non-pullable image would fail host boot and break the all-features leg. To turn it on:

1. Publish `crates/wash-runtime/tests/fixtures/kv-plugin` and `kv-plugin-caller` as OCI images.
2. Fill the empty `host_plugin_image` / `host_plugin_caller_image` matrix values in `wash.yml` (all-features leg).