### PR TITLE
fix(bench): harden compare-bench checkouts, accept #PR as a bench ref

### DIFF
--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -42,11 +42,11 @@ on:
           - wasmtime_serve
           - gungraun_plugin
       ref_a:
-        description: baseline ref (branch, tag, sha, or #PR)
+        description: "baseline ref (branch, tag, sha, or #PR)"
         type: string
         default: main
       ref_b:
-        description: candidate ref (branch, tag, sha, or #PR) — required
+        description: "candidate ref (branch, tag, sha, or #PR) — required"
         type: string
         required: true
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ on:
           - wasmtime_serve
           - gungraun_plugin
       ref:
-        description: git ref to bench (branch, tag, or sha; default = the workflow ref)
+        description: "git ref to bench (branch, tag, sha, or #PR; default = the workflow ref)"
         type: string
         default: ""
   # Auto-populate the releases timeline: when a tag is published, run the
@@ -57,7 +57,12 @@ jobs:
     timeout-minutes: 1
     outputs:
       benches: ${{ steps.set.outputs.benches }}
+      # `ref` is the label recorded on each data row; `checkout_ref` is what
+      # actions/checkout is given. They differ only for a pull-request ref,
+      # where the row says `pull/123` but the checkout needs the full
+      # refs/pull/123/head.
       ref: ${{ steps.set.outputs.ref }}
+      checkout_ref: ${{ steps.set.outputs.checkout_ref }}
     env:
       # Subset of inputs.bench.options to run automatically on `release:
       # published`. wasmtime_* are reference baselines for wasmtime itself
@@ -75,17 +80,43 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT" = "release" ]; then
-            echo "benches=${RELEASE_BENCHES}" >> "$GITHUB_OUTPUT"
-            echo "ref=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+            benches="${RELEASE_BENCHES}"
+            ref="${RELEASE_TAG}"
+            checkout_ref="${RELEASE_TAG}"
           else
-            echo "benches=[\"${INPUT_BENCH}\"]" >> "$GITHUB_OUTPUT"
+            benches="[\"${INPUT_BENCH}\"]"
             ref="${INPUT_REF:-${DEFAULT_REF}}"
             # Normalize to the short name (main, v2.5.2) so it matches
             # GITHUB_REF_NAME's style and, when it's a tag, passes the
             # releases view's strict-semver ref filter.
             ref="${ref#refs/heads/}"; ref="${ref#refs/tags/}"
-            echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+            checkout_ref="${ref}"
+            case "$ref" in
+              '#'* | pull/* | pr/*)
+                # Same spellings compare-bench.sh's resolve_sha accepts, so
+                # `#123` means the same thing in both bench workflows.
+                #
+                # GitHub publishes refs/pull/N/head on the base repo for fork
+                # PRs too, so actions/checkout fetches it directly — no API
+                # call, which keeps this job checkout-free at `permissions: {}`.
+                num="${ref#\#}"; num="${num#pull/}"; num="${num#pr/}"
+                if ! [[ "$num" =~ ^[0-9]+$ ]]; then
+                  echo "invalid pull-request ref '${ref}' (expected #N, pull/N, or pr/N)" >&2
+                  exit 1
+                fi
+                # The row is labelled `pull/N` rather than refs/pull/N/head:
+                # `sha` on the same row already pins the exact commit, so the
+                # label only has to say which PR it came from.
+                ref="pull/${num}"
+                checkout_ref="refs/pull/${num}/head"
+                ;;
+            esac
           fi
+          {
+            echo "benches=${benches}"
+            echo "ref=${ref}"
+            echo "checkout_ref=${checkout_ref}"
+          } >> "$GITHUB_OUTPUT"
 
   bench:
     needs: matrix
@@ -118,7 +149,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.matrix.outputs.ref }}
+          ref: ${{ needs.matrix.outputs.checkout_ref }}
           fetch-depth: 0
           # Don't leave the GITHUB_TOKEN in .git/config; the bench host
           # then runs untrusted user code (the bench under test) and we
@@ -161,13 +192,25 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
+      # A pull-request ref is benched for its step summary and artifact only —
+      # it never reaches S3. Two reasons, both of which apply equally to the
+      # raw-head-sha spelling that has always been possible here:
+      #
+      #   - The trends timeline tracks merged history. A PR row would sit in
+      #     it labelled `pull/N` forever, describing code that may never land.
+      #   - `cargo bench` has by this point run the ref's build scripts and
+      #     proc macros on a persistent self-hosted host. Not assuming the AWS
+      #     role afterwards keeps that code and these credentials in disjoint
+      #     runs, rather than relying on it to have been well-behaved.
       - name: configure aws credentials
+        if: ${{ success() && !startsWith(needs.matrix.outputs.ref, 'pull/') }}
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.WASMCLOUD_BENCH_AWS_ROLE_ARN }}
           aws-region: ${{ secrets.WASMCLOUD_BENCH_S3_REGION }}
 
       - name: push results to s3 + invalidate CloudFront
+        if: ${{ success() && !startsWith(needs.matrix.outputs.ref, 'pull/') }}
         env:
           WASMCLOUD_BENCH_S3_BUCKET: ${{ secrets.WASMCLOUD_BENCH_S3_BUCKET }}
           WASMCLOUD_BENCH_CF_DISTRIBUTION_ID: ${{ secrets.WASMCLOUD_BENCH_CF_DISTRIBUTION_ID }}

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -570,7 +570,15 @@ GitHub → **Actions** → **bench** → **Run workflow**:
 | Input   | Description                                                                                | Default          |
 | ------- | ------------------------------------------------------------------------------------------ | ---------------- |
 | `bench` | which bench to run (`http_invoke`, `service_http`, `gungraun`, `wasmtime_baseline`, `wasmtime_serve`, `gungraun_plugin`) | `http_invoke`    |
-| `ref`   | git ref to bench (branch, tag, or sha)                                                     | the workflow ref |
+| `ref`   | git ref to bench (branch, tag, sha, or a pull request as `#123` / `pull/123` / `pr/123` — the same spellings bench-compare accepts) | the workflow ref |
+
+A pull-request ref produces a step summary and an uploaded artifact but is
+deliberately **not** pushed to S3, so it never lands on the trends timeline —
+that timeline tracks merged history, and the run's data row would otherwise
+describe code that may never land. Rows from a PR run are labelled `pull/123`;
+the exact commit is on the row's `sha` field either way. To compare a PR
+against its baseline rather than read its absolute numbers, use **bench-compare**
+(§9.4) — that is the workflow built for it.
 
 **Bench types:**
 

--- a/scripts/bench/compare-bench.sh
+++ b/scripts/bench/compare-bench.sh
@@ -14,9 +14,12 @@
 #     median of the three is what the delta is computed from.
 #
 # Side effects:
-#   - Switches the working tree (git checkout). Saves and restores the
-#     original HEAD on exit (including failure) so a hung run doesn't
-#     leave the repo in a detached state.
+#   - Switches the working tree (git checkout --force, so any uncommitted
+#     changes are discarded — this assumes the disposable CI checkout on
+#     the bench host, not a developer's tree). Saves and restores the
+#     original branch — or the commit, when started detached — on exit
+#     (including failure) so a hung run doesn't strand the repo on a
+#     comparison ref.
 #   - Writes per-run snapshots to ${WASMCLOUD_BENCH_COMPARE_DIR:-/tmp/bench-compare}/{a,b}/.
 #   - `bench-tools delta` (invoked at the end) writes the rendered
 #     markdown delta to both stdout and ${WASMCLOUD_BENCH_COMPARE_DIR}/delta.md.
@@ -84,7 +87,11 @@ sha_a=$(resolve_sha "$ref_a")
 sha_b=$(resolve_sha "$ref_b")
 short_a=$(git rev-parse --short=12 "$sha_a")
 short_b=$(git rev-parse --short=12 "$sha_b")
-saved_head=$(git rev-parse HEAD)
+# Prefer the branch name over the commit it points at: `git rev-parse HEAD`
+# yields a sha, and checking a sha back out lands detached — the exact state
+# the cleanup trap below exists to avoid. Falls back to the sha when we
+# started detached already, which is all that can be restored then.
+saved_head=$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)
 
 mkdir -p "${compare_dir}/a" "${compare_dir}/b"
 
@@ -126,10 +133,15 @@ fi
 # restore itself fails, log it loudly: the operator needs to know the
 # worktree is in an unexpected state, otherwise the next local run picks
 # up half-applied state from the comparison.
+#
+# --force for the same reason as the checkout in run_one: the tree is
+# dirty by the time we get here (run-bench.sh and cargo's stale-lock
+# repair both write into it), and a non-forcing checkout would refuse,
+# stranding the host on a comparison ref.
 cleanup() {
   rc=$?
-  if ! git checkout --quiet "$saved_head" 2>/dev/null; then
-    echo "::warning::failed to restore worktree to ${saved_head:0:12}; worktree may be on a comparison ref" >&2
+  if ! git checkout --quiet --force "$saved_head" 2>/dev/null; then
+    echo "::warning::failed to restore worktree to ${saved_head}; worktree may be on a comparison ref" >&2
   fi
   exit $rc
 }
@@ -153,10 +165,15 @@ snapshot() {
   done
 }
 
+# --force because the bench host's tree is a disposable CI checkout and is
+# expected to be dirty between iterations: run-bench.sh writes into it, and
+# checking out a ref whose lockfile predates the current cargo leaves a
+# repaired Cargo.lock behind. Without --force the checkout aborts on those
+# local modifications and the whole comparison fails partway through.
 run_one() {
   local side="$1" sha="$2" iter="$3"
   step "[${side} iter ${iter}] checkout ${sha:0:12} and run ${bench}"
-  git checkout --quiet --detach "$sha"
+  git checkout --quiet --detach --force "$sha"
   "${script_dir}/run-bench.sh" "$bench"
   snapshot "$side" "$iter"
 }


### PR DESCRIPTION
A handful of bench fixes while working on concurrency for requests. 
 
- **compare-bench.sh no longer strands the bench host.** Both worktree checkouts were non-forcing, and were leaving the worktree dirty.
- bench.yml can now take refs e.g. when I added a new bench,  I couldn't compare it with main
- bench.yml now takes `#123` / `pull/123` / `pr/123`, handing actions/checkout `refs/pull/N/head` directly
- PR runs get a step summary and artifact but skip the S3 push and AWS role assumption.
- The descriptions advertising `#PR` were silently truncated by YAML