### PR TITLE
chore(wash-runtime): upgrade to wasmtime 47

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,14 +665,14 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "3.4.5"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
 dependencies = [
- "cap-primitives",
- "cap-std",
- "io-lifetimes",
- "windows-sys 0.59.0",
+ "cap-primitives 4.0.2",
+ "cap-std 4.0.2",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -681,8 +681,8 @@ version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
 dependencies = [
- "cap-primitives",
- "cap-std",
+ "cap-primitives 3.4.5",
+ "cap-std 3.4.5",
  "rustix",
  "smallvec",
 ]
@@ -695,8 +695,8 @@ checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
- "io-extras",
- "io-lifetimes",
+ "io-extras 0.18.4",
+ "io-lifetimes 2.0.4",
  "ipnet",
  "maybe-owned",
  "rustix",
@@ -706,29 +706,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras 0.19.0",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
 name = "cap-std"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
 dependencies = [
- "cap-primitives",
- "io-extras",
- "io-lifetimes",
+ "cap-primitives 3.4.5",
+ "io-extras 0.18.4",
+ "io-lifetimes 2.0.4",
  "rustix",
 ]
 
 [[package]]
-name = "cap-time-ext"
-version = "3.4.5"
+name = "cap-std"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
 dependencies = [
- "ambient-authority",
- "cap-primitives",
- "iana-time-zone",
- "once_cell",
+ "cap-primitives 4.0.2",
+ "io-extras 0.19.0",
+ "io-lifetimes 3.0.1",
  "rustix",
- "winx",
 ]
 
 [[package]]
@@ -1014,9 +1030,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -1041,24 +1057,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b374d3a9cbec48a5bdefa88cd3e55459319b06075f10c128876b7dec25da493e"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20250f55b050732e0cead176e2f7dd23721282ee8366836fc877cf6ac25ccc33"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ff547421e17d09340d61c09065043a6485b18c651b4eab80de3d3446a10889"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1066,8 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994d63dd3c34dfbc051d06d1d346520de9a44ad8b98c6ebb223fdbb723c7691f"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1076,8 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "400748ae61b3b9c6f198a9ca94035c77ffdaf12fc11ab45a5a250e38cbb2314b"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1106,8 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c227694acecbfbbad69adcf576b6cedb4c456228edd588bfb22c9a7b4331ec9f"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1118,21 +1140,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea30af1582f89202e3b35a5f5b58de17fd4e237430b3e57546b87aafb74bd4f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54214ea93b2f227567c56bf98e363239591af8c53716678d3fe741549aa2e52b"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37240456300f0ac5a6d4fc06360f9486c1bd98b56a6c3252bd77fe4b51f6f72a"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1142,8 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b5a840f761ab4096ec5c88e09b8c3bbd788912608f7c1dde85ae8bde5ad133"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -1154,13 +1180,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "932eb4a8a2cc24c55c4f11829a102254e9edf7f44dc7764b232c80494628c50c"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f757e7af29533480f8e662faaadf8c491c0c7c3c6b27d80c95a17c0f54712895"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1169,8 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "0.134.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711bd5976a9cdeae1a8f74ed43d0a5c8b96f1d46b9c242f132a3aab408e9d7cf"
 
 [[package]]
 name = "crc32fast"
@@ -1854,7 +1883,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "rustix",
  "windows-sys 0.59.0",
 ]
@@ -2659,8 +2688,18 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2668,6 +2707,12 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
@@ -4024,8 +4069,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b54ec63c3295549cc4561d73a29cb83819704646ef489cae0ad437e30e18167"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -4035,8 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afeb29aa3e850e05e5019133cd331cdb901edfec3455ff441f0fe66a14e1296"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6036,7 +6083,7 @@ dependencies = [
  "bon",
  "bytes",
  "cap-net-ext",
- "cap-std",
+ "cap-std 3.4.5",
  "chrono",
  "cidr",
  "criterion",
@@ -6051,7 +6098,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "moka",
  "names",
  "oci-client",
@@ -6122,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-gfx-runtime-shared"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace83d996af0f746fa0b878ce74f44fd9020ae51b6461daeb4032aa414ef49ed"
+checksum = "9e809c34ba8aae883f2c32d7ff86e02d000f051d3c292a6cdeb687bbf7d0bdb5"
 dependencies = [
  "async-broadcast",
  "futures",
@@ -6139,9 +6186,9 @@ checksum = "1b6c48003fe59c201c97a7786ff55feabe6b6f83b598aa9ff5bcc4f94d940bf3"
 
 [[package]]
 name = "wasi-webgpu-wasmtime"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae442a284775e6b80f1aefefc4eee0320f5570b0d57dbde97e8d7beb5cecc20d"
+checksum = "85341cf24693a86c6d66b9a93e925bd820040d2c56a2141f18788eba3f43e75e"
 dependencies = [
  "async-broadcast",
  "callback-future",
@@ -6240,9 +6287,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b089037d7eb453ed57b560fe7833de0707411c8b9fdc429745ced77e2a1bacb9"
+checksum = "d59b710751a35d54732a63851cdfacbfb2266b7160ce174faf269d3f4e84e31b"
 dependencies = [
  "anyhow",
  "heck",
@@ -6250,8 +6297,8 @@ dependencies = [
  "log",
  "petgraph 0.6.5",
  "smallvec",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
  "wat",
 ]
 
@@ -6263,16 +6310,6 @@ checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.251.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -6460,19 +6497,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.251.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
-dependencies = [
- "bitflags",
- "hashbrown 0.17.1",
- "indexmap 2.14.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
@@ -6481,6 +6505,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -6497,19 +6522,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
+checksum = "7142797de29b35ab8dbf15c00f55fda75d409da4c423a8ab8bd6b667a785824b"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.251.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52eccae7b639f124e474bc8fc052c11e5709143fba02a09ca6c0c2ee3903152"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -6541,8 +6567,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -6556,13 +6582,14 @@ dependencies = [
  "wasmtime-internal-versioned-export-macros",
  "wat",
  "windows-sys 0.61.2",
- "wit-parser 0.251.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c1cc5d238f59a62c5083208e4092e4770eceaaa8def4686c3412bc234703a9"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -6582,8 +6609,8 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -6591,8 +6618,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af161f18c43031b75969d7e3a89cc38855d1b3a8cb1814cc385f18f82de383c9"
 dependencies = [
  "base64",
  "directories-next",
@@ -6610,8 +6638,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55723606968f063d2c16dbdb82ee0bf6bbc6db283504cc5578f5dc7cdbf75d1e"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6619,18 +6648,20 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.251.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b083b0b746d9f3bec33323f5f15e9407d74c78d9f635bb156eb03934899859"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a34315bfd55a70ca52630bb1b0bcd834c455b5017ee1789d34f7d690d0696c0"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -6640,8 +6671,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1900c0379077c30f5ffe8f66d9803c43ef8f91ae790718113099fbd245bd226"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -6657,7 +6689,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.251.0",
+ "wasmparser 0.252.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -6666,8 +6698,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28065260eb11e36765721a5001da5a807705a8181396dcdcb113c919a1719a7a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -6680,8 +6713,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8d5b0d21932765a25a5f82826aa61a3324e3683ae2086e9f9fe7dfc7fa11477"
 dependencies = [
  "cc",
  "object",
@@ -6691,8 +6725,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66acb694c19ed2214bb8513d259cac8c27407c4c8a72551d80b723339ef35a91"
 dependencies = [
  "cfg-if",
  "libc",
@@ -6702,8 +6737,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2899faa12f7e9d5761164aa96522f03d29796097b2a70274341888eb6555f282"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -6714,8 +6750,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e655193dc7a8684d17cb255730419608b087197af5c5af4875c39554b3be99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6724,32 +6761,31 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b68ccf03917702ed7e8521e75ee9776c078ed291c76b2d235e49e980d88aa"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap 2.14.0",
- "wit-parser 0.251.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e869cf1e0d65b0a4b89aab7d2b7daccf89bc3e984bc15f2f6d74a09bd75a4a4b"
 dependencies = [
  "async-trait",
  "bitflags",
  "bytes",
  "cap-fs-ext",
- "cap-net-ext",
- "cap-std",
- "cap-time-ext",
+ "cap-std 4.0.2",
  "cfg-if",
  "futures",
- "io-extras",
- "io-lifetimes",
+ "io-lifetimes 3.0.1",
  "rand 0.10.1",
  "rustix",
  "thiserror 2.0.18",
@@ -6764,8 +6800,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2decfe2219ca493e66dd07a16d456f2f5842d80d56622da03bed78d147c7ec"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6782,13 +6819,14 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-io",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293ddc4b215d0b4d0975bd61dcf97a7cca36d680296ca9d811c4a6281c80e19c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6799,8 +6837,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8134f85760fba6e1542aae8c3d23ece20b42d6a8f0fa364d68debb3f70b735"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6810,7 +6849,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -7052,8 +7091,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a769bfe912a399f7e1ad5162a092abc145faa04df9261ea31fca28890a1d92"
 dependencies = [
  "bitflags",
  "thiserror 2.0.18",
@@ -7065,8 +7105,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcfccda4d927496531cf29e6f9ac718835ec6c3b836ae7402363af3f9ac7dff"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -7078,8 +7119,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "46.0.0"
-source = "git+https://github.com/ricochet/wasmtime?branch=release-46.0.0-implements#50519312393a7de2fecbb1dca5c87a96e5b09fc0"
+version = "47.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71bf73e531f11be92ded3e7daab070a4681b649306eb7b08b7685006671be06"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7613,25 +7655,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.251.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
-dependencies = [
- "anyhow",
- "hashbrown 0.17.1",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.251.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,19 +121,14 @@ wasm-pkg-client = { version = "0.16.0-rc.1", default-features = false }
 wasm-pkg-core = { version = "0.16.0-rc.1", default-features = false }
 wasm-metadata = { version = "0.253.0", default-features = false, features = ["oci"] }
 wasmcloud = { path = "crates/wasmcloud", default-features = false }
-# Pinned to the release-46.0.0 branch HEAD rather than the crates.io 46.0.0
-# release because we need the resource-implements feature
-# (bytecodealliance/wasmtime#13666): it merged to `main` and ships in wasmtime
-# 47 — it is NOT on the 46 release branch. To run it on 46 we maintain a
-# backport and pull it in via the
-# `[patch."https://github.com/bytecodealliance/wasmtime"]` section below. Bump
-# the rev when picking up release-branch fixes. Drop the git pin for a crates.io
-# `version` once the feature lands in a stock release (wasmtime 47).
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
-wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
-wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
-wasmtime-wasi-http = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
-wasmtime-wasi-tls = { git = "https://github.com/bytecodealliance/wasmtime", rev = "7535c0255b2b84f6ae4de6034649ba2eeda84173", default-features = false }
+# wasmtime 47 ships the resource-implements feature (bytecodealliance/wasmtime#13666)
+# in the stock release, so the workspace tracks crates.io directly — no git pin or
+# fork backport is needed anymore.
+wasmtime = { version = "47.0.1", default-features = false }
+wasmtime-wasi = { version = "47.0.1", default-features = false }
+wasmtime-wasi-io = { version = "47.0.1", default-features = false }
+wasmtime-wasi-http = { version = "47.0.1", default-features = false }
+wasmtime-wasi-tls = { version = "47.0.1", default-features = false }
 wit-component = { version = "0.253.0", default-features = false }
 wash-runtime = { path = "crates/wash-runtime", default-features = false }
 wat = { version = "1.253.0", default-features = false }
@@ -167,33 +162,3 @@ ignored = [
     "tonic",
    "tonic-prost",
 ]
-
-[patch.crates-io]
-# The wasi-gfx deps (behind the `wasi-webgpu` feature) depend on wasmtime 46
-# from crates.io, while the rest of the workspace uses the forked git wasmtime
-# below. Without this, two distinct wasmtime crates end up in the graph and the
-# gfx `add_to_linker` calls fail to typecheck. Redirect crates.io wasmtime to
-# the same fork so the whole graph shares one wasmtime. Retire alongside the
-# git-source patch block when the workspace moves to wasmtime 47.
-wasmtime = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
-wasmtime-wasi = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
-wasmtime-wasi-io = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
-
-# Redirect upstream wasmtime to a 46 backport carrying the resource-implements
-# feature (bytecodealliance/wasmtime#13666). The feature merged to `main` (47.0.0)
-# but is not on the 46 release branch, and wasmtime does not backport features to
-# release branches — so to ship it on 46 we maintain `release-46.0.0-implements`
-# on the fork: `release-46.0.0` + the cherry-picked implements commits. Cargo
-# requires the patch source to be version-compatible with the upstream dep, so the
-# branch MUST stay based on release-46.0.0 (46.0.0) to match the rev pinned above
-# — a main-based (47.0.0) branch will fail to apply.
-#
-# Re-cherry-pick onto a newer release-46.0.x base when bumping the rev above.
-# Retire this whole block (and the fork branch) once the workspace moves to
-# wasmtime 47, where the feature ships in the stock release.
-[patch."https://github.com/bytecodealliance/wasmtime"]
-wasmtime = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
-wasmtime-wasi = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
-wasmtime-wasi-io = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
-wasmtime-wasi-http = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }
-wasmtime-wasi-tls = { git = "https://github.com/ricochet/wasmtime", branch = "release-46.0.0-implements" }

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -147,7 +147,7 @@ webpki-roots = { workspace = true }
 # fails to build on Windows and s390x, so the deps are gated to match the
 # `#[cfg]` on `plugin::wasi_webgpu`.
 [target.'cfg(all(not(target_os = "windows"), not(target_arch = "s390x")))'.dependencies]
-wasi-webgpu-wasmtime = { version = "0.1", optional = true }
+wasi-webgpu-wasmtime = { version = "0.2", optional = true }
 
 # Proto codegen only. Wasm fixtures are built by `cargo xtask
 # build-fixtures` (see /xtask), which owns wit-component and the WASI

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -8,11 +8,7 @@ repository = "https://github.com/wasmCloud/wasmCloud"
 authors = ["The wasmCloud Team"]
 categories = ["wasm"]
 readme = "README.md"
-# Not published to crates.io: the optional `wasi-webgpu` feature pulls in
-# git-only deps (`wasi-graphics-context-wasmtime`, `wasi-webgpu-wasmtime`
-# from wasi-gfx/wasi-gfx-runtime) that have no crates.io release, and
-# cargo's publish manifest check rejects deps without a version
-# requirement. Revisit once those crates are on crates.io or vendored.
+# Not published to crates.io: this is an internal runtime crate.
 publish = false
 # Allowlist preserved for the eventual re-enable of publishing. Cargo
 # always includes Cargo.toml, Cargo.lock, Cargo.toml.orig, and

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -626,12 +626,14 @@ pub enum WasmProposal {
     /// crate feature.
     #[cfg(feature = "wasm_component_model_implements")]
     WasmComponentModelImplements,
-    /// Garbage collection. Enables `wasm_function_references` (a prerequisite)
-    /// and `wasm_gc`.
+    /// Garbage collection (with its `wasm_function_references` prerequisite).
+    /// Enabled by default in wasmtime >= 47; accepted for compatibility.
     Gc,
-    /// Exception handling. Enables `wasm_exceptions`.
+    /// Exception handling. Enabled by default in wasmtime >= 47; accepted for
+    /// compatibility.
     ExceptionHandling,
-    /// 128-bit wide arithmetic. Enables `wasm_wide_arithmetic`.
+    /// 128-bit wide arithmetic. Enabled by default in wasmtime >= 47; accepted
+    /// for compatibility.
     WideArithmetic,
     /// Shared-memory threads. Enables `wasm_threads`.
     Threads,
@@ -650,17 +652,11 @@ impl WasmProposal {
             WasmProposal::WasmComponentModelImplements => {
                 cfg.wasm_component_model_implements(true);
             }
-            WasmProposal::Gc => {
-                // GC builds on the function-references proposal.
-                cfg.wasm_function_references(true);
-                cfg.wasm_gc(true);
-            }
-            WasmProposal::ExceptionHandling => {
-                cfg.wasm_exceptions(true);
-            }
-            WasmProposal::WideArithmetic => {
-                cfg.wasm_wide_arithmetic(true);
-            }
+            // GC (with its `wasm_function_references` prerequisite), exception
+            // handling, and wide arithmetic are all enabled by default in
+            // wasmtime >= 47, so opting into them needs no config change. The
+            // variants stay accepted for CLI/config compatibility.
+            WasmProposal::Gc | WasmProposal::ExceptionHandling | WasmProposal::WideArithmetic => {}
             WasmProposal::Threads => {
                 cfg.wasm_threads(true);
             }

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -657,6 +657,11 @@ impl WasmProposal {
             // wasmtime >= 47, so opting into them needs no config change. The
             // variants stay accepted for CLI/config compatibility.
             WasmProposal::Gc | WasmProposal::ExceptionHandling | WasmProposal::WideArithmetic => {}
+            // Threads and tail calls are also on by default in wasmtime >= 47,
+            // but only conditionally — `wasm_threads` follows the `threads`
+            // crate feature and `wasm_tail_call` is off under the Winch compiler
+            // — so these set their flag explicitly to stay correct regardless of
+            // build or config.
             WasmProposal::Threads => {
                 cfg.wasm_threads(true);
             }

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -380,10 +380,10 @@ pub(crate) async fn run_trigger_driver(
         let outcomes = store
             .run_concurrent(async |accessor| {
                 // Spawn the cli/run co-driver once (first entry only).
-                if let Some(command) = command.take() {
-                    if let Err(e) = accessor.spawn(RunTask { command }) {
-                        tracing::error!(err = %e, "failed to spawn cli/run co-driver task");
-                    }
+                if let Some(command) = command.take()
+                    && let Err(e) = accessor.spawn(RunTask { command })
+                {
+                    tracing::error!(err = %e, "failed to spawn cli/run co-driver task");
                 }
                 // `join_all` steps out only once EVERY ingress serve returns, so a
                 // `FlushDrops` is prompt only when the Capability ingress is served

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -199,11 +199,13 @@ impl PreparedIngress {
         match self {
             PreparedIngress::Http { service, rx } => {
                 while let Some((req, resp_tx)) = rx.recv().await {
-                    accessor.spawn(HttpTask {
+                    if let Err(e) = accessor.spawn(HttpTask {
                         service: Arc::clone(service),
                         req,
                         resp_tx,
-                    });
+                    }) {
+                        tracing::error!(err = %e, "failed to spawn HTTP invocation task");
+                    }
                 }
                 ServeOutcome::Shutdown
             }
@@ -213,12 +215,14 @@ impl PreparedIngress {
                 rx,
             } => {
                 while let Some((msg, result_tx)) = rx.recv().await {
-                    accessor.spawn(MessagingTask {
+                    if let Err(e) = accessor.spawn(MessagingTask {
                         instance: *instance,
                         func_idx: *func_idx,
                         msg,
                         result_tx,
-                    });
+                    }) {
+                        tracing::error!(err = %e, "failed to spawn messaging invocation task");
+                    }
                 }
                 ServeOutcome::Shutdown
             }
@@ -286,13 +290,15 @@ impl PreparedIngress {
                             // itself.
                             let job = registry.admit(call.caller.clone());
                             let job_guard = JobGuard::new(Arc::clone(registry), job);
-                            accessor.spawn(CapabilityTask {
+                            if let Err(e) = accessor.spawn(CapabilityTask {
                                 instance: *instance,
                                 func_idx,
                                 call,
                                 in_flight: guard,
                                 job_guard,
-                            });
+                            }) {
+                                tracing::error!(err = %e, "failed to spawn capability call task");
+                            }
                         }
                     }
                 }
@@ -375,7 +381,9 @@ pub(crate) async fn run_trigger_driver(
             .run_concurrent(async |accessor| {
                 // Spawn the cli/run co-driver once (first entry only).
                 if let Some(command) = command.take() {
-                    accessor.spawn(RunTask { command });
+                    if let Err(e) = accessor.spawn(RunTask { command }) {
+                        tracing::error!(err = %e, "failed to spawn cli/run co-driver task");
+                    }
                 }
                 // `join_all` steps out only once EVERY ingress serve returns, so a
                 // `FlushDrops` is prompt only when the Capability ingress is served

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -45,11 +45,11 @@ use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use tracing::{debug, error, warn};
 use wasmtime::AsContextMut;
-use wasmtime::Store;
 use wasmtime::component::types::Type;
 use wasmtime::component::{
-    Accessor, Component, InstancePre, Linker, Resource, Val, types::ComponentItem,
+    Accessor, Component, GuestTaskId, InstancePre, Linker, Resource, Val, types::ComponentItem,
 };
+use wasmtime::{Store, StoreContextMut};
 
 use crate::engine::Engine;
 use crate::engine::ctx::{CallerIdentity, Ctx, SharedCtx};
@@ -337,6 +337,21 @@ fn build_plugin_linker(
 /// state by caller.
 const HOST_IDENTITY_INTERFACE: &str = "wasmcloud:host/identity@0.1.0";
 
+/// The caller's root guest task, or `None` if it can't be determined.
+///
+/// [`StoreContextMut::async_call_stack`] only errors in unusual states (e.g.
+/// called outside a guest invocation); treat that as "no caller" but leave a
+/// trace so the degradation isn't silent. Its last item is the root call.
+fn caller_root_task(store: &mut StoreContextMut<'_, SharedCtx>) -> Option<GuestTaskId> {
+    match store.async_call_stack() {
+        Ok(stack) => stack.last(),
+        Err(e) => {
+            debug!(err = %e, "async call stack unavailable; treating as no caller task");
+            None
+        }
+    }
+}
+
 /// Install the `wasmcloud:host/identity` import on the plugin's own linker: two
 /// no-argument funcs returning the workload/component id of the caller whose
 /// capability call is currently running. Each walks its async call stack back to
@@ -357,7 +372,7 @@ fn install_host_identity(
         .func_new(
             "get-workload-id",
             move |mut store, _ty, _params, results| {
-                let root = store.async_call_stack().ok().and_then(|stack| stack.last());
+                let root = caller_root_task(&mut store);
                 let id = root
                     .and_then(|task| workload_state.registry()?.caller_for_task(task))
                     .map(|c| c.workload_id.to_string())
@@ -374,7 +389,7 @@ fn install_host_identity(
         .func_new(
             "get-component-id",
             move |mut store, _ty, _params, results| {
-                let root = store.async_call_stack().ok().and_then(|stack| stack.last());
+                let root = caller_root_task(&mut store);
                 let id = root
                     .and_then(|task| component_state.registry()?.caller_for_task(task))
                     .map(|c| c.component_id.to_string())
@@ -411,7 +426,7 @@ fn install_host_cancel(
     let current_state = Arc::clone(state);
     instance
         .func_new("current-job", move |mut store, _ty, _params, results| {
-            let root = store.async_call_stack().ok().and_then(|stack| stack.last());
+            let root = caller_root_task(&mut store);
             let job = root
                 .and_then(|task| current_state.registry()?.job_for_task(task))
                 .unwrap_or(0);
@@ -428,7 +443,7 @@ fn install_host_cancel(
                 Some(Val::U64(job)) => *job,
                 _ => wasmtime::bail!("request-cancel expects a single u64 job id"),
             };
-            let root = store.async_call_stack().ok().and_then(|stack| stack.last());
+            let root = caller_root_task(&mut store);
             let accepted = match (root, cancel_state.registry()) {
                 (Some(task), Some(registry)) => match registry.caller_for_task(task) {
                     Some(requester) => registry.request_cancel(job, &requester),
@@ -445,7 +460,7 @@ fn install_host_cancel(
     let is_cancelled_state = Arc::clone(state);
     instance
         .func_new("is-cancelled", move |mut store, _ty, _params, results| {
-            let root = store.async_call_stack().ok().and_then(|stack| stack.last());
+            let root = caller_root_task(&mut store);
             let cancelled = root
                 .and_then(|task| {
                     let registry = is_cancelled_state.registry()?;

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -357,7 +357,7 @@ fn install_host_identity(
         .func_new(
             "get-workload-id",
             move |mut store, _ty, _params, results| {
-                let root = store.async_call_stack().last();
+                let root = store.async_call_stack().ok().and_then(|stack| stack.last());
                 let id = root
                     .and_then(|task| workload_state.registry()?.caller_for_task(task))
                     .map(|c| c.workload_id.to_string())
@@ -374,7 +374,7 @@ fn install_host_identity(
         .func_new(
             "get-component-id",
             move |mut store, _ty, _params, results| {
-                let root = store.async_call_stack().last();
+                let root = store.async_call_stack().ok().and_then(|stack| stack.last());
                 let id = root
                     .and_then(|task| component_state.registry()?.caller_for_task(task))
                     .map(|c| c.component_id.to_string())
@@ -411,7 +411,7 @@ fn install_host_cancel(
     let current_state = Arc::clone(state);
     instance
         .func_new("current-job", move |mut store, _ty, _params, results| {
-            let root = store.async_call_stack().last();
+            let root = store.async_call_stack().ok().and_then(|stack| stack.last());
             let job = root
                 .and_then(|task| current_state.registry()?.job_for_task(task))
                 .unwrap_or(0);
@@ -428,7 +428,7 @@ fn install_host_cancel(
                 Some(Val::U64(job)) => *job,
                 _ => wasmtime::bail!("request-cancel expects a single u64 job id"),
             };
-            let root = store.async_call_stack().last();
+            let root = store.async_call_stack().ok().and_then(|stack| stack.last());
             let accepted = match (root, cancel_state.registry()) {
                 (Some(task), Some(registry)) => match registry.caller_for_task(task) {
                     Some(requester) => registry.request_cancel(job, &requester),
@@ -445,7 +445,7 @@ fn install_host_cancel(
     let is_cancelled_state = Arc::clone(state);
     instance
         .func_new("is-cancelled", move |mut store, _ty, _params, results| {
-            let root = store.async_call_stack().last();
+            let root = store.async_call_stack().ok().and_then(|stack| stack.last());
             let cancelled = root
                 .and_then(|task| {
                     let registry = is_cancelled_state.registry()?;

--- a/crates/wash-runtime/src/sockets/host_tcp_p3.rs
+++ b/crates/wash-runtime/src/sockets/host_tcp_p3.rs
@@ -247,7 +247,7 @@ impl types::Host for WasiSocketsCtxView<'_> {
     }
 }
 
-impl<T> HostTcpSocketWithStore<T> for WasiSockets {
+impl<T: Send> HostTcpSocketWithStore<T> for WasiSockets {
     async fn connect(
         store: &Accessor<T, Self>,
         socket: Resource<UpstreamTcpSocket>,
@@ -293,11 +293,30 @@ impl<T> HostTcpSocketWithStore<T> for WasiSockets {
         })
     }
 
-    fn listen(
+    async fn listen(
         mut store: Access<'_, T, Self>,
         socket: Resource<UpstreamTcpSocket>,
     ) -> SocketResult<StreamReader<Resource<UpstreamTcpSocket>>> {
         let getter = store.getter();
+
+        // A socket that has not been explicitly bound implicitly binds to an
+        // ephemeral port during `listen`. Run the host's `socket_addr_check`
+        // against that implicit bind address first — the same check `bind`
+        // performs — so `listen` cannot be used to bind to an address the
+        // network policy would otherwise deny. (bytecodealliance/wasmtime#13677)
+        let implicit_addr = {
+            let view = store.get();
+            let socket_ref = get_socket_mut(view.table, &socket)?;
+            socket_ref
+                .needs_implicit_bind()
+                .then(|| crate::sockets::util::implicit_bind_addr(socket_ref.address_family()))
+        };
+        if let Some(addr) = implicit_addr {
+            let check = store.get().ctx.socket_addr_check.clone();
+            if !check(addr, SocketAddrUse::TcpBind).await {
+                return Err(types::ErrorCode::AccessDenied.into());
+            }
+        }
 
         // Scope: do the listen and extract info
         enum ListenKind {

--- a/crates/wash-runtime/src/sockets/host_udp_p3.rs
+++ b/crates/wash-runtime/src/sockets/host_udp_p3.rs
@@ -57,6 +57,22 @@ impl<T> HostUdpSocketWithStore<T> for WasiSockets {
             if !check(addr, SocketAddrUse::UdpOutgoingDatagram).await {
                 return Err(ErrorCode::AccessDenied.into());
             }
+
+            // An unbound socket implicitly binds to an ephemeral local port on
+            // its first `send-to`. Run socket_addr_check against that implicit
+            // bind address too, so the implicit bind is governed by the same
+            // network policy as an explicit `bind`. (bytecodealliance/wasmtime#13677)
+            let implicit_family = store.with(|mut store| {
+                let view = store.get();
+                let sock = get_socket_mut(view.table, &socket)?;
+                SocketResult::Ok(sock.needs_implicit_bind().then(|| sock.address_family()))
+            })?;
+            if let Some(family) = implicit_family {
+                let implicit_addr = crate::sockets::util::implicit_bind_addr(family);
+                if !check(implicit_addr, SocketAddrUse::UdpBind).await {
+                    return Err(ErrorCode::AccessDenied.into());
+                }
+            }
         }
 
         enum SendTarget {

--- a/crates/wash-runtime/src/sockets/host_udp_p3.rs
+++ b/crates/wash-runtime/src/sockets/host_udp_p3.rs
@@ -59,9 +59,10 @@ impl<T> HostUdpSocketWithStore<T> for WasiSockets {
             }
 
             // An unbound socket implicitly binds to an ephemeral local port on
-            // its first `send-to`. Run socket_addr_check against that implicit
-            // bind address too, so the implicit bind is governed by the same
-            // network policy as an explicit `bind`. (bytecodealliance/wasmtime#13677)
+            // its first `send-to`. Mirror wasmtime's p3 UDP send: check that
+            // implicit bind against the network policy (as an explicit `bind`
+            // is checked) and then perform it, leaving the socket bound so this
+            // runs once rather than on every datagram. (bytecodealliance/wasmtime#13677)
             let implicit_family = store.with(|mut store| {
                 let view = store.get();
                 let sock = get_socket_mut(view.table, &socket)?;
@@ -72,6 +73,18 @@ impl<T> HostUdpSocketWithStore<T> for WasiSockets {
                 if !check(implicit_addr, SocketAddrUse::UdpBind).await {
                     return Err(ErrorCode::AccessDenied.into());
                 }
+                store.with(|mut store| {
+                    let view = store.get();
+                    let mut loopback = view
+                        .ctx
+                        .loopback
+                        .lock()
+                        .map_err(|e| SocketError::trap(wasmtime::format_err!("{e}")))?;
+                    let sock = get_socket_mut(view.table, &socket)?;
+                    sock.bind(implicit_addr, &mut loopback).map_err(se)?;
+                    sock.finish_bind().map_err(se)?;
+                    SocketResult::Ok(())
+                })?;
             }
         }
 

--- a/crates/wash-runtime/src/sockets/tcp.rs
+++ b/crates/wash-runtime/src/sockets/tcp.rs
@@ -573,6 +573,13 @@ impl NetworkTcpSocket {
         Ok(())
     }
 
+    /// Whether this socket is still unbound (in its default post-create
+    /// state). A subsequent `listen` implicitly binds it, so the host's
+    /// `socket_addr_check` must run against the implicit bind address first.
+    pub(crate) fn is_unbound(&self) -> bool {
+        matches!(self.tcp_state, TcpState::Default(_))
+    }
+
     /// Start listening using P3 semantics (with implicit bind).
     ///
     /// Returns the shared listener so callers (and tests) can build accept
@@ -1377,6 +1384,14 @@ impl TcpSocket {
             _ => return Err(ErrorCode::InvalidState),
         };
         take_loopback_listen_info(lo)
+    }
+
+    /// Whether `listen` on this socket would perform an implicit bind to a
+    /// real network address. Only a freshly created, still-unbound socket
+    /// does; loopback and unspecified sockets have already been bound (and
+    /// checked) by an explicit `bind`.
+    pub(crate) fn needs_implicit_bind(&self) -> bool {
+        matches!(self, Self::Network(net) if net.is_unbound())
     }
 
     /// Listen using P3 semantics (with implicit bind).

--- a/crates/wash-runtime/src/sockets/udp.rs
+++ b/crates/wash-runtime/src/sockets/udp.rs
@@ -344,6 +344,14 @@ impl UdpSocket {
         }
     }
 
+    /// Whether a `send-to` on this socket would perform an implicit bind to a
+    /// real network address. Only a freshly created, still-unbound socket
+    /// does; loopback and unspecified sockets have already been bound (and
+    /// checked) by an explicit `bind`.
+    pub(crate) fn needs_implicit_bind(&self) -> bool {
+        matches!(self, Self::Network(_)) && !self.is_bound()
+    }
+
     pub(crate) fn disconnect(
         &mut self,
         loopback: &mut super::loopback::Network,

--- a/crates/wash-runtime/src/sockets/udp.rs
+++ b/crates/wash-runtime/src/sockets/udp.rs
@@ -119,6 +119,12 @@ impl NetworkUdpSocket {
         matches!(self.udp_state, UdpState::Connected(..) | UdpState::Bound)
     }
 
+    /// Whether this socket is still unbound (in its default post-create state),
+    /// the precondition for an implicit bind.
+    fn is_unbound(&self) -> bool {
+        matches!(self.udp_state, UdpState::Default)
+    }
+
     fn disconnect(&mut self) -> Result<(), ErrorCode> {
         if !self.is_connected() {
             return Err(ErrorCode::InvalidState);
@@ -349,7 +355,7 @@ impl UdpSocket {
     /// does; loopback and unspecified sockets have already been bound (and
     /// checked) by an explicit `bind`.
     pub(crate) fn needs_implicit_bind(&self) -> bool {
-        matches!(self, Self::Network(_)) && !self.is_bound()
+        matches!(self, Self::Network(net) if net.is_unbound())
     }
 
     pub(crate) fn disconnect(


### PR DESCRIPTION
Move the workspace off the git-pinned wasmtime 46 fork onto the stock crates.io wasmtime 47.0.1 release. The resource-implements feature (bytecodealliance/wasmtime#13666) that the ricochet fork backported now ships in 47, so both [patch] blocks and the fork branch are retired. wasi-webgpu-wasmtime moves to 0.2 (its wasmtime-47 release).

Adapt to 47 API changes:
- wasi:sockets p3 HostTcpSocketWithStore::listen is now `async fn` (and the impl now requires `T: Send`).
- Accessor::spawn now returns `Result<JoinHandle>`; log spawn failures in the trigger service ingress loops instead of dropping them.
- StoreContextMut::async_call_stack now returns `Result`; treat an error as "no caller task" in the component_host identity/cancel host funcs.

Port the socket_addr_check-on-implicit-bind fix (wasmtime#13677) to the loopback-aware fork: p3 `listen` and the first UDP `send-to` implicitly bind an unbound socket, so run the host's socket_addr_check against the implicit bind address (TcpBind / UdpBind) first. Without it a guest could implicitly bind to an address (e.g. all-interfaces 0.0.0.0) the network policy would otherwise deny.

wasmtime 47 enables the GC (and its wasm_function_references prerequisite), exception-handling, and wide-arithmetic proposals by default, so the WasmProposal::{Gc,ExceptionHandling,WideArithmetic} arms were re-asserting defaults. Collapse them into a documented no-op and update the variant docs.

The variants and FromStr stay unchanged so `--wasm-proposal gc` etc. still parse (accepted for compatibility). Threads and TailCall keep setting their flags since their defaults are conditional (the `threads` crate feature and non-Winch respectively); ComponentModelAsync and implements are default-off and still required.
