### PR TITLE
refactor(wash-runtime): rename HttpServer to Ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The wasmCloud platform has three primary parts, all developed in this repository
 The runtime exposes capabilities through three mechanisms:
 
 - **Built-in via `wasmtime-wasi`** — `wasi:filesystem`, `wasi:clocks`, `wasi:random`, `wasi:io`, `wasi:sockets`, `wasi:cli`.
-- **HTTP handler** (`HttpServer`) — `wasi:http` (client and server).
+- **Ingress** (`Ingress`) — `wasi:http` (client and server).
 - **Host plugins** (`with_plugin()`, feature-flagged in-memory and NATS-backed variants) — `wasi:keyvalue`, `wasi:blobstore`, `wasi:config`, `wasi:logging`, `wasmcloud:messaging`.
 
 Hosts can be extended with additional custom plugins at build time. See [Creating Host Plugins](https://wasmcloud.com/docs/runtime/creating-host-plugins).

--- a/crates/wash-runtime/README.md
+++ b/crates/wash-runtime/README.md
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use wash_runtime::{
     engine::Engine,
     host::{HostBuilder, HostApi,
-      http::{HttpServer, DynamicRouter},
+      http::{Ingress, DynamicRouter},
   },
     plugin::{
         wasi_config::DynamicConfig,
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Configure plugins
     let http_router = DynamicRouter::default();
-    let http_handler = HttpServer::new(http_router, "127.0.0.1:8080".parse()?).await?;
+    let ingress = Ingress::new(http_router, "127.0.0.1:8080".parse()?).await?;
     let wasi_config_plugin = DynamicConfig::default();
 
     // Build and start the host
@@ -47,7 +47,7 @@ async fn main() -> anyhow::Result<()> {
         .with_engine(engine)
         // if a handler is not provided, a 'deny all' implementation
         // will be used for outgoing http requests
-        .with_http_handler(Arc::new(http_handler))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(wasi_config_plugin))?
         .build()?;
 

--- a/crates/wash-runtime/benches/common/mod.rs
+++ b/crates/wash-runtime/benches/common/mod.rs
@@ -10,7 +10,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         Host, HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     types::{
         Component, LocalResources, Service, Workload, WorkloadStartRequest, WorkloadState,
@@ -112,12 +112,12 @@ impl BenchHost {
 pub async fn start_host_and_workload(
     req_for: impl FnOnce(&str) -> Workload,
 ) -> anyhow::Result<BenchHost> {
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
 
     let host = HostBuilder::new()
         .with_engine(engine())
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .build()?;
     let host = host.start().await?;
 

--- a/crates/wash-runtime/benches/gungraun.rs
+++ b/crates/wash-runtime/benches/gungraun.rs
@@ -39,7 +39,7 @@ use tokio::runtime::Runtime;
 use wash_runtime::{
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
 };
@@ -57,14 +57,14 @@ struct Warm {
 fn setup_warm(flavor: Flavor) -> Warm {
     let rt = Runtime::new().expect("tokio runtime");
     let (host, addr, client) = rt.block_on(async {
-        let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse().unwrap())
+        let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse().unwrap())
             .await
             .unwrap();
-        let addr = http_server.addr();
+        let addr = ingress.addr();
 
         let host = HostBuilder::new()
             .with_engine(engine())
-            .with_http_handler(Arc::new(http_server))
+            .with_http_handler(Arc::new(ingress))
             .build()
             .unwrap();
         let host = host.start().await.unwrap();

--- a/crates/wash-runtime/benches/gungraun_plugin.rs
+++ b/crates/wash-runtime/benches/gungraun_plugin.rs
@@ -75,7 +75,7 @@ use wash_runtime::{
     engine::workload::{UnresolvedWorkload, WorkloadComponent},
     host::{
         Host, HostApi, HostBuilder,
-        http::{DynamicRouter, HttpServer},
+        http::{DynamicRouter, Ingress},
     },
     plugin::component_host::ComponentHostPlugin,
     plugin::{HostPlugin, WitInterfaces},
@@ -257,15 +257,15 @@ fn setup_bare_host(call: Call) -> Warm {
     let rt = Runtime::new().expect("tokio runtime");
     let (host, addr, client) = rt.block_on(async {
         let engine = Engine::builder().build().expect("engine");
-        let http_server = HttpServer::new(DynamicRouter::default(), "127.0.0.1:0".parse().unwrap())
+        let ingress = Ingress::new(DynamicRouter::default(), "127.0.0.1:0".parse().unwrap())
             .await
             .unwrap();
-        let addr = http_server.addr();
+        let addr = ingress.addr();
         let plugin = ComponentHostPlugin::new(PLUGIN_ID, KV_PLUGIN_WASM, engine.clone())
             .expect("failed to build host component plugin");
         let host = HostBuilder::new()
             .with_engine(engine)
-            .with_http_handler(Arc::new(http_server))
+            .with_http_handler(Arc::new(ingress))
             .with_plugin(Arc::new(plugin))
             .unwrap()
             .build()

--- a/crates/wash-runtime/benches/http_invoke.rs
+++ b/crates/wash-runtime/benches/http_invoke.rs
@@ -41,7 +41,7 @@ use tokio::runtime::Runtime;
 use wash_runtime::{
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
 };
@@ -56,12 +56,12 @@ struct WarmHost {
 }
 
 async fn start_warm_host(flavor: Flavor) -> anyhow::Result<WarmHost> {
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
 
     let host = HostBuilder::new()
         .with_engine(engine())
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .build()?;
 
     let host = host.start().await?;

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -763,22 +763,29 @@ pub type ServiceHandlers = Arc<RwLock<HashMap<String, tokio::sync::mpsc::Sender<
 /// instance. Empty unless a workload's service exports a messaging handler.
 pub type MessagingHandlers = Arc<RwLock<HashMap<String, tokio::sync::mpsc::Sender<MessagingJob>>>>;
 
-/// HTTP server plugin that handles incoming HTTP requests for WebAssembly components.
+/// The host's HTTP ingress: it owns the listening socket and routes each
+/// inbound request to a workload by virtual host — either to a per-request
+/// `wasi:http/incoming-handler` instance or, when the workload runs a
+/// long-lived trigger service, to that service's live instance. HTTP and HTTPS
+/// are both supported, with optional mutual TLS.
 ///
-/// This plugin implements the `wasi:http/incoming-handler` interface and routes
-/// HTTP requests to appropriate WebAssembly components based on virtual hosting.
-/// It supports both HTTP and HTTPS connections with optional mutual TLS.
+/// It also holds the registries through which other host-side ingresses reach a
+/// trigger service's live instance: [`deliver_trigger_service_message`] hands a
+/// message received by a messaging plugin to that workload's
+/// `wasmcloud:messaging/handler` on the same instance.
 ///
-/// Use [`HttpServerBuilder`] to construct an instance:
+/// Use [`IngressBuilder`] to construct an instance:
 ///
 /// ```rust,ignore
-/// let server = HttpServer::builder(router, "127.0.0.1:8080".parse()?)
+/// let ingress = Ingress::builder(router, "127.0.0.1:8080".parse()?)
 ///     .outgoing_handler(my_handler)
 ///     .tls(TlsConfig::new(cert_path, key_path))
 ///     .build()
 ///     .await?;
 /// ```
-pub struct HttpServer<T: Router, O: OutgoingHandler = DefaultOutgoingHandler> {
+///
+/// [`deliver_trigger_service_message`]: HostHandler::deliver_trigger_service_message
+pub struct Ingress<T: Router, O: OutgoingHandler = DefaultOutgoingHandler> {
     router: Arc<T>,
     outgoing_handler: O,
     addr: SocketAddr,
@@ -793,15 +800,13 @@ pub struct HttpServer<T: Router, O: OutgoingHandler = DefaultOutgoingHandler> {
     meters: RwLock<Meters>,
 }
 
-impl<T: Router, O: OutgoingHandler> std::fmt::Debug for HttpServer<T, O> {
+impl<T: Router, O: OutgoingHandler> std::fmt::Debug for Ingress<T, O> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HttpServer")
-            .field("addr", &self.addr)
-            .finish()
+        f.debug_struct("Ingress").field("addr", &self.addr).finish()
     }
 }
 
-/// TLS configuration for [`HttpServerBuilder::tls`] / [`HttpServer::new_with_tls`].
+/// TLS configuration for [`IngressBuilder::tls`] / [`Ingress::new_with_tls`].
 #[derive(Debug, Clone)]
 pub struct TlsConfig {
     cert_path: std::path::PathBuf,
@@ -827,10 +832,10 @@ impl TlsConfig {
     }
 }
 
-/// Builder for [`HttpServer`].
+/// Builder for [`Ingress`].
 ///
 /// # Required
-/// - `router` and `addr` — set via [`HttpServer::builder`].
+/// - `router` and `addr` — set via [`Ingress::builder`].
 ///
 /// # Optional
 /// - [`outgoing_handler`](Self::outgoing_handler) — defaults to [`DefaultOutgoingHandler`].
@@ -839,25 +844,25 @@ impl TlsConfig {
 /// # Example
 /// ```rust,ignore
 /// // Minimal — plain HTTP, default outgoing handler
-/// let server = HttpServer::builder(DevRouter::default(), addr)
+/// let ingress = Ingress::builder(DevRouter::default(), addr)
 ///     .build()
 ///     .await?;
 ///
 /// // Full — HTTPS with custom egress
-/// let server = HttpServer::builder(DynamicRouter::default(), addr)
+/// let ingress = Ingress::builder(DynamicRouter::default(), addr)
 ///     .outgoing_handler(custom_handler)
 ///     .tls(TlsConfig::new(cert, key).with_ca(ca))
 ///     .build()
 ///     .await?;
 /// ```
-pub struct HttpServerBuilder<T: Router, O: OutgoingHandler = DefaultOutgoingHandler> {
+pub struct IngressBuilder<T: Router, O: OutgoingHandler = DefaultOutgoingHandler> {
     router: T,
     outgoing_handler: O,
     addr: SocketAddr,
     tls: Option<TlsConfig>,
 }
 
-impl<T: Router> HttpServerBuilder<T, DefaultOutgoingHandler> {
+impl<T: Router> IngressBuilder<T, DefaultOutgoingHandler> {
     fn new(router: T, addr: SocketAddr) -> Self {
         Self {
             router,
@@ -868,11 +873,11 @@ impl<T: Router> HttpServerBuilder<T, DefaultOutgoingHandler> {
     }
 }
 
-impl<T: Router, O: OutgoingHandler> HttpServerBuilder<T, O> {
+impl<T: Router, O: OutgoingHandler> IngressBuilder<T, O> {
     /// Set a custom [`OutgoingHandler`], changing the builder's handler type.
     /// The same handler serves both P2 and P3 outgoing requests.
-    pub fn outgoing_handler<O2: OutgoingHandler>(self, handler: O2) -> HttpServerBuilder<T, O2> {
-        HttpServerBuilder {
+    pub fn outgoing_handler<O2: OutgoingHandler>(self, handler: O2) -> IngressBuilder<T, O2> {
+        IngressBuilder {
             router: self.router,
             outgoing_handler: handler,
             addr: self.addr,
@@ -886,8 +891,8 @@ impl<T: Router, O: OutgoingHandler> HttpServerBuilder<T, O> {
         self
     }
 
-    /// Bind to the address and build the [`HttpServer`].
-    pub async fn build(self) -> anyhow::Result<HttpServer<T, O>> {
+    /// Bind to the address and build the [`Ingress`].
+    pub async fn build(self) -> anyhow::Result<Ingress<T, O>> {
         crate::init_crypto();
         let tls_acceptor = match &self.tls {
             Some(tls) => {
@@ -901,7 +906,7 @@ impl<T: Router, O: OutgoingHandler> HttpServerBuilder<T, O> {
         let listener = TcpListener::bind(self.addr).await?;
         let addr = listener.local_addr()?;
 
-        Ok(HttpServer {
+        Ok(Ingress {
             router: Arc::new(self.router),
             outgoing_handler: self.outgoing_handler,
             addr,
@@ -916,24 +921,25 @@ impl<T: Router, O: OutgoingHandler> HttpServerBuilder<T, O> {
     }
 }
 
-impl<T: Router> HttpServer<T, DefaultOutgoingHandler> {
-    /// Returns a new [`HttpServerBuilder`] with the default [`DefaultOutgoingHandler`].
-    pub fn builder(router: T, addr: SocketAddr) -> HttpServerBuilder<T, DefaultOutgoingHandler> {
-        HttpServerBuilder::new(router, addr)
+impl<T: Router> Ingress<T, DefaultOutgoingHandler> {
+    /// Returns a new [`IngressBuilder`] with the default [`DefaultOutgoingHandler`].
+    pub fn builder(router: T, addr: SocketAddr) -> IngressBuilder<T, DefaultOutgoingHandler> {
+        IngressBuilder::new(router, addr)
     }
 
-    /// Creates a new HTTP server bound to `addr` with the default outgoing handler.
+    /// Creates a new ingress listening on `addr` with the default outgoing handler.
     pub async fn new(router: T, addr: SocketAddr) -> anyhow::Result<Self> {
-        HttpServerBuilder::new(router, addr).build().await
+        IngressBuilder::new(router, addr).build().await
     }
 
-    /// Creates a new HTTPS server with TLS and the default outgoing handler.
+    /// Creates a new ingress listening on `addr` over TLS, with the default
+    /// outgoing handler.
     pub async fn new_with_tls(router: T, addr: SocketAddr, tls: TlsConfig) -> anyhow::Result<Self> {
-        HttpServerBuilder::new(router, addr).tls(tls).build().await
+        IngressBuilder::new(router, addr).tls(tls).build().await
     }
 }
 
-impl<T: Router, O: OutgoingHandler> HttpServer<T, O> {
+impl<T: Router, O: OutgoingHandler> Ingress<T, O> {
     /// Returns the actual bound address (useful when binding to port 0).
     pub fn addr(&self) -> SocketAddr {
         self.addr
@@ -941,7 +947,7 @@ impl<T: Router, O: OutgoingHandler> HttpServer<T, O> {
 }
 
 #[async_trait::async_trait]
-impl<T: Router, O: OutgoingHandler> HostHandler for HttpServer<T, O> {
+impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
     async fn inject_meters(&self, meters: &crate::observability::Meters) {
         *self.meters.write().await = meters.clone();
     }
@@ -2412,7 +2418,7 @@ mod tests {
     #[tokio::test]
     async fn custom_outgoing_handler_is_invoked() {
         let called = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let server = HttpServer::builder(DevRouter::default(), "127.0.0.1:0".parse().unwrap())
+        let server = Ingress::builder(DevRouter::default(), "127.0.0.1:0".parse().unwrap())
             .outgoing_handler(SpyHandler {
                 called: called.clone(),
             })
@@ -2432,7 +2438,7 @@ mod tests {
     #[tokio::test]
     async fn grpc_requests_bypass_outgoing_handler() {
         let called = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let server = HttpServer::builder(DevRouter::default(), "127.0.0.1:0".parse().unwrap())
+        let server = Ingress::builder(DevRouter::default(), "127.0.0.1:0".parse().unwrap())
             .outgoing_handler(SpyHandler {
                 called: called.clone(),
             })
@@ -2750,7 +2756,7 @@ mod tests {
     /// requests routed onto it 404.
     #[tokio::test]
     async fn service_http_unbind_removes_router_registration() {
-        let server = HttpServer::builder(DynamicRouter::default(), "127.0.0.1:0".parse().unwrap())
+        let server = Ingress::builder(DynamicRouter::default(), "127.0.0.1:0".parse().unwrap())
             .build()
             .await
             .unwrap();

--- a/crates/wash-runtime/src/host/trigger_service/http.rs
+++ b/crates/wash-runtime/src/host/trigger_service/http.rs
@@ -37,6 +37,12 @@ impl hyper::body::Body for ChannelBody {
 }
 
 /// Handles one inbound HTTP request on the shared service instance.
+///
+/// A handler `Err(error-code)` is an ordinary application outcome: this request
+/// gets a 500 and the instance keeps serving. A guest *trap* is answered the
+/// same way here, but it also faults the store, so the driver's
+/// `run_concurrent` returns an error and the service supervisor restarts (and
+/// re-registers) a fresh instance. See `test_trigger_service_http_restarts_on_fault`.
 pub(super) struct HttpTask {
     pub(super) service: Arc<Service>,
     pub(super) req: hyper::Request<hyper::body::Incoming>,

--- a/crates/wash-runtime/src/lib.rs
+++ b/crates/wash-runtime/src/lib.rs
@@ -27,9 +27,9 @@ pub use wasmtime;
 /// any number of threads. The install happens at most once per process. If
 /// another crate already installed a provider we leave it in place.
 ///
-/// Called automatically by [`host::http::HttpServer::new`] and
-/// [`host::http::HttpServer::new_with_tls`]; call it directly from binaries
-/// that touch TLS before constructing an `HttpServer` (for example, CLIs that
+/// Called automatically by [`host::http::Ingress::new`] and
+/// [`host::http::Ingress::new_with_tls`]; call it directly from binaries
+/// that touch TLS before constructing an `Ingress` (for example, CLIs that
 /// connect to a TLS NATS cluster during startup).
 pub fn init_crypto() {
     use std::sync::Once;
@@ -52,7 +52,7 @@ mod test {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use crate::host::http::HttpServer;
+    use crate::host::http::Ingress;
     use crate::plugin::wasi_config::DynamicConfig;
     use crate::{
         host::HostApi,
@@ -65,12 +65,12 @@ mod test {
     async fn can_run_engine() -> anyhow::Result<()> {
         let engine = Engine::builder().build()?;
         let http_handler = crate::host::http::DevRouter::default();
-        let http_plugin = HttpServer::new(http_handler, "127.0.0.1:0".parse()?).await?;
+        let ingress = Ingress::new(http_handler, "127.0.0.1:0".parse()?).await?;
         let wasi_config_plugin = DynamicConfig::default();
 
         let host = HostBuilder::new()
             .with_engine(engine)
-            .with_http_handler(Arc::new(http_plugin))
+            .with_http_handler(Arc::new(ingress))
             .with_plugin(Arc::new(wasi_config_plugin))?
             .build()?;
 

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -23,7 +23,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, DynamicRouter, HttpServer, TlsConfig},
+        http::{DevRouter, DynamicRouter, Ingress, TlsConfig},
     },
     plugin::{
         wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
@@ -267,12 +267,12 @@ pub async fn start_host_with_dev_router(
     addr: &str,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
-    let bound_addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), addr.parse()?).await?;
+    let bound_addr = ingress.addr();
     let host = with_standard_plugins(
         HostBuilder::new()
             .with_engine(engine)
-            .with_http_handler(Arc::new(http_server)),
+            .with_http_handler(Arc::new(ingress)),
     )?
     .build()?;
     let host = host.start().await.context("Failed to start host")?;
@@ -285,12 +285,12 @@ pub async fn start_host_with_dynamic_router(
     addr: &str,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DynamicRouter::default(), addr.parse()?).await?;
-    let bound_addr = http_server.addr();
+    let ingress = Ingress::new(DynamicRouter::default(), addr.parse()?).await?;
+    let bound_addr = ingress.addr();
     let host = with_standard_plugins(
         HostBuilder::new()
             .with_engine(engine)
-            .with_http_handler(Arc::new(http_server)),
+            .with_http_handler(Arc::new(ingress)),
     )?
     .build()?;
     let host = host.start().await.context("Failed to start host")?;
@@ -305,17 +305,17 @@ pub async fn start_host_with_tls(
     key_path: &Path,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new_with_tls(
+    let ingress = Ingress::new_with_tls(
         DevRouter::default(),
         "127.0.0.1:0".parse()?,
         TlsConfig::new(cert_path, key_path),
     )
     .await?;
-    let bound_addr = http_server.addr();
+    let bound_addr = ingress.addr();
     let host = with_standard_plugins(
         HostBuilder::new()
             .with_engine(engine)
-            .with_http_handler(Arc::new(http_server)),
+            .with_http_handler(Arc::new(ingress)),
     )?
     .build()?;
     let host = host.start().await.context("Failed to start host")?;
@@ -328,12 +328,12 @@ pub async fn start_host_with_p3_http_handler(
     addr: &str,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), addr.parse()?).await?;
-    let bound_addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), addr.parse()?).await?;
+    let bound_addr = ingress.addr();
     let host = with_standard_plugins(
         HostBuilder::new()
             .with_engine(engine)
-            .with_http_handler(Arc::new(http_server)),
+            .with_http_handler(Arc::new(ingress)),
     )?
     .build()?;
     let host = host.start().await.context("Failed to start host")?;
@@ -353,8 +353,8 @@ async fn start_host_with_component_plugin_router(
     max_restarts: Option<u32>,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(router, addr.parse()?).await?;
-    let bound_addr = http_server.addr();
+    let ingress = Ingress::new(router, addr.parse()?).await?;
+    let bound_addr = ingress.addr();
     let mut plugin = ComponentHostPlugin::new(plugin_id, plugin_wasm, engine.clone())
         .context("failed to build host component plugin")?;
     if let Some(max_restarts) = max_restarts {
@@ -363,7 +363,7 @@ async fn start_host_with_component_plugin_router(
     let host = with_standard_plugins(
         HostBuilder::new()
             .with_engine(engine)
-            .with_http_handler(Arc::new(http_server)),
+            .with_http_handler(Arc::new(ingress)),
     )?
     .with_plugin(Arc::new(plugin))?
     .build()?;
@@ -429,27 +429,23 @@ pub async fn start_host_with_component_plugin_max_restarts(
     .await
 }
 
-/// Like [`start_host_with_p3_http_handler`] but also returns the [`HttpServer`], so a test can
+/// Like [`start_host_with_p3_http_handler`] but also returns the [`Ingress`], so a test can
 /// drive host-side ingress hooks directly (e.g. deliver a message to a trigger service's
 /// messaging handler via `deliver_trigger_service_message`).
 pub async fn start_host_with_p3_handler(
     addr: &str,
-) -> Result<(
-    std::net::SocketAddr,
-    impl HostApi,
-    Arc<HttpServer<DevRouter>>,
-)> {
+) -> Result<(std::net::SocketAddr, impl HostApi, Arc<Ingress<DevRouter>>)> {
     let engine = Engine::builder().build()?;
-    let http_server = Arc::new(HttpServer::new(DevRouter::default(), addr.parse()?).await?);
-    let bound_addr = http_server.addr();
+    let ingress = Arc::new(Ingress::new(DevRouter::default(), addr.parse()?).await?);
+    let bound_addr = ingress.addr();
     let host = with_standard_plugins(
         HostBuilder::new()
             .with_engine(engine)
-            .with_http_handler(http_server.clone()),
+            .with_http_handler(ingress.clone()),
     )?
     .build()?;
     let host = host.start().await.context("Failed to start host")?;
-    Ok((bound_addr, host, http_server))
+    Ok((bound_addr, host, ingress))
 }
 
 /// Extract the numeric value of `"name":N` from a flat JSON body without

--- a/crates/wash-runtime/tests/common/postgres.rs
+++ b/crates/wash-runtime/tests/common/postgres.rs
@@ -17,7 +17,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasmcloud_postgres::WasmcloudPostgres,
     types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
@@ -88,15 +88,15 @@ pub async fn start_postgres_workload(
     host_header: &str,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
 
     // Base URL without a database — the plugin strips it and the workload's
     // interface config supplies `database`.
     let bouncer_url = format!("postgres://postgres:postgres@{host_addr}/");
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(WasmcloudPostgres::new(&bouncer_url)?))?
         .build()?;
     let host = host.start().await.context("failed to start host")?;

--- a/crates/wash-runtime/tests/fixtures/svc-counter/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/svc-counter/src/lib.rs
@@ -5,6 +5,10 @@
 //! count. Because both run on the same instance sharing the same statics, an
 //! HTTP response observing `cli_ticks > 0` (and growing between requests) proves
 //! the host co-drives the run loop concurrently with serving HTTP.
+//!
+//! A request for `/boom` traps instead of responding, so a test can fault the
+//! shared instance and watch the supervisor restart it. Both counters live in
+//! instance memory, so a fresh incarnation starts them over at zero.
 
 mod bindings;
 
@@ -31,7 +35,13 @@ impl RunGuest for Component {
 }
 
 impl HttpGuest for Component {
-    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        // A `/boom` path traps the handler, faulting the co-driven instance —
+        // the restart-behavior test uses this to force a supervised restart.
+        let path = request.get_path_with_query().unwrap_or_default();
+        if path.starts_with("/boom") {
+            panic!("svc-counter boom: deliberate handler trap for the restart test");
+        }
         let http_calls = HTTP_CALLS.fetch_add(1, Ordering::SeqCst) + 1;
         let cli_ticks = CLI_TICKS.load(Ordering::SeqCst);
         let body = format!("{{\"cli_ticks\":{cli_ticks},\"http_calls\":{http_calls}}}");

--- a/crates/wash-runtime/tests/integration_blobstore_default_p3.rs
+++ b/crates/wash-runtime/tests/integration_blobstore_default_p3.rs
@@ -28,7 +28,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_blobstore::{InMemoryProvider, MultiplexedAsyncBlobstore},
     types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
@@ -64,11 +64,11 @@ fn default_blob_iface() -> WitInterface {
 async fn p3_guest_plain_blobstore_uses_default_backend() -> Result<()> {
     // --- host with the async multiplexed blobstore plugin + in-memory provider ---
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(
             MultiplexedAsyncBlobstore::new().with_provider(Arc::new(InMemoryProvider)),
         ))?

--- a/crates/wash-runtime/tests/integration_blobstore_implements_p3.rs
+++ b/crates/wash-runtime/tests/integration_blobstore_implements_p3.rs
@@ -34,7 +34,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_blobstore::{MultiplexedAsyncBlobstore, NatsBlobProvider},
     types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
@@ -79,11 +79,11 @@ async fn p3_guest_streams_blobstore_through_nats() -> Result<()> {
 
     // --- host with the async multiplexed blobstore plugin + NATS provider ---
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(
             MultiplexedAsyncBlobstore::new().with_provider(Arc::new(NatsBlobProvider)),
         ))?

--- a/crates/wash-runtime/tests/integration_blobstore_span_names.rs
+++ b/crates/wash-runtime/tests/integration_blobstore_span_names.rs
@@ -20,7 +20,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_blobstore::InMemoryBlobstore,
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -63,13 +63,13 @@ async fn wasi_blobstore_handlers_emit_namespaced_spans() -> Result<()> {
         .context("failed to install tracing subscriber")?;
 
     let engine = Engine::builder().build()?;
-    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_plugin.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
     let blobstore_plugin = InMemoryBlobstore::new(None);
 
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_plugin))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(blobstore_plugin))?
         .build()?;
     let host = host.start().await.context("Failed to start host")?;

--- a/crates/wash-runtime/tests/integration_component_plugin_lifecycle.rs
+++ b/crates/wash-runtime/tests/integration_component_plugin_lifecycle.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 
 use wash_runtime::engine::Engine;
 use wash_runtime::engine::workload::{UnresolvedWorkload, WorkloadComponent};
-use wash_runtime::host::http::{DevRouter, DynamicRouter, HttpServer};
+use wash_runtime::host::http::{DevRouter, DynamicRouter, Ingress};
 use wash_runtime::host::{HostApi, HostBuilder};
 use wash_runtime::plugin::component_host::ComponentHostPlugin;
 use wash_runtime::plugin::{HostPlugin, WitInterfaces};
@@ -865,8 +865,8 @@ async fn start_host_keeping_plugin_router(
     router: impl wash_runtime::host::http::Router,
 ) -> Result<(std::net::SocketAddr, impl HostApi, Arc<ComponentHostPlugin>)> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(router, addr.parse()?).await?;
-    let bound_addr = http_server.addr();
+    let ingress = Ingress::new(router, addr.parse()?).await?;
+    let bound_addr = ingress.addr();
     let plugin = Arc::new(ComponentHostPlugin::new(
         PLUGIN_ID,
         KV_PLUGIN_WASM,
@@ -874,7 +874,7 @@ async fn start_host_keeping_plugin_router(
     )?);
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::clone(&plugin) as Arc<dyn HostPlugin>)?
         .build()?;
     let host = host.start().await.context("failed to start host")?;
@@ -889,13 +889,13 @@ async fn start_host_with_lifecycle_timeout(
     timeout: Duration,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DynamicRouter::default(), addr.parse()?).await?;
-    let bound_addr = http_server.addr();
+    let ingress = Ingress::new(DynamicRouter::default(), addr.parse()?).await?;
+    let bound_addr = ingress.addr();
     let plugin = ComponentHostPlugin::new(PLUGIN_ID, KV_PLUGIN_WASM, engine.clone())?
         .with_lifecycle_call_timeout(timeout);
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(plugin) as Arc<dyn HostPlugin>)?
         .build()?;
     let host = host.start().await.context("failed to start host")?;

--- a/crates/wash-runtime/tests/integration_http_allowed_hosts.rs
+++ b/crates/wash-runtime/tests/integration_http_allowed_hosts.rs
@@ -39,7 +39,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DynamicRouter, HttpServer, OutgoingHandler},
+        http::{DynamicRouter, Ingress, OutgoingHandler},
     },
     plugin::{wasi_config::DynamicConfig, wasi_logging::TracingLogger},
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -106,14 +106,14 @@ impl OutgoingHandler for FakeOutgoingHandler {
 
 async fn start_host(addr: &str) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::builder(DynamicRouter::default(), addr.parse()?)
+    let ingress = Ingress::builder(DynamicRouter::default(), addr.parse()?)
         .outgoing_handler(FakeOutgoingHandler)
         .build()
         .await?;
-    let bound_addr = http_server.addr();
+    let bound_addr = ingress.addr();
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(TracingLogger::default()))?
         .with_plugin(Arc::new(DynamicConfig::default()))?
         .build()?;

--- a/crates/wash-runtime/tests/integration_http_blobstore.rs
+++ b/crates/wash-runtime/tests/integration_http_blobstore.rs
@@ -17,7 +17,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_blobstore::InMemoryBlobstore,
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -38,8 +38,8 @@ async fn test_http_blobstore_integration() -> Result<()> {
     let engine = Engine::builder().build()?;
 
     // Create HTTP server plugin on a dynamically allocated port
-    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_plugin.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
 
     // Create blobstore plugin
     let blobstore_plugin = InMemoryBlobstore::new(None);
@@ -47,7 +47,7 @@ async fn test_http_blobstore_integration() -> Result<()> {
     // Build host with plugins following the existing pattern from lib.rs test
     let host = HostBuilder::new()
         .with_engine(engine.clone())
-        .with_http_handler(Arc::new(http_plugin))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(blobstore_plugin))?
         .build()?;
 
@@ -204,11 +204,11 @@ async fn test_plugin_lifecycle() -> Result<()> {
     println!("Testing plugin lifecycle");
 
     let engine = Engine::builder().build()?;
-    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
 
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_plugin))
+        .with_http_handler(Arc::new(ingress))
         .build()?;
 
     // Start host
@@ -230,14 +230,14 @@ async fn test_plugin_lifecycle() -> Result<()> {
 
 //     let engine = Engine::builder().build()?;
 //     let addr: SocketAddr = "127.0.0.1:8082".parse().unwrap();
-//     let http_plugin = HttpServer::new(addr);
+//     let ingress = Ingress::new(addr);
 
 //     // Create blobstore plugin with large capacity (2GB limit for this test)
 //     let blobstore_plugin = WasiBlobstore::new(Some(2_147_483_648)); // 2GB limit
 
 //     let host = HostBuilder::new()
 //         .with_engine(engine)
-//         .with_plugin(Arc::new(http_plugin))
+//         .with_plugin(Arc::new(ingress))
 //         .with_plugin(Arc::new(blobstore_plugin))
 //         .with_plugin(Arc::new(WasiLogging {}))
 //         .build()?;

--- a/crates/wash-runtime/tests/integration_http_tls.rs
+++ b/crates/wash-runtime/tests/integration_http_tls.rs
@@ -1,7 +1,7 @@
 //! Integration test for TLS-enabled HTTP server
 //!
 //! Verifies that HTTPS requests are correctly handled when the HTTP server
-//! is configured with TLS via `HttpServer::new_with_tls()`.
+//! is configured with TLS via `Ingress::new_with_tls()`.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 

--- a/crates/wash-runtime/tests/integration_http_webgpu.rs
+++ b/crates/wash-runtime/tests/integration_http_webgpu.rs
@@ -23,7 +23,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_webgpu::{WebGpu, WebGpuBackend},
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -44,13 +44,13 @@ async fn test_http_webgpu_integration() -> Result<()> {
     let engine = Engine::builder().build()?;
 
     // Create HTTP server plugin on a dynamically allocated port
-    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_plugin.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
 
     // Build host with plugins following the existing pattern from lib.rs test
     let host = HostBuilder::new()
         .with_engine(engine.clone())
-        .with_http_handler(Arc::new(http_plugin))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(WebGpu::new(WebGpuBackend::Noop)))?
         .build()?;
 

--- a/crates/wash-runtime/tests/integration_inter_component_call.rs
+++ b/crates/wash-runtime/tests/integration_inter_component_call.rs
@@ -27,7 +27,7 @@ use wash_runtime::{
     },
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::{
         HostPlugin, WitInterfaces, wasi_config::DynamicConfig, wasi_keyvalue::InMemoryKeyValue,
@@ -164,8 +164,8 @@ async fn test_inter_component_call() -> Result<()> {
     let engine = Engine::builder().build()?;
 
     // Create HTTP server plugin on a dynamically allocated port
-    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_plugin.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
 
     // Create keyvalue plugin for counter persistence (still using built-in)
     let keyvalue_plugin = InMemoryKeyValue::new();
@@ -180,7 +180,7 @@ async fn test_inter_component_call() -> Result<()> {
     // We'll use the blobstore-filesystem component instead
     let host = HostBuilder::new()
         .with_engine(engine.clone())
-        .with_http_handler(Arc::new(http_plugin))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(keyvalue_plugin))?
         .with_plugin(Arc::new(logging_plugin))?
         .with_plugin(Arc::new(config_plugin))?

--- a/crates/wash-runtime/tests/integration_keyvalue_aba_implements_p3.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_aba_implements_p3.rs
@@ -33,7 +33,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_keyvalue::{InMemoryProvider, MultiplexedAsyncKeyValue},
     types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
@@ -62,11 +62,11 @@ fn kv_store_iface(name: &str) -> WitInterface {
 #[tokio::test]
 async fn p3_guest_cas_swap_detects_aba() -> Result<()> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(
             MultiplexedAsyncKeyValue::new().with_provider(Arc::new(InMemoryProvider)),
         ))?

--- a/crates/wash-runtime/tests/integration_keyvalue_async_coexistence.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_async_coexistence.rs
@@ -34,7 +34,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_keyvalue::{
         InMemoryKeyValue, InMemoryProvider, MultiplexedAsyncKeyValue, MultiplexedKeyValue,
@@ -110,11 +110,11 @@ fn workload(
 #[tokio::test]
 async fn standalone_sync_and_async_keyvalue_coexist() -> Result<()> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(InMemoryKeyValue::new()))?
         .with_plugin(Arc::new(
             MultiplexedKeyValue::new().with_provider(Arc::new(InMemoryProvider)),

--- a/crates/wash-runtime/tests/integration_keyvalue_coexistence.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_coexistence.rs
@@ -30,7 +30,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_keyvalue::{InMemoryKeyValue, InMemoryProvider, MultiplexedKeyValue},
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -64,8 +64,8 @@ fn kv_interface(name: Option<&str>, backend: Option<&str>) -> WitInterface {
 #[tokio::test]
 async fn standalone_and_multiplexed_keyvalue_coexist() -> Result<()> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
 
     // Both plugins on one host: the standalone serves the unnamed import, the
     // multiplexed serves the named ones. The multiplexed plugin defaults named
@@ -73,7 +73,7 @@ async fn standalone_and_multiplexed_keyvalue_coexist() -> Result<()> {
     let multiplexed = MultiplexedKeyValue::new().with_provider(Arc::new(InMemoryProvider));
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(InMemoryKeyValue::new()))?
         .with_plugin(Arc::new(multiplexed))?
         .build()?;

--- a/crates/wash-runtime/tests/integration_keyvalue_default_p3.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_default_p3.rs
@@ -27,7 +27,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_keyvalue::{InMemoryProvider, MultiplexedAsyncKeyValue},
     types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
@@ -57,11 +57,11 @@ fn default_kv_iface() -> WitInterface {
 async fn p3_guest_plain_keyvalue_uses_default_backend() -> Result<()> {
     // --- host with the async multiplexed keyvalue plugin + in-memory provider ---
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(
             MultiplexedAsyncKeyValue::new().with_provider(Arc::new(InMemoryProvider)),
         ))?

--- a/crates/wash-runtime/tests/integration_keyvalue_implements.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_implements.rs
@@ -31,7 +31,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_keyvalue::{InMemoryProvider, MultiplexedKeyValue},
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -64,15 +64,15 @@ fn named_store(name: &str) -> WitInterface {
 #[tokio::test]
 async fn implements_imports_route_to_isolated_backends() -> Result<()> {
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
 
     // One multiplexed plugin serves both labeled imports; each named interface
     // defaults to its own isolated in-memory backend via `InMemoryProvider`.
     let multiplexed = MultiplexedKeyValue::new().with_provider(Arc::new(InMemoryProvider));
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(multiplexed))?
         .build()?;
     let host = host.start().await.context("failed to start host")?;

--- a/crates/wash-runtime/tests/integration_nats_blobstore.rs
+++ b/crates/wash-runtime/tests/integration_nats_blobstore.rs
@@ -19,7 +19,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasi_blobstore::NatsBlobstore,
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -60,13 +60,13 @@ async fn setup() -> Result<TestHarness> {
         .context("Failed to connect to NATS")?;
 
     let engine = Engine::builder().build()?;
-    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_plugin.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
     let blobstore_plugin = NatsBlobstore::new(&nats_client);
 
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_plugin))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(blobstore_plugin))?
         .build()?;
 

--- a/crates/wash-runtime/tests/integration_nats_messaging.rs
+++ b/crates/wash-runtime/tests/integration_nats_messaging.rs
@@ -22,7 +22,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasmcloud_messaging::NatsMessaging,
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -83,14 +83,14 @@ async fn setup(workloads: Vec<WorkloadStartRequest>) -> Result<TestHarness> {
     );
 
     let engine = Engine::builder().build()?;
-    // HttpServer is required by HostBuilder even though this test doesn't
+    // Ingress is required by HostBuilder even though this test doesn't
     // exercise HTTP — bind to ephemeral port 0.
-    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
     let messaging_plugin = NatsMessaging::new(plugin_client);
 
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_plugin))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(messaging_plugin))?
         .build()?;
 

--- a/crates/wash-runtime/tests/integration_nats_messaging_fault.rs
+++ b/crates/wash-runtime/tests/integration_nats_messaging_fault.rs
@@ -36,7 +36,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasmcloud_messaging::NatsMessaging,
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -195,12 +195,12 @@ async fn setup(latency: Duration) -> Result<TestHarness> {
     );
 
     let engine = Engine::builder().build()?;
-    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
     let messaging_plugin = NatsMessaging::new(plugin_client);
 
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_plugin))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(messaging_plugin))?
         .build()?;
     let host = host.start().await.context("Failed to start host")?;

--- a/crates/wash-runtime/tests/integration_postgres_implements.rs
+++ b/crates/wash-runtime/tests/integration_postgres_implements.rs
@@ -37,7 +37,7 @@ use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
-        http::{DevRouter, HttpServer},
+        http::{DevRouter, Ingress},
     },
     plugin::wasmcloud_postgres::{PgId, WasmcloudPostgres},
     types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadState},
@@ -125,12 +125,12 @@ async fn implements_imports_route_to_per_credential_connections() -> Result<()> 
     // Stand up a host with the postgres plugin (no shared bouncer URL: purely
     // implements-routed) plus an HTTP entrypoint to drive the guest.
     let engine = Engine::builder().build()?;
-    let http_server = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
-    let addr = http_server.addr();
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
 
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_server))
+        .with_http_handler(Arc::new(ingress))
         .with_plugin(Arc::new(WasmcloudPostgres::multiplex_only()))?
         .build()?;
     let host = host.start().await.context("failed to start host")?;

--- a/crates/wash-runtime/tests/integration_service_http.rs
+++ b/crates/wash-runtime/tests/integration_service_http.rs
@@ -7,6 +7,10 @@
 //! process-global counter from its `cli/run` loop and reporting it from each
 //! HTTP response — a response observing `cli_ticks > 0` that grows across
 //! requests can only happen if the run loop is co-driven concurrently.
+//!
+//! The fixture's `/boom` path traps, which also covers the fault path: a
+//! trapped instance is restarted and re-registered, and serving resumes on the
+//! fresh incarnation.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -34,7 +38,7 @@ fn parse_counter(body: &str) -> (u64, u64) {
     )
 }
 
-fn svc_counter_request(host: &str) -> WorkloadStartRequest {
+fn svc_counter_request(host: &str, max_restarts: u64) -> WorkloadStartRequest {
     WorkloadStartRequest {
         workload_id: uuid::Uuid::new_v4().to_string(),
         workload: Workload {
@@ -45,7 +49,7 @@ fn svc_counter_request(host: &str) -> WorkloadStartRequest {
                 digest: None,
                 bytes: bytes::Bytes::from_static(SVC_COUNTER_WASM),
                 local_resources: LocalResources::default(),
-                max_restarts: 0,
+                max_restarts,
             }),
             components: vec![],
             host_interfaces: http_only_host_interfaces(host),
@@ -60,7 +64,7 @@ fn svc_counter_request(host: &str) -> WorkloadStartRequest {
 async fn test_service_http_co_drives_cli_run() -> Result<()> {
     let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
 
-    host.workload_start(svc_counter_request("svc-counter"))
+    host.workload_start(svc_counter_request("svc-counter", 0))
         .await
         .context("failed to start p3 service-http workload")?;
 
@@ -129,6 +133,89 @@ async fn test_service_http_co_drives_cli_run() -> Result<()> {
     Ok(())
 }
 
+/// Restart: an HTTP handler trap faults the co-driven instance; the supervisor
+/// restarts it within `max_restarts` and re-registers the HTTP handler, so
+/// serving resumes on a FRESH incarnation (its per-instance `http_calls` starts
+/// over at 1 rather than continuing the pre-fault count).
+///
+/// The trap faults the store, so the driver's `run_concurrent` returns an error
+/// and the supervisor re-instantiates; the restart budget is what makes that
+/// recovery possible, and at `max_restarts: 0` the service never serves again.
+/// An ordinary handler error outcome does not fault the store — the co-drive
+/// test above proves consecutive requests keep the instance.
+///
+/// The messaging-ingress twin of this test is
+/// `test_trigger_service_restarts_and_resubscribes_on_fault` in
+/// `integration_trigger_service_messaging.rs`.
+#[tokio::test]
+async fn test_trigger_service_http_restarts_on_fault() -> Result<()> {
+    let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
+    host.workload_start(svc_counter_request("svc-boom", 3))
+        .await
+        .context("failed to start p3 service-http workload")?;
+
+    // No connection pooling: a retry on a stale pooled connection would land
+    // twice on the instance and break the exactly-once http_calls counts.
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()?;
+    let get = |path: &'static str| {
+        let client = client.clone();
+        async move {
+            let resp = timeout(
+                Duration::from_secs(10),
+                client
+                    .get(format!("http://{addr}{path}"))
+                    .header("HOST", "svc-boom")
+                    .send(),
+            )
+            .await??;
+            let status = resp.status();
+            Ok::<_, anyhow::Error>((status, resp.text().await?))
+        }
+    };
+
+    // Prime the initial incarnation to http_calls=2, so a post-restart response
+    // reading 1 can only come from a fresh instance (a surviving one would
+    // report 3).
+    for expected in 1..=2 {
+        let (status, body) = get("/").await?;
+        anyhow::ensure!(status.is_success(), "priming request failed: {status}");
+        let (_ticks, calls) = parse_counter(&body);
+        assert_eq!(calls, expected, "priming the initial incarnation");
+    }
+
+    // `/boom` traps the handler, faulting the instance; the supervisor restarts it.
+    let (boom_status, _) = get("/boom").await?;
+    assert_eq!(
+        boom_status, 500,
+        "a trapped handler answers the in-flight request with a 500"
+    );
+
+    // Serving resumes on a fresh incarnation. The restart is async, so poll
+    // until a request is SERVED again: requests arriving in the window between
+    // the fault and the re-registration hit the retired handler and come back
+    // 503 (or 500 if they raced the poisoned instance) — keep polling through
+    // those rather than mistaking them for a served response.
+    let mut got = None;
+    for _ in 0..100 {
+        let (status, body) = get("/").await?;
+        if status.is_success() {
+            got = Some(parse_counter(&body));
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let (_ticks, calls) = got.context("service never resumed serving HTTP after the fault")?;
+    assert_eq!(
+        calls, 1,
+        "after a fault the supervisor re-registers a FRESH instance, so its \
+         per-instance http_calls restarts at 1"
+    );
+
+    Ok(())
+}
+
 /// Regression for "N service replicas on one host serve like one". Two defects
 /// combined to pin all traffic to a single replica: service workloads never
 /// registered their hostname with the `DynamicRouter` (so a hostname router
@@ -152,7 +239,7 @@ async fn test_service_http_spreads_load_across_replicas() -> Result<()> {
 
     const REPLICAS: usize = 4;
     for _ in 0..REPLICAS {
-        host.workload_start(svc_counter_request("svc-rr"))
+        host.workload_start(svc_counter_request("svc-rr", 0))
             .await
             .context("failed to start svc-counter replica")?;
     }

--- a/crates/wash-runtime/tests/integration_trigger_service_messaging.rs
+++ b/crates/wash-runtime/tests/integration_trigger_service_messaging.rs
@@ -8,6 +8,10 @@
 //! on the SAME long-lived instance the trigger service co-drives — invoked via the
 //! dynamic `call_concurrent` path under `run_concurrent` — rather than a fresh
 //! instance per message.
+//!
+//! The end-to-end tests at the bottom drive the same path through a real
+//! messaging backend rather than the host-side delivery API, once against the
+//! in-memory backend and once against a NATS server in a container.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -16,13 +20,18 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use testcontainers::{
+    GenericImage,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
 use tokio::time::timeout;
 
 use wash_runtime::engine::Engine;
-use wash_runtime::host::http::{DevRouter, HostHandler, HttpServer};
+use wash_runtime::host::http::{DevRouter, HostHandler, Ingress};
 use wash_runtime::host::trigger_service::BrokerMessage;
 use wash_runtime::host::{HostApi, HostBuilder};
-use wash_runtime::plugin::wasmcloud_messaging::InMemoryMessaging;
+use wash_runtime::plugin::wasmcloud_messaging::{InMemoryMessaging, NatsMessaging};
 use wash_runtime::plugin::{
     wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig, wasi_keyvalue::InMemoryKeyValue,
     wasi_logging::TracingLogger,
@@ -58,7 +67,7 @@ fn msg_counter_request(workload_id: &str, max_restarts: u64) -> WorkloadStartReq
 }
 
 async fn deliver(
-    http_server: &Arc<HttpServer<DevRouter>>,
+    ingress: &Arc<Ingress<DevRouter>>,
     workload_id: &str,
     subject: &str,
 ) -> Result<Result<(), String>> {
@@ -69,7 +78,7 @@ async fn deliver(
     };
     timeout(
         Duration::from_secs(10),
-        http_server.deliver_trigger_service_message(workload_id, msg),
+        ingress.deliver_trigger_service_message(workload_id, msg),
     )
     .await
     .context("deliver_trigger_service_message timed out")?
@@ -78,7 +87,7 @@ async fn deliver(
 #[tokio::test]
 async fn test_trigger_service_co_drives_messaging_handler() -> Result<()> {
     let workload_id = uuid::Uuid::new_v4().to_string();
-    let (addr, host, http_server) = start_host_with_p3_handler("127.0.0.1:0").await?;
+    let (addr, host, ingress) = start_host_with_p3_handler("127.0.0.1:0").await?;
 
     host.workload_start(msg_counter_request(&workload_id, 0))
         .await
@@ -87,14 +96,14 @@ async fn test_trigger_service_co_drives_messaging_handler() -> Result<()> {
     // Two messages land on the SAME long-lived instance, so the handler's
     // process-global count climbs 1 -> 2 (a fresh instance per message would
     // return 1 both times).
-    let r1 = deliver(&http_server, &workload_id, "first").await?;
+    let r1 = deliver(&ingress, &workload_id, "first").await?;
     assert_eq!(
         r1,
         Err("1:first".to_string()),
         "first message handled on the co-driven instance"
     );
 
-    let r2 = deliver(&http_server, &workload_id, "second").await?;
+    let r2 = deliver(&ingress, &workload_id, "second").await?;
     assert_eq!(
         r2,
         Err("2:second".to_string()),
@@ -135,14 +144,14 @@ async fn test_trigger_service_co_drives_messaging_handler() -> Result<()> {
 #[tokio::test]
 async fn test_trigger_service_stop_drops_messaging_subscription() -> Result<()> {
     let workload_id = uuid::Uuid::new_v4().to_string();
-    let (_addr, host, http_server) = start_host_with_p3_handler("127.0.0.1:0").await?;
+    let (_addr, host, ingress) = start_host_with_p3_handler("127.0.0.1:0").await?;
 
     host.workload_start(msg_counter_request(&workload_id, 0))
         .await
         .context("failed to start msg-counter trigger service workload")?;
 
     // Delivery works while running.
-    let live = deliver(&http_server, &workload_id, "live").await?;
+    let live = deliver(&ingress, &workload_id, "live").await?;
     assert_eq!(
         live,
         Err("1:live".to_string()),
@@ -159,12 +168,10 @@ async fn test_trigger_service_stop_drops_messaging_subscription() -> Result<()> 
     // registration is gone, so delivery fails at lookup rather than reaching a
     // torn-down channel.
     assert!(
-        !http_server
-            .has_trigger_service_messaging(&workload_id)
-            .await,
+        !ingress.has_trigger_service_messaging(&workload_id).await,
         "stop must drop the messaging subscription"
     );
-    let after = deliver(&http_server, &workload_id, "after").await;
+    let after = deliver(&ingress, &workload_id, "after").await;
     assert!(
         after.is_err(),
         "a message published after stop must not be delivered, got {after:?}"
@@ -188,13 +195,13 @@ async fn test_trigger_service_stop_drops_messaging_subscription() -> Result<()> 
 #[tokio::test]
 async fn test_trigger_service_restarts_and_resubscribes_on_fault() -> Result<()> {
     let workload_id = uuid::Uuid::new_v4().to_string();
-    let (_addr, host, http_server) = start_host_with_p3_handler("127.0.0.1:0").await?;
+    let (_addr, host, ingress) = start_host_with_p3_handler("127.0.0.1:0").await?;
     host.workload_start(msg_counter_request(&workload_id, 3))
         .await
         .context("failed to start msg-counter trigger service workload")?;
 
     // Prime the count on the initial instance.
-    let r1 = deliver(&http_server, &workload_id, "first").await?;
+    let r1 = deliver(&ingress, &workload_id, "first").await?;
     assert_eq!(
         r1,
         Err("1:first".to_string()),
@@ -202,7 +209,7 @@ async fn test_trigger_service_restarts_and_resubscribes_on_fault() -> Result<()>
     );
 
     // `boom` traps the handler, faulting the instance; the supervisor restarts it.
-    let _ = deliver(&http_server, &workload_id, "boom").await;
+    let _ = deliver(&ingress, &workload_id, "boom").await;
 
     // After the restart, delivery resumes (re-subscribed) on a fresh instance
     // whose per-instance count starts over at 1. The restart is async, so poll
@@ -212,7 +219,7 @@ async fn test_trigger_service_restarts_and_resubscribes_on_fault() -> Result<()>
     // those rather than mistaking them for a handled message.
     let mut got = None;
     for _ in 0..100 {
-        if let Ok(Err(s)) = deliver(&http_server, &workload_id, "after").await
+        if let Ok(Err(s)) = deliver(&ingress, &workload_id, "after").await
             && s.ends_with(":after")
         {
             got = Some(s);
@@ -230,21 +237,31 @@ async fn test_trigger_service_restarts_and_resubscribes_on_fault() -> Result<()>
 }
 
 /// The `wasmcloud:messaging/handler` host interface, so the messaging plugin
-/// binds to the service (empty config → the service subscribes to everything).
-fn messaging_handler_interface() -> WitInterface {
+/// binds to the service. `subscriptions` names the subjects the service
+/// receives on; the in-memory backend also accepts none, which subscribes it to
+/// everything.
+fn messaging_handler_interface(subscriptions: Option<&str>) -> WitInterface {
+    let mut config = HashMap::new();
+    if let Some(subscriptions) = subscriptions {
+        config.insert("subscriptions".to_string(), subscriptions.to_string());
+    }
     WitInterface {
         namespace: "wasmcloud".to_string(),
         package: "messaging".to_string(),
         interfaces: ["handler".to_string()].into_iter().collect(),
         version: Some(semver::Version::new(0, 2, 0)),
-        config: HashMap::new(),
+        config,
         name: None,
     }
 }
 
-fn msg_counter_e2e_request(workload_id: &str, host: &str) -> WorkloadStartRequest {
+fn msg_counter_e2e_request(
+    workload_id: &str,
+    host: &str,
+    subscriptions: Option<&str>,
+) -> WorkloadStartRequest {
     let mut host_interfaces = http_only_host_interfaces(host);
-    host_interfaces.push(messaging_handler_interface());
+    host_interfaces.push(messaging_handler_interface(subscriptions));
     WorkloadStartRequest {
         workload_id: workload_id.to_string(),
         workload: Workload {
@@ -284,19 +301,38 @@ async fn get_count(
     Ok(common::json_u64_field(&body, "count"))
 }
 
+/// Poll [`get_count`] until it reaches `want`, giving up after ~5s. Returns the
+/// last value observed, so a failed expectation reports what the service
+/// actually handled rather than a bare timeout.
+async fn await_count(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host: &str,
+    want: u64,
+) -> Result<u64> {
+    let mut observed = 0;
+    for _ in 0..100 {
+        observed = get_count(client, addr, host).await?;
+        if observed >= want {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    Ok(observed)
+}
+
 /// End-to-end: a message published through the in-memory messaging backend is
 /// delivered to the long-lived trigger service (not a fresh per-message
 /// instance), so the count observed over the service's HTTP handler advances.
 #[tokio::test]
 async fn test_trigger_service_messaging_via_in_memory_backend() -> Result<()> {
     let engine = Engine::builder().build()?;
-    let http_server =
-        Arc::new(HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?);
-    let addr = http_server.addr();
+    let ingress = Arc::new(Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?);
+    let addr = ingress.addr();
     let messaging = Arc::new(InMemoryMessaging::new());
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(http_server.clone())
+        .with_http_handler(ingress.clone())
         .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
         .with_plugin(Arc::new(InMemoryKeyValue::new()))?
         .with_plugin(Arc::new(TracingLogger::default()))?
@@ -307,7 +343,7 @@ async fn test_trigger_service_messaging_via_in_memory_backend() -> Result<()> {
 
     let workload_id = uuid::Uuid::new_v4().to_string();
     let host_header = "msg-e2e";
-    host.workload_start(msg_counter_e2e_request(&workload_id, host_header))
+    host.workload_start(msg_counter_e2e_request(&workload_id, host_header, None))
         .await
         .context("failed to start msg-counter trigger service workload")?;
 
@@ -326,17 +362,104 @@ async fn test_trigger_service_messaging_via_in_memory_backend() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("publish failed: {e}"))?;
 
     // Delivery + handling is async; poll until the count reflects it.
-    let mut observed = 0;
-    for _ in 0..40 {
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        observed = get_count(&client, addr, host_header).await?;
-        if observed >= 1 {
-            break;
-        }
-    }
     assert_eq!(
-        observed, 1,
+        await_count(&client, addr, host_header, 1).await?,
+        1,
         "the published message was handled on the co-driven trigger service instance"
+    );
+
+    Ok(())
+}
+
+/// The same end-to-end path as [`test_trigger_service_messaging_via_in_memory_backend`],
+/// but over a real NATS server: the in-memory backend delivers in-process, so it
+/// cannot catch a break in `NatsMessaging`'s own subscribe/receive loop —
+/// notably that a *service* workload has no per-message instance to
+/// pre-instantiate and must instead be recognized as a registered trigger
+/// service and delivered to its live instance.
+///
+/// Two messages are published: the count climbing 1 → 2 proves both landed on
+/// the SAME long-lived instance the trigger service co-drives.
+///
+/// Requires Docker (NATS); marked `#[ignore]`, run with `cargo test --include-ignored`.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn test_trigger_service_messaging_via_nats_backend() -> Result<()> {
+    // NATS needs an explicit subject to subscribe to, unlike the in-memory
+    // backend, where an empty config subscribes the service to everything.
+    const SUBJECT: &str = "trigger.service.e2e";
+
+    let container = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start NATS container: {e}"))?;
+    let port = container
+        .get_host_port_ipv4(4222)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get NATS host port: {e}"))?;
+    let nats_url = format!("nats://127.0.0.1:{port}");
+
+    // The plugin holds its own client, matching how `wash host` wires it up.
+    let plugin_client = Arc::new(
+        async_nats::connect(&nats_url)
+            .await
+            .context("failed to connect the plugin's NATS client")?,
+    );
+    let publisher = async_nats::connect(&nats_url)
+        .await
+        .context("failed to connect the test's NATS client")?;
+
+    let engine = Engine::builder().build()?;
+    let ingress = Arc::new(Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?);
+    let addr = ingress.addr();
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(ingress.clone())
+        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
+        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
+        .with_plugin(Arc::new(TracingLogger::default()))?
+        .with_plugin(Arc::new(DynamicConfig::default()))?
+        .with_plugin(Arc::new(NatsMessaging::new(plugin_client)))?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    let workload_id = uuid::Uuid::new_v4().to_string();
+    let host_header = "msg-nats-e2e";
+    host.workload_start(msg_counter_e2e_request(
+        &workload_id,
+        host_header,
+        Some(SUBJECT),
+    ))
+    .await
+    .context("failed to start msg-counter trigger service workload")?;
+
+    let client = reqwest::Client::new();
+    assert_eq!(
+        get_count(&client, addr, host_header).await?,
+        0,
+        "no messages handled yet"
+    );
+
+    publisher
+        .publish(SUBJECT, bytes::Bytes::from_static(b"first"))
+        .await
+        .context("failed to publish the first message")?;
+    assert_eq!(
+        await_count(&client, addr, host_header, 1).await?,
+        1,
+        "the message published to NATS reached the co-driven trigger service instance"
+    );
+
+    publisher
+        .publish(SUBJECT, bytes::Bytes::from_static(b"second"))
+        .await
+        .context("failed to publish the second message")?;
+    assert_eq!(
+        await_count(&client, addr, host_header, 2).await?,
+        2,
+        "the second message hit the same long-lived instance (count persists)"
     );
 
     Ok(())

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -200,22 +200,22 @@ impl CliCommand for DevCommand {
             if let Some(ca) = dev_config.tls_ca_path.as_deref() {
                 tls = tls.with_ca(ca);
             }
-            let http_server = wash_runtime::host::http::HttpServer::new_with_tls(
+            let ingress = wash_runtime::host::http::Ingress::new_with_tls(
                 http_handler,
                 http_addr.parse()?,
                 tls,
             )
             .await?;
 
-            host_builder = host_builder.with_http_handler(Arc::new(http_server));
+            host_builder = host_builder.with_http_handler(Arc::new(ingress));
 
             debug!("TLS configured - server will use HTTPS");
             "https"
         } else {
             debug!("No TLS configuration provided - server will use HTTP");
-            let http_server =
-                wash_runtime::host::http::HttpServer::new(http_handler, http_addr.parse()?).await?;
-            host_builder = host_builder.with_http_handler(Arc::new(http_server));
+            let ingress =
+                wash_runtime::host::http::Ingress::new(http_handler, http_addr.parse()?).await?;
+            host_builder = host_builder.with_http_handler(Arc::new(ingress));
             "http"
         };
 

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -199,7 +199,7 @@ fn host_plugin_registry_credentials(
 impl CliCommand for HostCommand {
     async fn handle(&self, ctx: &CliContext) -> anyhow::Result<CommandOutput> {
         // Installed before connect_nats so TLS-enabled NATS clusters have a
-        // crypto provider available. Idempotent; also called by HttpServer::new.
+        // crypto provider available. Idempotent; also called by Ingress::new.
         wash_runtime::init_crypto();
 
         let scheduler_nats_client = wash_runtime::washlet::connect_nats(
@@ -296,18 +296,18 @@ impl CliCommand for HostCommand {
 
         if let Some(addr) = self.http_addr {
             let http_router = wash_runtime::host::http::DynamicRouter::default();
-            let http_server = if let (Some(cert_path), Some(key_path)) =
+            let ingress = if let (Some(cert_path), Some(key_path)) =
                 (&self.tls_cert_path, &self.tls_key_path)
             {
                 let mut tls = wash_runtime::host::http::TlsConfig::new(cert_path, key_path);
                 if let Some(ca) = self.tls_ca_path.as_deref() {
                     tls = tls.with_ca(ca);
                 }
-                wash_runtime::host::http::HttpServer::new_with_tls(http_router, addr, tls).await?
+                wash_runtime::host::http::Ingress::new_with_tls(http_router, addr, tls).await?
             } else {
-                wash_runtime::host::http::HttpServer::new(http_router, addr).await?
+                wash_runtime::host::http::Ingress::new(http_router, addr).await?
             };
-            cluster_host_builder = cluster_host_builder.with_http_handler(Arc::new(http_server));
+            cluster_host_builder = cluster_host_builder.with_http_handler(Arc::new(ingress));
         }
 
         // Enable otel plugin


### PR DESCRIPTION
With the introduction of TriggerServices, we now have a generic framework for adding additional types of Ingresses to workloads and part of that refactor was `HttpServer` stopped being only an HTTP server.

This change renames it (and `HttpServerBuilder`) to `Ingress`, per review on #5333.

Note this leaves two `Ingress` types in the crate: `host::http::Ingress` here and `host::trigger_service::Ingress`, the per-service handler-channel enum. They never appear in the same scope.

Fixes #5344