### PR TITLE
benches ci fixes

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -107,8 +107,8 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
       # Compile the wash-runtime wasm test fixtures. The test/bench targets
-      # `include_bytes!` these, so they must exist before `cargo test`/`cargo
-      # bench` below. Targets wasm32-wasip2/wasip1 come from setup-rust.
+      # `include_bytes!` these, so they must exist before the `cargo test`
+      # steps below. Targets wasm32-wasip2/wasip1 come from setup-rust.
       - name: Build test fixtures
         run: cargo xtask build-fixtures
       - name: Build
@@ -136,10 +136,18 @@ jobs:
         run: |
           cargo test -p wash-runtime --features wasm_component_model_implements,wasi-tls -- --ignored
           cargo test -p wash --test integration_oci -- --ignored
+      # Bitrot guard: the benches must still compile. Built via `cargo test
+      # --benches` rather than `cargo bench --no-run` because the `bench`
+      # profile inherits `release`, which shares no artifacts with the dev/test
+      # builds above and so rebuilds the whole tree (wasmtime included) just to
+      # compile-check four targets; the test profile reuses them. wash-runtime
+      # gates no code on `debug_assertions`, so both profiles compile the same
+      # source. Optimized bench builds happen only in bench.yml (manual
+      # dispatch), so an opt-level-only break surfaces there, not here.
       - name: Build benchmarks
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cargo bench -p wash-runtime --no-run
+          cargo test -p wash-runtime --benches --no-run
 
   lint:
     needs:

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -386,7 +386,7 @@ with a fresh token). It:
 - Installs **rustup as the `bench` user** so `cargo` is available in
   the workflow's PATH. The actual toolchain is auto-installed on
   first build via `rust-toolchain.toml`.
-- Downloads `actions-runner-linux-x64-2.334.0.tar.gz`, **verifies the
+- Downloads `actions-runner-linux-x64-2.335.1.tar.gz`, **verifies the
   SHA256** (constant in the script — bump version + sha together
   when upgrading), extracts to `/opt/actions-runner`.
 - Registers the runner with labels `self-hosted, bench, hetzner` and

--- a/scripts/bench/install-runner.sh
+++ b/scripts/bench/install-runner.sh
@@ -4,7 +4,7 @@
 #
 #   sudo WASMCLOUD_BENCH_RUNNER_TOKEN=<TOKEN> bash scripts/bench/install-runner.sh \
 #     [--repo  wasmCloud/wasmCloud] \
-#     [--version 2.334.0]
+#     [--version 2.335.1]
 #
 # The registration token is one-shot. Get one from:
 #   GitHub Repo > Settings > Actions > Runners > New self-hosted runner
@@ -30,7 +30,7 @@
 set -euo pipefail
 
 REPO="wasmCloud/wasmCloud"
-RUNNER_VERSION="2.334.0"
+RUNNER_VERSION="2.335.1"
 # Default to the actual hostname of the box (set by installimage). Override with
 # --name if needed. No hardcoded value here — the box's identity isn't in the repo.
 RUNNER_NAME="$(hostname)"
@@ -42,7 +42,7 @@ TARGET_DIR="/var/lib/bench/target"
 # SHA256 of actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz, copied from
 # https://github.com/actions/runner/releases/tag/v${RUNNER_VERSION}. Bump
 # both `RUNNER_VERSION` and this constant together.
-RUNNER_SHA256="048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271"
+RUNNER_SHA256="4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf"
 
 usage() {
   sed -n '2,/^$/p' "$0" | sed 's/^# \?//'

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -147,8 +147,21 @@ fn build_fixtures(workspace: &Path) -> Result<()> {
 /// `cargo build`, and wraps a wasip1 core module into a component. Build `wash`
 /// if no compiled copy is present.
 fn ensure_wash(workspace: &Path) -> Result<PathBuf> {
+    // `cargo build -p wash` writes under CARGO_TARGET_DIR when the environment
+    // sets one (the bench hosts point it outside the workspace so the cargo
+    // cache survives `actions/checkout --clean`), and under `<workspace>/target`
+    // otherwise. Resolve the binary against the same directory cargo uses, or
+    // the built `wash` is looked for at a path nothing was written to.
+    // Join against workspace so a relative CARGO_TARGET_DIR resolves the same
+    // way cargo resolves it (cargo runs below with current_dir = workspace); an
+    // absolute value replaces the base, matching cargo too.
+    let target_dir = workspace.join(
+        std::env::var_os("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("target")),
+    );
     for profile in ["release", "debug"] {
-        let candidate = workspace.join(format!("target/{profile}/wash"));
+        let candidate = target_dir.join(profile).join("wash");
         if candidate.exists() {
             return Ok(candidate);
         }
@@ -162,7 +175,7 @@ fn ensure_wash(workspace: &Path) -> Result<PathBuf> {
     if !status.success() {
         bail!("failed to build the wash binary");
     }
-    Ok(workspace.join("target/debug/wash"))
+    Ok(target_dir.join("debug").join("wash"))
 }
 
 /// Build one fixture through `wash build` and stage the resulting component


### PR DESCRIPTION
Three fixes related to running benchmarks:

- **ci(wash): compile-check benches under test profile**
- **fix(xtask): honor CARGO_TARGET_DIR when locating the wash binary**
- **ci(bench): bump self-hosted runner to v2.335.1**

One is related to changes made today for xtask using wash to build test fixtures.
For our benches, we need to honor CARGO_TARGET_DIR when locating the wash binary.

Additionally by using the test profile to validate the benches code compiles,
we can save 14 minutes in CI. The "Build benchmarks" step ran `cargo bench -p wash-runtime --no-run`. The `bench` profile inherits `release`, which shares no artifacts with the dev/test builds earlier in the job, so this recompiled the entire dependency tree just to confirm four bench targets still build.