### PR TITLE
fix(runtime-operator): describe CRD kinds accurately

### DIFF
--- a/charts/runtime-operator/crds/runtime.wasmcloud.dev_artifacts.yaml
+++ b/charts/runtime-operator/crds/runtime.wasmcloud.dev_artifacts.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Artifact is the Schema for the artifacts API.
+        description: Artifact represents a WebAssembly component image that can be
+          fetched and cached for use by workloads.
         properties:
           apiVersion:
             description: |-

--- a/charts/runtime-operator/crds/runtime.wasmcloud.dev_hosts.yaml
+++ b/charts/runtime-operator/crds/runtime.wasmcloud.dev_hosts.yaml
@@ -33,7 +33,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Host is the Schema for the Hosts API.
+        description: Host represents a running wasmCloud host that workloads can be
+          scheduled onto.
         properties:
           apiVersion:
             description: |-

--- a/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloaddeployments.yaml
+++ b/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloaddeployments.yaml
@@ -24,7 +24,9 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: WorkloadDeployment is the Schema for the artifacts API.
+        description: WorkloadDeployment manages the deployment and scaling of a Workload
+          across hosts, creating WorkloadReplicaSets to maintain the desired number
+          of replicas.
         properties:
           apiVersion:
             description: |-

--- a/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloadreplicasets.yaml
+++ b/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloadreplicasets.yaml
@@ -24,7 +24,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: WorkloadReplicaSet is the Schema for the artifacts API.
+        description: WorkloadReplicaSet maintains a specified number of running Workload
+          replicas; it is normally created and managed by a WorkloadDeployment.
         properties:
           apiVersion:
             description: |-

--- a/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloads.yaml
+++ b/charts/runtime-operator/crds/runtime.wasmcloud.dev_workloads.yaml
@@ -32,7 +32,9 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Workload is the Schema for the artifacts API.
+        description: Workload defines a set of WebAssembly components and services
+          to run on wasmCloud hosts, with the configuration, volumes, and host interfaces
+          they use.
         properties:
           apiVersion:
             description: |-

--- a/runtime-operator/api/runtime/v1alpha1/artifact_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/artifact_types.go
@@ -29,7 +29,7 @@ type ArtifactStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Artifact is the Schema for the artifacts API.
+// Artifact represents a WebAssembly component image that can be fetched and cached for use by workloads.
 type Artifact struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/runtime-operator/api/runtime/v1alpha1/host_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/host_types.go
@@ -35,7 +35,7 @@ type HostStatus struct {
 // +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
-// Host is the Schema for the Hosts API.
+// Host represents a running wasmCloud host that workloads can be scheduled onto.
 type Host struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/runtime-operator/api/runtime/v1alpha1/workload_deployment_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_deployment_types.go
@@ -73,7 +73,7 @@ type WorkloadDeploymentStatus struct {
 // +kubebuilder:printcolumn:name="REPLICAS",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 
-// WorkloadDeployment is the Schema for the artifacts API.
+// WorkloadDeployment manages the deployment and scaling of a Workload across hosts, creating WorkloadReplicaSets to maintain the desired number of replicas.
 type WorkloadDeployment struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/runtime-operator/api/runtime/v1alpha1/workload_replicaset_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_replicaset_types.go
@@ -64,7 +64,7 @@ type WorkloadReplicaSetStatus struct {
 // +kubebuilder:printcolumn:name="REPLICAS",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 
-// WorkloadReplicaSet is the Schema for the artifacts API.
+// WorkloadReplicaSet maintains a specified number of running Workload replicas; it is normally created and managed by a WorkloadDeployment.
 type WorkloadReplicaSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/runtime-operator/api/runtime/v1alpha1/workload_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_types.go
@@ -385,7 +385,7 @@ type WorkloadStatus struct {
 // +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
-// Workload is the Schema for the artifacts API.
+// Workload defines a set of WebAssembly components and services to run on wasmCloud hosts, with the configuration, volumes, and host interfaces they use.
 type Workload struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_artifacts.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_artifacts.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Artifact is the Schema for the artifacts API.
+        description: Artifact represents a WebAssembly component image that can be
+          fetched and cached for use by workloads.
         properties:
           apiVersion:
             description: |-

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_hosts.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_hosts.yaml
@@ -33,7 +33,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Host is the Schema for the Hosts API.
+        description: Host represents a running wasmCloud host that workloads can be
+          scheduled onto.
         properties:
           apiVersion:
             description: |-

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloaddeployments.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloaddeployments.yaml
@@ -24,7 +24,9 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: WorkloadDeployment is the Schema for the artifacts API.
+        description: WorkloadDeployment manages the deployment and scaling of a Workload
+          across hosts, creating WorkloadReplicaSets to maintain the desired number
+          of replicas.
         properties:
           apiVersion:
             description: |-

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloadreplicasets.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloadreplicasets.yaml
@@ -24,7 +24,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: WorkloadReplicaSet is the Schema for the artifacts API.
+        description: WorkloadReplicaSet maintains a specified number of running Workload
+          replicas; it is normally created and managed by a WorkloadDeployment.
         properties:
           apiVersion:
             description: |-

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloads.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloads.yaml
@@ -32,7 +32,9 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Workload is the Schema for the artifacts API.
+        description: Workload defines a set of WebAssembly components and services
+          to run on wasmCloud hosts, with the configuration, volumes, and host interfaces
+          they use.
         properties:
           apiVersion:
             description: |-


### PR DESCRIPTION
The runtime CRD kind descriptions for Workload, WorkloadDeployment, and WorkloadReplicaSet all read "is the Schema for the artifacts API" (and Host read "Hosts API"). This PR updates those to concise one-line descriptions of each resource, which surface in `kubectl explain` and generated API docs.