### PR TITLE
refactor:  consolidate component loading

### DIFF
--- a/crates/wash-runtime/src/component_source.rs
+++ b/crates/wash-runtime/src/component_source.rs
@@ -1,0 +1,378 @@
+//! Where a WebAssembly component's bytes come from, and the one way to fetch
+//! them.
+//!
+//! Every front-end that runs or reads a component names its wasm the same two
+//! ways: an OCI image reference or a local file path. Workload components and
+//! services, `wash dev` components, host component plugins, `wash oci pull` and
+//! `wash inspect` all make that choice. [`ComponentSource`] is the choice and
+//! [`ComponentSource::load`] is the fetch, so a caller that gains one gains the
+//! other.
+//!
+//! Three shapes of input converge here:
+//!
+//! - Separate `image` / `file` fields (a YAML config block, `key=value` CLI
+//!   fields). [`ComponentSource::from_image_or_file`] enforces exactly one and
+//!   rejects a pull policy on a file.
+//! - A single positional reference with nothing to disambiguate it.
+//!   [`ComponentSource::from_reference`] classifies it.
+//! - An already-decided source uses the enum variants directly.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result, bail, ensure};
+use bytes::Bytes;
+
+use crate::oci::{OciConfig, OciPullPolicy, pull_component};
+
+/// Where a component's wasm bytes come from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ComponentSource {
+    /// Pulled from an OCI registry by image reference.
+    Oci {
+        image: String,
+        pull_policy: OciPullPolicy,
+    },
+    /// Read from a local file path.
+    File(PathBuf),
+}
+
+/// The bytes a [`ComponentSource`] resolved to, plus the identity they can be
+/// cached under.
+#[derive(Debug, Clone)]
+pub struct LoadedComponent {
+    pub bytes: Bytes,
+    /// Registry digest of the pulled image, `None` for a file source.
+    ///
+    /// The engine keys its compilation cache on this. A local path carries no
+    /// such identity. The same path can hold different bytes between two
+    /// reads so a file source declines to be cached rather than offering a
+    /// name that would collide with every other file.
+    pub digest: Option<String>,
+}
+
+impl LoadedComponent {
+    /// Check the fetched bytes against a pinned registry digest.
+    ///
+    /// Callers add their own context (which plugin, which component); this
+    /// supplies the reason. A file source has no digest to check, so pinning
+    /// one is a configuration error rather than a mismatch.
+    pub fn verify_digest(&self, expected: &str) -> Result<()> {
+        match &self.digest {
+            Some(digest) if digest == expected => Ok(()),
+            Some(digest) => bail!("digest mismatch: fetched {digest}, expected {expected}"),
+            None => bail!("digest pinning applies only to `image` sources"),
+        }
+    }
+}
+
+impl ComponentSource {
+    /// An OCI source that prefers the cache, the default nearly every caller
+    /// wants.
+    pub fn image(image: impl Into<String>) -> Self {
+        Self::Oci {
+            image: image.into(),
+            pull_policy: OciPullPolicy::IfNotPresent,
+        }
+    }
+
+    /// Resolve a source declared as separate `image` / `file` fields, requiring
+    /// exactly one of them.
+    ///
+    /// `name` names the thing being configured and leads every error, so pass
+    /// something the user can find in their config, e.g. `"host plugin 'acme-kv'"`,
+    /// `"dev.components['sidecar']"`.
+    ///
+    /// `pull_policy` belongs to an image; supplying one alongside a file is
+    /// rejected rather than ignored, so a config that reads as if it controls
+    /// caching actually does.
+    pub fn from_image_or_file(
+        image: Option<String>,
+        file: Option<PathBuf>,
+        pull_policy: Option<OciPullPolicy>,
+        name: &str,
+    ) -> Result<Self> {
+        match (image, file) {
+            (Some(image), None) => Ok(Self::Oci {
+                image,
+                pull_policy: pull_policy.unwrap_or(OciPullPolicy::IfNotPresent),
+            }),
+            (None, Some(file)) => {
+                ensure!(
+                    pull_policy.is_none(),
+                    "{name}: pull policy applies only to `image` sources"
+                );
+                ensure!(
+                    !file.as_os_str().is_empty(),
+                    "{name}: `file` source is empty"
+                );
+                Ok(Self::File(file))
+            }
+            (Some(_), Some(_)) => {
+                bail!("{name} sets both `image` and `file`; use exactly one")
+            }
+            (None, None) => bail!("{name} needs an `image` or `file` source"),
+        }
+    }
+
+    /// Classify a single user-supplied reference, for a positional CLI argument
+    /// where no separate field says which kind it is.
+    ///
+    /// An existing path is a file. Otherwise anything spelled like a path — an
+    /// absolute, home-relative or explicitly relative prefix, or a `.wasm`
+    /// extension — stays a file so that a mistyped path reports a missing file
+    /// instead of an obscure registry error. Everything else is an image
+    /// reference.
+    pub fn from_reference(reference: &str) -> Self {
+        let path = Path::new(reference);
+        if path.exists() || spelled_like_a_path(reference) {
+            Self::File(path.to_path_buf())
+        } else {
+            Self::image(reference)
+        }
+    }
+
+    /// Fetch the bytes and check them against a pinned registry digest.
+    ///
+    /// A source that carries no digest is rejected before any bytes move, so a
+    /// pin on a file is a configuration error rather than wasted I/O.
+    pub async fn load_pinned(
+        &self,
+        oci_config: OciConfig,
+        expected_digest: Option<&str>,
+    ) -> Result<LoadedComponent> {
+        let Some(expected) = expected_digest else {
+            return self.load(oci_config).await;
+        };
+        ensure!(
+            matches!(self, Self::Oci { .. }),
+            "digest pinning applies only to `image` sources"
+        );
+        let loaded = self.load(oci_config).await?;
+        loaded.verify_digest(expected)?;
+        Ok(loaded)
+    }
+
+    /// Fetch the bytes: pull the image or read the file.
+    ///
+    /// `oci_config` is ignored by a file source, so callers that accept either
+    /// kind can build one unconditionally.
+    pub async fn load(&self, oci_config: OciConfig) -> Result<LoadedComponent> {
+        match self {
+            Self::Oci { image, pull_policy } => {
+                // `pull_component` already names the reference it failed on.
+                let (bytes, digest) =
+                    pull_component(image, oci_config, pull_policy.clone()).await?;
+                Ok(LoadedComponent {
+                    bytes: bytes.into(),
+                    digest: Some(digest),
+                })
+            }
+            Self::File(path) => {
+                let bytes = tokio::fs::read(path)
+                    .await
+                    .with_context(|| format!("failed to read component file {}", path.display()))?;
+                Ok(LoadedComponent {
+                    bytes: bytes.into(),
+                    digest: None,
+                })
+            }
+        }
+    }
+}
+
+/// Whether a reference is written the way a filesystem path is written, for
+/// [`ComponentSource::from_reference`] to fall back on when nothing exists at
+/// that path yet.
+fn spelled_like_a_path(reference: &str) -> bool {
+    reference.starts_with('/')
+        || reference.starts_with('~')
+        || reference.starts_with("./")
+        || reference.starts_with(".\\")
+        || reference.starts_with("../")
+        || reference.starts_with("..\\")
+        || Path::new(reference)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("wasm"))
+}
+
+impl std::fmt::Display for ComponentSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Oci { image, .. } => write!(f, "{image}"),
+            Self::File(path) => write!(f, "{}", path.display()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_or_file_takes_exactly_one_source() {
+        let image = ComponentSource::from_image_or_file(
+            Some("ghcr.io/acme/kv:1".into()),
+            None,
+            Some(OciPullPolicy::Always),
+            "host plugin 'kv'",
+        )
+        .unwrap();
+        assert_eq!(
+            image,
+            ComponentSource::Oci {
+                image: "ghcr.io/acme/kv:1".into(),
+                pull_policy: OciPullPolicy::Always,
+            }
+        );
+
+        let file = ComponentSource::from_image_or_file(
+            None,
+            Some("./kv.wasm".into()),
+            None,
+            "host plugin 'kv'",
+        )
+        .unwrap();
+        assert_eq!(file, ComponentSource::File("./kv.wasm".into()));
+
+        for (image, file) in [
+            (
+                Some("ghcr.io/acme/kv:1".to_string()),
+                Some(PathBuf::from("./kv.wasm")),
+            ),
+            (None, None),
+        ] {
+            assert!(
+                ComponentSource::from_image_or_file(image, file, None, "host plugin 'kv'").is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn image_defaults_to_cached_pull_and_file_refuses_a_pull_policy() {
+        let image =
+            ComponentSource::from_image_or_file(Some("ghcr.io/acme/kv:1".into()), None, None, "kv")
+                .unwrap();
+        assert_eq!(
+            image,
+            ComponentSource::Oci {
+                image: "ghcr.io/acme/kv:1".into(),
+                pull_policy: OciPullPolicy::IfNotPresent,
+            }
+        );
+
+        let err = ComponentSource::from_image_or_file(
+            None,
+            Some("./kv.wasm".into()),
+            Some(OciPullPolicy::Always),
+            "host plugin 'kv'",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("host plugin 'kv'"), "{err}");
+        assert!(err.contains("pull policy"), "{err}");
+    }
+
+    #[test]
+    fn empty_file_source_is_rejected() {
+        assert!(
+            ComponentSource::from_image_or_file(None, Some(PathBuf::new()), None, "sidecar")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn reference_classifies_paths_and_images() {
+        for path in [
+            "./kv.wasm",
+            "../build/kv.wasm",
+            "/opt/kv.wasm",
+            "~/kv.wasm",
+            "build/kv.wasm",
+            "kv.WASM",
+        ] {
+            assert_eq!(
+                ComponentSource::from_reference(path),
+                ComponentSource::File(path.into()),
+                "{path} should be a file"
+            );
+        }
+
+        for image in [
+            "ghcr.io/acme/kv:1.0.0",
+            "ghcr.io/acme/kv@sha256:abc",
+            "localhost:5000/kv:latest",
+            "kv",
+        ] {
+            assert_eq!(
+                ComponentSource::from_reference(image),
+                ComponentSource::image(image),
+                "{image} should be an image"
+            );
+        }
+    }
+
+    #[test]
+    fn an_existing_path_wins_over_image_spelling() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("kv");
+        std::fs::write(&path, b"\0asm").unwrap();
+        let reference = path.to_str().unwrap();
+
+        assert_eq!(
+            ComponentSource::from_reference(reference),
+            ComponentSource::File(path.clone())
+        );
+    }
+
+    #[tokio::test]
+    async fn a_file_source_loads_bytes_without_a_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("kv.wasm");
+        std::fs::write(&path, b"\0asm\x0d\0\x01\0").unwrap();
+
+        let loaded = ComponentSource::File(path)
+            .load(OciConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(loaded.bytes.as_ref(), b"\0asm\x0d\0\x01\0");
+        assert!(loaded.digest.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_missing_file_names_the_path() {
+        let err = ComponentSource::File("/nonexistent/kv.wasm".into())
+            .load(OciConfig::default())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("/nonexistent/kv.wasm"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn a_digest_pin_on_a_file_is_rejected_before_reading_it() {
+        // The path does not exist: reaching the read at all would report a
+        // missing file instead of the pin being misplaced.
+        let err = ComponentSource::File("/nonexistent/kv.wasm".into())
+            .load_pinned(OciConfig::default(), Some("sha256:abc"))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("digest pinning"), "{err}");
+    }
+
+    #[test]
+    fn digest_pinning_needs_a_digest_to_check() {
+        let file = LoadedComponent {
+            bytes: Bytes::new(),
+            digest: None,
+        };
+        assert!(file.verify_digest("sha256:abc").is_err());
+
+        let pulled = LoadedComponent {
+            bytes: Bytes::new(),
+            digest: Some("sha256:abc".into()),
+        };
+        assert!(pulled.verify_digest("sha256:abc").is_ok());
+        assert!(pulled.verify_digest("sha256:def").is_err());
+    }
+}

--- a/crates/wash-runtime/src/lib.rs
+++ b/crates/wash-runtime/src/lib.rs
@@ -10,6 +10,9 @@ pub mod types;
 pub mod wit;
 
 #[cfg(feature = "oci")]
+pub mod component_source;
+
+#[cfg(feature = "oci")]
 pub mod oci;
 
 #[cfg(feature = "washlet")]

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -73,8 +73,8 @@ use crate::host::trigger_service::{
     CapabilityCall, CapabilityFunc, CapabilityJob, Ingress, LifecycleReplay, TriggerService,
     decode_bind_reply,
 };
-use crate::oci::{self, OciConfig};
-use crate::plugin::component_plugin_spec::{ComponentPluginSpec, PluginSource};
+use crate::oci::OciConfig;
+use crate::plugin::component_plugin_spec::ComponentPluginSpec;
 use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 
@@ -348,44 +348,14 @@ pub async fn load_component_plugin(
     engine: &Engine,
     oci_config: OciConfig,
 ) -> anyhow::Result<Arc<ComponentHostPlugin>> {
-    let (bytes, digest) = match &spec.source {
-        PluginSource::Oci { image, pull_policy } => {
-            oci::pull_component(image, oci_config, pull_policy.clone())
-                .await
-                .with_context(|| {
-                    format!(
-                        "failed to pull host component plugin '{}' from {image}",
-                        spec.id
-                    )
-                })?
-        }
-        PluginSource::File(path) => {
-            anyhow::ensure!(
-                spec.expected_digest.is_none(),
-                "host component plugin '{}': digest pinning applies only to `image=` sources",
-                spec.id
-            );
-            let bytes = tokio::fs::read(path).await.with_context(|| {
-                format!(
-                    "failed to read host component plugin '{}' from {}",
-                    spec.id,
-                    path.display()
-                )
-            })?;
-            (bytes, String::new())
-        }
-    };
-
-    if let Some(expected) = &spec.expected_digest {
-        anyhow::ensure!(
-            &digest == expected,
-            "host component plugin '{}' digest mismatch: pulled {digest}, expected {expected}",
-            spec.id
-        );
-    }
+    let loaded = spec
+        .source
+        .load_pinned(oci_config, spec.expected_digest.as_deref())
+        .await
+        .with_context(|| format!("loading host component plugin '{}'", spec.id))?;
 
     let id = intern_plugin_id(&spec.id);
-    let mut plugin = ComponentHostPlugin::new(id, &bytes, engine.clone())
+    let mut plugin = ComponentHostPlugin::new(id, &loaded.bytes, engine.clone())
         .with_context(|| format!("failed to build host component plugin '{}'", spec.id))?;
     if let Some(max_restarts) = spec.max_restarts {
         plugin = plugin.with_max_restarts(max_restarts);

--- a/crates/wash-runtime/src/plugin/component_plugin_spec.rs
+++ b/crates/wash-runtime/src/plugin/component_plugin_spec.rs
@@ -14,19 +14,7 @@ use std::str::FromStr;
 
 use anyhow::{Context as _, anyhow, bail, ensure};
 
-use crate::oci::OciPullPolicy;
-
-/// Where a host component plugin's wasm bytes come from.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PluginSource {
-    /// Pulled from an OCI registry by image reference.
-    Oci {
-        image: String,
-        pull_policy: OciPullPolicy,
-    },
-    /// Read from a local file path.
-    File(PathBuf),
-}
+use crate::component_source::ComponentSource;
 
 /// A host component plugin to load: a host-unique id, a source for its wasm, and
 /// optional supervision/integrity settings.
@@ -35,19 +23,19 @@ pub struct ComponentPluginSpec {
     /// Host-unique plugin id. Collides loudly with an existing plugin's id at
     /// registration time (`HostBuilder::with_plugin` dedupes).
     pub id: String,
-    pub source: PluginSource,
+    pub source: ComponentSource,
     /// Supervised driver restarts before the plugin is declared dead. `None`
     /// uses the loader default.
     pub max_restarts: Option<u32>,
     /// Optional OCI digest to pin for supply-chain integrity. Only meaningful
-    /// for [`PluginSource::Oci`]; the loader rejects it on a file source.
+    /// for [`ComponentSource::Oci`]; the loader rejects it on a file source.
     pub expected_digest: Option<String>,
 }
 
 impl ComponentPluginSpec {
     /// Build a spec from an id and source with default supervision/integrity
     /// settings (no restart-cap override, no digest pin).
-    pub fn from_plugin_source(id: impl Into<String>, source: PluginSource) -> Self {
+    pub fn from_plugin_source(id: impl Into<String>, source: ComponentSource) -> Self {
         Self {
             id: id.into(),
             source,
@@ -108,23 +96,8 @@ impl FromStr for ComponentPluginSpec {
         }
 
         let id = id.context("host plugin spec is missing required `id=`")?;
-        let source = match (image, file) {
-            (Some(image), None) => PluginSource::Oci {
-                image,
-                pull_policy: pull.unwrap_or(OciPullPolicy::IfNotPresent),
-            },
-            (None, Some(file)) => {
-                ensure!(
-                    pull.is_none(),
-                    "host plugin '{id}': `pull=` applies only to `image=` sources"
-                );
-                PluginSource::File(file)
-            }
-            (Some(_), Some(_)) => {
-                bail!("host plugin '{id}' sets both `image=` and `file=`; use exactly one")
-            }
-            (None, None) => bail!("host plugin '{id}' needs an `image=` or `file=` source"),
-        };
+        let source =
+            ComponentSource::from_image_or_file(image, file, pull, &format!("host plugin '{id}'"))?;
 
         Ok(Self {
             id,
@@ -138,6 +111,7 @@ impl FromStr for ComponentPluginSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::oci::OciPullPolicy;
 
     #[test]
     fn parses_oci_spec_with_all_fields() {
@@ -148,7 +122,7 @@ mod tests {
         assert_eq!(spec.id, "acme-kv");
         assert_eq!(
             spec.source,
-            PluginSource::Oci {
+            ComponentSource::Oci {
                 image: "ghcr.io/acme/kv:1.0.0".into(),
                 pull_policy: OciPullPolicy::Always,
             }
@@ -160,16 +134,10 @@ mod tests {
     #[test]
     fn parses_file_spec_and_defaults_pull_policy_for_oci() {
         let file: ComponentPluginSpec = "id=kv,file=./kv.wasm".parse().unwrap();
-        assert_eq!(file.source, PluginSource::File("./kv.wasm".into()));
+        assert_eq!(file.source, ComponentSource::File("./kv.wasm".into()));
 
         let oci: ComponentPluginSpec = "id=kv,image=ghcr.io/acme/kv:1".parse().unwrap();
-        assert_eq!(
-            oci.source,
-            PluginSource::Oci {
-                image: "ghcr.io/acme/kv:1".into(),
-                pull_policy: OciPullPolicy::IfNotPresent,
-            }
-        );
+        assert_eq!(oci.source, ComponentSource::image("ghcr.io/acme/kv:1"));
     }
 
     #[test]

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -22,9 +22,10 @@
 //! - [`wasi_logging`] - Structured logging (`wasi:logging`)
 //! - [`wasi_otel`] - OpenTelemetry tracing, metrics, and logs (`wasi:otel/*`)
 
+use std::collections::HashMap;
 use std::future::Future;
-use std::path::PathBuf;
-use std::{collections::HashMap, path::Path};
+#[cfg(any(feature = "wasi-blobstore", feature = "wasi-keyvalue"))]
+use std::path::{Path, PathBuf};
 
 use crate::engine::workload::WorkloadItem;
 use crate::{
@@ -53,16 +54,20 @@ pub mod wasi_otel;
 pub mod wasmcloud_messaging;
 
 /// Host capabilities provided by a WebAssembly component running in its own
-/// supervised store (rather than by a Rust plugin running in-store).
-#[cfg(feature = "host-component-plugins")]
+/// supervised store (rather than by a Rust plugin running in-store). Needs
+/// `oci` for the loader that fetches a plugin's wasm.
+#[cfg(all(feature = "host-component-plugins", feature = "oci"))]
 pub mod component_host;
 
-/// Declarative spec for a host component plugin (id + wasm source). Always
-/// compiled so front-ends can accept a plugin declaration and fail clearly when
-/// built without the `host-component-plugins` feature; the loader that consumes
-/// it lives in [`component_host`].
+/// Declarative spec for a host component plugin (id + wasm source). Compiled
+/// whenever the sources it can name are reachable, independent of
+/// `host-component-plugins`, so front-ends can accept a plugin declaration and
+/// fail clearly when built without that feature; the loader that consumes it
+/// lives in [`component_host`].
+#[cfg(feature = "oci")]
 pub mod component_plugin_spec;
-pub use component_plugin_spec::{ComponentPluginSpec, PluginSource};
+#[cfg(feature = "oci")]
+pub use component_plugin_spec::ComponentPluginSpec;
 
 /// Shared `(implements ..)` multiplexing core
 #[cfg(feature = "wasm_component_model_implements")]
@@ -431,6 +436,10 @@ impl<T, Y> WorkloadTracker<T, Y> {
 }
 
 /// Locks an untrusted path to be within the given root directory.
+///
+/// Only the filesystem-backed plugins hand it untrusted names, so it compiles
+/// with them.
+#[cfg(any(feature = "wasi-blobstore", feature = "wasi-keyvalue"))]
 pub(crate) fn lock_root(root: impl AsRef<Path>, untrusted: &str) -> Result<PathBuf, &'static str> {
     let path = Path::new(untrusted);
 

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::component_source::ComponentSource;
 use crate::host::{Host, HostApi, HostConfig};
 use crate::oci::{self, OciConfig};
 use crate::plugin::HostPlugin;
@@ -404,23 +405,18 @@ async fn workload_start(
         let mut pulled_components = Vec::with_capacity(wit_world.components.len());
         for component in &wit_world.components {
             let oci_config = image_pull_secret_to_oci_config(config, &component.image_pull_secret);
-            let (bytes, digest) = match oci::pull_component(
-                &component.image,
-                oci_config,
-                component.image_pull_policy().into(),
-            )
-            .await
-            {
-                Ok(res) => res,
+            let source = ComponentSource::Oci {
+                image: component.image.clone(),
+                pull_policy: component.image_pull_policy().into(),
+            };
+            let loaded = match source.load(oci_config).await {
+                Ok(loaded) => loaded,
                 Err(e) => {
                     return Ok(types::v2::WorkloadStartResponse {
                         workload_status: Some(types::v2::WorkloadStatus {
                             workload_id: workload_id.clone(),
                             workload_state: types::v2::WorkloadState::Error.into(),
-                            message: format!(
-                                "failed to pull component image {}: {}",
-                                component.image, e
-                            ),
+                            message: format!("{e:#}"),
                         }),
                     });
                 }
@@ -445,8 +441,8 @@ async fn workload_start(
             };
             pulled_components.push(crate::types::Component {
                 name: component.name.clone(),
-                bytes: bytes.into(),
-                digest: Some(digest),
+                bytes: loaded.bytes,
+                digest: loaded.digest,
                 local_resources,
                 pool_size: component.pool_size,
                 max_invocations: component.max_invocations,
@@ -466,20 +462,18 @@ async fn workload_start(
 
     let service = if let Some(service) = service {
         let oci_config = image_pull_secret_to_oci_config(config, &service.image_pull_secret);
-        let (bytes, digest) = match oci::pull_component(
-            &service.image,
-            oci_config,
-            service.image_pull_policy().into(),
-        )
-        .await
-        {
-            Ok(res) => res,
+        let source = ComponentSource::Oci {
+            image: service.image.clone(),
+            pull_policy: service.image_pull_policy().into(),
+        };
+        let loaded = match source.load(oci_config).await {
+            Ok(loaded) => loaded,
             Err(e) => {
                 return Ok(types::v2::WorkloadStartResponse {
                     workload_status: Some(types::v2::WorkloadStatus {
                         workload_id: workload_id.clone(),
                         workload_state: types::v2::WorkloadState::Error.into(),
-                        message: format!("failed to pull service image {}: {}", service.image, e),
+                        message: format!("{e:#}"),
                     }),
                 });
             }
@@ -500,8 +494,8 @@ async fn workload_start(
             None => crate::types::LocalResources::default(),
         };
         Some(crate::types::Service {
-            bytes: bytes.into(),
-            digest: Some(digest),
+            bytes: loaded.bytes,
+            digest: loaded.digest,
             local_resources,
             max_restarts: service.max_restarts,
         })

--- a/crates/wash-runtime/tests/integration_host_plugin_loader.rs
+++ b/crates/wash-runtime/tests/integration_host_plugin_loader.rs
@@ -8,10 +8,11 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use wash_runtime::component_source::ComponentSource;
 use wash_runtime::engine::Engine;
 use wash_runtime::oci::{OciConfig, OciPullPolicy};
 use wash_runtime::plugin::component_host::load_component_plugin;
-use wash_runtime::plugin::{ComponentPluginSpec, HostPlugin as _, PluginSource};
+use wash_runtime::plugin::{ComponentPluginSpec, HostPlugin as _};
 
 fn kv_plugin_path() -> PathBuf {
     PathBuf::from(concat!(
@@ -25,7 +26,7 @@ async fn loads_component_plugin_from_file() -> Result<()> {
     let engine = Engine::builder().build()?;
     let spec = ComponentPluginSpec::from_plugin_source(
         "acme-kv-plugin",
-        PluginSource::File(kv_plugin_path()),
+        ComponentSource::File(kv_plugin_path()),
     );
 
     let plugin = load_component_plugin(&spec, &engine, OciConfig::default()).await?;
@@ -63,7 +64,7 @@ async fn loads_component_plugin_from_oci() -> Result<()> {
     let engine = Engine::builder().build()?;
     let spec = ComponentPluginSpec::from_plugin_source(
         "acme-kv-plugin",
-        PluginSource::Oci {
+        ComponentSource::Oci {
             image: reference.clone(),
             pull_policy: OciPullPolicy::Always,
         },
@@ -93,7 +94,7 @@ async fn rejects_digest_pin_on_file_source() {
     let engine = Engine::builder().build().unwrap();
     let mut spec = ComponentPluginSpec::from_plugin_source(
         "acme-kv-plugin",
-        PluginSource::File(kv_plugin_path()),
+        ComponentSource::File(kv_plugin_path()),
     );
     spec.expected_digest = Some("sha256:deadbeef".into());
 
@@ -112,7 +113,7 @@ async fn missing_file_errors_with_id_and_context() {
     let engine = Engine::builder().build().unwrap();
     let spec = ComponentPluginSpec::from_plugin_source(
         "ghost",
-        PluginSource::File("/nonexistent/does-not-exist.wasm".into()),
+        ComponentSource::File("/nonexistent/does-not-exist.wasm".into()),
     );
 
     let err = load_component_plugin(&spec, &engine, OciConfig::default())

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -13,6 +13,7 @@ use wash_runtime::{
     engine::{Engine, WasmProposal},
     host::{Host, HostApi},
     observability::Meters,
+    oci::OciConfig,
     plugin::{self},
     types::{
         Component, HostPathVolume, LocalResources, Service, Volume, VolumeMount, VolumeType,
@@ -22,7 +23,10 @@ use wash_runtime::{
 };
 
 use crate::{
-    cli::{CliCommand, CliContext, CommandOutput, component_build::build_dev_component},
+    cli::{
+        CliCommand, CliContext, CommandOutput, component_build::build_dev_component,
+        oci::OCI_CACHE_DIR,
+    },
     config::{Config, load_config},
     wit::WitConfig,
     workload::{ResolvedWorkload, resolve_component_workload, resolve_workload},
@@ -57,6 +61,13 @@ impl CliCommand for DevCommand {
         .context("failed to load config for development")?;
 
         let dev_config = config.dev();
+
+        // Shared by every image source a dev session can name: the dev
+        // component's sidecars, its service, and the host component plugins.
+        // Cached under the same directory `wash oci pull` uses, so a pull here
+        // is a pull there.
+        let mut oci_config = OciConfig::new_with_cache(ctx.cache_dir().join(OCI_CACHE_DIR));
+        oci_config.insecure = dev_config.allow_insecure_registries;
 
         let http_addr = dev_config
             .address
@@ -147,7 +158,7 @@ impl CliCommand for DevCommand {
             let plugin = wash_runtime::plugin::component_host::load_component_plugin(
                 &spec,
                 &engine,
-                wash_runtime::oci::OciConfig::default(),
+                oci_config.clone(),
             )
             .await
             .with_context(|| format!("failed to load host component plugin '{}'", spec.id))?;
@@ -371,6 +382,7 @@ impl CliCommand for DevCommand {
             project_dir,
             wasm_bytes.into(),
             &resolved_workload,
+            &oci_config,
         )
         .await?;
         // Running workload ID for reloads
@@ -419,7 +431,7 @@ impl CliCommand for DevCommand {
 /// reads anything that is not a positive pool size as "do not keep instances".
 const UNSET_LIMIT: i32 = -1;
 
-struct LoadedComponent {
+struct SidecarComponent {
     name: String,
     bytes: Bytes,
     interfaces: HashSet<WitInterface>,
@@ -433,14 +445,14 @@ struct LoadedComponent {
 /// Thin wrapper around [`build_workload`]: extracts dev-component
 /// interfaces, loads sidecar bytes + interfaces, resolves each sidecar's
 /// overrides over the workload-level base, and (when configured) loads the
-/// service-file bytes. All workload-construction logic lives in
-/// `build_workload`.
+/// service bytes. All workload-construction logic lives in `build_workload`.
 async fn create_workload(
     host: &Host,
     config: &Config,
     project_dir: &Path,
     bytes: Bytes,
     resolved_workload: &ResolvedWorkload,
+    oci_config: &OciConfig,
 ) -> anyhow::Result<Workload> {
     let dev_config = config.dev();
 
@@ -450,16 +462,15 @@ async fn create_workload(
 
     let mut sidecars = Vec::with_capacity(dev_config.components.len());
     for dev_component in &dev_config.components {
-        let comp_bytes = tokio::fs::read(&dev_component.file)
+        let name = &dev_component.name;
+        let loaded = dev_component
+            .source
+            .to_source(&format!("dev.components['{name}']"))?
+            .load(oci_config.clone())
             .await
-            .with_context(|| {
-                format!(
-                    "failed to read component file at {}",
-                    dev_component.file.display()
-                )
-            })?;
+            .with_context(|| format!("dev.components['{name}']"))?;
         let interfaces = host
-            .intersect_interfaces(&comp_bytes)
+            .intersect_interfaces(&loaded.bytes)
             .context("failed to extract component interfaces")?;
         // Errors already name the component.
         let workload = resolve_component_workload(
@@ -469,9 +480,9 @@ async fn create_workload(
             project_dir,
             Some(project_dir),
         )?;
-        sidecars.push(LoadedComponent {
-            name: dev_component.name.clone(),
-            bytes: Bytes::from(comp_bytes),
+        sidecars.push(SidecarComponent {
+            name: name.clone(),
+            bytes: loaded.bytes,
             interfaces,
             workload,
             pool_size: dev_component.pool_size,
@@ -479,19 +490,20 @@ async fn create_workload(
         });
     }
 
-    // The service file is only deployed as a service when the dev component
+    // The configured service is only deployed as one when the dev component
     // isn't itself the service (`dev.service = false`); see `build_workload`.
-    // When `dev.service` is true the file is ignored, so there's no point
-    // reading it or folding its imports into the workload host interfaces.
-    let (service_file_bytes, service_interfaces) = match &dev_config.service_file {
-        Some(service_path) if !dev_config.service => {
-            let raw = tokio::fs::read(service_path).await.with_context(|| {
-                format!("failed to read service file at {}", service_path.display())
-            })?;
+    // When `dev.service` is true it is ignored, so there's no point fetching it
+    // or folding its imports into the workload host interfaces.
+    let (service_bytes, service_interfaces) = match dev_config.service_source()? {
+        Some(source) if !dev_config.service => {
+            let loaded = source
+                .load(oci_config.clone())
+                .await
+                .context("failed to load the dev service component")?;
             let interfaces = host
-                .intersect_interfaces(&raw)
-                .context("failed to extract service file interfaces")?;
-            (Some(Bytes::from(raw)), Some(interfaces))
+                .intersect_interfaces(&loaded.bytes)
+                .context("failed to extract service interfaces")?;
+            (Some(loaded.bytes), Some(interfaces))
         }
         _ => (None, None),
     };
@@ -501,7 +513,7 @@ async fn create_workload(
         bytes,
         dev_interfaces,
         sidecars,
-        service_file_bytes,
+        service_bytes,
         service_interfaces,
         resolved_workload,
     ))
@@ -526,8 +538,8 @@ fn build_workload(
     dev_config: &crate::config::DevConfig,
     bytes: Bytes,
     dev_interfaces: HashSet<WitInterface>,
-    sidecars: Vec<LoadedComponent>,
-    service_file_bytes: Option<Bytes>,
+    sidecars: Vec<SidecarComponent>,
+    service_bytes: Option<Bytes>,
     service_interfaces: Option<HashSet<WitInterface>>,
     resolved_workload: &ResolvedWorkload,
 ) -> Workload {
@@ -592,7 +604,7 @@ fn build_workload(
             max_invocations: UNSET_LIMIT,
         });
 
-        if let Some(service_bytes) = service_file_bytes {
+        if let Some(service_bytes) = service_bytes {
             service = Some(Service {
                 bytes: service_bytes,
                 digest: None,
@@ -768,8 +780,8 @@ mod tests {
 
     /// A sidecar input with the given pre-merged workload values, as
     /// `create_workload` would produce it.
-    fn loaded_sidecar(name: &str, workload: ResolvedWorkload) -> LoadedComponent {
-        LoadedComponent {
+    fn loaded_sidecar(name: &str, workload: ResolvedWorkload) -> SidecarComponent {
+        SidecarComponent {
             name: name.into(),
             bytes: fake_bytes(name),
             interfaces: HashSet::new(),
@@ -978,9 +990,9 @@ mod tests {
 
     #[test]
     fn build_workload_service_file_sidecar_gets_workload_values() {
-        // dev.service = false + dev.service_file = Some(...) loads a sidecar
-        // service alongside the dev component. Workload values are
-        // workload-wide, so the sidecar service receives them too.
+        // dev.service = false plus a configured service source (file or image)
+        // loads a sidecar service alongside the dev component. Workload values
+        // are workload-wide, so the sidecar service receives them too.
         let resolved = ResolvedWorkload {
             environment: HashMap::from([("LOG".into(), "info".into())]),
             ..Default::default()
@@ -1061,7 +1073,7 @@ mod tests {
             components: vec![dev_component_named("sidecar")],
             ..Default::default()
         };
-        let sidecars = vec![LoadedComponent {
+        let sidecars = vec![SidecarComponent {
             name: "sidecar".into(),
             bytes: fake_bytes("sidecar"),
             interfaces: HashSet::from([iface("wasi", "config")]),
@@ -1087,11 +1099,11 @@ mod tests {
 
     #[test]
     fn build_workload_service_file_interfaces_reach_host_interfaces() {
-        // Regression for #5351: a service_file that imports a plugin
+        // Regression for #5351: a configured service that imports a plugin
         // interface (e.g. wasi:keyvalue) must have that interface folded into
         // the workload's host_interfaces so the plugin binds to the service.
         // Here neither the dev component nor any sidecar imports it, so the
-        // interface can only reach host_interfaces via the service file.
+        // interface can only reach host_interfaces via the service.
         let dev_cfg = DevConfig::default();
 
         let workload = build_workload(

--- a/crates/wash/src/cli/inspect.rs
+++ b/crates/wash/src/cli/inspect.rs
@@ -1,47 +1,43 @@
 use clap::Args;
 use tracing::instrument;
+use wash_runtime::component_source::ComponentSource;
 
 use crate::{
-    cli::{CliCommand, CliContext, CommandOutput},
+    cli::{CliCommand, CliContext, CommandOutput, oci::RegistryArgs},
     inspect::{decode_component, get_component_wit},
 };
-use anyhow::Context;
+use anyhow::{Context, ensure};
 use std::path::Path;
 
 #[derive(Args, Debug, Clone)]
 pub struct InspectCommand {
-    /// Inspect a component at a given path.
-    #[arg(value_name = "COMPONENT_PATH")]
+    /// Inspect a component, given either a local path or an OCI reference.
+    #[arg(value_name = "COMPONENT_REFERENCE")]
     pub component_reference: String,
+    /// Registry settings, used only when the reference is an OCI image.
+    #[command(flatten)]
+    pub registry: RegistryArgs,
 }
 
 impl CliCommand for InspectCommand {
     #[instrument(level = "debug", skip_all, name = "inspect")]
-    async fn handle(&self, _ctx: &CliContext) -> anyhow::Result<CommandOutput> {
-        // Handle the optional component reference - default to current directory if not provided
+    async fn handle(&self, ctx: &CliContext) -> anyhow::Result<CommandOutput> {
         let component_reference = &self.component_reference;
 
-        let path = Path::new(&component_reference);
+        // A directory is the one input the shared source resolution cannot make
+        // sense of: it exists, so it is classified as a file, and reading it
+        // fails with an OS error that does not say what to do instead.
+        let path = Path::new(component_reference);
+        ensure!(
+            !path.is_dir(),
+            "Directory '{component_reference}' specified. Please provide a file path or OCI reference."
+        );
 
-        let bytes = if path.exists() {
-            if path.is_file() {
-                tokio::fs::read(&component_reference)
-                    .await
-                    .context("failed to read component file")?
-            } else if path.is_dir() {
-                anyhow::bail!(
-                    "Directory '{component_reference}' specified. Please provide a file path."
-                );
-            } else {
-                anyhow::bail!(
-                    "Path '{component_reference}' exists but is neither a file nor directory"
-                );
-            }
-        } else {
-            anyhow::bail!("Path '{component_reference}' does not exist locally");
-        };
+        let loaded = ComponentSource::from_reference(component_reference)
+            .load(self.registry.oci_config(ctx))
+            .await?;
 
-        let component = decode_component(bytes.as_slice())
+        let component = decode_component(loaded.bytes.as_ref())
             .await
             .context("failed to decode component")?;
 

--- a/crates/wash/src/cli/oci.rs
+++ b/crates/wash/src/cli/oci.rs
@@ -5,12 +5,47 @@ use anyhow::Context as _;
 use chrono::Utc;
 use clap::{Args, Parser, Subcommand};
 use tracing::instrument;
-use wash_runtime::oci::{OciConfig, OciPullPolicy, pull_component, push_component};
+use wash_runtime::component_source::ComponentSource;
+use wash_runtime::oci::{OciConfig, OciPullPolicy, push_component};
 use wasm_metadata::Payload;
 
 pub(crate) const OCI_CACHE_DIR: &str = "oci";
 
 use crate::cli::{CliCommand, CliContext, CommandOutput};
+
+/// How to reach a registry, for every command that names an OCI reference.
+#[derive(Args, Debug, Clone, Default)]
+pub struct RegistryArgs {
+    /// Use HTTP or HTTPS protocol
+    #[arg(long = "insecure", default_value_t = false)]
+    pub insecure: bool,
+    /// Username for basic authentication
+    #[arg(short, long)]
+    pub user: Option<String>,
+    /// Password for basic authentication
+    #[arg(short, long)]
+    pub password: Option<String>,
+}
+
+impl RegistryArgs {
+    /// Build the config these flags describe, cached under the shared OCI cache
+    /// so a pull by one command is a cache hit for the next.
+    ///
+    /// Supplying only one half of a credential pair is a no-op rather than an
+    /// error: the ambient docker credential helper may well have the answer.
+    pub fn oci_config(&self, ctx: &CliContext) -> OciConfig {
+        let mut oci_config = OciConfig::new_with_cache(ctx.cache_dir().join(OCI_CACHE_DIR));
+        oci_config.insecure = self.insecure;
+
+        if let (Some(user), Some(password)) = (&self.user, &self.password) {
+            oci_config.credentials = Some((user.clone(), password.clone()));
+        } else if self.user.as_ref().or(self.password.as_ref()).is_some() {
+            tracing::warn!("username or password provided without the other");
+        }
+
+        oci_config
+    }
+}
 
 /// Push or pull Wasm components to/from an OCI registry
 #[derive(Parser, Debug, Clone)]
@@ -53,34 +88,24 @@ pub struct PullCommand {
     /// The path to write the pulled component to
     #[arg(default_value = "component.wasm")]
     pub component_path: PathBuf,
-    /// Use HTTP or HTTPS protocol
-    #[arg(long = "insecure", default_value_t = false)]
-    pub insecure: bool,
-    /// Username for basic authentication
-    #[arg(short, long)]
-    pub user: Option<String>,
-    /// Password for basic authentication
-    #[arg(short, long)]
-    pub password: Option<String>,
+    #[command(flatten)]
+    pub registry: RegistryArgs,
 }
 
 impl PullCommand {
     /// Handle the OCI command
     #[instrument(level = "debug", skip_all, name = "oci")]
     pub async fn handle(&self, ctx: &CliContext) -> anyhow::Result<CommandOutput> {
-        let mut oci_config = OciConfig::new_with_cache(ctx.cache_dir().join(OCI_CACHE_DIR));
-        oci_config.insecure = self.insecure;
+        let oci_config = self.registry.oci_config(ctx);
 
-        if let Some(ref user) = self.user
-            && let Some(ref password) = self.password
-        {
-            oci_config.credentials = Some((user.clone(), password.clone()));
-        } else if self.user.as_ref().or(self.password.as_ref()).is_some() {
-            tracing::warn!("username or password provided without the other");
+        // `pull` means pull: go to the registry even when the cache already has
+        // this reference.
+        let loaded = ComponentSource::Oci {
+            image: self.reference.clone(),
+            pull_policy: OciPullPolicy::Always,
         }
-
-        let (c, digest) =
-            pull_component(&self.reference, oci_config, OciPullPolicy::Always).await?;
+        .load(oci_config)
+        .await?;
 
         // Resolve component path relative to project directory if not absolute
         let component_path = if self.component_path.is_absolute() {
@@ -90,7 +115,7 @@ impl PullCommand {
         };
 
         // Write the component to the specified output path
-        tokio::fs::write(&component_path, &c)
+        tokio::fs::write(&component_path, &loaded.bytes)
             .await
             .context("failed to write pulled component to output path")?;
 
@@ -99,8 +124,8 @@ impl PullCommand {
             Some(serde_json::json!({
                 "message": "OCI command executed successfully.",
                 "output_path": component_path.to_string_lossy(),
-                "bytes": c.len(),
-                "digest": digest,
+                "bytes": loaded.bytes.len(),
+                "digest": loaded.digest,
                 "success": true,
             })),
         ))
@@ -113,15 +138,8 @@ pub struct PushCommand {
     pub reference: String,
     /// The path to the component to push
     pub component_path: PathBuf,
-    /// Use HTTP or HTTPS protocol
-    #[arg(long = "insecure", default_value_t = false)]
-    pub insecure: bool,
-    /// Username for basic authentication
-    #[arg(short, long)]
-    pub user: Option<String>,
-    /// Password for basic authentication
-    #[arg(short, long)]
-    pub password: Option<String>,
+    #[command(flatten)]
+    pub registry: RegistryArgs,
 }
 
 impl PushCommand {
@@ -188,16 +206,7 @@ impl PushCommand {
             Utc::now().to_rfc3339(),
         );
 
-        let mut oci_config = OciConfig::new_with_cache(ctx.cache_dir().join(OCI_CACHE_DIR));
-        oci_config.insecure = self.insecure;
-
-        if let Some(ref user) = self.user
-            && let Some(ref password) = self.password
-        {
-            oci_config.credentials = Some((user.clone(), password.clone()));
-        } else if self.user.as_ref().or(self.password.as_ref()).is_some() {
-            tracing::warn!("username or password provided without the other");
-        }
+        let oci_config = self.registry.oci_config(ctx);
 
         let digest = push_component(
             &self.reference,

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -14,7 +14,9 @@ use figment::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::info;
+use wash_runtime::component_source::ComponentSource;
 use wash_runtime::host::allowed_hosts::AllowedHost;
+use wash_runtime::oci::OciPullPolicy;
 use wash_runtime::wit::WitInterface;
 
 use crate::{
@@ -327,6 +329,61 @@ pub struct DevVolume {
     pub guest_path: PathBuf,
 }
 
+/// Where a config block's wasm component comes from: exactly one of `file` or
+/// `image`, plus a pull policy that only an image can honor.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentSourceConfig {
+    /// Local wasm file path. Mutually exclusive with `image`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<PathBuf>,
+    /// OCI image reference. Mutually exclusive with `file`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    /// Pull policy for `image` sources: `always`, `ifNotPresent`, or `never`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_policy: Option<String>,
+}
+
+impl ComponentSourceConfig {
+    /// A local file source.
+    pub fn file(path: impl Into<PathBuf>) -> Self {
+        Self {
+            file: Some(path.into()),
+            ..Default::default()
+        }
+    }
+
+    /// An OCI image source, pulled under the default policy.
+    pub fn image(image: impl Into<String>) -> Self {
+        Self {
+            image: Some(image.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Resolve to a runtime [`ComponentSource`].
+    ///
+    /// `name` names the config block and leads every error. Pass something the
+    /// user can find in their `config.yaml`, e.g. `"dev.components['sidecar']"`.
+    pub fn to_source(&self, name: &str) -> Result<ComponentSource> {
+        let pull_policy = match &self.pull_policy {
+            Some(policy) => Some(
+                policy
+                    .parse::<OciPullPolicy>()
+                    .with_context(|| name.to_string())?,
+            ),
+            None => None,
+        };
+        ComponentSource::from_image_or_file(
+            self.image.clone(),
+            self.file.clone(),
+            pull_policy,
+            name,
+        )
+    }
+}
+
 /// A component loaded alongside the main dev component.
 ///
 /// `environment` / `config` / `allowedHosts` override the workload-level
@@ -337,8 +394,9 @@ pub struct DevVolume {
 pub struct DevComponent {
     /// Name of the component
     pub name: String,
-    /// Path to the component file
-    pub file: PathBuf,
+    /// Where the component's wasm comes from: a local `file` or an `image`.
+    #[serde(flatten)]
+    pub source: ComponentSourceConfig,
     /// Environment variables (wasi:cli/env), merged over
     /// `workload.environment`. This component wins on key conflicts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -370,11 +428,17 @@ pub struct DevComponent {
 }
 
 impl DevComponent {
-    /// Creates a component entry with no per-component overrides.
+    /// Creates a file-backed component entry with no per-component overrides.
     pub fn new(name: impl Into<String>, file: impl Into<PathBuf>) -> Self {
+        Self::from_source(name, ComponentSourceConfig::file(file))
+    }
+
+    /// Creates a component entry from any source with no per-component
+    /// overrides.
+    pub fn from_source(name: impl Into<String>, source: ComponentSourceConfig) -> Self {
         Self {
             name: name.into(),
-            file: file.into(),
+            source,
             environment: None,
             config: HashMap::new(),
             allowed_hosts: None,
@@ -394,15 +458,9 @@ impl DevComponent {
 pub struct HostPluginConfig {
     /// Host-unique plugin id.
     pub id: String,
-    /// Local wasm file path. Mutually exclusive with `image`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub file: Option<PathBuf>,
-    /// OCI image reference. Mutually exclusive with `file`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub image: Option<String>,
-    /// Pull policy for `image` sources: `always`, `ifNotPresent`, or `never`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pull_policy: Option<String>,
+    /// Where the plugin's wasm comes from: a local `file` or an `image`.
+    #[serde(flatten)]
+    pub source: ComponentSourceConfig,
     /// Supervised driver restarts before the plugin is declared dead.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_restarts: Option<u32>,
@@ -412,57 +470,19 @@ pub struct HostPluginConfig {
 }
 
 impl HostPluginConfig {
-    /// Convert to a runtime [`wash_runtime::plugin::ComponentPluginSpec`],
-    /// validating that exactly one source is set and that `pullPolicy`/
-    /// `expectedDigest` are used only with an `image` source.
+    /// Convert to a runtime [`wash_runtime::plugin::ComponentPluginSpec`].
+    ///
+    /// `expectedDigest` on a file source is caught by the loader when it finds
+    /// no digest to check against, so this only has to validate what it can see
+    /// without fetching.
     pub fn to_spec(&self) -> Result<wash_runtime::plugin::ComponentPluginSpec> {
-        use wash_runtime::plugin::{ComponentPluginSpec, PluginSource};
-
         if self.id.is_empty() {
             bail!("dev.host_plugins entry is missing a non-empty `id`");
         }
-        let source = match (&self.file, &self.image) {
-            (Some(file), None) => {
-                if self.pull_policy.is_some() {
-                    bail!(
-                        "dev.host_plugins '{}': pullPolicy applies only to image sources",
-                        self.id
-                    );
-                }
-                if self.expected_digest.is_some() {
-                    bail!(
-                        "dev.host_plugins '{}': expectedDigest applies only to image sources",
-                        self.id
-                    );
-                }
-                PluginSource::File(file.clone())
-            }
-            (None, Some(image)) => {
-                let pull_policy = match &self.pull_policy {
-                    Some(p) => p
-                        .parse::<wash_runtime::oci::OciPullPolicy>()
-                        .with_context(|| format!("dev.host_plugins '{}'", self.id))?,
-                    None => wash_runtime::oci::OciPullPolicy::IfNotPresent,
-                };
-                PluginSource::Oci {
-                    image: image.clone(),
-                    pull_policy,
-                }
-            }
-            (Some(_), Some(_)) => {
-                bail!(
-                    "dev.host_plugins '{}' sets both `file` and `image`; use exactly one",
-                    self.id
-                )
-            }
-            (None, None) => bail!(
-                "dev.host_plugins '{}' needs a `file` or `image` source",
-                self.id
-            ),
-        };
-        Ok(ComponentPluginSpec {
+        let what = format!("dev.host_plugins '{}'", self.id);
+        Ok(wash_runtime::plugin::ComponentPluginSpec {
             id: self.id.clone(),
-            source,
+            source: self.source.to_source(&what)?,
             max_restarts: self.max_restarts,
             expected_digest: self.expected_digest.clone(),
         })
@@ -489,9 +509,23 @@ pub struct DevConfig {
     /// Whether the component under development should be treated as a service
     #[serde(default)]
     pub service: bool,
-    /// Optional path to a wasm component to be used as a service
+    /// Optional path to a wasm component to be used as a service. Mutually
+    /// exclusive with `service_image`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_file: Option<PathBuf>,
+    /// Optional OCI image for the component to be used as a service. Mutually
+    /// exclusive with `service_file`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_image: Option<String>,
+    /// Pull policy for `service_image`: `always`, `ifNotPresent`, or `never`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_pull_policy: Option<String>,
+
+    /// Reach registries over HTTP instead of HTTPS. Applies to every image a
+    /// dev session pulls components, the service, and host plugins.
+    /// Mirrors `wash host --allow-insecure-registries`.
+    #[serde(default)]
+    pub allow_insecure_registries: bool,
 
     /// Additional components to load alongside the main component
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -577,6 +611,24 @@ pub struct DevConfig {
 }
 
 impl DevConfig {
+    /// Where the separately-configured service component comes from, or `None`
+    /// when none is configured.
+    ///
+    /// `dev.service = true` makes the component under development the service,
+    /// and then this is ignored. See `wash dev`'s workload assembly.
+    pub fn service_source(&self) -> Result<Option<ComponentSource>> {
+        if self.service_file.is_none() && self.service_image.is_none() {
+            return Ok(None);
+        }
+        ComponentSourceConfig {
+            file: self.service_file.clone(),
+            image: self.service_image.clone(),
+            pull_policy: self.service_pull_policy.clone(),
+        }
+        .to_source("dev.service_file/service_image")
+        .map(Some)
+    }
+
     pub fn validate(&self) -> Result<()> {
         let mut errors: Vec<String> = Vec::new();
 
@@ -643,9 +695,22 @@ impl DevConfig {
             if comp.name.trim().is_empty() {
                 errors.push("dev.components contains an entry with empty name".to_string());
             }
-            if comp.file.as_os_str().is_empty() {
-                errors.push(format!("dev.components['{}'].file is empty", comp.name));
+            if let Err(err) = comp
+                .source
+                .to_source(&format!("dev.components['{}']", comp.name))
+            {
+                errors.push(format!("{err:#}"));
             }
+        }
+
+        for plugin in &self.host_plugins {
+            if let Err(err) = plugin.to_spec() {
+                errors.push(format!("{err:#}"));
+            }
+        }
+
+        if let Err(err) = self.service_source() {
+            errors.push(format!("{err:#}"));
         }
 
         if errors.is_empty() {
@@ -1222,16 +1287,111 @@ workload:
             ..Default::default()
         };
         let err = cfg.validate().unwrap_err().to_string();
-        assert!(err.contains("file is empty"));
+        assert!(err.contains("`file` source is empty"), "{err}");
     }
 
     #[test]
     fn dev_component_valid_is_ok() {
         let cfg = DevConfig {
-            components: vec![DevComponent::new("sidecar", "sidecar.wasm")],
+            components: vec![
+                DevComponent::new("sidecar", "sidecar.wasm"),
+                DevComponent::from_source(
+                    "pulled",
+                    ComponentSourceConfig::image("ghcr.io/acme/sidecar:1"),
+                ),
+            ],
             ..Default::default()
         };
         assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn dev_component_ambiguous_source_is_err() {
+        // Both sources, then neither, then a pull policy on a file.
+        for source in [
+            ComponentSourceConfig {
+                file: Some("sidecar.wasm".into()),
+                image: Some("ghcr.io/acme/sidecar:1".into()),
+                pull_policy: None,
+            },
+            ComponentSourceConfig::default(),
+            ComponentSourceConfig {
+                file: Some("sidecar.wasm".into()),
+                image: None,
+                pull_policy: Some("always".into()),
+            },
+            ComponentSourceConfig {
+                file: None,
+                image: Some("ghcr.io/acme/sidecar:1".into()),
+                pull_policy: Some("sometimes".into()),
+            },
+        ] {
+            let cfg = DevConfig {
+                components: vec![DevComponent::from_source("sidecar", source)],
+                ..Default::default()
+            };
+            let err = cfg.validate().unwrap_err().to_string();
+            assert!(err.contains("dev.components['sidecar']"), "{err}");
+        }
+    }
+
+    #[test]
+    fn dev_component_image_source_parses_from_yaml() {
+        // `image` / `pullPolicy` are flattened alongside `file`, so a sidecar
+        // names its wasm exactly the way a host plugin does.
+        let yaml = r#"
+dev:
+  components:
+    - name: sidecar
+      image: ghcr.io/acme/sidecar:1.0.0
+      pullPolicy: always
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let dev = config.dev();
+        let source = dev.components[0].source.to_source("sidecar").unwrap();
+        assert_eq!(
+            source,
+            ComponentSource::Oci {
+                image: "ghcr.io/acme/sidecar:1.0.0".into(),
+                pull_policy: OciPullPolicy::Always,
+            }
+        );
+    }
+
+    #[test]
+    fn dev_service_takes_a_file_or_an_image_but_not_both() {
+        let none = DevConfig::default();
+        assert!(none.service_source().unwrap().is_none());
+
+        let file = DevConfig {
+            service_file: Some("service.wasm".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            file.service_source().unwrap(),
+            Some(ComponentSource::File("service.wasm".into()))
+        );
+
+        let image = DevConfig {
+            service_image: Some("ghcr.io/acme/svc:1".into()),
+            service_pull_policy: Some("always".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            image.service_source().unwrap(),
+            Some(ComponentSource::Oci {
+                image: "ghcr.io/acme/svc:1".into(),
+                pull_policy: OciPullPolicy::Always,
+            })
+        );
+
+        let both = DevConfig {
+            service_file: Some("service.wasm".into()),
+            service_image: Some("ghcr.io/acme/svc:1".into()),
+            ..Default::default()
+        };
+        assert!(both.service_source().is_err());
+        assert!(both.validate().is_err());
     }
 
     #[test]
@@ -1277,7 +1437,6 @@ dev:
 
     #[test]
     fn dev_host_plugins_parse_from_yaml_and_convert_to_spec() {
-        use wash_runtime::plugin::PluginSource;
         // The `dev.host_plugins` key follows DevConfig's snake_case; each entry's
         // fields follow the camelCase used by other nested dev structs.
         let yaml = r#"
@@ -1298,12 +1457,15 @@ dev:
         assert_eq!(kv.id, "acme-kv");
         assert_eq!(
             kv.source,
-            PluginSource::File("./build/kv_plugin.wasm".into())
+            ComponentSource::File("./build/kv_plugin.wasm".into())
         );
         assert_eq!(kv.max_restarts, Some(3));
 
         let widgets = dev.host_plugins[1].to_spec().unwrap();
-        assert!(matches!(widgets.source, PluginSource::Oci { .. }));
+        assert_eq!(
+            widgets.source,
+            ComponentSource::image("ghcr.io/acme/widgets:1.2.0")
+        );
     }
 
     #[test]
@@ -1311,8 +1473,11 @@ dev:
         // Both sources set.
         let both = HostPluginConfig {
             id: "x".into(),
-            file: Some("a.wasm".into()),
-            image: Some("ghcr.io/x:1".into()),
+            source: ComponentSourceConfig {
+                file: Some("a.wasm".into()),
+                image: Some("ghcr.io/x:1".into()),
+                pull_policy: None,
+            },
             ..Default::default()
         };
         assert!(both.to_spec().is_err());
@@ -1327,15 +1492,18 @@ dev:
         // pullPolicy with a file source.
         let pull_on_file = HostPluginConfig {
             id: "x".into(),
-            file: Some("a.wasm".into()),
-            pull_policy: Some("always".into()),
+            source: ComponentSourceConfig {
+                file: Some("a.wasm".into()),
+                image: None,
+                pull_policy: Some("always".into()),
+            },
             ..Default::default()
         };
         assert!(pull_on_file.to_spec().is_err());
 
         // Empty id.
         let empty_id = HostPluginConfig {
-            file: Some("a.wasm".into()),
+            source: ComponentSourceConfig::file("a.wasm"),
             ..Default::default()
         };
         assert!(empty_id.to_spec().is_err());

--- a/crates/wash/tests/integration_oci.rs
+++ b/crates/wash/tests/integration_oci.rs
@@ -10,7 +10,7 @@ use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, GenericImage};
 use tokio::time::timeout;
 use wash::cli::CliContext;
-use wash::cli::oci::{PullCommand, PushCommand};
+use wash::cli::oci::{PullCommand, PushCommand, RegistryArgs};
 
 /// Start a local OCI registry container (distribution/distribution) on a random host port.
 async fn start_registry() -> Result<(ContainerAsync<GenericImage>, u16)> {
@@ -60,9 +60,10 @@ async fn oci_push_pull_round_trip() -> Result<()> {
     let push_cmd = PushCommand {
         reference: reference.clone(),
         component_path: push_path,
-        insecure: true,
-        user: None,
-        password: None,
+        registry: RegistryArgs {
+            insecure: true,
+            ..Default::default()
+        },
     };
     let push_result = timeout(Duration::from_secs(30), push_cmd.handle(&ctx))
         .await
@@ -86,9 +87,10 @@ async fn oci_push_pull_round_trip() -> Result<()> {
     let pull_cmd = PullCommand {
         reference: reference.clone(),
         component_path: pull_path.clone(),
-        insecure: true,
-        user: None,
-        password: None,
+        registry: RegistryArgs {
+            insecure: true,
+            ..Default::default()
+        },
     };
     let pull_result = timeout(Duration::from_secs(30), pull_cmd.handle(&ctx))
         .await

--- a/templates/http-api-with-distributed-workloads/README.md
+++ b/templates/http-api-with-distributed-workloads/README.md
@@ -128,6 +128,20 @@ dev:
         reverse.prefix: "🔁 "
 ```
 
+A component that you are not editing can come from a registry instead of the
+build directory. Give it an `image` in place of `file`, optionally with a
+`pullPolicy` of `always`, `ifNotPresent` (the default) or `never`:
+
+```yaml
+dev:
+  components:
+    - name: task-leet
+      image: ghcr.io/acme/task-leet:1.0.0
+      pullPolicy: ifNotPresent
+      config:
+        subscriptions: tasks.leet
+```
+
 Two kinds of per-component config are at work:
 
 - **`subscriptions`** is read by the messaging backend (in-memory for

--- a/templates/service-tcp/README.md
+++ b/templates/service-tcp/README.md
@@ -116,7 +116,7 @@ The `.wash/config.yaml` file tells `wash dev` how to build and run this project:
 
 - **`build.command`** — Builds the entire workspace for `wasm32-wasip2`
 - **`build.component_path`** — Points to the HTTP API component (the primary request handler)
-- **`dev.service_file`** — Points to the TCP service, which `wash dev` starts as a long-running background process alongside the HTTP handler
+- **`dev.service_file`** — Points to the TCP service, which `wash dev` starts as a long-running background process alongside the HTTP handler. To run a published service instead of a locally built one, replace it with `dev.service_image` (plus an optional `dev.service_pull_policy`)
 
 The runtime treats these two workloads differently:
 


### PR DESCRIPTION
Introduces a single way to load components via ComponentSource and refactors the 4 different ways we were previously loading components to one path.

Surfaces new api in wash dev for imagePullPolicy and loading services from images.

Part of improvements called out in #5344