### PR TITLE
fix(runtime): context for component load

### DIFF
--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -409,18 +409,24 @@ async fn workload_start(
                 image: component.image.clone(),
                 pull_policy: component.image_pull_policy().into(),
             };
-            let loaded = match source.load(oci_config).await {
-                Ok(loaded) => loaded,
-                Err(e) => {
-                    return Ok(types::v2::WorkloadStartResponse {
-                        workload_status: Some(types::v2::WorkloadStatus {
-                            workload_id: workload_id.clone(),
-                            workload_state: types::v2::WorkloadState::Error.into(),
-                            message: format!("{e:#}"),
-                        }),
-                    });
-                }
-            };
+            // `load` already names the reference it failed on; this says which
+            // of the workload's components asked for it, so a multi-component
+            // start reports something the operator can act on.
+            let loaded =
+                match source.load(oci_config).await.with_context(|| {
+                    format!("failed to pull image for component '{}'", component.name)
+                }) {
+                    Ok(loaded) => loaded,
+                    Err(e) => {
+                        return Ok(types::v2::WorkloadStartResponse {
+                            workload_status: Some(types::v2::WorkloadStatus {
+                                workload_id: workload_id.clone(),
+                                workload_state: types::v2::WorkloadState::Error.into(),
+                                message: format!("{e:#}"),
+                            }),
+                        });
+                    }
+                };
             let local_resources = match component.local_resources.clone() {
                 Some(lr) => match crate::types::LocalResources::try_from(lr) {
                     Ok(lr) => lr,
@@ -466,7 +472,13 @@ async fn workload_start(
             image: service.image.clone(),
             pull_policy: service.image_pull_policy().into(),
         };
-        let loaded = match source.load(oci_config).await {
+        // Distinguishes a service pull failure from a component one; both
+        // otherwise report the same reference and cause.
+        let loaded = match source
+            .load(oci_config)
+            .await
+            .context("failed to pull image for the workload service")
+        {
             Ok(loaded) => loaded,
             Err(e) => {
                 return Ok(types::v2::WorkloadStartResponse {

--- a/crates/wash-runtime/tests/fixtures/secrets-host/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/secrets-host/src/lib.rs
@@ -72,8 +72,8 @@ impl LifecycleGuest for Component {
         // operator sourced from `secretFrom`.
         let mut config = BTreeMap::new();
         for binding in &workload.interfaces {
-            for entry in &binding.config {
-                config.insert(entry.key.clone(), entry.value.clone());
+            for (key, value) in &binding.config {
+                config.insert(key.clone(), value.clone());
             }
         }
         BINDS.lock().unwrap().insert(workload.id, config);

--- a/crates/wash-runtime/tests/integration_washlet_api.rs
+++ b/crates/wash-runtime/tests/integration_washlet_api.rs
@@ -324,11 +324,18 @@ async fn pull_failure_does_not_consume_workload_id() -> Result<()> {
 
     let failed = harness.start(&request).await?;
     assert_eq!(failed.workload_state(), v2::WorkloadState::Error);
-    assert!(
-        failed.message.contains("failed to pull component image"),
-        "unexpected failure message: {}",
-        failed.message
-    );
+    // The operator surfaces this message verbatim, so it has to say which
+    // component wanted which image, not just that some pull failed.
+    for expected in [
+        "failed to pull image for component 'unpullable'",
+        "127.0.0.1:1/nope:latest",
+    ] {
+        assert!(
+            failed.message.contains(expected),
+            "failure message should contain {expected:?}, got: {}",
+            failed.message
+        );
+    }
 
     // The failed pull never reached the host, so the ID is still free.
     assert_eq!(


### PR DESCRIPTION
Fixes test pull_failure_does_not_consume_workload_id

And a dumb miss when refactoring to a map which surfaces when building test fixtures. 