### PR TITLE
Host component imports for wasi:config and http

### DIFF
--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -998,6 +998,17 @@ pub fn imports_wasi_http(component: &Component) -> bool {
         .any(|(import, _item)| import.starts_with("wasi:http"))
 }
 
+/// Whether a component imports any `wasi:config` interface. Used to decide
+/// whether a host component plugin's linker needs the `wasi:config/store`
+/// host functions.
+pub fn imports_wasi_config(component: &Component) -> bool {
+    let ty: wasmtime::component::types::Component = component.component_type();
+    let engine = component.engine();
+
+    ty.imports(engine)
+        .any(|(import, _item)| import.starts_with("wasi:config"))
+}
+
 // TL;DR this is likely best for machines that can handle the large virtual memory requirement of the pooling allocator
 // https://github.com/bytecodealliance/wasmtime/blob/b943666650696f1eb7ff8b217762b58d5ef5779d/src/commands/serve.rs#L641-L656
 fn is_pooling_allocator_supported() -> anyhow::Result<bool> {

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -344,6 +344,7 @@ impl Host {
         for (id, plugin) in &self.plugins {
             plugin.inject_meters(&self.meters).await;
             plugin.set_workload_failure_sink(failure_sink.clone());
+            plugin.set_http_handler(self.http_handler.clone());
 
             if let Err(e) = plugin.start().await {
                 tracing::error!(id = id, err = ?e, "failed to start plugin");

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -47,7 +47,7 @@
 //! submodule; this module drives it from `ComponentHostPlugin`'s `HostPlugin`
 //! impl.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -68,6 +68,8 @@ use crate::engine::ctx::{CallerIdentity, Ctx, SharedCtx};
 use crate::engine::store::relocate::{self, Relocated};
 use crate::engine::store::resource_bridge::{self, ProxyResource};
 use crate::engine::workload::{UnresolvedWorkload, WorkloadItem};
+use crate::host::allowed_hosts::AllowedHost;
+use crate::host::http::HostHandler;
 use crate::host::job_registry::JobRegistry;
 use crate::host::trigger_service::{
     CapabilityCall, CapabilityFunc, CapabilityJob, Ingress, LifecycleReplay, TriggerService,
@@ -75,7 +77,7 @@ use crate::host::trigger_service::{
 };
 use crate::oci::OciConfig;
 use crate::plugin::component_plugin_spec::ComponentPluginSpec;
-use crate::plugin::{HostPlugin, WitInterfaces};
+use crate::plugin::{HostPlugin, WitInterfaces, wasi_config};
 use crate::wit::{WitInterface, WitWorld};
 
 mod lifecycle;
@@ -173,6 +175,14 @@ struct ComponentHostPluginState {
     /// lifecycle call, written at most once (before start), so a relaxed atomic
     /// is enough.
     lifecycle_timeout_ms: AtomicU64,
+    /// The host's outgoing-HTTP handler, injected via
+    /// [`HostPlugin::set_http_handler`] before `start()`. Each (re)built plugin
+    /// store carries it so the plugin's `wasi:http` imports are served by the
+    /// host's HTTP stack with unrestricted egress (native-plugin parity).
+    /// Absent when the plugin is driven without a host (e.g. tests): `wasi:http`
+    /// calls then trap, as before. Written once before `start()`, read once per
+    /// store build, so a plain mutex is fine.
+    http_handler: Mutex<Option<Arc<dyn HostHandler>>>,
 }
 
 impl ComponentHostPluginState {
@@ -254,6 +264,7 @@ impl ComponentHostPlugin {
             lifecycle_timeout_ms: AtomicU64::new(
                 crate::timeouts::plugin_lifecycle_call().as_millis() as u64,
             ),
+            http_handler: Mutex::new(None),
         });
 
         let (exports, lifecycle, pre) = build_plugin_linker(&engine, id, wasm, &state)?;
@@ -385,6 +396,14 @@ impl HostPlugin for ComponentHostPlugin {
 
     fn set_workload_failure_sink(&self, sink: crate::plugin::WorkloadFailureSink) {
         self.state.failure_sink.store(Some(Arc::new(sink)));
+    }
+
+    fn set_http_handler(&self, handler: Arc<dyn HostHandler>) {
+        *self
+            .state
+            .http_handler
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(handler);
     }
 
     async fn start(&self) -> anyhow::Result<()> {
@@ -665,6 +684,10 @@ fn build_plugin_linker(
     InstancePre<SharedCtx>,
 )> {
     let (component, mut linker) = engine.prepare_host_component(wasm)?;
+    if crate::engine::imports_wasi_config(&component) {
+        wasi_config::add_store_to_linker(&mut linker)
+            .with_context(|| format!("failed to add wasi:config to plugin '{id}' linker"))?;
+    }
     let mut lifecycle = None;
     let mut exports = Vec::new();
     for export in introspect_exports(&component)? {
@@ -1062,7 +1085,7 @@ async fn run_supervisor(
 ) {
     let mut restarts = 0u32;
     loop {
-        let store = build_plugin_store(&engine, state.id);
+        let store = build_plugin_store(&engine, &state);
         // A fresh job registry per incarnation, published on `state` so the
         // baked-in identity/cancel imports reach this store's live jobs. Stale
         // jobs from a faulted incarnation die with its store (their guards retire
@@ -1209,11 +1232,32 @@ async fn run_supervisor(
     }
 }
 
-/// Build the plugin's own store with a minimal host-scoped context. The plugin
-/// is not part of any workload; its `workload_id`/`component_id` are just its
-/// own id.
-fn build_plugin_store(engine: &Engine, id: &'static str) -> Store<SharedCtx> {
-    let ctx = Ctx::builder(id, id).build();
+/// Build the plugin's own store with a host-scoped context. The plugin is not
+/// part of any workload; its `workload_id`/`component_id` are just its own id.
+///
+/// A host component plugin is the trust peer of a native plugin, so the
+/// context carries the host authority its imports reach for:
+/// - an environment-backed `wasi:config` view (snapshotted fresh for each
+///   supervised incarnation), and
+/// - when the host injected one, the host's outgoing-HTTP handler with
+///   unrestricted egress — a native plugin connects wherever its operator
+///   config points, and so may a component plugin.
+fn build_plugin_store(engine: &Engine, state: &ComponentHostPluginState) -> Store<SharedCtx> {
+    let id = state.id;
+    let config_view: Arc<dyn HostPlugin + Send + Sync> = Arc::new(wasi_config::env_view(id));
+    let mut builder = Ctx::builder(id, id)
+        .with_plugins(HashMap::from([(wasi_config::WASI_CONFIG_ID, config_view)]));
+    let http_handler = state
+        .http_handler
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    if let Some(handler) = http_handler {
+        builder = builder
+            .with_http_handler(handler)
+            .with_allowed_hosts(Arc::from(vec![AllowedHost::Any]));
+    }
+    let ctx = builder.build();
     // The registry marks this as the plugin (real) side of the resource bridge
     // and keeps the resources it hands out across the boundary alive.
     Store::new(engine.inner(), SharedCtx::new(ctx).with_resource_registry())

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -211,6 +211,14 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
     /// component plugin evicting a workload whose lifecycle bind crash-loops).
     fn set_workload_failure_sink(&self, _sink: WorkloadFailureSink) {}
 
+    /// Inject the host's outgoing-HTTP handler. Called once during host start,
+    /// before [`HostPlugin::start`]. The default ignores it: a native plugin is
+    /// host code and reaches the network directly. A plugin that runs guest
+    /// code in its own store (a host component plugin) overrides this so the
+    /// store's `wasi:http` imports are satisfied by the host's HTTP stack
+    /// instead of trapping.
+    fn set_http_handler(&self, _handler: std::sync::Arc<dyn crate::host::http::HostHandler>) {}
+
     /// Called when the plugin is started during host initialization.
     ///
     /// This method allows plugins to perform any necessary setup before

--- a/crates/wash-runtime/src/plugin/wasi_config/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_config/mod.rs
@@ -40,7 +40,7 @@ mod bindings {
     });
 }
 
-const WASI_CONFIG_ID: &str = "wasi-config";
+pub(crate) const WASI_CONFIG_ID: &str = "wasi-config";
 
 type ConfigMap = HashMap<Arc<str>, HashMap<String, String>>;
 
@@ -74,6 +74,46 @@ pub struct DynamicConfig {
     /// the builder surface.
     #[builder(skip)]
     config: Arc<RwLock<ConfigMap>>,
+}
+
+/// Link the `wasi:config/store` host functions onto a host component plugin's
+/// linker. The values served come from whatever [`DynamicConfig`] view is
+/// registered on that store's `Ctx` under [`WASI_CONFIG_ID`] — for a plugin
+/// store, the environment-backed view from [`env_view`].
+#[cfg(feature = "host-component-plugins")]
+pub(crate) fn add_store_to_linker(
+    linker: &mut wasmtime::component::Linker<SharedCtx>,
+) -> anyhow::Result<()> {
+    bindings::wasi::config::store::add_to_linker::<_, SharedCtx>(linker, extract_active_ctx)?;
+    Ok(())
+}
+
+/// An environment-backed `wasi:config` view for a host component plugin store,
+/// served under `view_id` (the plugin's id, which is also the plugin store's
+/// `component_id`).
+///
+/// A host component plugin is the trust peer of the native plugins compiled
+/// into the host, which read `std::env` freely — so the view is a snapshot of
+/// the **full host process environment**, taken when the plugin store is built
+/// (fresh on each supervised restart). Each variable is served under its raw
+/// name and, when different, under a kebab-case alias (`ETCD_ENDPOINTS` →
+/// `etcd-endpoints`) so components can use conventional `wasi:config` keys.
+#[cfg(feature = "host-component-plugins")]
+pub(crate) fn env_view(view_id: &str) -> DynamicConfig {
+    let mut view = HashMap::new();
+    for (name, value) in std::env::vars() {
+        let kebab = name.to_ascii_lowercase().replace(['_', '.'], "-");
+        if kebab != name {
+            view.insert(kebab, value.clone());
+        }
+        view.insert(name, value);
+    }
+    let mut config = ConfigMap::new();
+    config.insert(Arc::from(view_id), view);
+    DynamicConfig {
+        copy_environment: false,
+        config: Arc::new(RwLock::new(config)),
+    }
 }
 
 impl<'a> bindings::wasi::config::store::Host for ActiveCtx<'a> {

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -634,11 +634,27 @@ fn build_workload_host_interfaces(
             if interface.namespace == "wasi" && interface.package == "config" {
                 any_imports_wasi_config = true;
             }
-            if !base
-                .iter()
-                .any(|i| i.namespace == interface.namespace && i.package == interface.package)
-            {
-                base.push(interface.clone());
+            // Merge same-package entries (same or unversioned) by unioning
+            // their interface names: a component importing two interfaces of
+            // one package (e.g. `wasmcloud:secrets` `store` + `reveal`)
+            // arrives as one WitInterface per name, and dropping the later
+            // ones would leave part of the import surface unbound.
+            match base.iter_mut().find(|i| {
+                i.namespace == interface.namespace
+                    && i.package == interface.package
+                    && (i.version == interface.version
+                        || i.version.is_none()
+                        || interface.version.is_none())
+            }) {
+                Some(existing) => {
+                    existing
+                        .interfaces
+                        .extend(interface.interfaces.iter().cloned());
+                    if existing.version.is_none() {
+                        existing.version = interface.version.clone();
+                    }
+                }
+                None => base.push(interface.clone()),
             }
         }
     }


### PR DESCRIPTION
## Description

Host component plugins do not have the same level of trust as native host plugins due to the native plugin runs as host code vs the host component running in its own wasmtime store. This is designed since it supports the component model approach.

### wash-runtime
This change adds supports for allowing a host component to import configuration settings through the `wasi:config` interface `wasi_config` host plugin, as well as providing egress support by passing the host's http handler.

#### on the wasi_config change:
When a wasm Workload uses the `wasi_config` host interface, the config values are all put together in `on_workload_item_bind`.  There isn't a current setup of a **plugin using another plugin** (i.e. `on_component_plugin_bind` ?), so this approach needs to be reviewed carefully, as this does give the ability for a host component to read any environment variable through the wasi_config host plugin.

### wash
- **fix(wash): union interface names when merging same-package WIT imports into host_interfaces**

