### PR TITLE
feat(wash-runtime): add service HTTP benchmarks

### DIFF
--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -36,6 +36,7 @@ on:
         default: gungraun
         options:
           - http_invoke
+          - service_http
           - gungraun
           - wasmtime_baseline
           - wasmtime_serve

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,6 +9,7 @@ on:
         default: http_invoke
         options:
           - http_invoke
+          - service_http
           - gungraun
           - wasmtime_baseline
           - wasmtime_serve
@@ -61,7 +62,7 @@ jobs:
       # published`. wasmtime_* are reference baselines for wasmtime itself
       # and don't shift with our changes — run them on demand via
       # workflow_dispatch when wasmtime is upgraded.
-      RELEASE_BENCHES: '["http_invoke","gungraun"]'
+      RELEASE_BENCHES: '["http_invoke","service_http","gungraun"]'
     steps:
       - id: set
         env:

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -186,6 +186,10 @@ name = "http_invoke"
 harness = false
 
 [[bench]]
+name = "service_http"
+harness = false
+
+[[bench]]
 name = "gungraun"
 harness = false
 

--- a/crates/wash-runtime/benches/common/mod.rs
+++ b/crates/wash-runtime/benches/common/mod.rs
@@ -1,5 +1,36 @@
+//! Shared helpers for the wash-runtime benches. Each bench target compiles
+//! this module separately and uses a subset of it, so unused items are
+//! expected per-target.
+#![allow(dead_code)]
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use anyhow::Context as _;
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        Host, HostApi, HostBuilder,
+        http::{DevRouter, HttpServer},
+    },
+    types::{
+        Component, LocalResources, Service, Workload, WorkloadStartRequest, WorkloadState,
+        WorkloadStopRequest,
+    },
+    wit::WitInterface,
+};
+
 const HTTP_HANDLER_P2_WASM: &[u8] = include_bytes!("../../tests/wasm/http_handler_p2.wasm");
 const HTTP_HANDLER_P3_WASM: &[u8] = include_bytes!("../../tests/wasm/http_handler_p3.wasm");
+const HTTP_SVC_PROXY_WASM: &[u8] = include_bytes!("../../tests/wasm/svc_http_proxy.wasm");
+
+/// Body served by the `svc-http-proxy` fixture when a request carries no
+/// `x-backend` header.
+pub const DIRECT_BODY: &str = "hello from service";
+
+/// Upper bound on any single bench request, warmup or measured. Generous
+/// enough to never clip a real measurement; its purpose is turning a wedged
+/// host into a loud failure instead of a silently hung bench run.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Copy, Clone, Debug)]
 pub enum Flavor {
@@ -28,4 +59,182 @@ impl Flavor {
             Flavor::P3 => "hello from p3",
         }
     }
+
+    /// `Host` header configured for (and sent to) this flavor's workload.
+    pub fn host_header(self) -> &'static str {
+        match self {
+            Flavor::P2 => "bench-p2",
+            Flavor::P3 => "bench-p3",
+        }
+    }
+}
+
+pub fn engine() -> Engine {
+    Engine::builder().build().expect("failed to build engine")
+}
+
+pub fn http_host_interfaces(host: &str) -> Vec<WitInterface> {
+    let mut config = HashMap::new();
+    config.insert("host".to_string(), host.to_string());
+    vec![WitInterface {
+        namespace: "wasi".to_string(),
+        package: "http".to_string(),
+        interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.2.2").expect("valid version")),
+        config,
+        name: None,
+    }]
+}
+
+/// A started host bound to a concrete address, kept alive for the duration of
+/// a benchmark group. Dropping a host does NOT abort a running service driver
+/// (its spawned task holds the store and keeps ticking), so every consumer
+/// must call [`BenchHost::shutdown`] — leaked instances accumulate across
+/// iterations and eventually abort the process.
+pub struct BenchHost {
+    host: Arc<Host>,
+    workload_id: String,
+    pub addr: std::net::SocketAddr,
+}
+
+impl BenchHost {
+    pub async fn shutdown(self) {
+        let _ = self
+            .host
+            .workload_stop(WorkloadStopRequest {
+                workload_id: self.workload_id,
+            })
+            .await;
+        let _ = self.host.stop().await;
+    }
+}
+
+pub async fn start_host_and_workload(
+    req_for: impl FnOnce(&str) -> Workload,
+) -> anyhow::Result<BenchHost> {
+    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_server.addr();
+
+    let host = HostBuilder::new()
+        .with_engine(engine())
+        .with_http_handler(Arc::new(http_server))
+        .build()?;
+    let host = host.start().await?;
+
+    let workload_id = uuid::Uuid::new_v4().to_string();
+    let resp = host
+        .workload_start(WorkloadStartRequest {
+            workload_id: workload_id.clone(),
+            workload: req_for("bench"),
+        })
+        .await?;
+    anyhow::ensure!(
+        resp.workload_status.workload_state == WorkloadState::Running,
+        "workload did not start: {:?}: {}",
+        resp.workload_status.workload_state,
+        resp.workload_status.message
+    );
+
+    Ok(BenchHost {
+        host,
+        workload_id,
+        addr,
+    })
+}
+
+/// Start a host serving `flavor`'s HTTP component per-request. This backend
+/// is not what we bench against; it instead hosts a component that serves an endpoint that the
+/// client under bench calls.
+pub async fn start_backend_host(flavor: Flavor) -> anyhow::Result<BenchHost> {
+    start_host_and_workload(|host| Workload {
+        namespace: "bench".to_string(),
+        name: format!("backend-{}", flavor.name()),
+        annotations: HashMap::new(),
+        service: None,
+        components: vec![Component {
+            name: format!("hello-{}.wasm", flavor.name()),
+            digest: None,
+            bytes: bytes::Bytes::from_static(flavor.wasm()),
+            local_resources: LocalResources::default(),
+            // 0/0 → runtime defaults (128 reuses × 16 concurrent on the P3
+            // instance-reuse path; ignored by the non-reuse path).
+            pool_size: 0,
+            max_invocations: 0,
+        }],
+        host_interfaces: http_host_interfaces(host),
+        volumes: vec![],
+    })
+    .await
+}
+
+/// Start a host running the `svc-http-proxy` service workload. Loopback
+/// egress is allowed so the routed benchmarks can reach a backend host.
+pub async fn start_service_host() -> anyhow::Result<BenchHost> {
+    start_host_and_workload(|host| Workload {
+        namespace: "bench".to_string(),
+        name: "bench-service".to_string(),
+        annotations: HashMap::new(),
+        service: Some(Service {
+            digest: None,
+            bytes: bytes::Bytes::from_static(HTTP_SVC_PROXY_WASM),
+            local_resources: LocalResources {
+                allowed_hosts: vec!["127.0.0.1".parse().expect("valid allowed host")].into(),
+                ..LocalResources::default()
+            },
+            max_restarts: 0,
+        }),
+        components: vec![],
+        host_interfaces: http_host_interfaces(host),
+        volumes: vec![],
+    })
+    .await
+}
+
+pub fn bench_client() -> reqwest::Client {
+    // One pooled HTTP/1.1 client for the client -> host hop so the outer
+    // connection is not part of the measurement.
+    reqwest::Client::builder()
+        .pool_max_idle_per_host(64)
+        .tcp_nodelay(true)
+        .build()
+        .expect("reqwest client")
+}
+
+/// GET the service; with `backend` set the service proxies to that authority.
+/// Bounded by [`REQUEST_TIMEOUT`] so a wedged host fails the run instead of
+/// hanging it.
+pub async fn service_request(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    backend: Option<std::net::SocketAddr>,
+) -> anyhow::Result<bytes::Bytes> {
+    let mut req = client.get(format!("http://{addr}/"));
+    if let Some(backend) = backend {
+        req = req.header("x-backend", backend.to_string());
+    }
+    tokio::time::timeout(REQUEST_TIMEOUT, async {
+        let resp = req.send().await?;
+        anyhow::ensure!(resp.status().is_success(), "non-2xx: {}", resp.status());
+        Ok(resp.bytes().await?)
+    })
+    .await
+    .context("request timed out")?
+}
+
+/// Send one request and validate the body - used at setup so a misrouted or
+/// silently-degraded path fails loudly instead of producing numbers for the
+/// wrong thing.
+pub async fn checked_request(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    backend: Option<std::net::SocketAddr>,
+    expected_body: &str,
+) -> anyhow::Result<()> {
+    let body = service_request(client, addr, backend).await?;
+    anyhow::ensure!(
+        body == expected_body.as_bytes(),
+        "unexpected body: {:?} (want {expected_body:?})",
+        String::from_utf8_lossy(&body)
+    );
+    Ok(())
 }

--- a/crates/wash-runtime/benches/gungraun.rs
+++ b/crates/wash-runtime/benches/gungraun.rs
@@ -10,6 +10,12 @@
 //! component). A cold-path measurement is included to track startup-cost
 //! drift (component compile + host build + first request).
 //!
+//! The `service` group is the instruction-count counterpart of the
+//! `service_http` wall-clock bench: a request served by a long-lived
+//! `svc-http-proxy` service instance (direct), the same request routed
+//! through the service's `wasi:http/client` import to a per-request HTTP
+//! component on a second host (p2/p3), and the service's cold start.
+//!
 //! Requires the `gungraun-runner` binary on `PATH` and `valgrind`
 //! installed:
 //! ```text
@@ -23,43 +29,20 @@ mod common;
 
 use std::{collections::HashMap, hint::black_box, sync::Arc};
 
-use common::Flavor;
+use common::{
+    BenchHost, DIRECT_BODY, Flavor, bench_client, checked_request, engine, http_host_interfaces,
+    service_request, start_backend_host, start_service_host,
+};
 use gungraun::{library_benchmark, library_benchmark_group, main};
 use tokio::runtime::Runtime;
 
 use wash_runtime::{
-    engine::Engine,
     host::{
         HostApi, HostBuilder,
         http::{DevRouter, HttpServer},
     },
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
-    wit::WitInterface,
 };
-
-fn flavor_host_header(flavor: Flavor) -> &'static str {
-    match flavor {
-        Flavor::P2 => "bench-p2",
-        Flavor::P3 => "bench-p3",
-    }
-}
-
-fn engine() -> Engine {
-    Engine::builder().build().expect("failed to build engine")
-}
-
-fn http_host_interfaces(host: &str) -> Vec<WitInterface> {
-    let mut config = HashMap::new();
-    config.insert("host".to_string(), host.to_string());
-    vec![WitInterface {
-        namespace: "wasi".to_string(),
-        package: "http".to_string(),
-        interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-        version: Some(semver::Version::parse("0.2.2").unwrap()),
-        config,
-        name: None,
-    }]
-}
 
 /// Warm host bundled with the runtime that owns it. The host's drop impl
 /// must run inside its tokio runtime, so the two have to die together.
@@ -101,7 +84,7 @@ fn setup_warm(flavor: Flavor) -> Warm {
                     pool_size: 0,
                     max_invocations: 0,
                 }],
-                host_interfaces: http_host_interfaces(flavor_host_header(flavor)),
+                host_interfaces: http_host_interfaces(flavor.host_header()),
                 volumes: vec![],
             },
         };
@@ -116,7 +99,7 @@ fn setup_warm(flavor: Flavor) -> Warm {
         // Warmup primes any one-time lazy state and validates the fixture.
         let warmup = client
             .get(format!("http://{addr}/"))
-            .header("HOST", flavor_host_header(flavor))
+            .header("HOST", flavor.host_header())
             .send()
             .await
             .unwrap();
@@ -140,7 +123,7 @@ fn setup_warm(flavor: Flavor) -> Warm {
         _host: host,
         addr,
         client,
-        host_header: flavor_host_header(flavor),
+        host_header: flavor.host_header(),
     }
 }
 
@@ -187,9 +170,114 @@ fn cold_invocation(flavor: Flavor) -> Warm {
     setup_warm(flavor)
 }
 
+/// Warm service (plus optional routed backend) bundled with the runtime that
+/// owns them. Unlike the component hosts above, dropping is not enough at
+/// teardown: the service driver task keeps its store alive, so workload and
+/// host must be stopped explicitly — see [`shutdown_service`].
+struct WarmService {
+    rt: Runtime,
+    service: BenchHost,
+    backend: Option<BenchHost>,
+    client: reqwest::Client,
+}
+
+/// Start a warm, validated service host; with `backend` set, also a second
+/// host serving that flavor's HTTP component per-request, reached through the
+/// service's `wasi:http/client` import.
+fn setup_service(backend: Option<Flavor>) -> WarmService {
+    let rt = Runtime::new().expect("tokio runtime");
+    let (service, backend, client) = rt.block_on(async {
+        let service = start_service_host().await.unwrap();
+        let (backend, expected_body) = match backend {
+            Some(flavor) => (
+                Some(start_backend_host(flavor).await.unwrap()),
+                flavor.expected_body(),
+            ),
+            None => (None, DIRECT_BODY),
+        };
+        let client = bench_client();
+        checked_request(
+            &client,
+            service.addr,
+            backend.as_ref().map(|b| b.addr),
+            expected_body,
+        )
+        .await
+        .unwrap();
+        (service, backend, client)
+    });
+    WarmService {
+        rt,
+        service,
+        backend,
+        client,
+    }
+}
+
+/// Teardown outside the measurement window: stop the workload(s) and host(s).
+fn shutdown_service(warm: WarmService) {
+    let WarmService {
+        rt,
+        service,
+        backend,
+        client,
+    } = warm;
+    drop(client);
+    rt.block_on(async {
+        service.shutdown().await;
+        if let Some(backend) = backend {
+            backend.shutdown().await;
+        }
+    });
+}
+
+// Hot service path: one request answered directly by the long-lived service
+// instance (HTTP server -> ingress channel -> co-driven `http/handler`).
+#[library_benchmark]
+#[bench::direct(args = (None), setup = setup_service, teardown = shutdown_service)]
+fn hot_service(warm: WarmService) -> WarmService {
+    warm.rt.block_on(async {
+        let body = service_request(&warm.client, warm.service.addr, None)
+            .await
+            .unwrap();
+        let _ = black_box(body);
+    });
+    warm
+}
+
+// Routed service path: the request is forwarded through the service's
+// `wasi:http/client` import to a per-request HTTP component on a second host.
+#[library_benchmark]
+#[bench::p2(args = (Some(Flavor::P2)), setup = setup_service, teardown = shutdown_service)]
+#[bench::p3(args = (Some(Flavor::P3)), setup = setup_service, teardown = shutdown_service)]
+fn service_to_component(warm: WarmService) -> WarmService {
+    let backend_addr = warm.backend.as_ref().map(|b| b.addr);
+    warm.rt.block_on(async {
+        let body = service_request(&warm.client, warm.service.addr, backend_addr)
+            .await
+            .unwrap();
+        let _ = black_box(body);
+    });
+    warm
+}
+
+// Cold service path: host build + service workload start (trigger driver,
+// ingress registration) + first request, all counted. Teardown stops the
+// workload and host outside the measurement window.
+#[library_benchmark]
+#[bench::direct(args = (None), teardown = shutdown_service)]
+fn cold_service(backend: Option<Flavor>) -> WarmService {
+    setup_service(backend)
+}
+
 library_benchmark_group!(
     name = http;
     benchmarks = hot_invocation, cold_invocation
 );
 
-main!(library_benchmark_groups = http);
+library_benchmark_group!(
+    name = service;
+    benchmarks = hot_service, service_to_component, cold_service
+);
+
+main!(library_benchmark_groups = http, service);

--- a/crates/wash-runtime/benches/gungraun.rs
+++ b/crates/wash-runtime/benches/gungraun.rs
@@ -181,10 +181,10 @@ struct WarmService {
     client: reqwest::Client,
 }
 
-/// Start a warm, validated service host; with `backend` set, also a second
-/// host serving that flavor's HTTP component per-request, reached through the
-/// service's `wasi:http/client` import.
-fn setup_service(backend: Option<Flavor>) -> WarmService {
+/// Start a service host (plus a backend host for that flavor's HTTP
+/// component when `backend` is set), validated with exactly one round-trip —
+/// the shape the cold benchmark measures.
+fn start_service(backend: Option<Flavor>) -> WarmService {
     let rt = Runtime::new().expect("tokio runtime");
     let (service, backend, client) = rt.block_on(async {
         let service = start_service_host().await.unwrap();
@@ -212,6 +212,24 @@ fn setup_service(backend: Option<Flavor>) -> WarmService {
         backend,
         client,
     }
+}
+
+/// [`start_service`] plus extra validated warmup round-trips, so a measured
+/// hot call starts from a steady state (on the routed path the extras also
+/// settle the backend's reused p3 instance) rather than right behind
+/// first-request setup. Setup for the hot benchmarks only — the cold
+/// benchmark measures [`start_service`] with its single round-trip.
+fn setup_service(backend: Option<Flavor>) -> WarmService {
+    let warm = start_service(backend);
+    warm.rt.block_on(async {
+        let backend_addr = warm.backend.as_ref().map(|b| b.addr);
+        for _ in 0..2 {
+            let _ = service_request(&warm.client, warm.service.addr, backend_addr)
+                .await
+                .unwrap();
+        }
+    });
+    warm
 }
 
 /// Teardown outside the measurement window: stop the workload(s) and host(s).
@@ -267,7 +285,7 @@ fn service_to_component(warm: WarmService) -> WarmService {
 #[library_benchmark]
 #[bench::direct(args = (None), teardown = shutdown_service)]
 fn cold_service(backend: Option<Flavor>) -> WarmService {
-    setup_service(backend)
+    start_service(backend)
 }
 
 library_benchmark_group!(

--- a/crates/wash-runtime/benches/http_invoke.rs
+++ b/crates/wash-runtime/benches/http_invoke.rs
@@ -34,43 +34,17 @@ use std::{
     time::{Duration, Instant},
 };
 
-use common::Flavor;
+use common::{Flavor, engine, http_host_interfaces};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
 use wash_runtime::{
-    engine::Engine,
     host::{
         HostApi, HostBuilder,
         http::{DevRouter, HttpServer},
     },
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
-    wit::WitInterface,
 };
-
-fn flavor_host_header(flavor: Flavor) -> &'static str {
-    match flavor {
-        Flavor::P2 => "bench-p2",
-        Flavor::P3 => "bench-p3",
-    }
-}
-
-fn engine() -> Engine {
-    Engine::builder().build().expect("failed to build engine")
-}
-
-fn http_host_interfaces(host: &str) -> Vec<WitInterface> {
-    let mut config = HashMap::new();
-    config.insert("host".to_string(), host.to_string());
-    vec![WitInterface {
-        namespace: "wasi".to_string(),
-        package: "http".to_string(),
-        interfaces: ["incoming-handler".to_string()].into_iter().collect(),
-        version: Some(semver::Version::parse("0.2.2").unwrap()),
-        config,
-        name: None,
-    }]
-}
 
 /// Holds a warm host bound to a concrete address with a workload resolved and
 /// ready to serve requests. Kept alive for the duration of a benchmark group.
@@ -111,7 +85,7 @@ async fn start_warm_host(flavor: Flavor) -> anyhow::Result<WarmHost> {
                 pool_size: 0,
                 max_invocations: 0,
             }],
-            host_interfaces: http_host_interfaces(flavor_host_header(flavor)),
+            host_interfaces: http_host_interfaces(flavor.host_header()),
             volumes: vec![],
         },
     };
@@ -127,7 +101,7 @@ async fn start_warm_host(flavor: Flavor) -> anyhow::Result<WarmHost> {
     // Correctness check  - also primes any one-time lazy caches before bench.
     let warmup = client
         .get(format!("http://{addr}/"))
-        .header("HOST", flavor_host_header(flavor))
+        .header("HOST", flavor.host_header())
         .send()
         .await?;
     anyhow::ensure!(
@@ -145,7 +119,7 @@ async fn start_warm_host(flavor: Flavor) -> anyhow::Result<WarmHost> {
         _host: Box::new(host),
         addr,
         client,
-        host_header: flavor_host_header(flavor),
+        host_header: flavor.host_header(),
     })
 }
 

--- a/crates/wash-runtime/benches/service_http.rs
+++ b/crates/wash-runtime/benches/service_http.rs
@@ -61,7 +61,7 @@ use common::{
 /// iterations from accumulating live service instances without folding the
 /// stop path into the startup numbers.
 fn bench_cold(c: &mut Criterion) {
-    let rt = Runtime::new().expect("tokio runtime");
+    let rt = Runtime::new().expect("cold bench runtime");
     let mut group = c.benchmark_group("service_cold_invocation");
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(10));
@@ -88,7 +88,7 @@ fn bench_cold(c: &mut Criterion) {
 /// Hot latency of the direct path: client -> HTTP server -> service ingress
 /// channel -> live instance handler -> streamed response.
 fn bench_hot_direct(c: &mut Criterion) {
-    let rt = Runtime::new().expect("tokio runtime");
+    let rt = Runtime::new().expect("hot bench runtime");
     let mut group = c.benchmark_group("service_hot_invocation");
     group.throughput(Throughput::Elements(1));
     group.measurement_time(Duration::from_secs(10));
@@ -120,7 +120,7 @@ fn bench_throughput_direct(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .expect("tokio runtime");
+        .expect("throughput bench runtime");
 
     let mut group = c.benchmark_group("service_http_throughput");
     group.throughput(Throughput::Elements(BATCH as u64));
@@ -216,7 +216,7 @@ fn bench_service_to_component(c: &mut Criterion) {
     /// Untimed requests absorbing the post-pause wake-up cost.
     const WARMERS: usize = 2;
 
-    let rt = Runtime::new().expect("tokio runtime");
+    let rt = Runtime::new().expect("svc->component runtime");
     let mut group = c.benchmark_group("service_to_component");
     group.throughput(Throughput::Elements(1));
     group.sample_size(20);

--- a/crates/wash-runtime/benches/service_http.rs
+++ b/crates/wash-runtime/benches/service_http.rs
@@ -1,0 +1,284 @@
+//! Service HTTP benchmarks for wash-runtime.
+//!
+//! A wasmCloud *service* is a long-lived p3 instance: the host co-drives
+//! `wasi:cli/run` with `wasi:http/handler` on one store, and the HTTP server
+//! delivers inbound requests to the live instance over a channel instead of
+//! instantiating a component per request. These benchmarks measure that plane
+//! with the `svc-http-proxy` fixture:
+//!
+//! 1. **Cold start** - end-to-end cost of building a host, starting a service
+//!    workload (trigger-service driver, ingress registration), and serving the
+//!    first HTTP request. Teardown runs every iteration but outside the timed
+//!    window, so the numbers are comparable to `http_invoke`'s cold path.
+//! 2. **Hot invocation (direct)** - steady-state single-request latency
+//!    against the warm service instance answering from its own handler.
+//! 3. **Throughput (direct)** - concurrent RPS against the warm service
+//!    instance, saturating the service ingress channel.
+//! 4. **Service -> component (routed)** - the service forwards each request to
+//!    an HTTP component workload on a second host via its imported
+//!    `wasi:http/client`. This exercises the full routing chain: service
+//!    ingress -> guest handler -> outbound egress (allowed-hosts policy,
+//!    client span, stock p3 send) -> TCP -> second host's HTTP server ->
+//!    router -> per-request component instance -> response streamed back
+//!    through the service. Benched against both P2 and P3 backends.
+//!
+//! The routed leg opens a fresh TCP connection per request (the stock p3
+//! egress has no connection pooling), and each connection's client-side
+//! TIME_WAIT holds a loopback ephemeral port for 30-60s. The routed loop is
+//! therefore burst-paced below the port pool's drain rate (~500
+//! connections/s on both macOS and Linux) - see
+//! [`bench_service_to_component`] for why bursts rather than a per-request
+//! gap.
+//!
+//! Run with:
+//! ```text
+//! cargo bench -p wash-runtime --bench service_http
+//! ```
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+
+use common::{
+    DIRECT_BODY, Flavor, REQUEST_TIMEOUT, bench_client, checked_request, service_request,
+    start_backend_host, start_service_host,
+};
+
+/// Cold start: build the host, start the service workload, serve + validate
+/// the first request. The scale-from-zero cost of a service. Shutdown runs
+/// per iteration but outside the timed window - it keeps hundreds of
+/// iterations from accumulating live service instances without folding the
+/// stop path into the startup numbers.
+fn bench_cold(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("service_cold_invocation");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+
+    group.bench_function("p3-service", |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let start = Instant::now();
+                let service = start_service_host().await.expect("service host");
+                let client = bench_client();
+                checked_request(&client, service.addr, None, DIRECT_BODY)
+                    .await
+                    .expect("first request");
+                total += start.elapsed();
+                service.shutdown().await;
+            }
+            total
+        });
+    });
+    group.finish();
+}
+
+/// Hot latency of the direct path: client -> HTTP server -> service ingress
+/// channel -> live instance handler -> streamed response.
+fn bench_hot_direct(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("service_hot_invocation");
+    group.throughput(Throughput::Elements(1));
+    group.measurement_time(Duration::from_secs(10));
+
+    let (service, client) = rt.block_on(async {
+        let service = start_service_host().await.expect("service host");
+        let client = bench_client();
+        checked_request(&client, service.addr, None, DIRECT_BODY)
+            .await
+            .expect("warmup");
+        (service, client)
+    });
+
+    group.bench_function("direct", |b| {
+        b.to_async(&rt).iter(|| async {
+            service_request(&client, service.addr, None).await.unwrap();
+        });
+    });
+    group.finish();
+    rt.block_on(service.shutdown());
+}
+
+/// Concurrent throughput of the direct path: RPS with N in-flight requests
+/// against the single live service instance.
+fn bench_throughput_direct(c: &mut Criterion) {
+    const CONCURRENCY: usize = 32;
+    const BATCH: usize = 256;
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let mut group = c.benchmark_group("service_http_throughput");
+    group.throughput(Throughput::Elements(BATCH as u64));
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(15));
+
+    let (service, client) = rt.block_on(async {
+        let service = start_service_host().await.expect("service host");
+        let client = bench_client();
+        checked_request(&client, service.addr, None, DIRECT_BODY)
+            .await
+            .expect("warmup");
+        (service, client)
+    });
+    let url = format!("http://{}/", service.addr);
+
+    let failures = Arc::new(AtomicUsize::new(0));
+    let failures_ref = failures.clone();
+    group.bench_function("direct", |b| {
+        b.to_async(&rt).iter_custom(|iters| {
+            let url = url.clone();
+            let client = client.clone();
+            let failures = failures_ref.clone();
+            async move {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let start = Instant::now();
+                    let mut handles = Vec::with_capacity(CONCURRENCY);
+                    let per_worker = BATCH / CONCURRENCY;
+                    for _ in 0..CONCURRENCY {
+                        let client = client.clone();
+                        let url = url.clone();
+                        let failures = failures.clone();
+                        handles.push(tokio::spawn(async move {
+                            for _ in 0..per_worker {
+                                let ok = tokio::time::timeout(REQUEST_TIMEOUT, async {
+                                    match client.get(&url).send().await {
+                                        Ok(resp) if resp.status().is_success() => {
+                                            resp.bytes().await.is_ok()
+                                        }
+                                        _ => false,
+                                    }
+                                })
+                                .await
+                                .unwrap_or(false);
+                                if !ok {
+                                    failures.fetch_add(1, Ordering::Relaxed);
+                                }
+                            }
+                        }));
+                    }
+                    for h in handles {
+                        h.await.expect("worker");
+                    }
+                    total += start.elapsed();
+                }
+                total
+            }
+        });
+    });
+    let failed = failures.load(Ordering::Relaxed);
+    if failed > 0 {
+        eprintln!("[service_http_throughput/direct] {failed} requests failed during bench run");
+    }
+    group.finish();
+    rt.block_on(service.shutdown());
+}
+
+/// Hot latency of the routed path: the service forwards each request to a
+/// per-request HTTP component on a second host and streams the backend's
+/// response through.
+///
+/// Every routed request opens a fresh outbound TCP connection (stock p3
+/// egress has no pooling) whose client-side TIME_WAIT parks an ephemeral
+/// port for 30s (macOS, ~16k-port pool) or 60s (Linux, ~28k). Left unpaced,
+/// the loop empties the pool mid-run and measures the OS refusing
+/// connections. Pacing every request instead distorts the numbers the other
+/// way: an idle gap before each request lets the OS power-manage the
+/// process (timer oversleep, frequency ramp, efficiency-core placement) and
+/// each request then pays a multi-millisecond wake-up tax.
+///
+/// So the loop paces in BURSTS: runs of back-to-back requests (timed, warm)
+/// separated by one long untimed pause that keeps the average connection
+/// rate under the pool's drain rate (~500/s on both platforms), with a
+/// couple of untimed warmer requests after each pause so the timed burst
+/// never includes the post-idle cold edge.
+fn bench_service_to_component(c: &mut Criterion) {
+    /// Timed requests per pacing cycle.
+    const BURST: u64 = 64;
+    /// Untimed pause between bursts. (BURST + warmers) / PAUSE stays well
+    /// under the ephemeral-port drain rate.
+    const PAUSE: Duration = Duration::from_millis(200);
+    /// Untimed requests absorbing the post-pause wake-up cost.
+    const WARMERS: usize = 2;
+
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("service_to_component");
+    group.throughput(Throughput::Elements(1));
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_millis(300));
+    group.measurement_time(Duration::from_secs(1));
+
+    for flavor in [Flavor::P2, Flavor::P3] {
+        let (service, backend, client) = rt.block_on(async {
+            let service = start_service_host().await.expect("service host");
+            let backend = start_backend_host(flavor).await.expect("backend host");
+            let client = bench_client();
+            checked_request(
+                &client,
+                service.addr,
+                Some(backend.addr),
+                flavor.expected_body(),
+            )
+            .await
+            .expect("routed warmup");
+            (service, backend, client)
+        });
+        let (service_addr, backend_addr) = (service.addr, backend.addr);
+
+        group.bench_function(BenchmarkId::from_parameter(flavor.name()), |b| {
+            b.to_async(&rt).iter_custom(|iters| {
+                let client = client.clone();
+                async move {
+                    let mut total = Duration::ZERO;
+                    let mut in_burst = 0u64;
+                    for _ in 0..iters {
+                        if in_burst == BURST {
+                            in_burst = 0;
+                            tokio::time::sleep(PAUSE).await;
+                            for _ in 0..WARMERS {
+                                let _ = service_request(&client, service_addr, Some(backend_addr))
+                                    .await;
+                            }
+                        }
+                        let start = Instant::now();
+                        service_request(&client, service_addr, Some(backend_addr))
+                            .await
+                            .unwrap();
+                        total += start.elapsed();
+                        in_burst += 1;
+                    }
+                    total
+                }
+            });
+        });
+        rt.block_on(async {
+            service.shutdown().await;
+            backend.shutdown().await;
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_cold,
+    bench_hot_direct,
+    bench_throughput_direct,
+    bench_service_to_component
+);
+criterion_main!(benches);

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -336,6 +336,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-loopback-gateway"
+version = "0.0.0"
+dependencies = [
+ "futures",
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
 name = "http-webgpu"
 version = "0.1.0"
 dependencies = [
@@ -750,6 +758,14 @@ dependencies = [
 name = "svc-http-proxy"
 version = "0.0.0"
 dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
+name = "svc-tcp-echo"
+version = "0.0.0"
+dependencies = [
+ "futures",
  "wit-bindgen 0.59.0",
 ]
 

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -747,6 +747,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "svc-http-proxy"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "keyvalue-default-p3",
     "postgres-stream-p3",
     "svc-counter",
+    "svc-http-proxy",
     "msg-counter",
     "bridge-backend",
     "bridge-service",

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -41,6 +41,8 @@ members = [
     "postgres-stream-p3",
     "svc-counter",
     "svc-http-proxy",
+    "svc-tcp-echo",
+    "http-loopback-gateway",
     "msg-counter",
     "bridge-backend",
     "bridge-service",

--- a/crates/wash-runtime/tests/fixtures/http-loopback-gateway/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/http-loopback-gateway/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/http_loopback_gateway.wasm

--- a/crates/wash-runtime/tests/fixtures/http-loopback-gateway/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/http-loopback-gateway/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "http-loopback-gateway"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }
+futures = { workspace = true, features = ["alloc", "async-await"] }

--- a/crates/wash-runtime/tests/fixtures/http-loopback-gateway/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/http-loopback-gateway/src/lib.rs
@@ -1,0 +1,70 @@
+//! HTTP -> loopback gateway: each request opens a virtualized-loopback TCP
+//! connection to the `svc-tcp-echo` service (127.0.0.1:9099), sends `ping`,
+//! and returns the echoed reply as the response body. The pair reproduces a
+//! long-lived service reached guest-to-guest, with the HTTP side driving one
+//! request at a time.
+
+mod bindings {
+    wit_bindgen::generate!({ world: "http-loopback-gateway", generate_all });
+}
+
+use bindings::exports::wasi::http::handler::Guest as Handler;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::wasi::sockets::types::{
+    IpAddressFamily, IpSocketAddress, Ipv4SocketAddress, TcpSocket,
+};
+
+const ECHO_PORT: u16 = 9099;
+
+struct Component;
+
+impl Handler for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        let reply = echo_roundtrip()
+            .await
+            .map_err(|e| ErrorCode::InternalError(Some(e.to_string())))?;
+        Ok(make_response(reply))
+    }
+}
+
+async fn echo_roundtrip() -> Result<Vec<u8>, &'static str> {
+    let client = TcpSocket::create(IpAddressFamily::Ipv4).map_err(|_| "create failed")?;
+    client
+        .connect(IpSocketAddress::Ipv4(Ipv4SocketAddress {
+            port: ECHO_PORT,
+            address: (127, 0, 0, 1),
+        }))
+        .await
+        .map_err(|_| "connect failed")?;
+
+    // Send the request; dropping the writer ends the stream, which the echo
+    // service observes as end-of-request.
+    let (mut tx, tx_stream) = bindings::wit_stream::new();
+    let (send_result, ()) = futures::join!(async { client.send(tx_stream).await }, async {
+        tx.write_all(b"ping".to_vec()).await;
+        drop(tx);
+    });
+    send_result.map_err(|_| "send failed")?;
+
+    let (mut rx, _rx_result) = client.receive();
+    let (_result, reply) = rx.read(Vec::with_capacity(1024)).await;
+    if reply.is_empty() {
+        return Err("empty reply");
+    }
+    Ok(reply)
+}
+
+fn make_response(body: Vec<u8>) -> Response {
+    let headers = Fields::new();
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    response
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/http-loopback-gateway/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/http-loopback-gateway/wit/world.wit
@@ -1,0 +1,12 @@
+package wasmcloud:test-p3@0.1.0;
+
+/// A p3 HTTP component that proxies each request over the workload's
+/// virtualized loopback: it connects to 127.0.0.1:9099 (the `svc-tcp-echo`
+/// service), sends a fixed payload, and returns the echoed reply as the HTTP
+/// response body.
+world http-loopback-gateway {
+    import wasi:http/types@0.3.0;
+    import wasi:sockets/types@0.3.0;
+
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/http-loopback-gateway/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/http-loopback-gateway/wkg.toml
@@ -1,0 +1,7 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:http" = { path = "../p3-wit-deps/wasi-http-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }

--- a/crates/wash-runtime/tests/fixtures/svc-http-proxy/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/svc-http-proxy/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/svc_http_proxy.wasm

--- a/crates/wash-runtime/tests/fixtures/svc-http-proxy/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/svc-http-proxy/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "svc-http-proxy"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/svc-http-proxy/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/svc-http-proxy/src/lib.rs
@@ -1,0 +1,96 @@
+//! A p3 proxy service: `cli/run` parks forever while `http/handler` serves
+//! ingress on the same long-lived instance.
+//!
+//! A request carrying an `x-backend` header (an `authority` such as
+//! `127.0.0.1:8080`) is forwarded to that authority through the imported
+//! `wasi:http/client` — the host's outbound HTTP path — and the backend's
+//! response resource is returned unchanged, so its body streams through
+//! without a guest-side copy. A request without the header is answered
+//! directly from the service; a present-but-malformed header is an error,
+//! never a silent fallback to the (much faster) direct path.
+
+mod bindings {
+    wit_bindgen::generate!({ world: "svc-http-proxy", generate_all });
+}
+
+use bindings::exports::wasi::cli::run::Guest as RunGuest;
+use bindings::exports::wasi::http::handler::Guest as HttpGuest;
+use bindings::wasi::http::client as outbound;
+use bindings::wasi::http::types::{ErrorCode, Fields, Method, Request, Response, Scheme};
+
+struct Component;
+
+impl RunGuest for Component {
+    async fn run() -> Result<(), ()> {
+        use bindings::wasi::clocks::monotonic_clock;
+        // The run loop has no work of its own; it only has to stay alive so
+        // the trigger driver keeps co-driving the handler. No periodic tick:
+        // each in-flight HTTP job re-enters the store and drives the
+        // instance's tasks itself, and a tick would only add wakeups that
+        // show up as latency outliers in the benchmarks.
+        loop {
+            monotonic_clock::wait_for(u64::MAX).await;
+        }
+    }
+}
+
+impl HttpGuest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        match request
+            .get_headers()
+            .get(&"x-backend".to_string())
+            .into_iter()
+            .next()
+        {
+            Some(value) => {
+                let authority = String::from_utf8(value)
+                    .map_err(|_| internal("x-backend header is not UTF-8"))?;
+                proxy(&authority).await
+            }
+            None => Ok(direct_response()),
+        }
+    }
+}
+
+fn internal(msg: &str) -> ErrorCode {
+    ErrorCode::InternalError(Some(msg.to_string()))
+}
+
+/// Forward a `GET /` to `authority` over the imported client and return the
+/// backend's response as-is.
+async fn proxy(authority: &str) -> Result<Response, ErrorCode> {
+    let headers = Fields::new();
+    // No request body: dropping the unwritten trailers writer resolves the
+    // future with the default `Ok(None)` as soon as the host polls it.
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    drop(trailers_tx);
+    let (request, _sent) = Request::new(headers, None, trailers_rx, None);
+    request
+        .set_method(&Method::Get)
+        .map_err(|()| internal("set_method rejected GET"))?;
+    request
+        .set_scheme(Some(&Scheme::Http))
+        .map_err(|()| internal("set_scheme rejected http"))?;
+    request
+        .set_authority(Some(authority))
+        .map_err(|()| internal("set_authority rejected the x-backend value"))?;
+    request
+        .set_path_with_query(Some("/"))
+        .map_err(|()| internal("set_path_with_query rejected /"))?;
+    outbound::send(request).await
+}
+
+fn direct_response() -> Response {
+    let headers = Fields::new();
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(b"hello from service".to_vec()).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    response
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/svc-http-proxy/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/svc-http-proxy/src/lib.rs
@@ -1,5 +1,5 @@
-//! A p3 proxy service: `cli/run` parks forever while `http/handler` serves
-//! ingress on the same long-lived instance.
+//! A p3 proxy trigger service: `cli/run` parks forever while `http/handler`
+//! serves ingress on the same long-lived instance.
 //!
 //! A request carrying an `x-backend` header (an `authority` such as
 //! `127.0.0.1:8080`) is forwarded to that authority through the imported
@@ -13,10 +13,16 @@ mod bindings {
     wit_bindgen::generate!({ world: "svc-http-proxy", generate_all });
 }
 
+use std::sync::LazyLock;
+
 use bindings::exports::wasi::cli::run::Guest as RunGuest;
 use bindings::exports::wasi::http::handler::Guest as HttpGuest;
 use bindings::wasi::http::client as outbound;
 use bindings::wasi::http::types::{ErrorCode, Fields, Method, Request, Response, Scheme};
+
+/// Header name as the owned `String` the generated `Fields::get` borrows,
+/// built once instead of allocating per request.
+static X_BACKEND: LazyLock<String> = LazyLock::new(|| "x-backend".to_string());
 
 struct Component;
 
@@ -36,23 +42,17 @@ impl RunGuest for Component {
 
 impl HttpGuest for Component {
     async fn handle(request: Request) -> Result<Response, ErrorCode> {
-        match request
-            .get_headers()
-            .get(&"x-backend".to_string())
-            .into_iter()
-            .next()
-        {
-            Some(value) => {
-                let authority = String::from_utf8(value)
-                    .map_err(|_| internal("x-backend header is not UTF-8"))?;
-                proxy(&authority).await
-            }
-            None => Ok(direct_response()),
+        let mut values = request.get_headers().get(&X_BACKEND);
+        if values.is_empty() {
+            return Ok(direct_response());
         }
+        let authority = String::from_utf8(values.swap_remove(0))
+            .map_err(|_| internal_err("x-backend header is not UTF-8"))?;
+        proxy(&authority).await
     }
 }
 
-fn internal(msg: &str) -> ErrorCode {
+fn internal_err(msg: &str) -> ErrorCode {
     ErrorCode::InternalError(Some(msg.to_string()))
 }
 
@@ -67,16 +67,16 @@ async fn proxy(authority: &str) -> Result<Response, ErrorCode> {
     let (request, _sent) = Request::new(headers, None, trailers_rx, None);
     request
         .set_method(&Method::Get)
-        .map_err(|()| internal("set_method rejected GET"))?;
+        .map_err(|()| internal_err("set_method rejected GET"))?;
     request
         .set_scheme(Some(&Scheme::Http))
-        .map_err(|()| internal("set_scheme rejected http"))?;
+        .map_err(|()| internal_err("set_scheme rejected http"))?;
     request
         .set_authority(Some(authority))
-        .map_err(|()| internal("set_authority rejected the x-backend value"))?;
+        .map_err(|()| internal_err("set_authority rejected the x-backend value"))?;
     request
         .set_path_with_query(Some("/"))
-        .map_err(|()| internal("set_path_with_query rejected /"))?;
+        .map_err(|()| internal_err("set_path_with_query rejected /"))?;
     outbound::send(request).await
 }
 

--- a/crates/wash-runtime/tests/fixtures/svc-http-proxy/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/svc-http-proxy/wit/world.wit
@@ -1,0 +1,15 @@
+package wasmcloud:test-p3@0.1.0;
+
+/// A p3 proxy service: one long-lived instance co-drives `cli/run` and
+/// `http/handler`. A request carrying an `x-backend` header is forwarded to
+/// that authority through the imported `wasi:http/client` (the host's
+/// outbound HTTP path) and the backend's response is returned unchanged; a
+/// request without the header is answered directly from the service.
+world svc-http-proxy {
+    import wasi:http/types@0.3.0;
+    import wasi:http/client@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:clocks/monotonic-clock@0.3.0;
+    export wasi:cli/run@0.3.0;
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/svc-http-proxy/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/svc-http-proxy/wkg.toml
@@ -1,0 +1,7 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:http" = { path = "../p3-wit-deps/wasi-http-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }

--- a/crates/wash-runtime/tests/fixtures/svc-tcp-echo/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/svc-tcp-echo/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/svc_tcp_echo.wasm

--- a/crates/wash-runtime/tests/fixtures/svc-tcp-echo/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/svc-tcp-echo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "svc-tcp-echo"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }
+futures = { workspace = true, features = ["alloc", "async-await"] }

--- a/crates/wash-runtime/tests/fixtures/svc-tcp-echo/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/svc-tcp-echo/src/lib.rs
@@ -1,0 +1,101 @@
+//! Tick-free p3 echo service over the virtualized loopback.
+//!
+//! `cli/run` binds 127.0.0.1:9099, accepts connections, and spawns a handler
+//! per connection; the reply travels handler -> spawned writer task through a
+//! pure guest-side waker handoff (no host waitable involved), and the writer
+//! drives the outbound stream — the same shapes as a connection pooler's
+//! checkout wakers and per-session stream drivers. There is NO periodic clock
+//! tick: if either a spawned task or a guest-waker wake needs an unrelated
+//! host event to be observed, the reply never flushes.
+
+mod bindings {
+    wit_bindgen::generate!({ world: "svc-tcp-echo", generate_all });
+}
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::task::{Poll, Waker};
+
+use bindings::exports::wasi::cli::run::Guest;
+use bindings::wasi::sockets::types::{
+    IpAddressFamily, IpSocketAddress, Ipv4SocketAddress, TcpSocket,
+};
+
+const ECHO_PORT: u16 = 9099;
+
+/// A single-value handoff between two tasks on this instance, woken purely by
+/// a guest-side [`Waker`] — the wake class that historically needed an
+/// unrelated host event to be observed.
+#[derive(Default)]
+struct Handoff {
+    value: RefCell<Option<Vec<u8>>>,
+    waker: RefCell<Option<Waker>>,
+}
+
+impl Handoff {
+    fn put(&self, value: Vec<u8>) {
+        *self.value.borrow_mut() = Some(value);
+        if let Some(waker) = self.waker.borrow_mut().take() {
+            waker.wake();
+        }
+    }
+
+    async fn take(&self) -> Vec<u8> {
+        std::future::poll_fn(|cx| {
+            if let Some(value) = self.value.borrow_mut().take() {
+                Poll::Ready(value)
+            } else {
+                *self.waker.borrow_mut() = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        })
+        .await
+    }
+}
+
+struct Component;
+
+impl Guest for Component {
+    async fn run() -> Result<(), ()> {
+        let listener = TcpSocket::create(IpAddressFamily::Ipv4).map_err(|_| ())?;
+        listener
+            .bind(IpSocketAddress::Ipv4(Ipv4SocketAddress {
+                port: ECHO_PORT,
+                address: (127, 0, 0, 1),
+            }))
+            .map_err(|_| ())?;
+        listener.set_listen_backlog_size(16).map_err(|_| ())?;
+        let mut accept = listener.listen().map_err(|_| ())?;
+
+        while let Some(sock) = accept.next().await {
+            wit_bindgen::spawn_local(handle(sock));
+        }
+        Ok(())
+    }
+}
+
+async fn handle(sock: TcpSocket) {
+    // Take the receive side first; the socket itself moves into the writer
+    // task, which owns the send side and waits on the handoff — a pure
+    // guest-waker await with no host waitable.
+    let (mut rx, _rx_result) = sock.receive();
+    let handoff = Rc::new(Handoff::default());
+    let (mut tx, tx_stream) = bindings::wit_stream::new();
+    wit_bindgen::spawn_local({
+        let handoff = Rc::clone(&handoff);
+        async move {
+            let reply = handoff.take().await;
+            let _ = futures::join!(async { sock.send(tx_stream).await }, async {
+                tx.write_all(reply).await;
+                drop(tx);
+            });
+        }
+    });
+
+    let (_result, data) = rx.read(Vec::with_capacity(1024)).await;
+    let mut reply = b"echo:".to_vec();
+    reply.extend_from_slice(&data);
+    handoff.put(reply);
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/svc-tcp-echo/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/svc-tcp-echo/wit/world.wit
@@ -1,0 +1,13 @@
+package wasmcloud:test-p3@0.1.0;
+
+/// A p3 `cli/run` service that serves a TCP echo protocol on the virtualized
+/// loopback (127.0.0.1:9099): accept connections, and for each one a spawned
+/// handler reads the request and passes the reply through a pure guest-waker
+/// handoff to a second spawned task that writes it. Deliberately tick-free —
+/// this fixture exists to probe whether guest-spawned tasks and guest-side
+/// wakes are driven without periodic host events.
+world svc-tcp-echo {
+    import wasi:sockets/types@0.3.0;
+
+    export wasi:cli/run@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/svc-tcp-echo/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/svc-tcp-echo/wkg.toml
@@ -1,0 +1,7 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:http" = { path = "../p3-wit-deps/wasi-http-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }

--- a/crates/wash-runtime/tests/integration_p3_loopback_service.rs
+++ b/crates/wash-runtime/tests/integration_p3_loopback_service.rs
@@ -1,0 +1,110 @@
+//! Regression test for p3 guest-spawned task scheduling: a tick-free
+//! `cli/run` service serving the virtualized loopback must answer promptly.
+//!
+//! Historically, a long-lived p3 service's spawned tasks were only polled
+//! when the executor was re-entered by a host event, so sequential
+//! guest-to-guest loopback requests lagged by one and services carried a
+//! periodic clock-tick workaround. This test pins the fixed behavior with a
+//! deliberately tick-free service: `svc-tcp-echo` accepts loopback
+//! connections in `cli/run` and drives every reply through spawned tasks,
+//! while the `http-loopback-gateway` component proxies one HTTP request at a
+//! time into it. If spawned tasks ever again require an unrelated host event
+//! to make progress, the first request here hangs (each request is awaited to
+//! completion before the next is sent, so nothing else re-enters the store)
+//! and the per-request timeout fails the test.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{collections::HashMap, time::Duration, time::Instant};
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::host::HostApi;
+use wash_runtime::types::{Component, LocalResources, Service, Workload, WorkloadStartRequest};
+
+mod common;
+use common::{http_only_host_interfaces, start_host_with_p3_http_handler};
+
+const SVC_TCP_ECHO_WASM: &[u8] = include_bytes!("wasm/svc_tcp_echo.wasm");
+const HTTP_LOOPBACK_GATEWAY_WASM: &[u8] = include_bytes!("wasm/http_loopback_gateway.wasm");
+
+fn echo_workload(host: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: host.to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(SVC_TCP_ECHO_WASM),
+                local_resources: LocalResources::default(),
+                max_restarts: 0,
+            }),
+            components: vec![Component {
+                name: "http-loopback-gateway".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_LOOPBACK_GATEWAY_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 1000,
+            }],
+            host_interfaces: http_only_host_interfaces(host),
+            volumes: vec![],
+        },
+    }
+}
+
+/// Sequential loopback round-trips complete promptly without any tick in the
+/// service. Requests are strictly serialized (each awaited before the next),
+/// so a service whose spawned tasks need an unrelated host event to progress
+/// has nothing to re-enter it — the request would hang until the timeout.
+#[tokio::test]
+async fn test_tickless_loopback_service_answers_promptly() -> Result<()> {
+    let host_name = "loopback-echo";
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    host.workload_start(echo_workload(host_name))
+        .await
+        .context("failed to start loopback echo workload")?;
+
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()?;
+
+    for i in 0..5 {
+        let started = Instant::now();
+        let resp = timeout(
+            Duration::from_secs(5),
+            client
+                .get(format!("http://{addr}/"))
+                .header("HOST", host_name)
+                .send(),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "request {i} did not complete: the echo service's spawned tasks \
+                 were not driven without an unrelated host event"
+            )
+        })??;
+        anyhow::ensure!(
+            resp.status().is_success(),
+            "request {i} failed: {}",
+            resp.status()
+        );
+        let body = resp.text().await?;
+        anyhow::ensure!(
+            body == "echo:ping",
+            "request {i} returned unexpected body {body:?}"
+        );
+        // Well under the timeout: catch "slow but not hung" regressions too.
+        let elapsed = started.elapsed();
+        anyhow::ensure!(
+            elapsed < Duration::from_secs(2),
+            "request {i} took {elapsed:?}; loopback round-trips should be fast"
+        );
+    }
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -116,6 +116,7 @@ const P3_FIXTURES: &[&str] = &[
     "keyvalue-default-p3",
     "postgres-stream-p3",
     "svc-counter",
+    "svc-http-proxy",
     "msg-counter",
     "bridge-backend",
     "bridge-service",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -117,6 +117,8 @@ const P3_FIXTURES: &[&str] = &[
     "postgres-stream-p3",
     "svc-counter",
     "svc-http-proxy",
+    "svc-tcp-echo",
+    "http-loopback-gateway",
     "msg-counter",
     "bridge-backend",
     "bridge-service",


### PR DESCRIPTION
Criterion bench suite (service_http) for the service HTTP plane. A long-lived p3 instance co-driving wasi:cli/run with wasi:http/handler, served through the ingress channel instead of per-request instantiation:

- cold start: host build + service workload start + first request (teardown runs per iteration but outside the timed window)
- hot invocation: steady-state latency against the warm instance
- throughput: RPS with 32 concurrent clients against the one instance
- service -> component: the service forwards each request through its wasi:http/client import to an HTTP component workload on a second host (allowed-hosts policy -> egress -> TCP -> router -> per-request instance), measured against both P2 and P3 backends

Adds the svc-http-proxy fixture: a p3 trigger service that proxies a request carrying an `x-backend` header to that authority and answers directly without one. A malformed header is an error, never a silent fallback to the faster direct path.

The gungraun bench gains a matching `service` group (hot_service, service_to_component, cold_service) for instruction-count regression tracking in CI.

Shared bench plumbing moves to benches/common: host/workload builders, request helpers with a 30s bound so a wedged host fails loudly, and a BenchHost handle whose shutdown stops the workload before the host — dropping a host does not abort a running service driver, and leaked instances accumulate until the process aborts.

Run locally: `cargo bench -p wash-runtime --bench service_http`