### PR TITLE
fix(helm): update workload crds, add check

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -31,7 +31,9 @@ jobs:
           filters: |
             relevant:
               - 'charts/**'
+              - 'runtime-operator/config/crd/bases/**'
               - '.github/workflows/charts.yml'
+              - 'Makefile'
 
   test:
     needs:
@@ -45,6 +47,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-go
+      - name: Check bundled CRDs
+        run: make helm-crds-check
       - name: Render
         run: make helm-render
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ helm-build:
 helm-render:
 	helm template -n example-ns example-name charts/runtime-operator
 
+.PHONY: helm-crds-check
+helm-crds-check:
+	diff --recursive --unified runtime-operator/config/crd/bases charts/runtime-operator/crds
+
 .PHONY: helm-install
 helm-install:
 	helm upgrade --install --create-namespace -n wasmcloud-system -f charts/runtime-operator/values.local.yaml operator-dev charts/runtime-operator
@@ -41,4 +45,3 @@ helm-install:
 .PHONY: helm-uninstall
 helm-uninstall:
 	helm delete -n wasmcloud-system --ignore-not-found --cascade foreground operator-dev
-

--- a/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloaddeployments.yaml
+++ b/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloaddeployments.yaml
@@ -173,6 +173,31 @@ spec:
                                     pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                                     type: string
                                   type: array
+                                allowedIpNameLookups:
+                                  description: |-
+                                    AllowedIPNameLookups is the set of names this component may resolve
+                                    through wasi:sockets/ip-name-lookup (resolve-addresses).
+
+                                    Each entry must match one of:
+                                      - "*"                (resolve any name)
+                                      - "*.suffix"         e.g. "*.wasmcloud.io"
+                                      - "host"             e.g. "api.wasmcloud.io"
+                                      - a literal IP address, e.g. "10.0.0.1" or "::1"
+
+                                    A name is not a URL: entries must not carry a scheme, port, path,
+                                    query string, or fragment. The wildcard must be "*.<rest>" with a
+                                    leading dot; a bare "*foo" is rejected.
+
+                                    Empty or absent allowedIpNameLookups denies every lookup, reported to
+                                    the component as permanent-resolver-failure. To resolve any name,
+                                    set allowedIpNameLookups: ["*"] explicitly. Resolution is granted
+                                    separately from allowedHosts, which governs outbound connections
+                                    rather than name lookups. Final validation runs in the runtime.
+                                    This regex is an admission-time guard, not the source of truth.
+                                  items:
+                                    pattern: ^\*$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$|^[0-9A-Fa-f:.]+$
+                                    type: string
+                                  type: array
                                 config:
                                   additionalProperties:
                                     type: string
@@ -283,6 +308,17 @@ spec:
                       hostId:
                         type: string
                       hostInterfaces:
+                        description: |-
+                          HostInterfaces declares the host-provided interfaces this workload needs.
+                          Two routing invariants are enforced at admission, complementing the
+                          host-side checks:
+                            1. No two entries may be exact duplicates (same namespace, package,
+                               name, and version).
+                            2. At most one entry of a given namespace:package may be unnamed — the
+                               unnamed entry is the default route and cannot be shared. Declare
+                               distinct `name`s to route multiple imports of the same package to
+                               different backends. Semver-incompatible versions of the same package
+                               may coexist (they are distinct interfaces).
                         items:
                           properties:
                             config:
@@ -319,14 +355,19 @@ spec:
                             name:
                               description: |-
                                 Name uniquely identifies this interface instance when multiple entries
-                                share the same namespace+package. Components use this name as the
-                                identifier parameter in resource-opening functions (e.g., store::open(name)).
+                                share the same namespace+package. It is the `(implements <name>)` id the
+                                host uses to route a component's named import to this interface's backend,
+                                so two imports of the same namespace:package can resolve to different
+                                backends.
                                 Required when multiple entries of the same namespace:package exist.
+                              maxLength: 64
                               pattern: ^[a-z0-9][a-z0-9-]*$
                               type: string
                             namespace:
+                              maxLength: 128
                               type: string
                             package:
+                              maxLength: 128
                               type: string
                             secretFrom:
                               description: |-
@@ -351,13 +392,29 @@ spec:
                                 x-kubernetes-map-type: atomic
                               type: array
                             version:
+                              maxLength: 64
                               type: string
                           required:
                           - interfaces
                           - namespace
                           - package
                           type: object
+                        maxItems: 64
                         type: array
+                        x-kubernetes-validations:
+                        - message: hostInterfaces must not contain duplicate entries
+                            with the same namespace, package, name, and version
+                          rule: 'self.all(x, self.exists_one(y, y.__namespace__ ==
+                            x.__namespace__ && y.__package__ == x.__package__ && (has(y.name)
+                            ? y.name : '''') == (has(x.name) ? x.name : '''') && (has(y.version)
+                            ? y.version : '''') == (has(x.version) ? x.version : '''')))'
+                        - message: at most one unnamed hostInterface is allowed per
+                            namespace:package; set a unique name to disambiguate multiple
+                            imports of the same package
+                          rule: self.all(x, (has(x.name) && x.name != '') || self.filter(y,
+                            y.__namespace__ == x.__namespace__ && y.__package__ ==
+                            x.__package__ && !(has(y.name) && y.name != '')).size()
+                            == 1)
                       hostSelector:
                         additionalProperties:
                           type: string
@@ -440,6 +497,31 @@ spec:
                                   is an admission-time guard, not the source of truth.
                                 items:
                                   pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
+                                  type: string
+                                type: array
+                              allowedIpNameLookups:
+                                description: |-
+                                  AllowedIPNameLookups is the set of names this component may resolve
+                                  through wasi:sockets/ip-name-lookup (resolve-addresses).
+
+                                  Each entry must match one of:
+                                    - "*"                (resolve any name)
+                                    - "*.suffix"         e.g. "*.wasmcloud.io"
+                                    - "host"             e.g. "api.wasmcloud.io"
+                                    - a literal IP address, e.g. "10.0.0.1" or "::1"
+
+                                  A name is not a URL: entries must not carry a scheme, port, path,
+                                  query string, or fragment. The wildcard must be "*.<rest>" with a
+                                  leading dot; a bare "*foo" is rejected.
+
+                                  Empty or absent allowedIpNameLookups denies every lookup, reported to
+                                  the component as permanent-resolver-failure. To resolve any name,
+                                  set allowedIpNameLookups: ["*"] explicitly. Resolution is granted
+                                  separately from allowedHosts, which governs outbound connections
+                                  rather than name lookups. Final validation runs in the runtime.
+                                  This regex is an admission-time guard, not the source of truth.
+                                items:
+                                  pattern: ^\*$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$|^[0-9A-Fa-f:.]+$
                                   type: string
                                 type: array
                               config:

--- a/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloadreplicasets.yaml
+++ b/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloadreplicasets.yaml
@@ -122,6 +122,31 @@ spec:
                                     pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
                                     type: string
                                   type: array
+                                allowedIpNameLookups:
+                                  description: |-
+                                    AllowedIPNameLookups is the set of names this component may resolve
+                                    through wasi:sockets/ip-name-lookup (resolve-addresses).
+
+                                    Each entry must match one of:
+                                      - "*"                (resolve any name)
+                                      - "*.suffix"         e.g. "*.wasmcloud.io"
+                                      - "host"             e.g. "api.wasmcloud.io"
+                                      - a literal IP address, e.g. "10.0.0.1" or "::1"
+
+                                    A name is not a URL: entries must not carry a scheme, port, path,
+                                    query string, or fragment. The wildcard must be "*.<rest>" with a
+                                    leading dot; a bare "*foo" is rejected.
+
+                                    Empty or absent allowedIpNameLookups denies every lookup, reported to
+                                    the component as permanent-resolver-failure. To resolve any name,
+                                    set allowedIpNameLookups: ["*"] explicitly. Resolution is granted
+                                    separately from allowedHosts, which governs outbound connections
+                                    rather than name lookups. Final validation runs in the runtime.
+                                    This regex is an admission-time guard, not the source of truth.
+                                  items:
+                                    pattern: ^\*$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$|^[0-9A-Fa-f:.]+$
+                                    type: string
+                                  type: array
                                 config:
                                   additionalProperties:
                                     type: string
@@ -232,6 +257,17 @@ spec:
                       hostId:
                         type: string
                       hostInterfaces:
+                        description: |-
+                          HostInterfaces declares the host-provided interfaces this workload needs.
+                          Two routing invariants are enforced at admission, complementing the
+                          host-side checks:
+                            1. No two entries may be exact duplicates (same namespace, package,
+                               name, and version).
+                            2. At most one entry of a given namespace:package may be unnamed — the
+                               unnamed entry is the default route and cannot be shared. Declare
+                               distinct `name`s to route multiple imports of the same package to
+                               different backends. Semver-incompatible versions of the same package
+                               may coexist (they are distinct interfaces).
                         items:
                           properties:
                             config:
@@ -268,14 +304,19 @@ spec:
                             name:
                               description: |-
                                 Name uniquely identifies this interface instance when multiple entries
-                                share the same namespace+package. Components use this name as the
-                                identifier parameter in resource-opening functions (e.g., store::open(name)).
+                                share the same namespace+package. It is the `(implements <name>)` id the
+                                host uses to route a component's named import to this interface's backend,
+                                so two imports of the same namespace:package can resolve to different
+                                backends.
                                 Required when multiple entries of the same namespace:package exist.
+                              maxLength: 64
                               pattern: ^[a-z0-9][a-z0-9-]*$
                               type: string
                             namespace:
+                              maxLength: 128
                               type: string
                             package:
+                              maxLength: 128
                               type: string
                             secretFrom:
                               description: |-
@@ -300,13 +341,29 @@ spec:
                                 x-kubernetes-map-type: atomic
                               type: array
                             version:
+                              maxLength: 64
                               type: string
                           required:
                           - interfaces
                           - namespace
                           - package
                           type: object
+                        maxItems: 64
                         type: array
+                        x-kubernetes-validations:
+                        - message: hostInterfaces must not contain duplicate entries
+                            with the same namespace, package, name, and version
+                          rule: 'self.all(x, self.exists_one(y, y.__namespace__ ==
+                            x.__namespace__ && y.__package__ == x.__package__ && (has(y.name)
+                            ? y.name : '''') == (has(x.name) ? x.name : '''') && (has(y.version)
+                            ? y.version : '''') == (has(x.version) ? x.version : '''')))'
+                        - message: at most one unnamed hostInterface is allowed per
+                            namespace:package; set a unique name to disambiguate multiple
+                            imports of the same package
+                          rule: self.all(x, (has(x.name) && x.name != '') || self.filter(y,
+                            y.__namespace__ == x.__namespace__ && y.__package__ ==
+                            x.__package__ && !(has(y.name) && y.name != '')).size()
+                            == 1)
                       hostSelector:
                         additionalProperties:
                           type: string
@@ -389,6 +446,31 @@ spec:
                                   is an admission-time guard, not the source of truth.
                                 items:
                                   pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
+                                  type: string
+                                type: array
+                              allowedIpNameLookups:
+                                description: |-
+                                  AllowedIPNameLookups is the set of names this component may resolve
+                                  through wasi:sockets/ip-name-lookup (resolve-addresses).
+
+                                  Each entry must match one of:
+                                    - "*"                (resolve any name)
+                                    - "*.suffix"         e.g. "*.wasmcloud.io"
+                                    - "host"             e.g. "api.wasmcloud.io"
+                                    - a literal IP address, e.g. "10.0.0.1" or "::1"
+
+                                  A name is not a URL: entries must not carry a scheme, port, path,
+                                  query string, or fragment. The wildcard must be "*.<rest>" with a
+                                  leading dot; a bare "*foo" is rejected.
+
+                                  Empty or absent allowedIpNameLookups denies every lookup, reported to
+                                  the component as permanent-resolver-failure. To resolve any name,
+                                  set allowedIpNameLookups: ["*"] explicitly. Resolution is granted
+                                  separately from allowedHosts, which governs outbound connections
+                                  rather than name lookups. Final validation runs in the runtime.
+                                  This regex is an admission-time guard, not the source of truth.
+                                items:
+                                  pattern: ^\*$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$|^[0-9A-Fa-f:.]+$
                                   type: string
                                 type: array
                               config:

--- a/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloads.yaml
+++ b/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloads.yaml
@@ -91,7 +91,51 @@ spec:
                         made available to a workload component.
                       properties:
                         allowedHosts:
+                          description: |-
+                            AllowedHosts is the outbound egress allowlist for this component.
+
+                            Each entry must match one of:
+                              - "*"                       (allow all)
+                              - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                              - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                              - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                              - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                            This is a hosts policy, not a URL policy: entries must not include a
+                            path (beyond bare `/`), query string, or fragment. The wildcard must
+                            be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                            Empty or absent allowedHosts denies all outgoing requests
+                            (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                            ["*"]` explicitly. Final validation runs in the runtime. This regex
+                            is an admission-time guard, not the source of truth.
                           items:
+                            pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
+                            type: string
+                          type: array
+                        allowedIpNameLookups:
+                          description: |-
+                            AllowedIPNameLookups is the set of names this component may resolve
+                            through wasi:sockets/ip-name-lookup (resolve-addresses).
+
+                            Each entry must match one of:
+                              - "*"                (resolve any name)
+                              - "*.suffix"         e.g. "*.wasmcloud.io"
+                              - "host"             e.g. "api.wasmcloud.io"
+                              - a literal IP address, e.g. "10.0.0.1" or "::1"
+
+                            A name is not a URL: entries must not carry a scheme, port, path,
+                            query string, or fragment. The wildcard must be "*.<rest>" with a
+                            leading dot; a bare "*foo" is rejected.
+
+                            Empty or absent allowedIpNameLookups denies every lookup, reported to
+                            the component as permanent-resolver-failure. To resolve any name,
+                            set allowedIpNameLookups: ["*"] explicitly. Resolution is granted
+                            separately from allowedHosts, which governs outbound connections
+                            rather than name lookups. Final validation runs in the runtime.
+                            This regex is an admission-time guard, not the source of truth.
+                          items:
+                            pattern: ^\*$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$|^[0-9A-Fa-f:.]+$
                             type: string
                           type: array
                         config:
@@ -202,6 +246,17 @@ spec:
               hostId:
                 type: string
               hostInterfaces:
+                description: |-
+                  HostInterfaces declares the host-provided interfaces this workload needs.
+                  Two routing invariants are enforced at admission, complementing the
+                  host-side checks:
+                    1. No two entries may be exact duplicates (same namespace, package,
+                       name, and version).
+                    2. At most one entry of a given namespace:package may be unnamed — the
+                       unnamed entry is the default route and cannot be shared. Declare
+                       distinct `name`s to route multiple imports of the same package to
+                       different backends. Semver-incompatible versions of the same package
+                       may coexist (they are distinct interfaces).
                 items:
                   properties:
                     config:
@@ -238,14 +293,19 @@ spec:
                     name:
                       description: |-
                         Name uniquely identifies this interface instance when multiple entries
-                        share the same namespace+package. Components use this name as the
-                        identifier parameter in resource-opening functions (e.g., store::open(name)).
+                        share the same namespace+package. It is the `(implements <name>)` id the
+                        host uses to route a component's named import to this interface's backend,
+                        so two imports of the same namespace:package can resolve to different
+                        backends.
                         Required when multiple entries of the same namespace:package exist.
+                      maxLength: 64
                       pattern: ^[a-z0-9][a-z0-9-]*$
                       type: string
                     namespace:
+                      maxLength: 128
                       type: string
                     package:
+                      maxLength: 128
                       type: string
                     secretFrom:
                       description: |-
@@ -270,13 +330,28 @@ spec:
                         x-kubernetes-map-type: atomic
                       type: array
                     version:
+                      maxLength: 64
                       type: string
                   required:
                   - interfaces
                   - namespace
                   - package
                   type: object
+                maxItems: 64
                 type: array
+                x-kubernetes-validations:
+                - message: hostInterfaces must not contain duplicate entries with
+                    the same namespace, package, name, and version
+                  rule: 'self.all(x, self.exists_one(y, y.__namespace__ == x.__namespace__
+                    && y.__package__ == x.__package__ && (has(y.name) ? y.name : '''')
+                    == (has(x.name) ? x.name : '''') && (has(y.version) ? y.version
+                    : '''') == (has(x.version) ? x.version : '''')))'
+                - message: at most one unnamed hostInterface is allowed per namespace:package;
+                    set a unique name to disambiguate multiple imports of the same
+                    package
+                  rule: self.all(x, (has(x.name) && x.name != '') || self.filter(y,
+                    y.__namespace__ == x.__namespace__ && y.__package__ == x.__package__
+                    && !(has(y.name) && y.name != '')).size() == 1)
               hostSelector:
                 additionalProperties:
                   type: string
@@ -339,7 +414,51 @@ spec:
                       available to a workload component.
                     properties:
                       allowedHosts:
+                        description: |-
+                          AllowedHosts is the outbound egress allowlist for this component.
+
+                          Each entry must match one of:
+                            - "*"                       (allow all)
+                            - "host[:port]"             e.g. "example.com" or "example.com:8443"
+                            - "scheme://host[:port][/]" e.g. "https://api.example.com" or "https://api.example.com/"
+                            - "*.suffix[:port]"         e.g. "*.example.com" or "*.example.com:8443"
+                            - "scheme://*.suffix[:port][/]" e.g. "https://*.example.com"
+
+                          This is a hosts policy, not a URL policy: entries must not include a
+                          path (beyond bare `/`), query string, or fragment. The wildcard must
+                          be `*.<rest>` (leading dot required); a bare `*foo` is rejected.
+
+                          Empty or absent allowedHosts denies all outgoing requests
+                          (fail-closed). To opt into unrestricted egress, set `allowedHosts:
+                          ["*"]` explicitly. Final validation runs in the runtime. This regex
+                          is an admission-time guard, not the source of truth.
                         items:
+                          pattern: ^\*$|^([A-Za-z][A-Za-z0-9+.-]*://)(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?/?$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*(:[0-9]{1,5})?$
+                          type: string
+                        type: array
+                      allowedIpNameLookups:
+                        description: |-
+                          AllowedIPNameLookups is the set of names this component may resolve
+                          through wasi:sockets/ip-name-lookup (resolve-addresses).
+
+                          Each entry must match one of:
+                            - "*"                (resolve any name)
+                            - "*.suffix"         e.g. "*.wasmcloud.io"
+                            - "host"             e.g. "api.wasmcloud.io"
+                            - a literal IP address, e.g. "10.0.0.1" or "::1"
+
+                          A name is not a URL: entries must not carry a scheme, port, path,
+                          query string, or fragment. The wildcard must be "*.<rest>" with a
+                          leading dot; a bare "*foo" is rejected.
+
+                          Empty or absent allowedIpNameLookups denies every lookup, reported to
+                          the component as permanent-resolver-failure. To resolve any name,
+                          set allowedIpNameLookups: ["*"] explicitly. Resolution is granted
+                          separately from allowedHosts, which governs outbound connections
+                          rather than name lookups. Final validation runs in the runtime.
+                          This regex is an admission-time guard, not the source of truth.
+                        items:
+                          pattern: ^\*$|^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$|^[0-9A-Fa-f:.]+$
                           type: string
                         type: array
                       config:


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->

This doesn't change the deny-by-default nature, but at the very least people will be able to now set the allowed ip name lookups.


Resolves #5421 

