### PR TITLE
ci(codeowners): own /xtask/ by ci&wash maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,6 +43,12 @@
 /crates/bench-tools/                    @wasmCloud/ci-maintainers @wasmCloud/wash-maintainers
 /crates/wash-runtime/benches/           @wasmCloud/ci-maintainers @wasmCloud/wash-maintainers
 
+# The xtask build-fixtures runner compiles the wash-runtime test fixtures, so
+# it's owned jointly: wash maintainers keep context on the fixture build, ci
+# maintainers gate the build tooling. Without this it falls to the default
+# owner below.
+/xtask/                                 @wasmCloud/ci-maintainers @wasmCloud/wash-maintainers
+
 # Examples and project templates
 /examples/              @wasmCloud/examples-maintainers
 /templates/             @wasmCloud/examples-maintainers


### PR DESCRIPTION
Noticed that org-maintainers was pulled in as a reviwer for xtask changes.
