### PR TITLE
test(wash): add e2e k8s host test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,28 @@ cargo test --lib
 cargo test --bin wash
 ```
 
+The Rust Kubernetes host smoke test is ignored by default because it builds a
+host image and creates a complete kind cluster, and generally takes a long time
+to run.
+
+The smoke test requires:
+
+* A `docker`-compatible daemon
+* `helm`
+* `kubectl`
+
+During the test we download the pinned kind/Kubernetes and chart images to create and use
+a temporary kubeconfig in a `testcontainers`-managed, DinD `kind` cluster.
+
+To run the smoke test:
+
+```bash
+# (optional) if the host image is already built with tag 'localhost/wasmcloud-wash:rust-k8s-e2e', you can skip that build
+# export TEST_WASH_INT_K8S_SKIP_HOST_IMAGE_BUILD=true
+
+cargo test -p wash --test k8s_host_serves_http_workload -- --include-ignored --nocapture
+```
+
 ## Project Structure
 
 This repository is a workspace. The `wash` CLI lives in `crates/wash` and the core Wasm runtime it depends on lives in `crates/wash-runtime`:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6092,6 +6092,7 @@ dependencies = [
  "toml 0.8.23",
  "tonic-prost-build",
  "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
  "wash-runtime",

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -92,6 +92,7 @@ tokio = { version = "1.45.1", default-features = false, features = ["full"] }
 reqwest = { workspace = true, features = ["json"] }
 wash-runtime = { workspace = true, features = ["wasi-keyvalue", "wasi-blobstore"] }
 testcontainers = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "ansi", "time", "json"] }
 wat = { workspace = true }
 
 [package.metadata.binstall]

--- a/crates/wash/tests/common/docker/kind.rs
+++ b/crates/wash/tests/common/docker/kind.rs
@@ -1,0 +1,222 @@
+//! Utilities for managing [kind][kind] clusters during tests
+//!
+//! [kind]: <https://kind.sigs.k8s.io/>
+
+use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail, ensure};
+use tokio::process::Command;
+use tracing::debug;
+use url::Url;
+
+use crate::common::{DEFAULT_CLUSTER_API_PORT, DEFAULT_GATEWAY_NODE_PORT, DEFAULT_HOST_IMAGE};
+
+const KIND_NODE_IMAGE: &str = "kindest/node:v1.36.1";
+
+const DOCKER_BIN: &str = "docker";
+const KIND_BIN: &str = "kind";
+
+/// Representation of a kind cluster that may or may not have been started
+#[allow(unused)]
+pub struct KindCluster {
+    // pub dind_container: ContainerAsync<GenericImage>,
+    pub work_dir: PathBuf,
+    pub cargo_workspace_dir: PathBuf,
+    pub kubeconfig_path: PathBuf,
+    pub cluster_url: url::Url,
+    pub cluster_name: String,
+    pub gateway_addr: SocketAddr,
+}
+
+impl KindCluster {
+    pub async fn start(
+        work_dir: &Path,
+        cargo_workspace_dir: &Path,
+        cluster_name: &str,
+    ) -> Result<Self> {
+        let shared_dir = work_dir.canonicalize().with_context(|| {
+            format!(
+                "failed to canonicalize the working dir [{}]",
+                work_dir.display()
+            )
+        })?;
+
+        // Determine path to kubeconfig that will be written
+        let kubeconfig_path = shared_dir.join("kubeconfig");
+        debug!(?kubeconfig_path, "wrote kubeconfig");
+
+        // Write out kind config
+        let kind_config_path = shared_dir.join("kind-config.yaml");
+        tokio::fs::write(&kind_config_path, kind_config_yaml())
+            .await
+            .context("failed to write the derived kind config")?;
+
+        // Create kind cluster
+        debug!(
+            cluster_name,
+            kind_docker_image = KIND_NODE_IMAGE,
+            "creating kind cluster..."
+        );
+        let kind_create_output = Command::new(KIND_BIN)
+            .args([
+                "create",
+                "cluster",
+                "--name",
+                cluster_name,
+                "--image",
+                KIND_NODE_IMAGE,
+                "--config",
+                &format!("{}", kind_config_path.display()),
+                "--kubeconfig",
+                &format!("{}", kubeconfig_path.display()),
+                "--wait",
+                "5m",
+            ])
+            .output()
+            .await
+            .context("failed to create the kind cluster")?;
+        if !kind_create_output.status.success() {
+            eprintln!(
+                "kind cluster create command failed\nSTDOUT:\n{}\nSTDERR:\n{}",
+                String::from_utf8_lossy(&kind_create_output.stdout),
+                String::from_utf8_lossy(&kind_create_output.stderr),
+            );
+        }
+        ensure!(
+            kind_create_output.status.success(),
+            "kind cluster create succeeded"
+        );
+
+        let cluster_url = get_server_url_from_kubeconfig(&kubeconfig_path).await?;
+        let gateway_addr = match cluster_url.host().context("cluster URL has no host")? {
+            url::Host::Ipv4(addr) => {
+                SocketAddr::V4(SocketAddrV4::new(addr, DEFAULT_GATEWAY_NODE_PORT))
+            }
+            url::Host::Ipv6(addr) => {
+                SocketAddr::V6(SocketAddrV6::new(addr, DEFAULT_GATEWAY_NODE_PORT, 0, 0))
+            }
+            _ => bail!("unexpected host for cluster URL"),
+        };
+
+        Ok(Self {
+            work_dir: PathBuf::from(work_dir),
+            cargo_workspace_dir: PathBuf::from(cargo_workspace_dir),
+            kubeconfig_path,
+            cluster_url,
+            cluster_name: cluster_name.into(),
+            gateway_addr,
+        })
+    }
+
+    pub async fn build_and_load_host_image(&self, skip_image_build: bool) -> Result<()> {
+        debug!("building host image with docker...");
+
+        // If the docker image tag exists, we can skip building it
+        if !skip_image_build {
+            debug!(tag = DEFAULT_HOST_IMAGE, "building host image...");
+            let docker_build_output = Command::new(DOCKER_BIN)
+                .args([
+                    "build",
+                    "--tag",
+                    DEFAULT_HOST_IMAGE,
+                    &format!("{}", self.cargo_workspace_dir.display()),
+                ])
+                .output()
+                .await
+                .context("failed to build the host image in the isolated Docker daemon")?;
+            ensure!(docker_build_output.status.success(), "docker build failed");
+        } else {
+            debug!(tag = DEFAULT_HOST_IMAGE, "skipping host image build...");
+        }
+
+        debug!("loading host image into kind...");
+        let kind_load_output = Command::new(KIND_BIN)
+            .args([
+                "load",
+                "docker-image",
+                "--name",
+                &self.cluster_name,
+                DEFAULT_HOST_IMAGE,
+            ])
+            .output()
+            .await
+            .context("failed to load the host image into the kind node")?;
+        ensure!(kind_load_output.status.success(), "kind image load failed");
+
+        Ok(())
+    }
+
+    pub async fn delete(self) -> Result<()> {
+        debug!("shutting down kind cluster...");
+        let kind_delete_output = Command::new(KIND_BIN)
+            .args(["delete", "cluster", "--name", &self.cluster_name])
+            .output()
+            .await
+            .context("kind delete failed")?;
+        if !kind_delete_output.status.success() {
+            eprintln!(
+                "kind cluster delete command failed\nSTDOUT:\n{}\nSTDERR:\n{}",
+                String::from_utf8_lossy(&kind_delete_output.stdout),
+                String::from_utf8_lossy(&kind_delete_output.stderr),
+            );
+        }
+        ensure!(
+            kind_delete_output.status.success(),
+            "kind delete cluster command failed"
+        );
+        Ok(())
+    }
+}
+
+/// Generate configuration for a default-ish kind config
+pub fn kind_config_yaml() -> String {
+    format!(
+        r#"kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "0.0.0.0"
+  apiServerPort: {DEFAULT_CLUSTER_API_PORT}
+kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        enable-admission-plugins: NodeRestriction,OwnerReferencesPermissionEnforcement
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: {DEFAULT_GATEWAY_NODE_PORT}
+        hostPort: {DEFAULT_GATEWAY_NODE_PORT}
+        listenAddress: "0.0.0.0"
+        protocol: TCP
+"#
+    )
+}
+
+/// Retrieve serve details from the kubeconfig
+async fn get_server_url_from_kubeconfig(kubeconfig_path: &Path) -> Result<Url> {
+    let contents = tokio::fs::read_to_string(kubeconfig_path)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to read the generated kubeconfig @ [{}]",
+                kubeconfig_path.display()
+            )
+        })?;
+    let mut document: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(&contents).context("failed to parse the generated kubeconfig")?;
+    let cluster = document
+        .get_mut("clusters")
+        .and_then(serde_yaml_ng::Value::as_sequence_mut)
+        .context("generated kubeconfig has no clusters")?
+        .first_mut()
+        .and_then(|entry| entry.get_mut("cluster"))
+        .and_then(serde_yaml_ng::Value::as_mapping_mut)
+        .context("generated kubeconfig has no cluster configuration")?;
+    let server_addr = cluster
+        .get("server")
+        .and_then(serde_yaml_ng::Value::as_str)
+        .context("failed to parse server addresss string")?;
+    Url::parse(server_addr).context("failed to parse server URL")
+}

--- a/crates/wash/tests/common/docker/mod.rs
+++ b/crates/wash/tests/common/docker/mod.rs
@@ -1,0 +1,37 @@
+use anyhow::{Context, Result};
+use testcontainers::core::{CmdWaitFor, ExecCommand};
+use testcontainers::{ContainerAsync, GenericImage};
+
+pub mod kind;
+
+/// Execute a container command
+#[allow(unused)]
+pub async fn exec_container_command<const N: usize>(
+    container: &ContainerAsync<GenericImage>,
+    args: [&str; N],
+) -> Result<String> {
+    let command: Vec<_> = args.iter().map(|arg| (*arg).to_string()).collect();
+    let mut result = container
+        .exec(ExecCommand::new(command).with_cmd_ready_condition(CmdWaitFor::exit_code(0)))
+        .await
+        .with_context(|| {
+            format!(
+                "failed to execute command in container ID [{}]",
+                container.id()
+            )
+        })?;
+    let stdout = result
+        .stdout_to_vec()
+        .await
+        .context("failed to read container command stdout")?;
+    let stderr = result
+        .stderr_to_vec()
+        .await
+        .context("failed to read container command stderr")?;
+    let stdout = String::from_utf8_lossy(&stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&stderr).into_owned();
+    if !stderr.trim().is_empty() {
+        eprintln!("{stderr}");
+    }
+    Ok(stdout)
+}

--- a/crates/wash/tests/common/helm.rs
+++ b/crates/wash/tests/common/helm.rs
@@ -1,0 +1,103 @@
+//! Utilities for running helm in tests
+
+use std::path::Path;
+
+use anyhow::{Context, Result, ensure};
+use tokio::process::Command;
+
+use crate::common::{
+    DEFAULT_HOST_IMAGE_REPOSITORY, DEFAULT_HOST_IMAGE_TAG, DEFAULT_K8S_NAMESPACE, DEFAULT_RELEASE,
+    exec_command,
+};
+
+/// Ensure all required files and binaries are present
+pub async fn validate_deploy_prerequisites(workspace: &Path) -> Result<()> {
+    for path in [
+        workspace.join("Dockerfile"),
+        workspace.join("charts/runtime-operator/Chart.yaml"),
+        workspace.join("deploy/kind/kind-config.yaml"),
+        workspace.join("runtime-operator/config/samples/service_deployment.yaml"),
+    ] {
+        ensure!(
+            path.is_file(),
+            "required repository file is missing: {}",
+            path.display()
+        );
+    }
+    for (tool, args) in [
+        ("helm", &["version", "--short"][..]),
+        ("kubectl", &["version", "--client"][..]),
+    ] {
+        exec_command(
+            &format!("find required tool {tool}"),
+            Command::new(tool).args(args),
+        )
+        .await
+        .with_context(|| format!("{tool} is required on PATH"))?;
+    }
+    Ok(())
+}
+
+/// Install a the runtime-operator helm chart in the workspace
+pub async fn install_chart(workspace: &Path, kubeconfig: &Path) -> Result<()> {
+    let chart = workspace.join("charts/runtime-operator");
+    let mut command = Command::new("helm");
+    command
+        .arg("upgrade")
+        .arg("--install")
+        .arg("--create-namespace")
+        .arg("--namespace")
+        .arg(DEFAULT_K8S_NAMESPACE)
+        .arg("--kubeconfig")
+        .arg(kubeconfig)
+        .arg("--wait")
+        .arg("--timeout=5m")
+        .arg("--set")
+        .arg("gateway.enabled=false")
+        .arg("--set")
+        .arg("runtime.hostGroups[0].name=default")
+        .arg("--set")
+        .arg("runtime.hostGroups[0].replicas=1")
+        .arg("--set")
+        .arg("runtime.hostGroups[0].http.enabled=true")
+        .arg("--set")
+        .arg("runtime.hostGroups[0].http.port=80")
+        .arg("--set")
+        .arg("runtime.hostGroups[0].webgpu.enabled=false")
+        .arg("--set")
+        .arg("runtime.hostGroups[0].resources.requests.memory=64Mi")
+        .arg("--set")
+        .arg("runtime.hostGroups[0].resources.requests.cpu=250m")
+        .arg("--set")
+        .arg("runtime.hostGroups[0].resources.limits.memory=512Mi")
+        .arg("--set")
+        .arg("runtime.hostGroups[0].resources.limits.cpu=500m")
+        .arg("--set")
+        .arg("runtime.image.registry=")
+        .arg("--set")
+        .arg(format!(
+            "runtime.image.repository={DEFAULT_HOST_IMAGE_REPOSITORY}"
+        ))
+        .arg("--set")
+        .arg(format!("runtime.image.tag={DEFAULT_HOST_IMAGE_TAG}"))
+        .arg("--set")
+        .arg("runtime.image.pull_policy=Never")
+        .arg(DEFAULT_RELEASE)
+        .arg(chart);
+    exec_command("install the runtime-operator chart", &mut command).await?;
+    Ok(())
+}
+
+/// Print helm related diagnostics
+pub async fn print_diagnostics(kubeconfig: &Path) {
+    let mut helm = Command::new("helm");
+    helm.arg("status")
+        .arg(DEFAULT_RELEASE)
+        .arg("--namespace")
+        .arg(DEFAULT_K8S_NAMESPACE)
+        .arg("--kubeconfig")
+        .arg(kubeconfig);
+    if let Err(err) = exec_command("collect Helm status", &mut helm).await {
+        eprintln!("{err:#}");
+    }
+}

--- a/crates/wash/tests/common/k8s.rs
+++ b/crates/wash/tests/common/k8s.rs
@@ -1,0 +1,92 @@
+//! k8s utilities
+
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Output;
+
+use anyhow::Result;
+use tokio::process::Command;
+
+use crate::common::{DEFAULT_K8S_NAMESPACE, exec_command, helm};
+
+/// Run a k8s command
+pub async fn kubectl<I, S>(kubeconfig: &Path, args: I) -> Result<Output>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new("kubectl");
+    command.arg("--kubeconfig").arg(kubeconfig).args(args);
+    exec_command("run kubectl", &mut command).await
+}
+
+/// Parse kubectl command output
+pub async fn kubectl_output<const N: usize>(kubeconfig: &Path, args: [&str; N]) -> Result<String> {
+    let output = kubectl(kubeconfig, args).await?;
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Print k8s cluster diagnostics
+pub async fn print_diagnostics(kubeconfig: &Path) {
+    let commands: &[&[&str]] = &[
+        &[
+            "get",
+            "pods,services,deployments,endpointslices",
+            "--all-namespaces",
+            "--output",
+            "wide",
+        ],
+        &[
+            "get",
+            "hosts.runtime.wasmcloud.dev,workloaddeployments.runtime.wasmcloud.dev,workloads.runtime.wasmcloud.dev",
+            "--all-namespaces",
+            "--output",
+            "yaml",
+        ],
+        &[
+            "get",
+            "events",
+            "--all-namespaces",
+            "--sort-by=.lastTimestamp",
+        ],
+        &[
+            "logs",
+            "--namespace",
+            DEFAULT_K8S_NAMESPACE,
+            "--selector",
+            "wasmcloud.com/name=runtime-operator",
+            "--tail=500",
+        ],
+        &[
+            "logs",
+            "--namespace",
+            DEFAULT_K8S_NAMESPACE,
+            "--selector",
+            "wasmcloud.com/name=hostgroup",
+            "--tail=500",
+        ],
+        &[
+            "logs",
+            "--namespace",
+            DEFAULT_K8S_NAMESPACE,
+            "--selector",
+            "wasmcloud.com/name=runtime-gateway",
+            "--tail=500",
+        ],
+    ];
+    for args in commands {
+        let rendered = args.join(" ");
+        match kubectl(kubeconfig, args.iter().copied()).await {
+            Ok(output) => {
+                eprintln!(
+                    "\n>>> kubectl {rendered}\n{}{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            Err(err) => eprintln!("\n>>> kubectl {rendered}\n{err:#}"),
+        }
+    }
+
+    helm::print_diagnostics(kubeconfig).await;
+}

--- a/crates/wash/tests/common/mod.rs
+++ b/crates/wash/tests/common/mod.rs
@@ -1,0 +1,191 @@
+//! Common utilities for use during integration tests
+
+use std::ffi::OsStr;
+use std::future::Future;
+use std::path::Path;
+use std::process::Output;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use reqwest::{Client, StatusCode, header::HOST};
+use tokio::process::Command;
+use tokio::time::sleep;
+
+pub mod docker;
+pub mod helm;
+pub mod k8s;
+
+use docker::kind::KindCluster;
+
+pub const DEFAULT_K8S_NAMESPACE: &str = "wasmcloud-system";
+pub const DEFAULT_HOST_IMAGE_REPOSITORY: &str = "localhost/wasmcloud-wash";
+pub const DEFAULT_HOST_IMAGE_TAG: &str = "rust-k8s-e2e";
+pub const DEFAULT_HOST_IMAGE: &str = "localhost/wasmcloud-wash:rust-k8s-e2e";
+pub const DEFAULT_RELEASE: &str = "rust-host-e2e";
+pub const DEFAULT_CLUSTER_API_PORT: u16 = 6443;
+pub const DEFAULT_GATEWAY_NODE_PORT: u16 = 30950;
+
+/// Execute a CLI command
+pub async fn exec_command(description: &str, command: &mut Command) -> Result<Output> {
+    let std_cmd = command.as_std();
+    let command_arr = std::iter::once(std_cmd.get_program())
+        .chain(std_cmd.get_args())
+        .map(|arg| arg.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let output = command
+        .output()
+        .await
+        .with_context(|| format!("failed to {description}: {command_arr}"))?;
+    if !output.status.success() {
+        bail!(
+            "failed to {description}: {command_arr}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(output)
+}
+
+/// Wait for a given condition, with configurable timeout & interval
+pub async fn wait_for<F, Fut>(
+    description: &str,
+    timeout: Duration,
+    interval: Duration,
+    mut check: F,
+) -> Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<()>>,
+{
+    let deadline = Instant::now() + timeout;
+    let mut last_error = anyhow!("condition was never checked");
+    while Instant::now() < deadline {
+        match check().await {
+            Ok(()) => return Ok(()),
+            Err(err) => last_error = err,
+        }
+        sleep(interval).await;
+    }
+    Err(last_error).with_context(|| format!("timed out waiting for {description}"))
+}
+
+/// Deploy and start a basic HTTP wasmCloud workload on a given kind cluster
+pub async fn deploy_and_start_basic_http_workload(
+    workspace: &Path,
+    cluster: &KindCluster,
+    skip_image_build: bool,
+) -> Result<()> {
+    cluster.build_and_load_host_image(skip_image_build).await?;
+
+    helm::install_chart(workspace, &cluster.kubeconfig_path).await?;
+
+    wait_for(
+        "a registered wasmCloud host",
+        Duration::from_secs(180),
+        Duration::from_secs(3),
+        || async {
+            let output = k8s::kubectl_output(
+                &cluster.kubeconfig_path,
+                [
+                    "get",
+                    "hosts.runtime.wasmcloud.dev",
+                    "--namespace",
+                    DEFAULT_K8S_NAMESPACE,
+                    "--output",
+                    "jsonpath={.items[0].metadata.name}",
+                ],
+            )
+            .await?;
+            ensure!(!output.trim().is_empty(), "no Host resource registered yet");
+            Ok(())
+        },
+    )
+    .await?;
+
+    // Start the workload
+    let workload = workspace.join("runtime-operator/config/samples/service_deployment.yaml");
+    k8s::kubectl(
+        &cluster.kubeconfig_path,
+        [
+            OsStr::new("apply"),
+            OsStr::new("--namespace"),
+            OsStr::new(DEFAULT_K8S_NAMESPACE),
+            OsStr::new("--filename"),
+            workload.as_os_str(),
+        ],
+    )
+    .await?;
+
+    wait_for(
+        "the hello-workload WorkloadDeployment",
+        Duration::from_secs(180),
+        Duration::from_secs(3),
+        || async {
+            let ready = k8s::kubectl_output(
+                &cluster.kubeconfig_path,
+                [
+                    "get",
+                    // see: service_deployment.yaml
+                    "workloaddeployment/hello-workload",
+                    "--namespace",
+                    DEFAULT_K8S_NAMESPACE,
+                    "--output",
+                    "jsonpath={.status.conditions[?(@.type==\"Ready\")].status}",
+                ],
+            )
+            .await?;
+            ensure!(ready.trim() == "True", "last Ready condition was {ready:?}");
+            Ok(())
+        },
+    )
+    .await?;
+
+    let endpoint = format!("http://{}", cluster.gateway_addr);
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("failed to construct the HTTP client")?;
+    wait_for(
+        "the hello-world HTTP route",
+        Duration::from_secs(15),
+        Duration::from_secs(2),
+        || async {
+            let response_status = client
+                .get(&endpoint)
+                .header(HOST, "hello.localhost.direct")
+                .send()
+                .await
+                .context("HTTP request failed")?
+                .status();
+            ensure!(
+                response_status == StatusCode::OK,
+                "HTTP route returned {response_status:#?}",
+            );
+            Ok(())
+        },
+    )
+    .await?;
+
+    for path in ["/", "/?source=rust-kubernetes-e2e", "/"] {
+        let response = client
+            .get(format!("{endpoint}{path}"))
+            .header(HOST, "hello.localhost.direct")
+            .send()
+            .await
+            .with_context(|| format!("request to {path} failed"))?;
+        ensure!(
+            response.status() == StatusCode::OK,
+            "request to {path} returned {}",
+            response.status()
+        );
+        let body = response
+            .text()
+            .await
+            .with_context(|| format!("failed to read the response body for {path}"))?;
+        ensure!(!body.is_empty(), "request to {path} returned an empty body");
+    }
+
+    Ok(())
+}

--- a/crates/wash/tests/integration_k8s_host.rs
+++ b/crates/wash/tests/integration_k8s_host.rs
@@ -1,0 +1,64 @@
+//! End-to-end smoke test for running the Rust wasmCloud host on Kubernetes.
+//!
+//! This test is intentionally ignored: it builds the host image and creates a
+//! complete kind cluster inside a testcontainers-managed Docker-in-Docker
+//! container. Run it from the repository root with:
+//!
+//! ```text
+//! cargo test -p wash --test integration_k8s_host -- --include-ignored --nocapture
+//! ```
+//!
+//! Prerequisites: a reachable Docker daemon plus `helm` and `kubectl` on
+//! `PATH`. The test downloads pinned kind/Kubernetes images and the chart's
+//! service images.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tempfile::TempDir;
+
+mod common;
+use common::deploy_and_start_basic_http_workload;
+use common::docker::kind::KindCluster;
+use common::helm::validate_deploy_prerequisites;
+use common::k8s::print_diagnostics;
+
+/// Get the workspace root for the project
+fn workspace_root() -> Result<PathBuf> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .context("failed to locate the workspace root")
+}
+
+#[tokio::test]
+#[ignore = "requires Docker, kind, Helm, kubectl"]
+async fn k8s_host_serves_http_workload() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init()
+        .ok();
+
+    // Find workspace root, ensure we have all required deps
+    let cargo_workspace = workspace_root()?;
+    validate_deploy_prerequisites(&cargo_workspace).await?;
+
+    // Create a new temporary directory for all the intermediate files,
+    // then star ta KinD cluster
+    let temp = TempDir::new().context("failed to create E2E temporary directory")?;
+    let temp_path = temp.keep();
+    eprintln!("TEMP PATH [{}]", temp_path.display());
+    let cluster = KindCluster::start(&temp_path, &cargo_workspace, "rust-host-e2e").await?;
+
+    // Deploy wasmCloud and a basic HTTP workload
+    let skip_image_build = std::env::var("TEST_WASH_INT_K8S_SKIP_HOST_IMAGE_BUILD").is_ok();
+    let result =
+        deploy_and_start_basic_http_workload(&cargo_workspace, &cluster, skip_image_build).await;
+    if let Err(err) = &result {
+        eprintln!("k8s host E2E failed: {err:#}");
+        print_diagnostics(&cluster.kubeconfig_path).await;
+    }
+
+    cluster.delete().await?;
+    result
+}


### PR DESCRIPTION
This commit adds an E2E test that ensures from the Rust perspective that the E2E flow of running in k8s (installing with Helm, etc), works. 

Right now the test isn't run by default but that's something we can add (maybe to release PRs) -- right now it runs locally and is relatively easy to test out (see the updated `CONTRIBUTING.md`), though the build can be long if the host has to be built from scratch.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->