### PR TITLE
fix(wash-runtime): build stores under a read lock without cloning the linker

### DIFF
--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -348,68 +348,47 @@ async fn new_ephemeral_store(
     component_ids.dedup();
     resolve_component_volume_mounts_in_map(&call.components, &component_ids).await?;
 
-    let (active_metadata, linked_metadata) = {
-        let components = call.components.read().await;
-        let active = components
-            .get(&call.active_component_id)
-            .with_context(|| {
-                format!(
-                    "ephemeral linked component '{}' not found",
-                    call.active_component_id
-                )
-            })?
-            .metadata
-            .clone();
-        let linked = call
-            .linked_component_ids
-            .iter()
-            .map(|component_id| {
-                components
-                    .get(component_id)
-                    .with_context(|| format!("linked component '{component_id}' not found"))
-                    .map(|component| component.metadata.clone())
-            })
-            .collect::<wasmtime::Result<Vec<_>>>()?;
-        (active, linked)
+    // One read-lock scope, no `WorkloadMetadata` clones: cloning metadata would
+    // deep-clone its by-value `Linker`, and `pre_instantiate_ref` needs only
+    // read access, so concurrent ephemeral calls don't serialize on a write
+    // lock. Nothing is retained past this store.
+    #[cfg(feature = "wasi-tls")]
+    let template_of = |metadata: &WorkloadMetadata| {
+        component_ctx_template_from_metadata_with_tls(metadata, call.tls_provider.clone())
     };
-
     #[cfg(not(feature = "wasi-tls"))]
-    let active = component_ctx_template_from_metadata(&active_metadata);
-    #[cfg(feature = "wasi-tls")]
-    let active =
-        component_ctx_template_from_metadata_with_tls(&active_metadata, call.tls_provider.clone());
+    let template_of = component_ctx_template_from_metadata;
 
-    #[cfg(not(feature = "wasi-tls"))]
-    let linked = linked_metadata
-        .iter()
-        .map(component_ctx_template_from_metadata)
-        .collect::<Vec<_>>();
-    #[cfg(feature = "wasi-tls")]
-    let linked = linked_metadata
-        .iter()
-        .map(|metadata| {
-            component_ctx_template_from_metadata_with_tls(metadata, call.tls_provider.clone())
-        })
-        .collect::<Vec<_>>();
-
-    let linked_instances = {
-        let mut components = call.components.write().await;
-        call.linked_component_ids
-            .iter()
-            .map(|component_id| {
-                let component = components.get_mut(component_id).ok_or_else(|| {
-                    wasmtime::format_err!("linked component '{component_id}' not found")
-                })?;
-                component
-                    .pre_instantiate()
-                    .map(|pre| (component_id.clone(), pre))
-            })
-            .collect::<wasmtime::Result<Vec<_>>>()
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "failed to pre-instantiate linked components for ephemeral call: {e}"
-                )
-            })?
+    let (active, linked, linked_instances) = {
+        let components = call.components.read().await;
+        let active = template_of(
+            &components
+                .get(&call.active_component_id)
+                .with_context(|| {
+                    format!(
+                        "ephemeral linked component '{}' not found",
+                        call.active_component_id
+                    )
+                })?
+                .metadata,
+        );
+        let mut linked = Vec::with_capacity(call.linked_component_ids.len());
+        let mut linked_instances = Vec::with_capacity(call.linked_component_ids.len());
+        for component_id in &call.linked_component_ids {
+            let component = components
+                .get(component_id)
+                .with_context(|| format!("linked component '{component_id}' not found"))?;
+            linked.push(template_of(&component.metadata));
+            linked_instances.push((
+                component_id.clone(),
+                component.pre_instantiate_ref().map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to pre-instantiate linked components for ephemeral call: {e}"
+                    )
+                })?,
+            ));
+        }
+        (active, linked, linked_instances)
     };
 
     new_store_from_templates(

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -394,6 +394,16 @@ impl WorkloadComponent {
         self.metadata.linker.instantiate_pre(&component)
     }
 
+    /// Like [`Self::pre_instantiate`] but without requiring `&mut self`:
+    /// `Linker::instantiate_pre` only needs `&self`, so callers holding a read
+    /// lock on the component map can pre-instantiate without serializing on a
+    /// write lock.
+    pub fn pre_instantiate_ref(&self) -> wasmtime::Result<InstancePre<SharedCtx>> {
+        self.metadata
+            .linker
+            .instantiate_pre(&self.metadata.component)
+    }
+
     pub fn metadata(&self) -> &WorkloadMetadata {
         &self.metadata
     }
@@ -1404,21 +1414,47 @@ impl ResolvedWorkload {
     }
 
     /// Helper to create a new wasmtime Store for multiple components and set active given component in the workload.
+    ///
+    /// Builds the store under one read lock: cloning `WorkloadMetadata` would
+    /// deep-clone its by-value `Linker`, and `pre_instantiate_ref` needs only
+    /// read access, so concurrent callers don't serialize on a write lock.
+    /// Nothing is retained past the returned store.
     pub async fn new_store(
         &self,
         component_id: &str,
     ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
-        // Clone + drop the lock before building: the store factory write-locks
-        // `components`, so a held read lock would deadlock.
-        let metadata = {
+        let (engine, active_template, linked_templates, linked_instances) = {
             let components = self.components.read().await;
-            components
+            let component = components
                 .get(component_id)
-                .context("component ID not found in workload")?
-                .metadata
-                .clone()
+                .context("component ID not found in workload")?;
+            let metadata = &component.metadata;
+            let active_template = self.component_ctx_template(metadata);
+            let mut linked_templates = Vec::with_capacity(metadata.linked_components.len());
+            let mut linked_instances = Vec::with_capacity(metadata.linked_components.len());
+            for linked_id in &metadata.linked_components {
+                let linked = components.get(linked_id).with_context(|| {
+                    format!("linked component '{linked_id}' not found in workload")
+                })?;
+                linked_templates.push(self.component_ctx_template(&linked.metadata));
+                linked_instances.push((linked_id.clone(), linked.pre_instantiate_ref()?));
+            }
+            (
+                metadata.engine().clone(),
+                active_template,
+                linked_templates,
+                linked_instances,
+            )
         };
-        self.new_store_from_metadata(&metadata, false).await
+        new_store_from_templates(
+            &engine,
+            self.http_handler.clone(),
+            &active_template,
+            &linked_templates,
+            &linked_instances,
+            false,
+        )
+        .await
     }
 
     /// Creates a new wasmtime Store for multiple components from the given workload metadata.


### PR DESCRIPTION
new_store() and new_ephemeral_store() run once per request / cross-component call, each cloning WorkloadMetadata which deep-clones its by-value Linker and pre-instantiating linked components under a write lock on the component map. The linker is read-only after linking, so neither was required.

Add WorkloadComponent::pre_instantiate_ref(&self) (Linker::instantiate_pre only needs &self) and rebuild both paths under a single read lock: templates copy only the cheap fields and linked components pre-instantiate via read access, so concurrent callers no longer serialize on the write lock. Nothing is retained past the returned store; InstancePres are still built per call.

Found by @LiamRandall

Significant perf boost:
<img width="1428" height="777" alt="Screenshot 2026-07-21 at 2 57 44 PM" src="https://github.com/user-attachments/assets/3714447b-17ae-4a04-8682-770de9bb6ddf" />

https://github.com/wasmCloud/wasmCloud/actions/runs/29858830240