### PR TITLE
ci(wit): move pinned tool versions out of wit.yml

### DIFF
--- a/.github/scripts/bump-wit-tools.mjs
+++ b/.github/scripts/bump-wit-tools.mjs
@@ -1,17 +1,21 @@
 #!/usr/bin/env node
-// Bumps the wit pipeline's pinned tool versions in wit.yml to upstream's
-// latest stable GitHub releases. Driven by wit-tools-bump.yml.
+// Bumps the wit pipeline's pinned tool versions to upstream's latest stable
+// GitHub releases. Driven by wit-tools-bump.yml.
 //
-// Each tracked tool has a `<VAR>: '<bare-semver>'` line in wit.yml's
-// workflow-level env: block. For each, this resolves the latest
+// Each tracked tool has a `<VAR>=<bare-semver>` line in
+// .github/wit-tools-versions.env. For each, this resolves the latest
 // non-prerelease, non-draft release and rewrites the pin in place.
+//
+// The pins live in that .env file rather than wit.yml because the bump
+// workflow pushes with the default GITHUB_TOKEN, which GitHub forbids from
+// updating files under .github/workflows/.
 //
 // Tracked tools:
 //   WASM_TOOLS_VERSION ← bytecodealliance/wasm-tools
 //
-// Usage: node bump-wit-tools.mjs [path-to-wit.yml]
-//   Defaults to .github/workflows/wit.yml; the optional arg exists so the
-//   script can be exercised against a copy without touching the real file.
+// Usage: node bump-wit-tools.mjs [path-to-versions.env]
+//   Defaults to .github/wit-tools-versions.env; the optional arg exists so
+//   the script can be exercised against a copy without touching the real file.
 //
 // Env:
 //   GH_TOKEN / GITHUB_TOKEN   optional; raises the GitHub API rate limit.
@@ -55,14 +59,14 @@ async function latestVersion(repo, token) {
   return tag.replace(/^v/, '');
 }
 
-// The regex is anchored to the two-space indent that the workflow-level
-// env: block uses; if that indent changes, this extractor must change too.
+// Matches a `NAME=<value>` pin line in the versions .env file. The value
+// runs to end-of-line (no quotes); if the file format changes, update this.
 function pinRe(name) {
-  return new RegExp(`^(  ${name}: ')([^']+)(')`, 'm');
+  return new RegExp(`^(${name}=)(\\S+)$`, 'm');
 }
 
 async function main() {
-  const file = process.argv[2] ?? '.github/workflows/wit.yml';
+  const file = process.argv[2] ?? '.github/wit-tools-versions.env';
 
   const githubOutput = process.env.GITHUB_OUTPUT;
   if (!githubOutput) {
@@ -88,7 +92,7 @@ async function main() {
       console.log(`${tool.name} is already at ${latest} — nothing to do`);
       continue;
     }
-    content = content.replace(re, `$1${latest}$3`);
+    content = content.replace(re, `$1${latest}`);
     bumps.push(
       `- ${tool.name} \`${current}\` → \`${latest}\` ` +
         `([release notes](https://github.com/${tool.repo}/releases/tag/v${latest}))`,

--- a/.github/wit-tools-versions.env
+++ b/.github/wit-tools-versions.env
@@ -1,0 +1,14 @@
+# Pinned wit-pipeline tool versions. Bare semver (no leading `v`).
+#
+# Lives outside .github/workflows/ on purpose: wit-tools-bump.yml pushes
+# updates to this file with the default GITHUB_TOKEN, and GitHub refuses to
+# let that token create or update files under .github/workflows/ (there is
+# no `workflows` permission grantable to GITHUB_TOKEN). Keeping the pins
+# here lets the weekly bump PR push without a PAT or GitHub App token.
+#
+# Consumed by .github/workflows/wit.yml, which appends the KEY=VALUE lines
+# below to $GITHUB_ENV. Kept in sync by .github/workflows/wit-tools-bump.yml.
+#
+# Format: KEY=VALUE, one per line (no quotes, no inline comments), so the
+# non-comment lines drop straight into $GITHUB_ENV.
+WASM_TOOLS_VERSION=1.252.0

--- a/.github/workflows/wit-tools-bump.yml
+++ b/.github/workflows/wit-tools-bump.yml
@@ -1,7 +1,7 @@
 name: wit-tools-bump
 
 # Opens a PR when bytecodealliance/wasm-tools publishes a new stable GitHub
-# release. The pinned version lives in wit.yml's top-level `env:` block.
+# release. The pinned version lives in .github/wit-tools-versions.env.
 #
 # Why this exists: Dependabot's `github-actions` ecosystem tracks `uses:`
 # refs (the action SHA), not arbitrary `with:` inputs or versions fetched

--- a/.github/workflows/wit.yml
+++ b/.github/workflows/wit.yml
@@ -43,6 +43,7 @@ on:
     # users always see a result.
     paths:
       - '.github/workflows/wit.yml'
+      - '.github/wit-tools-versions.env'
       - 'wit/**'
 
 concurrency:
@@ -51,14 +52,12 @@ concurrency:
 
 permissions: {}
 
-# Pinned tool versions. Bare semver (no leading `v`).
-# Kept in sync by .github/workflows/wit-tools-bump.yml, which opens a
-# weekly PR when upstream publishes a new stable release.
+# Pinned tool versions live in .github/wit-tools-versions.env (outside
+# .github/workflows/ so wit-tools-bump.yml's GITHUB_TOKEN can push updates
+# to them). The validate job loads that file into $GITHUB_ENV below.
 #
 # wash itself is installed via wasmcloud/setup-wash-action (defaulting to
-# the latest release) and is not pinned here.
-env:
-  WASM_TOOLS_VERSION: '1.252.0'
+# the latest release) and is not pinned there.
 
 jobs:
   changes:
@@ -79,6 +78,7 @@ jobs:
           filters: |
             relevant:
               - '.github/workflows/wit.yml'
+              - '.github/wit-tools-versions.env'
               - 'wit/**'
 
   validate:
@@ -95,6 +95,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      - name: Load pinned tool versions
+        # Appends the KEY=VALUE lines from the pins file to $GITHUB_ENV,
+        # skipping comment and blank lines. Subsequent steps then see
+        # e.g. ${{ env.WASM_TOOLS_VERSION }}.
+        run: grep -vE '^[[:space:]]*(#|$)' .github/wit-tools-versions.env >> "${GITHUB_ENV}"
 
       - name: Setup wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3


### PR DESCRIPTION
wit-tools-bump.yml opens its weekly PR with the default GITHUB_TOKEN, but GitHub refuses to let a GitHub App token create or update files under .github/workflows/ (there is no `workflows` permission grantable to GITHUB_TOKEN). Because the WASM_TOOLS_VERSION pin lived in wit.yml's env: block, the bot's push was rejected:

    refusing to allow a GitHub App to create or update workflow
    `.github/workflows/wit.yml` without `workflows` permission

Move the pin into .github/wit-tools-versions.env (outside workflows/) so the bot only ever edits a non-workflow file:

- wit.yml loads the pins file into $GITHUB_ENV in the validate job and gains the file in its push paths + changes paths-filter so a bump PR still triggers validation.
- bump-wit-tools.mjs now edits the .env file (NAME=value) by default.
