### PR TITLE
test(runtime-operator): serve e2e fixtures component oci-registry

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -339,6 +339,47 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # Build ONLY the e2e fixture components (not the whole `check` matrix) plus the
+  # in-repo wash, and upload them. The runtime-operator-e2e all-features leg then
+  # pushes them into the in-cluster registry without a Rust build on that leg.
+  #
+  # TODO(wash release): the in-repo wash is built here (and uploaded for the push
+  # side) only because the released wash can't build fixtures from their local
+  # wkg.toml refs. Once it can, use setup-wash-action instead and drop the protoc
+  # step below (needed only to compile wash, not the fixtures).
+  e2e-fixtures:
+    needs:
+      - changes
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.relevant == 'true') && (github.event_name == 'pull_request' || ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/free-disk-space
+      - name: Setup protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "29.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup-rust
+      - name: Build e2e fixture components + wash
+        working-directory: runtime-operator
+        run: make e2e-images
+        env:
+          E2E_IMAGES_MODE: build
+          E2E_FIXTURES_DIR: ${{ runner.temp }}/e2e-fixtures
+      - name: Upload e2e fixture components + wash
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-fixtures
+          path: ${{ runner.temp }}/e2e-fixtures
+          if-no-files-found: error
+          retention-days: 1
+
   # Integration gate: install the shared wash image alongside the
   # runtime-operator chart in a kind cluster, and run the operator's e2e
   # suite (including the messaging round-trip from #5074) against it. The
@@ -348,47 +389,77 @@ jobs:
   runtime-operator-e2e:
     needs:
       - wash-image
+      - e2e-fixtures
     # `wash-image` runs via `if: always() && ...` to bypass the skipped
     # `changes` job on main pushes. Without an explicit `if:` here, GHA
     # propagates the skipped state of that indirect upstream through and
     # marks this job skipped even though `wash-image` itself succeeded.
     # Result: canary-publish never fires on main. Explicit gate on
     # wash-image's actual result is the documented workaround.
-    if: always() && needs.wash-image.result == 'success'
+    if: always() && needs.wash-image.result == 'success' && needs.e2e-fixtures.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     permissions:
       contents: read
-    # Run the suite twice, against two host images:
-    #   release      — the exact DEFAULT-features bytes we ship (build_push).
-    #                  This leg is the guarantee that we test what we release;
-    #                  IMPLEMENTS_E2E_IMAGE is empty so the implements spec
-    #                  self-skips (a released host has no `(implements ..)`).
-    #   all-features — a coverage build (NOT shipped) with every optional host
-    #                  feature on; this leg exercises the implements spec.
+    # Run the suite twice. Both legs stand up an in-cluster oci-registry on a
+    # pinned all-features `registry` hostgroup and serve every fixture from it;
+    # the legs differ only in the image the DEFAULT (fixture) hostgroup runs:
+    #   release      — the shipped DEFAULT-features build. Validates that the
+    #                  shipped host pulls the fixtures from the registry (insecure
+    #                  HTTP) and runs them. `implements` self-skips (it needs a
+    #                  feature host); http + messaging run.
+    #   all-features — every optional host feature on; runs the full set incl.
+    #                  `implements`. Not shipped — a coverage build.
+    # default_tag/registry_tag select the per-hostgroup images (loaded below); the
+    # registry host is always all-features (it needs the async wasmcloud:blobstore
+    # plugin).
     strategy:
       fail-fast: false
       matrix:
         include:
           - variant: release
-            tarball: wash-image-tarball-release-amd64
-            implements_image: ""
+            default_tag: release
+            registry_tag: all-features
           - variant: all-features
-            tarball: wash-image-tarball-all-features-amd64
-            implements_image: ghcr.io/wasmcloud/components/keyvalue-implements:0.1.0
+            default_tag: all-features
+            registry_tag: all-features
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-go
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      # The fixture components + the in-repo wash were built by the e2e-fixtures
+      # job; download them so `make e2e-images` (push mode) just deploys the
+      # registry and pushes — no Rust build on this leg. Both legs push fixtures.
+      - name: Download e2e fixture components + wash
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ matrix.tarball }}
+          name: e2e-fixtures
+          path: ${{ runner.temp }}/e2e-fixtures
+      # The registry host is always all-features; load it as :all-features on both
+      # legs. The tarballs internally tag localhost/wasmcloud-wash:e2e, so retag.
+      - name: Download all-features host image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: wash-image-tarball-all-features-amd64
           path: /tmp
-      - name: Load wash runtime image (${{ matrix.variant }})
-        # Exactly one tarball is downloaded per leg; both tag as
-        # localhost/wasmcloud-wash:e2e, the tag the operator chart deploys.
-        run: docker load -i /tmp/*.tar
+      - name: Load all-features host image
+        run: |
+          docker load -i /tmp/wash-image-all-features.tar
+          docker tag localhost/wasmcloud-wash:e2e localhost/wasmcloud-wash:all-features
+      # The release leg's fixture host is the shipped build; load it as :release
+      # alongside the all-features registry host so one cluster runs both.
+      - name: Download release host image
+        if: matrix.variant == 'release'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: wash-image-tarball-release-amd64
+          path: /tmp
+      - name: Load release host image
+        if: matrix.variant == 'release'
+        run: |
+          docker load -i /tmp/wash-image-release.tar
+          docker tag localhost/wasmcloud-wash:e2e localhost/wasmcloud-wash:release
       - name: Build runtime-operator image
         working-directory: runtime-operator
         run: make docker-build IMG=localhost/runtime-operator:e2e
@@ -405,13 +476,16 @@ jobs:
           SKIP_IMAGE_BUILD: "true"
           BUILD_RUNTIME_IMAGE: "true"
           SKIP_RUNTIME_BUILD: "true"
-          # Messaging runs on BOTH legs — it's the #5074 regression and the
-          # whole reason the gate exists (a core capability the released host
-          # runs too).
-          MESSAGING_E2E_IMAGE: ghcr.io/wasmcloud/components/messaging-echo-rust:0.1.0
-          # Only the `all-features` leg sets this; empty on `release`, so the
-          # implements spec self-skips there (the released host lacks the feature).
-          IMPLEMENTS_E2E_IMAGE: ${{ matrix.implements_image }}
+          # Both legs run the in-cluster registry. The default (fixture) hostgroup
+          # runs default_tag; the registry hostgroup runs registry_tag (always
+          # all-features). implements self-skips when they differ (release leg).
+          E2E_IN_CLUSTER_REGISTRY: "true"
+          E2E_RUNTIME_IMAGE_TAG: ${{ matrix.default_tag }}
+          E2E_REGISTRY_HOST_IMAGE_TAG: ${{ matrix.registry_tag }}
+          # Reuse the components + wash the e2e-fixtures job built (downloaded
+          # above): `make e2e-images` pushes them rather than rebuilding.
+          E2E_IMAGES_MODE: push
+          E2E_FIXTURES_DIR: ${{ runner.temp }}/e2e-fixtures
           PROMETHEUS_INSTALL_SKIP: "true"
           CERT_MANAGER_INSTALL_SKIP: "true"
           KIND_CLUSTER_NAME: wasmcloud-e2e
@@ -436,6 +510,7 @@ jobs:
       - check
       - lint
       - wash-image
+      - e2e-fixtures
       - runtime-operator-e2e
       - canary-publish
       - canary-binaries

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -130,9 +130,6 @@ spec:
             {{- if and (.webgpu) (.webgpu.enabled) }}
             - "--wasi-webgpu"
             {{- end }}
-            {{- if and (.wasip3) (.wasip3.enabled) }}
-            - "--wasip3"
-            {{- end }}
             {{- range .wasmProposals }}
             - "--wasm-proposal={{ . }}"
             {{- end }}

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -1,7 +1,13 @@
-{{- $registry := .Values.runtime.image.registry | default .Values.global.image.registry -}}
 {{- $top := . }}
 {{- range .Values.runtime.hostGroups }}
 {{- $ns := default $top.Release.Namespace .namespace }}
+{{- /* Per-hostgroup image: `.image.{registry,repository,tag}` override the
+       chart-wide runtime.image, so one release can mix host versions (e.g. an
+       all-features host for one group and the shipped image for another). */}}
+{{- $hi := default (dict) .image }}
+{{- $imgRegistry := $hi.registry | default $top.Values.runtime.image.registry | default $top.Values.global.image.registry }}
+{{- $imgRepo := $hi.repository | default $top.Values.runtime.image.repository }}
+{{- $imgTag := $hi.tag | default $top.Values.runtime.image.tag | default $top.Chart.AppVersion }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -62,7 +68,7 @@ spec:
       {{- include "runtime-operator.imagePullSecrets" $top | nindent 6 }}
       containers:
         - name: host
-          image: {{ if $registry }}{{ printf "%s/%s" $registry $top.Values.runtime.image.repository }}{{ else }}{{ $top.Values.runtime.image.repository }}{{ end }}:{{ $top.Values.runtime.image.tag | default $top.Chart.AppVersion }}
+          image: {{ if $imgRegistry }}{{ printf "%s/%s" $imgRegistry $imgRepo }}{{ else }}{{ $imgRepo }}{{ end }}:{{ $imgTag }}
           env:
             # wash resolves its XDG data/config/cache dirs under $HOME; point it
             # at the writable /tmp emptyDir so the host runs with a read-only root

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -350,8 +350,6 @@ runtime:
         type: ClusterIP
       webgpu:
         enabled: false
-      wasip3:
-        enabled: false
       # -- Additional wasm proposals to enable on this host group's engine,
       # rendered as `--wasm-proposal=<name>` args. Accepted names:
       # component-model-async, gc, exception-handling, wide-arithmetic,

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -340,6 +340,12 @@ runtime:
       envFrom: []
       # -- Per-host-group extra CLI args, appended after `runtime.extraArgs`.
       extraArgs: []
+      # -- Per-host-group host image override. Any of `registry`, `repository`,
+      # `tag` set here take precedence over the chart-wide `runtime.image`; unset
+      # keys inherit it. Lets one release mix host versions (e.g. run one host
+      # group on a newer/feature build). Omit to use `runtime.image` for the group.
+      # image:
+      #   tag: "some-other-tag"
       service:
         type: ClusterIP
       webgpu:

--- a/deploy/kind/kind-config.yaml
+++ b/deploy/kind/kind-config.yaml
@@ -20,6 +20,12 @@ kubeadmConfigPatches:
 nodes:
   - role: control-plane
     extraPortMappings:
+      # Pinned to 127.0.0.1 (kind's default is 0.0.0.0, which claims :80 on every
+      # local address). The e2e's `make e2e-images` port-forwards the in-cluster
+      # oci-registry to 127.0.0.2:80 to push fixtures; pinning this mapping to
+      # 127.0.0.1 keeps 127.0.0.2:80 free. The http specs still reach the gateway
+      # via localhost:80 (= 127.0.0.1:80).
       - containerPort: 30950
         hostPort: 80
+        listenAddress: "127.0.0.1"
         protocol: TCP

--- a/runtime-operator/Makefile
+++ b/runtime-operator/Makefile
@@ -72,7 +72,16 @@ test: manifests generate fmt vet envtest ## Run tests.
 test-e2e: ## Run the e2e tests. Expected an isolated environment using Kind.
 	@command -v kind >/dev/null 2>&1 || { echo "kind is required"; exit 1; }
 	@kind get clusters | grep -q "$${KIND_CLUSTER_NAME:-kind}" || { echo "Kind cluster not found"; exit 1; }
-	go test ./test/e2e/ -v -ginkgo.v -timeout=30m
+	go test ./test/e2e/ -v -ginkgo.v -timeout=40m
+
+.PHONY: e2e-images
+e2e-images: ## Build the e2e fixtures, deploy the in-cluster oci-registry, and push the fixtures into it.
+	# Runs after `helm install` (which brings up the registry + default
+	# hostgroups) and before the specs. The e2e suite invokes this from
+	# BeforeSuite; it can also be run standalone against an installed cluster.
+	# The implementation is the `e2e-images` xtask (repo root); this target is a
+	# convenience wrapper. Configured via env (E2E_IMAGES_MODE, E2E_FIXTURES_DIR).
+	cargo xtask e2e-images
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/runtime-operator/config/samples/deployment.yaml
+++ b/runtime-operator/config/samples/deployment.yaml
@@ -6,6 +6,9 @@ spec:
   replicas: 1
   template:
     spec:
+      # Schedule onto the chart's default hostgroup.
+      hostSelector:
+        hostgroup: default
       hostInterfaces:
         - namespace: wasi
           package: http

--- a/runtime-operator/config/samples/messaging.yaml
+++ b/runtime-operator/config/samples/messaging.yaml
@@ -22,6 +22,6 @@ spec:
         - name: messaging-echo
           # Component exports wasmcloud:messaging/handler@0.2.0 and replies to
           # incoming messages by publishing the body back to msg.reply_to. The
-          # fixture under crates/wash-runtime/tests/fixtures/messaging-handler
+          # fixture under crates/wash-runtime/tests/fixtures/messaging-echo
           # is the source.
           image: ghcr.io/wasmcloud/components/messaging-echo-rust:0.1.0

--- a/runtime-operator/config/samples/service_deployment.yaml
+++ b/runtime-operator/config/samples/service_deployment.yaml
@@ -26,6 +26,9 @@ spec:
       name: hello-workload
   template:
     spec:
+      # Schedule onto the chart's default hostgroup.
+      hostSelector:
+        hostgroup: default
       hostInterfaces:
         - namespace: wasi
           package: http

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -310,15 +310,18 @@ func buildBaseHelmSets() []string {
 		sets = append(sets,
 			"runtime.hostGroups[0].extraArgs[0]=--allow-insecure-registries",
 			// hostGroups[1]: the `registry` hostgroup. Stays on HTTPS so it can
-			// pull the oci-registry component from ghcr, and enables wasip3 for
-			// its p3 wasi:http/handler export. It runs only the oci-registry
-			// workload (testdata/oci-registry.yaml, hostSelector: hostgroup=registry).
+			// pull the oci-registry component from ghcr. It runs only the
+			// oci-registry workload (testdata/oci-registry.yaml, hostSelector:
+			// hostgroup=registry). The oci-registry exports a p3 async
+			// wasi:http/handler and imports the async wasmcloud:blobstore plugin;
+			// the all-features engine enables the component-model-async proposal
+			// by default (crates/wash-runtime/src/engine/mod.rs build()), so no
+			// extra host flag is required.
 			"runtime.hostGroups[1].name=registry",
 			"runtime.hostGroups[1].replicas=1",
 			"runtime.hostGroups[1].service.type=ClusterIP",
 			"runtime.hostGroups[1].http.enabled=true",
 			"runtime.hostGroups[1].http.port=80",
-			"runtime.hostGroups[1].wasip3.enabled=true",
 			"runtime.hostGroups[1].webgpu.enabled=false",
 			"runtime.hostGroups[1].resources.requests.memory=64Mi",
 			"runtime.hostGroups[1].resources.requests.cpu=250m",

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -57,16 +57,48 @@ var (
 	// e2e is testing whatever upstream shipped, not your branch. Set
 	// SKIP_RUNTIME_BUILD=true alongside BUILD_RUNTIME_IMAGE=true to reuse a
 	// previously-built local image (so iteration on test code doesn't
-	// trigger a full cargo build per run).
+	// trigger a full cargo build per run). In CI the wash.yml legs supply the
+	// host image(s) as pre-built tarballs (SKIP_RUNTIME_BUILD=true) and select
+	// them per hostgroup via E2E_RUNTIME_IMAGE_TAG / E2E_REGISTRY_HOST_IMAGE_TAG.
 	runtimeImageRepo  = "localhost/wasmcloud-wash"
 	buildRuntimeImage = os.Getenv("BUILD_RUNTIME_IMAGE") == envBoolTrue
 	skipRuntimeBuild  = os.Getenv("SKIP_RUNTIME_BUILD") == envBoolTrue
+	// defaultHostImageTag is the wash-runtime image tag the default (fixture)
+	// hostgroup runs. The wash.yml legs set E2E_RUNTIME_IMAGE_TAG to the release
+	// or all-features build; unset (local) uses the locally-built operatorImageTag.
+	defaultHostImageTag = envOrDefault("E2E_RUNTIME_IMAGE_TAG", operatorImageTag)
+	// registryHostImageTag is the tag the `registry` hostgroup runs. The
+	// oci-registry needs the async wasmcloud:blobstore plugin, so it must be an
+	// all-features build; the wash.yml release leg sets E2E_REGISTRY_HOST_IMAGE_TAG
+	// to it. Defaults to the default host image — local runs and the all-features
+	// leg use a single (feature) image for both hostgroups.
+	registryHostImageTag = envOrDefault("E2E_REGISTRY_HOST_IMAGE_TAG", defaultHostImageTag)
+	// defaultHostAllFeatures reports whether the fixture host can run feature-only
+	// components (the implements spec) — true when it shares the all-features
+	// image the registry host uses (local + the all-features leg; not the release
+	// leg, whose default host is the shipped build).
+	defaultHostAllFeatures = defaultHostImageTag == registryHostImageTag
 	// RUNTIME_LOG_LEVEL optionally sets the wash host's `--log-level`. When
 	// unset (the default), the chart leaves the flag off and the host runs
 	// at its built-in INFO level — matching production. Set to e.g. "debug"
 	// when iterating on a failing run that needs the NatsMessaging plugin's
 	// instrumentation in the diagnostic dump.
 	runtimeLogLevel = os.Getenv("RUNTIME_LOG_LEVEL")
+
+	// inClusterRegistry serves the fixture images from an in-cluster
+	// oci-registry (the examples/oci-registry wasm component) instead of
+	// published ghcr refs. The registry itself needs an all-features host (the
+	// async wasmcloud:blobstore plugin), so it runs on a dedicated `registry`
+	// hostgroup pinned to that image — but the p2 fixtures it serves are pullable
+	// by the shipped (release) host too, so BOTH wash.yml legs enable this. Off
+	// for the canary runtime-operator.yml job and plain local runs, where the
+	// registry-served specs self-skip and the http specs use published refs.
+	//
+	// TODO(wash release): once the async wasmcloud:blobstore plugin ships in the
+	// default wash build (not just under the wasm_component_model_implements
+	// feature), the registry can run on the shipped host — dropping this
+	// all-features-only gating so every leg serves fixtures from the registry.
+	inClusterRegistry = os.Getenv("E2E_IN_CLUSTER_REGISTRY") == envBoolTrue
 
 	// helmChartPath points to the runtime-operator Helm chart relative to the project dir (runtime-operator/)
 	helmChartPath = "../charts/runtime-operator"
@@ -91,6 +123,15 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	// The in-cluster registry runs on an all-features host image; without
+	// BUILD_RUNTIME_IMAGE the run falls back to the default-features canary,
+	// which can't run the registry (the async wasmcloud:blobstore plugin is
+	// feature-gated). Fail fast with a clear message rather than a 5m wait.
+	if inClusterRegistry && !buildRuntimeImage {
+		Fail("E2E_IN_CLUSTER_REGISTRY=true requires BUILD_RUNTIME_IMAGE=true " +
+			"(the oci-registry needs an all-features host image)")
+	}
+
 	if !skipImageBuild {
 		By("building the operator image")
 		cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
@@ -103,21 +144,29 @@ var _ = BeforeSuite(func() {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the operator image into Kind")
 
 	if buildRuntimeImage {
-		runtimeImageRef := fmt.Sprintf("%s:%s", runtimeImageRepo, operatorImageTag)
 		if !skipRuntimeBuild {
 			By("building the wash-runtime image from the local tree")
 			// Repo root sits one level above runtime-operator/. Build wash with
-			// `(implements ..)` multiplexing enabled.
+			// `(implements ..)` multiplexing enabled. A local run builds a single
+			// feature image tagged defaultHostImageTag, which both the default and
+			// registry hostgroups use.
+			ref := fmt.Sprintf("%s:%s", runtimeImageRepo, defaultHostImageTag)
 			cmd := exec.Command("docker", "build",
 				"--build-arg", "CARGO_FEATURES=wasm_component_model_implements",
-				"-t", runtimeImageRef, "..")
+				"-t", ref, "..")
 			_, err := utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the wash-runtime image")
 		}
 
-		By("loading the wash-runtime image into Kind")
-		err := utils.LoadImageToKindClusterWithName(runtimeImageRef)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the wash-runtime image into Kind")
+		// kind-load each distinct host image the release references: the default
+		// (fixture) host, and — when it differs (the release leg) — the
+		// all-features registry host. In CI these were docker-loaded from the
+		// wash-image tarballs; locally the default one was just built.
+		for _, tag := range dedupeStrings(defaultHostImageTag, registryHostImageTag) {
+			By(fmt.Sprintf("loading the wash-runtime image %s into Kind", tag))
+			err := utils.LoadImageToKindClusterWithName(fmt.Sprintf("%s:%s", runtimeImageRepo, tag))
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the wash-runtime image into Kind")
+		}
 	}
 
 	By("installing the runtime-operator via Helm")
@@ -133,6 +182,20 @@ var _ = BeforeSuite(func() {
 	cmd := exec.Command("helm", helmArgs...)
 	_, err = utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to install the runtime-operator via Helm")
+
+	// On the all-features leg, build the fixture components, deploy the
+	// in-cluster oci-registry onto the `registry` hostgroup, and push the
+	// fixtures into it. The specs then pull those images by their in-cluster ref
+	// (registryRef), so no image is published out of band. Kept as a Make target
+	// so the same flow runs locally and in CI; it must run after the Helm install
+	// brought the hostgroups up. Skipped when inClusterRegistry is off (the
+	// registry needs an all-features host that other legs don't run).
+	if inClusterRegistry {
+		By("building and pushing e2e fixture images into the in-cluster registry")
+		cmd = exec.Command("make", "e2e-images")
+		_, err = utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build/push e2e fixture images")
+	}
 
 	// Setup Prometheus and CertManager before the suite if not skipped and if not already installed
 	if !skipPrometheusInstall {
@@ -157,12 +220,56 @@ var _ = BeforeSuite(func() {
 	}
 })
 
+// registryImageTag is the tag the `e2e-images` xtask pushes every fixture
+// under. Kept in sync with TAG in xtask/src/e2e_images.rs.
+const registryImageTag = "e2e"
+
+// registryRef returns the in-cluster pull ref for a fixture that
+// `make e2e-images` built and pushed. The insecure hostgroups resolve it over
+// plain HTTP via the oci-registry Service DNS, so specs never depend on an
+// image published out of band.
+func registryRef(name string) string {
+	return fmt.Sprintf("oci-registry.%s.svc/fixtures/%s:%s", namespace, name, registryImageTag)
+}
+
+// envOrDefault returns the env var value, or def when unset/empty.
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// dedupeStrings returns vals with duplicates removed, preserving order.
+func dedupeStrings(vals ...string) []string {
+	seen := make(map[string]bool, len(vals))
+	out := make([]string, 0, len(vals))
+	for _, v := range vals {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// extraHostGroupIndex is the hostGroups index the helm-upgrade scenarios
+// (tenant, scoped) append their group at. When inClusterRegistry is on, the
+// registry occupies [1], so they use [2]; otherwise [1].
+func extraHostGroupIndex() int {
+	if inClusterRegistry {
+		return 2
+	}
+	return 1
+}
+
 // buildBaseHelmSets returns the `--set` values used to install the
-// runtime-operator chart for the e2e suite. The list intentionally
-// targets `runtime.hostGroups[0]` (the default hostGroup that the
-// existing tests exercise) and is shared by both the initial install
-// in BeforeSuite and the helm upgrade scenarios that append additional
-// hostGroups (e.g. a tenant-namespace group at `runtime.hostGroups[1]`).
+// runtime-operator chart for the e2e suite. It always configures `hostGroups[0]`
+// (the `default` group the fixture specs exercise); when inClusterRegistry is
+// on it also makes that group insecure and adds a secure `hostGroups[1]`
+// (`registry`) that runs the in-cluster oci-registry. It is shared by the
+// initial install in BeforeSuite and the helm upgrade scenarios that append a
+// further hostGroup (at extraHostGroupIndex()).
 func buildBaseHelmSets() []string {
 	sets := []string{
 		"operator.image.registry=",
@@ -186,13 +293,54 @@ func buildBaseHelmSets() []string {
 		// chart's `{{- if .logLevel }}` guard off, so wash uses INFO.
 		fmt.Sprintf("runtime.hostGroups[0].logLevel=%s", runtimeLogLevel),
 	}
+	if inClusterRegistry {
+		// The default hostgroup pulls the test fixtures from the in-cluster
+		// oci-registry over plain HTTP. The host's insecure flag is global (it
+		// forces HTTP for every registry), which is why the registry component
+		// itself lives on a separate, secure hostgroup below. Added on both
+		// wash.yml legs (each runs a registry); off for the canary
+		// runtime-operator.yml job and plain local runs, which keep the default
+		// hostgroup on HTTPS and pull published ghcr images.
+		//
+		// TODO(wash release): once wash supports per-registry insecure config
+		// (allow HTTP for the in-cluster registry only, not globally), the
+		// registry can share the default hostgroup — dropping this second
+		// hostgroup and the extraHostGroupIndex() shuffle in the tenant/scoped
+		// specs.
+		sets = append(sets,
+			"runtime.hostGroups[0].extraArgs[0]=--allow-insecure-registries",
+			// hostGroups[1]: the `registry` hostgroup. Stays on HTTPS so it can
+			// pull the oci-registry component from ghcr, and enables wasip3 for
+			// its p3 wasi:http/handler export. It runs only the oci-registry
+			// workload (testdata/oci-registry.yaml, hostSelector: hostgroup=registry).
+			"runtime.hostGroups[1].name=registry",
+			"runtime.hostGroups[1].replicas=1",
+			"runtime.hostGroups[1].service.type=ClusterIP",
+			"runtime.hostGroups[1].http.enabled=true",
+			"runtime.hostGroups[1].http.port=80",
+			"runtime.hostGroups[1].wasip3.enabled=true",
+			"runtime.hostGroups[1].webgpu.enabled=false",
+			"runtime.hostGroups[1].resources.requests.memory=64Mi",
+			"runtime.hostGroups[1].resources.requests.cpu=250m",
+			"runtime.hostGroups[1].resources.limits.memory=512Mi",
+			"runtime.hostGroups[1].resources.limits.cpu=500m",
+			fmt.Sprintf("runtime.hostGroups[1].logLevel=%s", runtimeLogLevel),
+		)
+		// The registry host must be an all-features build (for the async
+		// blobstore plugin). When the default host isn't one — the release leg,
+		// where it's the shipped image — override just this hostgroup's image tag
+		// so the fixture host can still be validated pulling from the registry.
+		if buildRuntimeImage && registryHostImageTag != defaultHostImageTag {
+			sets = append(sets, fmt.Sprintf("runtime.hostGroups[1].image.tag=%s", registryHostImageTag))
+		}
+	}
 	if buildRuntimeImage {
 		// Point at the locally-built image and disable pull so kubelet
 		// uses the kind-loaded copy.
 		sets = append(sets,
 			"runtime.image.registry=",
 			fmt.Sprintf("runtime.image.repository=%s", runtimeImageRepo),
-			fmt.Sprintf("runtime.image.tag=%s", operatorImageTag),
+			fmt.Sprintf("runtime.image.tag=%s", defaultHostImageTag),
 			"runtime.image.pull_policy=Never",
 		)
 	} else {

--- a/runtime-operator/test/e2e/e2e_test.go
+++ b/runtime-operator/test/e2e/e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -364,18 +365,22 @@ var _ = Describe("Manager", Ordered, func() {
 	})
 
 	Context("Finalizer", func() {
-		It("should terminate all hostgroup pods when scaled to zero to test finalizer", func() {
-			By("scaling the hostgroup deployment to zero")
+		It("should terminate the default hostgroup pods when scaled to zero to test finalizer", func() {
+			// Scale only the `default` hostgroup, not every hostgroup. On the
+			// all-features leg the `registry` hostgroup runs the in-cluster
+			// oci-registry, whose in-memory contents the later Tenant/Scoped
+			// specs (and the randomized messaging/implements specs) still pull.
+			By("scaling the default hostgroup deployment to zero")
 			cmd := exec.Command("kubectl", "scale", "deployment",
-				"-l", "wasmcloud.com/name=hostgroup",
+				"-l", "wasmcloud.com/hostgroup=default",
 				"--replicas=0", "-n", namespace)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("waiting for all hostgroup pods to be removed")
+			By("waiting for the default hostgroup pods to be removed")
 			verifyNoPods := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "pods",
-					"-l", "wasmcloud.com/name=hostgroup",
+					"-l", "wasmcloud.com/hostgroup=default",
 					"-n", namespace, "-o", "jsonpath={.items}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -433,25 +438,32 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 
 		It("performs a helm upgrade adding a hostGroup in the tenant namespace", func() {
-			// Append a second hostGroup pinned to the tenant namespace.
-			// We deliberately do NOT set `operator.hostNamespaces` here
-			// — the chart's `runtime-operator.hostNamespaces` helper
-			// should auto-derive it from the hostGroup's namespace
-			// override, and we assert that below.
+			// Append a hostGroup pinned to the tenant namespace, at the index
+			// after buildBaseHelmSets's groups (extraHostGroupIndex: [2] when the
+			// registry occupies [1], else [1]). When the registry flow is active
+			// this host runs the http fixture pulled from the in-cluster registry,
+			// so it's made insecure to match. We deliberately do NOT set
+			// `operator.hostNamespaces` here — the chart's
+			// `runtime-operator.hostNamespaces` helper should auto-derive it from
+			// the hostGroup's namespace override, and we assert that below.
+			hg := fmt.Sprintf("runtime.hostGroups[%d]", extraHostGroupIndex())
 			sets := append(buildBaseHelmSets(),
-				fmt.Sprintf("runtime.hostGroups[1].name=%s", tenantHostGroup),
-				fmt.Sprintf("runtime.hostGroups[1].namespace=%s", tenantNamespace),
-				"runtime.hostGroups[1].replicas=1",
-				"runtime.hostGroups[1].service.type=ClusterIP",
-				"runtime.hostGroups[1].http.enabled=true",
-				"runtime.hostGroups[1].http.port=80",
-				"runtime.hostGroups[1].webgpu.enabled=false",
-				"runtime.hostGroups[1].resources.requests.memory=64Mi",
-				"runtime.hostGroups[1].resources.requests.cpu=250m",
-				"runtime.hostGroups[1].resources.limits.memory=512Mi",
-				"runtime.hostGroups[1].resources.limits.cpu=500m",
-				fmt.Sprintf("runtime.hostGroups[1].logLevel=%s", runtimeLogLevel),
+				fmt.Sprintf("%s.name=%s", hg, tenantHostGroup),
+				fmt.Sprintf("%s.namespace=%s", hg, tenantNamespace),
+				fmt.Sprintf("%s.replicas=1", hg),
+				fmt.Sprintf("%s.service.type=ClusterIP", hg),
+				fmt.Sprintf("%s.http.enabled=true", hg),
+				fmt.Sprintf("%s.http.port=80", hg),
+				fmt.Sprintf("%s.webgpu.enabled=false", hg),
+				fmt.Sprintf("%s.resources.requests.memory=64Mi", hg),
+				fmt.Sprintf("%s.resources.requests.cpu=250m", hg),
+				fmt.Sprintf("%s.resources.limits.memory=512Mi", hg),
+				fmt.Sprintf("%s.resources.limits.cpu=500m", hg),
+				fmt.Sprintf("%s.logLevel=%s", hg, runtimeLogLevel),
 			)
+			if inClusterRegistry {
+				sets = append(sets, fmt.Sprintf("%s.extraArgs[0]=--allow-insecure-registries", hg))
+			}
 
 			helmArgs := make([]string, 0, 5+2*len(sets)+4)
 			helmArgs = append(helmArgs, "upgrade", "--install", "-n", namespace)
@@ -564,8 +576,8 @@ spec:
             host: hello.localhost.direct
       components:
         - name: hello-world
-          image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
-`, tenantWorkloadName, tenantNamespace, tenantNamespace, tenantHostGroup)
+          image: %s
+`, tenantWorkloadName, tenantNamespace, tenantNamespace, tenantHostGroup, httpWorkloadImage())
 
 			f, err := os.CreateTemp("", "tenant-workload-*.yaml")
 			Expect(err).NotTo(HaveOccurred())
@@ -671,8 +683,8 @@ spec:
             host: hello.localhost.direct
       components:
         - name: hello-world
-          image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
-`, name, ns, ns, hostgroup)
+          image: %s
+`, name, ns, ns, hostgroup, httpWorkloadImage())
 
 			f, err := os.CreateTemp("", "scoped-workload-*.yaml")
 			Expect(err).NotTo(HaveOccurred())
@@ -756,27 +768,34 @@ spec:
 		})
 
 		It("helm upgrades the release into scoped mode", func() {
-			helmUpgrade([]string{
+			// Run a host inside the watched namespace so a workload applied there
+			// has something to schedule onto, at the index after buildBaseHelmSets's
+			// groups (extraHostGroupIndex: [2] when the registry occupies [1], else
+			// [1]). When the registry flow is active it runs the http fixture from
+			// the in-cluster registry, so it's made insecure to match. The chart's
+			// `runtime-operator.hostNamespaces` helper auto-derives -host-namespaces
+			// from runtime.hostGroups[].namespace, so we don't set
+			// operator.hostNamespaces directly.
+			hg := fmt.Sprintf("runtime.hostGroups[%d]", extraHostGroupIndex())
+			scopedSets := []string{
 				fmt.Sprintf("operator.watchNamespaces[0]=%s", watchedNamespace),
-				// Run a host inside the watched namespace so a workload
-				// applied there has something to schedule onto. The
-				// chart's `runtime-operator.hostNamespaces` helper
-				// auto-derives -host-namespaces from
-				// runtime.hostGroups[].namespace, so we don't set
-				// operator.hostNamespaces directly.
-				fmt.Sprintf("runtime.hostGroups[1].name=%s", scopedHostGroup),
-				fmt.Sprintf("runtime.hostGroups[1].namespace=%s", watchedNamespace),
-				"runtime.hostGroups[1].replicas=1",
-				"runtime.hostGroups[1].service.type=ClusterIP",
-				"runtime.hostGroups[1].http.enabled=true",
-				"runtime.hostGroups[1].http.port=80",
-				"runtime.hostGroups[1].webgpu.enabled=false",
-				"runtime.hostGroups[1].resources.requests.memory=64Mi",
-				"runtime.hostGroups[1].resources.requests.cpu=250m",
-				"runtime.hostGroups[1].resources.limits.memory=512Mi",
-				"runtime.hostGroups[1].resources.limits.cpu=500m",
-				fmt.Sprintf("runtime.hostGroups[1].logLevel=%s", runtimeLogLevel),
-			}, "helm upgrade into scoped mode failed")
+				fmt.Sprintf("%s.name=%s", hg, scopedHostGroup),
+				fmt.Sprintf("%s.namespace=%s", hg, watchedNamespace),
+				fmt.Sprintf("%s.replicas=1", hg),
+				fmt.Sprintf("%s.service.type=ClusterIP", hg),
+				fmt.Sprintf("%s.http.enabled=true", hg),
+				fmt.Sprintf("%s.http.port=80", hg),
+				fmt.Sprintf("%s.webgpu.enabled=false", hg),
+				fmt.Sprintf("%s.resources.requests.memory=64Mi", hg),
+				fmt.Sprintf("%s.resources.requests.cpu=250m", hg),
+				fmt.Sprintf("%s.resources.limits.memory=512Mi", hg),
+				fmt.Sprintf("%s.resources.limits.cpu=500m", hg),
+				fmt.Sprintf("%s.logLevel=%s", hg, runtimeLogLevel),
+			}
+			if inClusterRegistry {
+				scopedSets = append(scopedSets, fmt.Sprintf("%s.extraArgs[0]=--allow-insecure-registries", hg))
+			}
+			helmUpgrade(scopedSets, "helm upgrade into scoped mode failed")
 		})
 
 		It("removes the cluster-scoped operator RBAC", func() {
@@ -962,6 +981,32 @@ spec:
 	})
 })
 
+// httpHelloWorldImage is the published component the http-serving sample
+// manifests (config/samples) reference. On the all-features leg the suite serves
+// an equivalent in-tree fixture (http-handler-p2) from the in-cluster registry
+// instead; other legs keep pulling this published ref.
+const httpHelloWorldImage = "ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0"
+
+// httpWorkloadImage is the image the http-serving specs deploy: the in-cluster
+// http-handler-p2 fixture on the all-features leg, else the published
+// http-hello-world component.
+func httpWorkloadImage() string {
+	if inClusterRegistry {
+		return registryRef("http-handler-p2")
+	}
+	return httpHelloWorldImage
+}
+
+// rewriteWorkloadImages swaps the published http image in a sample manifest for
+// its in-cluster registry equivalent when the registry flow is active; a no-op
+// otherwise (the release/canary legs deploy the published component as-is).
+func rewriteWorkloadImages(manifest string) string {
+	if !inClusterRegistry {
+		return manifest
+	}
+	return strings.ReplaceAll(manifest, httpHelloWorldImage, registryRef("http-handler-p2"))
+}
+
 // verifyWorkloadDeploy applies a WorkloadDeployment manifest and verifies the
 // deployment becomes ready, along with its ReplicaSet and Workload CRs.
 // deploymentName is the metadata.name of the WorkloadDeployment in the sample
@@ -970,8 +1015,14 @@ spec:
 // with `-n ns` regardless of any metadata.namespace it carries.
 func verifyWorkloadDeploy(sampleDeployment, deploymentName, ns string) {
 	By("applying the sample WorkloadDeployment")
-	cmd := exec.Command("kubectl", "apply", "-n", ns, "-f", sampleDeployment)
-	_, err := utils.Run(cmd)
+	// Rewrite any published workload image to its in-cluster registry
+	// equivalent so the (insecure) hostgroups pull from the registry rather
+	// than ghcr. No-op for manifests already built with registryRef.
+	manifest, err := os.ReadFile(sampleDeployment)
+	Expect(err).NotTo(HaveOccurred())
+	cmd := exec.Command("kubectl", "apply", "-n", ns, "-f", "-")
+	cmd.Stdin = strings.NewReader(rewriteWorkloadImages(string(manifest)))
+	_, err = utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("waiting for WorkloadDeployment to become Ready")

--- a/runtime-operator/test/e2e/e2e_test.go
+++ b/runtime-operator/test/e2e/e2e_test.go
@@ -253,11 +253,7 @@ var _ = Describe("Manager", Ordered, func() {
 
 			By("waiting for Workload CRs to be cleaned up")
 			verifyCleanup := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "workloads.runtime.wasmcloud.dev",
-					"-n", namespace, "-o", "jsonpath={.items}")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("[]"))
+				expectNoTestWorkloads(g, namespace)
 			}
 			Eventually(verifyCleanup).WithTimeout(1 * time.Minute).Should(Succeed())
 		})
@@ -354,11 +350,7 @@ var _ = Describe("Manager", Ordered, func() {
 
 			By("waiting for Workload CRs to be cleaned up")
 			verifyCleanup := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "workloads.runtime.wasmcloud.dev",
-					"-n", namespace, "-o", "jsonpath={.items}")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("[]"))
+				expectNoTestWorkloads(g, namespace)
 			}
 			Eventually(verifyCleanup).WithTimeout(1 * time.Minute).Should(Succeed())
 		})
@@ -1005,6 +997,27 @@ func rewriteWorkloadImages(manifest string) string {
 		return manifest
 	}
 	return strings.ReplaceAll(manifest, httpHelloWorldImage, registryRef("http-handler-p2"))
+}
+
+// expectNoTestWorkloads asserts that no Workload CRs remain in ns once the
+// in-cluster oci-registry infrastructure workload is excluded. The registry runs
+// as a long-lived Workload in this namespace for the whole suite (serving every
+// fixture image), so a bare "the items list is empty" check no longer holds on
+// the legs that run it. When the registry flow is off, nothing is filtered and
+// this is equivalent to asserting the list is empty.
+func expectNoTestWorkloads(g Gomega, ns string) {
+	cmd := exec.Command("kubectl", "get", "workloads.runtime.wasmcloud.dev",
+		"-n", ns, "-o", "jsonpath={.items[*].metadata.name}")
+	output, err := utils.Run(cmd)
+	g.Expect(err).NotTo(HaveOccurred())
+	var remaining []string
+	for _, name := range strings.Fields(output) {
+		if strings.HasPrefix(name, "oci-registry") {
+			continue
+		}
+		remaining = append(remaining, name)
+	}
+	g.Expect(remaining).To(BeEmpty(), "test Workload CRs were not cleaned up")
 }
 
 // verifyWorkloadDeploy applies a WorkloadDeployment manifest and verifies the

--- a/runtime-operator/test/e2e/implements_test.go
+++ b/runtime-operator/test/e2e/implements_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -36,23 +35,30 @@ import (
 // api/runtime/v1alpha1/workload_types_test.go, and envtest (`make test`)
 // validates the CEL rules against a live apiserver.
 //
-// To run this spec, set IMPLEMENTS_E2E_IMAGE to an OCI ref the cluster can pull
-// for a component that exports wasi:http/incoming-handler and imports
-// wasi:keyvalue/store twice under the labels `team-a` and `team-b` (build from
-// crates/wash-runtime/tests/fixtures/keyvalue-implements). Excluded from
-// `make test` (which skips ./test/e2e); runs in the dedicated `make test-e2e`
-// job, which sets IMPLEMENTS_E2E_IMAGE, and skips when that's unset.
+// The component under test is the keyvalue-implements fixture
+// (crates/wash-runtime/tests/fixtures/keyvalue-implements): it exports
+// wasi:http/incoming-handler and imports wasi:keyvalue/store twice under the
+// labels `team-a` and `team-b`. Like every e2e fixture it is built and served
+// from the in-cluster registry (make e2e-images), so this spec runs only when
+// that flow is enabled (the all-features leg — also the only host with
+// `(implements ..)` support) and self-skips otherwise. Excluded from `make test`
+// (which skips ./test/e2e); runs in the dedicated `make test-e2e` job.
 var _ = Describe("Implements Named Host Interfaces", Ordered, func() {
 	const workloadName = "keyvalue-implements"
 
 	var componentImage string
 
 	BeforeAll(func() {
-		componentImage = os.Getenv("IMPLEMENTS_E2E_IMAGE")
-		if componentImage == "" {
-			Skip("IMPLEMENTS_E2E_IMAGE not set; skipping implements e2e " +
-				"(see runtime-operator/test/e2e/implements_test.go for setup)")
+		// The keyvalue-implements fixture is built and served from the in-cluster
+		// registry (make e2e-images), like every other e2e fixture. But unlike the
+		// others it needs a feature-enabled host to RUN (`(implements ..)`
+		// multiplexing), so it runs only when the registry flow is on AND the
+		// fixture host is an all-features build — i.e. the all-features leg.
+		if !inClusterRegistry || !defaultHostAllFeatures {
+			Skip("skipping implements e2e (needs the in-cluster registry and an " +
+				"all-features fixture host)")
 		}
+		componentImage = registryRef("keyvalue-implements")
 
 		// Scale a hostgroup pod up and wait for a Host CR so workload placement
 		// is independent of spec ordering (see messaging_test.go for the
@@ -133,6 +139,10 @@ spec:
   replicas: 1
   template:
     spec:
+      # Pin to the insecure default hostgroup; the registry hostgroup stays on
+      # HTTPS and can't pull this fixture from the in-cluster (plain-HTTP) registry.
+      hostSelector:
+        hostgroup: default
       hostInterfaces:
         - namespace: wasi
           package: http

--- a/runtime-operator/test/e2e/messaging_test.go
+++ b/runtime-operator/test/e2e/messaging_test.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -35,17 +34,14 @@ import (
 // Before the fix, the WorkloadDeployment reached Ready=True but no SUB ever
 // landed on NATS, so requests on the configured subject silently timed out.
 //
-// To run this test fully, two pieces of infrastructure are required:
-//
-//  1. MESSAGING_E2E_IMAGE — an OCI ref the cluster can pull, pointing at a
-//     wasm component that exports wasmcloud:messaging/handler@0.2.0 and
-//     replies to incoming messages by publishing the body back on
-//     msg.reply_to. The fixture under
-//     crates/wash-runtime/tests/fixtures/messaging-handler does exactly that;
-//     publish it (e.g. `ghcr.io/wasmcloud/components/messaging-echo-rust:0.1.0`).
-//  2. BUILD_RUNTIME_IMAGE=true — builds the wash-runtime (host) image from
-//     the local tree so the host pod actually exercises the code under
-//     test. Without this the e2e runs against the published canary image.
+// The component under test is the messaging-handler fixture
+// (crates/wash-runtime/tests/fixtures/messaging-handler): it exports
+// wasmcloud:messaging/handler@0.2.0 and replies to incoming messages by
+// publishing the body back on msg.reply_to. Like every e2e fixture it is built
+// and served from the in-cluster registry (make e2e-images) rather than a
+// published image; it runs on any host, so it runs on both wash.yml legs (the
+// release and all-features fixture hosts) and self-skips only where the registry
+// flow is off.
 //
 // On failure, the spec dumps hostgroup pod logs (with RUST_LOG bumped to
 // debug for `wash_runtime`) so the NatsMessaging plugin's instrumentation
@@ -57,11 +53,15 @@ var _ = Describe("Messaging Subscription", Ordered, func() {
 	var componentImage string
 
 	BeforeAll(func() {
-		componentImage = os.Getenv("MESSAGING_E2E_IMAGE")
-		if componentImage == "" {
-			Skip("MESSAGING_E2E_IMAGE not set; skipping messaging e2e " +
-				"(see runtime-operator/test/e2e/messaging_test.go for setup)")
+		// The messaging-handler fixture is built and served from the in-cluster
+		// registry (make e2e-images), like every other e2e fixture, and it runs on
+		// any host — so this spec runs on both wash.yml legs (the release and
+		// all-features fixture hosts both pull it from the registry). It self-skips
+		// only where the registry flow is off (the canary job, plain local runs).
+		if !inClusterRegistry {
+			Skip("in-cluster registry disabled; skipping messaging e2e")
 		}
+		componentImage = registryRef("messaging-handler")
 
 		// Earlier specs (Finalizer) may have scaled the hostgroup to zero;
 		// scale back up and wait for a host to be Ready so this spec is
@@ -171,6 +171,10 @@ spec:
   replicas: 1
   template:
     spec:
+      # Pin to the insecure default hostgroup; the registry hostgroup stays on
+      # HTTPS and can't pull this fixture from the in-cluster (plain-HTTP) registry.
+      hostSelector:
+        hostgroup: default
       hostInterfaces:
         - namespace: wasmcloud
           package: messaging

--- a/runtime-operator/test/e2e/messaging_test.go
+++ b/runtime-operator/test/e2e/messaging_test.go
@@ -34,8 +34,8 @@ import (
 // Before the fix, the WorkloadDeployment reached Ready=True but no SUB ever
 // landed on NATS, so requests on the configured subject silently timed out.
 //
-// The component under test is the messaging-handler fixture
-// (crates/wash-runtime/tests/fixtures/messaging-handler): it exports
+// The component under test is the messaging-echo fixture
+// (crates/wash-runtime/tests/fixtures/messaging-echo): it exports
 // wasmcloud:messaging/handler@0.2.0 and replies to incoming messages by
 // publishing the body back on msg.reply_to. Like every e2e fixture it is built
 // and served from the in-cluster registry (make e2e-images) rather than a
@@ -53,7 +53,7 @@ var _ = Describe("Messaging Subscription", Ordered, func() {
 	var componentImage string
 
 	BeforeAll(func() {
-		// The messaging-handler fixture is built and served from the in-cluster
+		// The messaging-echo fixture is built and served from the in-cluster
 		// registry (make e2e-images), like every other e2e fixture, and it runs on
 		// any host — so this spec runs on both wash.yml legs (the release and
 		// all-features fixture hosts both pull it from the registry). It self-skips
@@ -61,7 +61,7 @@ var _ = Describe("Messaging Subscription", Ordered, func() {
 		if !inClusterRegistry {
 			Skip("in-cluster registry disabled; skipping messaging e2e")
 		}
-		componentImage = registryRef("messaging-handler")
+		componentImage = registryRef("messaging-echo")
 
 		// Earlier specs (Finalizer) may have scaled the hostgroup to zero;
 		// scale back up and wait for a host to be Ready so this spec is
@@ -183,14 +183,6 @@ spec:
             - handler
           config:
             subscriptions: "%s"
-        # The messaging-handler fixture also imports wasi:logging; declare it so
-        # the host binds the logging plugin, otherwise the component fails to
-        # instantiate with "wasi:logging/logging import not satisfied".
-        - namespace: wasi
-          package: logging
-          version: "0.1.0-draft"
-          interfaces:
-            - logging
       components:
         - name: messaging-echo
           image: %s

--- a/runtime-operator/test/e2e/messaging_test.go
+++ b/runtime-operator/test/e2e/messaging_test.go
@@ -183,6 +183,14 @@ spec:
             - handler
           config:
             subscriptions: "%s"
+        # The messaging-handler fixture also imports wasi:logging; declare it so
+        # the host binds the logging plugin, otherwise the component fails to
+        # instantiate with "wasi:logging/logging import not satisfied".
+        - namespace: wasi
+          package: logging
+          version: "0.1.0-draft"
+          interfaces:
+            - logging
       components:
         - name: messaging-echo
           image: %s

--- a/runtime-operator/test/e2e/testdata/oci-registry.yaml
+++ b/runtime-operator/test/e2e/testdata/oci-registry.yaml
@@ -1,0 +1,71 @@
+# In-cluster OCI registry for the e2e suite.
+#
+# The `oci-registry` example component (a spec-compliant OCI v2 registry that
+# stores through wasmcloud:blobstore) runs as a WorkloadDeployment on the
+# `registry` hostgroup — the one hostgroup left on HTTPS so it can pull this
+# component from ghcr. Every other e2e fixture is then built locally and pushed
+# into this registry, and the insecure `default` hostgroup pulls them back over
+# plain HTTP. See runtime-operator/test/e2e/README or the `e2e-images` Make
+# target for the surrounding flow.
+#
+# Reachability: the host's HTTP server demuxes by an exact-match Host header and
+# rejects any hostname containing a port, so the registry must answer on port 80
+# (clients omit the default port) and every authority a client uses must be
+# registered as `host`/`host-aliases`:
+#   - pull (in-cluster host): oci-registry.wasmcloud-system.svc
+#   - push (CI runner / dev):  127.0.0.2  (the Make target port-forwards here)
+# The operator only injects Service-DNS aliases for p2 `incoming-handler`, so a
+# p3 `handler` interface keeps exactly the aliases set below.
+#
+# TODO(wash release): the port-80 requirement + the 127.0.0.2 push alias exist
+# only because the host router matches the Host header exactly and rejects a
+# host carrying a port. Once the router matches host-without-port, this can serve
+# on a normal port and drop the extra push alias.
+apiVersion: v1
+kind: Service
+metadata:
+  name: oci-registry
+  namespace: wasmcloud-system
+spec:
+  # No selector: the operator maintains the route EndpointSlice pointing at the
+  # registry hostgroup pod (keyed on this Service name). port 80 -> the host's
+  # HTTP port (the registry hostgroup runs http.port=80).
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+---
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: oci-registry
+  namespace: wasmcloud-system
+spec:
+  replicas: 1
+  kubernetes:
+    service:
+      name: oci-registry
+  template:
+    spec:
+      hostSelector:
+        hostgroup: registry
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          version: "0.3.0"
+          interfaces:
+            - handler
+          config:
+            host: oci-registry
+            host-aliases: oci-registry.wasmcloud-system,oci-registry.wasmcloud-system.svc,127.0.0.2
+        - namespace: wasmcloud
+          package: blobstore
+          version: "0.1.0"
+          interfaces:
+            - blobstore
+          config:
+            backend: in-memory
+      components:
+        - name: oci-registry
+          image: ghcr.io/wasmcloud/components/oci-registry:0.1.0

--- a/xtask/src/e2e_images.rs
+++ b/xtask/src/e2e_images.rs
@@ -37,11 +37,7 @@ use anyhow::{Context, Result, bail};
 /// and push. Each is a wasm32-wasip2 cdylib served at
 /// <registry>/fixtures/<name>:e2e. To add a fixture: drop a wash-buildable dir,
 /// add a row here, and reference `registryRef("<name>")` in a spec.
-const FIXTURES: &[&str] = &[
-    "messaging-handler",
-    "keyvalue-implements",
-    "http-handler-p2",
-];
+const FIXTURES: &[&str] = &["messaging-echo", "keyvalue-implements", "http-handler-p2"];
 
 /// Fixed so it always matches the pull side (registryImageTag in
 /// e2e_suite_test.go) — the two have no shared source, so this isn't a knob.

--- a/xtask/src/e2e_images.rs
+++ b/xtask/src/e2e_images.rs
@@ -1,0 +1,367 @@
+//! `cargo xtask e2e-images`: build the e2e fixture components, deploy the
+//! in-cluster oci-registry, and push the fixtures into it.
+//!
+//! The runtime-operator e2e suite invokes this from BeforeSuite after
+//! `helm install` brings up the `registry` and `default` hostgroups; it can
+//! also be run standalone against an installed cluster.
+//!
+//! `E2E_IMAGES_MODE` selects which phases run:
+//!   all   (default) build the fixtures, then deploy the registry and push — the
+//!                   self-contained local path.
+//!   build           only build the fixture components (no cluster). A CI job
+//!                   runs this and uploads the results so the e2e leg can reuse
+//!                   them without rebuilding.
+//!   push            skip the build; deploy the registry and push fixtures that
+//!                   were already built (read from `E2E_FIXTURES_DIR`).
+//!
+//! `E2E_FIXTURES_DIR` (optional): a flat directory of prebuilt `<name>.wasm`
+//! components plus the `wash` binary. `build` stages the outputs here; `push`
+//! reads them from here instead of rebuilding.
+//!
+//! Reachability: the specs pull the same content from the in-cluster Service DNS
+//! (`oci-registry.wasmcloud-system.svc`) — a different authority than the push
+//! side, which is fine (OCI stores by repo path + tag, not by hostname). See
+//! runtime-operator/test/e2e/testdata/oci-registry.yaml for why both authorities
+//! must be portless.
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread::sleep;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+
+/// The fixture directories (under crates/wash-runtime/tests/fixtures) to build
+/// and push. Each is a wasm32-wasip2 cdylib served at
+/// <registry>/fixtures/<name>:e2e. To add a fixture: drop a wash-buildable dir,
+/// add a row here, and reference `registryRef("<name>")` in a spec.
+const FIXTURES: &[&str] = &[
+    "messaging-handler",
+    "keyvalue-implements",
+    "http-handler-p2",
+];
+
+/// Fixed so it always matches the pull side (registryImageTag in
+/// e2e_suite_test.go) — the two have no shared source, so this isn't a knob.
+const TAG: &str = "e2e";
+
+/// Dedicated loopback so the port-forward doesn't clash with kind's :80 mapping
+/// (pinned to 127.0.0.1 in deploy/kind/kind-config.yaml). :80 keeps the Host
+/// header portless so the host's exact-match router accepts it.
+const PUSH_ADDR: &str = "127.0.0.2";
+
+#[derive(Copy, Clone, PartialEq)]
+enum Mode {
+    Build,
+    Push,
+    All,
+}
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let mode = match env::var("E2E_IMAGES_MODE").as_deref().unwrap_or("all") {
+        "build" => Mode::Build,
+        "push" => Mode::Push,
+        "all" => Mode::All,
+        other => bail!("invalid E2E_IMAGES_MODE={other} (want build|push|all)"),
+    };
+    let fixtures_dir = workspace.join("crates/wash-runtime/tests/fixtures");
+    let namespace = env::var("NAMESPACE").unwrap_or_else(|_| "wasmcloud-system".to_string());
+    let fixtures_out = env::var("E2E_FIXTURES_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from);
+
+    // The wash used to build/push. In `all` mode the build phase resolves it and
+    // the push phase reuses it.
+    let mut wash: Option<PathBuf> = None;
+
+    if mode != Mode::Push {
+        wash = Some(build_phase(
+            workspace,
+            &fixtures_dir,
+            fixtures_out.as_deref(),
+        )?);
+        if mode == Mode::Build {
+            eprintln!(">>> e2e-images: built {} fixtures", FIXTURES.len());
+            return Ok(());
+        }
+    }
+
+    let wash = match wash {
+        Some(w) => w,
+        None => push_wash(fixtures_out.as_deref())?,
+    };
+    push_phase(
+        workspace,
+        &fixtures_dir,
+        &namespace,
+        &wash,
+        mode,
+        fixtures_out.as_deref(),
+    )
+}
+
+/// Build the in-repo wash and each fixture; when E2E_FIXTURES_DIR is set, stage
+/// the wash binary + built components there (for a CI job to upload).
+fn build_phase(
+    workspace: &Path,
+    fixtures_dir: &Path,
+    fixtures_out: Option<&Path>,
+) -> Result<PathBuf> {
+    let wash = build_wash(workspace)?;
+
+    if let Some(out) = fixtures_out {
+        fs::create_dir_all(out).with_context(|| format!("creating {}", out.display()))?;
+        // Stage the wash we built so the push side (a separate CI job) reuses
+        // this exact binary rather than a released wash.
+        fs::copy(&wash, out.join("wash")).context("staging wash")?;
+    }
+
+    for fixture in FIXTURES {
+        eprintln!(">>> e2e-images: wash build {fixture}");
+        wash_build(&wash, &fixtures_dir.join(fixture))
+            .with_context(|| format!("wash build {fixture}"))?;
+        if let Some(out) = fixtures_out {
+            let built = built_component(fixtures_dir, fixture)?;
+            fs::copy(&built, out.join(component_name(fixture)))
+                .with_context(|| format!("staging {fixture}"))?;
+        }
+    }
+    Ok(wash)
+}
+
+/// Deploy the registry, wait until it serves, port-forward it on a loopback,
+/// and push every fixture.
+fn push_phase(
+    workspace: &Path,
+    fixtures_dir: &Path,
+    namespace: &str,
+    wash: &Path,
+    mode: Mode,
+    fixtures_out: Option<&Path>,
+) -> Result<()> {
+    let manifest = workspace.join("runtime-operator/test/e2e/testdata/oci-registry.yaml");
+    // Resolve the kubeconfig up front so the sudo'd port-forward (root, different
+    // HOME) still targets this cluster.
+    let kubeconfig = env::var("KUBECONFIG")
+        .unwrap_or_else(|_| format!("{}/.kube/config", env::var("HOME").unwrap_or_default()));
+
+    eprintln!(">>> e2e-images: deploying oci-registry");
+    kubectl(&kubeconfig, &["apply", "-f", &manifest.to_string_lossy()])?;
+    kubectl(
+        &kubeconfig,
+        &[
+            "wait",
+            "--for=condition=Ready",
+            "--timeout=5m",
+            "-n",
+            namespace,
+            "workloaddeployment/oci-registry",
+        ],
+    )?;
+
+    // macOS only creates 127.0.0.1 by default; alias the loopback we forward to.
+    #[cfg(target_os = "macos")]
+    {
+        let _ = Command::new("sudo")
+            .args(["ifconfig", "lo0", "alias", PUSH_ADDR, "up"])
+            .status();
+    }
+
+    eprintln!(">>> e2e-images: port-forwarding deployment/hostgroup-registry -> {PUSH_ADDR}:80");
+    let _pf = PortForward::start(&kubeconfig, namespace)?;
+    wait_for_registry()?;
+
+    for fixture in FIXTURES {
+        let component = match (mode, fixtures_out) {
+            (Mode::Push, Some(out)) => out.join(component_name(fixture)),
+            _ => built_component(fixtures_dir, fixture)?,
+        };
+        let reference = format!("{PUSH_ADDR}/fixtures/{fixture}:{TAG}");
+        eprintln!(">>> e2e-images: wash oci push {reference}");
+        run_checked(
+            Command::new(wash).args([
+                "oci",
+                "push",
+                "--insecure",
+                &reference,
+                &component.to_string_lossy(),
+            ]),
+            "wash oci push",
+        )?;
+    }
+
+    eprintln!(">>> e2e-images: pushed {} fixtures", FIXTURES.len());
+    Ok(())
+}
+
+/// The in-repo wash to build fixtures with. WASH overrides it; otherwise build
+/// it debug (matches `cargo xtask build-fixtures`; the released wash can't build
+/// fixtures from their local wkg.toml refs).
+///
+/// TODO(wash release): once a released wash can `wash build` these fixtures from
+/// their local wkg.toml refs, use it (setup-wash-action) and drop this build +
+/// the wash staging + the protoc/setup-rust the e2e-fixtures job carries for it.
+fn build_wash(workspace: &Path) -> Result<PathBuf> {
+    if let Some(w) = env::var("WASH").ok().filter(|s| !s.is_empty()) {
+        return Ok(PathBuf::from(w));
+    }
+    // Reuse the shared resolver so this honors CARGO_TARGET_DIR (and reuses an
+    // existing build) exactly like `cargo xtask build-fixtures`.
+    crate::ensure_wash(workspace)
+}
+
+/// The wash to push with (push-only mode). Prefer the staged in-repo wash in
+/// E2E_FIXTURES_DIR (downloaded from the build job), then WASH, then PATH.
+fn push_wash(fixtures_out: Option<&Path>) -> Result<PathBuf> {
+    if let Some(w) = env::var("WASH").ok().filter(|s| !s.is_empty()) {
+        return Ok(PathBuf::from(w));
+    }
+    if let Some(out) = fixtures_out {
+        let staged = out.join("wash");
+        if staged.is_file() {
+            // Artifact download can drop the exec bit; restore it.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = fs::metadata(&staged)?.permissions();
+                perms.set_mode(0o755);
+                fs::set_permissions(&staged, perms)?;
+            }
+            return Ok(staged);
+        }
+    }
+    // Fall back to a wash on PATH (a released wash can push).
+    Ok(PathBuf::from("wash"))
+}
+
+fn wash_build(wash: &Path, fixture_dir: &Path) -> Result<()> {
+    if !fixture_dir.exists() {
+        bail!("fixture directory {} does not exist", fixture_dir.display());
+    }
+    run_checked(
+        Command::new(wash)
+            .args(["-C", &fixture_dir.to_string_lossy(), "build"])
+            // The bench hosts set a job-wide CARGO_TARGET_DIR; drop it so the
+            // nested build lands in fixtures/target, where the component lookup
+            // below expects it.
+            .env_remove("CARGO_TARGET_DIR"),
+        "wash build",
+    )
+}
+
+/// The built component filename: the wasm32-wasip2 cdylib underscore name.
+fn component_name(fixture: &str) -> String {
+    format!("{}.wasm", fixture.replace('-', "_"))
+}
+
+/// The built component path for a fixture (all e2e fixtures are wasm32-wasip2).
+fn built_component(fixtures_dir: &Path, fixture: &str) -> Result<PathBuf> {
+    let path = fixtures_dir
+        .join("target/wasm32-wasip2/release")
+        .join(component_name(fixture));
+    if !path.exists() {
+        bail!("no wasm artifact for {fixture} at {}", path.display());
+    }
+    Ok(path)
+}
+
+fn kubectl(kubeconfig: &str, args: &[&str]) -> Result<()> {
+    run_checked(
+        Command::new("kubectl")
+            .arg("--kubeconfig")
+            .arg(kubeconfig)
+            .args(args),
+        "kubectl",
+    )
+}
+
+fn run_checked(cmd: &mut Command, what: &str) -> Result<()> {
+    let status = cmd
+        .status()
+        .with_context(|| format!("failed to run {what}"))?;
+    if !status.success() {
+        bail!("{what} failed with {status}");
+    }
+    Ok(())
+}
+
+/// Wait until the registry answers `/v2/` through the port-forward.
+fn wait_for_registry() -> Result<()> {
+    let url = format!("http://{PUSH_ADDR}/v2/");
+    eprintln!(">>> e2e-images: waiting for the registry API on {url}");
+    for attempt in 1..=30 {
+        let ok = Command::new("curl")
+            .args(["-fsS", &url])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            return Ok(());
+        }
+        if attempt == 30 {
+            bail!("registry never answered /v2/ through the port-forward");
+        }
+        sleep(Duration::from_secs(2));
+    }
+    Ok(())
+}
+
+/// A `sudo kubectl port-forward` running in the background, killed on drop.
+///
+/// Forwards to the registry hostgroup pod (via its Deployment), not the Service:
+/// the oci-registry Service is selectorless (the operator manages its route
+/// EndpointSlice), so `kubectl port-forward svc/...` can't resolve a target pod.
+/// The pod's HTTP server demuxes by Host header, and PUSH_ADDR (:80, portless)
+/// is a registered alias, so this reaches the registry all the same. The Service
+/// remains the in-cluster pull path.
+///
+/// TODO(wash release): the :80 + dedicated-loopback + sudo dance exists only
+/// because the host's HTTP router matches the Host header exactly and rejects a
+/// host that carries a port. Once the host matches on host-without-port (or the
+/// registry gets ingress that isn't Host-demuxed), forward a normal Service port
+/// and drop the loopback + sudo.
+struct PortForward {
+    child: Child,
+}
+
+impl PortForward {
+    fn start(kubeconfig: &str, namespace: &str) -> Result<Self> {
+        let child = Command::new("sudo")
+            .args([
+                "kubectl",
+                "--kubeconfig",
+                kubeconfig,
+                "port-forward",
+                "--address",
+                PUSH_ADDR,
+                "-n",
+                namespace,
+                "deployment/hostgroup-registry",
+                "80:80",
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("starting kubectl port-forward (needs sudo to bind :80)")?;
+        Ok(Self { child })
+    }
+}
+
+impl Drop for PortForward {
+    fn drop(&mut self) {
+        // $! is the sudo pid; sudo relays SIGTERM to kubectl. pkill is a backstop
+        // in case it doesn't.
+        let _ = Command::new("sudo")
+            .args(["kill", &self.child.id().to_string()])
+            .status();
+        let _ = Command::new("sudo")
+            .args(["pkill", "-f", "port-forward.*hostgroup-registry"])
+            .status();
+        let _ = self.child.wait();
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,8 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 
+mod e2e_images;
+
 #[derive(Parser)]
 #[command(name = "xtask", about = "wasmCloud workspace tasks", version)]
 struct Cli {
@@ -25,6 +27,10 @@ enum Task {
     /// Build the wash-runtime wasm test fixtures into
     /// `crates/wash-runtime/tests/wasm/`.
     BuildFixtures,
+    /// Build the runtime-operator e2e fixture components, deploy the in-cluster
+    /// oci-registry, and push the fixtures into it. Configured via env
+    /// (E2E_IMAGES_MODE, E2E_FIXTURES_DIR); see the e2e_images module.
+    E2eImages,
 }
 
 fn main() -> Result<()> {
@@ -32,6 +38,7 @@ fn main() -> Result<()> {
     let workspace = workspace_dir().context("failed to locate workspace root")?;
     match cli.task {
         Task::BuildFixtures => build_fixtures(&workspace),
+        Task::E2eImages => e2e_images::run(&workspace),
     }
 }
 
@@ -146,7 +153,7 @@ fn build_fixtures(workspace: &Path) -> Result<()> {
 /// each fixture's WIT deps from its `wkg.toml` local file refs, runs its
 /// `cargo build`, and wraps a wasip1 core module into a component. Build `wash`
 /// if no compiled copy is present.
-fn ensure_wash(workspace: &Path) -> Result<PathBuf> {
+pub(crate) fn ensure_wash(workspace: &Path) -> Result<PathBuf> {
     // `cargo build -p wash` writes under CARGO_TARGET_DIR when the environment
     // sets one (the bench hosts point it outside the workspace so the cargo
     // cache survives `actions/checkout --clean`), and under `<workspace>/target`


### PR DESCRIPTION
The operator e2e referenced component images that had to already exist in a
pullable registry: http-hello-world was hardcoded to ghcr, and the
messaging/implements specs skipped unless a human first built the fixture and
published it out of band.

Build the fixtures in CI (and locally) and serve them from an in-cluster OCI
registry using our own examples/oci-registry wasm component so the run also
exercises the registry end-to-end. Adding a fixture is now declarative: a
wash-buildable dir, one row in the e2e-images xtask, and a registryRef() in a
spec; no out-of-band publish. This has the additional benefit of not needing
to rely on often flakey ghcr.io for our tests.

The registry runs as a WorkloadDeployment on a dedicated all-features `registry`
hostgroup (it imports the async wasmcloud:blobstore plugin, which is
feature-gated) and bootstraps itself from ghcr. This is the only image left there.
`cargo xtask e2e-images` builds the fixtures with the in-repo wash, deploys the
registry, and pushes the fixtures over an insecure loopback port-forward; the
fixture hostgroups run insecure and pull from the registry over plain HTTP.

Both wash.yml operator-e2e legs now stand up a registry. The release leg runs
the shipped default-features host as the fixture host.

Supporting changes:
- chart: per-hostgroup `hostGroups[].image` override (falls back to
  runtime.image) so one release can mix host versions.
- swap the published http-hello-world for the in-tree http-handler-p2 fixture.
- kind-config: pin the :80 mapping to 127.0.0.1 to free 127.0.0.2:80 for the
  push port-forward.
- narrow the Finalizer spec's scale-to-zero to the default hostgroup so the
  in-memory registry survives.
