### PR TITLE
[FEAT] plugin workload lifecycle

### DIFF
--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -79,13 +79,18 @@ pub struct SharedCtx {
     pub resource_registry: Option<crate::engine::store::resource_bridge::ResourceRegistry>,
 }
 
-/// The identity of a workload making a capability call — a `(workload_id,
-/// component_id)` pair, used by a host component plugin to partition state per
-/// caller.
+/// The identity of whoever is invoking a host component plugin, used to
+/// partition state per caller.
+///
+/// `component_id` is `None` when there is no component behind the call: a
+/// `wasmcloud:host/workload-lifecycle` hook is delivered by the host about a
+/// whole workload, not on behalf of any one of its items. Encoding that as a
+/// real id — an empty string, say — would make the host invent a component that
+/// does not exist, and would collide with a genuinely unresolvable caller.
 #[derive(Clone, Debug)]
 pub struct CallerIdentity {
     pub workload_id: Arc<str>,
-    pub component_id: Arc<str>,
+    pub component_id: Option<Arc<str>>,
 }
 
 impl SharedCtx {

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -38,7 +38,7 @@
 //!    that call's work. A guest that spawns background work and relies on it
 //!    being torn down with the call should not be pooled.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 
@@ -59,7 +59,7 @@ use crate::types::Component;
 /// would quietly acquire state that outlives a call, just because something
 /// else in the workload imports it.
 pub(crate) fn poolable(
-    components: &HashMap<Arc<str>, WorkloadComponent>,
+    components: &BTreeMap<Arc<str>, WorkloadComponent>,
     component_id: &str,
     linked: &HashSet<Arc<str>>,
 ) -> Option<Arc<InstancePool>> {

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -17,7 +17,7 @@
 //! assemble the store (pre-instantiating the linked components). See
 //! [`EphemeralLinkedCall`] for how the ephemeral path is captured at link time.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -138,7 +138,7 @@ pub(crate) fn component_ctx_template_from_metadata_with_tls(
 pub(crate) struct EphemeralLinkedCall {
     pub(crate) engine: wasmtime::Engine,
     pub(crate) http_handler: Arc<dyn crate::host::http::HostHandler>,
-    pub(crate) components: Arc<RwLock<HashMap<Arc<str>, WorkloadComponent>>>,
+    pub(crate) components: Arc<RwLock<BTreeMap<Arc<str>, WorkloadComponent>>>,
     pub(crate) active_component_id: Arc<str>,
     pub(crate) linked_component_ids: Vec<Arc<str>>,
     #[cfg(feature = "wasi-tls")]

--- a/crates/wash-runtime/src/engine/volumes.rs
+++ b/crates/wash-runtime/src/engine/volumes.rs
@@ -7,7 +7,7 @@
 //! mounts once and cache them on its [`WorkloadMetadata`], so request-path
 //! store creation never re-canonicalizes.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -75,7 +75,7 @@ pub(crate) async fn resolve_volume_mounts(
 /// mounts are then written back under a single write lock. Components whose
 /// mounts are already resolved are skipped, so this is cheap to call repeatedly.
 pub(crate) async fn resolve_component_volume_mounts_in_map(
-    components: &Arc<RwLock<HashMap<Arc<str>, WorkloadComponent>>>,
+    components: &Arc<RwLock<BTreeMap<Arc<str>, WorkloadComponent>>>,
     component_ids: &[Arc<str>],
 ) -> anyhow::Result<()> {
     let pending = {

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1629,6 +1629,37 @@ impl ResolvedWorkload {
             }
         }
 
+        // The service item records plugin bindings just like a component;
+        // unbind them the same way so a plugin bound only to the service is
+        // not left tracking a stopped workload.
+        if let Some(service) = self.service.as_ref()
+            && let Some(plugins) = service.plugins()
+        {
+            for (plugin_id, plugin) in plugins.iter() {
+                let world = service.world();
+                let plugin_world = plugin.world();
+                let bound_interfaces = world
+                    .imports
+                    .iter()
+                    .filter(|import| plugin_world.imports.contains(import))
+                    .cloned()
+                    .collect::<std::collections::HashSet<_>>();
+
+                if let Err(e) = plugin
+                    .on_workload_unbind(self.id(), WitInterfaces::new(&bound_interfaces))
+                    .await
+                {
+                    warn!(
+                        plugin_id,
+                        service_id = service.id(),
+                        workload_id = self.id.as_ref(),
+                        error = ?e,
+                        "failed to unbind plugin from service, continuing cleanup"
+                    );
+                }
+            }
+        }
+
         // A trigger service registered its HTTP/messaging handlers at start
         // (`execute_trigger_service`); drop those registrations on stop so it no
         // longer receives host-invoked deliveries on a torn-down instance.
@@ -2063,6 +2094,27 @@ impl UnresolvedWorkload {
                     interfaces = ?unmatched,
                     "no plugins found for requested interfaces"
                 );
+                // The same rollback the bind-failure paths perform: without it
+                // every successfully bound plugin keeps tracking a workload
+                // that never deploys.
+                for (bound_plugin, bound_interfaces, _) in
+                    bound_plugins_with_interfaces.iter().rev()
+                {
+                    debug!(
+                        plugin_id = bound_plugin.id(),
+                        "calling on_workload_unbind for cleanup after unmatched interfaces"
+                    );
+                    if let Err(cleanup_err) = bound_plugin
+                        .on_workload_unbind(self.id(), WitInterfaces::new(bound_interfaces))
+                        .await
+                    {
+                        warn!(
+                            plugin_id = bound_plugin.id(),
+                            error = ?cleanup_err,
+                            "failed to cleanup plugin after unmatched interfaces"
+                        );
+                    }
+                }
                 bail!(
                     "workload component {component_id} requested interfaces that are not available on this host: {unmatched:?}",
                 )
@@ -2217,6 +2269,19 @@ impl UnresolvedWorkload {
     /// Gets the namespace of the workload
     pub fn namespace(&self) -> &str {
         &self.namespace
+    }
+
+    /// Id of this workload's service, if it has one.
+    pub fn service_id(&self) -> Option<Arc<str>> {
+        self.service.as_ref().map(|s| Arc::from(s.id()))
+    }
+
+    /// Ids of this workload's components, sorted (deterministic despite the
+    /// backing map). Excludes the service — see [`Self::service_id`].
+    pub fn component_ids(&self) -> Vec<Arc<str>> {
+        let mut components: Vec<Arc<str>> = self.components.keys().cloned().collect();
+        components.sort();
+        components
     }
 
     /// Retrieves the interface configuration for a given WIT interface, if it exists.

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1,7 +1,7 @@
 //! This module is primarily concerned with converting an [`UnresolvedWorkload`] into a [`ResolvedWorkload`] by
 //! resolving all components and their dependencies.
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::{Deref, DerefMut},
     path::PathBuf,
     sync::Arc,
@@ -526,7 +526,7 @@ pub struct ResolvedWorkload {
     namespace: Arc<str>,
     /// All components in the workload. This is behind a `RwLock` to support mutable
     /// access to the component linkers.
-    components: Arc<RwLock<HashMap<Arc<str>, WorkloadComponent>>>,
+    components: Arc<RwLock<BTreeMap<Arc<str>, WorkloadComponent>>>,
     /// The HTTP handler for outgoing HTTP requests
     http_handler: Arc<dyn crate::host::http::HostHandler>,
     /// An optional service component that runs once to completion or for the duration of the workload
@@ -887,7 +887,7 @@ impl ResolvedWorkload {
         }
     }
 
-    pub fn components(&self) -> Arc<RwLock<HashMap<Arc<str>, WorkloadComponent>>> {
+    pub fn components(&self) -> Arc<RwLock<BTreeMap<Arc<str>, WorkloadComponent>>> {
         self.components.clone()
     }
 
@@ -1713,7 +1713,7 @@ pub struct UnresolvedWorkload {
     /// The [`WorkloadService`] associated with this workload, if any
     service: Option<WorkloadService>,
     /// All [`WorkloadComponent`]s in the workload
-    components: HashMap<Arc<str>, WorkloadComponent>,
+    components: BTreeMap<Arc<str>, WorkloadComponent>,
     /// Component IDs in manifest order. Used to pick the first in the manifest
     /// whenever the host can dispatch an export to only one component
     component_order: Vec<Arc<str>>,
@@ -2276,12 +2276,10 @@ impl UnresolvedWorkload {
         self.service.as_ref().map(|s| Arc::from(s.id()))
     }
 
-    /// Ids of this workload's components, sorted (deterministic despite the
-    /// backing map). Excludes the service — see [`Self::service_id`].
+    /// Ids of this workload's components, in sorted order. Excludes the
+    /// service — see [`Self::service_id`].
     pub fn component_ids(&self) -> Vec<Arc<str>> {
-        let mut components: Vec<Arc<str>> = self.components.keys().cloned().collect();
-        components.sort();
-        components
+        self.components.keys().cloned().collect()
     }
 
     /// Retrieves the interface configuration for a given WIT interface, if it exists.

--- a/crates/wash-runtime/src/host/job_registry.rs
+++ b/crates/wash-runtime/src/host/job_registry.rs
@@ -42,6 +42,29 @@ struct Inner {
     /// Maps a running guest task to its job and the caller that started it, so a
     /// host import can resolve either from the current async call stack.
     by_task: BTreeMap<GuestTaskId, (JobId, CallerIdentity)>,
+    /// Progress of this incarnation's lifecycle-bind replay, for post-fault
+    /// attribution. A guest trap short-circuits `run_concurrent` and drops the
+    /// serving future before its error handler runs, so a fault cannot be
+    /// attributed from the trapping task itself. Instead the serve loop replays
+    /// binds serially and records, *before* spawning each one, which workload it
+    /// is about to (re)bind; the supervisor reads this after the driver faults —
+    /// it survives the store because the registry outlives it (held via
+    /// `state.registry`). See [`ReplayProgress`] and [`JobRegistry::replay_progress`].
+    replay: ReplayProgress,
+}
+
+/// The serial lifecycle-bind replay's progress on one incarnation.
+#[derive(Default, Clone)]
+pub struct ReplayProgress {
+    /// The workload whose bind is currently being replayed, set before the
+    /// bind is spawned and cleared when it returns cleanly. If the driver
+    /// faults with this still set, that workload's replayed bind is the cause.
+    pub current: Option<CallerIdentity>,
+    /// Set once every replayed bind has completed. If the driver faults with
+    /// this still `false`, the fault happened during replay (attributable to
+    /// `current`); if `true`, it happened while serving and is not a replay's
+    /// fault.
+    pub completed: bool,
 }
 
 /// Registry of the cancellable jobs on one store incarnation. See the module
@@ -124,6 +147,32 @@ impl JobRegistry {
             .is_some_and(|entry| entry.cancelled)
     }
 
+    /// Record that `caller`'s bind is about to be replayed. Set before the bind
+    /// is spawned so that, if it traps, the fault is attributable to it even
+    /// though the trapping task's own error handler never runs.
+    pub fn replay_begin(&self, caller: CallerIdentity) {
+        self.lock().replay.current = Some(caller);
+    }
+
+    /// Record that the current replayed bind returned cleanly, clearing the
+    /// in-flight marker before the next one is replayed.
+    pub fn replay_finish(&self) {
+        self.lock().replay.current = None;
+    }
+
+    /// Record that every replayed bind has completed; a later fault is then a
+    /// serving fault, not a replay's.
+    pub fn replay_complete(&self) {
+        let mut inner = self.lock();
+        inner.replay.current = None;
+        inner.replay.completed = true;
+    }
+
+    /// Snapshot the replay progress, for the supervisor to attribute a fault.
+    pub fn replay_progress(&self) -> ReplayProgress {
+        self.lock().replay.clone()
+    }
+
     /// Remove a job and its task binding. Called by [`JobGuard`] on drop, so it
     /// runs whether the task completes normally or its future is dropped (e.g. on
     /// store teardown), with no store access required.
@@ -202,7 +251,7 @@ mod tests {
     fn caller(workload: &str, component: &str) -> CallerIdentity {
         CallerIdentity {
             workload_id: Arc::from(workload),
-            component_id: Arc::from(component),
+            component_id: Some(Arc::from(component)),
         }
     }
 

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -55,7 +55,7 @@ use wasmtime::component::Component;
 use crate::engine::workload::ResolvedWorkload;
 use crate::engine::{Engine, uses_wasi_http};
 use crate::observability::Meters;
-use crate::plugin::HostPlugin;
+use crate::plugin::{HostPlugin, WorkloadFailure, WorkloadFailureSink};
 use crate::types::*;
 use crate::wit::{WitInterface, WitWorld};
 
@@ -330,9 +330,19 @@ impl Host {
             .await
             .context("failed to start HTTP handler")?;
 
-        // Start all plugins, any errors means the host fails to start.
+        // A plugin can fail a workload out of band (a host component plugin
+        // evicting one whose lifecycle bind crash-loops). Give each plugin a
+        // sink to report that on, drained by a background task that transitions
+        // the workload to a failed state.
+        let (failure_tx, failure_rx) = tokio::sync::mpsc::unbounded_channel();
+        let failure_sink = WorkloadFailureSink::new(failure_tx);
+
+        // Start all plugins, any errors means the host fails to start. The
+        // failure sink is injected before `start` so a plugin that evicts a
+        // workload immediately still has somewhere to report it.
         for (id, plugin) in &self.plugins {
             plugin.inject_meters(&self.meters).await;
+            plugin.set_workload_failure_sink(failure_sink.clone());
 
             if let Err(e) = plugin.start().await {
                 tracing::error!(id = id, err = ?e, "failed to start plugin");
@@ -340,7 +350,48 @@ impl Host {
             }
         }
 
-        Ok(Arc::new(self))
+        let host = Arc::new(self);
+        // Weak, not strong: the sinks handed to the plugins live inside
+        // `host.plugins`, so the channel stays open for as long as the host
+        // does. A strong handle here would therefore be a cycle — the drain
+        // would keep the host alive, and the host would keep the drain's
+        // channel open — leaking the host, its engine, and every compiled
+        // component. `Host::stop` cannot break it either: it stops the plugins
+        // but never drops them.
+        tokio::spawn(consume_workload_failures(Arc::downgrade(&host), failure_rx));
+        Ok(host)
+    }
+
+    /// Transition a running workload to a failed state on a plugin's report
+    /// (e.g. an evicted crash-looping bind): swap it to `Error`, so its status
+    /// reports failed, and tear down its resources like a stop would. A workload
+    /// that is already gone or not running is left as-is.
+    async fn fail_workload(&self, workload_id: &str, reason: String) {
+        let resolved = {
+            let mut workloads = self.workloads.write().await;
+            match workloads.get_mut(workload_id) {
+                Some(slot) => {
+                    let previous = std::mem::replace(slot, HostWorkload::Error(reason.clone()));
+                    match previous {
+                        HostWorkload::Running(rw) => Some(*rw),
+                        // Not running (starting/stopping/already error): leave the
+                        // Error we just wrote, nothing to tear down.
+                        _ => None,
+                    }
+                }
+                None => None,
+            }
+        };
+        if let Some(resolved) = resolved {
+            resolved.stop_service();
+            if let Err(e) = resolved.unbind_all_plugins().await {
+                warn!(workload_id, error = ?e, "error unbinding plugins while failing workload");
+            }
+        }
+        warn!(
+            workload_id,
+            reason, "workload failed by a plugin; marked as errored"
+        );
     }
 
     /// Stop the host and shut down all plugins.
@@ -826,6 +877,29 @@ impl std::fmt::Debug for Host {
             .field("started_at", &self.started_at)
             .field("workloads", &self.workloads)
             .finish()
+    }
+}
+
+/// Drain plugin-reported workload failures for the lifetime of the host,
+/// transitioning each reported workload to a failed state. Ends when the host
+/// is dropped, or when the last [`WorkloadFailureSink`] is (a host with no
+/// plugin that keeps one).
+///
+/// The host is held weakly and upgraded per report so this task never keeps it
+/// alive — see the spawn site in [`Host::start`].
+async fn consume_workload_failures(
+    host: std::sync::Weak<Host>,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<WorkloadFailure>,
+) {
+    while let Some(WorkloadFailure {
+        workload_id,
+        reason,
+    }) = rx.recv().await
+    {
+        let Some(host) = host.upgrade() else {
+            break;
+        };
+        host.fail_workload(&workload_id, reason).await;
     }
 }
 

--- a/crates/wash-runtime/src/host/trigger_service/capability.rs
+++ b/crates/wash-runtime/src/host/trigger_service/capability.rs
@@ -3,6 +3,7 @@
 //!
 //! [`Ingress::Capability`]: super::Ingress::Capability
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
@@ -14,7 +15,7 @@ use wasmtime::error::Context as _;
 
 use crate::engine::ctx::{CallerIdentity, SharedCtx};
 use crate::engine::store::relocate::{self, Relocated};
-use crate::host::job_registry::JobGuard;
+use crate::host::job_registry::{JobGuard, JobRegistry};
 
 /// One exported capability function the TriggerService should be ready to serve,
 /// identified by its interface and function name (e.g. `acme:kv/store@0.1.0` /
@@ -65,6 +66,44 @@ pub struct CapabilityCall {
     pub reply: tokio::sync::oneshot::Sender<wasmtime::Result<Vec<Relocated>>>,
 }
 
+/// A `wasmcloud:host/workload-lifecycle` bind a fresh plugin incarnation must
+/// complete before serving capability calls: the replay performed for every
+/// workload still bound, so the incarnation's per-workload state exists before
+/// any of those workloads' queued calls run.
+pub struct LifecycleReplay {
+    /// Instance name of the plugin's lifecycle export.
+    pub interface: Arc<str>,
+    /// The bind function's name within that interface.
+    pub func: Arc<str>,
+    /// The workload the bind concerns (its id, with an empty component id).
+    pub caller: CallerIdentity,
+    /// The `workload-info` argument (handle-free).
+    pub args: Vec<Relocated>,
+    /// The bind function's result types.
+    pub result_tys: Arc<[Type]>,
+}
+
+/// Interpret the reply of an `on-workload-bind` call (`result<_, string>`):
+/// `Ok(())` when the guest accepted the bind, `Err(msg)` when it rejected it.
+/// Any other reply shape is a contract violation surfaced as a `wasmtime`
+/// error.
+pub(crate) fn decode_bind_reply(results: &[Relocated]) -> wasmtime::Result<Result<(), String>> {
+    match results {
+        [Relocated::Val(Val::Result(Ok(_)))] => Ok(Ok(())),
+        [Relocated::Val(Val::Result(Err(Some(payload))))] => match payload.as_ref() {
+            Val::String(msg) => Ok(Err(msg.clone())),
+            other => {
+                wasmtime::bail!("on-workload-bind error payload is not a string: {other:?}")
+            }
+        },
+        [Relocated::Val(Val::Result(Err(None)))] => Ok(Err(String::new())),
+        other => wasmtime::bail!(
+            "on-workload-bind returned an unexpected reply shape ({} values)",
+            other.len()
+        ),
+    }
+}
+
 /// Hard ceiling on capability-call tasks in flight on one plugin instance at
 /// once, counting re-entrant hops (each hop of an `A -> plugin -> ... -> A`
 /// chain is a live task suspended awaiting the next). A call that would exceed
@@ -85,6 +124,64 @@ pub struct CapabilityCall {
 /// `try_acquire` semaphore would behave like this counter but carries a waiter
 /// queue and fairness machinery we never use, so a plain atomic is lighter.
 pub(super) const MAX_INFLIGHT_CAPABILITY_CALLS: usize = 512;
+
+/// Admit one capability call under the in-flight ceiling and spawn it as a
+/// concurrent task on the shared instance, or send the rejection/routing error
+/// on the call's reply. Shared by the serve loop (channel-delivered calls) and
+/// the lifecycle bind replay a fresh incarnation performs before serving.
+///
+/// Admission is a non-blocking reservation (fetch_add + compare): the caller
+/// NEVER blocks, so a re-entrant call is always admitted while the store is
+/// under the ceiling — no bounded-pool deadlock. A runaway self-recursion
+/// consumes a slot per hop and is rejected at the cap.
+pub(super) fn admit_and_spawn_call(
+    accessor: &Accessor<SharedCtx>,
+    instance: Instance,
+    func_map: &BTreeMap<Arc<str>, BTreeMap<Arc<str>, ComponentExportIndex>>,
+    registry: &Arc<JobRegistry>,
+    in_flight: &Arc<AtomicUsize>,
+    call: CapabilityCall,
+) {
+    use std::sync::atomic::Ordering;
+    if in_flight.fetch_add(1, Ordering::SeqCst) >= MAX_INFLIGHT_CAPABILITY_CALLS {
+        in_flight.fetch_sub(1, Ordering::SeqCst);
+        let _ = call.reply.send(Err(wasmtime::format_err!(
+            "host component plugin is at its in-flight capability-call \
+             ceiling ({MAX_INFLIGHT_CAPABILITY_CALLS}); a call cycle or \
+             overload is likely"
+        )));
+        return;
+    }
+    let guard = InFlightGuard::new(Arc::clone(in_flight));
+    let Some(func_idx) = func_map
+        .get(&*call.interface)
+        .and_then(|fns| fns.get(&*call.func))
+        .copied()
+    else {
+        let _ = call.reply.send(Err(wasmtime::format_err!(
+            "plugin does not export {}/{}",
+            call.interface,
+            call.func
+        )));
+        return;
+    };
+    // Register the call as a cancellable job. The `JobGuard` moves into the
+    // task and retires the job on completion or drop. The `Accessor::spawn`
+    // handle is not retained: wasmtime cannot hard-cancel the guest subtask,
+    // so cancellation is cooperative — `request-cancel` marks the job and the
+    // guest unwinds itself.
+    let job = registry.admit(call.caller.clone());
+    let job_guard = JobGuard::new(Arc::clone(registry), job);
+    if let Err(e) = accessor.spawn(CapabilityTask {
+        instance,
+        func_idx,
+        call,
+        in_flight: guard,
+        job_guard,
+    }) {
+        tracing::error!(err = %e, "failed to spawn capability call task");
+    }
+}
 
 /// Serves one cross-store capability call on the shared plugin instance: looks
 /// up the resolved export, invokes it via the dynamic concurrent path

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -41,7 +41,7 @@ use wasmtime_wasi_http::p3::bindings::Service;
 use crate::engine::ctx::SharedCtx;
 use crate::host::http::ServiceHttpJob;
 #[cfg(feature = "host-component-plugins")]
-use crate::host::job_registry::{JobGuard, JobRegistry};
+use crate::host::job_registry::JobRegistry;
 
 #[cfg(feature = "host-component-plugins")]
 mod capability;
@@ -49,14 +49,14 @@ mod http;
 mod messaging;
 
 #[cfg(feature = "host-component-plugins")]
-pub use capability::{CapabilityCall, CapabilityFunc, CapabilityJob};
+pub use capability::{CapabilityCall, CapabilityFunc, CapabilityJob, LifecycleReplay};
 pub use messaging::{BrokerMessage, MessagingJob};
 
 #[cfg(feature = "host-component-plugins")]
-use capability::{
-    CapabilityTask, InFlightGuard, MAX_INFLIGHT_CAPABILITY_CALLS, drain_plugin_resources,
-    flush_pending_resource_drops,
-};
+pub(crate) use capability::decode_bind_reply;
+
+#[cfg(feature = "host-component-plugins")]
+use capability::{admit_and_spawn_call, drain_plugin_resources, flush_pending_resource_drops};
 use http::HttpTask;
 use messaging::{HANDLE_MESSAGE, MESSAGING_HANDLER, MessagingTask};
 
@@ -73,12 +73,15 @@ pub enum Ingress {
     Messaging(tokio::sync::mpsc::Receiver<MessagingJob>),
     /// Cross-store capability calls for a host component plugin. `funcs` lists
     /// every exported function to resolve up front; `rx` delivers the calls;
-    /// `registry` tracks each served call as a cancellable job.
+    /// `registry` tracks each served call as a cancellable job; `replay` holds
+    /// the lifecycle binds this incarnation must complete before serving `rx`
+    /// (the per-workload state rebuild after a restart).
     #[cfg(feature = "host-component-plugins")]
     Capability {
         funcs: Vec<CapabilityFunc>,
         rx: tokio::sync::mpsc::Receiver<CapabilityJob>,
         registry: Arc<JobRegistry>,
+        replay: Vec<LifecycleReplay>,
     },
 }
 
@@ -121,6 +124,7 @@ impl Ingress {
                 funcs,
                 rx,
                 registry,
+                replay,
             } => {
                 // Resolve every exported capability function to a call index up
                 // front (mirroring the messaging arm), so serving a call is a
@@ -148,6 +152,7 @@ impl Ingress {
                     func_map,
                     rx,
                     registry,
+                    replay,
                     in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
                 })
             }
@@ -173,6 +178,9 @@ enum PreparedIngress {
         func_map: BTreeMap<Arc<str>, BTreeMap<Arc<str>, ComponentExportIndex>>,
         rx: tokio::sync::mpsc::Receiver<CapabilityJob>,
         registry: Arc<JobRegistry>,
+        /// Lifecycle binds to complete before serving `rx`; drained on the
+        /// first `serve` entry (empty on re-entry after a drop flush).
+        replay: Vec<LifecycleReplay>,
         in_flight: Arc<std::sync::atomic::AtomicUsize>,
     },
 }
@@ -232,9 +240,56 @@ impl PreparedIngress {
                 func_map,
                 rx,
                 registry,
+                replay,
                 in_flight,
             } => {
-                use std::sync::atomic::Ordering;
+                // Replay lifecycle binds before serving capability calls, and
+                // await each one's COMPLETION: a queued call from a rebound
+                // workload must never run before that workload's per-workload
+                // state has been rebuilt. Outcomes are logged, not fatal — the
+                // workloads are already running, so a rejected replay must not
+                // take the plugin down with them.
+                //
+                // Replay is SERIAL, one bind at a time, with the registry marker
+                // (`replay_begin`) set before each spawn: a guest bind trap
+                // short-circuits `run_concurrent` and drops this serving future
+                // mid-await — so `replay_finish`/`replay_complete` never run and
+                // the marker is left naming the trapping workload, the only
+                // reliable way to attribute the fault (the trapping task's own
+                // error handler does not run). The supervisor reads the marker
+                // to quarantine a crash-looping bind.
+                let replays = std::mem::take(replay);
+                for replay in replays {
+                    let LifecycleReplay {
+                        interface,
+                        func,
+                        caller,
+                        args,
+                        result_tys,
+                    } = replay;
+                    let workload_id = Arc::clone(&caller.workload_id);
+                    registry.replay_begin(caller.clone());
+                    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+                    admit_and_spawn_call(
+                        accessor,
+                        *instance,
+                        func_map,
+                        registry,
+                        in_flight,
+                        CapabilityCall {
+                            interface,
+                            func,
+                            caller,
+                            args,
+                            result_tys,
+                            reply: reply_tx,
+                        },
+                    );
+                    await_replay_outcome(workload_id, reply_rx).await;
+                    registry.replay_finish();
+                }
+                registry.replay_complete();
+
                 while let Some(job) = rx.recv().await {
                     match job {
                         CapabilityJob::DropResource { proxy_id, reply } => {
@@ -251,60 +306,60 @@ impl PreparedIngress {
                             return ServeOutcome::FlushDrops;
                         }
                         CapabilityJob::Call(call) => {
-                            // Admit the call only under the in-flight ceiling. A
-                            // non-blocking reservation (fetch_add + compare): the
-                            // serve loop NEVER blocks, so a re-entrant call is
-                            // always admitted while the store is under the ceiling
-                            // — no bounded-pool deadlock. A runaway self-recursion
-                            // consumes a slot per hop and is rejected at the cap.
-                            if in_flight.fetch_add(1, Ordering::SeqCst)
-                                >= MAX_INFLIGHT_CAPABILITY_CALLS
-                            {
-                                in_flight.fetch_sub(1, Ordering::SeqCst);
-                                let _ = call.reply.send(Err(wasmtime::format_err!(
-                                    "host component plugin is at its in-flight capability-call \
-                                     ceiling ({MAX_INFLIGHT_CAPABILITY_CALLS}); a call cycle or \
-                                     overload is likely"
-                                )));
-                                continue;
-                            }
-                            let guard = InFlightGuard::new(Arc::clone(in_flight));
-                            let Some(func_idx) = func_map
-                                .get(&*call.interface)
-                                .and_then(|fns| fns.get(&*call.func))
-                                .copied()
-                            else {
-                                let _ = call.reply.send(Err(wasmtime::format_err!(
-                                    "plugin does not export {}/{}",
-                                    call.interface,
-                                    call.func
-                                )));
-                                continue;
-                            };
-                            // Register the call as a cancellable job. The
-                            // `JobGuard` moves into the task and retires the job on
-                            // completion or drop. The `Accessor::spawn` handle is
-                            // not retained: wasmtime cannot hard-cancel the guest
-                            // subtask, so cancellation is cooperative —
-                            // `request-cancel` marks the job and the guest unwinds
-                            // itself.
-                            let job = registry.admit(call.caller.clone());
-                            let job_guard = JobGuard::new(Arc::clone(registry), job);
-                            if let Err(e) = accessor.spawn(CapabilityTask {
-                                instance: *instance,
-                                func_idx,
-                                call,
-                                in_flight: guard,
-                                job_guard,
-                            }) {
-                                tracing::error!(err = %e, "failed to spawn capability call task");
-                            }
+                            admit_and_spawn_call(
+                                accessor, *instance, func_map, registry, in_flight, call,
+                            );
                         }
                     }
                 }
                 ServeOutcome::Shutdown
             }
         }
+    }
+}
+
+/// Await one replayed bind's completion, bounded by
+/// [`crate::timeouts::plugin_lifecycle_call`], and log its outcome. The wait
+/// must be bounded: a replayed bind that itself calls one of the plugin's own
+/// capabilities (a self-import) cannot complete until replay ends and the
+/// channel is served, so an unbounded wait would wedge the incarnation. On
+/// expiry the bind keeps running as a concurrent task and finishes once
+/// serving starts — only its completes-before-serving guarantee is forfeited.
+#[cfg(feature = "host-component-plugins")]
+async fn await_replay_outcome(
+    workload_id: Arc<str>,
+    reply_rx: tokio::sync::oneshot::Receiver<
+        wasmtime::Result<Vec<crate::engine::store::relocate::Relocated>>,
+    >,
+) {
+    let reply = tokio::time::timeout(crate::timeouts::plugin_lifecycle_call(), reply_rx).await;
+    match reply {
+        Ok(Ok(Ok(results))) => match decode_bind_reply(&results) {
+            Ok(Ok(())) => {}
+            Ok(Err(msg)) => tracing::warn!(
+                %workload_id,
+                msg,
+                "plugin rejected a replayed workload bind"
+            ),
+            Err(e) => tracing::warn!(
+                %workload_id,
+                err = %e,
+                "replayed workload bind returned a malformed reply"
+            ),
+        },
+        Ok(Ok(Err(e))) => tracing::warn!(
+            %workload_id,
+            err = %e,
+            "replayed workload bind failed"
+        ),
+        Ok(Err(_)) => tracing::warn!(
+            %workload_id,
+            "replayed workload bind reply was dropped"
+        ),
+        Err(_) => tracing::warn!(
+            %workload_id,
+            "replayed workload bind did not complete in time; serving anyway"
+        ),
     }
 }
 

--- a/crates/wash-runtime/src/plugin/component_host/lifecycle.rs
+++ b/crates/wash-runtime/src/plugin/component_host/lifecycle.rs
@@ -1,0 +1,505 @@
+//! The optional `wasmcloud:host/workload-lifecycle` export a host component
+//! plugin may provide to hear about the workloads calling it: the host delivers
+//! `on-workload-bind` (with the workload's identity and per-interface manifest
+//! config) before any capability call from that workload, and
+//! `on-workload-unbind` when it goes away — so the plugin can provision and
+//! reclaim per-workload state eagerly rather than lazily on first call.
+//!
+//! Both hooks' signatures are shape-checked at registration
+//! ([`lifecycle_funcs`]). A bind that overruns the plugin's lifecycle-call
+//! timeout fails the deploy at the budget rather than waiting the
+//! (uncancellable) hook out; because the hook keeps running, the rollback
+//! unbind is *deferred* until it returns ([`spawn_deferred_unbind`]), so state
+//! it provisions late is still reclaimed.
+//!
+//! Because a supervised restart rebuilds the store (losing all guest state)
+//! while bound workloads keep running, each fresh incarnation replays
+//! `on-workload-bind` for every workload still bound ([`replay_snapshot`]) —
+//! completing the replay before serving any queued capability call, which is
+//! why the hook must be idempotent. Replay is serial: a guest bind trap
+//! short-circuits `run_concurrent` and drops the serving future before its
+//! handler runs, so the fault can only be attributed by the marker the serve
+//! loop records *before* each replayed bind (`ReplayProgress`, read by
+//! [`attribute_replay_fault`]). A bind that crash-loops the shared store is
+//! struck on each attributed fault and, past a strike ceiling
+//! ([`POISON_EVICT_STRIKES`]), evicted — dropped from the replay set so the
+//! store recovers for every other tenant — and reported to the host so the
+//! evicted workload's scheduling health becomes failed. Such attributed faults
+//! do not consume the plugin-wide restart budget.
+//!
+//! [`ComponentHostPlugin`](super::ComponentHostPlugin) drives all of this from
+//! its [`HostPlugin`](crate::plugin::HostPlugin) impl.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use tracing::{debug, error, warn};
+use wasmtime::component::Val;
+use wasmtime::component::types::Type;
+
+use crate::engine::ctx::CallerIdentity;
+use crate::engine::store::relocate::Relocated;
+use crate::engine::workload::UnresolvedWorkload;
+use crate::host::trigger_service::{CapabilityCall, CapabilityJob, LifecycleReplay};
+use crate::plugin::WitInterfaces;
+use crate::wit::WitInterface;
+
+use super::{CapabilitySender, ComponentHostPluginState, ExportedFunc, ExportedInterface};
+
+/// Interface name of the optional lifecycle export a plugin may provide to
+/// hear about the workloads binding to (and unbinding from) it.
+pub(super) const HOST_LIFECYCLE_INTERFACE: &str = "wasmcloud:host/workload-lifecycle@0.1.0";
+/// The lifecycle export's bind hook.
+const ON_WORKLOAD_BIND: &str = "on-workload-bind";
+/// The lifecycle export's unbind hook.
+const ON_WORKLOAD_UNBIND: &str = "on-workload-unbind";
+
+/// Consecutive `on-workload-bind` traps a workload may accumulate before it is
+/// evicted (dropped from the replay set and reported failed). Kept below
+/// [`DEFAULT_MAX_RESTARTS`](super::DEFAULT_MAX_RESTARTS) so a
+/// deterministically-poison bind is quarantined — contained to its own workload
+/// — before its crash loop can exhaust the whole plugin's restart budget and
+/// take every tenant down with it. Strikes reset
+/// after a healthy uptime, so only a rapid crash loop escalates to eviction.
+pub(super) const POISON_EVICT_STRIKES: u32 = 2;
+
+/// The plugin's `wasmcloud:host/workload-lifecycle` export, introspected at
+/// construction: the instance name plus both hook functions' types, ready to
+/// drive the dynamic cross-store calls.
+pub(super) struct LifecycleFuncs {
+    pub(super) interface: Arc<str>,
+    pub(super) bind: ExportedFunc,
+    pub(super) unbind: ExportedFunc,
+}
+
+/// Forget `workload_id` and deliver `on-workload-unbind` for it. The removal
+/// and the sender read share one `bound` lock so the unbind lands on the
+/// incarnation that will not also replay the removed entry (see
+/// [`replay_snapshot`]).
+pub(super) async fn remove_and_unbind(
+    state: &ComponentHostPluginState,
+    lifecycle: &LifecycleFuncs,
+    workload_id: &Arc<str>,
+) -> anyhow::Result<()> {
+    let (was_bound, sender) = {
+        let mut bound = state
+            .bound
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let was_bound = bound.remove(workload_id.as_ref()).is_some();
+        (was_bound, state.sender())
+    };
+    // Only a workload whose bind we actually delivered gets an unbind:
+    // this dedupes the engine's per-item unbind fan-out (a plugin bound to
+    // N items is unbound N times) and skips ids that were never bound.
+    if !was_bound {
+        return Ok(());
+    }
+    let sender = sender
+        .ok_or_else(|| anyhow::anyhow!("host component plugin '{}' is not running", state.id))?;
+    call_lifecycle(
+        &sender,
+        state,
+        lifecycle,
+        &lifecycle.unbind,
+        Val::String(workload_id.to_string()),
+        workload_id,
+    )
+    .await
+    .map(|_| ())
+}
+
+/// Pull the two lifecycle hooks out of the plugin's introspected
+/// `wasmcloud:host/workload-lifecycle` export. Presence, arity, and the
+/// top-level shape of each signature are checked here so a mismatched plugin
+/// fails at registration with a clear message rather than on its first
+/// workload deploy. Deep per-field types (every field of `workload-info`)
+/// still surface as a per-delivery typecheck error — the fixed shape below
+/// catches the mistakes worth catching cheaply.
+pub(super) fn lifecycle_funcs(
+    id: &str,
+    mut export: ExportedInterface,
+) -> anyhow::Result<LifecycleFuncs> {
+    let mut bind = None;
+    let mut unbind = None;
+    for func in export.funcs.drain(..) {
+        match func.name.as_ref() {
+            ON_WORKLOAD_BIND => bind = Some(func),
+            ON_WORKLOAD_UNBIND => unbind = Some(func),
+            _ => {}
+        }
+    }
+    let bind = bind.with_context(|| {
+        format!("host component plugin '{id}' lifecycle export is missing {ON_WORKLOAD_BIND}")
+    })?;
+    let unbind = unbind.with_context(|| {
+        format!("host component plugin '{id}' lifecycle export is missing {ON_WORKLOAD_UNBIND}")
+    })?;
+
+    // `on-workload-bind: func(workload-info) -> result<_, string>`
+    anyhow::ensure!(
+        bind.result_tys.len() == 1 && matches!(bind.param_tys.first(), Some(Type::Record(_))),
+        "host component plugin '{id}' {ON_WORKLOAD_BIND} must take one argument, the workload-info \
+         record"
+    );
+    match bind.result_tys.first() {
+        Some(Type::Result(rt)) => anyhow::ensure!(
+            rt.ok().is_none() && matches!(rt.err(), Some(Type::String)),
+            "host component plugin '{id}' {ON_WORKLOAD_BIND} must return result<_, string>"
+        ),
+        _ => anyhow::bail!(
+            "host component plugin '{id}' {ON_WORKLOAD_BIND} must return result<_, string>"
+        ),
+    }
+
+    // `on-workload-unbind: func(workload-id)` — one string, no result.
+    anyhow::ensure!(
+        unbind.result_tys.is_empty() && matches!(unbind.param_tys.first(), Some(Type::String)),
+        "host component plugin '{id}' {ON_WORKLOAD_UNBIND} must take one argument, the workload-id \
+         string, and return nothing"
+    );
+
+    Ok(LifecycleFuncs {
+        interface: export.name,
+        bind,
+        unbind,
+    })
+}
+
+/// Snapshot the bound-workloads map into the replay list for a fresh
+/// incarnation. MUST be taken while holding the `bound` lock, atomically with
+/// publishing the incarnation's sender: that exclusion is what guarantees a
+/// concurrent bind/unbind is either reflected in the snapshot (recorded before
+/// the swap, its own send targeting the previous, now-dead channel) or
+/// delivered through the new channel — never both, so no double delivery.
+pub(super) fn replay_snapshot(
+    bound: &BTreeMap<Arc<str>, Val>,
+    lifecycle: Option<&LifecycleFuncs>,
+) -> Vec<LifecycleReplay> {
+    let Some(lifecycle) = lifecycle else {
+        return Vec::new();
+    };
+    bound
+        .iter()
+        .map(|(workload_id, info)| LifecycleReplay {
+            interface: Arc::clone(&lifecycle.interface),
+            func: Arc::clone(&lifecycle.bind.name),
+            // A replayed bind is about the workload, not any component of it.
+            caller: CallerIdentity {
+                workload_id: Arc::clone(workload_id),
+                component_id: None,
+            },
+            args: vec![Relocated::Val(info.clone())],
+            result_tys: Arc::clone(&lifecycle.bind.result_tys),
+        })
+        .collect()
+}
+
+/// Attribute the just-observed store fault to a replayed bind, if the faulted
+/// incarnation was mid-replay. Returns the culprit workload when the fault
+/// happened during replay and the serve loop had marked one in-flight — that is
+/// a per-workload poison (its bind crash-loops the shared store), which the
+/// supervisor strikes and eventually evicts, and which must NOT consume the
+/// plugin-wide restart budget. A fault while serving (replay already completed)
+/// returns `None`: it is ordinary instability and charges the budget as before.
+///
+/// The marker lives in the faulted incarnation's registry, still reachable via
+/// `state.registry` until the supervisor publishes the next one — this runs in
+/// that window, right after the driver returns.
+pub(super) fn attribute_replay_fault(state: &ComponentHostPluginState) -> Option<Arc<str>> {
+    let progress = state.registry()?.replay_progress();
+    if progress.completed {
+        return None;
+    }
+    let workload_id = progress.current?.workload_id;
+    state
+        .bind_trap_log
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(Arc::clone(&workload_id));
+    Some(workload_id)
+}
+
+/// Evict a workload whose `on-workload-bind` crash-looped past the strike
+/// ceiling: drop it from the bound set (so the next incarnation stops replaying
+/// it and recovers for every other tenant) and forget its strikes. The
+/// workload is left provisioned nowhere; the caller reports it failed to the
+/// host so its scheduling health reflects the eviction.
+pub(super) fn evict_workload(state: &ComponentHostPluginState, workload_id: &Arc<str>) {
+    state
+        .bound
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(workload_id);
+    state
+        .poison
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(workload_id);
+    error!(
+        id = state.id,
+        %workload_id,
+        strikes = POISON_EVICT_STRIKES,
+        "evicting workload after repeated on-workload-bind traps; reporting it failed"
+    );
+}
+
+/// Report an evicted workload to the host so its scheduling health becomes
+/// failed. A no-op if no failure sink was injected (the plugin is running
+/// without a host, e.g. driven directly in a test).
+pub(super) fn report_workload_failed(state: &ComponentHostPluginState, workload_id: &Arc<str>) {
+    if let Some(sink) = state.failure_sink.load_full() {
+        sink.report(
+            workload_id.to_string(),
+            format!(
+                "host component plugin '{}' evicted the workload: its on-workload-bind \
+                 repeatedly trapped ({POISON_EVICT_STRIKES} strikes)",
+                state.id
+            ),
+        );
+    }
+}
+
+/// The reply receiver for one in-flight lifecycle call.
+pub(super) type LifecycleReplyRx = tokio::sync::oneshot::Receiver<wasmtime::Result<Vec<Relocated>>>;
+
+/// The result of awaiting an `on-workload-bind` reply.
+pub(super) enum BindReply {
+    /// The hook returned (its relocated results, or a delivery/drop error).
+    Completed(anyhow::Result<Vec<Relocated>>),
+    /// The reply did not arrive within the budget; the hook may still be
+    /// running. Its receiver is handed back so cleanup can be deferred until it
+    /// resolves (a guest hook cannot be cancelled).
+    TimedOut(LifecycleReplyRx),
+}
+
+/// Enqueue one lifecycle call on `sender` and return its pending reply
+/// receiver. Bounded by [`crate::timeouts::plugin_lifecycle_call`] so a full
+/// channel cannot park a deploy or a stop; a send that times out (or hits a
+/// closed channel) leaves the job un-enqueued — tokio's bounded send only
+/// enqueues on completion — so the caller knows no hook is running. The call
+/// runs under the workload's identity (empty component id) so
+/// `wasmcloud:host/identity` answers consistently inside the hook.
+pub(super) async fn send_lifecycle_job(
+    sender: &CapabilitySender,
+    state: &ComponentHostPluginState,
+    lifecycle: &LifecycleFuncs,
+    func: &ExportedFunc,
+    arg: Val,
+    workload_id: &Arc<str>,
+) -> anyhow::Result<LifecycleReplyRx> {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    let job = CapabilityJob::Call(CapabilityCall {
+        interface: Arc::clone(&lifecycle.interface),
+        func: Arc::clone(&func.name),
+        caller: CallerIdentity {
+            workload_id: Arc::clone(workload_id),
+            component_id: None,
+        },
+        args: vec![Relocated::Val(arg)],
+        result_tys: Arc::clone(&func.result_tys),
+        reply: reply_tx,
+    });
+    tokio::time::timeout(state.lifecycle_timeout(), sender.send(job))
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "host component plugin '{}' channel send timed out",
+                state.id
+            )
+        })?
+        .map_err(|_| anyhow::anyhow!("host component plugin '{}' channel closed", state.id))?;
+    Ok(reply_rx)
+}
+
+/// Interpret a resolved lifecycle reply receiver value into relocated results
+/// or a diagnostic error.
+fn interpret_reply(
+    reply: Result<wasmtime::Result<Vec<Relocated>>, tokio::sync::oneshot::error::RecvError>,
+    state: &ComponentHostPluginState,
+) -> anyhow::Result<Vec<Relocated>> {
+    match reply {
+        Ok(Ok(results)) => Ok(results),
+        Ok(Err(e)) => Err(anyhow::Error::from(e)),
+        Err(_) => Err(anyhow::anyhow!(
+            "host component plugin '{}' dropped the lifecycle reply",
+            state.id
+        )),
+    }
+}
+
+/// Await a bind reply, keeping the receiver if the budget elapses first so the
+/// caller can defer cleanup until the still-running hook returns.
+pub(super) async fn await_bind_reply(
+    mut reply_rx: LifecycleReplyRx,
+    state: &ComponentHostPluginState,
+) -> BindReply {
+    let deadline = tokio::time::sleep(state.lifecycle_timeout());
+    tokio::pin!(deadline);
+    tokio::select! {
+        reply = &mut reply_rx => BindReply::Completed(interpret_reply(reply, state)),
+        () = &mut deadline => BindReply::TimedOut(reply_rx),
+    }
+}
+
+/// Deliver one lifecycle call over `sender` and await its relocated results,
+/// bounded by [`crate::timeouts::plugin_lifecycle_call`] on both the send and
+/// the reply. Used for unbind (and item-bind rollback) where — unlike bind —
+/// there is nothing to defer on a timeout.
+async fn call_lifecycle(
+    sender: &CapabilitySender,
+    state: &ComponentHostPluginState,
+    lifecycle: &LifecycleFuncs,
+    func: &ExportedFunc,
+    arg: Val,
+    workload_id: &Arc<str>,
+) -> anyhow::Result<Vec<Relocated>> {
+    let reply_rx = send_lifecycle_job(sender, state, lifecycle, func, arg, workload_id).await?;
+    match tokio::time::timeout(state.lifecycle_timeout(), reply_rx).await {
+        Ok(reply) => interpret_reply(reply, state),
+        Err(_) => Err(anyhow::anyhow!(
+            "lifecycle call to host component plugin '{}' timed out",
+            state.id
+        )),
+    }
+}
+
+/// Reclaim whatever a timed-out `on-workload-bind` provisions, once it actually
+/// returns. The deploy has already failed and the workload is out of the bound
+/// map; this waits for the runaway hook's reply (guaranteeing bind-then-unbind
+/// order), then delivers the unbind only if the incarnation the bind ran on is
+/// still live — pointer-comparing the captured sender against the current one.
+/// If a restart intervened, the hook's state died with that store, so there is
+/// nothing to reclaim and no unbind is sent.
+pub(super) fn spawn_deferred_unbind(
+    incarnation: Arc<CapabilitySender>,
+    reply_rx: LifecycleReplyRx,
+    workload_id: Arc<str>,
+    lifecycle: Arc<LifecycleFuncs>,
+    state: Arc<ComponentHostPluginState>,
+) {
+    tokio::spawn(async move {
+        // Wait for the runaway hook to finish (or its reply to be dropped by a
+        // store teardown).
+        let _ = reply_rx.await;
+        match state.sender_arc() {
+            Some(current) if Arc::ptr_eq(&current, &incarnation) => {
+                if let Err(e) = call_lifecycle(
+                    &incarnation,
+                    &state,
+                    &lifecycle,
+                    &lifecycle.unbind,
+                    Val::String(workload_id.to_string()),
+                    &workload_id,
+                )
+                .await
+                {
+                    warn!(id = state.id, %workload_id, err = %e, "deferred unbind not delivered");
+                }
+            }
+            _ => {
+                debug!(
+                    id = state.id,
+                    %workload_id,
+                    "skipping deferred unbind; the bind's incarnation is gone"
+                );
+            }
+        }
+    });
+}
+
+/// Build the `workload-info` record delivered to `on-workload-bind`: the
+/// workload's identity plus every interface instance it matched on this plugin,
+/// each with its manifest config — ordered deterministically.
+pub(super) fn workload_info_val(
+    workload: &UnresolvedWorkload,
+    interfaces: &WitInterfaces<'_>,
+) -> Val {
+    let service = Val::Option(
+        workload
+            .service_id()
+            .map(|id| Box::new(Val::String(id.to_string()))),
+    );
+    let components = Val::List(
+        workload
+            .component_ids()
+            .into_iter()
+            .map(|id| Val::String(id.to_string()))
+            .collect(),
+    );
+    let mut matched: Vec<&WitInterface> = interfaces.iter().collect();
+    matched.sort_by_key(|i| i.instance());
+    let interfaces = Val::List(matched.into_iter().map(interface_binding_val).collect());
+    Val::Record(vec![
+        ("id".to_string(), Val::String(workload.id().to_string())),
+        ("name".to_string(), Val::String(workload.name().to_string())),
+        (
+            "namespace".to_string(),
+            Val::String(workload.namespace().to_string()),
+        ),
+        ("service".to_string(), service),
+        ("components".to_string(), components),
+        ("interfaces".to_string(), interfaces),
+    ])
+}
+
+/// One matched [`WitInterface`] as a lifecycle `interface-binding` record.
+fn interface_binding_val(iface: &WitInterface) -> Val {
+    let mut names: Vec<&String> = iface.interfaces.iter().collect();
+    names.sort();
+    let mut config: Vec<(&String, &String)> = iface.config.iter().collect();
+    config.sort();
+    Val::Record(vec![
+        (
+            "namespace".to_string(),
+            Val::String(iface.namespace.clone()),
+        ),
+        ("package".to_string(), Val::String(iface.package.clone())),
+        (
+            "interfaces".to_string(),
+            Val::List(names.into_iter().map(|n| Val::String(n.clone())).collect()),
+        ),
+        (
+            "version".to_string(),
+            Val::Option(iface.version.as_ref().map(|v| Box::new(version_val(v)))),
+        ),
+        (
+            "name".to_string(),
+            Val::Option(
+                iface
+                    .name
+                    .as_ref()
+                    .map(|n| Box::new(Val::String(n.clone()))),
+            ),
+        ),
+        // Stubbed until component-model external-id lands (wasmCloud#5393):
+        // `WitInterface` grows an `external_id` there, and this becomes
+        // `iface.external_id.as_ref().map(..)` like `name` above. The WIT field
+        // exists now so that merge does not change the record shape again —
+        // adding a field to a WIT record is breaking for compiled plugins.
+        ("external-id".to_string(), Val::Option(None)),
+        (
+            "config".to_string(),
+            Val::List(
+                config
+                    .into_iter()
+                    .map(|(k, v)| Val::Tuple(vec![Val::String(k.clone()), Val::String(v.clone())]))
+                    .collect(),
+            ),
+        ),
+    ])
+}
+
+/// A [`semver::Version`] as a lifecycle `version` record.
+fn version_val(v: &semver::Version) -> Val {
+    let pre = (!v.pre.is_empty()).then(|| Box::new(Val::String(v.pre.as_str().to_string())));
+    let build = (!v.build.is_empty()).then(|| Box::new(Val::String(v.build.as_str().to_string())));
+    Val::Record(vec![
+        ("major".to_string(), Val::U64(v.major)),
+        ("minor".to_string(), Val::U64(v.minor)),
+        ("patch".to_string(), Val::U64(v.patch)),
+        ("pre".to_string(), Val::Option(pre)),
+        ("build".to_string(), Val::Option(build)),
+    ])
+}

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -39,31 +39,13 @@
 //! unsupported.
 //!
 //! A plugin may additionally *export* `wasmcloud:host/workload-lifecycle` to
-//! hear about the workloads calling it: the host delivers `on-workload-bind`
-//! (with the workload's identity and per-interface manifest config) before any
-//! capability call from that workload, and `on-workload-unbind` when it goes
-//! away — so the plugin can provision and reclaim per-workload state eagerly
-//! rather than lazily on first call. `wasmcloud:host` exports are reserved:
-//! they are host-invoked contracts, never workload-matchable capabilities.
-//! Both hooks' signatures are shape-checked at registration (`lifecycle_funcs`).
-//! A bind that overruns the plugin's lifecycle-call timeout fails the deploy at
-//! the budget rather than waiting the (uncancellable) hook out; because the hook
-//! keeps running, the rollback unbind is *deferred* until it returns
-//! (`spawn_deferred_unbind`), so state it provisions late is still reclaimed.
-//!
-//! Because a supervised restart rebuilds the store (losing all guest state)
-//! while bound workloads keep running, each fresh incarnation replays
-//! `on-workload-bind` for every workload still bound — completing the replay
-//! before serving any queued capability call, which is why the hook must be
-//! idempotent. Replay is serial: a guest bind trap short-circuits
-//! `run_concurrent` and drops the serving future before its handler runs, so
-//! the fault can only be attributed by the marker the serve loop records
-//! *before* each replayed bind (`ReplayProgress`). A bind that crash-loops the
-//! shared store is struck on each attributed fault and, past a strike ceiling
-//! (`POISON_EVICT_STRIKES`), evicted — dropped from the replay set so the store
-//! recovers for every other tenant — and reported to the host so the evicted
-//! workload's scheduling health becomes failed. Such attributed faults do not
-//! consume the plugin-wide restart budget.
+//! hear about the workloads calling it, so it can provision and reclaim
+//! per-workload state eagerly rather than lazily on first call. `wasmcloud:host`
+//! exports are reserved: they are host-invoked contracts, never
+//! workload-matchable capabilities. The whole hook path — signature check,
+//! delivery, post-restart replay, and quarantine — lives in the `lifecycle`
+//! submodule; this module drives it from `ComponentHostPlugin`'s `HostPlugin`
+//! impl.
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -96,6 +78,15 @@ use crate::plugin::component_plugin_spec::{ComponentPluginSpec, PluginSource};
 use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 
+mod lifecycle;
+
+use lifecycle::{
+    BindReply, HOST_LIFECYCLE_INTERFACE, LifecycleFuncs, POISON_EVICT_STRIKES,
+    attribute_replay_fault, await_bind_reply, evict_workload, lifecycle_funcs, remove_and_unbind,
+    replay_snapshot, report_workload_failed, send_lifecycle_job, spawn_deferred_unbind,
+    workload_info_val,
+};
+
 /// Capacity of a plugin incarnation's capability-call channel. Bounds queued
 /// (not-yet-served) calls; in-flight (being-served) calls are separately capped
 /// by the TriggerService's per-store in-flight-task ceiling.
@@ -105,14 +96,6 @@ const CAPABILITY_CHANNEL_CAPACITY: usize = 256;
 /// before the plugin is declared dead. One store now serves every workload, so
 /// a restart story is required rather than optional.
 const DEFAULT_MAX_RESTARTS: u32 = 3;
-
-/// Consecutive `on-workload-bind` traps a workload may accumulate before it is
-/// evicted (dropped from the replay set and reported failed). Kept below
-/// [`DEFAULT_MAX_RESTARTS`] so a deterministically-poison bind is quarantined —
-/// contained to its own workload — before its crash loop can exhaust the whole
-/// plugin's restart budget and take every tenant down with it. Strikes reset
-/// after a healthy uptime, so only a rapid crash loop escalates to eviction.
-const POISON_EVICT_STRIKES: u32 = 2;
 
 type CapabilitySender = tokio::sync::mpsc::Sender<CapabilityJob>;
 
@@ -140,28 +123,11 @@ struct ExportedInterface {
     resources: Vec<Arc<str>>,
 }
 
-/// Interface name of the optional lifecycle export a plugin may provide to
-/// hear about the workloads binding to (and unbinding from) it.
-const HOST_LIFECYCLE_INTERFACE: &str = "wasmcloud:host/workload-lifecycle@0.1.0";
-/// The lifecycle export's bind hook.
-const ON_WORKLOAD_BIND: &str = "on-workload-bind";
-/// The lifecycle export's unbind hook.
-const ON_WORKLOAD_UNBIND: &str = "on-workload-unbind";
-
 /// Whether an interface belongs to the reserved `wasmcloud:host` package —
 /// host-invoked contracts (like the lifecycle export), never capabilities a
 /// workload may import.
 fn is_reserved(wit: &WitInterface) -> bool {
     wit.namespace == "wasmcloud" && wit.package == "host"
-}
-
-/// The plugin's `wasmcloud:host/workload-lifecycle` export, introspected at
-/// construction: the instance name plus both hook functions' types, ready to
-/// drive the dynamic cross-store calls.
-struct LifecycleFuncs {
-    interface: Arc<str>,
-    bind: ExportedFunc,
-    unbind: ExportedFunc,
 }
 
 /// Runtime state shared between the plugin, the linker shims it installs, and
@@ -370,44 +336,6 @@ impl ComponentHostPlugin {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .contains_key(workload_id)
-    }
-
-    /// Forget `workload_id` and deliver `on-workload-unbind` for it. The
-    /// removal and the sender read share one `bound` lock so the unbind lands
-    /// on the incarnation that will not also replay the removed entry (see
-    /// [`replay_snapshot`]).
-    async fn remove_and_unbind(
-        &self,
-        lifecycle: &LifecycleFuncs,
-        workload_id: &Arc<str>,
-    ) -> anyhow::Result<()> {
-        let (was_bound, sender) = {
-            let mut bound = self
-                .state
-                .bound
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let was_bound = bound.remove(workload_id.as_ref()).is_some();
-            (was_bound, self.state.sender())
-        };
-        // Only a workload whose bind we actually delivered gets an unbind:
-        // this dedupes the engine's per-item unbind fan-out (a plugin bound to
-        // N items is unbound N times) and skips ids that were never bound.
-        if !was_bound {
-            return Ok(());
-        }
-        let sender = sender
-            .ok_or_else(|| anyhow::anyhow!("host component plugin '{}' is not running", self.id))?;
-        call_lifecycle(
-            &sender,
-            &self.state,
-            lifecycle,
-            &lifecycle.unbind,
-            Val::String(workload_id.to_string()),
-            workload_id,
-        )
-        .await
-        .map(|_| ())
     }
 }
 
@@ -627,8 +555,8 @@ impl HostPlugin for ComponentHostPlugin {
         // The bind returned (rejection, malformed reply, or a delivery error
         // after the hook ran): the hook is no longer in flight, so roll back
         // immediately with a best-effort unbind.
-        if let Err(e) = self.remove_and_unbind(lifecycle, &workload_id).await {
-            debug!(id = self.id, %workload_id, err = %e, "post-failure unbind not delivered");
+        if let Err(e) = remove_and_unbind(&self.state, lifecycle, &workload_id).await {
+            warn!(id = self.id, %workload_id, err = %e, "post-failure unbind not delivered");
         }
         Err(failure)
     }
@@ -655,9 +583,10 @@ impl HostPlugin for ComponentHostPlugin {
                 // is not yet on that list — so roll back the bind delivered in
                 // `on_workload_bind` ourselves.
                 if let Some(lifecycle) = &self.lifecycle
-                    && let Err(unbind_err) = self.remove_and_unbind(lifecycle, &workload_id).await
+                    && let Err(unbind_err) =
+                        remove_and_unbind(&self.state, lifecycle, &workload_id).await
                 {
-                    debug!(
+                    warn!(
                         id = self.id,
                         %workload_id,
                         err = %unbind_err,
@@ -684,7 +613,7 @@ impl HostPlugin for ComponentHostPlugin {
         // the plugin is stopped or restarting its per-workload state is already
         // gone with the store.
         let workload_id: Arc<str> = Arc::from(workload_id);
-        match self.remove_and_unbind(lifecycle, &workload_id).await {
+        match remove_and_unbind(&self.state, lifecycle, &workload_id).await {
             Ok(()) => {
                 debug!(id = self.id, %workload_id, "workload unbound from host component plugin");
             }
@@ -806,399 +735,6 @@ fn build_plugin_linker(
         .map_err(anyhow::Error::from)
         .context("failed to pre-instantiate host component plugin")
         .map(|pre| (exports, lifecycle, pre))
-}
-
-/// Pull the two lifecycle hooks out of the plugin's introspected
-/// `wasmcloud:host/workload-lifecycle` export. Presence, arity, and the
-/// top-level shape of each signature are checked here so a mismatched plugin
-/// fails at registration with a clear message rather than on its first
-/// workload deploy. Deep per-field types (every field of `workload-info`)
-/// still surface as a per-delivery typecheck error — the fixed shape below
-/// catches the mistakes worth catching cheaply.
-fn lifecycle_funcs(id: &str, mut export: ExportedInterface) -> anyhow::Result<LifecycleFuncs> {
-    let mut bind = None;
-    let mut unbind = None;
-    for func in export.funcs.drain(..) {
-        match func.name.as_ref() {
-            ON_WORKLOAD_BIND => bind = Some(func),
-            ON_WORKLOAD_UNBIND => unbind = Some(func),
-            _ => {}
-        }
-    }
-    let bind = bind.with_context(|| {
-        format!("host component plugin '{id}' lifecycle export is missing {ON_WORKLOAD_BIND}")
-    })?;
-    let unbind = unbind.with_context(|| {
-        format!("host component plugin '{id}' lifecycle export is missing {ON_WORKLOAD_UNBIND}")
-    })?;
-
-    // `on-workload-bind: func(workload-info) -> result<_, string>`
-    anyhow::ensure!(
-        bind.result_tys.len() == 1 && matches!(bind.param_tys.first(), Some(Type::Record(_))),
-        "host component plugin '{id}' {ON_WORKLOAD_BIND} must take one argument, the workload-info \
-         record"
-    );
-    match bind.result_tys.first() {
-        Some(Type::Result(rt)) => anyhow::ensure!(
-            rt.ok().is_none() && matches!(rt.err(), Some(Type::String)),
-            "host component plugin '{id}' {ON_WORKLOAD_BIND} must return result<_, string>"
-        ),
-        _ => anyhow::bail!(
-            "host component plugin '{id}' {ON_WORKLOAD_BIND} must return result<_, string>"
-        ),
-    }
-
-    // `on-workload-unbind: func(workload-id)` — one string, no result.
-    anyhow::ensure!(
-        unbind.result_tys.is_empty() && matches!(unbind.param_tys.first(), Some(Type::String)),
-        "host component plugin '{id}' {ON_WORKLOAD_UNBIND} must take one argument, the workload-id \
-         string, and return nothing"
-    );
-
-    Ok(LifecycleFuncs {
-        interface: export.name,
-        bind,
-        unbind,
-    })
-}
-
-/// Snapshot the bound-workloads map into the replay list for a fresh
-/// incarnation. MUST be taken while holding the `bound` lock, atomically with
-/// publishing the incarnation's sender: that exclusion is what guarantees a
-/// concurrent bind/unbind is either reflected in the snapshot (recorded before
-/// the swap, its own send targeting the previous, now-dead channel) or
-/// delivered through the new channel — never both, so no double delivery.
-fn replay_snapshot(
-    bound: &BTreeMap<Arc<str>, Val>,
-    lifecycle: Option<&LifecycleFuncs>,
-) -> Vec<LifecycleReplay> {
-    let Some(lifecycle) = lifecycle else {
-        return Vec::new();
-    };
-    bound
-        .iter()
-        .map(|(workload_id, info)| LifecycleReplay {
-            interface: Arc::clone(&lifecycle.interface),
-            func: Arc::clone(&lifecycle.bind.name),
-            // A replayed bind is about the workload, not any component of it.
-            caller: CallerIdentity {
-                workload_id: Arc::clone(workload_id),
-                component_id: None,
-            },
-            args: vec![Relocated::Val(info.clone())],
-            result_tys: Arc::clone(&lifecycle.bind.result_tys),
-        })
-        .collect()
-}
-
-/// Attribute the just-observed store fault to a replayed bind, if the faulted
-/// incarnation was mid-replay. Returns the culprit workload when the fault
-/// happened during replay and the serve loop had marked one in-flight — that is
-/// a per-workload poison (its bind crash-loops the shared store), which the
-/// supervisor strikes and eventually evicts, and which must NOT consume the
-/// plugin-wide restart budget. A fault while serving (replay already completed)
-/// returns `None`: it is ordinary instability and charges the budget as before.
-///
-/// The marker lives in the faulted incarnation's registry, still reachable via
-/// `state.registry` until the supervisor publishes the next one — this runs in
-/// that window, right after the driver returns.
-fn attribute_replay_fault(state: &ComponentHostPluginState) -> Option<Arc<str>> {
-    let progress = state.registry()?.replay_progress();
-    if progress.completed {
-        return None;
-    }
-    let workload_id = progress.current?.workload_id;
-    state
-        .bind_trap_log
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .push(Arc::clone(&workload_id));
-    Some(workload_id)
-}
-
-/// Evict a workload whose `on-workload-bind` crash-looped past the strike
-/// ceiling: drop it from the bound set (so the next incarnation stops replaying
-/// it and recovers for every other tenant) and forget its strikes. The
-/// workload is left provisioned nowhere; the caller reports it failed to the
-/// host so its scheduling health reflects the eviction.
-fn evict_workload(state: &ComponentHostPluginState, workload_id: &Arc<str>) {
-    state
-        .bound
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .remove(workload_id);
-    state
-        .poison
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .remove(workload_id);
-    error!(
-        id = state.id,
-        %workload_id,
-        strikes = POISON_EVICT_STRIKES,
-        "evicting workload after repeated on-workload-bind traps; reporting it failed"
-    );
-}
-
-/// Report an evicted workload to the host so its scheduling health becomes
-/// failed. A no-op if no failure sink was injected (the plugin is running
-/// without a host, e.g. driven directly in a test).
-fn report_workload_failed(state: &ComponentHostPluginState, workload_id: &Arc<str>) {
-    if let Some(sink) = state.failure_sink.load_full() {
-        sink.report(
-            workload_id.to_string(),
-            format!(
-                "host component plugin '{}' evicted the workload: its on-workload-bind \
-                 repeatedly trapped ({POISON_EVICT_STRIKES} strikes)",
-                state.id
-            ),
-        );
-    }
-}
-
-/// The reply receiver for one in-flight lifecycle call.
-type LifecycleReplyRx = tokio::sync::oneshot::Receiver<wasmtime::Result<Vec<Relocated>>>;
-
-/// The result of awaiting an `on-workload-bind` reply.
-enum BindReply {
-    /// The hook returned (its relocated results, or a delivery/drop error).
-    Completed(anyhow::Result<Vec<Relocated>>),
-    /// The reply did not arrive within the budget; the hook may still be
-    /// running. Its receiver is handed back so cleanup can be deferred until it
-    /// resolves (a guest hook cannot be cancelled).
-    TimedOut(LifecycleReplyRx),
-}
-
-/// Enqueue one lifecycle call on `sender` and return its pending reply
-/// receiver. Bounded by [`crate::timeouts::plugin_lifecycle_call`] so a full
-/// channel cannot park a deploy or a stop; a send that times out (or hits a
-/// closed channel) leaves the job un-enqueued — tokio's bounded send only
-/// enqueues on completion — so the caller knows no hook is running. The call
-/// runs under the workload's identity (empty component id) so
-/// `wasmcloud:host/identity` answers consistently inside the hook.
-async fn send_lifecycle_job(
-    sender: &CapabilitySender,
-    state: &ComponentHostPluginState,
-    lifecycle: &LifecycleFuncs,
-    func: &ExportedFunc,
-    arg: Val,
-    workload_id: &Arc<str>,
-) -> anyhow::Result<LifecycleReplyRx> {
-    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-    let job = CapabilityJob::Call(CapabilityCall {
-        interface: Arc::clone(&lifecycle.interface),
-        func: Arc::clone(&func.name),
-        caller: CallerIdentity {
-            workload_id: Arc::clone(workload_id),
-            component_id: None,
-        },
-        args: vec![Relocated::Val(arg)],
-        result_tys: Arc::clone(&func.result_tys),
-        reply: reply_tx,
-    });
-    tokio::time::timeout(state.lifecycle_timeout(), sender.send(job))
-        .await
-        .map_err(|_| {
-            anyhow::anyhow!(
-                "host component plugin '{}' channel send timed out",
-                state.id
-            )
-        })?
-        .map_err(|_| anyhow::anyhow!("host component plugin '{}' channel closed", state.id))?;
-    Ok(reply_rx)
-}
-
-/// Interpret a resolved lifecycle reply receiver value into relocated results
-/// or a diagnostic error.
-fn interpret_reply(
-    reply: Result<wasmtime::Result<Vec<Relocated>>, tokio::sync::oneshot::error::RecvError>,
-    state: &ComponentHostPluginState,
-) -> anyhow::Result<Vec<Relocated>> {
-    match reply {
-        Ok(Ok(results)) => Ok(results),
-        Ok(Err(e)) => Err(anyhow::Error::from(e)),
-        Err(_) => Err(anyhow::anyhow!(
-            "host component plugin '{}' dropped the lifecycle reply",
-            state.id
-        )),
-    }
-}
-
-/// Await a bind reply, keeping the receiver if the budget elapses first so the
-/// caller can defer cleanup until the still-running hook returns.
-async fn await_bind_reply(
-    mut reply_rx: LifecycleReplyRx,
-    state: &ComponentHostPluginState,
-) -> BindReply {
-    let deadline = tokio::time::sleep(state.lifecycle_timeout());
-    tokio::pin!(deadline);
-    tokio::select! {
-        reply = &mut reply_rx => BindReply::Completed(interpret_reply(reply, state)),
-        () = &mut deadline => BindReply::TimedOut(reply_rx),
-    }
-}
-
-/// Deliver one lifecycle call over `sender` and await its relocated results,
-/// bounded by [`crate::timeouts::plugin_lifecycle_call`] on both the send and
-/// the reply. Used for unbind (and item-bind rollback) where — unlike bind —
-/// there is nothing to defer on a timeout.
-async fn call_lifecycle(
-    sender: &CapabilitySender,
-    state: &ComponentHostPluginState,
-    lifecycle: &LifecycleFuncs,
-    func: &ExportedFunc,
-    arg: Val,
-    workload_id: &Arc<str>,
-) -> anyhow::Result<Vec<Relocated>> {
-    let reply_rx = send_lifecycle_job(sender, state, lifecycle, func, arg, workload_id).await?;
-    match tokio::time::timeout(state.lifecycle_timeout(), reply_rx).await {
-        Ok(reply) => interpret_reply(reply, state),
-        Err(_) => Err(anyhow::anyhow!(
-            "lifecycle call to host component plugin '{}' timed out",
-            state.id
-        )),
-    }
-}
-
-/// Reclaim whatever a timed-out `on-workload-bind` provisions, once it actually
-/// returns. The deploy has already failed and the workload is out of the bound
-/// map; this waits for the runaway hook's reply (guaranteeing bind-then-unbind
-/// order), then delivers the unbind only if the incarnation the bind ran on is
-/// still live — pointer-comparing the captured sender against the current one.
-/// If a restart intervened, the hook's state died with that store, so there is
-/// nothing to reclaim and no unbind is sent.
-fn spawn_deferred_unbind(
-    incarnation: Arc<CapabilitySender>,
-    reply_rx: LifecycleReplyRx,
-    workload_id: Arc<str>,
-    lifecycle: Arc<LifecycleFuncs>,
-    state: Arc<ComponentHostPluginState>,
-) {
-    tokio::spawn(async move {
-        // Wait for the runaway hook to finish (or its reply to be dropped by a
-        // store teardown).
-        let _ = reply_rx.await;
-        match state.sender_arc() {
-            Some(current) if Arc::ptr_eq(&current, &incarnation) => {
-                if let Err(e) = call_lifecycle(
-                    &incarnation,
-                    &state,
-                    &lifecycle,
-                    &lifecycle.unbind,
-                    Val::String(workload_id.to_string()),
-                    &workload_id,
-                )
-                .await
-                {
-                    debug!(id = state.id, %workload_id, err = %e, "deferred unbind not delivered");
-                }
-            }
-            _ => {
-                debug!(
-                    id = state.id,
-                    %workload_id,
-                    "skipping deferred unbind; the bind's incarnation is gone"
-                );
-            }
-        }
-    });
-}
-
-/// Build the `workload-info` record delivered to `on-workload-bind`: the
-/// workload's identity plus every interface instance it matched on this plugin,
-/// each with its manifest config — ordered deterministically.
-fn workload_info_val(workload: &UnresolvedWorkload, interfaces: &WitInterfaces<'_>) -> Val {
-    let service = Val::Option(
-        workload
-            .service_id()
-            .map(|id| Box::new(Val::String(id.to_string()))),
-    );
-    let components = Val::List(
-        workload
-            .component_ids()
-            .into_iter()
-            .map(|id| Val::String(id.to_string()))
-            .collect(),
-    );
-    let mut matched: Vec<&WitInterface> = interfaces.iter().collect();
-    matched.sort_by_key(|i| i.instance());
-    let interfaces = Val::List(matched.into_iter().map(interface_binding_val).collect());
-    Val::Record(vec![
-        ("id".to_string(), Val::String(workload.id().to_string())),
-        ("name".to_string(), Val::String(workload.name().to_string())),
-        (
-            "namespace".to_string(),
-            Val::String(workload.namespace().to_string()),
-        ),
-        ("service".to_string(), service),
-        ("components".to_string(), components),
-        ("interfaces".to_string(), interfaces),
-    ])
-}
-
-/// One matched [`WitInterface`] as a lifecycle `interface-binding` record.
-fn interface_binding_val(iface: &WitInterface) -> Val {
-    let mut names: Vec<&String> = iface.interfaces.iter().collect();
-    names.sort();
-    let mut config: Vec<(&String, &String)> = iface.config.iter().collect();
-    config.sort();
-    Val::Record(vec![
-        (
-            "namespace".to_string(),
-            Val::String(iface.namespace.clone()),
-        ),
-        ("package".to_string(), Val::String(iface.package.clone())),
-        (
-            "interfaces".to_string(),
-            Val::List(names.into_iter().map(|n| Val::String(n.clone())).collect()),
-        ),
-        (
-            "version".to_string(),
-            Val::Option(iface.version.as_ref().map(|v| Box::new(version_val(v)))),
-        ),
-        (
-            "name".to_string(),
-            Val::Option(
-                iface
-                    .name
-                    .as_ref()
-                    .map(|n| Box::new(Val::String(n.clone()))),
-            ),
-        ),
-        // Stubbed until component-model external-id lands (wasmCloud#5393):
-        // `WitInterface` grows an `external_id` there, and this becomes
-        // `iface.external_id.as_ref().map(..)` like `name` above. The WIT field
-        // exists now so that merge does not change the record shape again —
-        // adding a field to a WIT record is breaking for compiled plugins.
-        ("external-id".to_string(), Val::Option(None)),
-        (
-            "config".to_string(),
-            Val::List(
-                config
-                    .into_iter()
-                    .map(|(k, v)| {
-                        Val::Record(vec![
-                            ("key".to_string(), Val::String(k.clone())),
-                            ("value".to_string(), Val::String(v.clone())),
-                        ])
-                    })
-                    .collect(),
-            ),
-        ),
-    ])
-}
-
-/// A [`semver::Version`] as a lifecycle `version` record.
-fn version_val(v: &semver::Version) -> Val {
-    let pre = (!v.pre.is_empty()).then(|| Box::new(Val::String(v.pre.as_str().to_string())));
-    let build = (!v.build.is_empty()).then(|| Box::new(Val::String(v.build.as_str().to_string())));
-    Val::Record(vec![
-        ("major".to_string(), Val::U64(v.major)),
-        ("minor".to_string(), Val::U64(v.minor)),
-        ("patch".to_string(), Val::U64(v.patch)),
-        ("pre".to_string(), Val::Option(pre)),
-        ("build".to_string(), Val::Option(build)),
-    ])
 }
 
 /// Interface name of the host identity import a plugin may use to partition

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -37,8 +37,38 @@
 //! (polling `is-cancelled`, or observing a dropped stream reader) — without
 //! disturbing the store's other tenants. Only `error-context` values remain
 //! unsupported.
+//!
+//! A plugin may additionally *export* `wasmcloud:host/workload-lifecycle` to
+//! hear about the workloads calling it: the host delivers `on-workload-bind`
+//! (with the workload's identity and per-interface manifest config) before any
+//! capability call from that workload, and `on-workload-unbind` when it goes
+//! away — so the plugin can provision and reclaim per-workload state eagerly
+//! rather than lazily on first call. `wasmcloud:host` exports are reserved:
+//! they are host-invoked contracts, never workload-matchable capabilities.
+//! Both hooks' signatures are shape-checked at registration (`lifecycle_funcs`).
+//! A bind that overruns the plugin's lifecycle-call timeout fails the deploy at
+//! the budget rather than waiting the (uncancellable) hook out; because the hook
+//! keeps running, the rollback unbind is *deferred* until it returns
+//! (`spawn_deferred_unbind`), so state it provisions late is still reclaimed.
+//!
+//! Because a supervised restart rebuilds the store (losing all guest state)
+//! while bound workloads keep running, each fresh incarnation replays
+//! `on-workload-bind` for every workload still bound — completing the replay
+//! before serving any queued capability call, which is why the hook must be
+//! idempotent. Replay is serial: a guest bind trap short-circuits
+//! `run_concurrent` and drops the serving future before its handler runs, so
+//! the fault can only be attributed by the marker the serve loop records
+//! *before* each replayed bind (`ReplayProgress`). A bind that crash-loops the
+//! shared store is struck on each attributed fault and, past a strike ceiling
+//! (`POISON_EVICT_STRIKES`), evicted — dropped from the replay set so the store
+//! recovers for every other tenant — and reported to the host so the evicted
+//! workload's scheduling health becomes failed. Such attributed faults do not
+//! consume the plugin-wide restart budget.
 
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::Context as _;
 use arc_swap::ArcSwapOption;
@@ -55,10 +85,11 @@ use crate::engine::Engine;
 use crate::engine::ctx::{CallerIdentity, Ctx, SharedCtx};
 use crate::engine::store::relocate::{self, Relocated};
 use crate::engine::store::resource_bridge::{self, ProxyResource};
-use crate::engine::workload::WorkloadItem;
+use crate::engine::workload::{UnresolvedWorkload, WorkloadItem};
 use crate::host::job_registry::JobRegistry;
 use crate::host::trigger_service::{
-    CapabilityCall, CapabilityFunc, CapabilityJob, Ingress, TriggerService,
+    CapabilityCall, CapabilityFunc, CapabilityJob, Ingress, LifecycleReplay, TriggerService,
+    decode_bind_reply,
 };
 use crate::oci::{self, OciConfig};
 use crate::plugin::component_plugin_spec::{ComponentPluginSpec, PluginSource};
@@ -74,6 +105,14 @@ const CAPABILITY_CHANNEL_CAPACITY: usize = 256;
 /// before the plugin is declared dead. One store now serves every workload, so
 /// a restart story is required rather than optional.
 const DEFAULT_MAX_RESTARTS: u32 = 3;
+
+/// Consecutive `on-workload-bind` traps a workload may accumulate before it is
+/// evicted (dropped from the replay set and reported failed). Kept below
+/// [`DEFAULT_MAX_RESTARTS`] so a deterministically-poison bind is quarantined —
+/// contained to its own workload — before its crash loop can exhaust the whole
+/// plugin's restart budget and take every tenant down with it. Strikes reset
+/// after a healthy uptime, so only a rapid crash loop escalates to eviction.
+const POISON_EVICT_STRIKES: u32 = 2;
 
 type CapabilitySender = tokio::sync::mpsc::Sender<CapabilityJob>;
 
@@ -101,6 +140,30 @@ struct ExportedInterface {
     resources: Vec<Arc<str>>,
 }
 
+/// Interface name of the optional lifecycle export a plugin may provide to
+/// hear about the workloads binding to (and unbinding from) it.
+const HOST_LIFECYCLE_INTERFACE: &str = "wasmcloud:host/workload-lifecycle@0.1.0";
+/// The lifecycle export's bind hook.
+const ON_WORKLOAD_BIND: &str = "on-workload-bind";
+/// The lifecycle export's unbind hook.
+const ON_WORKLOAD_UNBIND: &str = "on-workload-unbind";
+
+/// Whether an interface belongs to the reserved `wasmcloud:host` package —
+/// host-invoked contracts (like the lifecycle export), never capabilities a
+/// workload may import.
+fn is_reserved(wit: &WitInterface) -> bool {
+    wit.namespace == "wasmcloud" && wit.package == "host"
+}
+
+/// The plugin's `wasmcloud:host/workload-lifecycle` export, introspected at
+/// construction: the instance name plus both hook functions' types, ready to
+/// drive the dynamic cross-store calls.
+struct LifecycleFuncs {
+    interface: Arc<str>,
+    bind: ExportedFunc,
+    unbind: ExportedFunc,
+}
+
 /// Runtime state shared between the plugin, the linker shims it installs, and
 /// its supervisor task.
 struct ComponentHostPluginState {
@@ -118,6 +181,32 @@ struct ComponentHostPluginState {
     /// linker at construction — read it from here so they reach the live store's
     /// registry. Lock-free reads for the same reason as `tx`.
     registry: ArcSwapOption<JobRegistry>,
+    /// Workloads currently bound to this plugin, as workload id → the
+    /// `workload-info` value delivered to `on-workload-bind`. The supervisor
+    /// snapshots it on each (re)start to replay binds into the fresh
+    /// incarnation. Empty unless the plugin exports the lifecycle interface.
+    bound: Mutex<BTreeMap<Arc<str>, Val>>,
+    /// Consecutive `on-workload-bind` traps attributed to each workload since it
+    /// last bound cleanly — the quarantine strike count. Harvested from the
+    /// faulted incarnation's registry after each fault; a workload reaching
+    /// [`POISON_EVICT_STRIKES`] is evicted so its poison bind stops crash-looping
+    /// the shared store for every other tenant. Reset for all workloads after a
+    /// healthy uptime, like the restart budget.
+    poison: Mutex<BTreeMap<Arc<str>, u32>>,
+    /// Append-only log of workload ids whose `on-workload-bind` was observed to
+    /// trap, in harvest order. Diagnostic, and the observable the attribution
+    /// tests assert against.
+    bind_trap_log: Mutex<Vec<Arc<str>>>,
+    /// Sink for reporting an evicted workload to the host so its scheduling
+    /// health becomes failed. Injected once at start; absent when the plugin is
+    /// used without a host (e.g. driven directly in tests).
+    failure_sink: ArcSwapOption<crate::plugin::WorkloadFailureSink>,
+    /// Per-call budget for a lifecycle (bind/unbind) delivery, in milliseconds.
+    /// Defaults to [`crate::timeouts::plugin_lifecycle_call`]; overridable via
+    /// [`ComponentHostPlugin::with_lifecycle_call_timeout`]. Read on every
+    /// lifecycle call, written at most once (before start), so a relaxed atomic
+    /// is enough.
+    lifecycle_timeout_ms: AtomicU64,
 }
 
 impl ComponentHostPluginState {
@@ -127,10 +216,33 @@ impl ComponentHostPluginState {
         self.tx.load_full().map(|tx| (*tx).clone())
     }
 
+    /// The current incarnation's sender as a shared handle, whose `Arc` identity
+    /// names the incarnation: a restart publishes a new `Arc`, so
+    /// [`Arc::ptr_eq`] against a captured handle tells a deferred task whether
+    /// the incarnation it spoke to is still the live one.
+    fn sender_arc(&self) -> Option<Arc<CapabilitySender>> {
+        self.tx.load_full()
+    }
+
+    /// Remove `workload_id` from the bound-workloads map without delivering an
+    /// unbind. Used when a bind never reached the guest (its enqueue failed) or
+    /// when its unbind is being deferred separately.
+    fn forget_workload(&self, workload_id: &str) {
+        self.bound
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(workload_id);
+    }
+
     /// The current incarnation's job registry, or `None` if the plugin is not
     /// running. Read by the host `identity`/`cancel` imports.
     fn registry(&self) -> Option<Arc<JobRegistry>> {
         self.registry.load_full()
+    }
+
+    /// The per-call budget for a lifecycle (bind/unbind) delivery.
+    fn lifecycle_timeout(&self) -> Duration {
+        Duration::from_millis(self.lifecycle_timeout_ms.load(Ordering::Relaxed))
     }
 }
 
@@ -146,6 +258,8 @@ pub struct ComponentHostPlugin {
     exports: Arc<Vec<ExportedInterface>>,
     /// Every exported function, flattened, for the TriggerService to resolve up front.
     capability_funcs: Vec<CapabilityFunc>,
+    /// The plugin's `wasmcloud:host/workload-lifecycle` export, if it has one.
+    lifecycle: Option<Arc<LifecycleFuncs>>,
     max_restarts: u32,
     state: Arc<ComponentHostPluginState>,
 }
@@ -167,15 +281,22 @@ impl ComponentHostPlugin {
             tx: ArcSwapOption::empty(),
             supervisor: Mutex::new(None),
             registry: ArcSwapOption::empty(),
+            bound: Mutex::new(BTreeMap::new()),
+            poison: Mutex::new(BTreeMap::new()),
+            bind_trap_log: Mutex::new(Vec::new()),
+            failure_sink: ArcSwapOption::empty(),
+            lifecycle_timeout_ms: AtomicU64::new(
+                crate::timeouts::plugin_lifecycle_call().as_millis() as u64,
+            ),
         });
 
-        let (exports, pre) = build_plugin_linker(&engine, id, wasm, &state)?;
+        let (exports, lifecycle, pre) = build_plugin_linker(&engine, id, wasm, &state)?;
 
         let world = WitWorld {
             imports: exports.iter().map(|e| e.wit.clone()).collect(),
             exports: Default::default(),
         };
-        let capability_funcs = exports
+        let mut capability_funcs: Vec<CapabilityFunc> = exports
             .iter()
             .flat_map(|e| {
                 e.funcs.iter().map(|f| CapabilityFunc {
@@ -184,6 +305,18 @@ impl ComponentHostPlugin {
                 })
             })
             .collect();
+        // The lifecycle hooks are served on the same instance as the
+        // capabilities, so the TriggerService must resolve them too.
+        if let Some(lifecycle) = &lifecycle {
+            capability_funcs.push(CapabilityFunc {
+                interface: Arc::clone(&lifecycle.interface),
+                func: Arc::clone(&lifecycle.bind.name),
+            });
+            capability_funcs.push(CapabilityFunc {
+                interface: Arc::clone(&lifecycle.interface),
+                func: Arc::clone(&lifecycle.unbind.name),
+            });
+        }
 
         Ok(Self {
             id,
@@ -192,6 +325,7 @@ impl ComponentHostPlugin {
             world,
             exports: Arc::new(exports),
             capability_funcs,
+            lifecycle: lifecycle.map(Arc::new),
             max_restarts: DEFAULT_MAX_RESTARTS,
             state,
         })
@@ -202,6 +336,78 @@ impl ComponentHostPlugin {
     pub fn with_max_restarts(mut self, max_restarts: u32) -> Self {
         self.max_restarts = max_restarts;
         self
+    }
+
+    /// Override the per-call budget for a lifecycle (bind/unbind) delivery
+    /// (default [`crate::timeouts::plugin_lifecycle_call`]). Bounds how long a
+    /// deploy or stop waits on a hook before failing and, for bind, deferring
+    /// the rollback unbind.
+    pub fn with_lifecycle_call_timeout(self, timeout: Duration) -> Self {
+        self.state
+            .lifecycle_timeout_ms
+            .store(timeout.as_millis() as u64, Ordering::Relaxed);
+        self
+    }
+
+    /// The workload ids whose `on-workload-bind` has been observed to trap, in
+    /// harvest order — a diagnostic view of the fault-attribution the supervisor
+    /// performs after each restart.
+    pub fn bind_trap_log(&self) -> Vec<String> {
+        self.state
+            .bind_trap_log
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .map(|id| id.to_string())
+            .collect()
+    }
+
+    /// Whether `workload_id` is still bound (present in the replay set). A
+    /// workload evicted for a crash-looping bind is no longer bound.
+    pub fn is_bound(&self, workload_id: &str) -> bool {
+        self.state
+            .bound
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains_key(workload_id)
+    }
+
+    /// Forget `workload_id` and deliver `on-workload-unbind` for it. The
+    /// removal and the sender read share one `bound` lock so the unbind lands
+    /// on the incarnation that will not also replay the removed entry (see
+    /// [`replay_snapshot`]).
+    async fn remove_and_unbind(
+        &self,
+        lifecycle: &LifecycleFuncs,
+        workload_id: &Arc<str>,
+    ) -> anyhow::Result<()> {
+        let (was_bound, sender) = {
+            let mut bound = self
+                .state
+                .bound
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let was_bound = bound.remove(workload_id.as_ref()).is_some();
+            (was_bound, self.state.sender())
+        };
+        // Only a workload whose bind we actually delivered gets an unbind:
+        // this dedupes the engine's per-item unbind fan-out (a plugin bound to
+        // N items is unbound N times) and skips ids that were never bound.
+        if !was_bound {
+            return Ok(());
+        }
+        let sender = sender
+            .ok_or_else(|| anyhow::anyhow!("host component plugin '{}' is not running", self.id))?;
+        call_lifecycle(
+            &sender,
+            &self.state,
+            lifecycle,
+            &lifecycle.unbind,
+            Val::String(workload_id.to_string()),
+            workload_id,
+        )
+        .await
+        .map(|_| ())
     }
 }
 
@@ -279,16 +485,33 @@ impl HostPlugin for ComponentHostPlugin {
         self.world.clone()
     }
 
+    fn set_workload_failure_sink(&self, sink: crate::plugin::WorkloadFailureSink) {
+        self.state.failure_sink.store(Some(Arc::new(sink)));
+    }
+
     async fn start(&self) -> anyhow::Result<()> {
         let (tx, rx) = tokio::sync::mpsc::channel(CAPABILITY_CHANNEL_CAPACITY);
-        self.state.tx.store(Some(Arc::new(tx)));
+        // Publish the sender and snapshot the bound workloads atomically (see
+        // [`replay_snapshot`]); leftover binds (a stop()/start() cycle) replay,
+        // while binds arriving from now on deliver through the channel.
+        let replay = {
+            let bound = self
+                .state
+                .bound
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            self.state.tx.store(Some(Arc::new(tx)));
+            replay_snapshot(&bound, self.lifecycle.as_deref())
+        };
 
         let supervisor = tokio::spawn(run_supervisor(
             self.engine.clone(),
             self.pre.clone(),
             self.capability_funcs.clone(),
+            self.lifecycle.clone(),
             Arc::clone(&self.state),
             self.max_restarts,
+            replay,
             rx,
         ));
         *self
@@ -300,11 +523,122 @@ impl HostPlugin for ComponentHostPlugin {
         Ok(())
     }
 
+    async fn on_workload_bind(
+        &self,
+        workload: &UnresolvedWorkload,
+        interfaces: WitInterfaces<'_>,
+    ) -> anyhow::Result<()> {
+        let Some(lifecycle) = &self.lifecycle else {
+            return Ok(());
+        };
+        let info = workload_info_val(workload, &interfaces);
+        let workload_id: Arc<str> = Arc::from(workload.id());
+        // Record the workload and read the current sender (as an incarnation
+        // handle) under one `bound` lock: the supervisor swaps incarnations
+        // under the same lock (see [`replay_snapshot`]), so this bind is either
+        // in the next replay snapshot (and this send targets the previous, dead
+        // channel) or delivered through the live channel — never both.
+        // Recording before delivery also means a restart DURING the call
+        // replays the bind (the hook is idempotent); rolled back below on
+        // failure.
+        let sender_arc = {
+            let mut bound = self
+                .state
+                .bound
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            bound.insert(Arc::clone(&workload_id), info.clone());
+            self.state.sender_arc()
+        };
+        let Some(sender_arc) = sender_arc else {
+            self.state.forget_workload(&workload_id);
+            return Err(anyhow::anyhow!(
+                "host component plugin '{}' is not running",
+                self.id
+            ));
+        };
+
+        // Enqueue the bind. A send timeout / closed channel means it never
+        // reached the guest (tokio's bounded send does not enqueue a dropped
+        // send), so no hook is running — forget the workload and fail, no
+        // unbind needed.
+        let reply_rx = match send_lifecycle_job(
+            &sender_arc,
+            &self.state,
+            lifecycle,
+            &lifecycle.bind,
+            info,
+            &workload_id,
+        )
+        .await
+        {
+            Ok(reply_rx) => reply_rx,
+            Err(e) => {
+                self.state.forget_workload(&workload_id);
+                return Err(e.context(format!(
+                    "failed to deliver workload bind to host component plugin '{}'",
+                    self.id
+                )));
+            }
+        };
+
+        // Await the reply, but keep the receiver if it times out: we cannot
+        // cancel a running guest hook, so on timeout the bind is still in
+        // flight. Fail the deploy now and defer the rollback unbind until the
+        // hook actually returns — guaranteeing bind-then-unbind ordering so
+        // whatever it provisions late is still reclaimed (see
+        // [`spawn_deferred_unbind`]).
+        let failure = match await_bind_reply(reply_rx, &self.state).await {
+            BindReply::Completed(Ok(results)) => match decode_bind_reply(&results) {
+                Ok(Ok(())) => {
+                    debug!(id = self.id, %workload_id, "workload bound to host component plugin");
+                    return Ok(());
+                }
+                Ok(Err(msg)) => anyhow::anyhow!(
+                    "host component plugin '{}' rejected workload '{workload_id}': {msg}",
+                    self.id
+                ),
+                Err(e) => anyhow::Error::from(e).context(format!(
+                    "host component plugin '{}' returned a malformed on-workload-bind reply",
+                    self.id
+                )),
+            },
+            BindReply::Completed(Err(e)) => e.context(format!(
+                "failed to deliver workload bind to host component plugin '{}'",
+                self.id
+            )),
+            BindReply::TimedOut(pending) => {
+                self.state.forget_workload(&workload_id);
+                spawn_deferred_unbind(
+                    sender_arc,
+                    pending,
+                    Arc::clone(&workload_id),
+                    Arc::clone(lifecycle),
+                    Arc::clone(&self.state),
+                );
+                return Err(anyhow::anyhow!(
+                    "on-workload-bind to host component plugin '{}' timed out; deploy failed, \
+                     cleanup deferred until the hook returns",
+                    self.id
+                ));
+            }
+        };
+
+        // The bind returned (rejection, malformed reply, or a delivery error
+        // after the hook ran): the hook is no longer in flight, so roll back
+        // immediately with a best-effort unbind.
+        if let Err(e) = self.remove_and_unbind(lifecycle, &workload_id).await {
+            debug!(id = self.id, %workload_id, err = %e, "post-failure unbind not delivered");
+        }
+        Err(failure)
+    }
+
     async fn on_workload_item_bind<'a>(
         &self,
         item: &mut WorkloadItem<'a>,
         interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
+        let workload_id: Arc<str> = Arc::from(item.workload_id());
         let linker = item.linker();
 
         for exported in self.exports.iter() {
@@ -315,10 +649,54 @@ impl HostPlugin for ComponentHostPlugin {
                 continue;
             }
 
-            add_capabilities_to_linker(linker, &self.state, exported)?;
+            if let Err(e) = add_capabilities_to_linker(linker, &self.state, exported) {
+                // The engine's bind-failure cleanup only unbinds plugins whose
+                // item binds ALL succeeded — a plugin failing its own item bind
+                // is not yet on that list — so roll back the bind delivered in
+                // `on_workload_bind` ourselves.
+                if let Some(lifecycle) = &self.lifecycle
+                    && let Err(unbind_err) = self.remove_and_unbind(lifecycle, &workload_id).await
+                {
+                    debug!(
+                        id = self.id,
+                        %workload_id,
+                        err = %unbind_err,
+                        "item-bind rollback unbind not delivered"
+                    );
+                }
+                return Err(e);
+            }
             debug!(id = self.id, interface = %exported.name, "wired host component capability");
         }
 
+        Ok(())
+    }
+
+    async fn on_workload_unbind(
+        &self,
+        workload_id: &str,
+        _interfaces: WitInterfaces<'_>,
+    ) -> anyhow::Result<()> {
+        let Some(lifecycle) = &self.lifecycle else {
+            return Ok(());
+        };
+        // Best-effort by design: the workload is going away regardless, and if
+        // the plugin is stopped or restarting its per-workload state is already
+        // gone with the store.
+        let workload_id: Arc<str> = Arc::from(workload_id);
+        match self.remove_and_unbind(lifecycle, &workload_id).await {
+            Ok(()) => {
+                debug!(id = self.id, %workload_id, "workload unbound from host component plugin");
+            }
+            Err(e) => {
+                warn!(
+                    id = self.id,
+                    %workload_id,
+                    err = %e,
+                    "failed to deliver workload unbind to host component plugin (best-effort)"
+                );
+            }
+        }
         Ok(())
     }
 
@@ -326,7 +704,18 @@ impl HostPlugin for ComponentHostPlugin {
         // Clearing the sender closes the current incarnation's channel, ending
         // the TriggerService's serve loop and letting the supervisor exit cleanly; the
         // registry goes with it (the driver's tasks retire their jobs as they end).
-        self.state.tx.store(None);
+        // Cleared under the `bound` lock so it cannot interleave with the
+        // supervisor's restart republish, which re-checks the sender under the
+        // same lock — otherwise a republish racing this clear could leave a
+        // "stopped" plugin with a live sender.
+        {
+            let _bound = self
+                .state
+                .bound
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            self.state.tx.store(None);
+        }
         self.state.registry.store(None);
         let supervisor = self
             .state
@@ -362,15 +751,35 @@ impl HostPlugin for ComponentHostPlugin {
 /// - a route back to the plugin's own capability channel for any interface it
 ///   both imports and exports (a self-import).
 ///
-/// Returns the introspected exports alongside the resulting [`InstancePre`].
+/// The introspected exports are partitioned: reserved `wasmcloud:host` exports
+/// (only the lifecycle interface is allowed) are host-invoked contracts, while
+/// everything else is a capability workloads may import. Returns the capability
+/// exports and the lifecycle export (if any) alongside the [`InstancePre`].
 fn build_plugin_linker(
     engine: &Engine,
     id: &str,
     wasm: &[u8],
     state: &Arc<ComponentHostPluginState>,
-) -> anyhow::Result<(Vec<ExportedInterface>, InstancePre<SharedCtx>)> {
+) -> anyhow::Result<(
+    Vec<ExportedInterface>,
+    Option<LifecycleFuncs>,
+    InstancePre<SharedCtx>,
+)> {
     let (component, mut linker) = engine.prepare_host_component(wasm)?;
-    let exports = introspect_exports(&component)?;
+    let mut lifecycle = None;
+    let mut exports = Vec::new();
+    for export in introspect_exports(&component)? {
+        if is_reserved(&export.wit) {
+            anyhow::ensure!(
+                export.name.as_ref() == HOST_LIFECYCLE_INTERFACE,
+                "host component plugin '{id}' exports reserved host interface {}",
+                export.name
+            );
+            lifecycle = Some(lifecycle_funcs(id, export)?);
+        } else {
+            exports.push(export);
+        }
+    }
     anyhow::ensure!(
         exports.iter().any(|e| !e.funcs.is_empty()),
         "host component plugin '{id}' exports no capability functions to serve"
@@ -396,7 +805,400 @@ fn build_plugin_linker(
         .instantiate_pre(&component)
         .map_err(anyhow::Error::from)
         .context("failed to pre-instantiate host component plugin")
-        .map(|pre| (exports, pre))
+        .map(|pre| (exports, lifecycle, pre))
+}
+
+/// Pull the two lifecycle hooks out of the plugin's introspected
+/// `wasmcloud:host/workload-lifecycle` export. Presence, arity, and the
+/// top-level shape of each signature are checked here so a mismatched plugin
+/// fails at registration with a clear message rather than on its first
+/// workload deploy. Deep per-field types (every field of `workload-info`)
+/// still surface as a per-delivery typecheck error — the fixed shape below
+/// catches the mistakes worth catching cheaply.
+fn lifecycle_funcs(id: &str, mut export: ExportedInterface) -> anyhow::Result<LifecycleFuncs> {
+    let mut bind = None;
+    let mut unbind = None;
+    for func in export.funcs.drain(..) {
+        match func.name.as_ref() {
+            ON_WORKLOAD_BIND => bind = Some(func),
+            ON_WORKLOAD_UNBIND => unbind = Some(func),
+            _ => {}
+        }
+    }
+    let bind = bind.with_context(|| {
+        format!("host component plugin '{id}' lifecycle export is missing {ON_WORKLOAD_BIND}")
+    })?;
+    let unbind = unbind.with_context(|| {
+        format!("host component plugin '{id}' lifecycle export is missing {ON_WORKLOAD_UNBIND}")
+    })?;
+
+    // `on-workload-bind: func(workload-info) -> result<_, string>`
+    anyhow::ensure!(
+        bind.result_tys.len() == 1 && matches!(bind.param_tys.first(), Some(Type::Record(_))),
+        "host component plugin '{id}' {ON_WORKLOAD_BIND} must take one argument, the workload-info \
+         record"
+    );
+    match bind.result_tys.first() {
+        Some(Type::Result(rt)) => anyhow::ensure!(
+            rt.ok().is_none() && matches!(rt.err(), Some(Type::String)),
+            "host component plugin '{id}' {ON_WORKLOAD_BIND} must return result<_, string>"
+        ),
+        _ => anyhow::bail!(
+            "host component plugin '{id}' {ON_WORKLOAD_BIND} must return result<_, string>"
+        ),
+    }
+
+    // `on-workload-unbind: func(workload-id)` — one string, no result.
+    anyhow::ensure!(
+        unbind.result_tys.is_empty() && matches!(unbind.param_tys.first(), Some(Type::String)),
+        "host component plugin '{id}' {ON_WORKLOAD_UNBIND} must take one argument, the workload-id \
+         string, and return nothing"
+    );
+
+    Ok(LifecycleFuncs {
+        interface: export.name,
+        bind,
+        unbind,
+    })
+}
+
+/// Snapshot the bound-workloads map into the replay list for a fresh
+/// incarnation. MUST be taken while holding the `bound` lock, atomically with
+/// publishing the incarnation's sender: that exclusion is what guarantees a
+/// concurrent bind/unbind is either reflected in the snapshot (recorded before
+/// the swap, its own send targeting the previous, now-dead channel) or
+/// delivered through the new channel — never both, so no double delivery.
+fn replay_snapshot(
+    bound: &BTreeMap<Arc<str>, Val>,
+    lifecycle: Option<&LifecycleFuncs>,
+) -> Vec<LifecycleReplay> {
+    let Some(lifecycle) = lifecycle else {
+        return Vec::new();
+    };
+    bound
+        .iter()
+        .map(|(workload_id, info)| LifecycleReplay {
+            interface: Arc::clone(&lifecycle.interface),
+            func: Arc::clone(&lifecycle.bind.name),
+            // A replayed bind is about the workload, not any component of it.
+            caller: CallerIdentity {
+                workload_id: Arc::clone(workload_id),
+                component_id: None,
+            },
+            args: vec![Relocated::Val(info.clone())],
+            result_tys: Arc::clone(&lifecycle.bind.result_tys),
+        })
+        .collect()
+}
+
+/// Attribute the just-observed store fault to a replayed bind, if the faulted
+/// incarnation was mid-replay. Returns the culprit workload when the fault
+/// happened during replay and the serve loop had marked one in-flight — that is
+/// a per-workload poison (its bind crash-loops the shared store), which the
+/// supervisor strikes and eventually evicts, and which must NOT consume the
+/// plugin-wide restart budget. A fault while serving (replay already completed)
+/// returns `None`: it is ordinary instability and charges the budget as before.
+///
+/// The marker lives in the faulted incarnation's registry, still reachable via
+/// `state.registry` until the supervisor publishes the next one — this runs in
+/// that window, right after the driver returns.
+fn attribute_replay_fault(state: &ComponentHostPluginState) -> Option<Arc<str>> {
+    let progress = state.registry()?.replay_progress();
+    if progress.completed {
+        return None;
+    }
+    let workload_id = progress.current?.workload_id;
+    state
+        .bind_trap_log
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(Arc::clone(&workload_id));
+    Some(workload_id)
+}
+
+/// Evict a workload whose `on-workload-bind` crash-looped past the strike
+/// ceiling: drop it from the bound set (so the next incarnation stops replaying
+/// it and recovers for every other tenant) and forget its strikes. The
+/// workload is left provisioned nowhere; the caller reports it failed to the
+/// host so its scheduling health reflects the eviction.
+fn evict_workload(state: &ComponentHostPluginState, workload_id: &Arc<str>) {
+    state
+        .bound
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(workload_id);
+    state
+        .poison
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(workload_id);
+    error!(
+        id = state.id,
+        %workload_id,
+        strikes = POISON_EVICT_STRIKES,
+        "evicting workload after repeated on-workload-bind traps; reporting it failed"
+    );
+}
+
+/// Report an evicted workload to the host so its scheduling health becomes
+/// failed. A no-op if no failure sink was injected (the plugin is running
+/// without a host, e.g. driven directly in a test).
+fn report_workload_failed(state: &ComponentHostPluginState, workload_id: &Arc<str>) {
+    if let Some(sink) = state.failure_sink.load_full() {
+        sink.report(
+            workload_id.to_string(),
+            format!(
+                "host component plugin '{}' evicted the workload: its on-workload-bind \
+                 repeatedly trapped ({POISON_EVICT_STRIKES} strikes)",
+                state.id
+            ),
+        );
+    }
+}
+
+/// The reply receiver for one in-flight lifecycle call.
+type LifecycleReplyRx = tokio::sync::oneshot::Receiver<wasmtime::Result<Vec<Relocated>>>;
+
+/// The result of awaiting an `on-workload-bind` reply.
+enum BindReply {
+    /// The hook returned (its relocated results, or a delivery/drop error).
+    Completed(anyhow::Result<Vec<Relocated>>),
+    /// The reply did not arrive within the budget; the hook may still be
+    /// running. Its receiver is handed back so cleanup can be deferred until it
+    /// resolves (a guest hook cannot be cancelled).
+    TimedOut(LifecycleReplyRx),
+}
+
+/// Enqueue one lifecycle call on `sender` and return its pending reply
+/// receiver. Bounded by [`crate::timeouts::plugin_lifecycle_call`] so a full
+/// channel cannot park a deploy or a stop; a send that times out (or hits a
+/// closed channel) leaves the job un-enqueued — tokio's bounded send only
+/// enqueues on completion — so the caller knows no hook is running. The call
+/// runs under the workload's identity (empty component id) so
+/// `wasmcloud:host/identity` answers consistently inside the hook.
+async fn send_lifecycle_job(
+    sender: &CapabilitySender,
+    state: &ComponentHostPluginState,
+    lifecycle: &LifecycleFuncs,
+    func: &ExportedFunc,
+    arg: Val,
+    workload_id: &Arc<str>,
+) -> anyhow::Result<LifecycleReplyRx> {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    let job = CapabilityJob::Call(CapabilityCall {
+        interface: Arc::clone(&lifecycle.interface),
+        func: Arc::clone(&func.name),
+        caller: CallerIdentity {
+            workload_id: Arc::clone(workload_id),
+            component_id: None,
+        },
+        args: vec![Relocated::Val(arg)],
+        result_tys: Arc::clone(&func.result_tys),
+        reply: reply_tx,
+    });
+    tokio::time::timeout(state.lifecycle_timeout(), sender.send(job))
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "host component plugin '{}' channel send timed out",
+                state.id
+            )
+        })?
+        .map_err(|_| anyhow::anyhow!("host component plugin '{}' channel closed", state.id))?;
+    Ok(reply_rx)
+}
+
+/// Interpret a resolved lifecycle reply receiver value into relocated results
+/// or a diagnostic error.
+fn interpret_reply(
+    reply: Result<wasmtime::Result<Vec<Relocated>>, tokio::sync::oneshot::error::RecvError>,
+    state: &ComponentHostPluginState,
+) -> anyhow::Result<Vec<Relocated>> {
+    match reply {
+        Ok(Ok(results)) => Ok(results),
+        Ok(Err(e)) => Err(anyhow::Error::from(e)),
+        Err(_) => Err(anyhow::anyhow!(
+            "host component plugin '{}' dropped the lifecycle reply",
+            state.id
+        )),
+    }
+}
+
+/// Await a bind reply, keeping the receiver if the budget elapses first so the
+/// caller can defer cleanup until the still-running hook returns.
+async fn await_bind_reply(
+    mut reply_rx: LifecycleReplyRx,
+    state: &ComponentHostPluginState,
+) -> BindReply {
+    let deadline = tokio::time::sleep(state.lifecycle_timeout());
+    tokio::pin!(deadline);
+    tokio::select! {
+        reply = &mut reply_rx => BindReply::Completed(interpret_reply(reply, state)),
+        () = &mut deadline => BindReply::TimedOut(reply_rx),
+    }
+}
+
+/// Deliver one lifecycle call over `sender` and await its relocated results,
+/// bounded by [`crate::timeouts::plugin_lifecycle_call`] on both the send and
+/// the reply. Used for unbind (and item-bind rollback) where — unlike bind —
+/// there is nothing to defer on a timeout.
+async fn call_lifecycle(
+    sender: &CapabilitySender,
+    state: &ComponentHostPluginState,
+    lifecycle: &LifecycleFuncs,
+    func: &ExportedFunc,
+    arg: Val,
+    workload_id: &Arc<str>,
+) -> anyhow::Result<Vec<Relocated>> {
+    let reply_rx = send_lifecycle_job(sender, state, lifecycle, func, arg, workload_id).await?;
+    match tokio::time::timeout(state.lifecycle_timeout(), reply_rx).await {
+        Ok(reply) => interpret_reply(reply, state),
+        Err(_) => Err(anyhow::anyhow!(
+            "lifecycle call to host component plugin '{}' timed out",
+            state.id
+        )),
+    }
+}
+
+/// Reclaim whatever a timed-out `on-workload-bind` provisions, once it actually
+/// returns. The deploy has already failed and the workload is out of the bound
+/// map; this waits for the runaway hook's reply (guaranteeing bind-then-unbind
+/// order), then delivers the unbind only if the incarnation the bind ran on is
+/// still live — pointer-comparing the captured sender against the current one.
+/// If a restart intervened, the hook's state died with that store, so there is
+/// nothing to reclaim and no unbind is sent.
+fn spawn_deferred_unbind(
+    incarnation: Arc<CapabilitySender>,
+    reply_rx: LifecycleReplyRx,
+    workload_id: Arc<str>,
+    lifecycle: Arc<LifecycleFuncs>,
+    state: Arc<ComponentHostPluginState>,
+) {
+    tokio::spawn(async move {
+        // Wait for the runaway hook to finish (or its reply to be dropped by a
+        // store teardown).
+        let _ = reply_rx.await;
+        match state.sender_arc() {
+            Some(current) if Arc::ptr_eq(&current, &incarnation) => {
+                if let Err(e) = call_lifecycle(
+                    &incarnation,
+                    &state,
+                    &lifecycle,
+                    &lifecycle.unbind,
+                    Val::String(workload_id.to_string()),
+                    &workload_id,
+                )
+                .await
+                {
+                    debug!(id = state.id, %workload_id, err = %e, "deferred unbind not delivered");
+                }
+            }
+            _ => {
+                debug!(
+                    id = state.id,
+                    %workload_id,
+                    "skipping deferred unbind; the bind's incarnation is gone"
+                );
+            }
+        }
+    });
+}
+
+/// Build the `workload-info` record delivered to `on-workload-bind`: the
+/// workload's identity plus every interface instance it matched on this plugin,
+/// each with its manifest config — ordered deterministically.
+fn workload_info_val(workload: &UnresolvedWorkload, interfaces: &WitInterfaces<'_>) -> Val {
+    let service = Val::Option(
+        workload
+            .service_id()
+            .map(|id| Box::new(Val::String(id.to_string()))),
+    );
+    let components = Val::List(
+        workload
+            .component_ids()
+            .into_iter()
+            .map(|id| Val::String(id.to_string()))
+            .collect(),
+    );
+    let mut matched: Vec<&WitInterface> = interfaces.iter().collect();
+    matched.sort_by_key(|i| i.instance());
+    let interfaces = Val::List(matched.into_iter().map(interface_binding_val).collect());
+    Val::Record(vec![
+        ("id".to_string(), Val::String(workload.id().to_string())),
+        ("name".to_string(), Val::String(workload.name().to_string())),
+        (
+            "namespace".to_string(),
+            Val::String(workload.namespace().to_string()),
+        ),
+        ("service".to_string(), service),
+        ("components".to_string(), components),
+        ("interfaces".to_string(), interfaces),
+    ])
+}
+
+/// One matched [`WitInterface`] as a lifecycle `interface-binding` record.
+fn interface_binding_val(iface: &WitInterface) -> Val {
+    let mut names: Vec<&String> = iface.interfaces.iter().collect();
+    names.sort();
+    let mut config: Vec<(&String, &String)> = iface.config.iter().collect();
+    config.sort();
+    Val::Record(vec![
+        (
+            "namespace".to_string(),
+            Val::String(iface.namespace.clone()),
+        ),
+        ("package".to_string(), Val::String(iface.package.clone())),
+        (
+            "interfaces".to_string(),
+            Val::List(names.into_iter().map(|n| Val::String(n.clone())).collect()),
+        ),
+        (
+            "version".to_string(),
+            Val::Option(iface.version.as_ref().map(|v| Box::new(version_val(v)))),
+        ),
+        (
+            "name".to_string(),
+            Val::Option(
+                iface
+                    .name
+                    .as_ref()
+                    .map(|n| Box::new(Val::String(n.clone()))),
+            ),
+        ),
+        // Stubbed until component-model external-id lands (wasmCloud#5393):
+        // `WitInterface` grows an `external_id` there, and this becomes
+        // `iface.external_id.as_ref().map(..)` like `name` above. The WIT field
+        // exists now so that merge does not change the record shape again —
+        // adding a field to a WIT record is breaking for compiled plugins.
+        ("external-id".to_string(), Val::Option(None)),
+        (
+            "config".to_string(),
+            Val::List(
+                config
+                    .into_iter()
+                    .map(|(k, v)| {
+                        Val::Record(vec![
+                            ("key".to_string(), Val::String(k.clone())),
+                            ("value".to_string(), Val::String(v.clone())),
+                        ])
+                    })
+                    .collect(),
+            ),
+        ),
+    ])
+}
+
+/// A [`semver::Version`] as a lifecycle `version` record.
+fn version_val(v: &semver::Version) -> Val {
+    let pre = (!v.pre.is_empty()).then(|| Box::new(Val::String(v.pre.as_str().to_string())));
+    let build = (!v.build.is_empty()).then(|| Box::new(Val::String(v.build.as_str().to_string())));
+    Val::Record(vec![
+        ("major".to_string(), Val::U64(v.major)),
+        ("minor".to_string(), Val::U64(v.minor)),
+        ("patch".to_string(), Val::U64(v.patch)),
+        ("pre".to_string(), Val::Option(pre)),
+        ("build".to_string(), Val::Option(build)),
+    ])
 }
 
 /// Interface name of the host identity import a plugin may use to partition
@@ -456,9 +1258,18 @@ fn install_host_identity(
             "get-component-id",
             move |mut store, _ty, _params, results| {
                 let root = caller_root_task(&mut store);
+                // `get-component-id` returns a bare `string`, so "there is no
+                // component" has no representation of its own — a lifecycle
+                // hook (`component_id: None`) and an unresolvable caller both
+                // collapse to the empty string here, at the WIT boundary and
+                // nowhere earlier. Widening this to `option<string>` would
+                // break the released `wasmcloud:host/identity`; until then a
+                // plugin must read `workload-info` inside a hook rather than
+                // ask who is calling.
                 let id = root
                     .and_then(|task| component_state.registry()?.caller_for_task(task))
-                    .map(|c| c.component_id.to_string())
+                    .and_then(|c| c.component_id.clone())
+                    .map(|id| id.to_string())
                     .unwrap_or_default();
                 if let Some(slot) = results.first_mut() {
                     *slot = Val::String(id);
@@ -679,7 +1490,7 @@ async fn route_capability_call(
                 let ctx = &access.data_mut().active_ctx;
                 CallerIdentity {
                     workload_id: Arc::clone(&ctx.workload_id),
-                    component_id: Arc::clone(&ctx.component_id),
+                    component_id: Some(Arc::clone(&ctx.component_id)),
                 }
             };
             let mut dones = Vec::new();
@@ -732,12 +1543,15 @@ async fn route_capability_call(
 /// TriggerService, and await the driver. A clean shutdown (the sender cleared by
 /// `stop()`) exits; a fault restarts up to `max_restarts` times, handing each
 /// new incarnation a fresh channel whose sender the installed shims pick up.
+#[allow(clippy::too_many_arguments)]
 async fn run_supervisor(
     engine: Engine,
     pre: InstancePre<SharedCtx>,
     funcs: Vec<CapabilityFunc>,
+    lifecycle: Option<Arc<LifecycleFuncs>>,
     state: Arc<ComponentHostPluginState>,
     max_restarts: u32,
+    mut replay: Vec<LifecycleReplay>,
     mut rx: tokio::sync::mpsc::Receiver<CapabilityJob>,
 ) {
     let mut restarts = 0u32;
@@ -749,10 +1563,16 @@ async fn run_supervisor(
         // as the tasks drop).
         let registry = JobRegistry::new();
         state.registry.store(Some(Arc::clone(&registry)));
+        // `replay` was snapshotted when this incarnation's channel was
+        // published (in `start()` or the restart path below): the incarnation
+        // rebuilds its per-workload state from it before serving any queued
+        // capability call (the TriggerService completes the replay before
+        // reading the channel).
         let ingress = Ingress::Capability {
             funcs: funcs.clone(),
             rx,
             registry,
+            replay: std::mem::take(&mut replay),
         };
         let trigger_service = TriggerService::spawn(store, pre.clone(), vec![ingress]);
 
@@ -770,27 +1590,92 @@ async fn run_supervisor(
         }
 
         // A driver that stayed up for a while before faulting gets a fresh
-        // budget — only rapid crash loops should exhaust it.
-        if uptime >= crate::timeouts::plugin_healthy_uptime() {
+        // budget — only rapid crash loops should exhaust it. The poison strikes
+        // reset on the same signal, so a transient bind failure spread across
+        // healthy periods never accrues to eviction.
+        let healthy = uptime >= crate::timeouts::plugin_healthy_uptime();
+        if healthy {
             restarts = 0;
+            state
+                .poison
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clear();
         }
 
-        if restarts >= max_restarts {
-            error!(
+        // Attribute the fault. A fault during replay names the workload whose
+        // bind crash-looped the shared store (via the serve-loop marker, still
+        // reachable in the faulted registry). That is the workload's own poison,
+        // so it strikes that workload — evicting at the ceiling so the next
+        // incarnation stops replaying it and recovers for every other tenant —
+        // and does NOT consume the plugin-wide restart budget. Only an
+        // unattributed fault (a serving-phase trap, or a deploy bind trap) is
+        // charged to the budget.
+        // Only a plugin that exports the lifecycle interface replays binds, so
+        // only it can have a replay fault to attribute.
+        let culprit = if lifecycle.is_some() {
+            attribute_replay_fault(&state)
+        } else {
+            None
+        };
+        if let Some(workload_id) = culprit {
+            let strikes = {
+                let mut poison = state
+                    .poison
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let strikes = poison.entry(Arc::clone(&workload_id)).or_insert(0);
+                *strikes += 1;
+                *strikes
+            };
+            warn!(
                 id = state.id,
-                restarts, "host component plugin exceeded its restart budget; giving up"
+                %workload_id,
+                strikes,
+                "on-workload-bind trapped during replay; struck the workload"
             );
-            state.tx.store(None);
-            state.registry.store(None);
-            return;
+            if strikes >= POISON_EVICT_STRIKES {
+                evict_workload(&state, &workload_id);
+                report_workload_failed(&state, &workload_id);
+            }
+        } else {
+            if restarts >= max_restarts {
+                error!(
+                    id = state.id,
+                    restarts, "host component plugin exceeded its restart budget; giving up"
+                );
+                state.tx.store(None);
+                state.registry.store(None);
+                return;
+            }
+            restarts += 1;
         }
-        restarts += 1;
 
         // Fresh channel for the new incarnation; installed shims read the new
         // sender via `state.sender()` on their next call, and calls made during
-        // the backoff below queue on it rather than failing.
+        // the backoff below queue on it rather than failing. Published under
+        // the `bound` lock, atomically with the replay snapshot (see
+        // [`replay_snapshot`] for why).
         let (new_tx, new_rx) = tokio::sync::mpsc::channel(CAPABILITY_CHANNEL_CAPACITY);
-        state.tx.store(Some(Arc::new(new_tx)));
+        {
+            let bound = state
+                .bound
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            // The sender was live when the fault was observed; if it is gone
+            // now, `stop()` cleared it (under this same lock) in the window
+            // since — republishing would undo the stop and leave a zombie
+            // incarnation running past `stop()`.
+            if state.sender().is_none() {
+                debug!(
+                    id = state.id,
+                    "host component plugin stopped during fault handling"
+                );
+                return;
+            }
+            state.tx.store(Some(Arc::new(new_tx)));
+            replay = replay_snapshot(&bound, lifecycle.as_deref());
+        }
         rx = new_rx;
 
         // Back off before restarting so a store that faults instantly (e.g. a

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -112,6 +112,41 @@ impl<'a> WitInterfaces<'a> {
     }
 }
 
+/// A workload a plugin has failed out of band (after it was already running),
+/// delivered to the host so it can transition the workload to a failed state.
+/// Used when a host component plugin evicts a workload whose `on-workload-bind`
+/// crash-loops the shared store.
+pub struct WorkloadFailure {
+    /// The workload to fail.
+    pub workload_id: String,
+    /// Human-readable cause, surfaced in the workload's status message.
+    pub reason: String,
+}
+
+/// A cheap, cloneable handle a plugin uses to report a [`WorkloadFailure`] to
+/// the host. The host injects one into each plugin at start
+/// ([`HostPlugin::set_workload_failure_sink`]) and drains it on a background
+/// task, transitioning each reported workload to a failed state.
+#[derive(Clone)]
+pub struct WorkloadFailureSink(tokio::sync::mpsc::UnboundedSender<WorkloadFailure>);
+
+impl WorkloadFailureSink {
+    /// Wrap the sender end of the host's workload-failure channel.
+    pub fn new(tx: tokio::sync::mpsc::UnboundedSender<WorkloadFailure>) -> Self {
+        Self(tx)
+    }
+
+    /// Report that `workload_id` has failed for `reason`. Non-blocking and
+    /// infallible from the caller's view: if the host has torn down the
+    /// receiver, the report is dropped (the host is stopping anyway).
+    pub fn report(&self, workload_id: impl Into<String>, reason: impl Into<String>) {
+        let _ = self.0.send(WorkloadFailure {
+            workload_id: workload_id.into(),
+            reason: reason.into(),
+        });
+    }
+}
+
 /// The [`HostPlugin`] trait provides an interface for implementing built-in plugins for the host.
 /// A plugin is primarily responsible for implementing a specific [`WitWorld`] as a collection of
 /// imports and exports that will be directly linked to the workload's [`wasmtime::component::Linker`].
@@ -162,6 +197,14 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
     /// # Arguments
     /// * `meters` - A `Meters` object containing the metrics to inject.
     async fn inject_meters(&self, _meters: &crate::observability::Meters) {}
+
+    /// Inject a sink the plugin can use to report that a workload it manages has
+    /// failed out of band — after it was already running — so the host
+    /// transitions it to a failed state. Called once during host start, before
+    /// [`HostPlugin::start`]. The default ignores it; a plugin only needs to
+    /// override this if it can fail a workload asynchronously (e.g. a host
+    /// component plugin evicting a workload whose lifecycle bind crash-loops).
+    fn set_workload_failure_sink(&self, _sink: WorkloadFailureSink) {}
 
     /// Called when the plugin is started during host initialization.
     ///

--- a/crates/wash-runtime/src/timeouts.rs
+++ b/crates/wash-runtime/src/timeouts.rs
@@ -71,6 +71,12 @@ declare_timeouts! {
     /// resets its restart budget.
     #[cfg(feature = "host-component-plugins")]
     plugin_healthy_uptime = ("WASH_PLUGIN_HEALTHY_UPTIME_SECS", 60);
+    /// Max wall-clock for one `wasmcloud:host/workload-lifecycle` call into a
+    /// host component plugin. Bounds how long a plugin's bind handler can hold
+    /// up a workload deploy (bind fails on expiry) and how long its unbind
+    /// handler can hold up a workload stop (unbind is abandoned on expiry).
+    #[cfg(feature = "host-component-plugins")]
+    plugin_lifecycle_call = ("WASH_PLUGIN_LIFECYCLE_CALL_TIMEOUT_SECS", 30);
     /// Upper bound on a host component plugin's pre-restart backoff.
     #[cfg(feature = "host-component-plugins")]
     plugin_restart_backoff_max = ("WASH_PLUGIN_RESTART_BACKOFF_MAX_SECS", 5);

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -148,9 +148,23 @@ pub fn acme_kv_interface() -> WitInterface {
 /// `acme:kv/store` capability the host component plugin satisfies.
 #[cfg(feature = "host-component-plugins")]
 pub fn kv_plugin_caller_host_interfaces(host_header: &str) -> Vec<WitInterface> {
+    kv_plugin_caller_host_interfaces_with_config(host_header, HashMap::new())
+}
+
+/// Like [`kv_plugin_caller_host_interfaces`] but carrying interface-level
+/// config on the `acme:kv` entry — delivered to a lifecycle-exporting plugin's
+/// `on-workload-bind`.
+#[cfg(feature = "host-component-plugins")]
+pub fn kv_plugin_caller_host_interfaces_with_config(
+    host_header: &str,
+    config: HashMap<String, String>,
+) -> Vec<WitInterface> {
     vec![
         http_incoming_handler_interface(host_header, None),
-        acme_kv_interface(),
+        WitInterface {
+            config,
+            ..acme_kv_interface()
+        },
     ]
 }
 

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -27,6 +27,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
+name = "badlifecycle"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +465,13 @@ dependencies = [
 
 [[package]]
 name = "kv-plugin-caller"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
+name = "kv-plugin-service"
 version = "0.0.0"
 dependencies = [
  "wit-bindgen 0.59.0",

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -49,6 +49,8 @@ members = [
     "bridge-service",
     "kv-plugin",
     "kv-plugin-caller",
+    "kv-plugin-service",
+    "badlifecycle",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/acme-kv/store.wit
+++ b/crates/wash-runtime/tests/fixtures/acme-kv/store.wit
@@ -85,4 +85,22 @@ interface store {
     /// Ticks the `begin` under `name` has completed — lets a test observe
     /// truncation after a cancel without depending on the cancelled caller.
     progress: async func(name: string) -> u64;
+
+    /// Value under `key` in the CALLING workload's bind-time interface config,
+    /// captured by the plugin's `on-workload-bind` handler; `none` if this
+    /// incarnation holds no bind for the caller or the key is absent. Proves
+    /// manifest config reaches the plugin eagerly (and survives a restart via
+    /// the host's bind replay).
+    bound-config: async func(key: string) -> option<string>;
+
+    /// Rendered summary of the bind captured for `workload`
+    /// (`id=..;name=..;ns=..;components=..;ifaces=..`), or `none` if this
+    /// incarnation holds no bind for it — lets a test assert every typed field
+    /// of `workload-info` end-to-end.
+    bind-info: async func(workload: string) -> option<string>;
+
+    /// Lifecycle events THIS incarnation has observed, oldest first, as
+    /// `bind:{workload-id}` / `unbind:{workload-id}`. Resets when the plugin
+    /// store restarts.
+    lifecycle-log: async func() -> list<string>;
 }

--- a/crates/wash-runtime/tests/fixtures/badlifecycle/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/badlifecycle/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/badlifecycle.wasm

--- a/crates/wash-runtime/tests/fixtures/badlifecycle/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/badlifecycle/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "badlifecycle"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true }

--- a/crates/wash-runtime/tests/fixtures/badlifecycle/host-bad/workload-lifecycle.wit
+++ b/crates/wash-runtime/tests/fixtures/badlifecycle/host-bad/workload-lifecycle.wit
@@ -1,0 +1,12 @@
+package wasmcloud:host@0.1.0;
+
+/// Deliberately-malformed `workload-lifecycle` for the registration-rejection
+/// test. The real interface is `on-workload-bind: func(workload-info) ->
+/// result<_, string>`; here the argument is a bare string (not the
+/// workload-info record), which the host's registration-time shape check must
+/// reject with a clear error rather than accepting the plugin and failing on
+/// the first deploy.
+interface workload-lifecycle {
+    on-workload-bind: func(id: string) -> u32;
+    on-workload-unbind: func(id: string);
+}

--- a/crates/wash-runtime/tests/fixtures/badlifecycle/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/badlifecycle/src/lib.rs
@@ -1,8 +1,12 @@
 //! Host component plugin with a deliberately-malformed
-//! `wasmcloud:host/workload-lifecycle` export (its `on-workload-bind` takes a
-//! bare string instead of the `workload-info` record). Used only to assert that
-//! `ComponentHostPlugin::new` rejects the mismatched signature at registration;
-//! the hooks are never invoked.
+//! `wasmcloud:host/workload-lifecycle` export: its `on-workload-bind` takes a
+//! bare string instead of the `workload-info` record and returns `u32` instead
+//! of `result<_, string>`. Both mismatches are declared in this fixture's own
+//! copy of the interface (`host-bad/workload-lifecycle.wit`) rather than the
+//! canonical one, so the Rust signatures below are the ones wit-bindgen
+//! generates from that wrong WIT — nothing is being coerced into the real
+//! shape. Used only to assert that `ComponentHostPlugin::new` rejects the
+//! mismatched signature at registration; the hooks are never invoked.
 
 mod bindings {
     #![allow(unsafe_code)]

--- a/crates/wash-runtime/tests/fixtures/badlifecycle/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/badlifecycle/src/lib.rs
@@ -1,0 +1,35 @@
+//! Host component plugin with a deliberately-malformed
+//! `wasmcloud:host/workload-lifecycle` export (its `on-workload-bind` takes a
+//! bare string instead of the `workload-info` record). Used only to assert that
+//! `ComponentHostPlugin::new` rejects the mismatched signature at registration;
+//! the hooks are never invoked.
+
+mod bindings {
+    #![allow(unsafe_code)]
+    wit_bindgen::generate!({ world: "badlifecycle", generate_all });
+}
+
+use bindings::exports::test::badlc::ops::Guest as OpsGuest;
+use bindings::exports::wasmcloud::host::workload_lifecycle::Guest as LifecycleGuest;
+
+struct Component;
+
+impl OpsGuest for Component {
+    fn ping() -> u32 {
+        1
+    }
+}
+
+impl LifecycleGuest for Component {
+    fn on_workload_bind(_id: String) -> u32 {
+        0
+    }
+
+    fn on_workload_unbind(_id: String) {}
+}
+
+mod export {
+    #![allow(unsafe_code)]
+    use super::{bindings, Component};
+    bindings::export!(Component with_types_in bindings);
+}

--- a/crates/wash-runtime/tests/fixtures/badlifecycle/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/badlifecycle/wit/world.wit
@@ -1,0 +1,16 @@
+package test:badlc@0.1.0;
+
+/// A capability, so the plugin has something to serve (registration reaches the
+/// lifecycle shape check regardless).
+interface ops {
+    ping: func() -> u32;
+}
+
+/// Host component plugin exporting a real capability plus a deliberately
+/// malformed `wasmcloud:host/workload-lifecycle` — used to assert that
+/// `ComponentHostPlugin::new` rejects a mismatched lifecycle signature at
+/// registration.
+world badlifecycle {
+    export ops;
+    export wasmcloud:host/workload-lifecycle@0.1.0;
+}

--- a/crates/wash-runtime/tests/fixtures/badlifecycle/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/badlifecycle/wkg.toml
@@ -1,0 +1,4 @@
+[overrides]
+# Resolve `wasmcloud:host` to the local, deliberately-malformed copy rather than
+# the canonical in-repo WIT, so this fixture exports a bad lifecycle signature.
+"wasmcloud:host" = { path = "host-bad" }

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-caller/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-caller/src/lib.rs
@@ -194,6 +194,26 @@ impl HttpGuest for Component {
             let p = store::progress(name).await;
             return Ok(make_response(200, p.to_string().into_bytes()));
         }
+        if route.starts_with("/bound-config") {
+            // Bind-time interface config for THIS workload, captured by the
+            // plugin's on-workload-bind handler.
+            let key = query_get(query, "key").unwrap_or_default();
+            return match store::bound_config(key).await {
+                Some(v) => Ok(make_response(200, v.into_bytes())),
+                None => Ok(make_response(404, Vec::new())),
+            };
+        }
+        if route.starts_with("/bind-info") {
+            let workload = query_get(query, "workload").unwrap_or_default();
+            return match store::bind_info(workload).await {
+                Some(v) => Ok(make_response(200, v.into_bytes())),
+                None => Ok(make_response(404, Vec::new())),
+            };
+        }
+        if route.starts_with("/lifecycle-log") {
+            let log = store::lifecycle_log().await;
+            return Ok(make_response(200, log.join("\n").into_bytes()));
+        }
 
         Ok(make_response(404, Vec::new()))
     }

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-service/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-service/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/kv_plugin_service.wasm

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-service/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-service/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kv-plugin-service"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-service/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-service/src/lib.rs
@@ -1,0 +1,47 @@
+//! Workload SERVICE driving the imported `acme:kv/store` capability from
+//! `wasi:cli/run`.
+//!
+//! A service reaches a host component plugin through the same bind path a
+//! component does, but it is the workload's long-lived item, so the host
+//! reports it in `workload-info.service` rather than in `components`. On start
+//! it writes a key the test reads back through a co-tenant caller workload —
+//! proving both that the service bound and that a service can make cross-store
+//! capability calls at all.
+
+mod bindings {
+    #![allow(unsafe_code)]
+    wit_bindgen::generate!({ world: "kv-service", generate_all });
+}
+
+use bindings::acme::kv::store;
+use bindings::exports::wasi::cli::run::Guest;
+use bindings::wasi::clocks::monotonic_clock;
+
+/// Key the service writes on start, holding the ambient identity the plugin
+/// sees for the service's own capability call (`{workload-id}|{component-id}`).
+/// The test reads it back through a co-tenant and checks the component half
+/// against the id delivered as `workload-info.service` — so bind-time and
+/// call-time agree on what the service is called. Written with the GLOBAL
+/// `set` (not the per-caller `pset`) precisely so another workload can read it.
+const WHOAMI_KEY: &str = "service-whoami";
+
+struct Component;
+
+impl Guest for Component {
+    async fn run() -> Result<(), ()> {
+        let whoami = store::whoami().await;
+        store::set(WHOAMI_KEY.to_string(), whoami.into_bytes()).await;
+        // Services are long-lived. Park instead of returning so the workload
+        // stays deployed — and so its bind stays in the plugin's bound set —
+        // for as long as the test needs it.
+        loop {
+            monotonic_clock::wait_for(60_000_000_000).await;
+        }
+    }
+}
+
+mod export {
+    #![allow(unsafe_code)]
+    use super::{Component, bindings};
+    bindings::export!(Component with_types_in bindings);
+}

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-service/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-service/wit/world.wit
@@ -1,0 +1,13 @@
+package acme:kvservice@0.1.0;
+
+/// A workload SERVICE (not a component) that imports the plugin-provided
+/// `acme:kv/store` capability. Services are the workload's long-lived item —
+/// bound to a plugin through the same path as a component, but reported in
+/// `workload-info.service` rather than `components`. This fixture is what
+/// exercises that: without it nothing deploys a service against a host
+/// component plugin.
+world kv-service {
+    import wasi:clocks/monotonic-clock@0.3.0;
+    import acme:kv/store@0.1.0;
+    export wasi:cli/run@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-service/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-service/wkg.toml
@@ -1,0 +1,7 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }
+"acme:kv" = { path = "../acme-kv" }

--- a/crates/wash-runtime/tests/fixtures/kv-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin/src/lib.rs
@@ -17,7 +17,11 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use bindings::exports::acme::kv::store::{Bucket, Guest, GuestBucket};
+use bindings::exports::wasmcloud::host::workload_lifecycle::{
+    Guest as LifecycleGuest, InterfaceBinding, Version, WorkloadInfo,
+};
 use bindings::wasi::clocks::monotonic_clock;
+use bindings::wasi::clocks::system_clock;
 use bindings::wasmcloud::host::cancel;
 use wit_bindgen::{FutureReader, StreamReader, StreamResult};
 
@@ -55,6 +59,17 @@ static STORE: Mutex<BTreeMap<String, Vec<u8>>> = Mutex::new(BTreeMap::new());
 /// per-caller state isolation on the shared singleton.
 static PARTITIONS: Mutex<BTreeMap<String, BTreeMap<String, Vec<u8>>>> =
     Mutex::new(BTreeMap::new());
+
+/// Per-workload binds captured by `on-workload-bind`, keyed by workload id.
+/// The eager-provision pattern: bind stores the workload's manifest config
+/// here; capability calls correlate back via the identity import; unbind
+/// reclaims the entry.
+static BINDS: Mutex<BTreeMap<String, WorkloadInfo>> = Mutex::new(BTreeMap::new());
+
+/// Lifecycle events observed by this incarnation, oldest first — resets with
+/// the store on a supervised restart, which is what lets a test distinguish a
+/// replayed bind from surviving state.
+static LIFECYCLE_LOG: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
 /// `begin` name -> the host job id it registered, so `cancel-job` can look it up.
 static BEGUN: Mutex<BTreeMap<String, u64>> = Mutex::new(BTreeMap::new());
@@ -207,6 +222,150 @@ impl Guest for Component {
     async fn progress(name: String) -> u64 {
         PROGRESS.lock().unwrap().get(&name).copied().unwrap_or(0)
     }
+
+    async fn bound_config(key: String) -> Option<String> {
+        // Correlate the call back to bind-time state via the identity import —
+        // same key the host used to deliver `on-workload-bind`.
+        let caller = bindings::wasmcloud::host::identity::get_workload_id();
+        BINDS.lock().unwrap().get(&caller).and_then(|info| {
+            info.interfaces.iter().find_map(|binding| {
+                binding
+                    .config
+                    .iter()
+                    .find(|entry| entry.key == key)
+                    .map(|entry| entry.value.clone())
+            })
+        })
+    }
+
+    async fn bind_info(workload: String) -> Option<String> {
+        BINDS.lock().unwrap().get(&workload).map(render_info)
+    }
+
+    async fn lifecycle_log() -> Vec<String> {
+        LIFECYCLE_LOG.lock().unwrap().clone()
+    }
+}
+
+impl LifecycleGuest for Component {
+    async fn on_workload_bind(workload: WorkloadInfo) -> Result<(), String> {
+        // Test knobs read from the matched interface config:
+        //  - `reject`: fail the bind with the given message.
+        //  - `trap-on-bind`: panic every time (an always-poison bind).
+        //  - `trap-after-epoch-secs`: panic once wall-clock passes the given
+        //    unix second, so the bind succeeds on deploy but traps on any
+        //    replay after the threshold — a deterministic poison replay.
+        //  - `slow-bind-ms`: sleep this long BEFORE provisioning, so the hook
+        //    overruns a short host timeout and still completes later — exercises
+        //    the deferred rollback unbind.
+        let mut slow_bind_ms: u64 = 0;
+        for binding in &workload.interfaces {
+            for entry in &binding.config {
+                match entry.key.as_str() {
+                    "reject" => return Err(entry.value.clone()),
+                    "trap-on-bind" => panic!("kv-plugin trap-on-bind: deliberate bind trap"),
+                    "trap-after-epoch-secs" => {
+                        let threshold: i64 = entry.value.parse().unwrap_or(0);
+                        if system_clock::now().seconds >= threshold {
+                            panic!("kv-plugin trap-after-epoch-secs: deliberate poison replay");
+                        }
+                    }
+                    "slow-bind-ms" => slow_bind_ms = entry.value.parse().unwrap_or(0),
+                    _ => {}
+                }
+            }
+        }
+        if slow_bind_ms > 0 {
+            monotonic_clock::wait_for(slow_bind_ms.saturating_mul(1_000_000)).await;
+        }
+        record_hook_identity("bind", &workload.id);
+        LIFECYCLE_LOG
+            .lock()
+            .unwrap()
+            .push(format!("bind:{}", workload.id));
+        BINDS.lock().unwrap().insert(workload.id.clone(), workload);
+        Ok(())
+    }
+
+    async fn on_workload_unbind(id: String) {
+        record_hook_identity("unbind", &id);
+        LIFECYCLE_LOG.lock().unwrap().push(format!("unbind:{id}"));
+        BINDS.lock().unwrap().remove(&id);
+    }
+}
+
+/// Ambient identity inside a lifecycle hook must be the workload the hook
+/// concerns, with an empty component id. A mismatch poisons the lifecycle log,
+/// so every exact-log test assertion enforces the contract for free.
+fn record_hook_identity(hook: &str, expected_workload: &str) {
+    let workload = bindings::wasmcloud::host::identity::get_workload_id();
+    let component = bindings::wasmcloud::host::identity::get_component_id();
+    if workload != expected_workload || !component.is_empty() {
+        LIFECYCLE_LOG
+            .lock()
+            .unwrap()
+            .push(format!("{hook}-ident-mismatch:{workload}|{component}"));
+    }
+}
+
+/// Render every typed field of a captured bind into one line a test can
+/// assert on: `id=..;name=..;ns=..;components=a+b;ifaces=ns:pkg/i@ver#label?k=v`.
+fn render_info(info: &WorkloadInfo) -> String {
+    let ifaces = info
+        .interfaces
+        .iter()
+        .map(render_binding)
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!(
+        "id={};name={};ns={};service={};components={};ifaces={ifaces}",
+        info.id,
+        info.name,
+        info.namespace,
+        info.service.as_deref().unwrap_or("-"),
+        info.components.join("+"),
+    )
+}
+
+fn render_binding(binding: &InterfaceBinding) -> String {
+    let mut s = format!(
+        "{}:{}/{}",
+        binding.namespace,
+        binding.package,
+        binding.interfaces.join(",")
+    );
+    if let Some(version) = &binding.version {
+        s.push('@');
+        s.push_str(&render_version(version));
+    }
+    if let Some(name) = &binding.name {
+        s.push('#');
+        s.push_str(name);
+    }
+    if !binding.config.is_empty() {
+        let config = binding
+            .config
+            .iter()
+            .map(|entry| format!("{}={}", entry.key, entry.value))
+            .collect::<Vec<_>>()
+            .join("&");
+        s.push('?');
+        s.push_str(&config);
+    }
+    s
+}
+
+fn render_version(version: &Version) -> String {
+    let mut s = format!("{}.{}.{}", version.major, version.minor, version.patch);
+    if let Some(pre) = &version.pre {
+        s.push('-');
+        s.push_str(pre);
+    }
+    if let Some(build) = &version.build {
+        s.push('+');
+        s.push_str(build);
+    }
+    s
 }
 
 mod export {

--- a/crates/wash-runtime/tests/fixtures/kv-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin/src/lib.rs
@@ -232,8 +232,8 @@ impl Guest for Component {
                 binding
                     .config
                     .iter()
-                    .find(|entry| entry.key == key)
-                    .map(|entry| entry.value.clone())
+                    .find(|(k, _)| *k == key)
+                    .map(|(_, v)| v.clone())
             })
         })
     }
@@ -260,17 +260,17 @@ impl LifecycleGuest for Component {
         //    the deferred rollback unbind.
         let mut slow_bind_ms: u64 = 0;
         for binding in &workload.interfaces {
-            for entry in &binding.config {
-                match entry.key.as_str() {
-                    "reject" => return Err(entry.value.clone()),
+            for (key, value) in &binding.config {
+                match key.as_str() {
+                    "reject" => return Err(value.clone()),
                     "trap-on-bind" => panic!("kv-plugin trap-on-bind: deliberate bind trap"),
                     "trap-after-epoch-secs" => {
-                        let threshold: i64 = entry.value.parse().unwrap_or(0);
+                        let threshold: i64 = value.parse().unwrap_or(0);
                         if system_clock::now().seconds >= threshold {
                             panic!("kv-plugin trap-after-epoch-secs: deliberate poison replay");
                         }
                     }
-                    "slow-bind-ms" => slow_bind_ms = entry.value.parse().unwrap_or(0),
+                    "slow-bind-ms" => slow_bind_ms = value.parse().unwrap_or(0),
                     _ => {}
                 }
             }
@@ -346,7 +346,7 @@ fn render_binding(binding: &InterfaceBinding) -> String {
         let config = binding
             .config
             .iter()
-            .map(|entry| format!("{}={}", entry.key, entry.value))
+            .map(|(key, value)| format!("{key}={value}"))
             .collect::<Vec<_>>()
             .join("&");
         s.push('?');

--- a/crates/wash-runtime/tests/fixtures/kv-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin/wit/world.wit
@@ -8,6 +8,11 @@ package acme:kvplugin@0.1.0;
 /// used by the `slow` op to yield cooperatively.
 world kv-plugin {
     import wasi:clocks/monotonic-clock@0.3.0;
+    // Wall clock: the lifecycle-bind trap knobs read it so a bind can be made to
+    // succeed on deploy but trap once a real-time threshold passes — a
+    // deterministic poison replay for the quarantine tests (the store resets on
+    // restart, but wall-clock time does not).
+    import wasi:clocks/system-clock@0.3.0;
     // Host identity import: lets the plugin partition state by the calling
     // workload (the host answers based on the in-flight capability call).
     import wasmcloud:host/identity@0.1.0;
@@ -19,4 +24,8 @@ world kv-plugin {
     // plugin itself.
     import acme:kv/store@0.1.0;
     export acme:kv/store@0.1.0;
+    // Lifecycle export: the host calls these as workloads bind/unbind, letting
+    // the plugin capture per-workload manifest config eagerly (observed through
+    // the store interface's `bound-config`/`bind-info`/`lifecycle-log`).
+    export wasmcloud:host/workload-lifecycle@0.1.0;
 }

--- a/crates/wash-runtime/tests/integration_component_plugin_lifecycle.rs
+++ b/crates/wash-runtime/tests/integration_component_plugin_lifecycle.rs
@@ -1,0 +1,1070 @@
+//! Integration tests for the `wasmcloud:host/workload-lifecycle` export of
+//! host component plugins: the host delivers `on-workload-bind` (with the
+//! workload's identity and per-interface manifest config) before any
+//! capability call from that workload, and `on-workload-unbind` when it goes
+//! away. The `kv-plugin` fixture captures binds in guest state and exposes
+//! them through `bound-config`/`bind-info`/`lifecycle-log` on its capability
+//! interface, so the tests observe the hooks end-to-end through a caller
+//! workload.
+//!
+//! Covers:
+//!   - typed `workload-info` delivery (identity, components, interface
+//!     bindings with version and config), correlated at call time via the
+//!     identity import
+//!   - bind rejection failing the workload deploy (and the plugin staying
+//!     healthy for other workloads)
+//!   - unbind on workload stop
+//!   - bind replay into a fresh incarnation after a supervised restart
+//!   - reserved `wasmcloud:host` exports never becoming workload-matchable
+//!     capabilities
+//!   - plugins without the export being entirely unaffected
+
+#![cfg(feature = "host-component-plugins")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use std::sync::Arc;
+
+use wash_runtime::engine::Engine;
+use wash_runtime::engine::workload::{UnresolvedWorkload, WorkloadComponent};
+use wash_runtime::host::http::{DevRouter, DynamicRouter, HttpServer};
+use wash_runtime::host::{HostApi, HostBuilder};
+use wash_runtime::plugin::component_host::ComponentHostPlugin;
+use wash_runtime::plugin::{HostPlugin, WitInterfaces};
+use wash_runtime::types::{
+    LocalResources, WorkloadState, WorkloadStatusRequest, WorkloadStopRequest,
+};
+use wash_runtime::wit::WitInterface;
+
+mod common;
+use common::{
+    acme_kv_interface, component_workload_request, kv_plugin_caller_host_interfaces_with_config,
+    start_host_with_component_plugin, start_host_with_component_plugin_by_host,
+};
+
+const KV_PLUGIN_WASM: &[u8] = include_bytes!("wasm/kv_plugin.wasm");
+const KV_PLUGIN_CALLER_WASM: &[u8] = include_bytes!("wasm/kv_plugin_caller.wasm");
+const KV_PLUGIN_SERVICE_WASM: &[u8] = include_bytes!("wasm/kv_plugin_service.wasm");
+const BRIDGE_BACKEND_WASM: &[u8] = include_bytes!("wasm/bridge_backend.wasm");
+const BADLIFECYCLE_WASM: &[u8] = include_bytes!("wasm/badlifecycle.wasm");
+const PLUGIN_ID: &str = "acme-kv-plugin";
+
+/// GET `http://{addr}{path}` with the `HOST` header selecting the workload,
+/// returning the status and body text.
+async fn req(
+    client: &reqwest::Client,
+    addr: &std::net::SocketAddr,
+    host: &str,
+    path: &str,
+) -> Result<(reqwest::StatusCode, String)> {
+    let resp = timeout(
+        Duration::from_secs(15),
+        client
+            .get(format!("http://{addr}{path}"))
+            .header("HOST", host)
+            .send(),
+    )
+    .await
+    .context("request timed out")??;
+    let status = resp.status();
+    let body = resp.text().await?;
+    Ok((status, body))
+}
+
+/// Compilation-cache key for the one component every workload in this file
+/// deploys. `digest` is used for nothing but the engine's compiled-component
+/// cache (`Engine::load_component_bytes`), and without it EVERY `workload_start`
+/// re-runs cranelift over `kv-plugin-caller`.
+///
+/// That matters here because the timing-sensitive tests below wrap
+/// `workload_start` in a deadline: an uncached compile puts an unbounded,
+/// machine-dependent cost inside a window meant to measure only the plugin's
+/// lifecycle behavior. Every workload in this file deploys the same bytes, so a
+/// single constant key is correct — the first deploy per engine compiles and
+/// the rest hit the cache.
+const CALLER_DIGEST: &str = "sha256:kv-plugin-caller-fixture";
+
+/// A `kv-plugin-caller` workload addressed by `host`, with `config` set on its
+/// `acme:kv` interface entry (the config `on-workload-bind` delivers).
+fn caller_workload_with_config(
+    host: &str,
+    config: &[(&str, &str)],
+) -> wash_runtime::types::WorkloadStartRequest {
+    let config = config
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    let mut request = component_workload_request(
+        "kv-plugin-caller",
+        host,
+        KV_PLUGIN_CALLER_WASM,
+        LocalResources::default(),
+        kv_plugin_caller_host_interfaces_with_config(host, config),
+    );
+    for component in &mut request.workload.components {
+        component.digest = Some(CALLER_DIGEST.to_string());
+    }
+    request
+}
+
+/// A workload whose SERVICE — not a component — imports the plugin capability.
+/// `host_interfaces` carries only `acme:kv`: the service exports `wasi:cli/run`
+/// and serves no HTTP, so it is observed through a co-tenant caller rather than
+/// addressed directly.
+fn service_workload(name: &str) -> wash_runtime::types::WorkloadStartRequest {
+    wash_runtime::types::WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: wash_runtime::types::Workload {
+            namespace: "test".to_string(),
+            name: name.to_string(),
+            annotations: HashMap::new(),
+            service: Some(wash_runtime::types::Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(KV_PLUGIN_SERVICE_WASM),
+                local_resources: LocalResources::default(),
+                max_restarts: 0,
+            }),
+            components: vec![],
+            host_interfaces: vec![acme_kv_interface()],
+            volumes: vec![],
+        },
+    }
+}
+
+/// The lines of `/lifecycle-log` as seen by the workload addressed by `host`.
+async fn lifecycle_log(
+    client: &reqwest::Client,
+    addr: &std::net::SocketAddr,
+    host: &str,
+) -> Result<Vec<String>> {
+    let (status, body) = req(client, addr, host, "/lifecycle-log").await?;
+    anyhow::ensure!(status.as_u16() == 200, "/lifecycle-log got {status}");
+    Ok(body.lines().map(str::to_string).collect())
+}
+
+/// The ambient identity contract inside a lifecycle hook: `get-workload-id` is
+/// the workload the hook concerns, and `get-component-id` reports nothing —
+/// a hook is delivered about a whole workload, not on behalf of any one of its
+/// items, so the host never names a component. The fixture appends a
+/// `<hook>-ident-mismatch:<workload>|<component>` line when either half is
+/// wrong, so an absence of those lines is the contract holding.
+fn assert_hook_identity_contract(log: &[String]) {
+    let mismatches: Vec<&String> = log
+        .iter()
+        .filter(|l| l.contains("ident-mismatch"))
+        .collect();
+    assert!(
+        mismatches.is_empty(),
+        "a lifecycle hook saw the wrong ambient identity — the host must report \
+         the hook's workload and no component: {mismatches:?}"
+    );
+}
+
+/// Bind delivery: the plugin's `on-workload-bind` receives the typed
+/// `workload-info` — id, name, namespace, component ids, and the matched
+/// interface binding with its version and manifest config — before the
+/// workload's first capability call, and capability calls correlate back to
+/// that state via the identity import.
+#[tokio::test]
+async fn test_lifecycle_bind_delivers_typed_workload_info() -> Result<()> {
+    let host = "kv-lc-info";
+    let (addr, h) =
+        start_host_with_component_plugin("127.0.0.1:0", PLUGIN_ID, KV_PLUGIN_WASM).await?;
+    let request = caller_workload_with_config(host, &[("tier", "gold"), ("region", "us-east")]);
+    let workload_id = request.workload_id.clone();
+    h.workload_start(request).await?;
+    let client = reqwest::Client::new();
+
+    // The very first capability call sees bind-time config: the bind completed
+    // before any call from this workload was served.
+    let (status, body) = req(&client, &addr, host, "/bound-config?key=tier").await?;
+    assert_eq!(status.as_u16(), 200, "bind-time config must be captured");
+    assert_eq!(body, "gold");
+    let (status, body) = req(&client, &addr, host, "/bound-config?key=region").await?;
+    assert_eq!(status.as_u16(), 200);
+    assert_eq!(body, "us-east");
+    let (status, _) = req(&client, &addr, host, "/bound-config?key=absent").await?;
+    assert_eq!(status.as_u16(), 404, "an absent config key reads as none");
+
+    // Every typed field of workload-info, as the guest captured it.
+    let (status, info) = req(
+        &client,
+        &addr,
+        host,
+        &format!("/bind-info?workload={workload_id}"),
+    )
+    .await?;
+    assert_eq!(status.as_u16(), 200, "the bind must be captured by id");
+    assert!(
+        info.contains(&format!("id={workload_id};")),
+        "workload id must round-trip, got: {info}"
+    );
+    assert!(
+        info.contains(&format!(";name={host};")),
+        "workload name must round-trip, got: {info}"
+    );
+    assert!(
+        info.contains(";ns=test;"),
+        "workload namespace must round-trip, got: {info}"
+    );
+    // A component-only workload reports no service — the field is delivered
+    // and empty rather than absent, and the service id does NOT leak into
+    // `components` (the fixture renders `none` as `-`).
+    assert!(
+        info.contains(";service=-;"),
+        "a workload without a service must report none, got: {info}"
+    );
+    let components = info
+        .split_once("components=")
+        .and_then(|(_, rest)| rest.split_once(";ifaces="))
+        .map(|(components, _)| components)
+        .unwrap_or_default();
+
+    // The delivered component ids are the same id space the identity import
+    // reports at capability-call time: /whoami's component half must be
+    // exactly the single-component workload's `components` entry.
+    let (status, whoami) = req(&client, &addr, host, "/whoami").await?;
+    assert_eq!(status.as_u16(), 200);
+    let call_component = whoami
+        .split_once('|')
+        .map(|(_, component)| component)
+        .unwrap_or_default();
+    assert!(
+        !call_component.is_empty(),
+        "whoami must report a component id, got: {whoami}"
+    );
+    assert_eq!(
+        components, call_component,
+        "bind-time component ids must match the identity seen at call time"
+    );
+    // The matched interface binding: namespace/package/interface, the typed
+    // version, and the manifest config (sorted by key: region < tier).
+    assert!(
+        info.contains("ifaces=acme:kv/store@0.1.0?region=us-east&tier=gold"),
+        "the interface binding must carry version and config, got: {info}"
+    );
+
+    // The bind is also visible as an event in this incarnation's log.
+    let log = lifecycle_log(&client, &addr, host).await?;
+    assert_hook_identity_contract(&log);
+    assert_eq!(
+        log,
+        vec![format!("bind:{workload_id}")],
+        "exactly one bind event for the one bound workload"
+    );
+    Ok(())
+}
+
+/// Bind rejection: a workload whose bind the plugin rejects fails to deploy,
+/// with the guest's message surfaced — and the plugin keeps serving other
+/// workloads afterwards.
+#[tokio::test]
+async fn test_lifecycle_bind_rejection_fails_deploy() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin("127.0.0.1:0", PLUGIN_ID, KV_PLUGIN_WASM).await?;
+    let rejected =
+        caller_workload_with_config("kv-lc-rejected", &[("reject", "tenant quota exceeded")]);
+    let rejected_id = rejected.workload_id.clone();
+    let resp = h.workload_start(rejected).await?;
+    assert_eq!(
+        resp.workload_status.workload_state,
+        WorkloadState::Error,
+        "a rejected bind must fail the deploy; got {:?} ({})",
+        resp.workload_status.workload_state,
+        resp.workload_status.message
+    );
+    assert!(
+        resp.workload_status
+            .message
+            .contains("tenant quota exceeded"),
+        "the guest's rejection message must surface, got: {}",
+        resp.workload_status.message
+    );
+
+    // The plugin is unharmed: a clean workload binds and serves.
+    let good = caller_workload_with_config("kv-lc-good", &[("tier", "silver")]);
+    let good_id = good.workload_id.clone();
+    h.workload_start(good).await?;
+    let client = reqwest::Client::new();
+    let (status, body) = req(&client, &addr, "kv-lc-good", "/bound-config?key=tier").await?;
+    assert_eq!(status.as_u16(), 200);
+    assert_eq!(body, "silver");
+
+    // The rejected workload never became a bind event (the log may carry its
+    // post-failure unbind; it must not carry a bind).
+    let log = lifecycle_log(&client, &addr, "kv-lc-good").await?;
+    assert!(
+        log.contains(&format!("bind:{good_id}")),
+        "the clean workload's bind must be logged, got: {log:?}"
+    );
+    assert!(
+        !log.contains(&format!("bind:{rejected_id}")),
+        "a rejected bind must not be recorded as bound, got: {log:?}"
+    );
+    Ok(())
+}
+
+/// Unbind delivery: stopping a workload delivers `on-workload-unbind` to the
+/// plugin, which reclaims that workload's state while continuing to serve the
+/// other workload.
+///
+/// Multi-threaded: the host-header router uses `block_in_place`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_lifecycle_unbind_on_workload_stop() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, KV_PLUGIN_WASM).await?;
+    let first = caller_workload_with_config("kv-lc-stop-a", &[("tier", "gold")]);
+    let first_id = first.workload_id.clone();
+    h.workload_start(first).await?;
+    let second = caller_workload_with_config("kv-lc-stop-b", &[]);
+    let second_id = second.workload_id.clone();
+    h.workload_start(second).await?;
+    let client = reqwest::Client::new();
+
+    h.workload_stop(WorkloadStopRequest {
+        workload_id: first_id.clone(),
+    })
+    .await?;
+
+    // The surviving workload observes the unbind event; the stopped workload's
+    // bind state is gone while the survivor's remains.
+    let mut log = Vec::new();
+    for _ in 0..50 {
+        log = lifecycle_log(&client, &addr, "kv-lc-stop-b").await?;
+        if log.contains(&format!("unbind:{first_id}")) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        log.contains(&format!("bind:{first_id}"))
+            && log.contains(&format!("bind:{second_id}"))
+            && log.contains(&format!("unbind:{first_id}")),
+        "the stop must surface as an unbind event, got: {log:?}"
+    );
+    let (status, _) = req(
+        &client,
+        &addr,
+        "kv-lc-stop-b",
+        &format!("/bind-info?workload={first_id}"),
+    )
+    .await?;
+    assert_eq!(
+        status.as_u16(),
+        404,
+        "the stopped workload's bind state must be reclaimed"
+    );
+    let (status, _) = req(
+        &client,
+        &addr,
+        "kv-lc-stop-b",
+        &format!("/bind-info?workload={second_id}"),
+    )
+    .await?;
+    assert_eq!(status.as_u16(), 200, "the survivor's bind state remains");
+    Ok(())
+}
+
+/// Bind replay: a guest trap rebuilds the plugin store, wiping all guest state
+/// — including everything `on-workload-bind` provisioned. The fresh
+/// incarnation must re-receive a bind for the still-running workload before
+/// serving its calls, so bind-time config is available again without the
+/// workload redeploying.
+#[tokio::test]
+async fn test_lifecycle_replay_after_trap_restart() -> Result<()> {
+    let host = "kv-lc-replay";
+    let (addr, h) =
+        start_host_with_component_plugin("127.0.0.1:0", PLUGIN_ID, KV_PLUGIN_WASM).await?;
+    let request = caller_workload_with_config(host, &[("tier", "gold")]);
+    let workload_id = request.workload_id.clone();
+    h.workload_start(request).await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, host, "/bound-config?key=tier").await?;
+    assert_eq!((status.as_u16(), body.as_str()), (200, "gold"));
+
+    // Trap the plugin store; the supervisor rebuilds it.
+    let (status, _) = req(&client, &addr, host, "/boom").await?;
+    assert!(status.is_server_error(), "the trap must fail, got {status}");
+
+    // The fresh incarnation starts with EMPTY guest state, so a 200 here can
+    // only come from the host replaying the bind into it. The status split is
+    // the ordering assertion itself: a 5xx is the fault/restart window (retry),
+    // but a 404 means a capability call was served BEFORE the replayed bind
+    // completed — the replay-before-serving guarantee is broken — so it fails
+    // the test immediately rather than being retried into a false pass.
+    let mut recovered = false;
+    for _ in 0..50 {
+        if let Ok((status, body)) = req(&client, &addr, host, "/bound-config?key=tier").await {
+            anyhow::ensure!(
+                status.as_u16() != 404,
+                "a capability call was served before the replayed bind completed"
+            );
+            if status.as_u16() == 200 && body == "gold" {
+                recovered = true;
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        recovered,
+        "bind-time config must be replayed into the restarted plugin"
+    );
+
+    // And the new incarnation's log shows exactly the one replayed bind.
+    let log = lifecycle_log(&client, &addr, host).await?;
+    assert_eq!(
+        log,
+        vec![format!("bind:{workload_id}")],
+        "the fresh incarnation sees exactly one (replayed) bind"
+    );
+    Ok(())
+}
+
+/// Unix epoch seconds `secs_from_now` in the future — the wall-clock threshold
+/// after which a `trap-after-epoch-secs` bind starts trapping. The plugin reads
+/// the same real clock, which (unlike the store) survives a restart.
+/// How long the poison workload's bind stays clean before it is armed to trap.
+///
+/// Both deploys must complete inside this window, and the guest compares
+/// `system_clock` at whole-second granularity — so a threshold `N` seconds out
+/// is worth as little as `N-1` seconds depending on where in the current second
+/// the test starts. Sized for headroom on a loaded runner rather than for
+/// speed; the test's own sleep is derived from it below so the two cannot drift
+/// apart.
+const POISON_ARM_SECS: u64 = 5;
+
+/// Bounded settle budget for the post-fault polling loops: eviction needs two
+/// replay strikes, each costing a restart plus its backoff
+/// (`200ms * restarts`, capped at `plugin_restart_backoff_max`) and a replay of
+/// every bound workload. 50ms x this is the ceiling, not the expected wait.
+const SETTLE_POLLS: usize = 200;
+
+fn epoch_secs_from_now(secs_from_now: u64) -> u64 {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    now + secs_from_now
+}
+
+/// Quarantine + attribution + failed health, end to end. A workload's bind
+/// succeeds on deploy but is armed to trap once a wall-clock threshold passes;
+/// after the threshold a store fault forces a restart, and the workload's
+/// REPLAYED bind then crash-loops. The supervisor attributes each replay trap
+/// to that workload (via the serial-replay marker — the only reliable
+/// attribution, since a trapping task's own handler never runs), strikes it,
+/// and evicts it at the ceiling — WITHOUT taking the co-tenant workload down.
+/// The evicted workload is reported failed, so its scheduling health becomes
+/// `Error`, while the healthy workload keeps serving.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_poison_replay_bind_is_quarantined_and_evicted() -> Result<()> {
+    let (addr, h, plugin) = start_host_keeping_plugin_by_host("127.0.0.1:0").await?;
+
+    // A: a well-behaved co-tenant. P: armed to trap on any bind after ~2s.
+    let good = caller_workload_with_config("kv-lc-good2", &[("tier", "gold")]);
+    h.workload_start(good).await?;
+    let poison = caller_workload_with_config(
+        "kv-lc-poison",
+        &[(
+            "trap-after-epoch-secs",
+            &epoch_secs_from_now(POISON_ARM_SECS).to_string(),
+        )],
+    );
+    let poison_id = poison.workload_id.clone();
+    h.workload_start(poison).await?;
+    let client = reqwest::Client::new();
+
+    // Both bind cleanly on deploy (threshold not yet passed) and serve.
+    let (s, _) = req(&client, &addr, "kv-lc-good2", "/set?key=k&value=v").await?;
+    assert!(s.is_success(), "good workload should serve pre-fault");
+    let (s, _) = req(&client, &addr, "kv-lc-poison", "/set?key=k&value=v").await?;
+    assert!(
+        s.is_success(),
+        "poison workload should bind and serve pre-fault"
+    );
+
+    // Let the wall-clock threshold pass, then fault the shared store so a
+    // restart replays both binds — P's now traps.
+    // Overshoot the threshold rather than landing on it: the guest's
+    // comparison is `>=` at second granularity.
+    tokio::time::sleep(Duration::from_millis(POISON_ARM_SECS * 1000 + 500)).await;
+    let (s, _) = req(&client, &addr, "kv-lc-good2", "/boom").await?;
+    assert!(s.is_server_error(), "the boom must fault the store");
+
+    // The poison workload is evicted (dropped from the replay set) after its
+    // strikes accrue, and reported failed.
+    let mut evicted = false;
+    for _ in 0..SETTLE_POLLS {
+        if !plugin.is_bound(&poison_id) {
+            evicted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        evicted,
+        "the crash-looping poison bind must be evicted; bind-trap log was {:?}",
+        plugin.bind_trap_log()
+    );
+    assert!(
+        plugin.bind_trap_log().contains(&poison_id),
+        "the replay trap must be attributed to the poison workload"
+    );
+
+    // Its scheduling health reflects the eviction.
+    let mut failed = false;
+    for _ in 0..SETTLE_POLLS {
+        let status = h
+            .workload_status(WorkloadStatusRequest {
+                workload_id: poison_id.clone(),
+            })
+            .await?;
+        if status.workload_status.workload_state == WorkloadState::Error {
+            failed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(failed, "the evicted workload's health must become Error");
+
+    // The co-tenant is unharmed: the plugin recovered and serves it. The
+    // restart wiped the shared store's in-memory state (a documented
+    // consequence), so assert a FRESH round-trip rather than the pre-fault key.
+    let mut good_ok = false;
+    for _ in 0..SETTLE_POLLS {
+        let set = req(&client, &addr, "kv-lc-good2", "/set?key=after&value=ok").await;
+        let get = req(&client, &addr, "kv-lc-good2", "/get?key=after").await;
+        if let (Ok((s1, _)), Ok((s2, body))) = (set, get)
+            && s1.is_success()
+            && s2.as_u16() == 200
+            && body == "ok"
+        {
+            good_ok = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        good_ok,
+        "the healthy co-tenant must keep serving after the poison workload is quarantined"
+    );
+    Ok(())
+}
+
+/// Deferred rollback unbind (Problem 2): a bind hook that overruns the host's
+/// timeout fails the deploy PROMPTLY (at the budget, not the hook's full
+/// duration), and the host still reclaims what the uncancellable hook
+/// provisions once it returns — delivering the unbind after the bind, never
+/// before, so no phantom state is orphaned.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_bind_timeout_defers_rollback_unbind() -> Result<()> {
+    let (addr, h) =
+        start_host_with_lifecycle_timeout("127.0.0.1:0", Duration::from_secs(1)).await?;
+    // A healthy co-tenant to query the plugin's global lifecycle log and bind
+    // records through (the slow workload's own deploy fails, so it is not
+    // routable).
+    h.workload_start(caller_workload_with_config("obs", &[("tier", "gold")]))
+        .await?;
+    let client = reqwest::Client::new();
+
+    // A ~6s bind against a 1s budget: the deploy must fail near the budget, well
+    // before the hook finishes. The gap is wide (1s budget vs 6s hook) so that
+    // scheduler starvation under the concurrent test load — which inflates the
+    // 1s timer's wall-clock — cannot blur "failed at the budget" into "waited
+    // out the hook".
+    let slow = caller_workload_with_config("slow", &[("slow-bind-ms", "6000")]);
+    let slow_id = slow.workload_id.clone();
+    let started = Instant::now();
+    let resp = h.workload_start(slow).await?;
+    let elapsed = started.elapsed();
+
+    assert_eq!(
+        resp.workload_status.workload_state,
+        WorkloadState::Error,
+        "an over-budget bind must fail the deploy; got {:?} ({})",
+        resp.workload_status.workload_state,
+        resp.workload_status.message
+    );
+    assert!(
+        elapsed < Duration::from_millis(3500),
+        "the deploy must fail near the ~1s budget, not wait out the ~6s hook (took {elapsed:?})"
+    );
+
+    // The hook keeps running; once it returns (~6s) the deferred rollback fires.
+    // Eventually the log shows the slow bind both completed AND was unbound, and
+    // its late-provisioned state is reclaimed (bind-info 404).
+    let mut settled = false;
+    for _ in 0..240 {
+        let (ls, log) = req(&client, &addr, "obs", "/lifecycle-log").await?;
+        let (bs, _) = req(
+            &client,
+            &addr,
+            "obs",
+            &format!("/bind-info?workload={slow_id}"),
+        )
+        .await?;
+        if ls.as_u16() == 200
+            && log.lines().any(|l| l == format!("bind:{slow_id}"))
+            && log.lines().any(|l| l == format!("unbind:{slow_id}"))
+            && bs.as_u16() == 404
+        {
+            settled = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        settled,
+        "the deferred unbind must run after the slow bind completes and reclaim its state; \
+         log was {:?}",
+        lifecycle_log(&client, &addr, "obs").await?
+    );
+    Ok(())
+}
+
+/// The `acme:kv` interface set with `config` on it, as the engine would pass
+/// to `on_workload_bind` after matching.
+fn acme_kv_matched(config: &[(&str, &str)]) -> HashSet<WitInterface> {
+    let mut interface = acme_kv_interface();
+    interface.config = config
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    [interface].into_iter().collect()
+}
+
+/// A minimal `UnresolvedWorkload` for driving the plugin's `HostPlugin` hooks
+/// directly, without a running host.
+fn bare_workload(id: &str) -> UnresolvedWorkload {
+    UnresolvedWorkload::new(
+        id,
+        "bare",
+        "test",
+        None,
+        std::iter::empty::<WorkloadComponent>(),
+        Vec::new(),
+    )
+}
+
+/// A workload's SERVICE binds to a plugin just as a component does, and is
+/// reported in `workload-info.service` rather than being folded into
+/// `components`. The id delivered at bind time is the same id
+/// `identity.get-component-id` reports for calls the service itself makes — so
+/// a plugin can correlate a service's capability calls back to its bind.
+///
+/// Multi-threaded: the host-header router uses `block_in_place`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_lifecycle_bind_reports_workload_service() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, KV_PLUGIN_WASM).await?;
+    // A component co-tenant: the service serves no HTTP, so its bind record and
+    // its capability writes are read back through this workload.
+    h.workload_start(caller_workload_with_config("svc-obs", &[]))
+        .await?;
+
+    let service = service_workload("kv-svc");
+    let service_id = service.workload_id.clone();
+    h.workload_start(service).await?;
+    let client = reqwest::Client::new();
+
+    // The bind record names the service and leaves `components` empty — the
+    // service id must NOT appear as a component.
+    let (status, info) = req(
+        &client,
+        &addr,
+        "svc-obs",
+        &format!("/bind-info?workload={service_id}"),
+    )
+    .await?;
+    assert_eq!(status.as_u16(), 200, "the service's bind must be captured");
+    let bound_service = info
+        .split_once(";service=")
+        .and_then(|(_, rest)| rest.split_once(';'))
+        .map(|(service, _)| service)
+        .unwrap_or_default();
+    assert!(
+        !bound_service.is_empty() && bound_service != "-",
+        "a service-bearing workload must report its service id, got: {info}"
+    );
+    assert!(
+        info.contains(";components=;"),
+        "a service-only workload has no components, got: {info}"
+    );
+
+    // The service ran and reached the plugin: it wrote the ambient identity the
+    // plugin saw for its own call. Poll — `cli/run` is co-driven, so the write
+    // lands shortly after the deploy returns.
+    let mut whoami = String::new();
+    for _ in 0..SETTLE_POLLS {
+        let (status, body) = req(&client, &addr, "svc-obs", "/get?key=service-whoami").await?;
+        if status.as_u16() == 200 && !body.is_empty() {
+            whoami = body;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        whoami,
+        format!("{service_id}|{bound_service}"),
+        "the identity on a service's own capability call must be its workload id \
+         and the very id delivered as workload-info.service"
+    );
+
+    // A capability call from the service names it; the service's own BIND does
+    // not — the two halves of the contract, on the same workload.
+    let log = lifecycle_log(&client, &addr, "svc-obs").await?;
+    assert_hook_identity_contract(&log);
+    Ok(())
+}
+
+/// Reserved exports are host contracts, not capabilities: the lifecycle export
+/// must not appear in the plugin's world, so no workload import can ever match
+/// (and thus call) it — while the real capability still does.
+#[tokio::test]
+async fn test_reserved_lifecycle_export_not_workload_matchable() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let plugin = ComponentHostPlugin::new(PLUGIN_ID, KV_PLUGIN_WASM, engine)?;
+    let world = plugin.world();
+    assert!(
+        world
+            .imports
+            .iter()
+            .any(|i| i.namespace == "acme" && i.package == "kv"),
+        "the capability export must be matchable"
+    );
+    assert!(
+        !world
+            .imports
+            .iter()
+            .any(|i| i.namespace == "wasmcloud" && i.package == "host"),
+        "reserved wasmcloud:host exports must not be workload-matchable, got: {:?}",
+        world.imports
+    );
+    Ok(())
+}
+
+/// A malformed lifecycle signature (here `on-workload-bind` takes a bare
+/// string instead of the `workload-info` record) is rejected at registration —
+/// `ComponentHostPlugin::new` fails with a clear message — rather than being
+/// accepted and failing on the first workload deploy.
+#[tokio::test]
+async fn test_malformed_lifecycle_signature_rejected_at_registration() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let err = ComponentHostPlugin::new("badlifecycle-plugin", BADLIFECYCLE_WASM, engine)
+        .map(|_| ())
+        .expect_err("a malformed lifecycle signature must be rejected at construction");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("on-workload-bind") && msg.contains("workload-info record"),
+        "the error must name the offending hook and expected shape, got: {msg}"
+    );
+    Ok(())
+}
+
+/// Direct hook drive: the plugin delivers a bind whose typed fields include
+/// the `Some` shapes (instance label, pre-release + build version metadata),
+/// rejects one carrying the fixture's `reject` config with the guest's
+/// message, and treats unbind as best-effort success.
+#[tokio::test]
+async fn test_lifecycle_hooks_driven_directly() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let plugin = ComponentHostPlugin::new(PLUGIN_ID, KV_PLUGIN_WASM, engine)?;
+    plugin.start().await?;
+
+    // A bind exercising every optional field of the typed records: an instance
+    // label and a version with pre-release and build metadata. Acceptance
+    // proves the host-built values typecheck against the plugin's compiled
+    // lifecycle types.
+    let mut labeled = acme_kv_interface();
+    labeled.name = Some("cache".to_string());
+    labeled.version = Some(semver::Version::parse("0.1.0-rc.1+build5").unwrap());
+    labeled.config = HashMap::from([("tier".to_string(), "gold".to_string())]);
+    let labeled: HashSet<WitInterface> = [labeled].into_iter().collect();
+    plugin
+        .on_workload_bind(&bare_workload("wl-labeled"), WitInterfaces::new(&labeled))
+        .await
+        .context("a bind with labeled + pre-release interface data must be accepted")?;
+
+    // The fixture's reject knob fails the bind with the configured message.
+    let rejecting = acme_kv_matched(&[("reject", "no thanks")]);
+    let err = plugin
+        .on_workload_bind(
+            &bare_workload("wl-rejected"),
+            WitInterfaces::new(&rejecting),
+        )
+        .await
+        .expect_err("a bind the guest rejects must fail");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("rejected") && msg.contains("no thanks"),
+        "the rejection must carry the guest's message, got: {msg}"
+    );
+
+    // Unbind is best-effort success, including for ids never bound.
+    plugin
+        .on_workload_unbind("wl-labeled", WitInterfaces::new(&labeled))
+        .await?;
+    plugin
+        .on_workload_unbind("wl-never-bound", WitInterfaces::new(&labeled))
+        .await?;
+
+    plugin.stop().await?;
+    Ok(())
+}
+
+/// A plugin that is not running cannot accept a bind (the workload deploy must
+/// fail loudly), while unbind stays best-effort success.
+#[tokio::test]
+async fn test_lifecycle_bind_fails_when_plugin_not_running() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let plugin = ComponentHostPlugin::new(PLUGIN_ID, KV_PLUGIN_WASM, engine)?;
+
+    let matched = acme_kv_matched(&[]);
+    let err = plugin
+        .on_workload_bind(&bare_workload("wl-early"), WitInterfaces::new(&matched))
+        .await
+        .expect_err("a bind before start() must fail");
+    assert!(
+        format!("{err:#}").contains("not running"),
+        "the failure must say the plugin is not running, got: {err:#}"
+    );
+    plugin
+        .on_workload_unbind("wl-early", WitInterfaces::new(&matched))
+        .await?;
+    Ok(())
+}
+
+/// Like the common `start_host_with_component_plugin` helper, but returning
+/// the plugin `Arc` too — for tests that drive the plugin's own lifecycle
+/// (`stop`/`start`), inspect its quarantine state, or drive its `HostPlugin`
+/// hooks alongside a live host. `DevRouter` (last-resolved workload).
+async fn start_host_keeping_plugin(
+    addr: &str,
+) -> Result<(std::net::SocketAddr, impl HostApi, Arc<ComponentHostPlugin>)> {
+    start_host_keeping_plugin_router(addr, DevRouter::default()).await
+}
+
+/// Like [`start_host_keeping_plugin`] but with a `Host`-header router so two
+/// distinct workloads are individually reachable — for quarantine tests where
+/// one workload's poison bind must not take the other down.
+async fn start_host_keeping_plugin_by_host(
+    addr: &str,
+) -> Result<(std::net::SocketAddr, impl HostApi, Arc<ComponentHostPlugin>)> {
+    start_host_keeping_plugin_router(addr, DynamicRouter::default()).await
+}
+
+async fn start_host_keeping_plugin_router(
+    addr: &str,
+    router: impl wash_runtime::host::http::Router,
+) -> Result<(std::net::SocketAddr, impl HostApi, Arc<ComponentHostPlugin>)> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(router, addr.parse()?).await?;
+    let bound_addr = http_server.addr();
+    let plugin = Arc::new(ComponentHostPlugin::new(
+        PLUGIN_ID,
+        KV_PLUGIN_WASM,
+        engine.clone(),
+    )?);
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::clone(&plugin) as Arc<dyn HostPlugin>)?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+    Ok((bound_addr, host, plugin))
+}
+
+/// Start a host-header-routed host whose component plugin uses a shortened
+/// lifecycle-call `timeout` — for exercising the bind-timeout path without
+/// waiting out the default budget.
+async fn start_host_with_lifecycle_timeout(
+    addr: &str,
+    timeout: Duration,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let engine = Engine::builder().build()?;
+    let http_server = HttpServer::new(DynamicRouter::default(), addr.parse()?).await?;
+    let bound_addr = http_server.addr();
+    let plugin = ComponentHostPlugin::new(PLUGIN_ID, KV_PLUGIN_WASM, engine.clone())?
+        .with_lifecycle_call_timeout(timeout);
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(http_server))
+        .with_plugin(Arc::new(plugin) as Arc<dyn HostPlugin>)?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+    Ok((bound_addr, host))
+}
+
+/// Replay covers EVERY bound workload, not just one: two workloads bind with
+/// distinct config, one traps the shared store, and the fresh incarnation must
+/// re-receive both binds — each completing before that workload's capability
+/// calls are served (a 404 mid-recovery would mean a call outran its replayed
+/// bind and fails immediately).
+///
+/// Multi-threaded: the host-header router uses `block_in_place`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_lifecycle_replay_covers_all_bound_workloads() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, KV_PLUGIN_WASM).await?;
+    let a = caller_workload_with_config("kv-lc-multi-a", &[("tier", "gold")]);
+    let a_id = a.workload_id.clone();
+    h.workload_start(a).await?;
+    let b = caller_workload_with_config("kv-lc-multi-b", &[("tier", "silver")]);
+    let b_id = b.workload_id.clone();
+    h.workload_start(b).await?;
+    let client = reqwest::Client::new();
+
+    for (host, want) in [("kv-lc-multi-a", "gold"), ("kv-lc-multi-b", "silver")] {
+        let (status, body) = req(&client, &addr, host, "/bound-config?key=tier").await?;
+        assert_eq!((status.as_u16(), body.as_str()), (200, want));
+    }
+
+    let (status, _) = req(&client, &addr, "kv-lc-multi-a", "/boom").await?;
+    assert!(status.is_server_error(), "the trap must fail, got {status}");
+
+    for (host, want) in [("kv-lc-multi-a", "gold"), ("kv-lc-multi-b", "silver")] {
+        let mut recovered = false;
+        for _ in 0..50 {
+            if let Ok((status, body)) = req(&client, &addr, host, "/bound-config?key=tier").await {
+                anyhow::ensure!(
+                    status.as_u16() != 404,
+                    "{host}: a capability call was served before its replayed bind completed"
+                );
+                if status.as_u16() == 200 && body == want {
+                    recovered = true;
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(
+            recovered,
+            "{host}'s bind must be replayed after the restart"
+        );
+    }
+
+    // The fresh incarnation's log holds exactly the two replayed binds.
+    // Replays are spawned concurrently, so compare order-insensitively.
+    let mut log = lifecycle_log(&client, &addr, "kv-lc-multi-b").await?;
+    log.sort();
+    let mut expected = vec![format!("bind:{a_id}"), format!("bind:{b_id}")];
+    expected.sort();
+    assert_eq!(
+        log, expected,
+        "the fresh incarnation sees exactly the two replayed binds"
+    );
+    Ok(())
+}
+
+/// `stop()` then `start()` replays leftover binds: workloads bound before the
+/// stop are still bound after it, so the new incarnation must rebuild their
+/// state from the plugin's bound-workloads map — the same replay path a fault
+/// restart uses, but crossing a supervisor teardown instead.
+#[tokio::test]
+async fn test_lifecycle_replay_after_stop_start_cycle() -> Result<()> {
+    let host = "kv-lc-stopstart";
+    let (addr, h, plugin) = start_host_keeping_plugin("127.0.0.1:0").await?;
+    let request = caller_workload_with_config(host, &[("tier", "gold")]);
+    let workload_id = request.workload_id.clone();
+    h.workload_start(request).await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, host, "/bound-config?key=tier").await?;
+    assert_eq!((status.as_u16(), body.as_str()), (200, "gold"));
+
+    plugin.stop().await?;
+    // While stopped, capability calls fail promptly rather than queueing.
+    let (status, _) = req(&client, &addr, host, "/bound-config?key=tier").await?;
+    assert!(
+        status.is_server_error(),
+        "calls against a stopped plugin must fail, got {status}"
+    );
+
+    plugin.start().await?;
+    // Same 404-is-failure semantics as the trap-restart test: the leftover
+    // bind must be replayed before the fresh incarnation serves any call.
+    let mut recovered = false;
+    for _ in 0..50 {
+        if let Ok((status, body)) = req(&client, &addr, host, "/bound-config?key=tier").await {
+            anyhow::ensure!(
+                status.as_u16() != 404,
+                "a capability call was served before the replayed bind completed"
+            );
+            if status.as_u16() == 200 && body == "gold" {
+                recovered = true;
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(recovered, "leftover binds must replay across stop/start");
+
+    let log = lifecycle_log(&client, &addr, host).await?;
+    assert_eq!(
+        log,
+        vec![format!("bind:{workload_id}")],
+        "the restarted incarnation sees exactly the one replayed bind"
+    );
+    Ok(())
+}
+
+/// Every optional field of the typed records round-trips to the guest with its
+/// content intact: a direct bind on the live host's plugin carries an instance
+/// label and a pre-release+build version, and the guest's rendering — read
+/// back through a real caller workload — reproduces all of them.
+#[tokio::test]
+async fn test_lifecycle_optional_fields_round_trip() -> Result<()> {
+    let host = "kv-lc-optional";
+    let (addr, h, plugin) = start_host_keeping_plugin("127.0.0.1:0").await?;
+    h.workload_start(caller_workload_with_config(host, &[]))
+        .await?;
+    let client = reqwest::Client::new();
+
+    let mut labeled = acme_kv_interface();
+    labeled.name = Some("cache".to_string());
+    labeled.version = Some(semver::Version::parse("0.1.0-rc.1+build5").unwrap());
+    labeled.config = HashMap::from([("tier".to_string(), "gold".to_string())]);
+    let labeled: HashSet<WitInterface> = [labeled].into_iter().collect();
+    plugin
+        .on_workload_bind(&bare_workload("wl-optional"), WitInterfaces::new(&labeled))
+        .await
+        .context("the labeled bind must be accepted")?;
+
+    let (status, info) = req(&client, &addr, host, "/bind-info?workload=wl-optional").await?;
+    assert_eq!(status.as_u16(), 200, "the direct bind must be captured");
+    assert!(
+        info.contains("ifaces=acme:kv/store@0.1.0-rc.1+build5#cache?tier=gold"),
+        "label, pre-release, and build metadata must round-trip, got: {info}"
+    );
+    Ok(())
+}
+
+/// A plugin WITHOUT the lifecycle export is entirely unaffected: binds and
+/// unbinds are accepted as no-ops (nothing is delivered to the guest, nothing
+/// is tracked for replay).
+#[tokio::test]
+async fn test_plugin_without_lifecycle_export_is_unaffected() -> Result<()> {
+    let engine = Engine::builder().build()?;
+    let plugin = ComponentHostPlugin::new("bridge-backend-plugin", BRIDGE_BACKEND_WASM, engine)?;
+    plugin.start().await?;
+
+    let matched: HashSet<WitInterface> = [WitInterface::from("wasmcloud:bridge/ops@0.1.0")]
+        .into_iter()
+        .collect();
+    plugin
+        .on_workload_bind(&bare_workload("wl-plain"), WitInterfaces::new(&matched))
+        .await
+        .context("a bind on a lifecycle-less plugin must be a no-op success")?;
+    plugin
+        .on_workload_unbind("wl-plain", WitInterfaces::new(&matched))
+        .await?;
+    plugin.stop().await?;
+    Ok(())
+}

--- a/wit/host/wit/lifecycle.wit
+++ b/wit/host/wit/lifecycle.wit
@@ -36,12 +36,6 @@ interface workload-lifecycle {
     /// `identity.get-component-id`.
     type component-id = string;
 
-    /// One key/value configuration entry from the workload manifest.
-    record config-entry {
-        key: string,
-        value: string,
-    }
-
     /// Semantic version of an interface instance (e.g. `0.2.0-draft`).
     record version {
         major: u64,
@@ -78,8 +72,9 @@ interface workload-lifecycle {
         /// an identity — it carries no uniqueness requirement, and a binding may
         /// declare either name, both, or neither.
         external-id: option<string>,
-        /// Interface-level configuration from the workload manifest.
-        config: list<config-entry>,
+        /// Interface-level configuration from the workload manifest, as
+        /// key/value pairs sorted by key.
+        config: list<tuple<string, string>>,
     }
 
     /// Identity and configuration of a workload binding to this plugin.

--- a/wit/host/wit/lifecycle.wit
+++ b/wit/host/wit/lifecycle.wit
@@ -1,0 +1,117 @@
+package wasmcloud:host@0.1.0;
+
+/// Optionally exported by a host component plugin. The host calls these as
+/// workloads that import the plugin's capabilities are bound and unbound,
+/// letting the plugin provision and reclaim per-workload state eagerly —
+/// validate interface config at deploy time, allocate per-tenant resources,
+/// and free them when the workload goes away.
+///
+/// A plugin that does not export this interface simply never hears about
+/// workload lifecycle; its capability calls behave as before.
+///
+/// During a lifecycle call, `wasmcloud:host/identity#get-workload-id` reports
+/// the workload the call concerns, so bind-time state keyed by workload id
+/// lines up with the identity seen on later capability calls.
+///
+/// `get-component-id` is NOT meaningful inside these hooks and its value must
+/// not be relied on. A hook is delivered about a whole workload rather than on
+/// behalf of any one of its items, so there is no component to report; the
+/// interface returns a bare `string` and therefore cannot say "none". Every id
+/// a hook needs is already on the `workload-info` argument — the workload id,
+/// the service id if there is one, and every component id — so read it from
+/// there rather than asking who is calling.
+///
+/// Hooks should not invoke the plugin's own exported capabilities: during a
+/// post-restart replay such a self-call cannot be served until the replay
+/// completes, so the host times the hook out rather than waiting on it. A
+/// bind still running past the host's timeout may also observe the same
+/// workload's unbind delivered concurrently; state it provisions after that
+/// is reclaimed only by a later unbind or a plugin restart.
+interface workload-lifecycle {
+    /// Identifier of a workload; matches `identity.get-workload-id` for
+    /// capability calls made by the same workload.
+    type workload-id = string;
+
+    /// Identifier of a single component within a workload; matches
+    /// `identity.get-component-id`.
+    type component-id = string;
+
+    /// One key/value configuration entry from the workload manifest.
+    record config-entry {
+        key: string,
+        value: string,
+    }
+
+    /// Semantic version of an interface instance (e.g. `0.2.0-draft`).
+    record version {
+        major: u64,
+        minor: u64,
+        patch: u64,
+        /// Pre-release identifier, if any (e.g. `draft`, `rc.1`).
+        pre: option<string>,
+        /// Build metadata, if any.
+        build: option<string>,
+    }
+
+    /// One interface instance the workload matched on this plugin — e.g. the
+    /// `store` interface of `acme:kv@0.1.0`, labeled `cache`, with its
+    /// manifest config.
+    record interface-binding {
+        /// Interface namespace (e.g. `acme`).
+        namespace: string,
+        /// Package within the namespace (e.g. `kv`).
+        %package: string,
+        /// The matched interface names within the package (e.g. `store`).
+        interfaces: list<string>,
+        /// Version of the instance, if one was requested.
+        version: option<version>,
+        /// Instance label when the workload names multiple instances of the
+        /// same namespace:package, if any. Component-facing: what the component
+        /// calls this import.
+        name: option<string>,
+        /// Platform-facing id the binding was declared with, if any — what the
+        /// platform's configuration calls the same instance.
+        ///
+        /// Two names, one contract: `name` above and `external-id` here are the
+        /// two names an instance can carry, and both refer to the one interface
+        /// contract described by the rest of this record. An external-id is not
+        /// an identity — it carries no uniqueness requirement, and a binding may
+        /// declare either name, both, or neither.
+        external-id: option<string>,
+        /// Interface-level configuration from the workload manifest.
+        config: list<config-entry>,
+    }
+
+    /// Identity and configuration of a workload binding to this plugin.
+    record workload-info {
+        /// Unique id of the workload instance.
+        id: workload-id,
+        /// Human-readable workload name.
+        name: string,
+        /// Namespace the workload was deployed under.
+        namespace: string,
+        /// Id of the workload's service, if it has one. A service is the
+        /// workload's long-lived item; it can make capability calls just as a
+        /// component can, so this id also appears as `identity.get-component-id`
+        /// on calls the service makes.
+        service: option<component-id>,
+        /// Ids of the workload's components, excluding the service above.
+        components: list<component-id>,
+        /// Every interface instance the workload matched on this plugin.
+        interfaces: list<interface-binding>,
+    }
+
+    /// A workload importing one of this plugin's exported capabilities is
+    /// being bound. Runs to completion before any capability call from that
+    /// workload is delivered. Returning an error rejects the bind and the
+    /// workload fails to deploy.
+    ///
+    /// MUST be idempotent: after a plugin restart the host replays a bind for
+    /// every workload still bound, so the fresh incarnation can rebuild its
+    /// per-workload state before serving.
+    on-workload-bind: async func(workload: workload-info) -> result<_, string>;
+
+    /// The workload is gone — a normal stop, or cleanup after a failed bind.
+    /// Best-effort: must tolerate ids never bound or already unbound.
+    on-workload-unbind: async func(id: workload-id);
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -126,6 +126,8 @@ const P3_FIXTURES: &[&str] = &[
     "http-webgpu",
     "kv-plugin",
     "kv-plugin-caller",
+    "kv-plugin-service",
+    "badlifecycle",
 ];
 
 fn build_fixtures(workspace: &Path) -> Result<()> {


### PR DESCRIPTION
A host component plugin may now export `wasmcloud:host/workload-lifecycle@0.1.0` to react to the workloads that call it. The host delivers `on-workload-bind`, carrying the workload's identity, its service and component ids, and each matched interface instance with its typed version and manifest config, before any capability call from that workload is served, and a best-effort `on-workload-unbind` when the workload goes away.

This lets a plugin provision and reclaim per-workload state **eagerly** rather than lazily on first call: validate interface config at deploy time so a misconfigured workload fails to deploy instead of failing on its first request, allocate per-tenant resources up front, and free them deterministically. Later capability calls correlate back to that state through the existing `wasmcloud:host/identity` import.

A plugin that does not export the interface is entirely unaffected. It never hears about workload lifecycle and its capability calls behave exactly as before.

## The interface

```wit
interface workload-lifecycle {
    record workload-info {
        id: workload-id,
        name: string,
        namespace: string,
        service: option<component-id>,
        components: list<component-id>,
        interfaces: list<interface-binding>,
    }

    on-workload-bind: async func(workload: workload-info) -> result<_, string>;
    on-workload-unbind: async func(id: workload-id);
}
```

`interface-binding` carries the namespace, package, matched interface names, an optional typed `version` (major/minor/patch/pre/build), an optional instance label, and the interface-level config from the workload manifest.

`service` and `components` are reported separately. A service is the workload's stateful item and binds to a plugin through the same path a component does, but conflating the two would leave a plugin unable to tell which id is which, and the id in `service` is the same one `identity.get-component-id` reports for capability calls the service itself makes.

## Behavior

**Reserved namespace.** `wasmcloud:host` exports are reserved: only the lifecycle interface is accepted, it never enters the plugin's world, and no workload import can ever match or call it. Both hook signatures are shape-checked at registration (bind takes the `workload-info` record and returns `result<_, string>`; unbind takes the workload id), so a mismatched plugin fails at construction with a clear message rather than on first deploy.

**Bind rejection fails the deploy.** A bind the guest rejects with a `result` error fails the workload deploy with the guest's message surfaced. The plugin rolls back its bound-workload record and fires a best-effort unbind, since the engine only unbinds *previously*-bound plugins on a bind failure.

**Replay after a supervised restart.** A restart rebuilds the plugin store and loses all guest state while bound workloads keep running, so each fresh incarnation replays `on-workload-bind` for every workload still bound, and the TriggerService completes the replay before serving queued capability calls.

**Quarantine and eviction.** Replay is serial with a per-workload marker recorded before each bind: a guest trap short-circuits `run_concurrent` and drops the serving future before its handler runs, so a replay fault can only be attributed by the marker, which survives the store in the incarnation's registry. A bind that crash-loops the shared store is struck on each attributed fault and, past a strike ceiling (below the plugin restart budget, reset after a healthy uptime), evicted aka dropped from the replay set so the store recovers for every other tenant and reported to the host so the evicted workload's scheduling health becomes failed. Attributed replay faults do not consume the plugin-wide restart budget.

**Bounded lifecycle calls.** Lifecycle calls are bounded end-to-end (channel send plus reply) by `WASH_PLUGIN_LIFECYCLE_CALL_TIMEOUT_SECS` (default 30s, overridable per plugin) so a full channel or a hung hook cannot wedge a deploy or a stop. A bind that overruns the budget fails the deploy *at the budget* rather than waiting the hook out. The hook is uncancellable, so because it keeps running, the rollback unbind is deferred until it returns and scoped to the same incarnation, guaranteeing bind-then-unbind ordering so state the hook provisions late is still reclaimed.

## Engine-side fixes

Two pre-existing cleanup gaps this work surfaced, fixed for all plugins rather than just component plugins:

- `unbind_all_plugins` now unbinds plugins bound to the workload's **service** item; previously only components were visited, so a service's plugin bindings leaked on workload stop.
- The deploy-failure path for unsatisfiable interfaces now unbinds already-bound plugins, matching what the other bind-failure paths already did.

## Fixtures and tests

The `kv-plugin` fixture exports the interface end-to-end with eager provision at bind, identity-keyed lookup at call, reclaim at unbind and verifies the ambient identity contract inside hooks, and exposes captured binds through new `bound-config` / `bind-info` / `lifecycle-log` store functions. A dedicated `badlifecycle` fixture exercises the registration-time signature check, and a new `kv-plugin-service` fixture deploys as a workload **service** (exports `wasi:cli/run`, imports the plugin capability) to cover the service bind path, which previously had no coverage at all.

Covered by the `integration_component_plugin_lifecycle` suite with typed delivery, replay ordering, quarantine and eviction with failed health, deferred rollback unbind, and service-vs-component reporting plus the existing component-host plugin tests. The service test asserts that the id delivered as `workload-info.service` is the same id `identity.get-component-id` reports for the service's own capability calls, which is the property that makes the field useful to a plugin.

## Notes for reviewers

The feature is behind the `host-component-plugins` cargo feature, which is not on by default.

`workload-info` is a WIT `record`, so adding fields to it later is a breaking change for compiled plugins. 

Two timing-sensitive tests set an explicit `digest` on their workload requests. `digest` is used for nothing but the engine's compiled-component cache, and without it every `workload_start` re-runs cranelift over the fixture so putting an unbounded, machine-dependent cost inside a window meant to measure only the plugin's lifecycle behavior. This was a source of CI flakiness. Separately, and not addressed here: digest-less deploys recompiling on every start is a real inefficiency on the bytes-supplied path, since content-hashing would be far cheaper than recompiling.