### PR TITLE
feat(runtime): warm-instance pooling (pool_size / max_invocations)

### DIFF
--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -1,0 +1,173 @@
+//! Warm-instance pooling for ephemeral linked calls.
+//!
+//! By default a plain-value linked call runs in a store that is built,
+//! instantiated, invoked and dropped per call (see
+//! [`crate::engine::linked_call`]). That keeps component state ephemeral —
+//! the contract a `Component` is defined by — but it also means the guest
+//! rebuilds everything it caches in linear memory on every call: connection
+//! pools, lazily-built runtimes, parsed configuration.
+//!
+//! A component that sets `pool_size > 0` opts out of that: after a call
+//! returns cleanly its store is parked here and the next call to the same
+//! component reuses it, skipping the context build, the [`wasmtime::Store`]
+//! allocation and the instantiation. Guest state then survives across calls,
+//! which is the entire point — but it is also why pooling is opt-in rather
+//! than the default.
+//!
+//! Two rules bound how long any single instance lives:
+//!
+//!  * `max_invocations` retires an instance after it has served that many
+//!    calls (zero means no limit), so guest state cannot accumulate forever
+//!    and a workload still exercises the cold path it will hit in production.
+//!  * An instance is parked **only** after a call that returned cleanly. A
+//!    trap, a timeout, a host error, or a caller that was cancelled mid-call
+//!    all retire the store instead, because a guest interrupted partway
+//!    through a call may hold locks, half-written buffers or a protocol peer
+//!    in an indeterminate state.
+//!
+//! Two further consequences of an instance outliving a call, both of which a
+//! component opts into along with the pooling:
+//!
+//!  * The context it was built with (environment, config, resolved volume
+//!    mounts) is frozen for its lifetime. `max_invocations` bounds how stale
+//!    that can get.
+//!  * A task the guest spawned but did not await lives on the store's
+//!    concurrent state. Dropping the store per call used to discard it; a
+//!    parked store carries it to the next call, where it resumes alongside
+//!    that call's work. A guest that spawns background work and relies on it
+//!    being torn down with the call should not be pooled.
+
+use std::sync::Mutex;
+
+use wasmtime::component::Instance;
+
+use crate::engine::ctx::SharedCtx;
+
+/// A store that has been instantiated and is parked between calls.
+pub(crate) struct WarmInstance {
+    pub(crate) store: wasmtime::Store<SharedCtx>,
+    pub(crate) instance: Instance,
+    /// Calls this instance has already served, counted against
+    /// [`InstancePool::max_invocations`].
+    pub(crate) invocations: usize,
+}
+
+/// The warm instances of one component, shared by every clone of its
+/// [`crate::engine::workload::WorkloadComponent`] and therefore by every
+/// importer that calls into it.
+pub(crate) struct InstancePool {
+    idle: Mutex<Vec<WarmInstance>>,
+    /// How many warm instances to park. Zero disables pooling: every call
+    /// builds and drops its own store.
+    pool_size: usize,
+    /// Calls an instance serves before it is retired. Zero means unlimited.
+    max_invocations: usize,
+}
+
+impl InstancePool {
+    /// Build a pool from a component's configured limits. Both fields are
+    /// `sint32` on the wire and are `-1` when unset, so anything below zero
+    /// reads as "not configured".
+    pub(crate) fn new(pool_size: i32, max_invocations: i32) -> Self {
+        Self {
+            idle: Mutex::new(Vec::new()),
+            pool_size: pool_size.max(0) as usize,
+            max_invocations: max_invocations.max(0) as usize,
+        }
+    }
+
+    /// Whether this component keeps instances warm at all.
+    pub(crate) fn enabled(&self) -> bool {
+        self.pool_size > 0
+    }
+
+    /// Take a warm instance if one is parked. Returns `None` when pooling is
+    /// disabled or every warm instance is already in use — the caller then
+    /// builds a fresh store, so a burst past `pool_size` is served rather
+    /// than queued.
+    pub(crate) fn checkout(&self) -> Option<WarmInstance> {
+        if !self.enabled() {
+            return None;
+        }
+        self.idle.lock().ok()?.pop()
+    }
+
+    /// Park an instance that has just served a call cleanly, unless it has
+    /// reached `max_invocations` or the warm set is already full. Anything
+    /// not parked is dropped here.
+    pub(crate) fn release(&self, mut warm: WarmInstance) {
+        warm.invocations += 1;
+        if !self.enabled() {
+            return;
+        }
+        if self.max_invocations > 0 && warm.invocations >= self.max_invocations {
+            trace_retire("reached max_invocations", warm.invocations);
+            return;
+        }
+        // Drop the guard before the `WarmInstance` it rejected: dropping a
+        // store tears down the guest's resources and should not hold the pool
+        // shut while it runs.
+        let rejected = {
+            let Ok(mut idle) = self.idle.lock() else {
+                return;
+            };
+            if idle.len() < self.pool_size {
+                idle.push(warm);
+                None
+            } else {
+                Some(warm)
+            }
+        };
+        if let Some(warm) = rejected {
+            trace_retire("warm set full", warm.invocations);
+        }
+    }
+
+    /// Drop every parked instance, e.g. when the component is being shut
+    /// down. In-flight calls are unaffected; they own their stores.
+    pub(crate) fn clear(&self) {
+        let parked = match self.idle.lock() {
+            Ok(mut idle) => std::mem::take(&mut *idle),
+            Err(_) => return,
+        };
+        drop(parked);
+    }
+
+    /// How many instances are parked right now. Test/observability only.
+    #[cfg(test)]
+    pub(crate) fn idle_len(&self) -> usize {
+        self.idle.lock().map(|idle| idle.len()).unwrap_or(0)
+    }
+}
+
+fn trace_retire(reason: &str, invocations: usize) {
+    tracing::trace!(reason, invocations, "retiring warm instance");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InstancePool;
+
+    #[test]
+    fn disabled_by_default() {
+        let pool = InstancePool::new(0, 0);
+        assert!(!pool.enabled());
+        assert!(pool.checkout().is_none());
+    }
+
+    #[test]
+    fn unset_limits_read_as_disabled() {
+        // `wash dev` and the operator send -1 for "not configured".
+        let pool = InstancePool::new(-1, -1);
+        assert!(!pool.enabled());
+    }
+
+    #[test]
+    fn enabled_pool_starts_empty() {
+        let pool = InstancePool::new(4, 0);
+        assert!(pool.enabled());
+        assert_eq!(pool.idle_len(), 0);
+        // Nothing parked yet, so a checkout still falls back to a cold store.
+        assert!(pool.checkout().is_none());
+    }
+}

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -37,11 +37,49 @@
 //!    that call's work. A guest that spawns background work and relies on it
 //!    being torn down with the call should not be pooled.
 
-use std::sync::Mutex;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 
 use wasmtime::component::Instance;
 
 use crate::engine::ctx::SharedCtx;
+use crate::engine::workload::WorkloadComponent;
+
+/// The pool that `component_id`'s store may be parked in, or `None` when it
+/// must not be parked at all.
+///
+/// A store holds more than the one component: whatever that component is
+/// linked to is instantiated alongside it and lives exactly as long as the
+/// store does. Parking the store therefore keeps *every* instance in it warm,
+/// so every one of those components has to have opted in. Otherwise a
+/// component that left `pool_size` at zero — saying its state is ephemeral —
+/// would quietly acquire state that outlives a call, just because something
+/// else in the workload imports it.
+pub(crate) fn poolable(
+    components: &HashMap<Arc<str>, WorkloadComponent>,
+    component_id: &str,
+    linked: &HashSet<Arc<str>>,
+) -> Option<Arc<InstancePool>> {
+    let pool = Arc::clone(&components.get(component_id)?.instances);
+    if !pool.enabled() {
+        return None;
+    }
+    for linked_id in linked {
+        let linked_enabled = components
+            .get(linked_id)
+            .is_some_and(|c| c.instances.enabled());
+        if !linked_enabled {
+            tracing::debug!(
+                component_id,
+                linked_id = linked_id.as_ref(),
+                "not keeping instances warm: a linked component has not opted into pooling, \
+                 and it shares the store's lifetime"
+            );
+            return None;
+        }
+    }
+    Some(pool)
+}
 
 /// A store that has been instantiated and is parked between calls.
 pub(crate) struct WarmInstance {

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -1,18 +1,19 @@
-//! Warm-instance pooling for ephemeral linked calls.
+//! Instance pooling.
 //!
-//! By default a plain-value linked call runs in a store that is built,
-//! instantiated, invoked and dropped per call (see
-//! [`crate::engine::linked_call`]). That keeps component state ephemeral —
-//! the contract a `Component` is defined by — but it also means the guest
-//! rebuilds everything it caches in linear memory on every call: connection
-//! pools, lazily-built runtimes, parsed configuration.
+//! By default a call runs in a store that is built, instantiated, invoked and
+//! dropped per call, on the linked-call path (see
+//! [`crate::engine::linked_call`]) and on HTTP dispatch alike. That keeps
+//! component state ephemeral, which is the contract a `Component` is defined
+//! by, but it also means the guest rebuilds everything it caches in linear
+//! memory on every call: connection pools, lazily-built runtimes, parsed
+//! configuration.
 //!
-//! A component that sets `pool_size > 0` opts out of that: after a call
-//! returns cleanly its store is parked here and the next call to the same
-//! component reuses it, skipping the context build, the [`wasmtime::Store`]
-//! allocation and the instantiation. Guest state then survives across calls,
-//! which is the entire point — but it is also why pooling is opt-in rather
-//! than the default.
+//! A component whose [`InstancePolicy`] is [`InstancePolicy::Warm`] opts out
+//! of that: after a call returns cleanly its store is parked here and the next
+//! call to the same component reuses it, skipping the context build, the
+//! [`wasmtime::Store`] allocation and the instantiation. Guest state then
+//! survives across calls, which is the entire point — but it is also why
+//! pooling is opt-in rather than the default.
 //!
 //! Two rules bound how long any single instance lives:
 //!
@@ -38,12 +39,14 @@
 //!    being torn down with the call should not be pooled.
 
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 
 use wasmtime::component::Instance;
 
 use crate::engine::ctx::SharedCtx;
 use crate::engine::workload::WorkloadComponent;
+use crate::types::Component;
 
 /// The pool that `component_id`'s store may be parked in, or `None` when it
 /// must not be parked at all.
@@ -81,49 +84,97 @@ pub(crate) fn poolable(
     Some(pool)
 }
 
-/// A store that has been instantiated and is parked between calls.
-pub(crate) struct WarmInstance {
+/// An instantiated component in its own store: what a call runs on, and what
+/// the pool parks between calls when the component keeps instances warm.
+pub(crate) struct ComponentInstance {
     pub(crate) store: wasmtime::Store<SharedCtx>,
     pub(crate) instance: Instance,
     /// Calls this instance has already served, counted against
-    /// [`InstancePool::max_invocations`].
+    /// [`InstancePolicy::Warm::max_invocations`].
     pub(crate) invocations: usize,
+}
+
+/// What a component asked for by way of instance reuse.
+///
+/// `Component.pool_size` and `Component.max_invocations` arrive as `sint32`
+/// and carry two sentinels between them — negative for "the sender did not
+/// configure this" and zero for "no limit" — so they are decoded into this
+/// once, at the edge, rather than being re-interpreted at each use.
+/// Non-exhaustive in both directions on purpose: the limits a component can
+/// state are expected to grow (how many calls one warm instance may serve at
+/// once is next), and neither adding a variant nor adding a field to one
+/// should be a breaking change. Build one with [`InstancePolicy::from_component`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InstancePolicy {
+    /// No instance outlives the call it served. The default, and what keeps a
+    /// component's state ephemeral.
+    Ephemeral,
+    /// Park up to `pool_size` instances between calls, retiring each once it
+    /// has served `max_invocations` of them.
+    #[non_exhaustive]
+    Warm {
+        pool_size: NonZeroUsize,
+        /// `None` when an instance may serve calls indefinitely.
+        max_invocations: Option<NonZeroUsize>,
+    },
+}
+
+impl InstancePolicy {
+    /// Read the policy a component declared.
+    ///
+    /// Takes the whole component rather than its limits so that a limit added
+    /// to [`Component`] later reaches this without changing the signature.
+    pub fn from_component(component: &Component) -> Self {
+        Self::from_limits(component.pool_size, component.max_invocations)
+    }
+
+    /// Decode the wire pair. Anything that does not name a positive pool size,
+    /// whether unset (`-1`), zero or negative, means instances are not kept.
+    pub(crate) fn from_limits(pool_size: i32, max_invocations: i32) -> Self {
+        match usize::try_from(pool_size).ok().and_then(NonZeroUsize::new) {
+            Some(pool_size) => Self::Warm {
+                pool_size,
+                max_invocations: usize::try_from(max_invocations)
+                    .ok()
+                    .and_then(NonZeroUsize::new),
+            },
+            None => Self::Ephemeral,
+        }
+    }
+
+    /// Whether this component keeps instances warm at all.
+    pub fn keeps_instances_warm(&self) -> bool {
+        matches!(self, Self::Warm { .. })
+    }
 }
 
 /// The warm instances of one component, shared by every clone of its
 /// [`crate::engine::workload::WorkloadComponent`] and therefore by every
 /// importer that calls into it.
 pub(crate) struct InstancePool {
-    idle: Mutex<Vec<WarmInstance>>,
-    /// How many warm instances to park. Zero disables pooling: every call
-    /// builds and drops its own store.
-    pool_size: usize,
-    /// Calls an instance serves before it is retired. Zero means unlimited.
-    max_invocations: usize,
+    idle: Mutex<Vec<ComponentInstance>>,
+    policy: InstancePolicy,
 }
 
 impl InstancePool {
-    /// Build a pool from a component's configured limits. Both fields are
-    /// `sint32` on the wire and are `-1` when unset, so anything below zero
-    /// reads as "not configured".
-    pub(crate) fn new(pool_size: i32, max_invocations: i32) -> Self {
+    pub(crate) fn new(policy: InstancePolicy) -> Self {
         Self {
             idle: Mutex::new(Vec::new()),
-            pool_size: pool_size.max(0) as usize,
-            max_invocations: max_invocations.max(0) as usize,
+            policy,
         }
     }
 
     /// Whether this component keeps instances warm at all.
     pub(crate) fn enabled(&self) -> bool {
-        self.pool_size > 0
+        self.policy.keeps_instances_warm()
     }
 
     /// Take a warm instance if one is parked. Returns `None` when pooling is
     /// disabled or every warm instance is already in use — the caller then
     /// builds a fresh store, so a burst past `pool_size` is served rather
     /// than queued.
-    pub(crate) fn checkout(&self) -> Option<WarmInstance> {
+    pub(crate) fn checkout(&self) -> Option<ComponentInstance> {
         if !self.enabled() {
             return None;
         }
@@ -133,31 +184,35 @@ impl InstancePool {
     /// Park an instance that has just served a call cleanly, unless it has
     /// reached `max_invocations` or the warm set is already full. Anything
     /// not parked is dropped here.
-    pub(crate) fn release(&self, mut warm: WarmInstance) {
-        warm.invocations += 1;
-        if !self.enabled() {
+    pub(crate) fn release(&self, mut instance: ComponentInstance) {
+        instance.invocations += 1;
+        let InstancePolicy::Warm {
+            pool_size,
+            max_invocations,
+        } = self.policy
+        else {
+            return;
+        };
+        if max_invocations.is_some_and(|limit| instance.invocations >= limit.get()) {
+            trace_retire("reached max_invocations", instance.invocations);
             return;
         }
-        if self.max_invocations > 0 && warm.invocations >= self.max_invocations {
-            trace_retire("reached max_invocations", warm.invocations);
-            return;
-        }
-        // Drop the guard before the `WarmInstance` it rejected: dropping a
-        // store tears down the guest's resources and should not hold the pool
-        // shut while it runs.
+        // Drop the guard before the instance it rejected: dropping a store
+        // tears down the guest's resources and should not hold the pool shut
+        // while it runs.
         let rejected = {
             let Ok(mut idle) = self.idle.lock() else {
                 return;
             };
-            if idle.len() < self.pool_size {
-                idle.push(warm);
+            if idle.len() < pool_size.get() {
+                idle.push(instance);
                 None
             } else {
-                Some(warm)
+                Some(instance)
             }
         };
-        if let Some(warm) = rejected {
-            trace_retire("warm set full", warm.invocations);
+        if let Some(instance) = rejected {
+            trace_retire("warm set full", instance.invocations);
         }
     }
 
@@ -184,25 +239,58 @@ fn trace_retire(reason: &str, invocations: usize) {
 
 #[cfg(test)]
 mod tests {
-    use super::InstancePool;
+    use super::{InstancePolicy, InstancePool, NonZeroUsize};
+
+    /// Zero, and the `-1` that `wash dev` and the operator send for "not
+    /// configured", both mean instances are not kept.
+    #[test]
+    fn absent_or_zero_pool_size_is_ephemeral() {
+        for pool_size in [0, -1, i32::MIN] {
+            assert_eq!(
+                InstancePolicy::from_limits(pool_size, 0),
+                InstancePolicy::Ephemeral,
+                "pool_size {pool_size} should not keep instances"
+            );
+        }
+    }
+
+    /// A positive pool size keeps instances; zero or unset `max_invocations`
+    /// means an instance may serve calls indefinitely.
+    #[test]
+    fn positive_pool_size_is_warm() {
+        assert_eq!(
+            InstancePolicy::from_limits(4, 0),
+            InstancePolicy::Warm {
+                pool_size: NonZeroUsize::new(4).unwrap(),
+                max_invocations: None,
+            }
+        );
+        assert_eq!(
+            InstancePolicy::from_limits(4, -1),
+            InstancePolicy::Warm {
+                pool_size: NonZeroUsize::new(4).unwrap(),
+                max_invocations: None,
+            }
+        );
+        assert_eq!(
+            InstancePolicy::from_limits(2, 50),
+            InstancePolicy::Warm {
+                pool_size: NonZeroUsize::new(2).unwrap(),
+                max_invocations: NonZeroUsize::new(50),
+            }
+        );
+    }
 
     #[test]
-    fn disabled_by_default() {
-        let pool = InstancePool::new(0, 0);
+    fn disabled_pool_never_checks_out() {
+        let pool = InstancePool::new(InstancePolicy::Ephemeral);
         assert!(!pool.enabled());
         assert!(pool.checkout().is_none());
     }
 
     #[test]
-    fn unset_limits_read_as_disabled() {
-        // `wash dev` and the operator send -1 for "not configured".
-        let pool = InstancePool::new(-1, -1);
-        assert!(!pool.enabled());
-    }
-
-    #[test]
     fn enabled_pool_starts_empty() {
-        let pool = InstancePool::new(4, 0);
+        let pool = InstancePool::new(InstancePolicy::from_limits(4, 0));
         assert!(pool.enabled());
         assert_eq!(pool.idle_len(), 0);
         // Nothing parked yet, so a checkout still falls back to a cold store.

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -17,7 +17,7 @@
 //! assemble the store (pre-instantiating the linked components). See
 //! [`EphemeralLinkedCall`] for how the ephemeral path is captured at link time.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -34,7 +34,7 @@ use wasmtime_wasi::WasiCtxBuilder;
 #[cfg(feature = "wasi-tls")]
 use crate::engine::ctx::SharedTlsProvider;
 use crate::engine::ctx::{AccessorActiveCtxGuard, Ctx, SharedCtx, StoreActiveCtxGuard};
-use crate::engine::instance_pool::{InstancePool, WarmInstance};
+use crate::engine::instance_pool::{self, InstancePool, WarmInstance};
 use crate::engine::store::relocate::{self, Relocated, bridgeable_element_type};
 use crate::engine::store::stream_pump::Done;
 use crate::engine::value::{carries_cross_store_handle, lift_results, lower_params};
@@ -341,15 +341,16 @@ pub(crate) async fn new_store_from_templates(
 }
 
 /// The warm-instance pool of the component this call targets, or `None` when
-/// that component has not opted into pooling.
+/// this store must not be parked — see [`instance_pool::poolable`], which also
+/// accounts for the linked components instantiated into the same store.
 ///
 /// Read from the component map per call rather than captured at link time, so
 /// a component whose entry is replaced does not keep serving from a pool that
 /// belongs to the old entry.
 async fn callee_instance_pool(call: &EphemeralLinkedCall) -> Option<Arc<InstancePool>> {
     let components = call.components.read().await;
-    let pool = Arc::clone(&components.get(&call.active_component_id)?.instances);
-    pool.enabled().then_some(pool)
+    let linked: HashSet<Arc<str>> = call.linked_component_ids.iter().cloned().collect();
+    instance_pool::poolable(&components, &call.active_component_id, &linked)
 }
 
 async fn new_ephemeral_store(

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -34,6 +34,7 @@ use wasmtime_wasi::WasiCtxBuilder;
 #[cfg(feature = "wasi-tls")]
 use crate::engine::ctx::SharedTlsProvider;
 use crate::engine::ctx::{AccessorActiveCtxGuard, Ctx, SharedCtx, StoreActiveCtxGuard};
+use crate::engine::instance_pool::{InstancePool, WarmInstance};
 use crate::engine::store::relocate::{self, Relocated, bridgeable_element_type};
 use crate::engine::store::stream_pump::Done;
 use crate::engine::value::{carries_cross_store_handle, lift_results, lower_params};
@@ -337,6 +338,18 @@ pub(crate) async fn new_store_from_templates(
     }
 
     Ok(store)
+}
+
+/// The warm-instance pool of the component this call targets, or `None` when
+/// that component has not opted into pooling.
+///
+/// Read from the component map per call rather than captured at link time, so
+/// a component whose entry is replaced does not keep serving from a pool that
+/// belongs to the old entry.
+async fn callee_instance_pool(call: &EphemeralLinkedCall) -> Option<Arc<InstancePool>> {
+    let components = call.components.read().await;
+    let pool = Arc::clone(&components.get(&call.active_component_id)?.instances);
+    pool.enabled().then_some(pool)
 }
 
 async fn new_ephemeral_store(
@@ -643,23 +656,53 @@ async fn invoke_ephemeral_relocated(
     Ok(())
 }
 
-/// Run a plain-value async linked call in a short-lived store that is dropped
-/// (reclaiming its core-instance slots) as soon as the call returns.
+/// Run a plain-value async linked call.
+///
+/// The store is short-lived by default: built, invoked, and dropped per call
+/// so its core-instance slots are reclaimed immediately. A component that has
+/// opted into warm instances (`pool_size > 0`) instead reuses one parked by an
+/// earlier call and, if the call returns cleanly, parks it again — skipping
+/// the context build, the store allocation and the instantiation, and letting
+/// the guest keep whatever it cached in linear memory. See
+/// [`InstancePool`] for the rules that bound how long an instance lives.
 async fn invoke_ephemeral_plain(
     params: &[Val],
     results: &mut [Val],
     inv: &LinkedExportInvocation,
     ephemeral_call: &EphemeralLinkedCall,
 ) -> wasmtime::Result<()> {
-    let mut store = new_ephemeral_store(ephemeral_call)
-        .await
-        .map_err(|e| wasmtime::format_err!("{e:#}"))?;
+    let pool = callee_instance_pool(ephemeral_call).await;
+
+    // A warm instance if one is parked, otherwise a cold store. A burst past
+    // `pool_size` is served cold rather than queued, so pooling never adds
+    // latency it did not save.
+    let warm = match pool.as_ref().and_then(|pool| pool.checkout()) {
+        Some(warm) => {
+            trace!(
+                name = %inv.import_name,
+                fn_name = %inv.export_name,
+                invocations = warm.invocations,
+                "reusing warm instance for ephemeral dynamic export"
+            );
+            warm
+        }
+        None => {
+            let mut store = new_ephemeral_store(ephemeral_call)
+                .await
+                .map_err(|e| wasmtime::format_err!("{e:#}"))?;
+            let instance = inv.pre.instantiate_async(&mut store).await?;
+            WarmInstance {
+                store,
+                instance,
+                invocations: 0,
+            }
+        }
+    };
 
     let params_buf = params.to_vec();
     let mut results_buf = vec![Val::Bool(false); results.len()];
     let call_import_name = inv.import_name.clone();
     let call_export_name = inv.export_name.clone();
-    let callee_pre = inv.pre.clone();
     let func_idx = inv.func_idx;
 
     trace!(
@@ -669,9 +712,16 @@ async fn invoke_ephemeral_plain(
         "invoking ephemeral dynamic export"
     );
 
+    // The store travels into the task and back out with the result, so a
+    // caller cancelled mid-call (the `AbortOnDrop`) drops the store with the
+    // task instead of returning a half-finished instance to the pool.
     let mut task = AbortOnDrop(tokio::task::spawn(async move {
-        let instance = callee_pre.instantiate_async(&mut store).await?;
-        store
+        let WarmInstance {
+            mut store,
+            instance,
+            invocations,
+        } = warm;
+        let outcome = store
             .run_concurrent(async move |accessor| {
                 let func = accessor.with(|mut access| -> wasmtime::Result<_> {
                     instance.get_func(&mut access, func_idx).with_context(|| {
@@ -692,12 +742,40 @@ async fn invoke_ephemeral_plain(
                 Ok::<Vec<Val>, wasmtime::Error>(results_buf)
             })
             .await
-            .map_err(|e| wasmtime::format_err!("{e:#}"))?
+            .map_err(|e| wasmtime::format_err!("{e:#}"))
+            .and_then(|inner| inner);
+        (
+            WarmInstance {
+                store,
+                instance,
+                invocations,
+            },
+            outcome,
+        )
     }));
-    let call_result = (&mut task.0)
+    let (warm, outcome) = (&mut task.0)
         .await
-        .map_err(|e| wasmtime::format_err!("ephemeral linked call task failed: {e}"));
-    let call_result = call_result??;
+        .map_err(|e| wasmtime::format_err!("ephemeral linked call task failed: {e}"))?;
+
+    // Park only after a clean return. A trap, a timeout or a host error may
+    // have left the guest mid-operation, so those retire the instance — the
+    // next call then starts from a cold store. Anything not parked is dropped
+    // here rather than at the end of the call, so an unpooled component still
+    // reclaims its core-instance slots the moment the call returns.
+    let call_result = match (outcome, pool) {
+        (Ok(vals), Some(pool)) => {
+            pool.release(warm);
+            vals
+        }
+        (Ok(vals), None) => {
+            drop(warm);
+            vals
+        }
+        (Err(e), _) => {
+            drop(warm);
+            return Err(e);
+        }
+    };
 
     for (i, v) in call_result.into_iter().enumerate() {
         *results.get_mut(i).context("result index out of bounds")? = v;

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -34,7 +34,7 @@ use wasmtime_wasi::WasiCtxBuilder;
 #[cfg(feature = "wasi-tls")]
 use crate::engine::ctx::SharedTlsProvider;
 use crate::engine::ctx::{AccessorActiveCtxGuard, Ctx, SharedCtx, StoreActiveCtxGuard};
-use crate::engine::instance_pool::{self, InstancePool, WarmInstance};
+use crate::engine::instance_pool::{self, ComponentInstance, InstancePool};
 use crate::engine::store::relocate::{self, Relocated, bridgeable_element_type};
 use crate::engine::store::stream_pump::Done;
 use crate::engine::value::{carries_cross_store_handle, lift_results, lower_params};
@@ -692,7 +692,7 @@ async fn invoke_ephemeral_plain(
                 .await
                 .map_err(|e| wasmtime::format_err!("{e:#}"))?;
             let instance = inv.pre.instantiate_async(&mut store).await?;
-            WarmInstance {
+            ComponentInstance {
                 store,
                 instance,
                 invocations: 0,
@@ -717,7 +717,7 @@ async fn invoke_ephemeral_plain(
     // caller cancelled mid-call (the `AbortOnDrop`) drops the store with the
     // task instead of returning a half-finished instance to the pool.
     let mut task = AbortOnDrop(tokio::task::spawn(async move {
-        let WarmInstance {
+        let ComponentInstance {
             mut store,
             instance,
             invocations,
@@ -746,7 +746,7 @@ async fn invoke_ephemeral_plain(
             .map_err(|e| wasmtime::format_err!("{e:#}"))
             .and_then(|inner| inner);
         (
-            WarmInstance {
+            ComponentInstance {
                 store,
                 instance,
                 invocations,

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -218,6 +218,7 @@ pub fn targets_wasip3_http(component: &Component) -> bool {
 }
 
 pub mod ctx;
+mod instance_pool;
 mod linked_call;
 pub(crate) mod store;
 mod value;
@@ -557,9 +558,8 @@ impl Engine {
             component_volume_mounts,
             component.local_resources,
             loopback,
-            // TODO: implement pooling and instance limits
-            // component.pool_size,
-            // component.max_invocations,
+            component.pool_size,
+            component.max_invocations,
         ))
     }
 

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -219,6 +219,7 @@ pub fn targets_wasip3_http(component: &Component) -> bool {
 
 pub mod ctx;
 pub(crate) mod instance_pool;
+pub use instance_pool::InstancePolicy;
 mod linked_call;
 pub(crate) mod store;
 mod value;
@@ -514,6 +515,9 @@ impl Engine {
         validated_volumes: &std::collections::HashMap<String, PathBuf>,
         loopback: Arc<std::sync::Mutex<loopback::Network>>,
     ) -> anyhow::Result<WorkloadComponent> {
+        // Read before the component's fields are moved out below.
+        let instances = InstancePolicy::from_component(&component);
+
         // Create a wasmtime component from the bytes
         let wasmtime_component = self
             .load_component_bytes(component.bytes, component.digest)
@@ -558,8 +562,7 @@ impl Engine {
             component_volume_mounts,
             component.local_resources,
             loopback,
-            component.pool_size,
-            component.max_invocations,
+            instances,
         ))
     }
 

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -218,7 +218,7 @@ pub fn targets_wasip3_http(component: &Component) -> bool {
 }
 
 pub mod ctx;
-mod instance_pool;
+pub(crate) mod instance_pool;
 mod linked_call;
 pub(crate) mod store;
 mod value;

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -22,6 +22,7 @@ use crate::engine::ctx::SharedTlsProvider;
 use crate::{
     engine::{
         ctx::SharedCtx,
+        instance_pool::InstancePool,
         linked_call::{
             ComponentCtxTemplate, EphemeralCallMode, EphemeralLinkedCall, LinkedExportInvocation,
             func_is_bridge_safe, func_is_ephemeral_safe, invoke_linked_async_export,
@@ -345,15 +346,19 @@ pub struct WorkloadComponent {
     name: Arc<str>,
     /// The [`WorkloadMetadata`] for this component
     pub(crate) metadata: WorkloadMetadata,
-    /// The number of warm instances to keep for this component
-    pool_size: usize,
-    /// The maximum number of concurrent invocations allowed for this component
-    max_invocations: usize,
+    /// Instances kept warm between ephemeral linked calls. Shared by every
+    /// clone of this component, so all importers draw on the one warm set.
+    pub(crate) instances: Arc<InstancePool>,
 }
 
 impl WorkloadComponent {
     /// Create a new [`WorkloadComponent`] with the given workload ID,
     /// wasmtime [`Component`], [`Linker`], volume mounts, and instance limits.
+    ///
+    /// `pool_size` and `max_invocations` are the component's warm-instance
+    /// limits; both are `-1` when unset. `pool_size` of zero (or unset) keeps
+    /// the default behavior of a fresh store per linked call — see
+    /// [`InstancePool`] for what opting in changes.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         workload_id: impl Into<Arc<str>>,
@@ -365,6 +370,8 @@ impl WorkloadComponent {
         volume_mounts: Vec<(PathBuf, VolumeMount)>,
         local_resources: LocalResources,
         loopback: Arc<std::sync::Mutex<loopback::Network>>,
+        pool_size: i32,
+        max_invocations: i32,
     ) -> Self {
         Self {
             metadata: WorkloadMetadata {
@@ -382,9 +389,7 @@ impl WorkloadComponent {
                 linked_components: Default::default(),
             },
             name: component_name.into(),
-            // TODO: Implement pooling and instance limits
-            pool_size: 0,
-            max_invocations: 0,
+            instances: Arc::new(InstancePool::new(pool_size, max_invocations)),
         }
     }
 
@@ -458,8 +463,7 @@ impl std::fmt::Debug for WorkloadComponent {
             .field("id", &self.metadata.id.as_ref())
             .field("workload_id", &self.metadata.workload_id.as_ref())
             .field("volume_mounts", &self.metadata.volume_mounts)
-            .field("pool_size", &self.pool_size)
-            .field("max_invocations", &self.max_invocations)
+            .field("warm_instances", &self.instances.enabled())
             .finish()
     }
 }
@@ -1557,6 +1561,12 @@ impl ResolvedWorkload {
         );
 
         for component in self.components.read().await.values() {
+            // Warm instances hold guest resources (sockets, open files) for as
+            // long as they stay parked, so release them with the rest of the
+            // workload's teardown. Calls still in flight own their own stores
+            // and are unaffected.
+            component.instances.clear();
+
             if let Some(plugins) = component.plugins() {
                 for (plugin_id, plugin) in plugins.iter() {
                     trace!(
@@ -2533,6 +2543,8 @@ mod tests {
             Vec::new(),
             local_resources,
             Arc::default(),
+            0,
+            0,
         )
     }
 
@@ -2594,6 +2606,8 @@ mod tests {
             Vec::new(),
             local_resources,
             Arc::default(),
+            0,
+            0,
         )
     }
 
@@ -2685,6 +2699,8 @@ mod tests {
                 Vec::new(),
                 LocalResources::default(),
                 Arc::default(),
+                0,
+                0,
             )
         };
         for (plugin, iface) in cases {
@@ -2944,6 +2960,8 @@ mod tests {
             Vec::new(),
             LocalResources::default(),
             Arc::default(),
+            0,
+            0,
         );
 
         let mut http_interface = WitInterface::from("wasi:http/handler");

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -22,7 +22,7 @@ use crate::engine::ctx::SharedTlsProvider;
 use crate::{
     engine::{
         ctx::SharedCtx,
-        instance_pool::{self, InstancePool},
+        instance_pool::{self, InstancePolicy, InstancePool},
         linked_call::{
             ComponentCtxTemplate, EphemeralCallMode, EphemeralLinkedCall, LinkedExportInvocation,
             func_is_bridge_safe, func_is_ephemeral_safe, invoke_linked_async_export,
@@ -355,10 +355,10 @@ impl WorkloadComponent {
     /// Create a new [`WorkloadComponent`] with the given workload ID,
     /// wasmtime [`Component`], [`Linker`], volume mounts, and instance limits.
     ///
-    /// `pool_size` and `max_invocations` are the component's warm-instance
-    /// limits; both are `-1` when unset. `pool_size` of zero (or unset) keeps
-    /// the default behavior of a fresh store per linked call — see
-    /// [`InstancePool`] for what opting in changes.
+    /// `instances` is what the component asked for by way of instance reuse.
+    /// [`InstancePolicy::Ephemeral`] keeps the default behavior of a fresh
+    /// store per call; [`InstancePolicy::Warm`] parks instances between calls
+    /// so guest state survives them.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         workload_id: impl Into<Arc<str>>,
@@ -370,8 +370,7 @@ impl WorkloadComponent {
         volume_mounts: Vec<(PathBuf, VolumeMount)>,
         local_resources: LocalResources,
         loopback: Arc<std::sync::Mutex<loopback::Network>>,
-        pool_size: i32,
-        max_invocations: i32,
+        instances: InstancePolicy,
     ) -> Self {
         Self {
             metadata: WorkloadMetadata {
@@ -389,7 +388,7 @@ impl WorkloadComponent {
                 linked_components: Default::default(),
             },
             name: component_name.into(),
-            instances: Arc::new(InstancePool::new(pool_size, max_invocations)),
+            instances: Arc::new(InstancePool::new(instances)),
         }
     }
 
@@ -463,7 +462,7 @@ impl std::fmt::Debug for WorkloadComponent {
             .field("id", &self.metadata.id.as_ref())
             .field("workload_id", &self.metadata.workload_id.as_ref())
             .field("volume_mounts", &self.metadata.volume_mounts)
-            .field("warm_instances", &self.instances.enabled())
+            .field("has_warm_instances", &self.instances.enabled())
             .finish()
     }
 }
@@ -1472,7 +1471,7 @@ impl ResolvedWorkload {
     /// The component's linked components are instantiated into the same store
     /// by [`Self::new_store`] and live exactly as long as it does, so they have
     /// to have opted in too — see [`instance_pool::poolable`].
-    pub(crate) async fn instance_pool_for(
+    pub(crate) async fn instance_pool_for_component(
         &self,
         component_id: &str,
     ) -> Option<Arc<InstancePool>> {
@@ -2562,8 +2561,7 @@ mod tests {
             Vec::new(),
             local_resources,
             Arc::default(),
-            0,
-            0,
+            InstancePolicy::Ephemeral,
         )
     }
 
@@ -2625,8 +2623,7 @@ mod tests {
             Vec::new(),
             local_resources,
             Arc::default(),
-            0,
-            0,
+            InstancePolicy::Ephemeral,
         )
     }
 
@@ -2718,8 +2715,7 @@ mod tests {
                 Vec::new(),
                 LocalResources::default(),
                 Arc::default(),
-                0,
-                0,
+                InstancePolicy::Ephemeral,
             )
         };
         for (plugin, iface) in cases {
@@ -2979,8 +2975,7 @@ mod tests {
             Vec::new(),
             LocalResources::default(),
             Arc::default(),
-            0,
-            0,
+            InstancePolicy::Ephemeral,
         );
 
         let mut http_interface = WitInterface::from("wasi:http/handler");

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -22,7 +22,7 @@ use crate::engine::ctx::SharedTlsProvider;
 use crate::{
     engine::{
         ctx::SharedCtx,
-        instance_pool::InstancePool,
+        instance_pool::{self, InstancePool},
         linked_call::{
             ComponentCtxTemplate, EphemeralCallMode, EphemeralLinkedCall, LinkedExportInvocation,
             func_is_bridge_safe, func_is_ephemeral_safe, invoke_linked_async_export,
@@ -1464,6 +1464,25 @@ impl ResolvedWorkload {
             false,
         )
         .await
+    }
+
+    /// The pool a request store for `component_id` may be parked in, or `None`
+    /// when it must be built and dropped per request.
+    ///
+    /// The component's linked components are instantiated into the same store
+    /// by [`Self::new_store`] and live exactly as long as it does, so they have
+    /// to have opted in too — see [`instance_pool::poolable`].
+    pub(crate) async fn instance_pool_for(
+        &self,
+        component_id: &str,
+    ) -> Option<Arc<InstancePool>> {
+        let components = self.components.read().await;
+        let component = components.get(component_id)?;
+        instance_pool::poolable(
+            &components,
+            component_id,
+            &component.metadata.linked_components,
+        )
     }
 
     /// Creates a new wasmtime Store for multiple components from the given workload metadata.

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1627,13 +1627,15 @@ async fn invoke_component_handler(
         // Reuse a warm instance when the component has opted in, otherwise
         // build and instantiate a store for this request alone. A burst past
         // `pool_size` is served cold rather than queued.
-        let pool = workload_handle.instance_pool_for(component_id).await;
+        let pool = workload_handle
+            .instance_pool_for_component(component_id)
+            .await;
         let warm = match pool.as_ref().and_then(|pool| pool.checkout()) {
             Some(warm) => warm,
             None => {
                 let mut store = workload_handle.new_store(component_id).await?;
                 let instance = instance_pre.instantiate_async(&mut store).await?;
-                crate::engine::instance_pool::WarmInstance {
+                crate::engine::instance_pool::ComponentInstance {
                     store,
                     instance,
                     invocations: 0,

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1623,12 +1623,25 @@ async fn invoke_component_handler(
     req: hyper::Request<hyper::body::Incoming>,
     fuel_meter: FuelConsumptionMeter,
 ) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
-    let store = workload_handle.new_store(component_id).await?;
-
     if crate::engine::targets_wasip3_http(instance_pre.component()) {
+        // Reuse a warm instance when the component has opted in, otherwise
+        // build and instantiate a store for this request alone. A burst past
+        // `pool_size` is served cold rather than queued.
+        let pool = workload_handle.instance_pool_for(component_id).await;
+        let warm = match pool.as_ref().and_then(|pool| pool.checkout()) {
+            Some(warm) => warm,
+            None => {
+                let mut store = workload_handle.new_store(component_id).await?;
+                let instance = instance_pre.instantiate_async(&mut store).await?;
+                crate::engine::instance_pool::WarmInstance {
+                    store,
+                    instance,
+                    invocations: 0,
+                }
+            }
+        };
         let resp =
-            crate::host::http_p3::handle_component_request_p3(store, instance_pre, req, fuel_meter)
-                .await?;
+            crate::host::http_p3::handle_component_request_p3(warm, pool, req, fuel_meter).await?;
         let (parts, body) = resp.into_parts();
         let body = HyperOutgoingBody::new(
             body.map_err(|e| {
@@ -1641,6 +1654,10 @@ async fn invoke_component_handler(
         return Ok(hyper::Response::from_parts(parts, body));
     }
 
+    // The p2 path still builds and instantiates per request: its store is
+    // owned by a detached task that outlives the response head, so recovering
+    // it for reuse needs a restructure the p3 path did not.
+    let store = workload_handle.new_store(component_id).await?;
     handle_component_request(store, instance_pre, req, fuel_meter).await
 }
 

--- a/crates/wash-runtime/src/host/http_p3.rs
+++ b/crates/wash-runtime/src/host/http_p3.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use crate::engine::instance_pool::{InstancePool, WarmInstance};
+use crate::engine::instance_pool::{ComponentInstance, InstancePool};
 use crate::observability::FuelConsumptionMeter;
 use http_body_util::BodyExt;
 use tracing::Instrument;
@@ -19,7 +19,7 @@ use wasmtime_wasi_http::p3::bindings::Service;
 use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
 
 /// Body type used on the P3 outgoing path (also used as the return-body type
-/// for [`handle_component_request_p3`]).
+/// for `handle_component_request_p3`).
 pub type P3Body = http_body_util::combinators::UnsyncBoxBody<bytes::Bytes, ErrorCode>;
 
 /// Future returned to the guest to communicate request-side processing errors.
@@ -72,7 +72,7 @@ impl hyper::body::Body for ChannelBody {
 /// applies backpressure to the guest rather than buffering the whole body in
 /// memory.
 pub(crate) async fn handle_component_request_p3(
-    warm: WarmInstance,
+    warm: ComponentInstance,
     pool: Option<Arc<InstancePool>>,
     req: hyper::Request<hyper::body::Incoming>,
     fuel_meter: FuelConsumptionMeter,
@@ -105,7 +105,7 @@ pub(crate) async fn handle_component_request_p3(
     // task is aborted rather than detached to run unbounded.
     let task = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(
         async move {
-            let WarmInstance {
+            let ComponentInstance {
                 mut store,
                 instance,
                 invocations,
@@ -228,7 +228,7 @@ pub(crate) async fn handle_component_request_p3(
             match run {
                 Ok(Ok(())) => {
                     if let Some(pool) = pool {
-                        pool.release(WarmInstance {
+                        pool.release(ComponentInstance {
                             store,
                             instance,
                             invocations,

--- a/crates/wash-runtime/src/host/http_p3.rs
+++ b/crates/wash-runtime/src/host/http_p3.rs
@@ -9,13 +9,13 @@
 //! outgoing-request egress policy itself lives on the unified
 //! [`crate::host::http::OutgoingHandler`] trait via its `send_request_p3` method.
 
-use crate::engine::ctx::SharedCtx;
+use std::sync::Arc;
+
+use crate::engine::instance_pool::{InstancePool, WarmInstance};
 use crate::observability::FuelConsumptionMeter;
 use http_body_util::BodyExt;
 use tracing::Instrument;
-use wasmtime::Store;
-use wasmtime::component::InstancePre;
-use wasmtime_wasi_http::p3::bindings::ServicePre;
+use wasmtime_wasi_http::p3::bindings::Service;
 use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
 
 /// Body type used on the P3 outgoing path (also used as the return-body type
@@ -71,16 +71,13 @@ impl hyper::body::Body for ChannelBody {
 /// guest stays alive until the body has been fully drained, and a slow client
 /// applies backpressure to the guest rather than buffering the whole body in
 /// memory.
-pub async fn handle_component_request_p3(
-    mut store: Store<SharedCtx>,
-    pre: InstancePre<SharedCtx>,
+pub(crate) async fn handle_component_request_p3(
+    warm: WarmInstance,
+    pool: Option<Arc<InstancePool>>,
     req: hyper::Request<hyper::body::Incoming>,
     fuel_meter: FuelConsumptionMeter,
 ) -> anyhow::Result<hyper::Response<P3Body>> {
     let _ = &fuel_meter; // fuel metering integration deferred to match P2's observe() pattern
-
-    let service_pre = ServicePre::new(pre)
-        .map_err(|e| anyhow::anyhow!(e).context("failed to create P3 ServicePre"))?;
 
     // Convert the hyper request body — map error type since hyper::Error doesn't impl Into<ErrorCode>
     let (parts, body) = req.into_parts();
@@ -108,11 +105,19 @@ pub async fn handle_component_request_p3(
     // task is aborted rather than detached to run unbounded.
     let task = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(
         async move {
-            let service = match service_pre.instantiate_async(&mut store).await {
+            let WarmInstance {
+                mut store,
+                instance,
+                invocations,
+            } = warm;
+            // A binding view over the instance, rebuilt per request. Cheap
+            // (export lookups); the expensive part -- the store and the
+            // instantiation -- is what a warm instance carries over.
+            let service = match Service::new(&mut store, &instance) {
                 Ok(service) => service,
                 Err(e) => {
                     let _ = parts_tx.send(Err(
-                        anyhow::anyhow!(e).context("failed to instantiate P3 service")
+                        anyhow::anyhow!(e).context("failed to bind P3 service exports")
                     ));
                     return;
                 }
@@ -214,8 +219,22 @@ pub async fn handle_component_request_p3(
                     handler_result
                 })
                 .await;
+            // Park the instance only after a clean run, and only once the
+            // response body has been fully forwarded -- `run_concurrent` does
+            // not resolve until then, so reaching here means the guest is done
+            // with this request. A client that disconnects mid-body aborts
+            // this task instead, dropping the store with it, so a
+            // half-finished instance is never parked.
             match run {
-                Ok(Ok(())) => {}
+                Ok(Ok(())) => {
+                    if let Some(pool) = pool {
+                        pool.release(WarmInstance {
+                            store,
+                            instance,
+                            invocations,
+                        });
+                    }
+                }
                 Ok(Err(e)) => tracing::error!(err = ?e, "P3 response streaming failed"),
                 Err(e) => tracing::error!(err = ?e, "P3 run_concurrent failed"),
             }

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -762,6 +762,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "svc-no-run"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
 name = "svc-tcp-echo"
 version = "0.0.0"
 dependencies = [

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "svc-http-proxy",
     "svc-tcp-echo",
     "http-loopback-gateway",
+    "svc-no-run",
     "msg-counter",
     "bridge-backend",
     "bridge-service",

--- a/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/src/lib.rs
@@ -8,17 +8,28 @@ mod bindings {
         generate_all,
         async: [
             "export:wasmcloud:ephemeral-test/compute@0.1.0#run",
+            "export:wasmcloud:ephemeral-test/compute@0.1.0#calls",
         ],
     });
 }
 
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use bindings::exports::wasmcloud::ephemeral_test::compute::Guest;
+
+/// Lives in this instance's linear memory, so it starts at zero in every new
+/// instance and survives only for as long as the instance does.
+static CALLS: AtomicU32 = AtomicU32::new(0);
 
 struct Component;
 
 impl Guest for Component {
     async fn run(n: u32) -> u32 {
         n.wrapping_mul(2).wrapping_add(1)
+    }
+
+    async fn calls() -> u32 {
+        CALLS.fetch_add(1, Ordering::Relaxed) + 1
     }
 }
 

--- a/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/wit/world.wit
@@ -6,6 +6,12 @@ interface compute {
     /// dispatches a call to it through the *ephemeral store* path
     /// (instantiate-call-drop in a throwaway store).
     run: async func(n: u32) -> u32;
+
+    /// Count of calls this *instance* has served, incremented per call and
+    /// held in the guest's linear memory. It reports `1` every time when each
+    /// call gets a fresh instance, and climbs when the instance is kept warm
+    /// and reused (`pool_size > 0`), so it reveals which path a call took.
+    calls: async func() -> u32;
 }
 
 world ephemeral-callee {

--- a/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/src/lib.rs
@@ -10,6 +10,7 @@ mod bindings {
         generate_all,
         async: [
             "import:wasmcloud:ephemeral-test/compute@0.1.0#run",
+            "import:wasmcloud:ephemeral-test/compute@0.1.0#calls",
             "export:wasi:http/handler@0.3.0#handle",
         ],
     });
@@ -22,10 +23,17 @@ use bindings::wasmcloud::ephemeral_test::compute;
 struct Component;
 
 impl Handler for Component {
-    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
         // Plain-value async cross-component call -> ephemeral-store path.
+        // `/calls` reports how many calls the callee instance has served, so a
+        // caller can tell a reused instance from a fresh one; anything else is
         // run(21) = 21 * 2 + 1 = 43.
-        let result = compute::run(21).await;
+        let path = request.get_path_with_query().unwrap_or_default();
+        let result = if path.starts_with("/calls") {
+            compute::calls().await
+        } else {
+            compute::run(21).await
+        };
 
         let headers = Fields::new();
         let (mut tx, rx) = bindings::wit_stream::new::<u8>();

--- a/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/wit/world.wit
@@ -5,6 +5,10 @@ interface compute {
     /// fixture exactly so the dynamic linker wires the import of
     /// `wasmcloud:ephemeral-test/compute` to the callee's export.
     run: async func(n: u32) -> u32;
+
+    /// Calls the callee instance behind this import has served. See the callee
+    /// fixture's copy for what the number means.
+    calls: async func() -> u32;
 }
 
 world ephemeral-caller {

--- a/crates/wash-runtime/tests/fixtures/svc-no-run/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/svc-no-run/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/svc_no_run.wasm

--- a/crates/wash-runtime/tests/fixtures/svc-no-run/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/svc-no-run/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "svc-no-run"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/svc-no-run/src/bindings.rs
+++ b/crates/wash-runtime/tests/fixtures/svc-no-run/src/bindings.rs
@@ -1,0 +1,2 @@
+#![allow(unsafe_code)]
+wit_bindgen::generate!({ world: "svc-no-run", generate_all });

--- a/crates/wash-runtime/tests/fixtures/svc-no-run/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/svc-no-run/src/lib.rs
@@ -1,0 +1,46 @@
+//! A p3 service with **no `wasi:cli/run` export** — only `http/handler`.
+//!
+//! `http/handler` returns a per-instance call count held in a process-global.
+//! A service is instantiated once and serves every request as a concurrent
+//! task on that one instance, so the count climbs across requests. A component
+//! (the non-service path) is instantiated per request, so its count would read
+//! `1` every time. The response therefore says which one the host did.
+//!
+//! Mirrors `svc-counter` minus its `cli/run` tick loop, so the pair isolates
+//! exactly what `cli/run` is needed for.
+
+mod bindings;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use bindings::exports::wasi::http::handler::Guest as HttpGuest;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+
+static HTTP_CALLS: AtomicU64 = AtomicU64::new(0);
+
+struct Component;
+
+impl HttpGuest for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        let http_calls = HTTP_CALLS.fetch_add(1, Ordering::SeqCst) + 1;
+        let body = format!("{{\"http_calls\":{http_calls}}}");
+        Ok(make_response(200, body.into_bytes()))
+    }
+}
+
+fn make_response(status: u16, body: Vec<u8>) -> Response {
+    let headers = Fields::new();
+    let _ = headers.set(&"content-type".to_string(), &[b"application/json".to_vec()]);
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    let _ = response.set_status_code(status);
+    response
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/svc-no-run/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/svc-no-run/wit/world.wit
@@ -1,0 +1,14 @@
+package wasmcloud:test-p3@0.1.0;
+
+/// A p3 service that exports `http/handler` and NOTHING else — in particular
+/// no `wasi:cli/run`. The handler is an async p3 export, which is all the host
+/// needs to drive it: the service instance is created once and each request is
+/// served as a concurrent task on it, so `cli/run` is only required by a
+/// service that actually has long-running work of its own to co-drive.
+///
+/// Paired with `svc-counter` (the same counter, but *with* a `cli/run` tick
+/// loop), so the two fixtures differ only in whether `cli/run` is present.
+world svc-no-run {
+    import wasi:http/types@0.3.0;
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/svc-no-run/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/svc-no-run/wkg.toml
@@ -1,0 +1,7 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:http" = { path = "../p3-wit-deps/wasi-http-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }

--- a/crates/wash-runtime/tests/integration_cross_store_bridge.rs
+++ b/crates/wash-runtime/tests/integration_cross_store_bridge.rs
@@ -42,14 +42,16 @@ fn bridge_workload(host: &str) -> WorkloadStartRequest {
             }),
             // The backend is a stateless component linked to the service by its
             // `wasmcloud:bridge/ops` export; the host instantiates it fresh per
-            // call in its own store.
+            // call in its own store. `pool_size: 0` is what asks for that —
+            // keeping instances warm would carry the backend's counter across
+            // calls, which `test_bridge_backend_is_stateless` asserts against.
             components: vec![Component {
                 name: "bridge-backend".to_string(),
                 digest: None,
                 bytes: bytes::Bytes::from_static(BRIDGE_BACKEND_WASM),
                 local_resources: LocalResources::default(),
-                pool_size: 1,
-                max_invocations: 1000,
+                pool_size: 0,
+                max_invocations: 0,
             }],
             host_interfaces: http_only_host_interfaces(host),
             volumes: vec![],

--- a/crates/wash-runtime/tests/integration_service_no_cli_run.rs
+++ b/crates/wash-runtime/tests/integration_service_no_cli_run.rs
@@ -1,0 +1,95 @@
+//! A p3 service does not need a `wasi:cli/run` export.
+//!
+//! `wasi:cli/run` is what a service uses to drive long-running work of its own
+//! — an accept loop, a poller, a connection pool. It is not what makes the
+//! service instance live: the host instantiates the service once and serves
+//! each host-invoked export as a concurrent task on that instance (see
+//! [`wash_runtime::host::trigger_service`]), and `cli/run` is only co-driven
+//! alongside when it is present.
+//!
+//! The `svc-no-run` fixture exports `wasi:http/handler@0.3` and nothing else.
+//! It reports a process-global call count, which distinguishes the two possible
+//! dispatches: a single long-lived service instance makes the count climb
+//! across requests, while a per-request component instance would report `1`
+//! every time. `svc-counter` is the same fixture *with* a `cli/run` tick loop,
+//! so the pair isolates exactly what `cli/run` buys.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{collections::HashMap, time::Duration};
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::host::HostApi;
+use wash_runtime::types::{LocalResources, Service, Workload, WorkloadStartRequest};
+
+mod common;
+use common::{http_only_host_interfaces, json_u64_field, start_host_with_p3_http_handler};
+
+const SVC_NO_RUN_WASM: &[u8] = include_bytes!("wasm/svc_no_run.wasm");
+
+fn svc_no_run_request(host: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: host.to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(SVC_NO_RUN_WASM),
+                local_resources: LocalResources::default(),
+                max_restarts: 0,
+            }),
+            components: vec![],
+            host_interfaces: http_only_host_interfaces(host),
+            volumes: vec![],
+        },
+    }
+}
+
+/// A service whose only export is the async `http/handler` starts, serves, and
+/// keeps one instance alive across requests — no `cli/run` anywhere.
+#[tokio::test]
+async fn service_without_cli_run_serves_http_on_one_instance() -> Result<()> {
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+
+    host.workload_start(svc_no_run_request("svc-no-run"))
+        .await
+        .context("a service exporting only wasi:http/handler should start")?;
+
+    // No connection pooling: a GET retried on a stale pooled connection would
+    // land twice on the instance and break the exactly-once call counts.
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()?;
+
+    let mut counts = Vec::new();
+    for i in 0..5 {
+        let resp = timeout(
+            Duration::from_secs(10),
+            client
+                .get(format!("http://{addr}/"))
+                .header("HOST", "svc-no-run")
+                .send(),
+        )
+        .await
+        .with_context(|| format!("request {i} timed out"))?
+        .with_context(|| format!("request {i} failed"))?;
+        anyhow::ensure!(
+            resp.status().is_success(),
+            "request {i} returned {}",
+            resp.status()
+        );
+        counts.push(json_u64_field(&resp.text().await?, "http_calls"));
+    }
+
+    assert_eq!(
+        counts,
+        vec![1, 2, 3, 4, 5],
+        "every request must land on the same long-lived service instance; \
+         a repeated 1 would mean the host fell back to instantiating per request"
+    );
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_topology_overhead.rs
+++ b/crates/wash-runtime/tests/integration_topology_overhead.rs
@@ -1,0 +1,291 @@
+//! Gated measurement of what each workload *topology* costs, independent of
+//! what the workload does.
+//!
+//! The shared-Postgres-pool template is a service that routes to sub-components
+//! over linked calls. That shape buys isolation and a state/compute split, and
+//! this measures what it costs against the two simpler shapes, with the work
+//! held to a trivial constant in every case so the difference is the topology:
+//!
+//!  * **component** — one component exporting `wasi:http/handler`, no service.
+//!    The runtime builds a store and instantiates it per request.
+//!  * **service** — one service exporting `wasi:http/handler`. Instantiated
+//!    once; every request is a concurrent task on that instance.
+//!  * **service + component** — a service that calls a linked component per
+//!    request (the template's shape), measured with the callee cold (a store
+//!    per call, the default) and warm (`pool_size`).
+//!
+//! The response bodies are not byte-identical across fixtures (13, ~18 and 2
+//! bytes), but all are far too small for that to matter next to per-request
+//! store and instantiation costs.
+//!
+//! Run with:
+//!   cargo test --test integration_topology_overhead -- --ignored --nocapture
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use anyhow::Result;
+use tokio::time::Instant;
+
+use wash_runtime::host::HostApi;
+use wash_runtime::types::{Component, LocalResources, Service, Workload, WorkloadStartRequest};
+
+mod common;
+use common::{http_only_host_interfaces, start_host_with_p3_http_handler};
+
+/// One component exporting `wasi:http/handler@0.3`, nothing else.
+const HTTP_HANDLER_P3_WASM: &[u8] = include_bytes!("wasm/http_handler_p3.wasm");
+/// A service exporting `wasi:http/handler@0.3` and no `cli/run`.
+const SVC_NO_RUN_WASM: &[u8] = include_bytes!("wasm/svc_no_run.wasm");
+/// An HTTP handler that calls a plain-value async export of a linked component.
+const EPHEMERAL_CALLER_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_caller_p3.wasm");
+const EPHEMERAL_CALLEE_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_callee_p3.wasm");
+
+const LEVELS: &[usize] = &[1, 2, 4, 8, 16, 32];
+const PHASE: Duration = Duration::from_secs(5);
+const WARMUP: usize = 50;
+
+fn resources() -> LocalResources {
+    LocalResources::default()
+}
+
+/// A workload with a single component serving HTTP — no service at all.
+fn component_only(host: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "bench".to_string(),
+            name: host.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "handler".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_HANDLER_P3_WASM),
+                local_resources: resources(),
+                pool_size: 0,
+                max_invocations: 0,
+            }],
+            host_interfaces: http_only_host_interfaces(host),
+            volumes: vec![],
+        },
+    }
+}
+
+/// A workload with a single service serving HTTP — no sub-components.
+fn service_only(host: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "bench".to_string(),
+            name: host.to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(SVC_NO_RUN_WASM),
+                local_resources: resources(),
+                max_restarts: 0,
+            }),
+            components: vec![],
+            host_interfaces: http_only_host_interfaces(host),
+            volumes: vec![],
+        },
+    }
+}
+
+/// The template's shape: a service that calls a linked sub-component per
+/// request. `warm` is the callee's `pool_size`.
+fn service_plus_component(host: &str, warm: i32) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "bench".to_string(),
+            name: host.to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(EPHEMERAL_CALLER_P3_WASM),
+                local_resources: resources(),
+                max_restarts: 0,
+            }),
+            components: vec![Component {
+                name: "callee".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(EPHEMERAL_CALLEE_P3_WASM),
+                local_resources: resources(),
+                pool_size: warm,
+                max_invocations: 0,
+            }],
+            host_interfaces: http_only_host_interfaces(host),
+            volumes: vec![],
+        },
+    }
+}
+
+struct Stats {
+    elapsed: Duration,
+    errors: u64,
+    /// Sorted per-request latencies, in microseconds.
+    latencies: Vec<u64>,
+}
+
+impl Stats {
+    fn rps(&self) -> f64 {
+        self.latencies.len() as f64 / self.elapsed.as_secs_f64()
+    }
+    fn pct(&self, p: f64) -> f64 {
+        if self.latencies.is_empty() {
+            return f64::NAN;
+        }
+        let idx = ((self.latencies.len() as f64 - 1.0) * p).round() as usize;
+        self.latencies
+            .get(idx)
+            .map(|us| *us as f64 / 1000.0)
+            .unwrap_or(f64::NAN)
+    }
+}
+
+async fn load(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host: &'static str,
+    concurrency: usize,
+) -> Stats {
+    for _ in 0..WARMUP {
+        let _ = client
+            .get(format!("http://{addr}/"))
+            .header("HOST", host)
+            .send()
+            .await;
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let errors = Arc::new(AtomicU64::new(0));
+    let mut workers = Vec::new();
+    let started = Instant::now();
+    for _ in 0..concurrency {
+        let client = client.clone();
+        let stop = Arc::clone(&stop);
+        let errors = Arc::clone(&errors);
+        workers.push(tokio::spawn(async move {
+            let mut latencies = Vec::new();
+            while !stop.load(Ordering::Relaxed) {
+                let t0 = Instant::now();
+                let ok = match client
+                    .get(format!("http://{addr}/"))
+                    .header("HOST", host)
+                    .send()
+                    .await
+                {
+                    Ok(resp) => {
+                        let status = resp.status();
+                        let drained = resp.bytes().await.is_ok();
+                        status.is_success() && drained
+                    }
+                    Err(_) => false,
+                };
+                if ok {
+                    latencies.push(t0.elapsed().as_micros() as u64);
+                } else {
+                    errors.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            latencies
+        }));
+    }
+    tokio::time::sleep(PHASE).await;
+    stop.store(true, Ordering::Relaxed);
+
+    let mut latencies = Vec::new();
+    for w in workers {
+        latencies.extend(w.await.unwrap_or_default());
+    }
+    let elapsed = started.elapsed();
+    latencies.sort_unstable();
+    Stats {
+        elapsed,
+        errors: errors.load(Ordering::Relaxed),
+        latencies,
+    }
+}
+
+/// Sweep one topology on its own host, returning req/s per concurrency level.
+async fn sweep(
+    label: &str,
+    host: &'static str,
+    request: WorkloadStartRequest,
+) -> Result<Vec<f64>> {
+    let (addr, host_api) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    host_api.workload_start(request).await?;
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(64)
+        .timeout(Duration::from_secs(30))
+        .build()?;
+
+    println!("\n=== {label} ===");
+    println!(
+        "{:>5}  {:>10}  {:>9}  {:>9}  {:>7}",
+        "conc", "req/s", "p50 ms", "p99 ms", "errors"
+    );
+    let mut rps = Vec::new();
+    for &c in LEVELS {
+        let s = load(&client, addr, host, c).await;
+        println!(
+            "{:>5}  {:>10.1}  {:>9.3}  {:>9.3}  {:>7}",
+            c,
+            s.rps(),
+            s.pct(0.50),
+            s.pct(0.99),
+            s.errors
+        );
+        rps.push(s.rps());
+    }
+    drop(host_api);
+    Ok(rps)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "measurement; run with --ignored"]
+async fn bench_topology_overhead() -> Result<()> {
+    let component = sweep("component only (store + instantiate per request)", "topo-c", component_only("topo-c")).await?;
+    let service = sweep("service only (one long-lived instance)", "topo-s", service_only("topo-s")).await?;
+    let cold = sweep(
+        "service + linked component, callee cold (store per call)",
+        "topo-sc",
+        service_plus_component("topo-sc", 0),
+    )
+    .await?;
+    let warm = sweep(
+        "service + linked component, callee warm (pool_size 4)",
+        "topo-sw",
+        service_plus_component("topo-sw", 4),
+    )
+    .await?;
+
+    println!("\n=== relative throughput (higher is better; service-only = 1.00) ===");
+    println!(
+        "{:>5}  {:>12}  {:>12}  {:>12}  {:>12}",
+        "conc", "component", "service", "svc+comp", "svc+warm"
+    );
+    for (i, &c) in LEVELS.iter().enumerate() {
+        let base = service.get(i).copied().unwrap_or(f64::NAN);
+        let rel = |v: Option<&f64>| v.copied().unwrap_or(f64::NAN) / base;
+        println!(
+            "{:>5}  {:>12.2}  {:>12.2}  {:>12.2}  {:>12.2}",
+            c,
+            rel(component.get(i)),
+            1.0,
+            rel(cold.get(i)),
+            rel(warm.get(i)),
+        );
+    }
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_topology_overhead.rs
+++ b/crates/wash-runtime/tests/integration_topology_overhead.rs
@@ -221,11 +221,7 @@ async fn load(
 }
 
 /// Sweep one topology on its own host, returning req/s per concurrency level.
-async fn sweep(
-    label: &str,
-    host: &'static str,
-    request: WorkloadStartRequest,
-) -> Result<Vec<f64>> {
+async fn sweep(label: &str, host: &'static str, request: WorkloadStartRequest) -> Result<Vec<f64>> {
     let (addr, host_api) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
     host_api.workload_start(request).await?;
     let client = reqwest::Client::builder()
@@ -270,7 +266,12 @@ async fn bench_topology_overhead() -> Result<()> {
         component_only("topo-cw", 4),
     )
     .await?;
-    let service = sweep("service only (one long-lived instance)", "topo-s", service_only("topo-s")).await?;
+    let service = sweep(
+        "service only (one long-lived instance)",
+        "topo-s",
+        service_only("topo-s"),
+    )
+    .await?;
     let cold = sweep(
         "service + linked component, callee cold (store per call)",
         "topo-sc",

--- a/crates/wash-runtime/tests/integration_topology_overhead.rs
+++ b/crates/wash-runtime/tests/integration_topology_overhead.rs
@@ -7,9 +7,11 @@
 //! held to a trivial constant in every case so the difference is the topology:
 //!
 //!  * **component** — one component exporting `wasi:http/handler`, no service.
-//!    The runtime builds a store and instantiates it per request.
+//!    A store is built and instantiated per request unless `pool_size` says
+//!    otherwise; measured both ways.
 //!  * **service** — one service exporting `wasi:http/handler`. Instantiated
-//!    once; every request is a concurrent task on that instance.
+//!    once; every request is a concurrent task on that *one* instance, which
+//!    is also its ceiling.
 //!  * **service + component** — a service that calls a linked component per
 //!    request (the template's shape), measured with the callee cold (a store
 //!    per call, the default) and warm (`pool_size`).
@@ -58,7 +60,8 @@ fn resources() -> LocalResources {
 }
 
 /// A workload with a single component serving HTTP — no service at all.
-fn component_only(host: &str) -> WorkloadStartRequest {
+/// `warm` is its `pool_size`.
+fn component_only(host: &str, warm: i32) -> WorkloadStartRequest {
     WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),
         workload: Workload {
@@ -71,7 +74,7 @@ fn component_only(host: &str) -> WorkloadStartRequest {
                 digest: None,
                 bytes: bytes::Bytes::from_static(HTTP_HANDLER_P3_WASM),
                 local_resources: resources(),
-                pool_size: 0,
+                pool_size: warm,
                 max_invocations: 0,
             }],
             host_interfaces: http_only_host_interfaces(host),
@@ -255,7 +258,18 @@ async fn sweep(
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "measurement; run with --ignored"]
 async fn bench_topology_overhead() -> Result<()> {
-    let component = sweep("component only (store + instantiate per request)", "topo-c", component_only("topo-c")).await?;
+    let component = sweep(
+        "component only, cold (store + instantiate per request)",
+        "topo-c",
+        component_only("topo-c", 0),
+    )
+    .await?;
+    let component_warm = sweep(
+        "component only, warm (pool_size 4)",
+        "topo-cw",
+        component_only("topo-cw", 4),
+    )
+    .await?;
     let service = sweep("service only (one long-lived instance)", "topo-s", service_only("topo-s")).await?;
     let cold = sweep(
         "service + linked component, callee cold (store per call)",
@@ -272,16 +286,17 @@ async fn bench_topology_overhead() -> Result<()> {
 
     println!("\n=== relative throughput (higher is better; service-only = 1.00) ===");
     println!(
-        "{:>5}  {:>12}  {:>12}  {:>12}  {:>12}",
-        "conc", "component", "service", "svc+comp", "svc+warm"
+        "{:>5}  {:>10}  {:>10}  {:>10}  {:>10}  {:>10}",
+        "conc", "comp", "comp-warm", "service", "svc+comp", "svc+warm"
     );
     for (i, &c) in LEVELS.iter().enumerate() {
         let base = service.get(i).copied().unwrap_or(f64::NAN);
         let rel = |v: Option<&f64>| v.copied().unwrap_or(f64::NAN) / base;
         println!(
-            "{:>5}  {:>12.2}  {:>12.2}  {:>12.2}  {:>12.2}",
+            "{:>5}  {:>10.2}  {:>10.2}  {:>10.2}  {:>10.2}  {:>10.2}",
             c,
             rel(component.get(i)),
+            rel(component_warm.get(i)),
             1.0,
             rel(cold.get(i)),
             rel(warm.get(i)),

--- a/crates/wash-runtime/tests/integration_warm_instances.rs
+++ b/crates/wash-runtime/tests/integration_warm_instances.rs
@@ -1,0 +1,164 @@
+//! Integration tests for warm-instance pooling on the ephemeral linked-call
+//! path (`pool_size` / `max_invocations` on a [`Component`]).
+//!
+//! All three cases drive the same pair of fixtures: `ephemeral-caller-p3`
+//! serves HTTP and calls the plain-value async `calls()` export of the linked
+//! `ephemeral-callee-p3`, which returns how many calls **its own instance**
+//! has served. Because that count lives in the callee's linear memory, the
+//! response says directly whether the call reused an instance or got a fresh
+//! one:
+//!
+//!  * `pool_size: 0` — every call builds and drops its own store, so the
+//!    count is `1` every time. This is the default and the behavior before
+//!    warm instances existed.
+//!  * `pool_size: 1` — the instance is parked between calls and reused, so
+//!    the count climbs.
+//!  * `pool_size: 1, max_invocations: N` — the instance is retired once it has
+//!    served `N` calls, so the count climbs to `N` and then restarts.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use anyhow::{Context, Result};
+use std::{collections::HashMap, time::Duration};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    host::HostApi,
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+};
+
+mod common;
+use common::{http_only_host_interfaces, start_host_with_p3_http_handler};
+
+const EPHEMERAL_CALLER_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_caller_p3.wasm");
+const EPHEMERAL_CALLEE_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_callee_p3.wasm");
+
+/// Start a host running the caller/callee pair, with the callee configured to
+/// the given warm-instance limits. The caller is never pooled, so only the
+/// callee's behavior is under test.
+async fn start_pair(
+    host_header: &'static str,
+    callee_pool_size: i32,
+    callee_max_invocations: i32,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+
+    host.workload_start(WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: host_header.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![
+                Component {
+                    name: "ephemeral-caller".to_string(),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(EPHEMERAL_CALLER_P3_WASM),
+                    local_resources: LocalResources::default(),
+                    pool_size: 0,
+                    max_invocations: 0,
+                },
+                Component {
+                    name: "ephemeral-callee".to_string(),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(EPHEMERAL_CALLEE_P3_WASM),
+                    local_resources: LocalResources::default(),
+                    pool_size: callee_pool_size,
+                    max_invocations: callee_max_invocations,
+                },
+            ],
+            host_interfaces: http_only_host_interfaces(host_header),
+            volumes: vec![],
+        },
+    })
+    .await
+    .context("warm-instance workload should start")?;
+
+    Ok((addr, host))
+}
+
+/// Issue `n` sequential `GET /calls` requests, returning each body parsed as
+/// the callee instance's call count.
+async fn call_counts(
+    addr: std::net::SocketAddr,
+    host_header: &str,
+    n: usize,
+) -> Result<Vec<u32>> {
+    let client = reqwest::Client::new();
+    let mut counts = Vec::with_capacity(n);
+    for i in 0..n {
+        let response = timeout(
+            Duration::from_secs(10),
+            client
+                .get(format!("http://{addr}/calls"))
+                .header("HOST", host_header)
+                .send(),
+        )
+        .await
+        .with_context(|| format!("request {i} timed out"))?
+        .with_context(|| format!("request {i} failed"))?;
+        anyhow::ensure!(
+            response.status().is_success(),
+            "request {i} returned {}",
+            response.status()
+        );
+        let body = response.text().await?;
+        counts.push(
+            body.trim()
+                .parse::<u32>()
+                .with_context(|| format!("request {i} returned non-numeric body {body:?}"))?,
+        );
+    }
+    Ok(counts)
+}
+
+/// Without pooling every linked call gets its own instance, so the callee's
+/// in-memory counter is back at zero each time. This is the default and pins
+/// the ephemeral contract: component state does not survive a call.
+#[tokio::test]
+async fn unpooled_component_gets_a_fresh_instance_per_call() -> Result<()> {
+    let (addr, _host) = start_pair("warm-off", 0, 0).await?;
+
+    let counts = call_counts(addr, "warm-off", 5).await?;
+
+    assert_eq!(
+        counts,
+        vec![1, 1, 1, 1, 1],
+        "each call to an unpooled component must run in a fresh instance"
+    );
+    Ok(())
+}
+
+/// With `pool_size: 1` the instance is parked after each call and picked up by
+/// the next, so guest state accumulates — the reason a component would opt in.
+#[tokio::test]
+async fn pooled_component_reuses_a_warm_instance() -> Result<()> {
+    let (addr, _host) = start_pair("warm-on", 1, 0).await?;
+
+    let counts = call_counts(addr, "warm-on", 5).await?;
+
+    assert_eq!(
+        counts,
+        vec![1, 2, 3, 4, 5],
+        "a pooled component must keep serving from the same warm instance"
+    );
+    Ok(())
+}
+
+/// `max_invocations` bounds how long any one instance lives: it serves that
+/// many calls and is then retired, so the next call starts from a cold store
+/// and the counter restarts.
+#[tokio::test]
+async fn max_invocations_retires_a_warm_instance() -> Result<()> {
+    let (addr, _host) = start_pair("warm-retire", 1, 3).await?;
+
+    let counts = call_counts(addr, "warm-retire", 7).await?;
+
+    assert_eq!(
+        counts,
+        vec![1, 2, 3, 1, 2, 3, 1],
+        "an instance must be retired once it has served max_invocations calls"
+    );
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_warm_instances.rs
+++ b/crates/wash-runtime/tests/integration_warm_instances.rs
@@ -156,18 +156,17 @@ async fn http_call_counts(
             "request {i} returned {}",
             response.status()
         );
-        counts.push(common::json_u64_field(&response.text().await?, "http_calls"));
+        counts.push(common::json_u64_field(
+            &response.text().await?,
+            "http_calls",
+        ));
     }
     Ok(counts)
 }
 
 /// Issue `n` sequential `GET /calls` requests, returning each body parsed as
 /// the callee instance's call count.
-async fn call_counts(
-    addr: std::net::SocketAddr,
-    host_header: &str,
-    n: usize,
-) -> Result<Vec<u32>> {
+async fn call_counts(addr: std::net::SocketAddr, host_header: &str, n: usize) -> Result<Vec<u32>> {
     let client = reqwest::Client::new();
     let mut counts = Vec::with_capacity(n);
     for i in 0..n {

--- a/crates/wash-runtime/tests/integration_warm_instances.rs
+++ b/crates/wash-runtime/tests/integration_warm_instances.rs
@@ -1,20 +1,20 @@
-//! Integration tests for warm-instance pooling on the ephemeral linked-call
-//! path (`pool_size` / `max_invocations` on a [`Component`]).
+//! Integration tests for warm-instance pooling (`pool_size` /
+//! `max_invocations` on a [`Component`]), across both paths that build a store
+//! per call by default.
 //!
-//! All three cases drive the same pair of fixtures: `ephemeral-caller-p3`
-//! serves HTTP and calls the plain-value async `calls()` export of the linked
-//! `ephemeral-callee-p3`, which returns how many calls **its own instance**
-//! has served. Because that count lives in the callee's linear memory, the
-//! response says directly whether the call reused an instance or got a fresh
-//! one:
+//! Every case reads a counter out of the guest's linear memory, so the
+//! response says directly whether an instance was reused or freshly built:
+//! `1` every time means a fresh instance per call, a climbing count means one
+//! instance served them all.
 //!
-//!  * `pool_size: 0` — every call builds and drops its own store, so the
-//!    count is `1` every time. This is the default and the behavior before
-//!    warm instances existed.
-//!  * `pool_size: 1` — the instance is parked between calls and reused, so
-//!    the count climbs.
-//!  * `pool_size: 1, max_invocations: N` — the instance is retired once it has
-//!    served `N` calls, so the count climbs to `N` and then restarts.
+//!  * **Linked calls** — `ephemeral-caller-p3` calls the plain-value async
+//!    `calls()` export of the linked `ephemeral-callee-p3`.
+//!  * **HTTP dispatch** — `svc-no-run` deployed as a plain component (not a
+//!    service), reporting its own per-instance request count.
+//!  * **Linked components share the store's lifetime**, so a component is kept
+//!    warm only when everything instantiated alongside it has opted in too.
+//!    Otherwise `pool_size: 0` on a callee would stop meaning "my state is
+//!    ephemeral" the moment something else imported it.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -32,12 +32,25 @@ use common::{http_only_host_interfaces, start_host_with_p3_http_handler};
 
 const EPHEMERAL_CALLER_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_caller_p3.wasm");
 const EPHEMERAL_CALLEE_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_callee_p3.wasm");
+/// A p3 HTTP handler reporting a per-instance request count.
+const SVC_NO_RUN_WASM: &[u8] = include_bytes!("wasm/svc_no_run.wasm");
 
 /// Start a host running the caller/callee pair, with the callee configured to
 /// the given warm-instance limits. The caller is never pooled, so only the
 /// callee's behavior is under test.
 async fn start_pair(
     host_header: &'static str,
+    callee_pool_size: i32,
+    callee_max_invocations: i32,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    start_pair_with_caller_pool(host_header, 0, callee_pool_size, callee_max_invocations).await
+}
+
+/// As [`start_pair`], but with the caller's `pool_size` set too — the caller's
+/// store is what the callee is instantiated into, so the two interact.
+async fn start_pair_with_caller_pool(
+    host_header: &'static str,
+    caller_pool_size: i32,
     callee_pool_size: i32,
     callee_max_invocations: i32,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
@@ -56,7 +69,7 @@ async fn start_pair(
                     digest: None,
                     bytes: bytes::Bytes::from_static(EPHEMERAL_CALLER_P3_WASM),
                     local_resources: LocalResources::default(),
-                    pool_size: 0,
+                    pool_size: caller_pool_size,
                     max_invocations: 0,
                 },
                 Component {
@@ -76,6 +89,76 @@ async fn start_pair(
     .context("warm-instance workload should start")?;
 
     Ok((addr, host))
+}
+
+/// Start a host running `svc-no-run` as a plain **component** (not a service),
+/// so requests take the HTTP dispatch path: a store and an instance per
+/// request unless `pool_size` says otherwise. Its body reports how many
+/// requests its own instance has served.
+async fn start_http_component(
+    host_header: &'static str,
+    pool_size: i32,
+    max_invocations: i32,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+
+    host.workload_start(WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: host_header.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "http-counter".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(SVC_NO_RUN_WASM),
+                local_resources: LocalResources::default(),
+                pool_size,
+                max_invocations,
+            }],
+            host_interfaces: http_only_host_interfaces(host_header),
+            volumes: vec![],
+        },
+    })
+    .await
+    .context("HTTP component workload should start")?;
+
+    Ok((addr, host))
+}
+
+/// Issue `n` sequential `GET /` requests, returning the `http_calls` count the
+/// instance reports for each.
+async fn http_call_counts(
+    addr: std::net::SocketAddr,
+    host_header: &str,
+    n: usize,
+) -> Result<Vec<u64>> {
+    // No connection reuse: a retried GET on a stale pooled connection would
+    // land twice and break the exactly-once counts.
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()?;
+    let mut counts = Vec::with_capacity(n);
+    for i in 0..n {
+        let response = timeout(
+            Duration::from_secs(10),
+            client
+                .get(format!("http://{addr}/"))
+                .header("HOST", host_header)
+                .send(),
+        )
+        .await
+        .with_context(|| format!("request {i} timed out"))?
+        .with_context(|| format!("request {i} failed"))?;
+        anyhow::ensure!(
+            response.status().is_success(),
+            "request {i} returned {}",
+            response.status()
+        );
+        counts.push(common::json_u64_field(&response.text().await?, "http_calls"));
+    }
+    Ok(counts)
 }
 
 /// Issue `n` sequential `GET /calls` requests, returning each body parsed as
@@ -159,6 +242,120 @@ async fn max_invocations_retires_a_warm_instance() -> Result<()> {
         counts,
         vec![1, 2, 3, 1, 2, 3, 1],
         "an instance must be retired once it has served max_invocations calls"
+    );
+    Ok(())
+}
+
+/// A component reached over **HTTP** — no service, no linked call — is also
+/// kept warm when it opts in. The runtime builds a store and instantiates per
+/// request by default, which is what `pool_size` is meant to avoid.
+#[tokio::test]
+async fn pooled_component_serving_http_reuses_a_warm_instance() -> Result<()> {
+    let (addr, _host) = start_http_component("warm-http", 1, 0).await?;
+
+    let counts = http_call_counts(addr, "warm-http", 5).await?;
+
+    assert_eq!(
+        counts,
+        vec![1, 2, 3, 4, 5],
+        "an HTTP component that opted in must be served from one warm instance"
+    );
+    Ok(())
+}
+
+/// The default for an HTTP component is unchanged: a store and an instance per
+/// request, so nothing carries over.
+#[tokio::test]
+async fn unpooled_component_serving_http_is_fresh_per_request() -> Result<()> {
+    let (addr, _host) = start_http_component("cold-http", 0, 0).await?;
+
+    let counts = http_call_counts(addr, "cold-http", 4).await?;
+
+    assert_eq!(
+        counts,
+        vec![1, 1, 1, 1],
+        "an HTTP component that did not opt in must get a fresh instance per request"
+    );
+    Ok(())
+}
+
+/// A warm store is reused indefinitely by default, so anything a request
+/// leaves behind in it — resource-table entries for the request, the response,
+/// their bodies — accumulates instead of being reclaimed with the store. This
+/// drives a few thousand requests through a single warm instance and checks it
+/// still serves correctly at the end, which a store leaking a table entry per
+/// request would not.
+#[tokio::test]
+async fn a_warm_instance_survives_many_requests() -> Result<()> {
+    const REQUESTS: usize = 3000;
+    let (addr, _host) = start_http_component("warm-soak", 1, 0).await?;
+
+    let counts = http_call_counts(addr, "warm-soak", REQUESTS).await?;
+
+    // One instance served every request, and its count never restarted — so
+    // nothing forced a retirement partway through.
+    assert_eq!(
+        counts.first().copied(),
+        Some(1),
+        "the first request should land on a fresh instance"
+    );
+    assert_eq!(
+        counts.last().copied(),
+        Some(REQUESTS as u64),
+        "one warm instance must serve all {REQUESTS} requests without being retired"
+    );
+    Ok(())
+}
+
+/// `max_invocations` applies to the HTTP path too.
+#[tokio::test]
+async fn max_invocations_retires_an_http_instance() -> Result<()> {
+    let (addr, _host) = start_http_component("warm-http-retire", 1, 2).await?;
+
+    let counts = http_call_counts(addr, "warm-http-retire", 6).await?;
+
+    assert_eq!(
+        counts,
+        vec![1, 2, 1, 2, 1, 2],
+        "an HTTP instance must be retired once it has served max_invocations requests"
+    );
+    Ok(())
+}
+
+/// A store holds the component's linked components too, and they live exactly
+/// as long as it does. So a component is kept warm only when everything
+/// instantiated alongside it has also opted in — otherwise `pool_size: 0` on
+/// the callee would stop meaning "my state is ephemeral" as soon as something
+/// else imported it.
+///
+/// Here the caller opts in and the callee does not, so neither is kept warm:
+/// the callee reports `1` every time.
+#[tokio::test]
+async fn a_linked_component_that_did_not_opt_in_keeps_the_caller_cold() -> Result<()> {
+    let (addr, _host) = start_pair_with_caller_pool("warm-mixed", 4, 0, 0).await?;
+
+    let counts = call_counts(addr, "warm-mixed", 4).await?;
+
+    assert_eq!(
+        counts,
+        vec![1, 1, 1, 1],
+        "a warm caller must not silently give warm state to a callee that did not opt in"
+    );
+    Ok(())
+}
+
+/// The same shape with both opted in does keep them warm, so the rule above is
+/// about the callee's own setting and not an accident of the caller's.
+#[tokio::test]
+async fn both_opted_in_keeps_the_pair_warm() -> Result<()> {
+    let (addr, _host) = start_pair_with_caller_pool("warm-both", 4, 1, 0).await?;
+
+    let counts = call_counts(addr, "warm-both", 4).await?;
+
+    assert_eq!(
+        counts,
+        vec![1, 2, 3, 4],
+        "with both components opted in the callee instance must be reused"
     );
     Ok(())
 }

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -414,15 +414,20 @@ impl CliCommand for DevCommand {
 /// extracted WIT interface set, and its resolved workload values (workload
 /// base merged with the component's overrides), so the pure assembly step
 /// needs no further I/O or host calls.
+/// What `Component.pool_size` / `max_invocations` carry when `wash dev` has
+/// nothing to say about them: they are `sint32` on the wire, and the runtime
+/// reads anything that is not a positive pool size as "do not keep instances".
+const UNSET_LIMIT: i32 = -1;
+
 struct LoadedComponent {
     name: String,
     bytes: Bytes,
     interfaces: HashSet<WitInterface>,
     workload: ResolvedWorkload,
     /// Warm-instance limits from `dev.components[].poolSize` /
-    /// `maxInvocations`. `-1` where the config left them unset.
-    pool_size: i32,
-    max_invocations: i32,
+    /// `maxInvocations`, `None` where the config left them unset.
+    pool_size: Option<i32>,
+    max_invocations: Option<i32>,
 }
 
 /// Thin wrapper around [`build_workload`]: extracts dev-component
@@ -469,8 +474,8 @@ async fn create_workload(
             bytes: Bytes::from(comp_bytes),
             interfaces,
             workload,
-            pool_size: dev_component.pool_size.unwrap_or(-1),
-            max_invocations: dev_component.max_invocations.unwrap_or(-1),
+            pool_size: dev_component.pool_size,
+            max_invocations: dev_component.max_invocations,
         });
     }
 
@@ -583,8 +588,8 @@ fn build_workload(
             bytes,
             digest: None,
             local_resources: local_resources_for(resolved_workload),
-            pool_size: -1,
-            max_invocations: -1,
+            pool_size: UNSET_LIMIT,
+            max_invocations: UNSET_LIMIT,
         });
 
         if let Some(service_bytes) = service_file_bytes {
@@ -603,8 +608,11 @@ fn build_workload(
             bytes: sidecar.bytes,
             digest: None,
             local_resources: local_resources_for(&sidecar.workload),
-            pool_size: sidecar.pool_size,
-            max_invocations: sidecar.max_invocations,
+            // `Component` carries these as `sint32`, where a negative means
+            // "not configured"; the runtime decodes the pair into an
+            // `InstancePolicy`.
+            pool_size: sidecar.pool_size.unwrap_or(UNSET_LIMIT),
+            max_invocations: sidecar.max_invocations.unwrap_or(UNSET_LIMIT),
         });
     }
 
@@ -766,8 +774,8 @@ mod tests {
             bytes: fake_bytes(name),
             interfaces: HashSet::new(),
             workload,
-            pool_size: -1,
-            max_invocations: -1,
+            pool_size: None,
+            max_invocations: None,
         }
     }
 
@@ -837,8 +845,8 @@ mod tests {
             ..Default::default()
         };
         let mut pooled = loaded_sidecar("pooled", resolved.clone());
-        pooled.pool_size = 4;
-        pooled.max_invocations = 100;
+        pooled.pool_size = Some(4);
+        pooled.max_invocations = Some(100);
         let sidecars = vec![pooled, loaded_sidecar("unpooled", resolved.clone())];
 
         let workload = build_workload(
@@ -856,17 +864,18 @@ mod tests {
         assert_eq!(pooled.max_invocations, 100);
 
         let unpooled = find_component(&workload, "unpooled").unwrap();
-        assert_eq!(unpooled.pool_size, -1);
-        assert_eq!(unpooled.max_invocations, -1);
+        assert_eq!(unpooled.pool_size, UNSET_LIMIT);
+        assert_eq!(unpooled.max_invocations, UNSET_LIMIT);
     }
 
     /// The config keys are camelCase on the wire and optional, so a component
     /// entry that omits them round-trips as "unset" rather than zero.
     #[test]
     fn dev_component_warm_instance_limits_deserialize() {
-        let with: DevComponent =
-            serde_yaml_ng::from_str("name: pooled\nfile: pooled.wasm\npoolSize: 8\nmaxInvocations: 50")
-                .unwrap();
+        let with: DevComponent = serde_yaml_ng::from_str(
+            "name: pooled\nfile: pooled.wasm\npoolSize: 8\nmaxInvocations: 50",
+        )
+        .unwrap();
         assert_eq!(with.pool_size, Some(8));
         assert_eq!(with.max_invocations, Some(50));
 
@@ -1057,8 +1066,8 @@ mod tests {
             bytes: fake_bytes("sidecar"),
             interfaces: HashSet::from([iface("wasi", "config")]),
             workload: ResolvedWorkload::default(),
-            pool_size: -1,
-            max_invocations: -1,
+            pool_size: None,
+            max_invocations: None,
         }];
 
         let workload = build_workload(

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -419,6 +419,10 @@ struct LoadedComponent {
     bytes: Bytes,
     interfaces: HashSet<WitInterface>,
     workload: ResolvedWorkload,
+    /// Warm-instance limits from `dev.components[].poolSize` /
+    /// `maxInvocations`. `-1` where the config left them unset.
+    pool_size: i32,
+    max_invocations: i32,
 }
 
 /// Thin wrapper around [`build_workload`]: extracts dev-component
@@ -465,6 +469,8 @@ async fn create_workload(
             bytes: Bytes::from(comp_bytes),
             interfaces,
             workload,
+            pool_size: dev_component.pool_size.unwrap_or(-1),
+            max_invocations: dev_component.max_invocations.unwrap_or(-1),
         });
     }
 
@@ -597,8 +603,8 @@ fn build_workload(
             bytes: sidecar.bytes,
             digest: None,
             local_resources: local_resources_for(&sidecar.workload),
-            pool_size: -1,
-            max_invocations: -1,
+            pool_size: sidecar.pool_size,
+            max_invocations: sidecar.max_invocations,
         });
     }
 
@@ -760,6 +766,8 @@ mod tests {
             bytes: fake_bytes(name),
             interfaces: HashSet::new(),
             workload,
+            pool_size: -1,
+            max_invocations: -1,
         }
     }
 
@@ -812,6 +820,60 @@ mod tests {
             &sidecar.local_resources.allowed_hosts[..],
             &["https://api.example.com".parse().unwrap()]
         );
+    }
+
+    /// `poolSize` / `maxInvocations` on a `dev.components` entry must reach the
+    /// workload component; the runtime reads them to decide whether to keep
+    /// instances warm. A sidecar that sets neither stays at `-1` (unset), which
+    /// the runtime reads as "no pooling".
+    #[test]
+    fn build_workload_carries_warm_instance_limits() {
+        let resolved = ResolvedWorkload::default();
+        let dev_cfg = DevConfig {
+            components: vec![
+                dev_component_named("pooled"),
+                dev_component_named("unpooled"),
+            ],
+            ..Default::default()
+        };
+        let mut pooled = loaded_sidecar("pooled", resolved.clone());
+        pooled.pool_size = 4;
+        pooled.max_invocations = 100;
+        let sidecars = vec![pooled, loaded_sidecar("unpooled", resolved.clone())];
+
+        let workload = build_workload(
+            &dev_cfg,
+            fake_bytes("dev"),
+            HashSet::new(),
+            sidecars,
+            None,
+            None,
+            &resolved,
+        );
+
+        let pooled = find_component(&workload, "pooled").unwrap();
+        assert_eq!(pooled.pool_size, 4);
+        assert_eq!(pooled.max_invocations, 100);
+
+        let unpooled = find_component(&workload, "unpooled").unwrap();
+        assert_eq!(unpooled.pool_size, -1);
+        assert_eq!(unpooled.max_invocations, -1);
+    }
+
+    /// The config keys are camelCase on the wire and optional, so a component
+    /// entry that omits them round-trips as "unset" rather than zero.
+    #[test]
+    fn dev_component_warm_instance_limits_deserialize() {
+        let with: DevComponent =
+            serde_yaml_ng::from_str("name: pooled\nfile: pooled.wasm\npoolSize: 8\nmaxInvocations: 50")
+                .unwrap();
+        assert_eq!(with.pool_size, Some(8));
+        assert_eq!(with.max_invocations, Some(50));
+
+        let without: DevComponent =
+            serde_yaml_ng::from_str("name: plain\nfile: plain.wasm").unwrap();
+        assert_eq!(without.pool_size, None);
+        assert_eq!(without.max_invocations, None);
     }
 
     #[test]
@@ -995,6 +1057,8 @@ mod tests {
             bytes: fake_bytes("sidecar"),
             interfaces: HashSet::from([iface("wasi", "config")]),
             workload: ResolvedWorkload::default(),
+            pool_size: -1,
+            max_invocations: -1,
         }];
 
         let workload = build_workload(

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -358,8 +358,8 @@ pub struct DevComponent {
     /// and component state is ephemeral. Setting it lets an instance be reused
     /// by the next call, so whatever the guest caches in memory — a connection
     /// pool, a lazily built runtime — survives instead of being rebuilt per
-    /// call. Bursts past this many concurrent calls are still served, from
-    /// fresh instances.
+    /// call. Work past what the warm instances can take is still served, from
+    /// fresh ones.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pool_size: Option<i32>,
     /// How many calls a warm instance serves before it is retired and the next

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -352,6 +352,21 @@ pub struct DevComponent {
     /// workload list applies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_hosts: Option<Vec<AllowedHost>>,
+    /// How many instances of this component to keep warm between calls.
+    ///
+    /// Unset (or `0`) keeps the default: every call runs in a fresh instance
+    /// and component state is ephemeral. Setting it lets an instance be reused
+    /// by the next call, so whatever the guest caches in memory — a connection
+    /// pool, a lazily built runtime — survives instead of being rebuilt per
+    /// call. Bursts past this many concurrent calls are still served, from
+    /// fresh instances.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pool_size: Option<i32>,
+    /// How many calls a warm instance serves before it is retired and the next
+    /// call starts cold. Unset (or `0`) means no limit. Only meaningful
+    /// alongside `poolSize`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_invocations: Option<i32>,
 }
 
 impl DevComponent {
@@ -363,6 +378,8 @@ impl DevComponent {
             environment: None,
             config: HashMap::new(),
             allowed_hosts: None,
+            pool_size: None,
+            max_invocations: None,
         }
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -119,6 +119,7 @@ const P3_FIXTURES: &[&str] = &[
     "svc-http-proxy",
     "svc-tcp-echo",
     "http-loopback-gateway",
+    "svc-no-run",
     "msg-counter",
     "bridge-backend",
     "bridge-service",


### PR DESCRIPTION
Implements the `// TODO: Implement pooling and instance limits` in `engine/workload.rs`. `Component.pool_size` and `Component.max_invocations` have been on the proto, the CRD and `types::Component` all along, and were hardcoded to `0` in the runtime — set them today and nothing happens.

A component that sets `pool_size > 0` opts out of per-call instantiation: after a call returns cleanly its store is parked, and the next call reuses it skipping the context build, the `Store` allocation and the instantiation, and letting the guest keep whatever it cached in linear memory (a connection pool, a lazily built runtime, parsed config).

Both paths that build a store per call are covered:

* **linked calls** — a plain-value async call between components (`invoke_ephemeral_plain`)
* **HTTP dispatch (p3)** — a component reached over `wasi:http/handler@0.3`

Also plumbed through `wash dev`, so `.wash/config.yaml` can set `poolSize` / `maxInvocations` per component.

## Measured

Trivial work in every case, so these are the shapes' own costs (`integration_topology_overhead`, included):

| topology | peak req/s |
|---|---|
| component, cold | 19,900 |
| component, warm | **60,100** |
| service (one instance) | 34,500 |
| service + linked component, cold | 11,000 |
| service + linked component, warm | 22,100 |

Warm components overtake a single service because `pool_size` buys real parallelism: each warm instance is an independent store, where a service is one instance every request shares. Per-request cost read at concurrency 1: a store build + instantiation is ~44 µs, an ephemeral store for a linked call ~53 µs, and a warm linked call ~9 µs.

## Why it is opt-in

`Component` is defined as having ephemeral state, and this keeps that as the default. `pool_size: 0` (and unset, which arrives as `-1`) behaves exactly as before.

## The rules that bound an instance's life

* `max_invocations` retires an instance after that many calls (0 = unlimited).
* An instance is parked **only** after a call that returned cleanly. A trap, a
  timeout, a host error, or a caller cancelled mid-call all retire the store
  instead — a guest interrupted partway through may hold locks or half-written
  buffers. This is correct by construction rather than by checking: the store
  travels into the spawned task and back out with the result, so the
  `AbortOnDrop` guard drops it rather than parking it. On the HTTP path the
  release happens only once the response body has been fully forwarded
  (`run_concurrent` does not resolve until then).
* Bursts past `pool_size` are served from fresh stores rather than queued, so
  pooling never adds latency it did not save.

## Linked components share the store's lifetime

A store holds more than the one component: whatever it links to is instantiated into the same store and lives exactly as long as it does. So a store is parked only when **every** component in it has opted in.

## A service needs no `wasi:cli/run`

Folded in here because the topology comparison above needs a service fixture, and the simplest one has no `cli/run`.

`wasi:cli/run` is what a service uses to drive long-running work of its own — an
accept loop, a poller. It is *not* what keeps a service instance alive: the host
instantiates the service once and serves each host-invoked export as a
concurrent task on it, co-driving `cli/run` only when present
(`run_trigger_driver` already treats `Command::new` as optional). That was true
but untested for services — host component plugins covered the optional-`cli/run`
path already (`kv-plugin` exports none), but nothing covered a *service*
without one.

New `svc-no-run` fixture: exports `wasi:http/handler@0.3` and nothing else, and
reports a per-instance request count. Five sequential requests return
`1,2,3,4,5` — one long-lived instance served them all. It mirrors the existing
`svc-counter` fixture minus its `cli/run` tick loop, so the pair isolates
exactly what `cli/run` buys. The same fixture backs the HTTP-dispatch pooling
tests below.

## Tests

`integration_warm_instances` reads a counter out of the guest's linear memory,
so the response says directly whether an instance was reused:

* linked call, unpooled → `1,1,1,1,1`; pooled → `1,2,3,4,5`;
  `max_invocations: 3` → `1,2,3,1,2,3,1`
* HTTP dispatch, same three shapes
* caller opted in with an unpooled callee → stays cold (`1,1,1,1`); both opted
  in → warm (`1,2,3,4`)
* 3,000 sequential requests through one warm instance still serve correctly,
  which a store leaking a resource-table entry per request would not

## Not covered

**The p2 HTTP path (`wasi:http/incoming-handler@0.2`) still instantiates per
request.** Its store is owned by a detached task that outlives the response
head, so recovering it for reuse needs a restructure this PR does not do. Happy
to follow up.

A pooled instance freezes the context it was built with (environment, config,
resolved volume mounts) for its lifetime; `max_invocations` bounds how stale
that can get. Documented on `InstancePool`.

A service that owns a **loopback listener** still needs `cli/run`. Moving an
accept loop into a task spawned from the HTTP handler does not work: the spawned
task is driven (its first poll runs, and outbound sockets from such a task
complete fine), but the virtualized-loopback accept stream never delivers a
connection. Separate runtime gap, not addressed here.

## Reviewer note

`test_bridge_backend_is_stateless` carried `pool_size: 1` while asserting the
backend was stateless — inert boilerplate until now. It says `0` explicitly.
Worth knowing that `pool_size: 1` appears as boilerplate in ~25 test files; the
rest pass because their guests are stateless or are not reached via a pooled
path, but the values now mean something.
