### PR TITLE
Fix dropping span links and trace state in wasi-otel

### DIFF
--- a/crates/wash-runtime/src/plugin/wasi_otel/convert.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/convert.rs
@@ -2,7 +2,7 @@
 
 use opentelemetry::logs::{AnyValue, LogRecord as OtelLogRecord};
 use opentelemetry::trace::{
-    SpanContext, SpanId, SpanKind, Status, TraceContextExt, TraceFlags, TraceId, TraceState,
+    Link, SpanContext, SpanId, SpanKind, Status, TraceContextExt, TraceFlags, TraceId, TraceState,
 };
 use opentelemetry::{Context, Key, KeyValue};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -25,8 +25,26 @@ pub fn otel_span_context_to_wit(ctx: &SpanContext) -> WitSpanContext {
             WitTraceFlags::empty()
         },
         is_remote: ctx.is_remote(),
-        trace_state: vec![],
+        trace_state: otel_trace_state_to_wit(ctx.trace_state()),
     }
+}
+
+/// Convert an OTel `TraceState` into the WIT list-of-tuples representation.
+///
+/// `TraceState` exposes its entries only via the W3C header form
+/// (`key1=value1,key2=value2`), so we render that and split it back into pairs.
+fn otel_trace_state_to_wit(trace_state: &TraceState) -> Vec<(String, String)> {
+    let header = trace_state.header();
+    if header.is_empty() {
+        return vec![];
+    }
+    header
+        .split(',')
+        .filter_map(|entry| {
+            let (key, value) = entry.split_once('=')?;
+            Some((key.to_string(), value.to_string()))
+        })
+        .collect()
 }
 
 /// Converts a WASI OTEL LogRecord to populate an OpenTelemetry LogRecord
@@ -441,6 +459,20 @@ pub fn extract_span_events(
                 e.name.clone(),
                 convert_datetime(&e.time),
                 convert_key_values(&e.attributes),
+            )
+        })
+        .collect()
+}
+
+/// Extract span links, preserving each link's span context and attributes.
+pub fn extract_span_links(span: &wasi_tracing::SpanData) -> Vec<Link> {
+    span.links
+        .iter()
+        .map(|link| {
+            Link::new(
+                wit_span_context_to_otel(&link.span_context),
+                convert_key_values(&link.attributes),
+                0,
             )
         })
         .collect()

--- a/crates/wash-runtime/src/plugin/wasi_otel/convert.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/convert.rs
@@ -304,15 +304,20 @@ fn convert_key_values(attrs: &[super::bindings::wasi::otel::types::KeyValue]) ->
         .collect()
 }
 
+/// Convert WASI trace flags to OTel `TraceFlags`, preserving the sampled bit.
+fn wit_trace_flags_to_otel(flags: WitTraceFlags) -> TraceFlags {
+    if flags.contains(WitTraceFlags::SAMPLED) {
+        TraceFlags::SAMPLED
+    } else {
+        TraceFlags::default()
+    }
+}
+
 /// Convert WASI span context to OTel SpanContext
 pub fn wit_span_context_to_otel(ctx: &WitSpanContext) -> SpanContext {
     let trace_id = TraceId::from_hex(&ctx.trace_id).unwrap_or(TraceId::INVALID);
     let span_id = SpanId::from_hex(&ctx.span_id).unwrap_or(SpanId::INVALID);
-    let trace_flags = if ctx.trace_flags.contains(WitTraceFlags::SAMPLED) {
-        TraceFlags::SAMPLED
-    } else {
-        TraceFlags::default()
-    };
+    let trace_flags = wit_trace_flags_to_otel(ctx.trace_flags);
 
     // Convert trace state from list of tuples
     let trace_state = TraceState::from_key_value(
@@ -341,15 +346,7 @@ pub fn wasi_span_parent_context(span: &wasi_tracing::SpanData) -> Context {
     }
 
     let trace_id = TraceId::from_hex(&span.span_context.trace_id).unwrap_or(TraceId::INVALID);
-    let trace_flags = if span
-        .span_context
-        .trace_flags
-        .contains(WitTraceFlags::SAMPLED)
-    {
-        TraceFlags::SAMPLED
-    } else {
-        TraceFlags::default()
-    };
+    let trace_flags = wit_trace_flags_to_otel(span.span_context.trace_flags);
 
     let parent_span_context = SpanContext::new(
         trace_id,

--- a/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
@@ -7,8 +7,9 @@ mod convert;
 pub use convert::otel_span_context_to_wit;
 use convert::{
     convert_span_kind, convert_status, convert_wasi_log_record, extract_counter_values,
-    extract_gauge_values, extract_span_attributes, extract_span_events, summarize_resource_metrics,
-    summarize_span_data, wasi_span_parent_context, wit_span_context_to_otel,
+    extract_gauge_values, extract_span_attributes, extract_span_events, extract_span_links,
+    summarize_resource_metrics, summarize_span_data, wasi_span_parent_context,
+    wit_span_context_to_otel,
 };
 
 use anyhow::bail;
@@ -428,13 +429,15 @@ impl<'a> bindings::wasi::otel::tracing::Host for ActiveCtx<'a> {
                 let status = convert_status(&span_data.status);
                 let attributes = extract_span_attributes(&span_data);
                 let events = extract_span_events(&span_data);
+                let links = extract_span_links(&span_data);
 
                 // Create a span builder with the WASI span data
                 let mut builder = SpanBuilder::from_name(span_data.name.clone())
                     .with_trace_id(wasi_span_context.trace_id())
                     .with_span_id(wasi_span_context.span_id())
                     .with_kind(span_kind)
-                    .with_attributes(attributes);
+                    .with_attributes(attributes)
+                    .with_links(links);
 
                 // Set start time
                 builder = builder.with_start_time(summary.start_time);


### PR DESCRIPTION
Fix dropping span links and trace state in wasi-otel

on-end counted span_data.links into link_count but never attached them to the exported span, so guest-recorded links (producer/consumer correlation, fan-in batches) were lost. Build them into the SpanBuilder via with_links.

otel_span_context_to_wit hardcoded trace_state to an empty list, dropping W3C tracestate when the host hands its span context back to the guest over outer-span-context. Render the OTel TraceState and split it back into the WIT list-of-tuples form.