### PR TITLE
fix(runtime-gateway): key routes by object key

### DIFF
--- a/.github/workflows/runtime-gateway.yml
+++ b/.github/workflows/runtime-gateway.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Build
         working-directory: runtime-gateway
         run: go build -v ./
+      - name: Test
+        working-directory: runtime-gateway
+        run: go test -v ./...
 
   gate:
     needs:

--- a/runtime-gateway/main.go
+++ b/runtime-gateway/main.go
@@ -105,13 +105,7 @@ func main() {
 		fallback = externalFallback
 	}
 
-	tracker := &HostTracker{
-		Fallback: fallback,
-	}
-	if err := tracker.SetupWithManager(ctx, manager); err != nil {
-		setupLog.Error(err, "could not add HostTracker to manager")
-		os.Exit(1)
-	}
+	tracker := newHostTracker(fallback)
 
 	httpGateway := &HTTPGateway{
 		BindAddr: bindAddr,

--- a/runtime-gateway/reconciler.go
+++ b/runtime-gateway/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,6 +17,26 @@ const (
 	gatewayHostFinalizerName     = "runtime.wasmcloud.dev/gateway-host-finalizer"
 )
 
+// dropGatewayFinalizer removes a gateway finalizer from obj if it carries one.
+//
+// The gateway's routing tables live only in the process that built them, so
+// there is nothing to release once that process is gone. A gateway finalizer
+// outlives it, though: a cluster whose gateway has been scaled down, removed,
+// or replaced is left with objects that can never finish deleting, so strip the
+// finalizer wherever it turns up.
+func dropGatewayFinalizer(ctx context.Context, c client.Client, obj client.Object, finalizer string) error {
+	if !controllerutil.ContainsFinalizer(obj, finalizer) {
+		return nil
+	}
+
+	base := obj.DeepCopyObject().(client.Object)
+	controllerutil.RemoveFinalizer(obj, finalizer)
+	// A merge patch replaces the finalizer list wholesale, so patch under
+	// optimistic lock: without it a stale copy would silently restore
+	// finalizers the operator has since removed, or drop ones it has added.
+	return c.Patch(ctx, obj, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{}))
+}
+
 // WorkloadReconciler
 type WorkloadReconciler struct {
 	client.Client
@@ -27,23 +48,22 @@ func (a *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	workload := &runtimev1alpha1.Workload{}
 	if err := a.Get(ctx, req.NamespacedName, workload); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		if apierrors.IsNotFound(err) {
+			// A deletion can reach the reconciler after the object is gone, so
+			// the registry indexes routes by object key: that is all this has
+			// left to identify them by. Skipping it would keep proxying to the
+			// workload until the gateway restarts.
+			return ctrl.Result{}, a.Registry.DeregisterWorkload(ctx, req.NamespacedName)
+		}
+		return ctrl.Result{}, err
 	}
 
-	// Handle deletion: run cleanup and remove our finalizer before etcd removes
-	// the object. Without this, a deleted object may disappear from the cache
-	// before the reconciler runs, leaving stale HostTracker entries.
+	if err := dropGatewayFinalizer(ctx, a.Client, workload, gatewayWorkloadFinalizerName); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if workload.DeletionTimestamp != nil {
-		if controllerutil.ContainsFinalizer(workload, gatewayWorkloadFinalizerName) {
-			if err := a.deregisterWorkload(ctx, workload); err != nil {
-				log.Error(err, "failed to deregister workload on deletion")
-				return ctrl.Result{}, err
-			}
-			base := workload.DeepCopy()
-			controllerutil.RemoveFinalizer(workload, gatewayWorkloadFinalizerName)
-			return ctrl.Result{}, a.Patch(ctx, workload, client.MergeFrom(base))
-		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, a.Registry.DeregisterWorkload(ctx, req.NamespacedName)
 	}
 
 	// workload hasn't been placed, do nothing
@@ -53,41 +73,26 @@ func (a *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	hostname := workloadHostname(workload)
 
-	// no hostname configured, nothing to register
+	// no hostname configured, nothing to route
 	if hostname == "" {
-		return ctrl.Result{}, nil
-	}
-
-	// Ensure our finalizer is present so we can deregister on deletion.
-	if !controllerutil.ContainsFinalizer(workload, gatewayWorkloadFinalizerName) {
-		base := workload.DeepCopy()
-		controllerutil.AddFinalizer(workload, gatewayWorkloadFinalizerName)
-		return ctrl.Result{}, a.Patch(ctx, workload, client.MergeFrom(base))
+		return ctrl.Result{}, a.Registry.DeregisterWorkload(ctx, req.NamespacedName)
 	}
 
 	log.Info("Reconciling Workload")
 
 	if workload.Status.IsAvailable() {
-		if err := a.Registry.RegisterWorkload(ctx, workload.Status.HostID, workload.Status.WorkloadID, hostname); err != nil {
+		if err := a.Registry.RegisterWorkload(ctx, req.NamespacedName, workload.Status.HostID, workload.Status.WorkloadID, hostname); err != nil {
 			log.Error(err, "failed to register workload")
 			return ctrl.Result{}, err
 		}
 	} else {
-		if err := a.Registry.DeregisterWorkload(ctx, workload.Status.HostID, workload.Status.WorkloadID, hostname); err != nil {
+		if err := a.Registry.DeregisterWorkload(ctx, req.NamespacedName); err != nil {
 			log.Error(err, "failed to deregister workload")
 			return ctrl.Result{}, err
 		}
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func (a *WorkloadReconciler) deregisterWorkload(ctx context.Context, workload *runtimev1alpha1.Workload) error {
-	hostname := workloadHostname(workload)
-	if hostname == "" {
-		return nil
-	}
-	return a.Registry.DeregisterWorkload(ctx, workload.Status.HostID, workload.Status.WorkloadID, hostname)
 }
 
 func workloadHostname(workload *runtimev1alpha1.Workload) string {
@@ -130,40 +135,31 @@ func (a *HostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	host := &runtimev1alpha1.Host{}
 	if err := a.Get(ctx, req.NamespacedName, host); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	// Handle deletion: deregister before etcd removes the object. Without this,
-	// the host may vanish from the cache before we can clean up HostTracker.
-	if host.DeletionTimestamp != nil {
-		if controllerutil.ContainsFinalizer(host, gatewayHostFinalizerName) {
-			if err := a.Registry.DeregisterHost(ctx, host.HostID); err != nil {
-				log.Error(err, "failed to deregister host on deletion")
-				return ctrl.Result{}, err
-			}
-			base := host.DeepCopy()
-			controllerutil.RemoveFinalizer(host, gatewayHostFinalizerName)
-			return ctrl.Result{}, a.Patch(ctx, host, client.MergeFrom(base))
+		if apierrors.IsNotFound(err) {
+			// See the Workload reconciler: the object is gone, so its key is
+			// all that identifies what it registered.
+			return ctrl.Result{}, a.Registry.DeregisterHost(ctx, req.NamespacedName)
 		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
-	// Ensure our finalizer is present so we can deregister on deletion.
-	if !controllerutil.ContainsFinalizer(host, gatewayHostFinalizerName) {
-		base := host.DeepCopy()
-		controllerutil.AddFinalizer(host, gatewayHostFinalizerName)
-		return ctrl.Result{}, a.Patch(ctx, host, client.MergeFrom(base))
+	if err := dropGatewayFinalizer(ctx, a.Client, host, gatewayHostFinalizerName); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if host.DeletionTimestamp != nil {
+		return ctrl.Result{}, a.Registry.DeregisterHost(ctx, req.NamespacedName)
 	}
 
 	log.Info("Reconciling Host")
 
 	if host.Status.IsAvailable() {
-		if err := a.Registry.RegisterHost(ctx, host.HostID, host.Hostname, int(host.HTTPPort)); err != nil {
+		if err := a.Registry.RegisterHost(ctx, req.NamespacedName, host.HostID, host.Hostname, int(host.HTTPPort)); err != nil {
 			log.Error(err, "failed to register host")
 			return ctrl.Result{}, err
 		}
 	} else {
-		if err := a.Registry.DeregisterHost(ctx, host.HostID); err != nil {
+		if err := a.Registry.DeregisterHost(ctx, req.NamespacedName); err != nil {
 			log.Error(err, "failed to deregister host")
 			return ctrl.Result{}, err
 		}

--- a/runtime-gateway/reconciler_test.go
+++ b/runtime-gateway/reconciler_test.go
@@ -1,8 +1,18 @@
 package main
 
 import (
+	"context"
+	"slices"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"go.wasmcloud.dev/runtime-operator/v2/api/condition"
 	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
 )
 
@@ -69,5 +79,208 @@ func TestWorkloadHostname(t *testing.T) {
 				t.Errorf("workloadHostname() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// The finalizer the operator sets on the objects the gateway also watches.
+const operatorWorkloadFinalizer = "runtime.wasmcloud.dev/workload-finalizer"
+
+// recordingRegistry records what the reconcilers register, keyed the way the
+// tracker keys it.
+type recordingRegistry struct {
+	workloads map[types.NamespacedName]workloadRoute
+	hosts     map[types.NamespacedName]string
+}
+
+func newRecordingRegistry() *recordingRegistry {
+	return &recordingRegistry{
+		workloads: make(map[types.NamespacedName]workloadRoute),
+		hosts:     make(map[types.NamespacedName]string),
+	}
+}
+
+func (r *recordingRegistry) RegisterWorkload(_ context.Context, key types.NamespacedName, hostID string, workloadID string, hostname string) error {
+	r.workloads[key] = workloadRoute{hostID: hostID, workloadID: workloadID, hostname: hostname}
+	return nil
+}
+
+func (r *recordingRegistry) DeregisterWorkload(_ context.Context, key types.NamespacedName) error {
+	delete(r.workloads, key)
+	return nil
+}
+
+func (r *recordingRegistry) RegisterHost(_ context.Context, key types.NamespacedName, hostID string, hostname string, port int) error {
+	r.hosts[key] = hostID
+	return nil
+}
+
+func (r *recordingRegistry) DeregisterHost(_ context.Context, key types.NamespacedName) error {
+	delete(r.hosts, key)
+	return nil
+}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := runtimev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme() = %v", err)
+	}
+	return s
+}
+
+// availableWorkload builds a placed, ready Workload with an HTTP route.
+func availableWorkload(name string) *runtimev1alpha1.Workload {
+	w := &runtimev1alpha1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: name},
+	}
+	w.Spec.HostInterfaces = []runtimev1alpha1.HostInterface{httpInterface("incoming-handler", "a.localhost.direct")}
+	w.Status.HostID = "host-id"
+	w.Status.WorkloadID = "workload-id"
+	w.Status.SetConditions(
+		condition.Condition{Type: runtimev1alpha1.WorkloadConditionPlacement, Status: condition.ConditionTrue},
+		condition.Condition{Type: condition.TypeReady, Status: condition.ConditionTrue},
+	)
+	return w
+}
+
+func testRoute() workloadRoute {
+	return workloadRoute{hostID: "host-id", workloadID: "workload-id", hostname: "a.localhost.direct"}
+}
+
+// A Workload can be fully gone by the time its deletion reaches the reconciler,
+// so the route has to come out of the registry on the request key alone.
+func TestWorkloadReconcilerDeregistersMissingWorkload(t *testing.T) {
+	key := types.NamespacedName{Namespace: "ns", Name: "workload-a"}
+	registry := newRecordingRegistry()
+	registry.workloads[key] = testRoute()
+
+	r := &WorkloadReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(testScheme(t)).Build(),
+		Registry: registry,
+	}
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile() = %v", err)
+	}
+
+	if _, ok := registry.workloads[key]; ok {
+		t.Error("route for a deleted Workload is still registered")
+	}
+}
+
+// The gateway's routing tables live only in the process that built them, so a
+// gateway finalizer outlives everything that could release it: a Workload
+// carrying one can never finish deleting once the gateway is gone.
+func TestWorkloadReconcilerDropsGatewayFinalizer(t *testing.T) {
+	workload := availableWorkload("workload-a")
+	workload.Finalizers = []string{operatorWorkloadFinalizer, gatewayWorkloadFinalizerName}
+	key := client.ObjectKeyFromObject(workload)
+
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(workload).Build()
+	r := &WorkloadReconciler{Client: c, Registry: newRecordingRegistry()}
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile() = %v", err)
+	}
+
+	got := &runtimev1alpha1.Workload{}
+	if err := c.Get(t.Context(), key, got); err != nil {
+		t.Fatalf("Get() = %v", err)
+	}
+	if slices.Contains(got.Finalizers, gatewayWorkloadFinalizerName) {
+		t.Error("gateway finalizer is still on the Workload")
+	}
+	if !slices.Contains(got.Finalizers, operatorWorkloadFinalizer) {
+		t.Error("operator finalizer was dropped")
+	}
+}
+
+func TestWorkloadReconcilerRegistersAvailableWorkload(t *testing.T) {
+	workload := availableWorkload("workload-a")
+	key := client.ObjectKeyFromObject(workload)
+	registry := newRecordingRegistry()
+
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(workload).Build()
+	r := &WorkloadReconciler{Client: c, Registry: registry}
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile() = %v", err)
+	}
+
+	if got, want := registry.workloads[key], testRoute(); got != want {
+		t.Errorf("registered route = %+v, want %+v", got, want)
+	}
+
+	got := &runtimev1alpha1.Workload{}
+	if err := c.Get(t.Context(), key, got); err != nil {
+		t.Fatalf("Get() = %v", err)
+	}
+	if len(got.Finalizers) != 0 {
+		t.Errorf("Finalizers = %v, want none", got.Finalizers)
+	}
+}
+
+// A Workload under deletion still exists but must stop taking traffic.
+func TestWorkloadReconcilerDeregistersDeletingWorkload(t *testing.T) {
+	workload := availableWorkload("workload-a")
+	workload.Finalizers = []string{operatorWorkloadFinalizer}
+	deletedAt := metav1.Now()
+	workload.DeletionTimestamp = &deletedAt
+	key := client.ObjectKeyFromObject(workload)
+
+	registry := newRecordingRegistry()
+	registry.workloads[key] = testRoute()
+
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(workload).Build()
+	r := &WorkloadReconciler{Client: c, Registry: registry}
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile() = %v", err)
+	}
+
+	if _, ok := registry.workloads[key]; ok {
+		t.Error("route for a deleting Workload is still registered")
+	}
+}
+
+func TestHostReconcilerDeregistersMissingHost(t *testing.T) {
+	key := types.NamespacedName{Namespace: "ns", Name: "host-a"}
+	registry := newRecordingRegistry()
+	registry.hosts[key] = "host-id"
+
+	r := &HostReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(testScheme(t)).Build(),
+		Registry: registry,
+	}
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile() = %v", err)
+	}
+
+	if _, ok := registry.hosts[key]; ok {
+		t.Error("a deleted Host is still registered")
+	}
+}
+
+func TestHostReconcilerDropsGatewayFinalizer(t *testing.T) {
+	host := &runtimev1alpha1.Host{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "ns",
+			Name:       "host-a",
+			Finalizers: []string{gatewayHostFinalizerName},
+		},
+		HostID:   "host-id",
+		Hostname: "10.0.0.1",
+		HTTPPort: 8080,
+	}
+	key := client.ObjectKeyFromObject(host)
+
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(host).Build()
+	r := &HostReconciler{Client: c, Registry: newRecordingRegistry()}
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile() = %v", err)
+	}
+
+	got := &runtimev1alpha1.Host{}
+	if err := c.Get(t.Context(), key, got); err != nil {
+		t.Fatalf("Get() = %v", err)
+	}
+	if len(got.Finalizers) != 0 {
+		t.Errorf("Finalizers = %v, want none", got.Finalizers)
 	}
 }

--- a/runtime-gateway/tracker.go
+++ b/runtime-gateway/tracker.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var ErrHostnameNotFound = errors.New("hostname not found")
@@ -24,19 +24,32 @@ type HostResolver interface {
 	Resolve(ctx context.Context, req *http.Request) LookupResult
 }
 
+// HostRegistry tracks the hosts requests can be forwarded to. Registrations are
+// keyed by the Host object's key so that deregistering needs nothing but the
+// key of an object that may already be gone from the API server.
 type HostRegistry interface {
-	RegisterHost(ctx context.Context, hostID string, hostname string, port int) error
-	DeregisterHost(ctx context.Context, hostID string) error
+	RegisterHost(ctx context.Context, key types.NamespacedName, hostID string, hostname string, port int) error
+	DeregisterHost(ctx context.Context, key types.NamespacedName) error
 }
 
+// WorkloadRegistry tracks which workloads serve which hostname. As with
+// HostRegistry, registrations are keyed by the Workload object's key.
 type WorkloadRegistry interface {
-	RegisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string) error
-	DeregisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string) error
+	RegisterWorkload(ctx context.Context, key types.NamespacedName, hostID string, workloadID string, hostname string) error
+	DeregisterWorkload(ctx context.Context, key types.NamespacedName) error
 }
 
 var _ HostResolver = (*HostTracker)(nil)
 var _ HostRegistry = (*HostTracker)(nil)
 var _ WorkloadRegistry = (*HostTracker)(nil)
+
+// workloadRoute is everything a registered Workload contributes to the routing
+// tables, retained so the entry can be undone from the object's key alone.
+type workloadRoute struct {
+	hostID     string
+	workloadID string
+	hostname   string
+}
 
 type HostTracker struct {
 	// where to send requests that have no registered workloads
@@ -49,18 +62,21 @@ type HostTracker struct {
 	hostnames map[string]sets.Set[string]
 	// WorkloadID to HostID
 	workloads map[string]string
+	// Host object key to HostID
+	hostKeys map[types.NamespacedName]string
+	// Workload object key to the route it registered
+	workloadKeys map[types.NamespacedName]workloadRoute
 }
 
-func (ht *HostTracker) SetupWithManager(ctx context.Context, manager ctrl.Manager) error {
-	return manager.Add(ht)
-}
-
-func (ht *HostTracker) Start(ctx context.Context) error {
-	ht.hosts = make(map[string]string)
-	ht.hostnames = make(map[string]sets.Set[string])
-	ht.workloads = make(map[string]string)
-	<-ctx.Done()
-	return nil
+func newHostTracker(fallback Fallback) *HostTracker {
+	return &HostTracker{
+		Fallback:     fallback,
+		hosts:        make(map[string]string),
+		hostnames:    make(map[string]sets.Set[string]),
+		workloads:    make(map[string]string),
+		hostKeys:     make(map[types.NamespacedName]string),
+		workloadKeys: make(map[types.NamespacedName]workloadRoute),
+	}
 }
 
 func (ht *HostTracker) Resolve(ctx context.Context, req *http.Request) LookupResult {
@@ -116,29 +132,50 @@ func (ht *HostTracker) Resolve(ctx context.Context, req *http.Request) LookupRes
 	}
 }
 
-func (ht *HostTracker) RegisterHost(ctx context.Context, hostID string, hostname string, port int) error {
+func (ht *HostTracker) RegisterHost(ctx context.Context, key types.NamespacedName, hostID string, hostname string, port int) error {
 	ht.lock.Lock()
 	defer ht.lock.Unlock()
 
+	// A Host object that comes back under a new ID — a host pod that restarted
+	// and re-registered under the same object name — would otherwise leave its
+	// previous ID routing traffic.
+	if prev, ok := ht.hostKeys[key]; ok && prev != hostID {
+		ht.removeHost(prev)
+	}
+
+	ht.hostKeys[key] = hostID
 	ht.hosts[hostID] = net.JoinHostPort(hostname, strconv.Itoa(port))
 	return nil
 }
 
-func (ht *HostTracker) DeregisterHost(ctx context.Context, hostID string) error {
+func (ht *HostTracker) DeregisterHost(ctx context.Context, key types.NamespacedName) error {
 	ht.lock.Lock()
 	defer ht.lock.Unlock()
 
-	// Collect all workload IDs that were assigned to this host so we can clean
-	// them out of ht.workloads and ht.hostnames. Leaving them would leak memory
-	// proportional to workload churn and would cause stale hostname mappings if
-	// a new host ever reuses the same hostID.
-	var affected []string
-	for workloadID, hID := range ht.workloads {
-		if hID == hostID {
-			affected = append(affected, workloadID)
+	hostID, ok := ht.hostKeys[key]
+	if !ok {
+		return nil
+	}
+	delete(ht.hostKeys, key)
+	ht.removeHost(hostID)
+	return nil
+}
+
+// removeHost drops a host along with every workload placed on it. Leaving the
+// workloads would leak memory proportional to workload churn and would cause
+// stale hostname mappings if a new host ever reuses the same hostID.
+//
+// The caller must hold ht.lock.
+func (ht *HostTracker) removeHost(hostID string) {
+	for key, route := range ht.workloadKeys {
+		if route.hostID == hostID {
+			delete(ht.workloadKeys, key)
 		}
 	}
-	for _, workloadID := range affected {
+	for workloadID, hID := range ht.workloads {
+		if hID != hostID {
+			continue
+		}
 		delete(ht.workloads, workloadID)
 		for hostname, workloadSet := range ht.hostnames {
 			workloadSet.Delete(workloadID)
@@ -149,13 +186,20 @@ func (ht *HostTracker) DeregisterHost(ctx context.Context, hostID string) error 
 	}
 
 	delete(ht.hosts, hostID)
-	return nil
 }
 
-func (ht *HostTracker) RegisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string) error {
+func (ht *HostTracker) RegisterWorkload(ctx context.Context, key types.NamespacedName, hostID string, workloadID string, hostname string) error {
 	ht.lock.Lock()
 	defer ht.lock.Unlock()
 
+	route := workloadRoute{hostID: hostID, workloadID: workloadID, hostname: hostname}
+	// A workload that moved to another host, or whose routing hostname changed,
+	// must not keep serving its previous hostname.
+	if prev, ok := ht.workloadKeys[key]; ok && prev != route {
+		ht.removeWorkload(prev)
+	}
+
+	ht.workloadKeys[key] = route
 	ht.workloads[workloadID] = hostID
 	if workloadSet, ok := ht.hostnames[hostname]; !ok {
 		ht.hostnames[hostname] = sets.New(workloadID)
@@ -165,16 +209,26 @@ func (ht *HostTracker) RegisterWorkload(ctx context.Context, hostID string, work
 	return nil
 }
 
-func (ht *HostTracker) DeregisterWorkload(ctx context.Context, hostID string, workloadID string, hostname string) error {
+func (ht *HostTracker) DeregisterWorkload(ctx context.Context, key types.NamespacedName) error {
 	ht.lock.Lock()
 	defer ht.lock.Unlock()
 
-	delete(ht.workloads, workloadID)
-	if workloadSet, ok := ht.hostnames[hostname]; ok {
-		workloadSet.Delete(workloadID)
+	route, ok := ht.workloadKeys[key]
+	if !ok {
+		return nil
+	}
+	delete(ht.workloadKeys, key)
+	ht.removeWorkload(route)
+	return nil
+}
+
+// The caller must hold ht.lock.
+func (ht *HostTracker) removeWorkload(route workloadRoute) {
+	delete(ht.workloads, route.workloadID)
+	if workloadSet, ok := ht.hostnames[route.hostname]; ok {
+		workloadSet.Delete(route.workloadID)
 		if workloadSet.Len() == 0 {
-			delete(ht.hostnames, hostname)
+			delete(ht.hostnames, route.hostname)
 		}
 	}
-	return nil
 }

--- a/runtime-gateway/tracker_test.go
+++ b/runtime-gateway/tracker_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const fallbackEndpoint = "127.0.0.1:1"
+
+type testFallback struct{}
+
+func (testFallback) InvalidHostname(string) (string, string) { return "http", fallbackEndpoint }
+func (testFallback) NoWorkloads(string) (string, string)     { return "http", fallbackEndpoint }
+
+func resolve(t *testing.T, ht *HostTracker, hostname string) LookupResult {
+	t.Helper()
+	return ht.Resolve(t.Context(), &http.Request{Host: hostname})
+}
+
+func TestHostTrackerRoutesRegisteredWorkload(t *testing.T) {
+	ctx := t.Context()
+	ht := newHostTracker(testFallback{})
+
+	hostKey := types.NamespacedName{Namespace: "ns", Name: "host-a"}
+	workloadKey := types.NamespacedName{Namespace: "ns", Name: "workload-a"}
+
+	if err := ht.RegisterHost(ctx, hostKey, "host-id", "10.0.0.1", 8080); err != nil {
+		t.Fatalf("RegisterHost() = %v", err)
+	}
+	if err := ht.RegisterWorkload(ctx, workloadKey, "host-id", "workload-id", "a.example"); err != nil {
+		t.Fatalf("RegisterWorkload() = %v", err)
+	}
+
+	got := resolve(t, ht, "a.example")
+	if got.Hostname != "10.0.0.1:8080" || got.WorkloadID != "workload-id" {
+		t.Errorf("Resolve() = %+v, want the registered host and workload", got)
+	}
+}
+
+// Deregistration is keyed by the object key alone, because the reconciler that
+// observes a deletion no longer has the object it was registered from.
+func TestHostTrackerDeregisterWorkloadByKey(t *testing.T) {
+	ctx := t.Context()
+	ht := newHostTracker(testFallback{})
+
+	hostKey := types.NamespacedName{Namespace: "ns", Name: "host-a"}
+	workloadKey := types.NamespacedName{Namespace: "ns", Name: "workload-a"}
+
+	if err := ht.RegisterHost(ctx, hostKey, "host-id", "10.0.0.1", 8080); err != nil {
+		t.Fatalf("RegisterHost() = %v", err)
+	}
+	if err := ht.RegisterWorkload(ctx, workloadKey, "host-id", "workload-id", "a.example"); err != nil {
+		t.Fatalf("RegisterWorkload() = %v", err)
+	}
+	if err := ht.DeregisterWorkload(ctx, workloadKey); err != nil {
+		t.Fatalf("DeregisterWorkload() = %v", err)
+	}
+
+	if got := resolve(t, ht, "a.example"); got.Hostname != fallbackEndpoint {
+		t.Errorf("Resolve() = %+v, want the fallback endpoint", got)
+	}
+	// An unknown key is a no-op, not an error: a Workload the gateway never
+	// routed still reaches the reconciler when it is deleted.
+	if err := ht.DeregisterWorkload(ctx, types.NamespacedName{Namespace: "ns", Name: "unknown"}); err != nil {
+		t.Errorf("DeregisterWorkload(unknown) = %v", err)
+	}
+}
+
+func TestHostTrackerReregisterWorkloadDropsPreviousHostname(t *testing.T) {
+	ctx := t.Context()
+	ht := newHostTracker(testFallback{})
+
+	hostKey := types.NamespacedName{Namespace: "ns", Name: "host-a"}
+	workloadKey := types.NamespacedName{Namespace: "ns", Name: "workload-a"}
+
+	if err := ht.RegisterHost(ctx, hostKey, "host-id", "10.0.0.1", 8080); err != nil {
+		t.Fatalf("RegisterHost() = %v", err)
+	}
+	if err := ht.RegisterWorkload(ctx, workloadKey, "host-id", "workload-id", "a.example"); err != nil {
+		t.Fatalf("RegisterWorkload() = %v", err)
+	}
+	if err := ht.RegisterWorkload(ctx, workloadKey, "host-id", "workload-id", "b.example"); err != nil {
+		t.Fatalf("RegisterWorkload() = %v", err)
+	}
+
+	if got := resolve(t, ht, "a.example"); got.Hostname != fallbackEndpoint {
+		t.Errorf("Resolve(a.example) = %+v, want the fallback endpoint", got)
+	}
+	if got := resolve(t, ht, "b.example"); got.Hostname != "10.0.0.1:8080" {
+		t.Errorf("Resolve(b.example) = %+v, want the registered host", got)
+	}
+}
+
+func TestHostTrackerDeregisterHostDropsItsWorkloads(t *testing.T) {
+	ctx := t.Context()
+	ht := newHostTracker(testFallback{})
+
+	hostKey := types.NamespacedName{Namespace: "ns", Name: "host-a"}
+	workloadKey := types.NamespacedName{Namespace: "ns", Name: "workload-a"}
+
+	if err := ht.RegisterHost(ctx, hostKey, "host-id", "10.0.0.1", 8080); err != nil {
+		t.Fatalf("RegisterHost() = %v", err)
+	}
+	if err := ht.RegisterWorkload(ctx, workloadKey, "host-id", "workload-id", "a.example"); err != nil {
+		t.Fatalf("RegisterWorkload() = %v", err)
+	}
+	if err := ht.DeregisterHost(ctx, hostKey); err != nil {
+		t.Fatalf("DeregisterHost() = %v", err)
+	}
+
+	if got := resolve(t, ht, "a.example"); got.Hostname != fallbackEndpoint {
+		t.Errorf("Resolve() = %+v, want the fallback endpoint", got)
+	}
+	if len(ht.workloadKeys) != 0 {
+		t.Errorf("workloadKeys = %v, want the host's workloads dropped", ht.workloadKeys)
+	}
+}
+
+// A host pod that restarts re-registers under the same object name with a new
+// host ID; the entry for the old ID must not keep taking traffic.
+func TestHostTrackerReregisterHostReplacesPreviousID(t *testing.T) {
+	ctx := t.Context()
+	ht := newHostTracker(testFallback{})
+
+	hostKey := types.NamespacedName{Namespace: "ns", Name: "host-a"}
+
+	if err := ht.RegisterHost(ctx, hostKey, "host-id-1", "10.0.0.1", 8080); err != nil {
+		t.Fatalf("RegisterHost() = %v", err)
+	}
+	if err := ht.RegisterHost(ctx, hostKey, "host-id-2", "10.0.0.2", 8080); err != nil {
+		t.Fatalf("RegisterHost() = %v", err)
+	}
+
+	if _, ok := ht.hosts["host-id-1"]; ok {
+		t.Error("hosts still contains the replaced host ID")
+	}
+	if got := ht.hosts["host-id-2"]; got != "10.0.0.2:8080" {
+		t.Errorf("hosts[host-id-2] = %q, want %q", got, "10.0.0.2:8080")
+	}
+}


### PR DESCRIPTION
The gateway stamped a finalizer on every Host and Workload it routed so it could deregister before etcd removed the object. Its routing tables live only in the process that built them, though, so the finalizer outlives everything that could release it: once the gateway is scaled down, removed, or replaced, every object still carrying one is stuck Terminating forever.

That is the runtime-operator e2e flake in "should clean up workload resources on delete". The context deletes the runtime-gateway Deployment and deploys hello-workload a second later; a gateway pod still inside its termination grace period stamps the new Workload and then dies, leaving nothing to take the finalizer off.

HostTracker now indexes registrations by the object's NamespacedName, so a reconciler that observes a deletion can undo the routes from the request key alone. Both reconcilers strip the gateway finalizer wherever they find one so existing clusters recover on upgrade, patching under an optimistic lock because a merge patch replaces the whole finalizer list — the same whole-list replace behind the operator's "Forbidden: no new finalizers can be added" reconcile errors.

Keying by object also covers two stale-route cases the ID-keyed tables could not express: a Workload re-registered under a new hostname, and a Host object that comes back under a new host ID.

The runtime-gateway CI job only ran `go build`, so no test in that module had ever run; it now runs `go test` as well.