### PR TITLE
feat: enable implements and maps by default

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -124,11 +124,11 @@ jobs:
           RUST_BACKTRACE: "1"
         run: |
           cargo test --workspace
-      - name: Test with wasi-tls + wasm_component_model_implements
+      - name: Test with wasi-tls + host-component-plugins
         env:
           RUST_BACKTRACE: "1"
         run: |
-          cargo test -p wash-runtime --features wasi-tls,wasm_component_model_implements,host-component-plugins
+          cargo test -p wash-runtime --features wasi-tls,host-component-plugins
           cargo test -p wash --lib --features host-component-plugins
       # Docker/registry-backed `#[ignore]` integration tests, Linux only: the
       # macOS/Windows hosted runners have no Docker daemon (and macOS can't get
@@ -141,7 +141,7 @@ jobs:
         env:
           RUST_BACKTRACE: "1"
         run: |
-          cargo test -p wash-runtime --features wasm_component_model_implements,wasi-tls,host-component-plugins -- --ignored
+          cargo test -p wash-runtime --features wasi-tls,host-component-plugins -- --ignored
           cargo test -p wash --test integration_oci -- --ignored
       # Bitrot guard: the benches must still compile. Built via `cargo test
       # --benches` rather than `cargo bench --no-run` because the `bench`
@@ -191,7 +191,7 @@ jobs:
           cargo +nightly fmt -- --check
       - name: Lint
         run: |
-          cargo clippy --workspace --features wasm_component_model_implements,wasi-tls,host-component-plugins
+          cargo clippy --workspace --features wasi-tls,host-component-plugins
       - name: Lint anyhow context message casing
         run: |
           # anyhow `.context()` / `.with_context()` strings are error messages,
@@ -309,13 +309,12 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # ALL-FEATURES coverage image on arm64 — every optional host feature on
-  # (`(implements ..)` multiplexing AND host component plugins). NOT shipped:
-  # the operator-e2e `all-features` leg loads this tarball to exercise those
-  # features on a host built with them (a released host can't run them). Runs
-  # in parallel with `wash-image` (a separate job, not a second step) so the
-  # e2e gate waits on max(release, all-features), not their sum. Never pushed,
-  # so no digest.
+  # ALL-FEATURES coverage image on arm64 — every optional host feature on (host
+  # component plugins). NOT shipped: the operator-e2e `all-features` leg loads
+  # this tarball to exercise those features on a host built with them (a
+  # released host can't run them). Runs in parallel with `wash-image` (a
+  # separate job, not a second step) so the e2e gate waits on max(release,
+  # all-features), not their sum. Never pushed, so no digest.
   wash-image-all-features:
     needs:
       - changes
@@ -337,7 +336,7 @@ jobs:
           context: .
           outputs: type=docker,dest=/tmp/wash-image-all-features.tar,name=localhost/wasmcloud-wash:e2e
           build-args: |
-            CARGO_FEATURES=wasm_component_model_implements,host-component-plugins
+            CARGO_FEATURES=host-component-plugins
           cache-from: |
             type=gha,scope=wash-all-features-arm64-${{ github.head_ref || github.ref_name }}
             type=gha,scope=wash-all-features-arm64-main
@@ -486,10 +485,12 @@ jobs:
     # the legs differ only in the image the DEFAULT (fixture) hostgroup runs:
     #   release      — the shipped DEFAULT-features build. Validates that the
     #                  shipped host pulls the fixtures from the registry (insecure
-    #                  HTTP) and runs them. `implements` self-skips (it needs a
-    #                  feature host); http + messaging run.
+    #                  HTTP) and runs them. `implements` is a default feature, so
+    #                  it runs here too, alongside http + messaging; the host
+    #                  component plugin specs self-skip (they need a feature host).
     #   all-features — every optional host feature on; runs the full set incl.
-    #                  `implements`. Not shipped — a coverage build.
+    #                  the host component plugin specs. Not shipped — a coverage
+    #                  build.
     # default_tag/registry_tag select the per-hostgroup images (loaded below); the
     # registry host is always all-features (it needs the async wasmcloud:blobstore
     # plugin).

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 workspace = true
 
 [features]
-default = ["wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "washlet", "wasi-otel", "wasi-webgpu"]
+default = ["wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "washlet", "wasi-otel", "wasi-webgpu", "wasm_component_model_implements"]
 oci = ["dep:oci-client", "dep:oci-wasm", "dep:docker_credential", "dep:sha2", "dep:wit-component"]
 wasi-otel = []
 washlet = ["oci"]
@@ -41,7 +41,9 @@ wasi-config = []
 wasi-logging = []
 wasi-blobstore = []
 wasi-keyvalue = []
-# Component-model `(implements ..)` / `named_imports` multiplexing
+# Component-model `(implements ..)` / `named_imports` multiplexing. On by
+# default; disable with `--no-default-features` for a build that neither
+# accepts nor routes named imports.
 wasm_component_model_implements = []
 # Host component plugins: a component providing a host capability from its own
 # long-lived, supervised store, serving cross-store capability calls.

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -653,11 +653,15 @@ pub enum WasmProposal {
     /// Component model `(implements ..)` named imports, letting a component
     /// import the same interface multiple times under distinct names so host
     /// plugins can route each independently. Enables
-    /// `wasm_component_model_implements`. Requires the backported wasmtime
-    /// support, so it is only available with the `wasm_component_model_implements`
-    /// crate feature.
+    /// `wasm_component_model_implements`. Available with the
+    /// `wasm_component_model_implements` crate feature, which is on by default
+    /// and carries the plugin-side routing this proposal is useful for.
     #[cfg(feature = "wasm_component_model_implements")]
     WasmComponentModelImplements,
+    /// Component model `map<k, v>` type. Enables `wasm_component_model_map`,
+    /// which is what lets a component whose WIT uses `map` types be validated
+    /// and instantiated. Enabled by default, like [`Self::ComponentModelAsync`].
+    ComponentModelMap,
     /// Garbage collection (with its `wasm_function_references` prerequisite).
     /// Enabled by default in wasmtime >= 47; accepted for compatibility.
     Gc,
@@ -683,6 +687,9 @@ impl WasmProposal {
             #[cfg(feature = "wasm_component_model_implements")]
             WasmProposal::WasmComponentModelImplements => {
                 cfg.wasm_component_model_implements(true);
+            }
+            WasmProposal::ComponentModelMap => {
+                cfg.wasm_component_model_map(true);
             }
             // GC (with its `wasm_function_references` prerequisite), exception
             // handling, and wide arithmetic are all enabled by default in
@@ -712,8 +719,9 @@ impl std::fmt::Display for ParseWasmProposalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "unknown wasm proposal {:?}; expected one of: component-model-async, gc, \
-             exception-handling, wide-arithmetic, threads, tail-call",
+            "unknown wasm proposal {:?}; expected one of: component-model-async, \
+             component-model-map, gc, exception-handling, wide-arithmetic, threads, \
+             tail-call",
             self.0
         )
     }
@@ -730,6 +738,7 @@ impl FromStr for WasmProposal {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim().to_ascii_lowercase().replace('_', "-").as_str() {
             "component-model-async" => Ok(Self::ComponentModelAsync),
+            "component-model-map" => Ok(Self::ComponentModelMap),
             "gc" => Ok(Self::Gc),
             "exception-handling" => Ok(Self::ExceptionHandling),
             "wide-arithmetic" => Ok(Self::WideArithmetic),
@@ -937,12 +946,15 @@ impl EngineBuilder {
         // WASIP3's async ABI requires the component-model async proposal.
         self.proposals.insert(WasmProposal::ComponentModelAsync);
 
+        // Accept components whose WIT uses `map<k, v>` types.
+        self.proposals.insert(WasmProposal::ComponentModelMap);
+
         // Accept components that import an interface multiple times via the
         // component-model `(implements ..)` annotation, so host plugins can
         // route each named import (e.g. two `wasi:keyvalue/store` imports
-        // backed by redis vs NATS) independently. Only available with the
-        // backported wasmtime support behind the
-        // `wasm_component_model_implements` feature.
+        // backed by redis vs NATS) independently. Gated on the
+        // `wasm_component_model_implements` feature, which is on by default and
+        // also brings in the plugin-side routing.
         #[cfg(feature = "wasm_component_model_implements")]
         self.proposals
             .insert(WasmProposal::WasmComponentModelImplements);
@@ -1168,7 +1180,30 @@ mod tests {
             "component-model-async".parse(),
             Ok(WasmProposal::ComponentModelAsync)
         );
+        assert_eq!(
+            "component-model-map".parse(),
+            Ok(WasmProposal::ComponentModelMap)
+        );
         assert!("nonsense".parse::<WasmProposal>().is_err());
+    }
+
+    // A component whose type section uses `map<k, v>` fails validation unless
+    // the component-model map proposal is on, so compiling one on a
+    // default-built engine is what proves the proposal is enabled by default.
+    #[test]
+    fn default_engine_accepts_component_model_map() {
+        let bytes = wat::parse_str(
+            r#"(component
+                 (type $m (map string string))
+                 (import "test:map/iface" (instance
+                   (export "take" (func (param "m" $m)))
+                 ))
+               )"#,
+        )
+        .expect("map component should assemble");
+
+        let engine = Engine::builder().build().expect("engine should build");
+        Component::new(&engine.inner, &bytes).expect("map component should compile");
     }
 
     // A compile failure that goes through the cache reports everything the

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -12,12 +12,13 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-default = ["wasi-webgpu"]
+default = ["wasi-webgpu", "wasm_component_model_implements"]
 wasi-tls = ["wash-runtime/wasi-tls"]
 # Route component-model `(implements ..)` named imports to per-import backends.
-# When enabled, `wash host`/`wash dev` additionally register the multiplexed
-# keyvalue plugin (the unnamed/default import keeps its standalone backend, so
-# normal workloads are unaffected). Needs a wasmtime build with resource-implements.
+# On by default: `wash host`/`wash dev` register the multiplexed keyvalue plugin
+# (the unnamed/default import keeps its standalone backend, so normal workloads
+# are unaffected). Disable with `--no-default-features` for a build that rejects
+# components importing an interface more than once.
 wasm_component_model_implements = ["wash-runtime/wasm_component_model_implements"]
 # Host component plugins: host capabilities provided by wasm components running
 # in their own supervised stores (wash-runtime's `plugin::component_host`).

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -177,8 +177,8 @@ pub struct HostCommand {
 
     /// Enable additional wasm proposals on the engine. Accepts a comma-separated
     /// list and/or repeated flags, e.g. `--wasm-proposal gc,threads`. Accepted
-    /// names: component-model-async, gc, exception-handling, wide-arithmetic,
-    /// threads, tail-call.
+    /// names: component-model-async, component-model-map, gc,
+    /// exception-handling, wide-arithmetic, threads, tail-call.
     #[arg(
         long = "wasm-proposal",
         env = "WASH_WASM_PROPOSALS",

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -759,8 +759,9 @@ pub struct DevConfig {
     pub wasi_otel: bool,
 
     /// Additional wasm proposals to enable on the engine, by name. Accepted
-    /// names match `wash_runtime`'s `WasmProposal`: component-model-async, gc,
-    /// exception-handling, wide-arithmetic, threads, tail-call.
+    /// names match `wash_runtime`'s `WasmProposal`: component-model-async,
+    /// component-model-map, gc, exception-handling, wide-arithmetic, threads,
+    /// tail-call.
     #[serde(default)]
     pub wasm_proposals: Vec<String>,
 }

--- a/examples/oci-registry/README.md
+++ b/examples/oci-registry/README.md
@@ -21,7 +21,7 @@ uploads, tag listing, and the referrers API.
 
 - `cargo` (Rust 2024 edition)
 - A `wash` built from the [`async-backends`][async-backends] line — it provides
-  the async `wasmcloud:blobstore` host plugin (enabled with the
+  the async `wasmcloud:blobstore` host plugin (on by default via the
   `wasm_component_model_implements` feature) and a `wash` CLI that can build and
   run wasip3 components. A released `wash` (≤ 2.x) does not yet support this.
 - Optional, for the walkthrough: [`oras`](https://oras.land/docs/installation)

--- a/runtime-operator/test/e2e/implements_test.go
+++ b/runtime-operator/test/e2e/implements_test.go
@@ -40,8 +40,7 @@ import (
 // wasi:http/incoming-handler and imports wasi:keyvalue/store twice under the
 // labels `team-a` and `team-b`. Like every e2e fixture it is built and served
 // from the in-cluster registry (make e2e-images), so this spec runs only when
-// that flow is enabled (the all-features leg — also the only host with
-// `(implements ..)` support) and self-skips otherwise. Excluded from `make test`
+// that flow is enabled and self-skips otherwise. Excluded from `make test`
 // (which skips ./test/e2e); runs in the dedicated `make test-e2e` job.
 var _ = Describe("Implements Named Host Interfaces", Ordered, func() {
 	const workloadName = "keyvalue-implements"
@@ -50,13 +49,11 @@ var _ = Describe("Implements Named Host Interfaces", Ordered, func() {
 
 	BeforeAll(func() {
 		// The keyvalue-implements fixture is built and served from the in-cluster
-		// registry (make e2e-images), like every other e2e fixture. But unlike the
-		// others it needs a feature-enabled host to RUN (`(implements ..)`
-		// multiplexing), so it runs only when the registry flow is on AND the
-		// fixture host is an all-features build — i.e. the all-features leg.
-		if !inClusterRegistry || !defaultHostAllFeatures {
-			Skip("skipping implements e2e (needs the in-cluster registry and an " +
-				"all-features fixture host)")
+		// registry (make e2e-images), like every other e2e fixture, and
+		// `(implements ..)` multiplexing is a default host feature — so this runs
+		// on both legs whenever the registry flow is on.
+		if !inClusterRegistry {
+			Skip("skipping implements e2e (needs the in-cluster registry)")
 		}
 		componentImage = registryRef("keyvalue-implements")
 


### PR DESCRIPTION
WASI SG voted to depend on stabilized CM features maps and implements today.

This change turns on both component-model proposals for every host build.

- (implements ..) named imports — wasm_component_model_implements moves from opt-in to a default feature of both wash-runtime and wash. A shipped wash host / wash dev now accepts components that import an interface more than once under distinct labels, and registers the multiplexed plugin set that routes each named import to its own backend.
- map<k, v> types — new WasmProposal::ComponentModelMap, applied unconditionally in EngineBuilder::build() alongside ComponentModelAsync. Components whose WIT uses map types now validate and instantiate.

map needs no cargo feature: wasmtime exposes wasm_component_model_map under plain component-model, and no code in the tree is conditional on it. It parses as component-model-map for --wasm-proposal and dev.wasm_proposals.
