### PR TITLE
feat: async wasmcloud:secrets + secrets host component plugin

### DIFF
--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -168,6 +168,36 @@ pub fn kv_plugin_caller_host_interfaces_with_config(
     ]
 }
 
+/// The `wasmcloud:secrets` capability (store + reveal), provided by the
+/// `secrets-host` host component plugin.
+#[cfg(feature = "host-component-plugins")]
+pub fn secrets_interface(config: HashMap<String, String>) -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "secrets".to_string(),
+        interfaces: ["store".to_string(), "reveal".to_string()]
+            .into_iter()
+            .collect(),
+        version: Some(semver::Version::parse("2.0.0").unwrap()),
+        config,
+        name: None,
+    }
+}
+
+/// Interfaces for the `secrets-caller` workload: HTTP ingress plus the imported
+/// `wasmcloud:secrets` capability, carrying the credentials as interface config —
+/// which the secrets plugin captures in its `on-workload-bind`.
+#[cfg(feature = "host-component-plugins")]
+pub fn secrets_caller_host_interfaces_with_config(
+    host_header: &str,
+    config: HashMap<String, String>,
+) -> Vec<WitInterface> {
+    vec![
+        http_incoming_handler_interface(host_header, None),
+        secrets_interface(config),
+    ]
+}
+
 /// Interfaces for P3 HTTP + blobstore components.
 pub fn http_blobstore_host_interfaces(host_header: &str) -> Vec<WitInterface> {
     vec![

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -664,6 +664,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrets-caller"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
+name = "secrets-host"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.59.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -51,6 +51,8 @@ members = [
     "kv-plugin-caller",
     "kv-plugin-service",
     "badlifecycle",
+    "secrets-host",
+    "secrets-caller",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/secrets-caller/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/secrets-caller/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/secrets_caller.wasm

--- a/crates/wash-runtime/tests/fixtures/secrets-caller/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/secrets-caller/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "secrets-caller"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/secrets-caller/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/secrets-caller/src/lib.rs
@@ -1,0 +1,78 @@
+//! Workload component driving the imported `wasmcloud:secrets` capability over
+//! HTTP. The host resolves that import to the secrets host component plugin
+//! running in its own store, so each request is a cross-store call the test can
+//! drive by hitting an endpoint:
+//!
+//! - `GET /get?key=K` -> `store.get(K)` + `reveal` -> 200 body=value, or 404
+
+mod bindings {
+    #![allow(unsafe_code)]
+    wit_bindgen::generate!({ world: "secrets-caller", generate_all });
+}
+
+use bindings::exports::wasi::http::handler::Guest as HttpGuest;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::wasmcloud::secrets::reveal::reveal;
+use bindings::wasmcloud::secrets::store::{self, SecretValue};
+
+struct Component;
+
+impl HttpGuest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        let path = request
+            .get_path_with_query()
+            .unwrap_or_else(|| "/".to_string());
+        let (route, query) = match path.split_once('?') {
+            Some((r, q)) => (r, q),
+            None => (path.as_str(), ""),
+        };
+
+        if route.starts_with("/get") {
+            let key = query_get(query, "key").unwrap_or_default();
+            return match secret_string(&key).await {
+                Some(value) => Ok(make_response(200, value.into_bytes())),
+                None => Ok(make_response(404, Vec::new())),
+            };
+        }
+
+        Ok(make_response(404, Vec::new()))
+    }
+}
+
+/// Fetch `key` from the secrets plugin and reveal it as a UTF-8 string.
+async fn secret_string(key: &str) -> Option<String> {
+    let secret = store::get(key.to_string()).await.ok()?;
+    match reveal(&secret).await {
+        SecretValue::String(value) => Some(value),
+        SecretValue::Bytes(bytes) => String::from_utf8(bytes).ok(),
+    }
+}
+
+/// Return the value of `name` from a `k=v&k2=v2` query string, if present.
+fn query_get(query: &str, name: &str) -> Option<String> {
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k == name).then(|| v.to_string())
+    })
+}
+
+fn make_response(status: u16, body: Vec<u8>) -> Response {
+    let headers = Fields::new();
+    let _ = headers.set("content-type", &[b"application/octet-stream".to_vec()]);
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    let _ = response.set_status_code(status);
+    response
+}
+
+mod export {
+    #![allow(unsafe_code)]
+    use super::{bindings, Component};
+    bindings::export!(Component with_types_in bindings);
+}

--- a/crates/wash-runtime/tests/fixtures/secrets-caller/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/secrets-caller/wit/world.wit
@@ -1,0 +1,14 @@
+package wasmcloud:secrets-caller@0.1.0;
+
+// Workload component: HTTP ingress that, per request, resolves a credential
+// through the imported `wasmcloud:secrets` capability — which the host satisfies
+// with the secrets host component plugin running in its own store. Each request
+// runs under `run_concurrent`, so the async capability calls below hop across the
+// store boundary. `GET /get?key=K` returns the revealed value, or 404 when the
+// plugin has no such secret for this workload.
+world secrets-caller {
+    import wasi:http/types@0.3.0;
+    import wasmcloud:secrets/store@2.0.0;
+    import wasmcloud:secrets/reveal@2.0.0;
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/secrets-caller/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/secrets-caller/wkg.toml
@@ -1,0 +1,8 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:http" = { path = "../p3-wit-deps/wasi-http-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }
+"wasmcloud:secrets" = { path = "../../../../../wit/secrets/wit" }

--- a/crates/wash-runtime/tests/fixtures/secrets-host/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/secrets-host/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/secrets_host.wasm

--- a/crates/wash-runtime/tests/fixtures/secrets-host/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/secrets-host/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "secrets-host"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/secrets-host/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/secrets-host/src/lib.rs
@@ -1,0 +1,101 @@
+//! Host component plugin that serves `wasmcloud:secrets` from its own supervised
+//! store. It captures each consuming workload's secret configuration at
+//! `on-workload-bind` (the operator sources those values from `secretFrom`) and
+//! serves them back through `store`, correlating every call to the calling
+//! workload via the host identity import. Values leave only as opaque `secret`
+//! handles the caller unwraps with `reveal`.
+
+mod bindings {
+    #![allow(unsafe_code)]
+    wit_bindgen::generate!({ world: "secrets-host", generate_all });
+}
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use bindings::exports::wasmcloud::host::workload_lifecycle::{
+    Guest as LifecycleGuest, WorkloadInfo,
+};
+use bindings::exports::wasmcloud::secrets::reveal::{Guest as RevealGuest, SecretBorrow};
+use bindings::exports::wasmcloud::secrets::store::{
+    Guest as StoreGuest, GuestSecret, Secret, SecretValue, SecretsError,
+};
+use bindings::wasmcloud::host::identity;
+
+/// Per-workload secret configuration captured at bind, keyed by workload id then
+/// by config key. `on-workload-bind` fills it from the workload's matched
+/// interface config; `on-workload-unbind` reclaims it.
+static BINDS: Mutex<BTreeMap<String, BTreeMap<String, String>>> = Mutex::new(BTreeMap::new());
+
+/// Backing state for the exported `secret` resource: the resolved value, kept
+/// opaque to callers until they `reveal` it.
+struct SecretState {
+    value: SecretValue,
+}
+
+impl GuestSecret for SecretState {}
+
+struct Component;
+
+impl StoreGuest for Component {
+    type Secret = SecretState;
+
+    /// Resolve `key` from the calling workload's bind-time secret config. The
+    /// caller is identified via the host identity import, exact under
+    /// concurrency (resolved from this call's task). A missing key is `not-found`.
+    async fn get(key: String) -> Result<Secret, SecretsError> {
+        let caller = identity::get_workload_id();
+        let value = BINDS
+            .lock()
+            .unwrap()
+            .get(&caller)
+            .and_then(|config| config.get(&key).cloned());
+        match value {
+            Some(value) => Ok(Secret::new(SecretState {
+                value: SecretValue::String(value),
+            })),
+            None => Err(SecretsError::NotFound),
+        }
+    }
+}
+
+impl RevealGuest for Component {
+    async fn reveal(secret: SecretBorrow<'_>) -> SecretValue {
+        clone_value(&secret.get::<SecretState>().value)
+    }
+}
+
+impl LifecycleGuest for Component {
+    async fn on_workload_bind(workload: WorkloadInfo) -> Result<(), String> {
+        // Flatten every matched interface's config into one per-workload map;
+        // the `wasmcloud:secrets` binding's config carries the credentials the
+        // operator sourced from `secretFrom`.
+        let mut config = BTreeMap::new();
+        for binding in &workload.interfaces {
+            for entry in &binding.config {
+                config.insert(entry.key.clone(), entry.value.clone());
+            }
+        }
+        BINDS.lock().unwrap().insert(workload.id, config);
+        Ok(())
+    }
+
+    async fn on_workload_unbind(id: String) {
+        BINDS.lock().unwrap().remove(&id);
+    }
+}
+
+/// `secret-value` does not derive `Clone` in the generated bindings, so rebuild
+/// it by variant to return an owned copy.
+fn clone_value(value: &SecretValue) -> SecretValue {
+    match value {
+        SecretValue::String(s) => SecretValue::String(s.clone()),
+        SecretValue::Bytes(b) => SecretValue::Bytes(b.clone()),
+    }
+}
+
+mod export {
+    #![allow(unsafe_code)]
+    use super::{bindings, Component};
+    bindings::export!(Component with_types_in bindings);
+}

--- a/crates/wash-runtime/tests/fixtures/secrets-host/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/secrets-host/wit/world.wit
@@ -1,0 +1,19 @@
+package wasmcloud:secrets-host@0.1.0;
+
+// Host component plugin that serves `wasmcloud:secrets` from its own supervised
+// store. It captures each consuming workload's secret configuration at
+// `on-workload-bind` — the operator sources those values from `secretFrom` — and
+// serves them back through `store`, correlating every call to the calling
+// workload via the host identity import. Values leave only as opaque `secret`
+// handles the caller unwraps with `reveal`.
+world secrets-host {
+    // Correlate each capability call and lifecycle hook back to the calling
+    // workload, so credentials captured at bind are served to the right tenant.
+    import wasmcloud:host/identity@0.1.0;
+
+    export wasmcloud:secrets/store@2.0.0;
+    export wasmcloud:secrets/reveal@2.0.0;
+    // The host calls these as workloads importing `wasmcloud:secrets` bind and
+    // unbind; bind captures that workload's secret config, unbind reclaims it.
+    export wasmcloud:host/workload-lifecycle@0.1.0;
+}

--- a/crates/wash-runtime/tests/fixtures/secrets-host/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/secrets-host/wkg.toml
@@ -1,0 +1,6 @@
+[overrides]
+# `wasmcloud:host` (identity, workload-lifecycle) and `wasmcloud:secrets` are
+# defined in-repo; reference their source directly so the fixture tracks the
+# exact interfaces the host provides.
+"wasmcloud:host" = { path = "../../../../../wit/host/wit" }
+"wasmcloud:secrets" = { path = "../../../../../wit/secrets/wit" }

--- a/crates/wash-runtime/tests/integration_secrets_plugin.rs
+++ b/crates/wash-runtime/tests/integration_secrets_plugin.rs
@@ -1,0 +1,197 @@
+//! Integration test: `wasmcloud:secrets` served by the `secrets-host` host
+//! component plugin, with credentials delivered per-workload via workload
+//! lifecycle.
+//!
+//! Proves two things end to end, driven over HTTP through the `secrets-caller`
+//! workload:
+//!   - a capability (`store.get`/`reveal`) crosses the host component plugin
+//!     store boundary — the plugin serves it from its own supervised store;
+//!   - the interface config a workload declares (its credentials) reaches the
+//!     plugin via `on-workload-bind` and is served back, correlated to the
+//!     calling workload by the host identity import.
+
+#![cfg(feature = "host-component-plugins")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::host::HostApi;
+use wash_runtime::types::{LocalResources, WorkloadStopRequest};
+
+mod common;
+use common::{
+    component_workload_request, secrets_caller_host_interfaces_with_config,
+    start_host_with_component_plugin, start_host_with_component_plugin_by_host,
+};
+
+const SECRETS_HOST_WASM: &[u8] = include_bytes!("wasm/secrets_host.wasm");
+const SECRETS_CALLER_WASM: &[u8] = include_bytes!("wasm/secrets_caller.wasm");
+const PLUGIN_ID: &str = "wasmcloud-secrets";
+
+/// GET `http://{addr}{path}` with the `HOST` header selecting the workload,
+/// returning the status and body text.
+async fn req(
+    client: &reqwest::Client,
+    addr: &std::net::SocketAddr,
+    host: &str,
+    path: &str,
+) -> Result<(reqwest::StatusCode, String)> {
+    let resp = timeout(
+        Duration::from_secs(15),
+        client
+            .get(format!("http://{addr}{path}"))
+            .header("HOST", host)
+            .send(),
+    )
+    .await
+    .context("request timed out")??;
+    let status = resp.status();
+    let body = resp.text().await?;
+    Ok((status, body))
+}
+
+/// A `secrets-caller` workload addressed by `host`, with `config` set on its
+/// `wasmcloud:secrets` interface entry (the credentials `on-workload-bind`
+/// delivers to the plugin).
+fn caller_workload(
+    host: &str,
+    config: &[(&str, &str)],
+) -> wash_runtime::types::WorkloadStartRequest {
+    let config = config
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    component_workload_request(
+        "secrets-caller",
+        host,
+        SECRETS_CALLER_WASM,
+        LocalResources::default(),
+        secrets_caller_host_interfaces_with_config(host, config),
+    )
+}
+
+/// A workload's `wasmcloud:secrets` import resolves to the host component
+/// plugin; the credentials it declared at deploy time are served back through
+/// `store.get` + `reveal`, and an unknown key reads as `none` (404).
+#[tokio::test]
+async fn test_secret_delivered_and_revealed() -> Result<()> {
+    let host = "secrets-basic";
+    let (addr, h) =
+        start_host_with_component_plugin("127.0.0.1:0", PLUGIN_ID, SECRETS_HOST_WASM).await?;
+    h.workload_start(caller_workload(
+        host,
+        &[
+            ("registry-username", "alice"),
+            ("registry-password", "s3cr3t"),
+        ],
+    ))
+    .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, host, "/get?key=registry-username").await?;
+    assert_eq!(status.as_u16(), 200, "a bound secret must resolve");
+    assert_eq!(body, "alice", "the revealed value must round-trip");
+
+    let (status, body) = req(&client, &addr, host, "/get?key=registry-password").await?;
+    assert_eq!(status.as_u16(), 200);
+    assert_eq!(body, "s3cr3t");
+
+    let (status, _) = req(&client, &addr, host, "/get?key=absent").await?;
+    assert_eq!(status.as_u16(), 404, "an unbound key reads as none");
+
+    Ok(())
+}
+
+/// Secrets are partitioned per workload: two workloads that declare the same key
+/// with different values each resolve to their own value, proving the plugin
+/// keys bind-time config by the calling workload's identity rather than sharing
+/// one global map.
+///
+/// Multi-threaded: the by-host router uses `block_in_place`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_secrets_isolated_per_workload() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, SECRETS_HOST_WASM)
+            .await?;
+    h.workload_start(caller_workload(
+        "secrets-a",
+        &[("registry-username", "alice")],
+    ))
+    .await?;
+    h.workload_start(caller_workload(
+        "secrets-b",
+        &[("registry-username", "bob")],
+    ))
+    .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "secrets-a", "/get?key=registry-username").await?;
+    assert_eq!(status.as_u16(), 200);
+    assert_eq!(body, "alice");
+
+    let (status, body) = req(&client, &addr, "secrets-b", "/get?key=registry-username").await?;
+    assert_eq!(status.as_u16(), 200);
+    assert_eq!(body, "bob", "each workload must see only its own secret");
+
+    Ok(())
+}
+
+/// Stopping one workload delivers `on-workload-unbind` for it without disturbing
+/// the others: a surviving workload keeps resolving its own secret, and the
+/// stopped workload is no longer routable.
+///
+/// Multi-threaded: the by-host router uses `block_in_place`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_secret_survives_other_workload_stop() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, SECRETS_HOST_WASM)
+            .await?;
+    let stopped = caller_workload("secrets-stop", &[("registry-username", "carol")]);
+    let stopped_id = stopped.workload_id.clone();
+    h.workload_start(stopped).await?;
+    h.workload_start(caller_workload(
+        "secrets-keep",
+        &[("registry-username", "dave")],
+    ))
+    .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "secrets-keep", "/get?key=registry-username").await?;
+    assert_eq!(status.as_u16(), 200);
+    assert_eq!(body, "dave");
+
+    h.workload_stop(WorkloadStopRequest {
+        workload_id: stopped_id,
+    })
+    .await?;
+
+    // The survivor is untouched by the other workload's unbind.
+    let (status, body) = req(&client, &addr, "secrets-keep", "/get?key=registry-username").await?;
+    assert_eq!(status.as_u16(), 200);
+    assert_eq!(
+        body, "dave",
+        "stopping another workload must not disturb this one"
+    );
+
+    // The stopped workload is no longer routable (poll: teardown is async).
+    let mut stopped_status = 0;
+    for _ in 0..40 {
+        stopped_status = req(&client, &addr, "secrets-stop", "/get?key=registry-username")
+            .await?
+            .0
+            .as_u16();
+        if stopped_status == 404 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        stopped_status, 404,
+        "a stopped workload is no longer routable"
+    );
+
+    Ok(())
+}

--- a/examples/oci-registry/Cargo.lock
+++ b/examples/oci-registry/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +231,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 name = "oci-registry"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "hex",
  "serde_json",
  "sha2",

--- a/examples/oci-registry/Cargo.toml
+++ b/examples/oci-registry/Cargo.toml
@@ -48,6 +48,7 @@ wit-bindgen = { version = "0.58.0", features = ["async-spawn", "inter-task-wakeu
 serde_json = "1.0"
 sha2 = "0.10"
 hex = "0.4"
+base64 = "0.22"
 
 [profile.release]
 # Optimize for small code size

--- a/examples/oci-registry/src/auth.rs
+++ b/examples/oci-registry/src/auth.rs
@@ -1,0 +1,85 @@
+//! HTTP Basic authentication for the registry.
+//!
+//! Credentials come from a host component plugin (the secrets backend), imported
+//! as `wasmcloud:secrets/store` and unwrapped with `wasmcloud:secrets/reveal`.
+//! Every request must carry a matching `Authorization: Basic` header — including
+//! the `GET /v2/` probe, which is where an OCI client discovers it must
+//! authenticate.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use sha2::{Digest, Sha256};
+
+use crate::bindings::wasmcloud::secrets::reveal::reveal;
+use crate::bindings::wasmcloud::secrets::store::{self, SecretValue};
+use crate::http::{header_str, respond};
+use crate::{Fields, Response};
+
+/// Config keys the secrets backend is expected to serve.
+const USERNAME_KEY: &str = "registry-username";
+const PASSWORD_KEY: &str = "registry-password";
+const REALM: &str = "wasmcloud-oci-registry";
+
+/// Returns `Some(challenge)` — a `401` with a `WWW-Authenticate: Basic` header —
+/// when the request is not authenticated, and `None` when the credentials match.
+pub(crate) async fn require_basic(headers: &Fields) -> Option<Response> {
+    let (Some(username), Some(password)) = (
+        secret_string(USERNAME_KEY).await,
+        secret_string(PASSWORD_KEY).await,
+    ) else {
+        // The backend did not supply both credentials; deny rather than serve
+        // the registry without authentication.
+        return Some(challenge());
+    };
+    let expected = STANDARD.encode(format!("{username}:{password}"));
+    match header_str(headers, "authorization").and_then(|h| basic_token(&h)) {
+        Some(actual) if tokens_match(&actual, &expected) => None,
+        _ => Some(challenge()),
+    }
+}
+
+/// Fetch a credential from the secrets backend and reveal it as a UTF-8 string.
+async fn secret_string(key: &str) -> Option<String> {
+    let secret = store::get(key.to_string()).await.ok()?;
+    match reveal(&secret).await {
+        SecretValue::String(value) => Some(value),
+        SecretValue::Bytes(bytes) => String::from_utf8(bytes).ok(),
+    }
+}
+
+/// Extract the base64 credential token from an `Authorization: Basic <token>`
+/// header. The scheme is matched case-insensitively per RFC 7617; any other
+/// scheme (or a header without a token) yields `None`.
+fn basic_token(header: &str) -> Option<String> {
+    let (scheme, token) = header.trim().split_once(' ')?;
+    scheme
+        .eq_ignore_ascii_case("Basic")
+        .then(|| token.trim().to_string())
+}
+
+/// Constant-time credential comparison that leaks neither the value nor its
+/// length: each token is hashed to a fixed 32 bytes and the digests are compared
+/// byte-for-byte, so the work done is independent of the inputs. Equal digests
+/// imply equal tokens (SHA-256 is collision resistant).
+fn tokens_match(actual: &str, expected: &str) -> bool {
+    let actual = Sha256::digest(actual.as_bytes());
+    let expected = Sha256::digest(expected.as_bytes());
+    let mut diff = 0u8;
+    for (a, b) in actual.iter().zip(expected.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+fn challenge() -> Response {
+    let header = format!("Basic realm=\"{REALM}\"");
+    respond(
+        401,
+        &[
+            ("www-authenticate", header.as_str()),
+            ("content-type", "application/json"),
+            ("docker-distribution-api-version", "registry/2.0"),
+        ],
+        br#"{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}"#.to_vec(),
+    )
+}

--- a/examples/oci-registry/src/lib.rs
+++ b/examples/oci-registry/src/lib.rs
@@ -36,6 +36,7 @@ mod bindings {
     });
 }
 
+mod auth;
 mod blobs;
 mod http;
 mod keys;
@@ -88,6 +89,13 @@ async fn dispatch(request: Request) -> Result<Response, String> {
     let query = query.to_string();
 
     let headers = request.get_headers();
+
+    // Authenticate before anything else — including the `/v2/` version probe,
+    // which is where an OCI client discovers the registry requires credentials.
+    if let Some(challenge) = auth::require_basic(&headers).await {
+        return Ok(challenge);
+    }
+
     let content_type = header_str(&headers, "content-type");
     let content_range = header_str(&headers, "content-range");
 

--- a/examples/oci-registry/wit/world.wit
+++ b/examples/oci-registry/wit/world.wit
@@ -10,6 +10,13 @@ world oci-registry {
   // Random bytes for upload-session identifiers.
   import wasi:random/random@0.3.0;
 
+  // Basic-auth credentials, served by a host component plugin (the secrets
+  // backend). Consumed through the async `wasmcloud:secrets@2.0.0` interface —
+  // a host component plugin serves capability calls across its store boundary,
+  // which is inherently async.
+  import wasmcloud:secrets/store@2.0.0;
+  import wasmcloud:secrets/reveal@2.0.0;
+
   // HTTP entrypoint (wasip3 async handler).
   export wasi:http/handler@0.3.0;
 }

--- a/examples/oci-registry/wkg.toml
+++ b/examples/oci-registry/wkg.toml
@@ -1,0 +1,5 @@
+# `wasmcloud:secrets` is defined in-repo; resolve it from that source (rather
+# than a registry) so the example tracks the exact interface the host provides.
+# Every other dependency still resolves from the registries pinned in `wkg.lock`.
+[overrides]
+"wasmcloud:secrets" = { path = "../../wit/secrets/wit" }

--- a/wit/secrets/wit/world.wit
+++ b/wit/secrets/wit/world.wit
@@ -1,7 +1,12 @@
-package wasmcloud:secrets@1.0.0;
+package wasmcloud:secrets@2.0.0;
 
 /// Opaque-handle access to a secrets backend. Returning `secret` rather than
 /// the underlying value lets the host gate reveal independently of lookup.
+///
+/// The operations are `async`: a secrets backend is commonly served by a host
+/// component plugin from its own store, and cross-store capability calls are
+/// dispatched asynchronously. (This is the async revision of the synchronous
+/// `wasmcloud:secrets@1.0.0` interface.)
 interface store {
   /// An error type that encapsulates the different errors that can occur fetching secrets
   variant secrets-error {
@@ -34,7 +39,7 @@ interface store {
   resource secret;
 
   /// Gets a single opaque secrets value set at the given key if it exists
-  get: func(key: string) -> result<secret, secrets-error>;
+  get: async func(key: string) -> result<secret, secrets-error>;
 }
 
 /// Unwraps an opaque `secret` handle into its underlying value. Split from
@@ -44,7 +49,7 @@ interface reveal {
 
   /// Reveals the value of a secret to the caller.
   /// This lets you easily audit your code to discover where secrets are being used.
-  reveal: func(s: borrow<secret>) -> secret-value;
+  reveal: async func(s: borrow<secret>) -> secret-value;
 }
 
 world imports {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -128,6 +128,8 @@ const P3_FIXTURES: &[&str] = &[
     "kv-plugin-caller",
     "kv-plugin-service",
     "badlifecycle",
+    "secrets-host",
+    "secrets-caller",
 ];
 
 fn build_fixtures(workspace: &Path) -> Result<()> {


### PR DESCRIPTION
Depends on #5381 

This change revs `wit/secrets` from sync `@1.0.0` to async **`@2.0.0`** (`get`/`reveal` are `async func`), adds a test to excercise it and an example for how this can be used in a guest component (oci-reg with basic auth).

For Host Component Plugins, they require async API's to work. A host component plugin serves capability calls across its store boundary, which is inherently async. Right now the sync interface cannot be plugin-served (the cross-store shim only type-matches async imports). I did try hacking together basically a wasm shim composed in with an async wrapper but that added overhead.

The test shows how secrets can be delivered per-workload at `on-workload-bind` (operator sources it from `secretFrom`) and correlated to the caller via `wasmcloud:host/identity`.