### PR TITLE
fix(chart): add Reloader annotations, fix hashing

### DIFF
--- a/charts/runtime-operator/templates/_helpers.tpl
+++ b/charts/runtime-operator/templates/_helpers.tpl
@@ -225,6 +225,119 @@ with `fromJson`.
 {{- end }}
 
 {{/*
+The `wash host` config file (--config) for ONE host group's file-backed
+hostPlugins entries, rendered at column 0 so callers indent it where they need
+it.
+
+Two callers, and that is the point: host-plugin-config.yaml projects it into a
+ConfigMap, and deployment.yaml hashes it into a `checksum/host-plugin-config`
+pod annotation so an edit rolls the host (which reads this file once, at
+startup). Hashing the real rendered output rather than the values it derives
+from means a change to the shape of this file — not just to a value in it —
+also rolls the pod.
+
+Takes a `hostPluginPartition` result, passed in rather than recomputed so each
+caller evaluates it exactly once.
+
+`configFrom`/`secretFrom` name plain Kubernetes ConfigMaps/Secrets in the
+release namespace. deployment.yaml projects each referenced one as a volume
+under /etc/wasmcloud/host-plugin-{config,secrets}/<name> — the directory shape
+`dir:` (wash_runtime::config_source) reads, one file per key, matching how
+Kubernetes itself projects a ConfigMap/Secret volume. The catalog below points
+`dir:` at that exact mount path, so `host.hostPlugins[].configFrom/secretFrom`
+resolve by name exactly like `workload.environment.configFrom/secretFrom` do.
+Only the host process reads these paths — the target plugin only ever calls
+e.g. `wasmcloud:secrets`'s `get`.
+*/}}
+{{- define "runtime-operator.hostPluginConfigFile" -}}
+{{- $partition := . }}
+{{- $configNames := $partition.configFromNames }}
+{{- $secretNames := $partition.secretFromNames }}
+{{- if $configNames }}
+configs:
+  {{- range $configNames }}
+  {{ . }}:
+    dir: /etc/wasmcloud/host-plugin-config/{{ . }}
+  {{- end }}
+{{- end }}
+{{- if $secretNames }}
+secrets:
+  {{- range $secretNames }}
+  {{ . }}:
+    dir: /etc/wasmcloud/host-plugin-secrets/{{ . }}
+  {{- end }}
+{{- end }}
+host:
+  hostPlugins:
+    {{- range $partition.fileBacked }}
+    - id: {{ .id }}
+      {{- if .image }}
+      image: {{ .image }}
+      {{- if .pullPolicy }}
+      pullPolicy: {{ .pullPolicy }}
+      {{- end }}
+      {{- if .digest }}
+      expectedDigest: {{ .digest }}
+      {{- end }}
+      {{- else if .file }}
+      file: {{ .file }}
+      {{- end }}
+      {{- if .maxRestarts }}
+      maxRestarts: {{ .maxRestarts }}
+      {{- end }}
+      {{- with .config }}
+      config:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .configFrom }}
+      configFrom:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .secretFrom }}
+      secretFrom:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .allowedHosts }}
+      allowedHosts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .allowedIpNameLookups }}
+      allowedIpNameLookups:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+
+{{/*
+Reloader annotations naming the ConfigMaps/Secrets a host group's plugin config
+references.
+
+The host reads its config file once, at startup, and the kubelet updates a
+projected volume in place — so rotating a ConfigMap/Secret named by
+`configFrom`/`secretFrom` changes the bytes on disk while the running host goes
+on serving the values it resolved at boot. The `checksum/host-plugin-config`
+annotation cannot catch this: the referenced objects live outside this chart,
+and their contents are not part of any value it renders.
+
+These annotations delegate that to stakater/Reloader, which watches the named
+objects and rolls the Deployment when their data changes. They are inert
+without the controller installed, so they cost nothing when it isn't — but
+without it, rotation genuinely does not reach a running host until something
+else restarts it.
+
+Takes the same `hostPluginPartition` result as `runtime-operator.hostPluginConfigFile`.
+*/}}
+{{- define "runtime-operator.hostPluginReloaderAnnotations" -}}
+{{- $partition := . }}
+{{- if $partition.configFromNames }}
+configmap.reloader.stakater.com/reload: {{ join "," $partition.configFromNames | quote }}
+{{- end }}
+{{- if $partition.secretFromNames }}
+secret.reloader.stakater.com/reload: {{ join "," $partition.secretFromNames | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the imagePullSecrets section for the chart.
 */}}
 {{- define "runtime-operator.imagePullSecrets" -}}

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -46,18 +46,20 @@ spec:
              never rolls the Deployment, and the host keeps serving the old
              config it read once at startup until an unrelated restart.
 
-             Hashed against this group's own partition, not the ConfigMap
-             template's rendered output: host-plugin-config.yaml ranges over
-             every group in runtime.hostGroups, so hashing its `include`
-             output would give every group's Deployment the SAME checksum —
-             any one group's plugin-config edit would then roll every host in
-             the cluster. The partition (fileBacked entries + configFrom/
-             secretFrom names) is an exact proxy for what the ConfigMap
-             renders for this group alone (the mount paths are static), so
-             hashing it scopes the checksum correctly per group. */}}
+             Hashes the config file helper directly, for this group only:
+             host-plugin-config.yaml ranges over every group, so hashing THAT
+             template's output would give every group the same checksum and
+             one group's edit would roll every host in the cluster.
+
+             The reloader annotations cover what a checksum structurally
+             cannot — the contents of the ConfigMaps/Secrets this file only
+             references by name. See the helper. */}}
       {{- $annotations := dict }}
       {{- if $fileBackedPlugins }}
-      {{- $_ := set $annotations "checksum/host-plugin-config" (include "runtime-operator.hostPluginPartition" . | sha256sum) }}
+      {{- $configFile := include "runtime-operator.hostPluginConfigFile" $partition }}
+      {{- $_ := set $annotations "checksum/host-plugin-config" ($configFile | sha256sum) }}
+      {{- $reloader := include "runtime-operator.hostPluginReloaderAnnotations" $partition | fromYaml }}
+      {{- $annotations = merge $annotations $reloader }}
       {{- end }}
       {{- with $top.Values.runtime.podAnnotations }}
       {{- $annotations = merge $annotations . }}

--- a/charts/runtime-operator/templates/runtime/host-plugin-config.yaml
+++ b/charts/runtime-operator/templates/runtime/host-plugin-config.yaml
@@ -8,23 +8,15 @@ Rendered only when at least one such entry exists for the hostgroup; entries
 with none of those fields keep rendering as a plain `--host-plugin=...` arg in
 deployment.yaml, unchanged.
 
-`configFrom`/`secretFrom` name plain Kubernetes ConfigMaps/Secrets in this
-release's namespace. deployment.yaml projects each referenced one as a volume
-under /etc/wasmcloud/host-plugin-{config,secrets}/<name> — the same directory
-shape `dir:` (crates/wash/src/config.rs) reads (one file per key, matching how
-Kubernetes itself projects a ConfigMap/Secret volume). The config file below
-declares a `configs:`/`secrets:` catalog entry per referenced name, pointing
-`dir:` at that exact mount path, so `host.hostPlugins[].configFrom/secretFrom`
-resolve by name exactly like `workload.environment.configFrom/secretFrom`
-already do. Only the host process reads these paths — the target plugin only
-ever calls e.g. `wasmcloud:secrets::get(...)`.
+The file's contents come from the `runtime-operator.hostPluginConfigFile`
+helper, which deployment.yaml also hashes for its `checksum/host-plugin-config`
+pod annotation — see that helper for what the file declares and why.
 */}}
 {{- $top := . }}
 {{- range .Values.runtime.hostGroups }}
 {{- $ns := default $top.Release.Namespace .namespace }}
 {{- $partition := include "runtime-operator.hostPluginPartition" . | fromJson }}
-{{- $fileBacked := $partition.fileBacked }}
-{{- if $fileBacked }}
+{{- if $partition.fileBacked }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -36,61 +28,7 @@ metadata:
     {{- include "runtime-operator.labels" $top | nindent 4 }}
 data:
   config.yaml: |
-    {{- $configNames := $partition.configFromNames }}
-    {{- $secretNames := $partition.secretFromNames }}
-    {{- if $configNames }}
-    configs:
-      {{- range $configNames }}
-      {{ . }}:
-        dir: /etc/wasmcloud/host-plugin-config/{{ . }}
-      {{- end }}
-    {{- end }}
-    {{- if $secretNames }}
-    secrets:
-      {{- range $secretNames }}
-      {{ . }}:
-        dir: /etc/wasmcloud/host-plugin-secrets/{{ . }}
-      {{- end }}
-    {{- end }}
-    host:
-      hostPlugins:
-        {{- range $fileBacked }}
-        - id: {{ .id }}
-          {{- if .image }}
-          image: {{ .image }}
-          {{- if .pullPolicy }}
-          pullPolicy: {{ .pullPolicy }}
-          {{- end }}
-          {{- if .digest }}
-          expectedDigest: {{ .digest }}
-          {{- end }}
-          {{- else if .file }}
-          file: {{ .file }}
-          {{- end }}
-          {{- if .maxRestarts }}
-          maxRestarts: {{ .maxRestarts }}
-          {{- end }}
-          {{- with .config }}
-          config:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .configFrom }}
-          configFrom:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .secretFrom }}
-          secretFrom:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .allowedHosts }}
-          allowedHosts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .allowedIpNameLookups }}
-          allowedIpNameLookups:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-        {{- end }}
+{{ include "runtime-operator.hostPluginConfigFile" $partition | trim | indent 4 }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -392,6 +392,18 @@ runtime:
       #                   — a host component plugin is operator-controlled
       #                   and more privileged than a workload, so it gets no
       #                   ergonomic allow-all default.
+      #
+      # Editing any of these rolls the host automatically (the Deployment
+      # carries a checksum over the rendered config file). Rotating the
+      # CONTENTS of a ConfigMap/Secret named by `configFrom`/`secretFrom` is
+      # different: the host resolves that file once, at startup, and the
+      # kubelet updates the projected volume in place, so a running host keeps
+      # serving what it read at boot. The Deployment carries
+      # `{configmap,secret}.reloader.stakater.com/reload` annotations naming
+      # exactly those objects — install stakater/Reloader and a rotation rolls
+      # the host on its own. Without that controller the annotations are
+      # inert, and a rotation needs a manual `kubectl rollout restart`.
+      #
       #   allowedIpNameLookups  names this plugin's own
       #                   `wasi:sockets/ip-name-lookup` calls may resolve.
       #                   Omitted/empty denies every lookup.


### PR DESCRIPTION
The `checksum/host-plugin-config` annotation hashed the hostPlugins partition tuple rather than the config file actually rendered from it, so a change to the file's shape (not just a value) could roll every group with the same checksum. Extract the config file body into a shared `runtime-operator.hostPluginConfigFile` helper, used by both the ConfigMap and the checksum, so the hash covers exactly what's mounted.

Also add `{configmap,secret}.reloader.stakater.com/reload` annotations naming the configFrom/secretFrom sources: the checksum only catches edits to the chart-rendered file, not rotations of the ConfigMaps/ Secrets it references by name, which the host reads once at startup.
