### PR TITLE
refactor(runtime): one list for multiplexed plugins

### DIFF
--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -984,6 +984,19 @@ impl HostBuilder {
         Ok(self)
     }
 
+    /// Registers the multiplexed plugin set from
+    /// [`crate::plugin::multiplexed_plugins`], which is what makes
+    /// `(implements ..)` named imports resolvable. Without it, every
+    /// registered plugin reports `supports_named_instances() == false` and a
+    /// workload needing named multiplexing fails to bind.
+    #[cfg(feature = "wasm_component_model_implements")]
+    pub fn with_multiplexed_plugins(mut self) -> anyhow::Result<Self> {
+        for plugin in crate::plugin::multiplexed_plugins() {
+            self = self.with_plugin(plugin)?;
+        }
+        Ok(self)
+    }
+
     pub fn with_meters(mut self, meters: Meters) -> Self {
         self.meters = meters;
         self

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -450,3 +450,69 @@ pub(crate) fn lock_root(root: impl AsRef<Path>, untrusted: &str) -> Result<PathB
 
     Ok(root.as_ref().join(path))
 }
+
+/// The multiplexed plugin set a host registers to serve `(implements ..)`
+/// named imports.
+///
+/// Every single-backend plugin leaves [`HostPlugin::supports_named_instances`]
+/// at its default of `false`, so a workload declaring two entries of one
+/// namespace:package under distinct names fails to bind unless a multiplexed
+/// plugin is registered alongside. That makes this list load-bearing rather
+/// than optional, and it was previously written out by hand in every embedder:
+/// `wash host`, `wash dev`, and downstream hosts each kept their own copy.
+/// The copies drift — a downstream host lost `(implements ..)` support
+/// entirely for three weeks after a refactor rebuilt its registration list and
+/// omitted the block, with nothing at compile time to notice. One list here
+/// means adding a multiplexed plugin reaches every embedder at once.
+///
+/// Postgres is deliberately absent: whether it registers at all, and whether
+/// as `multiplex_only`, depends on the host's own configuration.
+#[cfg(feature = "wasm_component_model_implements")]
+pub fn multiplexed_plugins() -> Vec<std::sync::Arc<dyn HostPlugin>> {
+    #[allow(unused_mut)]
+    let mut plugins: Vec<std::sync::Arc<dyn HostPlugin>> = Vec::new();
+    #[allow(unused_imports)]
+    use std::sync::Arc;
+
+    #[cfg(feature = "wasi-keyvalue")]
+    {
+        plugins.push(Arc::new(
+            wasi_keyvalue::MultiplexedKeyValue::new()
+                .with_provider(Arc::new(wasi_keyvalue::InMemoryProvider))
+                .with_provider(Arc::new(wasi_keyvalue::RedisProvider))
+                .with_provider(Arc::new(wasi_keyvalue::NatsProvider))
+                .with_provider(Arc::new(wasi_keyvalue::FilesystemProvider)),
+        ));
+        plugins.push(Arc::new(
+            wasi_keyvalue::MultiplexedAsyncKeyValue::new()
+                .with_provider(Arc::new(wasi_keyvalue::InMemoryProvider))
+                .with_provider(Arc::new(wasi_keyvalue::RedisProvider))
+                .with_provider(Arc::new(wasi_keyvalue::NatsProvider))
+                .with_provider(Arc::new(wasi_keyvalue::FilesystemProvider)),
+        ));
+    }
+
+    #[cfg(feature = "wasi-blobstore")]
+    {
+        plugins.push(Arc::new(
+            wasi_blobstore::MultiplexedBlobstore::new()
+                .with_provider(Arc::new(wasi_blobstore::InMemoryProvider))
+                .with_provider(Arc::new(wasi_blobstore::FilesystemProvider))
+                .with_provider(Arc::new(wasi_blobstore::NatsBlobProvider)),
+        ));
+        plugins.push(Arc::new(
+            wasi_blobstore::MultiplexedAsyncBlobstore::new()
+                .with_provider(Arc::new(wasi_blobstore::InMemoryProvider))
+                .with_provider(Arc::new(wasi_blobstore::FilesystemProvider))
+                .with_provider(Arc::new(wasi_blobstore::NatsBlobProvider)),
+        ));
+    }
+
+    plugins.push(Arc::new(
+        wasmcloud_messaging::MultiplexedMessaging::new()
+            .with_provider(Arc::new(wasmcloud_messaging::InMemoryMsgProvider))
+            .with_provider(Arc::new(wasmcloud_messaging::NatsMsgProvider)),
+    ));
+
+    plugins
+}

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -76,6 +76,14 @@ impl ClusterHostBuilder {
         Ok(self)
     }
 
+    /// Registers the multiplexed plugin set. See
+    /// [`crate::host::HostBuilder::with_multiplexed_plugins`].
+    #[cfg(feature = "wasm_component_model_implements")]
+    pub fn with_multiplexed_plugins(mut self) -> anyhow::Result<Self> {
+        self.host_builder = self.host_builder.with_multiplexed_plugins()?;
+        Ok(self)
+    }
+
     pub fn with_artifact_cleaner(mut self, frequency: Duration, max_age: Duration) -> Self {
         self.cleanup_interval = Some(frequency);
         self.cleanup_age = Some(max_age);

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -250,42 +250,8 @@ impl CliCommand for DevCommand {
 
         #[cfg(feature = "wasm_component_model_implements")]
         {
-            host_builder = host_builder.with_plugin(Arc::new(
-                plugin::wasi_keyvalue::MultiplexedKeyValue::new()
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::InMemoryProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::RedisProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::NatsProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
-            ))?;
-            debug!("WASI KeyValue multiplexed plugin registered (implements)");
-            host_builder = host_builder.with_plugin(Arc::new(
-                plugin::wasmcloud_messaging::MultiplexedMessaging::new()
-                    .with_provider(Arc::new(plugin::wasmcloud_messaging::InMemoryMsgProvider))
-                    .with_provider(Arc::new(plugin::wasmcloud_messaging::NatsMsgProvider)),
-            ))?;
-            debug!("wasmcloud:messaging multiplexed plugin registered (implements)");
-            host_builder = host_builder.with_plugin(Arc::new(
-                plugin::wasi_blobstore::MultiplexedBlobstore::new()
-                    .with_provider(Arc::new(plugin::wasi_blobstore::InMemoryProvider))
-                    .with_provider(Arc::new(plugin::wasi_blobstore::FilesystemProvider))
-                    .with_provider(Arc::new(plugin::wasi_blobstore::NatsBlobProvider)),
-            ))?;
-            debug!("wasi:blobstore multiplexed plugin registered (implements)");
-            host_builder = host_builder.with_plugin(Arc::new(
-                plugin::wasi_blobstore::MultiplexedAsyncBlobstore::new()
-                    .with_provider(Arc::new(plugin::wasi_blobstore::InMemoryProvider))
-                    .with_provider(Arc::new(plugin::wasi_blobstore::FilesystemProvider))
-                    .with_provider(Arc::new(plugin::wasi_blobstore::NatsBlobProvider)),
-            ))?;
-            debug!("wasmcloud:blobstore async multiplexed plugin registered (implements)");
-            host_builder = host_builder.with_plugin(Arc::new(
-                plugin::wasi_keyvalue::MultiplexedAsyncKeyValue::new()
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::InMemoryProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::RedisProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::NatsProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
-            ))?;
-            debug!("wasmcloud:keyvalue async multiplexed plugin registered (implements)");
+            host_builder = host_builder.with_multiplexed_plugins()?;
+            debug!("multiplexed plugins registered (implements)");
         }
 
         // Add postgres plugin if configured

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -267,37 +267,7 @@ impl CliCommand for HostCommand {
 
         #[cfg(feature = "wasm_component_model_implements")]
         {
-            cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
-                plugin::wasi_keyvalue::MultiplexedKeyValue::new()
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::InMemoryProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::RedisProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::NatsProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
-            ))?;
-            cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
-                plugin::wasmcloud_messaging::MultiplexedMessaging::new()
-                    .with_provider(Arc::new(plugin::wasmcloud_messaging::InMemoryMsgProvider))
-                    .with_provider(Arc::new(plugin::wasmcloud_messaging::NatsMsgProvider)),
-            ))?;
-            cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
-                plugin::wasi_blobstore::MultiplexedBlobstore::new()
-                    .with_provider(Arc::new(plugin::wasi_blobstore::InMemoryProvider))
-                    .with_provider(Arc::new(plugin::wasi_blobstore::FilesystemProvider))
-                    .with_provider(Arc::new(plugin::wasi_blobstore::NatsBlobProvider)),
-            ))?;
-            cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
-                plugin::wasi_blobstore::MultiplexedAsyncBlobstore::new()
-                    .with_provider(Arc::new(plugin::wasi_blobstore::InMemoryProvider))
-                    .with_provider(Arc::new(plugin::wasi_blobstore::FilesystemProvider))
-                    .with_provider(Arc::new(plugin::wasi_blobstore::NatsBlobProvider)),
-            ))?;
-            cluster_host_builder = cluster_host_builder.with_plugin(Arc::new(
-                plugin::wasi_keyvalue::MultiplexedAsyncKeyValue::new()
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::InMemoryProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::RedisProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::NatsProvider))
-                    .with_provider(Arc::new(plugin::wasi_keyvalue::FilesystemProvider)),
-            ))?;
+            cluster_host_builder = cluster_host_builder.with_multiplexed_plugins()?;
         }
 
         if let Some(postgres_url) = &self.postgres_url {


### PR DESCRIPTION
`wash host`, `wash dev`, and downstream embedders each wrote out the same multiplexed plugin registrations by hand. The list is load-bearing, not decorative: every single-backend plugin leaves `HostPlugin::supports_named_instances()` at false, so without it a workload declaring two entries of one namespace:package under distinct names fails to bind and `(implements ..)` does not work at all.

Build the set once in `plugin::multiplexed_plugins()` and register it through `with_multiplexed_plugins()` on both builders, so adding a multiplexed plugin reaches every embedder at once. Postgres stays at the call sites: whether it registers, and whether as `multiplex_only`, depends on host configuration.