### PR TITLE
feat(wash-runtime): plugins and workloads publish declared ports

### DIFF
--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -541,6 +541,13 @@ pub struct ResolvedWorkload {
     service: Option<WorkloadService>,
     /// The requested host [`WitInterface`]s to resolve this workload
     host_interfaces: Vec<WitInterface>,
+    /// Real ports the host published on this workload's behalf.
+    ///
+    /// `Arc` because a `ResolvedWorkload` is cloned: the listeners are shared by
+    /// every clone and close when the last one drops, which is what makes
+    /// stopping a workload release its ports rather than leaking them to
+    /// whichever clone happened to outlive the others.
+    published_ports: Arc<Vec<crate::host::ports::PublishedPort>>,
     /// TLS provider override for `wasi:tls` client connections in this workload.
     #[cfg(feature = "wasi-tls")]
     tls_provider: Option<SharedTlsProvider>,
@@ -625,6 +632,30 @@ fn build_trigger_ingresses(
 }
 
 impl ResolvedWorkload {
+    /// The workload's virtual network, if it has a service to own one.
+    ///
+    /// Shared by the service and every component — that sharing is what lets a
+    /// component dial its service on `127.0.0.1`.
+    pub(crate) fn loopback(&self) -> Option<Arc<std::sync::Mutex<loopback::Network>>> {
+        self.service
+            .as_ref()
+            .map(|svc| Arc::clone(&svc.metadata.loopback))
+    }
+
+    /// Take ownership of the real listeners the host published for this
+    /// workload, so they close when it stops.
+    pub(crate) fn set_published_ports(&mut self, ports: Vec<crate::host::ports::PublishedPort>) {
+        self.published_ports = Arc::new(ports);
+    }
+
+    /// The real addresses this workload is published on, for status reporting.
+    pub fn published_addresses(&self) -> Vec<(String, std::net::SocketAddr)> {
+        self.published_ports
+            .iter()
+            .map(|p| (p.name().to_string(), p.local_addr()))
+            .collect()
+    }
+
     /// Executes the service, if present, and returns whether it was run.
     #[instrument(name="execute_service", skip_all, fields(workload.id = self.id.as_ref(), workload.name = self.name.as_ref(), workload.namespace = self.namespace.as_ref()))]
     pub(crate) async fn execute_service(&mut self) -> anyhow::Result<Option<Arc<JoinHandle<()>>>> {
@@ -2239,6 +2270,7 @@ impl UnresolvedWorkload {
             service: self.service,
             host_interfaces: self.host_interfaces,
             http_handler: http_handler.clone(),
+            published_ports: Arc::default(),
             #[cfg(feature = "wasi-tls")]
             tls_provider: self.tls_provider,
         };

--- a/crates/wash-runtime/src/host/declared_port.rs
+++ b/crates/wash-runtime/src/host/declared_port.rs
@@ -371,7 +371,10 @@ mod tests {
         let mut port = splice("dns", 5353, Some(31053));
         port.protocol = Protocol::Udp;
         let err = port.validate("p").unwrap_err().to_string();
-        assert!(err.contains("only TCP ports can be published"), "got: {err}");
+        assert!(
+            err.contains("only TCP ports can be published"),
+            "got: {err}"
+        );
         assert!(
             err.contains("Drop `publish`"),
             "the error should say what to do instead; got: {err}"

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -59,22 +59,22 @@ use crate::plugin::{HostPlugin, WorkloadFailure, WorkloadFailureSink};
 use crate::types::*;
 use crate::wit::{WitInterface, WitWorld};
 
-pub mod allowed_loopback;
-pub mod declared_port;
-pub mod egress_policy;
-pub mod loopback_http;
-pub mod ports;
-pub mod quota;
 mod sysinfo;
 use sysinfo::SystemMonitor;
 
 pub mod allowed_hosts;
 pub mod allowed_ip_name;
+pub mod allowed_loopback;
+pub mod declared_port;
+pub mod egress_policy;
 pub mod http;
 pub mod http_client;
 pub mod http_p3;
 #[cfg(feature = "host-component-plugins")]
 pub(crate) mod job_registry;
+pub mod loopback_http;
+pub mod ports;
+pub mod quota;
 pub mod trigger_service;
 
 /// The API for interacting with a wasmcloud host.
@@ -220,6 +220,8 @@ pub struct Host {
     system_monitor: Arc<RwLock<SystemMonitor>>,
     // endpoints: HashMap<String, EndpointConfiguration>
     pub(crate) http_handler: std::sync::Arc<dyn crate::host::http::HostHandler>,
+    port_table: Arc<crate::host::ports::PortTable>,
+    publish_config: Arc<crate::host::ports::PublishConfig>,
     /// The host's one record of which real ports are spoken for. Shared with
     /// every host component plugin and consulted by the socket policy, so one
     /// lookup answers "is this port taken, and by whom".
@@ -626,6 +628,13 @@ impl Host {
         request: WorkloadStartRequest,
     ) -> anyhow::Result<ResolvedWorkload> {
         let service_present = request.workload.service.is_some();
+        let declared_ports = request
+            .workload
+            .service
+            .as_ref()
+            .map(|svc| svc.ports.clone())
+            .unwrap_or_default();
+        let workload_id: Arc<str> = Arc::from(request.workload_id.as_str());
         // Initialize the workload using the engine, receiving the unresolved workload
         let unresolved_workload = self
             .engine
@@ -635,7 +644,17 @@ impl Host {
             .resolve(Some(&self.plugins), self.http_handler.clone())
             .await?;
 
+        // Bind real ports before the service is running, so a conflict fails the
+        // start with both holders named rather than surfacing later. The
+        // service's virtual listener does not exist yet; connections arriving
+        // before it does wait out the readiness window.
+        let published = self
+            .publish_workload_ports(&workload_id, &declared_ports, &resolved_workload)
+            .await?;
+        resolved_workload.set_published_ports(published);
+
         // If the service didn't run and we had one, warn
+        #[allow(clippy::items_after_statements)]
         if service_present && resolved_workload.execute_service().await?.is_none() {
             warn!(
                 workload_id = request.workload_id,
@@ -644,6 +663,69 @@ impl Host {
         }
 
         Ok(resolved_workload)
+    }
+
+    /// Bind a real listener for every declared port that asks to be published.
+    ///
+    /// A port declared without `publish` reserves nothing and binds nothing: the
+    /// service still binds it inside the workload's virtual network, where only
+    /// that workload's own components can reach it — exactly today's behavior.
+    ///
+    /// # Errors
+    ///
+    /// Fails if a port conflicts with one this host already published, falls
+    /// outside the configured range, or cannot be bound. Ports bound so far drop
+    /// on the error path, so a workload that fails to start leaves no port
+    /// claimed.
+    async fn publish_workload_ports(
+        &self,
+        workload_id: &Arc<str>,
+        ports: &[crate::host::declared_port::DeclaredPort],
+        workload: &ResolvedWorkload,
+    ) -> anyhow::Result<Vec<crate::host::ports::PublishedPort>> {
+        let wants_publish = ports.iter().any(|p| p.published_port().is_some());
+        if !wants_publish {
+            return Ok(Vec::new());
+        }
+        let Some(loopback) = workload.loopback() else {
+            bail!(
+                "workload declares published ports but has no service to bind them; ports are \
+                 listened on by the workload's service"
+            );
+        };
+        // Pinned rather than replaced per incarnation: a workload's virtual
+        // network is shared with its components, which is what lets a component
+        // dial its service.
+        let network = crate::host::ports::NetworkHandle::pinned(loopback);
+        let owner = crate::host::ports::PortOwner::Workload(Arc::clone(workload_id));
+
+        let mut published = Vec::new();
+        for port in ports {
+            let Some(host_port) = port.published_port() else {
+                continue;
+            };
+            let target = std::net::SocketAddr::new(
+                std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                port.port,
+            );
+            let request = crate::host::ports::PublishRequest::new(
+                port.protocol,
+                owner.clone(),
+                port.name.as_str(),
+                host_port,
+                target,
+                network.clone(),
+            )
+            // The same allowance the workload's components draw on, so its
+            // exposed ports cannot outrun what the workload as a whole may hold.
+            .with_quota(self.engine.socket_policy.quota_for(workload_id));
+            let handle =
+                crate::host::ports::publish(&self.publish_config, &self.port_table, request)
+                    .await
+                    .with_context(|| format!("failed to publish port '{}'", port.name))?;
+            published.push(handle);
+        }
+        Ok(published)
     }
 }
 
@@ -1170,6 +1252,8 @@ impl HostBuilder {
 
         Ok(Host {
             engine,
+            port_table: self.port_table.unwrap_or_default(),
+            publish_config: self.publish_config.unwrap_or_default(),
             workloads: Arc::default(),
             plugins: self.plugins,
             id: self.id,

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -401,6 +401,108 @@ impl ComponentHostPlugin {
         self
     }
 
+    /// Bind a real listener for every declared port that asks to be published.
+    ///
+    /// A port declared without `publish` reserves nothing and binds nothing: the
+    /// plugin still binds it inside its own virtual network, where it is
+    /// unreachable. A port with `bind` is held by the plugin itself, so all this
+    /// does is reserve it in the host's table — the collision check still has to
+    /// see it, or two plugins could each bind the same real address and only one
+    /// would notice.
+    ///
+    /// # Errors
+    ///
+    /// Fails if any port conflicts, is out of range, or cannot be bound. On
+    /// failure nothing stays published: the ports bound so far drop here, which
+    /// closes their listeners and releases their reservations, so a partially
+    /// started plugin does not leave a port claimed.
+    async fn publish_declared_ports(&self) -> anyhow::Result<()> {
+        if self.ports.is_empty() {
+            return Ok(());
+        }
+        let owner = crate::host::ports::PortOwner::Plugin(Arc::from(self.id));
+        let mut published = Vec::new();
+
+        for port in self.ports.iter() {
+            match port.mode() {
+                crate::host::declared_port::PortMode::Declared => {
+                    debug!(
+                        id = self.id,
+                        port = %port.name,
+                        "port declared without `publish`; reachable only inside the plugin"
+                    );
+                }
+                crate::host::declared_port::PortMode::Splice { publish } => {
+                    let target = core::net::SocketAddr::new(
+                        core::net::IpAddr::V4(core::net::Ipv4Addr::LOCALHOST),
+                        port.port,
+                    );
+                    let request = crate::host::ports::PublishRequest::new(
+                        port.protocol,
+                        owner.clone(),
+                        port.name.as_str(),
+                        publish,
+                        target,
+                        self.network.clone(),
+                    )
+                    // The same allowance this plugin's own outbound sockets
+                    // draw on, so its exposed ports cannot outrun it.
+                    .with_quota(self.socket_policy.quota_for(self.id));
+                    let handle = crate::host::ports::publish(
+                        &self.publish_config,
+                        &self.port_table,
+                        request,
+                    )
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed to publish port '{}' for plugin '{}'",
+                            port.name, self.id
+                        )
+                    })?;
+                    published.push(handle);
+                }
+                crate::host::declared_port::PortMode::Direct { bind } => {
+                    // The plugin holds this socket, so there is nothing to bind
+                    // here — only to record, so the port table stays the one
+                    // place that knows what this host has taken.
+                    let addr = core::net::SocketAddr::new(bind, port.port);
+                    let reservation = self
+                        .port_table
+                        .reserve(port.protocol, addr, owner.clone())
+                        .with_context(|| {
+                            format!(
+                                "failed to reserve direct-bind port '{}' for plugin '{}'",
+                                port.name, self.id
+                            )
+                        })?;
+                    self.direct_reservations()?.push(reservation);
+                    debug!(
+                        id = self.id,
+                        port = %port.name,
+                        %addr,
+                        "reserved direct-bind port; the plugin binds it itself"
+                    );
+                }
+            }
+        }
+
+        self.published
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .extend(published);
+        Ok(())
+    }
+
+    fn direct_reservations(
+        &self,
+    ) -> anyhow::Result<std::sync::MutexGuard<'_, Vec<crate::host::ports::PortReservation>>> {
+        Ok(self
+            .direct_reservations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner))
+    }
+
     /// Override the per-call budget for a lifecycle (bind/unbind) delivery
     /// (default [`crate::timeouts::plugin_lifecycle_call`]). Bounds how long a
     /// deploy or stop waits on a hook before failing and, for bind, deferring
@@ -529,6 +631,12 @@ impl HostPlugin for ComponentHostPlugin {
     }
 
     async fn start(&self) -> anyhow::Result<()> {
+        // Bind real ports before the first incarnation exists, so a conflict is
+        // a start failure naming both holders rather than a surprise later. The
+        // guest's virtual listener does not exist yet either; connections
+        // arriving before it does wait out the readiness window.
+        self.publish_declared_ports().await?;
+
         let (tx, rx) = tokio::sync::mpsc::channel(CAPABILITY_CHANNEL_CAPACITY);
         // Publish the sender and snapshot the bound workloads atomically (see
         // [`replay_snapshot`]); leftover binds (a stop()/start() cycle) replay,

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -259,6 +259,12 @@ pub struct ComponentHostPlugin {
     network: crate::host::ports::NetworkHandle,
     /// The host-level half of this plugin's socket policy.
     socket_policy: Arc<crate::sockets::policy::SocketPolicy>,
+    /// Ports this plugin declared, and how each is exposed.
+    ports: Arc<[crate::host::declared_port::DeclaredPort]>,
+    /// The host's one port table, so a collision names both holders.
+    port_table: Arc<crate::host::ports::PortTable>,
+    /// Host-wide publishing settings.
+    publish_config: Arc<crate::host::ports::PublishConfig>,
     /// Live published listeners. Dropped on `stop()`, which closes them and
     /// releases their port-table reservations.
     published: Mutex<Vec<crate::host::ports::PublishedPort>>,
@@ -311,6 +317,8 @@ impl ComponentHostPlugin {
         http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
         #[builder(default)] ports: Arc<[crate::host::declared_port::DeclaredPort]>,
         socket_policy: Option<Arc<crate::sockets::policy::SocketPolicy>>,
+        port_table: Option<Arc<crate::host::ports::PortTable>>,
+        publish_config: Option<Arc<crate::host::ports::PublishConfig>>,
     ) -> anyhow::Result<Self> {
         crate::host::declared_port::validate_ports(&ports, &format!("host plugin '{id}'"))?;
         let direct_binds = ports
@@ -388,6 +396,9 @@ impl ComponentHostPlugin {
             direct_binds: Arc::from(direct_binds),
             network: crate::host::ports::NetworkHandle::new(),
             socket_policy: socket_policy.unwrap_or_default(),
+            ports,
+            port_table: port_table.unwrap_or_default(),
+            publish_config: publish_config.unwrap_or_default(),
             published: Mutex::new(Vec::new()),
             direct_reservations: Mutex::new(Vec::new()),
             state,

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -263,6 +263,39 @@ fn with_standard_plugins(
         .with_plugin(Arc::new(WasmcloudSecrets::new()))
 }
 
+/// Start a host running one host component plugin that declares `ports`, with
+/// no HTTP ingress at all — the plugin's own listener is the only way in, which
+/// is the point.
+///
+/// Takes the [`PortTable`] rather than making one, so a caller can start two
+/// hosts against the *same* table and observe the conflict a real host would.
+#[cfg(feature = "host-component-plugins")]
+#[allow(dead_code)]
+pub async fn start_bare_host_with_plugin_ports(
+    plugin_id: &'static str,
+    plugin_wasm: &'static [u8],
+    ports: Vec<wash_runtime::host::declared_port::DeclaredPort>,
+    publish_config: wash_runtime::host::ports::PublishConfig,
+    port_table: Arc<wash_runtime::host::ports::PortTable>,
+) -> Result<impl HostApi> {
+    let engine = Engine::builder().build()?;
+    let builder = with_standard_plugins(HostBuilder::new().with_engine(engine.clone()))?;
+    let native_plugins = builder.native_plugins();
+    let plugin = ComponentHostPlugin::builder()
+        .id(plugin_id)
+        .wasm(plugin_wasm)
+        .engine(engine)
+        .native_plugins(native_plugins)
+        .ports(Arc::from(ports))
+        .port_table(port_table)
+        .publish_config(Arc::new(publish_config))
+        .build()
+        .await
+        .with_context(|| format!("failed to build host component plugin '{plugin_id}'"))?;
+    let host = builder.with_plugin(Arc::new(plugin))?.build()?;
+    host.start().await.context("failed to start host")
+}
+
 /// Start a host with a "DevRouter" backed HTTP server and the standard plugin
 /// set. Returns the bound address and a started `HostApi` ref.
 pub async fn start_host_with_dev_router(

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -802,6 +802,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket-echo-plugin"
+version = "0.0.0"
+dependencies = [
+ "futures",
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
 name = "socket-test-p3"
 version = "0.0.0"
 dependencies = [

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "bridge-backend",
     "bridge-service",
     "kv-plugin",
+    "socket-echo-plugin",
     "kv-plugin-caller",
     "kv-plugin-service",
     "badlifecycle",

--- a/crates/wash-runtime/tests/fixtures/socket-echo-plugin/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/socket-echo-plugin/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/socket_echo_plugin.wasm

--- a/crates/wash-runtime/tests/fixtures/socket-echo-plugin/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/socket-echo-plugin/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "socket-echo-plugin"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }
+futures = { workspace = true, features = ["alloc", "async-await"] }

--- a/crates/wash-runtime/tests/fixtures/socket-echo-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/socket-echo-plugin/src/lib.rs
@@ -1,0 +1,86 @@
+//! A host component plugin that listens on a TCP port and echoes.
+//!
+//! Its `wasi:cli/run` export binds `127.0.0.1:ECHO_PORT` inside the plugin's own
+//! private virtual loopback and serves an accept loop there forever. Nothing can
+//! reach that listener until the host publishes a real port that splices into
+//! it — which is exactly what the integration test does.
+//!
+//! The accept loop is **awaited from `cli/run`**, not spawned. A loopback accept
+//! stream only delivers when it is driven from the run task, so spawning it
+//! produces a plugin that binds successfully and then silently never accepts.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+    });
+}
+
+use bindings::exports::acme::echo::control::Guest as ControlGuest;
+use bindings::exports::wasi::cli::run::Guest as RunGuest;
+use bindings::wasi::sockets::types::{
+    IpAddressFamily, IpSocketAddress, Ipv4SocketAddress, TcpSocket,
+};
+use wit_bindgen::StreamResult;
+
+/// The port the plugin binds inside its own virtual network. Private to this
+/// plugin, so it cannot collide with anything else on the host — the real port
+/// the outside world sees is chosen by the operator, not here.
+const ECHO_PORT: u16 = 50051;
+
+struct Component;
+
+/// Echo one accepted connection until the peer closes.
+async fn echo_one(sock: TcpSocket) {
+    let (mut incoming, incoming_done) = sock.receive();
+    let (mut outgoing_tx, outgoing_rx) = bindings::wit_stream::new();
+
+    futures::join!(
+        async {
+            // Drives the send side for as long as the peer keeps writing.
+            let _ = sock.send(outgoing_rx).await;
+        },
+        async {
+            loop {
+                let (result, data) = incoming.read(Vec::with_capacity(8192)).await;
+                match result {
+                    StreamResult::Complete(n) if n > 0 => {
+                        outgoing_tx.write_all(data).await;
+                    }
+                    // Peer half-closed or the connection ended.
+                    _ => break,
+                }
+            }
+            drop(outgoing_tx);
+        }
+    );
+    let _ = incoming_done.await;
+}
+
+impl RunGuest for Component {
+    async fn run() -> Result<(), ()> {
+        let listener = TcpSocket::create(IpAddressFamily::Ipv4).map_err(|_| ())?;
+        listener
+            .bind(IpSocketAddress::Ipv4(Ipv4SocketAddress {
+                port: ECHO_PORT,
+                address: (127, 0, 0, 1),
+            }))
+            .map_err(|_| ())?;
+        listener.set_listen_backlog_size(16).map_err(|_| ())?;
+        let mut accept = listener.listen().map_err(|_| ())?;
+
+        // Awaited here, in the run task. Spawning this loop instead would bind
+        // the port and then never deliver a connection.
+        while let Some(sock) = accept.next().await {
+            echo_one(sock).await;
+        }
+        Ok(())
+    }
+}
+
+impl ControlGuest for Component {
+    async fn listening_port() -> u16 {
+        ECHO_PORT
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/socket-echo-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/socket-echo-plugin/wit/world.wit
@@ -1,0 +1,22 @@
+package acme:socketecho@0.1.0;
+
+/// Host component plugin that LISTENS. It binds a TCP port inside its own
+/// private virtual loopback from `wasi:cli/run` and echoes every byte back,
+/// which is what the host's published-port splice connects external clients to.
+///
+/// Two details this fixture exists to pin:
+///
+/// - The accept loop is awaited from `cli/run`, not spawned. A guest-spawned
+///   accept loop never delivers, and getting that wrong is the first mistake a
+///   plugin author makes.
+/// - It exports a capability (`acme:echo/control`) as well, because a host
+///   component plugin must export at least one capability interface to load at
+///   all. `listening-port` also lets a test tell "the plugin never bound" apart
+///   from "the splice did not reach it".
+world socket-echo-plugin {
+    import wasi:sockets/types@0.3.0;
+    import wasi:clocks/monotonic-clock@0.3.0;
+
+    export acme:echo/control@0.1.0;
+    export wasi:cli/run@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/socket-echo-plugin/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/socket-echo-plugin/wkg.toml
@@ -1,0 +1,7 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }
+"acme:echo" = { path = "../acme-echo" }

--- a/crates/wash-runtime/tests/integration_plugin_published_port.rs
+++ b/crates/wash-runtime/tests/integration_plugin_published_port.rs
@@ -1,0 +1,203 @@
+//! A host component plugin listens on a real port.
+//!
+//! The `socket-echo-plugin` fixture binds `127.0.0.1:50051` inside its own
+//! private virtual loopback from `wasi:cli/run` and echoes. Nothing can reach
+//! that listener on its own — the host publishes a real port and splices
+//! accepted connections into it.
+//!
+//! What these tests pin, beyond "bytes move":
+//!   - publishing is refused unless the host opted in, rather than silently
+//!     leaving a declared port unexposed
+//!   - a connection arriving before the plugin's accept loop is up is held
+//!     through the readiness window instead of being reset
+//!   - two plugins claiming one real port is a start failure naming both
+//!
+//! That the guest is handed the *real* external peer address is asserted in
+//! `host::ports`'s own tests, where the accepted connection is inspectable —
+//! the echo fixture has no way to report what it saw.
+
+#![cfg(feature = "host-component-plugins")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpListener, TcpStream};
+
+use wash_runtime::host::HostApi;
+use wash_runtime::host::declared_port::{DeclaredPort, Protocol};
+use wash_runtime::host::ports::{PortTable, PublishConfig};
+
+mod common;
+use common::start_bare_host_with_plugin_ports;
+
+const SOCKET_ECHO_PLUGIN_WASM: &[u8] = include_bytes!("wasm/socket_echo_plugin.wasm");
+
+/// The port the fixture binds inside its own virtual network.
+const ECHO_VIRTUAL_PORT: u16 = 50051;
+
+/// Reserve a free TCP port by binding and releasing it, so a test can declare a
+/// concrete `publish` number without colliding with a parallel test.
+async fn free_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+fn published(port: u16) -> DeclaredPort {
+    DeclaredPort {
+        name: "echo".into(),
+        port: ECHO_VIRTUAL_PORT,
+        protocol: Protocol::Tcp,
+        publish: Some(port),
+        bind: None,
+    }
+}
+
+/// Build a host running the echo plugin with `ports` declared, under `config`.
+async fn start_host_with_echo_plugin(
+    ports: Vec<DeclaredPort>,
+    config: PublishConfig,
+    table: Arc<PortTable>,
+) -> Result<impl HostApi> {
+    start_bare_host_with_plugin_ports(
+        "socket-echo-plugin",
+        SOCKET_ECHO_PLUGIN_WASM,
+        ports,
+        config,
+        table,
+    )
+    .await
+}
+
+fn enabled_config() -> PublishConfig {
+    PublishConfig {
+        enabled: true,
+        readiness_timeout: Duration::from_secs(10),
+        ..Default::default()
+    }
+}
+
+/// Round-trip real bytes, external client through the splice to a wasm plugin's
+/// virtual listener and back.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_published_plugin_port_echoes_for_an_external_client() -> Result<()> {
+    let port = free_port().await?;
+    let _host =
+        start_host_with_echo_plugin(vec![published(port)], enabled_config(), PortTable::new())
+            .await?;
+
+    let real_addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse()?;
+    let mut client = tokio::time::timeout(Duration::from_secs(10), TcpStream::connect(real_addr))
+        .await
+        .context("connecting to the published port timed out")??;
+
+    client.write_all(b"hello splice").await?;
+    let mut buf = vec![0u8; b"hello splice".len()];
+    tokio::time::timeout(Duration::from_secs(10), client.read_exact(&mut buf))
+        .await
+        .context("waiting for the plugin's echo timed out")??;
+    assert_eq!(&buf, b"hello splice");
+
+    Ok(())
+}
+
+/// The plugin's listener is registered from its run loop, so it does not exist
+/// when `start()` returns. A client connecting immediately must be held, not
+/// reset — that interval reopens on every supervised restart, so getting it
+/// wrong shows up as flaky first requests after every deploy.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_client_arriving_before_the_accept_loop_is_held_not_reset() -> Result<()> {
+    let port = free_port().await?;
+    let table = PortTable::new();
+    let host = start_host_with_echo_plugin(vec![published(port)], enabled_config(), table).await;
+
+    // Connect as early as possible — ideally before the plugin's `cli/run` has
+    // reached its `bind`.
+    let real_addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse()?;
+    let mut client = TcpStream::connect(real_addr)
+        .await
+        .context("the real port should accept before the guest listener exists")?;
+    let _host = host?;
+
+    client.write_all(b"early").await?;
+    let mut buf = vec![0u8; 5];
+    tokio::time::timeout(Duration::from_secs(10), client.read_exact(&mut buf))
+        .await
+        .context("a connection held through the readiness window should still be served")??;
+    assert_eq!(&buf, b"early");
+
+    Ok(())
+}
+
+/// Declaring a published port on a host that did not opt in must fail loudly.
+/// Coming up with the port unexposed would look like success to an operator
+/// whose manifest says otherwise.
+#[tokio::test(flavor = "multi_thread")]
+async fn publishing_without_the_host_flag_fails_the_plugin_start() {
+    let port = free_port().await.unwrap();
+    let err = start_host_with_echo_plugin(
+        vec![published(port)],
+        PublishConfig::default(),
+        PortTable::new(),
+    )
+    .await
+    .map(|_| ())
+    .expect_err("a declared published port must not start on a host that forbids publishing");
+    let err = format!("{err:#}");
+    assert!(err.contains("--publish-ports"), "got: {err}");
+}
+
+/// A port declared without `publish` binds inside the plugin and nothing else:
+/// no reservation, no listener, and no error either.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_declared_but_unpublished_port_exposes_nothing() -> Result<()> {
+    let table = PortTable::new();
+    let declared = DeclaredPort {
+        name: "echo".into(),
+        port: ECHO_VIRTUAL_PORT,
+        protocol: Protocol::Tcp,
+        publish: None,
+        bind: None,
+    };
+    // Publishing is disabled, and this must still start: nothing is exposed.
+    let _host =
+        start_host_with_echo_plugin(vec![declared], PublishConfig::default(), Arc::clone(&table))
+            .await?;
+
+    assert!(
+        !table.is_published(
+            Protocol::Tcp,
+            format!("127.0.0.1:{ECHO_VIRTUAL_PORT}").parse()?
+        ),
+        "an unpublished port must not reserve anything"
+    );
+    Ok(())
+}
+
+/// Two plugins on one host cannot both claim a real port. The point of a single
+/// host-owned table is that this is a start failure naming the other holder,
+/// rather than two listeners that each believe they own the address.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_port_conflict_between_plugins_names_the_other_holder() -> Result<()> {
+    let port = free_port().await?;
+    let table = PortTable::new();
+
+    let _first =
+        start_host_with_echo_plugin(vec![published(port)], enabled_config(), Arc::clone(&table))
+            .await?;
+
+    let err = start_host_with_echo_plugin(vec![published(port)], enabled_config(), table)
+        .await
+        .map(|_| ())
+        .expect_err("the second claim on a published port must fail");
+    let err = format!("{err:#}");
+    assert!(
+        err.contains("already published by") && err.contains("socket-echo-plugin"),
+        "the conflict should name the holder, got: {err}"
+    );
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_workload_published_port.rs
+++ b/crates/wash-runtime/tests/integration_workload_published_port.rs
@@ -1,0 +1,221 @@
+//! A workload's service listens on a real port.
+//!
+//! This is #5352's headline: the service binds `127.0.0.1:N` inside the
+//! workload's virtual loopback exactly as it does today, and the host binds a
+//! real port and splices accepted connections into it. The guest code does not
+//! change.
+//!
+//! It reuses the publisher host component plugins proved out first, so what is
+//! new here is only the declaration path — `service.ports` through the wire —
+//! and that the workload's *shared* virtual network is the splice target.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpListener, TcpStream};
+
+use wash_runtime::engine::Engine;
+use wash_runtime::host::declared_port::{DeclaredPort, Protocol};
+use wash_runtime::host::ports::{PortTable, PublishConfig, PublishContext};
+use wash_runtime::host::{HostApi, HostBuilder};
+use wash_runtime::types::{
+    LocalResources, Service, Workload, WorkloadStartRequest, WorkloadStopRequest,
+};
+
+const SOCKET_ECHO_WASM: &[u8] = include_bytes!("wasm/socket_echo_plugin.wasm");
+
+/// The port the echo fixture binds inside the virtual network. The fixture is
+/// shared with the plugin tests; run as a workload service its `cli/run` export
+/// is the service's long-running work, which is exactly the shape a service has.
+const ECHO_VIRTUAL_PORT: u16 = 50051;
+
+async fn free_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+fn enabled_config() -> PublishConfig {
+    PublishConfig {
+        enabled: true,
+        readiness_timeout: Duration::from_secs(10),
+        ..Default::default()
+    }
+}
+
+async fn start_host(table: Arc<PortTable>, config: PublishConfig) -> Result<impl HostApi> {
+    let engine = Engine::builder().build()?;
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_publish_context(PublishContext::new(table, config))
+        .build()?;
+    host.start().await.context("failed to start host")
+}
+
+fn service_workload(ports: Vec<DeclaredPort>) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "echo-service".to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(SOCKET_ECHO_WASM),
+                local_resources: LocalResources::default(),
+                max_restarts: 0,
+                ports,
+            }),
+            components: vec![],
+            host_interfaces: vec![],
+            volumes: vec![],
+        },
+    }
+}
+
+fn published(host_port: u16) -> DeclaredPort {
+    DeclaredPort {
+        name: "echo".into(),
+        port: ECHO_VIRTUAL_PORT,
+        protocol: Protocol::Tcp,
+        publish: Some(host_port),
+        bind: None,
+    }
+}
+
+/// The headline: an external client reaches a workload's service, and the
+/// service's own code binds nothing but `127.0.0.1`.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_external_client_reaches_a_workload_service() -> Result<()> {
+    let host_port = free_port().await?;
+    let h = start_host(PortTable::new(), enabled_config()).await?;
+    h.workload_start(service_workload(vec![published(host_port)]))
+        .await?;
+
+    let real_addr: std::net::SocketAddr = format!("127.0.0.1:{host_port}").parse()?;
+    let mut client = tokio::time::timeout(Duration::from_secs(10), TcpStream::connect(real_addr))
+        .await
+        .context("connecting to the published port timed out")??;
+
+    client.write_all(b"workload").await?;
+    let mut buf = vec![0u8; b"workload".len()];
+    tokio::time::timeout(Duration::from_secs(10), client.read_exact(&mut buf))
+        .await
+        .context("waiting for the service's echo timed out")??;
+    assert_eq!(&buf, b"workload");
+    Ok(())
+}
+
+/// Stopping the workload closes its listeners and frees the port table entry —
+/// the exposure is revoked with the workload, not left behind.
+#[tokio::test(flavor = "multi_thread")]
+async fn stopping_the_workload_revokes_the_exposure() -> Result<()> {
+    let host_port = free_port().await?;
+    let table = PortTable::new();
+    let h = start_host(Arc::clone(&table), enabled_config()).await?;
+
+    let request = service_workload(vec![published(host_port)]);
+    let workload_id = request.workload_id.clone();
+    h.workload_start(request).await?;
+
+    let real_addr: std::net::SocketAddr = format!("127.0.0.1:{host_port}").parse()?;
+    assert!(table.is_published(Protocol::Tcp, real_addr));
+
+    h.workload_stop(WorkloadStopRequest {
+        workload_id: workload_id.clone(),
+    })
+    .await?;
+
+    assert!(
+        !table.is_published(Protocol::Tcp, real_addr),
+        "stopping a workload must release its port"
+    );
+    Ok(())
+}
+
+/// A declared port with no `publish` is exactly today's behavior: the service
+/// binds it inside the workload and nothing outside can reach it.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_declared_but_unpublished_port_exposes_nothing() -> Result<()> {
+    let table = PortTable::new();
+    // Publishing disabled, and the workload must still start.
+    let h = start_host(Arc::clone(&table), PublishConfig::default()).await?;
+    h.workload_start(service_workload(vec![DeclaredPort {
+        name: "echo".into(),
+        port: ECHO_VIRTUAL_PORT,
+        protocol: Protocol::Tcp,
+        publish: None,
+        bind: None,
+    }]))
+    .await?;
+
+    assert!(!table.is_published(
+        Protocol::Tcp,
+        format!("127.0.0.1:{ECHO_VIRTUAL_PORT}").parse()?
+    ));
+    Ok(())
+}
+
+/// A workload asking to publish on a host that forbids it must fail loudly,
+/// not come up silently unexposed.
+#[tokio::test(flavor = "multi_thread")]
+async fn publishing_without_the_host_flag_fails_the_workload() -> Result<()> {
+    let host_port = free_port().await?;
+    let h = start_host(PortTable::new(), PublishConfig::default()).await?;
+    let response = h
+        .workload_start(service_workload(vec![published(host_port)]))
+        .await?;
+    assert_eq!(
+        response.workload_status.workload_state,
+        wash_runtime::types::WorkloadState::Error,
+        "expected the workload to fail, got: {}",
+        response.workload_status.message
+    );
+    assert!(
+        response.workload_status.message.contains("--publish-ports"),
+        "got: {}",
+        response.workload_status.message
+    );
+    Ok(())
+}
+
+/// A workload and a host component plugin share one port table, so a collision
+/// between them is caught rather than producing two listeners that each believe
+/// they own the address.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_workload_cannot_take_a_port_another_owner_holds() -> Result<()> {
+    let host_port = free_port().await?;
+    let table = PortTable::new();
+    let real_addr: std::net::SocketAddr = format!("127.0.0.1:{host_port}").parse()?;
+
+    // Stand in for another owner already holding the port.
+    let _held = table.reserve(
+        Protocol::Tcp,
+        real_addr,
+        wash_runtime::host::ports::PortOwner::Plugin("gateway".into()),
+    )?;
+
+    let h = start_host(Arc::clone(&table), enabled_config()).await?;
+    let response = h
+        .workload_start(service_workload(vec![published(host_port)]))
+        .await?;
+    assert_eq!(
+        response.workload_status.workload_state,
+        wash_runtime::types::WorkloadState::Error
+    );
+    assert!(
+        response
+            .workload_status
+            .message
+            .contains("host plugin 'gateway'"),
+        "the conflict should name the holder, got: {}",
+        response.workload_status.message
+    );
+    Ok(())
+}

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -327,6 +327,24 @@ impl CliCommand for DevCommand {
             debug!("WASI WebGPU plugin registered");
         }
 
+        // One table across every plugin *and* the workload's own service, so
+        // two declarations claiming the same real port is a start failure
+        // naming both rather than a race decided by start order.
+        //
+        // Publishing is on by default in the dev path, unlike `wash host`: a
+        // developer running `wash dev` is already trusting this code, and
+        // needing a flag to reach a port on your own machine is friction with
+        // nothing behind it. The default bind address is loopback, so this
+        // stays off the network regardless.
+        let publish = wash_runtime::host::ports::PublishContext::new(
+            wash_runtime::host::ports::PortTable::new(),
+            wash_runtime::host::ports::PublishConfig {
+                enabled: true,
+                ..Default::default()
+            },
+        );
+        host_builder = host_builder.with_publish_context(publish.clone());
+
         // Host component plugins: WebAssembly components that provide host
         // capabilities, each in its own supervised store. Fetched (local file or
         // OCI) and registered before the host starts — last, so every native
@@ -345,7 +363,7 @@ impl CliCommand for DevCommand {
                     oci_config.clone(),
                     &native_plugins,
                     http_handler.clone(),
-                    None,
+                    Some(publish.clone()),
                 )
                 .await
                 .with_context(|| format!("failed to load host component plugin '{}'", spec.id))?;
@@ -605,6 +623,7 @@ fn build_workload(
         ..Default::default()
     };
 
+    let service_ports = &dev_config.service_ports;
     let mut service: Option<Service> = None;
     let mut components = Vec::new();
     if dev_config.service {
@@ -613,7 +632,7 @@ fn build_workload(
             digest: None,
             max_restarts: 0,
             local_resources: local_resources_for(resolved_workload),
-            ports: Vec::new(),
+            ports: service_ports.to_vec(),
         })
     } else {
         components.push(Component {
@@ -632,7 +651,7 @@ fn build_workload(
                 digest: None,
                 max_restarts: 0,
                 local_resources: local_resources_for(resolved_workload),
-                ports: Vec::new(),
+                ports: service_ports.to_vec(),
             });
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -131,6 +131,7 @@ const P3_FIXTURES: &[&str] = &[
     "bridge-service",
     "http-webgpu",
     "kv-plugin",
+    "socket-echo-plugin",
     "kv-plugin-caller",
     "kv-plugin-service",
     "badlifecycle",


### PR DESCRIPTION
Closes #5352. Two commits, best reviewed in order.

### 1. `feat: let a host component plugin publish a port`

Plugins publish before workloads, for two reasons.

**The trust surface is already the operator's.** A plugin spec comes from `wash host --host-plugin` or `host.hostPlugins` — the same surface as `--http-addr` — so publishing a port for code the operator already chose to run host-wide is strictly less privilege than the unrestricted outbound connect that code has today. A workload's ports, by contrast, come from a tenant.

**There is no scheduling story to invent.** One plugin instance per host, ports declared at host start, conflicts detected deterministically at boot. No allocation, no capability advertisement, no `Service` object.

A plugin may bind its own virtual loopback unconditionally — that network is private and reaches nothing until a publish exists, so gating it buys no safety and costs local development. Beyond that it binds only an address the operator declared, matched exactly. Direct mode requires a **concrete** address: allowing the unspecified one would drag in the `Unspecified` socket machinery and put the plugin author, rather than the operator, in charge of which interface is exposed.

### 2. `feat: publish a workload service's declared ports`

A workload declares ports on its service and the host binds the real ones, reusing the publisher the plugin path proved. A port declared without `publish` reserves and binds nothing — the service still binds it inside the workload's virtual network, which is exactly today's behavior.

This is the arm that needed the socket egress policy first: a workload's published port punches through tenant isolation in a way a plugin's does not, since a co-tenant can reach it by dialing the host. The host-owned port check that refuses exactly that lands in PR 2.

Listeners hang off `ResolvedWorkload` behind an `Arc` so they close when the last clone drops — that is what makes stopping a workload release its ports rather than leaking them to whichever clone outlived the others.

Unlike a plugin's, a workload's virtual network is **pinned** rather than replaced per incarnation: it is shared with the workload's components, and that sharing is what lets a component dial its own service.

### What this costs, stated plainly

- A published port is externally drivable compute while `memory_limit_mb` and `cpu_limit` are still unenforced. Per-port connection caps and the owner's `inbound` quota are the only controls.
- A raw TCP peer carries no host-asserted `workload_id`. A plugin or service handling both a capability interface and a raw port **must not infer tenant identity from the socket** — authentication has to come from the protocol (mTLS, tokens).

### Authoring gotcha worth knowing

A loopback accept loop only delivers when awaited from the `cli/run` task. A guest that spawns its accept loop silently never accepts.

### Stack

4 of 4, based on `feat/internal-zone-and-ports`.
