### PR TITLE
fix(wash-runtime): create span from components `parent_span_id` in `on_end`

### DIFF
--- a/crates/wash-runtime/src/plugin/wasi_otel/convert.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/convert.rs
@@ -2,9 +2,9 @@
 
 use opentelemetry::logs::{AnyValue, LogRecord as OtelLogRecord};
 use opentelemetry::trace::{
-    SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+    SpanContext, SpanId, SpanKind, Status, TraceContextExt, TraceFlags, TraceId, TraceState,
 };
-use opentelemetry::{Key, KeyValue};
+use opentelemetry::{Context, Key, KeyValue};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::bindings::wasi::otel::logs::LogRecord as WasiLogRecord;
@@ -323,6 +323,43 @@ pub fn wit_span_context_to_otel(ctx: &WitSpanContext) -> SpanContext {
     .unwrap_or_default();
 
     SpanContext::new(trace_id, span_id, trace_flags, ctx.is_remote, trace_state)
+}
+
+/// Build the parent [`Context`] for a WASI span from its `parent_span_id`.
+///
+/// The guest already tracks its own span nesting (e.g. `compute` parented under
+/// `handler`); that relationship is carried over the wire as `parent_span_id` on
+/// `SpanData`. Without using it here, `Tracer::build` falls back to whatever OTel
+/// context is ambient on the host when `on-end` is processed, which flattens every
+/// guest span onto the host's current span instead of preserving guest-side nesting.
+pub fn wasi_span_parent_context(span: &wasi_tracing::SpanData) -> Context {
+    let Ok(parent_span_id) = SpanId::from_hex(&span.parent_span_id) else {
+        return Context::new();
+    };
+    if parent_span_id == SpanId::INVALID {
+        return Context::new();
+    }
+
+    let trace_id = TraceId::from_hex(&span.span_context.trace_id).unwrap_or(TraceId::INVALID);
+    let trace_flags = if span
+        .span_context
+        .trace_flags
+        .contains(WitTraceFlags::SAMPLED)
+    {
+        TraceFlags::SAMPLED
+    } else {
+        TraceFlags::default()
+    };
+
+    let parent_span_context = SpanContext::new(
+        trace_id,
+        parent_span_id,
+        trace_flags,
+        true,
+        TraceState::default(),
+    );
+
+    Context::new().with_remote_span_context(parent_span_context)
 }
 
 /// Convert WASI span kind to OTel SpanKind

--- a/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
@@ -8,7 +8,7 @@ pub use convert::otel_span_context_to_wit;
 use convert::{
     convert_span_kind, convert_status, convert_wasi_log_record, extract_counter_values,
     extract_gauge_values, extract_span_attributes, extract_span_events, summarize_resource_metrics,
-    summarize_span_data, wit_span_context_to_otel,
+    summarize_span_data, wasi_span_parent_context, wit_span_context_to_otel,
 };
 
 use anyhow::bail;
@@ -419,10 +419,11 @@ impl<'a> bindings::wasi::otel::tracing::Host for ActiveCtx<'a> {
 
                 let tracer = provider.tracer(plugin.config.service_name.clone());
 
-                // Build a span with the data from WASI
-                // Note: The SDK generates its own span/trace IDs. The WASI span context is logged
-                // for correlation purposes but the SDK span will have different IDs.
-                let _wasi_span_context = wit_span_context_to_otel(&span_data.span_context);
+                // Build a span with the data from WASI, preserving the guest's own
+                // trace/span IDs and parent linkage instead of letting the SDK mint
+                // fresh IDs and fall back to whatever host span is ambient.
+                let wasi_span_context = wit_span_context_to_otel(&span_data.span_context);
+                let parent_cx = wasi_span_parent_context(&span_data);
                 let span_kind = convert_span_kind(span_data.span_kind);
                 let status = convert_status(&span_data.status);
                 let attributes = extract_span_attributes(&span_data);
@@ -430,14 +431,16 @@ impl<'a> bindings::wasi::otel::tracing::Host for ActiveCtx<'a> {
 
                 // Create a span builder with the WASI span data
                 let mut builder = SpanBuilder::from_name(span_data.name.clone())
+                    .with_trace_id(wasi_span_context.trace_id())
+                    .with_span_id(wasi_span_context.span_id())
                     .with_kind(span_kind)
                     .with_attributes(attributes);
 
                 // Set start time
                 builder = builder.with_start_time(summary.start_time);
 
-                // Start the span
-                let mut span = tracer.build(builder);
+                // Start the span, parented according to the guest's own nesting
+                let mut span = tracer.build_with_context(builder, &parent_cx);
 
                 // Add events to the span
                 for (event_name, _event_time, event_attrs) in events {


### PR DESCRIPTION
# Description
- Fix don't drop parent span id when building trace to export
- https://github.com/wasmCloud/wasmCloud/issues/5353

## Testing
Tested using the following repository (as attached in the issue above).

https://github.com/jamesstocktonj1/wasi-otel-tracing

### Before
The `compute` span shows up as unrelated to it's parent `handler`:

<img width="1706" height="679" alt="Screenshot from 2026-07-17 05-23-08" src="https://github.com/user-attachments/assets/c4826fa4-b49a-4fdc-adb5-905d362fa67c" />

### After
Span `compute` correctly shows as having `handler` as the parent:

<img width="1721" height="679" alt="Screenshot from 2026-07-17 05-45-17" src="https://github.com/user-attachments/assets/9a7b6421-d022-4962-8496-91d5e47bbf26" />

This relationship also correctly shows up when platform tracing is enabled:

<img width="1721" height="679" alt="Screenshot from 2026-07-17 05-46-46" src="https://github.com/user-attachments/assets/40565ecb-5c62-4e4a-a624-3416324ee293" />



<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->