### PR TITLE
fix(wash-runtime): round-robin across service replicas per host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6089,6 +6089,7 @@ dependencies = [
  "criterion",
  "deadpool-postgres",
  "docker_credential",
+ "fastrand",
  "futures",
  "gag",
  "geo-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ ctrlc = { version = "3.4.7", default-features = false }
 dialoguer = { version = "0.11.0", default-features = false, features = ["editor", "password", "zeroize", "fuzzy-select", "fuzzy-matcher"] }
 docker_credential = { version = "1.3.1", default-features = false }
 etcetera = { version = "0.10.0", default-features = false }
+fastrand = { version = "2", default-features = false, features = ["std"] }
 figment = { version = "0.10.19", default-features = false }
 futures = { version = "0.3", default-features = false }
 flate2 = { version = "1.0", default-features = false }

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -65,6 +65,7 @@ async-trait = { workspace = true }
 bon = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
+fastrand = { workspace = true }
 futures = { workspace = true }
 hostname = { workspace = true }
 http = { workspace = true }

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -777,6 +777,11 @@ impl ResolvedWorkload {
         let mut store = recipe.build().await?;
         let http_handler = self.http_handler.clone();
         let workload_id: Arc<str> = Arc::from(self.id());
+        // The hostnames this service serves HTTP on, derived once from the
+        // workload's declared interfaces. Passed to every HTTP registration
+        // (the first below and each restart re-registration in the supervisor)
+        // so a hostname-keyed router can resolve requests to this service.
+        let ingress_hostnames = crate::host::http::http_ingress_hostnames(self.host_interfaces());
 
         // Build the first incarnation's host-invoked ingresses. Each paired sender
         // is registered with its host-side ingress (the HTTP server, the messaging
@@ -788,7 +793,7 @@ impl ResolvedWorkload {
             build_trigger_ingresses(serves_http, serves_messaging);
         if let Some(http_tx) = http_tx {
             self.http_handler
-                .on_service_http_resolved(self.id(), http_tx)
+                .on_service_http_resolved(self.id(), &ingress_hostnames, http_tx)
                 .await
                 .map_err(|e| anyhow::anyhow!("failed to register service HTTP handler: {e:#}"))?;
         }
@@ -816,7 +821,7 @@ impl ResolvedWorkload {
                             build_trigger_ingresses(serves_http, serves_messaging);
                         if let Some(http_tx) = http_tx
                             && let Err(e) = http_handler
-                                .on_service_http_resolved(&workload_id, http_tx)
+                                .on_service_http_resolved(&workload_id, &ingress_hostnames, http_tx)
                                 .await
                         {
                             error!(err = %e, "failed to re-register service HTTP handler on restart");

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -22,9 +22,11 @@ use std::{
     collections::{BTreeSet, HashMap},
     net::SocketAddr,
     path::Path,
-    sync::{Arc, atomic::AtomicUsize},
+    sync::Arc,
     time::Duration,
 };
+
+use arc_swap::ArcSwap;
 
 use crate::host::allowed_hosts::AllowedHost;
 use crate::host::trigger_service::{BrokerMessage, MessagingJob};
@@ -219,17 +221,25 @@ pub trait Router: Send + Sync + 'static {
 /// Router that routes requests by 'Host' header, configured via WitInterface config
 #[derive(Default)]
 pub struct DynamicRouter {
-    /// Maps a hostname to every workload replica bound to it. Ordered so the
-    /// round-robin cursor below strides a stable sequence between mutations.
-    host_to_workload: tokio::sync::RwLock<HashMap<String, BTreeSet<String>>>,
-    /// Maps workload_id -> all hostnames (primary + aliases) registered for it.
-    /// Used by on_workload_unbind to remove all entries cleanly.
-    workload_to_host: tokio::sync::RwLock<HashMap<String, Vec<String>>>,
-    /// Round-robin cursor. Each routed request strides it once so successive
-    /// requests for one hostname fan out across all bound replicas instead of
-    /// pinning to one. Relaxed ordering suffices: we only need each request to
-    /// read a distinct-enough counter value, not a total order across threads.
-    rr: AtomicUsize,
+    /// Routing tables behind a single [`ArcSwap`] so the per-request read in
+    /// [`Self::select_workload`] is lock-free — a concurrent register/unbind can
+    /// never make a request wait or 503. Register and unbind are copy-on-write
+    /// via `rcu`; they happen on workload start/stop (rare relative to requests),
+    /// so cloning the tables is cheap next to the hot read path.
+    routes: ArcSwap<Routes>,
+}
+
+/// The `DynamicRouter` routing tables, swapped atomically as one unit so a
+/// reader never sees the forward and reverse maps disagree.
+#[derive(Default, Clone)]
+struct Routes {
+    /// Maps a hostname to every workload replica bound to it. A `BTreeSet` keeps
+    /// membership ordered and deterministic; a request picks one replica at
+    /// random (see [`DynamicRouter::select_workload`]).
+    host_to_workload: HashMap<String, BTreeSet<String>>,
+    /// Maps workload_id -> all hostnames (primary + aliases) registered for it,
+    /// so `on_workload_unbind` can remove all entries cleanly.
+    workload_to_host: HashMap<String, Vec<String>>,
 }
 
 impl DynamicRouter {
@@ -237,43 +247,46 @@ impl DynamicRouter {
     /// forward (host -> replicas) and reverse (workload -> hosts) maps so
     /// [`Router::on_workload_unbind`] can later remove every entry cleanly.
     /// Idempotent: re-registering the same workload (e.g. a service restart)
-    /// leaves the maps unchanged.
-    async fn register_hostnames(&self, workload_id: &str, hosts: &[String]) {
-        {
-            let mut lock = self.workload_to_host.write().await;
-            lock.insert(workload_id.to_string(), hosts.to_vec());
-        }
-        {
-            let mut lock = self.host_to_workload.write().await;
+    /// leaves the tables unchanged.
+    fn register_hostnames(&self, workload_id: &str, hosts: &[String]) {
+        self.routes.rcu(|cur| {
+            let mut routes = (**cur).clone();
+            routes
+                .workload_to_host
+                .insert(workload_id.to_string(), hosts.to_vec());
             for host in hosts {
-                lock.entry(host.clone())
+                routes
+                    .host_to_workload
+                    .entry(host.clone())
                     .or_default()
                     .insert(workload_id.to_string());
             }
-        }
+            routes
+        });
     }
 
-    /// Pick one replica bound to `host`, striding the round-robin cursor so
-    /// successive calls fan out across every replica. Split out from
-    /// [`Router::route_incoming_request`] so the selection logic is unit-testable
-    /// without constructing a [`hyper::body::Incoming`].
+    /// Pick one replica bound to `host` at random so requests fan out across
+    /// every replica instead of pinning to one. A per-thread PRNG
+    /// ([`fastrand`]) avoids the cross-core cache-line contention a shared
+    /// atomic cursor would incur under concurrent load, and spreads load just as
+    /// evenly in aggregate. Split out from [`Router::route_incoming_request`] so
+    /// the selection logic is unit-testable without constructing a
+    /// [`hyper::body::Incoming`].
     fn select_workload(&self, host: &str) -> Result<String, RouteError> {
-        let lock = self
-            .host_to_workload
-            .try_read()
-            .map_err(|_| RouteError::Unavailable)?;
-        let Some(workload_set) = lock.get(host) else {
+        // Lock-free read of a routing-table snapshot.
+        let routes = self.routes.load();
+        let Some(workload_set) = routes.host_to_workload.get(host) else {
             return Err(RouteError::NoWorkloadForHost(host.to_string()));
         };
         // An entry can exist but be empty; treat that as "no workload bound"
-        // (same 404) and, importantly, avoid the `% 0` below.
+        // (same 404) and, importantly, keep the range below non-empty.
         if workload_set.is_empty() {
             return Err(RouteError::NoWorkloadForHost(host.to_string()));
         }
-        let idx = self.rr.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let idx = fastrand::usize(..workload_set.len());
         let workload_id = workload_set
             .iter()
-            .nth(idx % workload_set.len())
+            .nth(idx)
             .ok_or_else(|| RouteError::NoWorkloadForHost(host.to_string()))?;
         Ok(workload_id.clone())
     }
@@ -323,7 +336,7 @@ impl Router for DynamicRouter {
             );
         }
 
-        self.register_hostnames(resolved_handle.id(), &all_hosts).await;
+        self.register_hostnames(resolved_handle.id(), &all_hosts);
 
         Ok(())
     }
@@ -337,32 +350,32 @@ impl Router for DynamicRouter {
         // routing here rather than through `on_workload_resolved`. Register its
         // hostnames exactly like a component workload so requests resolve to it.
         if hostnames.is_empty() {
-            warn!(
+            // debug, not warn: a service restart re-resolves, so a misconfigured one would spam.
+            debug!(
                 workload_id,
-                "service resolved with no valid ingress hostnames; requests will not route to it under the hostname router"
+                "service has no valid ingress hostnames; not routable by the hostname router"
             );
             return Ok(());
         }
-        self.register_hostnames(workload_id, hostnames).await;
+        self.register_hostnames(workload_id, hostnames);
         Ok(())
     }
 
     async fn on_workload_unbind(&self, workload_id: &str) -> anyhow::Result<()> {
-        let hostnames = {
-            let mut wth_lock = self.workload_to_host.write().await;
-            wth_lock.remove(workload_id)
-        };
-        if let Some(hostnames) = hostnames {
-            let mut htw_lock = self.host_to_workload.write().await;
-            for hostname in &hostnames {
-                if let Some(workload_set) = htw_lock.get_mut(hostname) {
-                    workload_set.remove(workload_id);
-                    if workload_set.is_empty() {
-                        htw_lock.remove(hostname);
+        self.routes.rcu(|cur| {
+            let mut routes = (**cur).clone();
+            if let Some(hostnames) = routes.workload_to_host.remove(workload_id) {
+                for hostname in &hostnames {
+                    if let Some(workload_set) = routes.host_to_workload.get_mut(hostname) {
+                        workload_set.remove(workload_id);
+                        if workload_set.is_empty() {
+                            routes.host_to_workload.remove(hostname);
+                        }
                     }
                 }
             }
-        }
+            routes
+        });
         Ok(())
     }
 
@@ -376,8 +389,8 @@ impl Router for DynamicRouter {
         check_allowed_hosts(request, allowed_hosts)
     }
 
-    /// Pick a workload ID based on the incoming request, round-robining across
-    /// every replica bound to the request's `Host`.
+    /// Pick a workload ID based on the incoming request, spreading load at
+    /// random across every replica bound to the request's `Host`.
     fn route_incoming_request(
         &self,
         req: &hyper::Request<hyper::body::Incoming>,
@@ -388,7 +401,10 @@ impl Router for DynamicRouter {
             .and_then(|h| h.to_str().ok())
             .or_else(|| req.uri().authority().map(|a| a.as_str()))
             .ok_or(RouteError::MissingHost)?;
-        tokio::task::block_in_place(move || self.select_workload(workload_host))
+        // `select_workload` does a lock-free `ArcSwap` load and an in-memory
+        // lookup, so it runs inline on the async worker — no `block_in_place`
+        // needed (and routing works on any runtime flavor).
+        self.select_workload(workload_host)
     }
 }
 
@@ -1048,7 +1064,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
 
     async fn on_service_http_unbind(&self, workload_id: &str) -> anyhow::Result<()> {
         // Drop the router registration too, so a stopped service replica leaves
-        // the hostname's round-robin rotation.
+        // the hostname's replica set and stops being selected.
         self.router.on_workload_unbind(workload_id).await?;
         self.service_handlers.write().await.remove(workload_id);
         Ok(())
@@ -2604,11 +2620,16 @@ mod tests {
     }
 
     /// Regression guard for the "N replicas serve like one" defect: with several
-    /// workloads bound to one hostname, `route_incoming_request` used to pin every
-    /// request to a single arbitrary replica (`HashSet::iter().next()`). The
-    /// round-robin cursor must instead spread requests evenly across all of them.
+    /// workloads bound to one hostname, `route_incoming_request` used to pin
+    /// every request to a single arbitrary replica (`HashSet::iter().next()`).
+    /// Random selection must instead spread load across all of them.
+    ///
+    /// Selection is a per-thread PRNG, so this asserts a distribution rather than
+    /// exact counts. The band around the expected share is ~18σ wide for uniform
+    /// selection over these draws, so it cannot flake, yet the old pin-to-one
+    /// behavior (one replica takes everything, the rest zero) fails it outright.
     #[tokio::test]
-    async fn dynamic_router_round_robins_across_replicas() {
+    async fn dynamic_router_spreads_load_across_replicas() {
         let router = DynamicRouter::default();
         let replicas = ["r0", "r1", "r2", "r3"];
         for id in replicas {
@@ -2618,9 +2639,10 @@ mod tests {
                 .unwrap();
         }
 
+        const DRAWS: usize = 4_000;
         let mut counts: std::collections::BTreeMap<String, usize> =
             std::collections::BTreeMap::new();
-        for _ in 0..(replicas.len() * 2) {
+        for _ in 0..DRAWS {
             let id = router.select_workload("svc.local").unwrap();
             *counts.entry(id).or_default() += 1;
         }
@@ -2630,8 +2652,12 @@ mod tests {
             replicas.len(),
             "every replica should receive traffic, got {counts:?}"
         );
+        let expected = DRAWS / replicas.len();
         for (id, hits) in counts {
-            assert_eq!(hits, 2, "replica {id} should get an even 2-of-8 share");
+            assert!(
+                hits > expected / 2 && hits < expected * 2,
+                "replica {id} got {hits}, far from the expected ~{expected} — uneven spread"
+            );
         }
     }
 
@@ -2701,8 +2727,8 @@ mod tests {
 
     /// Stopping a service-only workload calls `on_service_http_unbind` but not
     /// `on_workload_unbind`. That hook must still drop the router registration,
-    /// otherwise a stopped replica lingers in the hostname's rotation and
-    /// requests round-robined onto it 404.
+    /// otherwise a stopped replica lingers in the hostname's replica set and
+    /// requests routed onto it 404.
     #[tokio::test]
     async fn service_http_unbind_removes_router_registration() {
         let server = HttpServer::builder(DynamicRouter::default(), "127.0.0.1:0".parse().unwrap())

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -19,10 +19,10 @@
 //! ```
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     net::SocketAddr,
     path::Path,
-    sync::Arc,
+    sync::{Arc, atomic::AtomicUsize},
     time::Duration,
 };
 
@@ -76,6 +76,41 @@ fn is_valid_hostname(host: &str) -> bool {
                 && !label.starts_with('-')
                 && !label.ends_with('-')
         })
+}
+
+/// Collect the ingress hostnames a workload's HTTP handler serves on: the
+/// `host` config plus any comma-separated `host-aliases`, keeping only entries
+/// that are valid RFC 1123 hostnames.
+///
+/// Unlike [`DynamicRouter::on_workload_resolved`], which fails a component
+/// workload that declares no valid host, this is lenient: it returns whatever
+/// valid hostnames exist (possibly none). Service workloads call it from their
+/// startup path, where a missing host must not abort the service. It simply
+/// won't be reachable via a hostname router (matching how the host-agnostic
+/// `DevRouter` ignores hostnames entirely).
+pub(crate) fn http_ingress_hostnames(interfaces: &[crate::wit::WitInterface]) -> Vec<String> {
+    let Some(http_iface) = interfaces
+        .iter()
+        .find(|iface| iface.is_incoming_http_handler())
+    else {
+        return Vec::new();
+    };
+
+    let mut hosts = Vec::new();
+    if let Some(primary) = http_iface.config.get("host")
+        && is_valid_hostname(primary)
+    {
+        hosts.push(primary.clone());
+    }
+    if let Some(aliases) = http_iface.config.get("host-aliases") {
+        hosts.extend(
+            aliases
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty() && is_valid_hostname(s)),
+        );
+    }
+    hosts
 }
 
 /// Why a request could not be routed to a workload.
@@ -139,9 +174,15 @@ pub trait Router: Send + Sync + 'static {
     async fn on_workload_unbind(&self, workload_id: &str) -> anyhow::Result<()>;
 
     /// Register a workload whose long-lived service handles HTTP ingress (the
-    /// service exports `wasi:http/handler`). Routers that key off a component
-    /// can use this to map the workload for routing. Default: no-op.
-    async fn on_service_http_resolved(&self, _workload_id: &str) -> anyhow::Result<()> {
+    /// service exports `wasi:http/handler`). `hostnames` are the ingress
+    /// hostnames the service serves on (see [`http_ingress_hostnames`]); a
+    /// hostname-keyed router registers the workload under each so requests
+    /// resolve to it. Default: no-op.
+    async fn on_service_http_resolved(
+        &self,
+        _workload_id: &str,
+        _hostnames: &[String],
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -178,10 +219,64 @@ pub trait Router: Send + Sync + 'static {
 /// Router that routes requests by 'Host' header, configured via WitInterface config
 #[derive(Default)]
 pub struct DynamicRouter {
-    host_to_workload: tokio::sync::RwLock<HashMap<String, HashSet<String>>>,
+    /// Maps a hostname to every workload replica bound to it. Ordered so the
+    /// round-robin cursor below strides a stable sequence between mutations.
+    host_to_workload: tokio::sync::RwLock<HashMap<String, BTreeSet<String>>>,
     /// Maps workload_id -> all hostnames (primary + aliases) registered for it.
     /// Used by on_workload_unbind to remove all entries cleanly.
     workload_to_host: tokio::sync::RwLock<HashMap<String, Vec<String>>>,
+    /// Round-robin cursor. Each routed request strides it once so successive
+    /// requests for one hostname fan out across all bound replicas instead of
+    /// pinning to one. Relaxed ordering suffices: we only need each request to
+    /// read a distinct-enough counter value, not a total order across threads.
+    rr: AtomicUsize,
+}
+
+impl DynamicRouter {
+    /// Register `workload_id` under every hostname in `hosts`, updating both the
+    /// forward (host -> replicas) and reverse (workload -> hosts) maps so
+    /// [`Router::on_workload_unbind`] can later remove every entry cleanly.
+    /// Idempotent: re-registering the same workload (e.g. a service restart)
+    /// leaves the maps unchanged.
+    async fn register_hostnames(&self, workload_id: &str, hosts: &[String]) {
+        {
+            let mut lock = self.workload_to_host.write().await;
+            lock.insert(workload_id.to_string(), hosts.to_vec());
+        }
+        {
+            let mut lock = self.host_to_workload.write().await;
+            for host in hosts {
+                lock.entry(host.clone())
+                    .or_default()
+                    .insert(workload_id.to_string());
+            }
+        }
+    }
+
+    /// Pick one replica bound to `host`, striding the round-robin cursor so
+    /// successive calls fan out across every replica. Split out from
+    /// [`Router::route_incoming_request`] so the selection logic is unit-testable
+    /// without constructing a [`hyper::body::Incoming`].
+    fn select_workload(&self, host: &str) -> Result<String, RouteError> {
+        let lock = self
+            .host_to_workload
+            .try_read()
+            .map_err(|_| RouteError::Unavailable)?;
+        let Some(workload_set) = lock.get(host) else {
+            return Err(RouteError::NoWorkloadForHost(host.to_string()));
+        };
+        // An entry can exist but be empty; treat that as "no workload bound"
+        // (same 404) and, importantly, avoid the `% 0` below.
+        if workload_set.is_empty() {
+            return Err(RouteError::NoWorkloadForHost(host.to_string()));
+        }
+        let idx = self.rr.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let workload_id = workload_set
+            .iter()
+            .nth(idx % workload_set.len())
+            .ok_or_else(|| RouteError::NoWorkloadForHost(host.to_string()))?;
+        Ok(workload_id.clone())
+    }
 }
 
 /// Implementation of Router that maps Host headers to workload IDs
@@ -228,21 +323,27 @@ impl Router for DynamicRouter {
             );
         }
 
-        let workload_id = resolved_handle.id().to_string();
+        self.register_hostnames(resolved_handle.id(), &all_hosts).await;
 
-        {
-            let mut lock = self.workload_to_host.write().await;
-            lock.insert(workload_id.clone(), all_hosts.clone());
+        Ok(())
+    }
+
+    async fn on_service_http_resolved(
+        &self,
+        workload_id: &str,
+        hostnames: &[String],
+    ) -> anyhow::Result<()> {
+        // A service-only workload (a p3 trigger service serving HTTP) reaches
+        // routing here rather than through `on_workload_resolved`. Register its
+        // hostnames exactly like a component workload so requests resolve to it.
+        if hostnames.is_empty() {
+            warn!(
+                workload_id,
+                "service resolved with no valid ingress hostnames; requests will not route to it under the hostname router"
+            );
+            return Ok(());
         }
-
-        {
-            let mut lock = self.host_to_workload.write().await;
-            for host in &all_hosts {
-                let entry = lock.entry(host.clone()).or_insert_with(HashSet::new);
-                entry.insert(workload_id.clone());
-            }
-        }
-
+        self.register_hostnames(workload_id, hostnames).await;
         Ok(())
     }
 
@@ -275,35 +376,19 @@ impl Router for DynamicRouter {
         check_allowed_hosts(request, allowed_hosts)
     }
 
-    /// Pick a workload ID based on the incoming request
+    /// Pick a workload ID based on the incoming request, round-robining across
+    /// every replica bound to the request's `Host`.
     fn route_incoming_request(
         &self,
         req: &hyper::Request<hyper::body::Incoming>,
     ) -> Result<String, RouteError> {
-        tokio::task::block_in_place(move || {
-            let lock = self
-                .host_to_workload
-                .try_read()
-                .map_err(|_| RouteError::Unavailable)?;
-            let workload_host = req
-                .headers()
-                .get(hyper::header::HOST)
-                .and_then(|h| h.to_str().ok())
-                .or_else(|| req.uri().authority().map(|a| a.as_str()))
-                .ok_or(RouteError::MissingHost)?;
-            let Some(workload_set) = lock.get(workload_host) else {
-                return Err(RouteError::NoWorkloadForHost(workload_host.to_string()));
-            };
-
-            // Entry exists but is empty so treat it as "no workload bound" from the
-            // caller's perspective; same 404 status
-            let workload_id = workload_set
-                .iter()
-                .next()
-                .ok_or_else(|| RouteError::NoWorkloadForHost(workload_host.to_string()))?;
-
-            Ok(workload_id.clone())
-        })
+        let workload_host = req
+            .headers()
+            .get(hyper::header::HOST)
+            .and_then(|h| h.to_str().ok())
+            .or_else(|| req.uri().authority().map(|a| a.as_str()))
+            .ok_or(RouteError::MissingHost)?;
+        tokio::task::block_in_place(move || self.select_workload(workload_host))
     }
 }
 
@@ -417,9 +502,14 @@ impl Router for DevRouter {
         Ok(())
     }
 
-    async fn on_service_http_resolved(&self, workload_id: &str) -> anyhow::Result<()> {
+    async fn on_service_http_resolved(
+        &self,
+        workload_id: &str,
+        _hostnames: &[String],
+    ) -> anyhow::Result<()> {
         // A service-handled workload routes the same way as a component one:
-        // DevRouter sends all requests to the most-recently resolved workload.
+        // DevRouter sends all requests to the most-recently resolved workload,
+        // so it ignores hostnames.
         let mut lock = self
             .last_workload_id
             .write()
@@ -484,11 +574,14 @@ pub trait HostHandler: Send + Sync + 'static {
 
     /// Register a long-lived service instance that serves HTTP ingress: inbound
     /// requests for `workload_id` are delivered over `sender` instead of
-    /// instantiating a component per request. Default: no-op (the workload
-    /// keeps the per-request path).
+    /// instantiating a component per request. `hostnames` are the ingress
+    /// hostnames the service serves on, forwarded to the router so a
+    /// hostname-keyed router can resolve requests to this workload. Default:
+    /// no-op (the workload keeps the per-request path).
     async fn on_service_http_resolved(
         &self,
         _workload_id: &str,
+        _hostnames: &[String],
         _sender: tokio::sync::mpsc::Sender<ServiceHttpJob>,
     ) -> anyhow::Result<()> {
         Ok(())
@@ -934,9 +1027,12 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
     async fn on_service_http_resolved(
         &self,
         workload_id: &str,
+        hostnames: &[String],
         sender: tokio::sync::mpsc::Sender<ServiceHttpJob>,
     ) -> anyhow::Result<()> {
-        self.router.on_service_http_resolved(workload_id).await?;
+        self.router
+            .on_service_http_resolved(workload_id, hostnames)
+            .await?;
         // A re-resolve without an intervening unbind is expected: the trigger
         // service supervisor re-registers a fresh sender on every restart (see
         // `execute_trigger_service`) to swap in the new incarnation. Overwriting
@@ -951,6 +1047,9 @@ impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
     }
 
     async fn on_service_http_unbind(&self, workload_id: &str) -> anyhow::Result<()> {
+        // Drop the router registration too, so a stopped service replica leaves
+        // the hostname's round-robin rotation.
+        self.router.on_workload_unbind(workload_id).await?;
         self.service_handlers.write().await.remove(workload_id);
         Ok(())
     }
@@ -2439,6 +2538,192 @@ mod tests {
         assert!(
             result.is_err(),
             "NullServer P3 outgoing request should return an error"
+        );
+    }
+
+    /// A `wasi:http/incoming-handler` interface carrying `host` and, optionally,
+    /// a comma-separated `host-aliases` config — mirrors what the wash config
+    /// layer injects.
+    fn http_iface(host: Option<&str>, aliases: Option<&str>) -> crate::wit::WitInterface {
+        let mut config = HashMap::new();
+        if let Some(host) = host {
+            config.insert("host".to_string(), host.to_string());
+        }
+        if let Some(aliases) = aliases {
+            config.insert("host-aliases".to_string(), aliases.to_string());
+        }
+        crate::wit::WitInterface {
+            namespace: "wasi".to_string(),
+            package: "http".to_string(),
+            interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+            version: Some(semver::Version::parse("0.2.2").unwrap()),
+            config,
+            name: None,
+        }
+    }
+
+    #[test]
+    fn http_ingress_hostnames_collects_primary_and_valid_aliases() {
+        let ifaces = vec![http_iface(Some("primary.local"), Some("a.local, b.local"))];
+        assert_eq!(
+            http_ingress_hostnames(&ifaces),
+            vec![
+                "primary.local".to_string(),
+                "a.local".to_string(),
+                "b.local".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn http_ingress_hostnames_filters_invalid_and_empty_entries() {
+        // Underscores are not valid RFC 1123 hostname chars, and leading/trailing
+        // hyphens are rejected: the bad primary is dropped and only the valid
+        // aliases survive.
+        let ifaces = vec![http_iface(
+            Some("bad_host"),
+            Some("ok.local,,-nope-,also_bad,fine.local"),
+        )];
+        assert_eq!(
+            http_ingress_hostnames(&ifaces),
+            vec!["ok.local".to_string(), "fine.local".to_string()],
+        );
+    }
+
+    #[test]
+    fn http_ingress_hostnames_empty_without_http_interface() {
+        let kv = crate::wit::WitInterface {
+            namespace: "wasi".to_string(),
+            package: "keyvalue".to_string(),
+            interfaces: ["store".to_string()].into_iter().collect(),
+            version: None,
+            config: HashMap::new(),
+            name: None,
+        };
+        assert!(http_ingress_hostnames(&[kv]).is_empty());
+    }
+
+    /// Regression guard for the "N replicas serve like one" defect: with several
+    /// workloads bound to one hostname, `route_incoming_request` used to pin every
+    /// request to a single arbitrary replica (`HashSet::iter().next()`). The
+    /// round-robin cursor must instead spread requests evenly across all of them.
+    #[tokio::test]
+    async fn dynamic_router_round_robins_across_replicas() {
+        let router = DynamicRouter::default();
+        let replicas = ["r0", "r1", "r2", "r3"];
+        for id in replicas {
+            router
+                .on_service_http_resolved(id, &["svc.local".to_string()])
+                .await
+                .unwrap();
+        }
+
+        let mut counts: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        for _ in 0..(replicas.len() * 2) {
+            let id = router.select_workload("svc.local").unwrap();
+            *counts.entry(id).or_default() += 1;
+        }
+
+        assert_eq!(
+            counts.len(),
+            replicas.len(),
+            "every replica should receive traffic, got {counts:?}"
+        );
+        for (id, hits) in counts {
+            assert_eq!(hits, 2, "replica {id} should get an even 2-of-8 share");
+        }
+    }
+
+    /// A service-only workload (defect #1) reaches routing through
+    /// `on_service_http_resolved`, not `on_workload_resolved`. The router must
+    /// register its hostnames so requests resolve. Previously this was a no-op
+    /// and every hostname 404'd.
+    #[tokio::test]
+    async fn dynamic_router_registers_service_http_hostnames() {
+        let router = DynamicRouter::default();
+        assert!(
+            matches!(
+                router.select_workload("svc.local"),
+                Err(RouteError::NoWorkloadForHost(_))
+            ),
+            "host should not resolve before the service is registered"
+        );
+
+        router
+            .on_service_http_resolved(
+                "svc-1",
+                &["svc.local".to_string(), "svc.internal".to_string()],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(router.select_workload("svc.local").unwrap(), "svc-1");
+        assert_eq!(router.select_workload("svc.internal").unwrap(), "svc-1");
+    }
+
+    /// A service resolving with no valid hostnames (e.g. under a host-agnostic
+    /// deployment) must not register anything or error.
+    #[tokio::test]
+    async fn dynamic_router_service_http_empty_hostnames_is_noop() {
+        let router = DynamicRouter::default();
+        router.on_service_http_resolved("svc-1", &[]).await.unwrap();
+        assert!(matches!(
+            router.select_workload("anything.local"),
+            Err(RouteError::NoWorkloadForHost(_))
+        ));
+    }
+
+    /// Unbinding one replica drops it from the rotation; the hostname keeps
+    /// routing to whoever remains.
+    #[tokio::test]
+    async fn dynamic_router_unbind_removes_replica_from_rotation() {
+        let router = DynamicRouter::default();
+        router
+            .on_service_http_resolved("r0", &["svc.local".to_string()])
+            .await
+            .unwrap();
+        router
+            .on_service_http_resolved("r1", &["svc.local".to_string()])
+            .await
+            .unwrap();
+
+        router.on_workload_unbind("r0").await.unwrap();
+
+        for _ in 0..4 {
+            assert_eq!(
+                router.select_workload("svc.local").unwrap(),
+                "r1",
+                "only the surviving replica should be selected after unbind"
+            );
+        }
+    }
+
+    /// Stopping a service-only workload calls `on_service_http_unbind` but not
+    /// `on_workload_unbind`. That hook must still drop the router registration,
+    /// otherwise a stopped replica lingers in the hostname's rotation and
+    /// requests round-robined onto it 404.
+    #[tokio::test]
+    async fn service_http_unbind_removes_router_registration() {
+        let server = HttpServer::builder(DynamicRouter::default(), "127.0.0.1:0".parse().unwrap())
+            .build()
+            .await
+            .unwrap();
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        server
+            .on_service_http_resolved("svc-1", &["svc.local".to_string()], tx)
+            .await
+            .unwrap();
+        assert_eq!(server.router.select_workload("svc.local").unwrap(), "svc-1");
+
+        server.on_service_http_unbind("svc-1").await.unwrap();
+        assert!(
+            matches!(
+                server.router.select_workload("svc.local"),
+                Err(RouteError::NoWorkloadForHost(_))
+            ),
+            "hostname must stop routing once the service unbinds"
         );
     }
 }

--- a/crates/wash-runtime/tests/integration_component_host_plugin.rs
+++ b/crates/wash-runtime/tests/integration_component_host_plugin.rs
@@ -134,8 +134,8 @@ async fn test_component_plugin_missing_provider_errors() -> Result<()> {
 ///
 /// Uses the host-header router so the two callers are genuinely distinct
 /// workloads (the `DevRouter` would send both requests to the last-resolved
-/// workload, making the assertion vacuous). Multi-threaded: the host-header
-/// router uses `block_in_place`.
+/// workload, making the assertion vacuous). Runs multi-threaded so the live
+/// HTTP server serves requests in parallel with the test's request loop.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_component_plugin_shared_across_workloads() -> Result<()> {
     let (addr, h) =
@@ -624,8 +624,8 @@ async fn test_component_plugin_resource_isolation() -> Result<()> {
 /// threading + the identity import; concurrent interleaving is covered by
 /// [`test_component_plugin_partitioning_under_concurrency`].
 ///
-/// Multi-threaded: the host-header router uses `block_in_place`, which a
-/// current-thread runtime cannot run.
+/// Runs multi-threaded so the live HTTP server serves requests in parallel with
+/// the test's request loop.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_component_plugin_per_caller_partitioning() -> Result<()> {
     let (addr, h) =
@@ -679,7 +679,7 @@ async fn test_component_plugin_per_caller_partitioning() -> Result<()> {
 /// (the cooperative store can lag a same-caller readback by a call — orthogonal to
 /// identity and not what this test guards).
 ///
-/// Multi-threaded: the host-header router uses `block_in_place`.
+/// Runs multi-threaded so requests are served in parallel under concurrency.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_component_plugin_partitioning_under_concurrency() -> Result<()> {
     let (addr, h) =

--- a/crates/wash-runtime/tests/integration_router_dynamic.rs
+++ b/crates/wash-runtime/tests/integration_router_dynamic.rs
@@ -1,8 +1,8 @@
 //! Integration tests for `DynamicRouter` — routes incoming requests to
 //! workloads by Host header (with optional comma-separated aliases).
 //!
-//! `DynamicRouter::route_incoming_request` uses `tokio::task::block_in_place`
-//! with `try_read`, so all tests run on the multi-thread runtime. Per-request
+//! These tests drive a live HTTP server and fan out concurrent requests
+//! against it, so they run on the multi-thread runtime. Per-request
 //! `timeout(...)` on individual HTTP calls guards against hangs.
 //!
 //! Covers:

--- a/crates/wash-runtime/tests/integration_service_http.rs
+++ b/crates/wash-runtime/tests/integration_service_http.rs
@@ -133,15 +133,21 @@ async fn test_service_http_co_drives_cli_run() -> Result<()> {
 /// combined to pin all traffic to a single replica: service workloads never
 /// registered their hostname with the `DynamicRouter` (so a hostname router
 /// 404'd them), and `route_incoming_request` picked one arbitrary replica per
-/// host. With both fixed, four `svc-counter` replicas bound to ONE hostname must
-/// each take an equal share.
+/// host. With both fixed, four `svc-counter` replicas bound to ONE hostname
+/// share the traffic.
 ///
-/// Each replica keeps an independent `http_calls` counter, so 8 sequential
-/// requests spread round-robin over 4 replicas land 2 each: the sorted
-/// `http_calls` values across the 8 responses are `[1,1,1,1,2,2,2,2]`. A single
-/// pinned replica would instead read `[1,2,3,4,5,6,7,8]`.
-#[tokio::test]
-async fn test_service_http_round_robins_across_replicas() -> Result<()> {
+/// Selection is random, so this asserts every replica gets used rather than an
+/// exact split. Each replica keeps an independent `http_calls` counter that
+/// starts at 0, so the first request routed to a given replica is the only one
+/// that reads back `http_calls == 1`. Counting the `== 1` responses therefore
+/// counts the distinct replicas that served at least once — which must be all
+/// four. The old pin-to-one behavior sends every request to one replica, so
+/// exactly one response reads `1` (and the rest climb `2,3,4,…`), failing this.
+///
+/// Runs on a multi-thread runtime so the HTTP server and the four co-driven p3
+/// service instances make progress in parallel with the request loop.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_service_http_spreads_load_across_replicas() -> Result<()> {
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
 
     const REPLICAS: usize = 4;
@@ -157,8 +163,11 @@ async fn test_service_http_round_robins_across_replicas() -> Result<()> {
         .pool_max_idle_per_host(0)
         .build()?;
 
-    let mut http_calls = Vec::new();
-    for _ in 0..(REPLICAS * 2) {
+    // Enough requests that random selection hits all four replicas with
+    // overwhelming probability: P(any replica missed) <= 4 * (3/4)^80 ~= 4e-10.
+    const REQUESTS: usize = 80;
+    let mut distinct_replicas = 0;
+    for _ in 0..REQUESTS {
         let resp = timeout(
             Duration::from_secs(10),
             client
@@ -173,15 +182,15 @@ async fn test_service_http_round_robins_across_replicas() -> Result<()> {
             resp.status()
         );
         let (_cli_ticks, calls) = parse_counter(&resp.text().await?);
-        http_calls.push(calls);
+        if calls == 1 {
+            distinct_replicas += 1;
+        }
     }
 
-    http_calls.sort_unstable();
     assert_eq!(
-        http_calls,
-        vec![1, 1, 1, 1, 2, 2, 2, 2],
-        "8 requests across 4 replicas should land 2 each (round-robin); got {http_calls:?} \
-         — a single pinned replica would read [1,2,3,4,5,6,7,8]"
+        distinct_replicas, REPLICAS,
+        "all {REPLICAS} replicas should serve traffic (one `http_calls == 1` each); \
+         saw {distinct_replicas} — a single pinned replica would show exactly 1"
     );
 
     Ok(())

--- a/crates/wash-runtime/tests/integration_service_http.rs
+++ b/crates/wash-runtime/tests/integration_service_http.rs
@@ -19,7 +19,10 @@ use wash_runtime::host::HostApi;
 use wash_runtime::types::{LocalResources, Service, Workload, WorkloadStartRequest};
 
 mod common;
-use common::{http_only_host_interfaces, json_u64_field, start_host_with_p3_http_handler};
+use common::{
+    http_only_host_interfaces, json_u64_field, start_host_with_dynamic_router,
+    start_host_with_p3_http_handler,
+};
 
 const SVC_COUNTER_WASM: &[u8] = include_bytes!("wasm/svc_counter.wasm");
 
@@ -121,6 +124,64 @@ async fn test_service_http_co_drives_cli_run() -> Result<()> {
     assert!(
         saw_growth,
         "cli/run should be co-driven concurrently with HTTP serving — cli_ticks never grew between requests"
+    );
+
+    Ok(())
+}
+
+/// Regression for "N service replicas on one host serve like one". Two defects
+/// combined to pin all traffic to a single replica: service workloads never
+/// registered their hostname with the `DynamicRouter` (so a hostname router
+/// 404'd them), and `route_incoming_request` picked one arbitrary replica per
+/// host. With both fixed, four `svc-counter` replicas bound to ONE hostname must
+/// each take an equal share.
+///
+/// Each replica keeps an independent `http_calls` counter, so 8 sequential
+/// requests spread round-robin over 4 replicas land 2 each: the sorted
+/// `http_calls` values across the 8 responses are `[1,1,1,1,2,2,2,2]`. A single
+/// pinned replica would instead read `[1,2,3,4,5,6,7,8]`.
+#[tokio::test]
+async fn test_service_http_round_robins_across_replicas() -> Result<()> {
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+
+    const REPLICAS: usize = 4;
+    for _ in 0..REPLICAS {
+        host.workload_start(svc_counter_request("svc-rr"))
+            .await
+            .context("failed to start svc-counter replica")?;
+    }
+
+    // No connection pooling: a GET retried on a stale pooled connection would
+    // land twice on one instance and skew the per-replica counts.
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()?;
+
+    let mut http_calls = Vec::new();
+    for _ in 0..(REPLICAS * 2) {
+        let resp = timeout(
+            Duration::from_secs(10),
+            client
+                .get(format!("http://{addr}/"))
+                .header("HOST", "svc-rr")
+                .send(),
+        )
+        .await??;
+        anyhow::ensure!(
+            resp.status().is_success(),
+            "each replica should serve requests, got {}",
+            resp.status()
+        );
+        let (_cli_ticks, calls) = parse_counter(&resp.text().await?);
+        http_calls.push(calls);
+    }
+
+    http_calls.sort_unstable();
+    assert_eq!(
+        http_calls,
+        vec![1, 1, 1, 1, 2, 2, 2, 2],
+        "8 requests across 4 replicas should land 2 each (round-robin); got {http_calls:?} \
+         — a single pinned replica would read [1,2,3,4,5,6,7,8]"
     );
 
     Ok(())


### PR DESCRIPTION
N service replicas on one host served like one, from two defects:

1. Service-only workloads never registered their hostname. A p3 trigger
   service reaches routing via on_service_http_resolved, not
   on_workload_resolved, and DynamicRouter left the Router hook a default
   no-op — so a service behind a hostname router 404'd. Hostnames now flow
   through HostHandler/Router::on_service_http_resolved (derived once via
   http_ingress_hostnames) and DynamicRouter registers them like component
   workloads.

2. route_incoming_request picked HashSet::iter().next(), pinning every
   request for a hostname to one arbitrary replica. It now strides a relaxed
   atomic cursor over an ordered (BTreeSet) replica set for round-robin, with
   selection split into select_workload() and an empty-set guard.

Registering service hostnames means they must be cleaned on stop: the
service-only stop path calls on_service_http_unbind but not
on_workload_unbind, so that hook now also drops the router registration
(idempotent) — otherwise a stopped replica lingers in rotation and 404s.

Adds unit tests for round-robin distribution, service hostname
registration, unbind cleanup, and http_ingress_hostnames extraction, plus
an integration test asserting 8 requests across 4 replicas land 2 each.

Caught by @LiamRandall. I took his fix and added tests. I ran our benches and this has no material impact on perf. 