### PR TITLE
feat(runtime): host component call a workload's exports

### DIFF
--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -167,6 +167,15 @@ fn type_is_ephemeral_safe(ty: &Type) -> bool {
     !carries_cross_store_handle(ty)
 }
 
+/// Whether every one of `tys` is a plain value, so a call carrying them copies
+/// cleanly into an ephemeral store. The type-list form of
+/// [`func_is_ephemeral_safe`], for a caller holding params and results
+/// separately rather than as one [`ComponentFunc`].
+#[cfg(feature = "host-component-plugins")]
+pub(crate) fn types_are_ephemeral_safe(tys: &[Type]) -> bool {
+    tys.iter().all(type_is_ephemeral_safe)
+}
+
 pub(crate) fn func_is_ephemeral_safe(func_ty: &ComponentFunc) -> bool {
     func_ty.params().all(|(_, ty)| type_is_ephemeral_safe(&ty))
         && func_ty.results().all(|ty| type_is_ephemeral_safe(&ty))
@@ -206,6 +215,14 @@ fn type_is_bridge_safe(ty: &Type) -> bool {
         // resource (own/borrow) / error-context: not relocatable here.
         _ => false,
     }
+}
+
+/// Whether every one of `tys` is [`type_is_bridge_safe`]. The type-list form of
+/// [`func_is_bridge_safe`], for a caller holding params and results separately
+/// rather than as one [`ComponentFunc`].
+#[cfg(feature = "host-component-plugins")]
+pub(crate) fn types_are_bridge_safe(tys: &[Type]) -> bool {
+    tys.iter().all(type_is_bridge_safe)
 }
 
 /// Whether every param/result of `func_ty` is [`type_is_bridge_safe`], so a call

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -221,7 +221,7 @@ pub mod ctx;
 pub(crate) mod instance_driver;
 pub(crate) mod instance_pool;
 pub use instance_pool::InstancePolicy;
-mod linked_call;
+pub(crate) mod linked_call;
 pub(crate) mod store;
 mod value;
 mod volumes;

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -2066,6 +2066,16 @@ impl UnresolvedWorkload {
 
         trace!(host_interfaces = ?host_interfaces, "determining missing guest interfaces");
 
+        // A workload serves itself before the host does. Every component's world
+        // up front, so an interface one component imports and another exports can
+        // be recognised as already answered from inside the workload — see
+        // [`served_within_workload`].
+        let component_worlds: Vec<(Arc<str>, WitWorld)> = self
+            .components
+            .iter()
+            .map(|(id, component)| (id.clone(), component.world()))
+            .collect();
+
         if let Some(service) = self.service.as_ref() {
             let world = service.world();
 
@@ -2073,6 +2083,9 @@ impl UnresolvedWorkload {
             let required_interfaces: HashSet<WitInterface> = host_interfaces
                 .iter()
                 .filter(|wit_interface| world.includes_bidirectional(wit_interface))
+                .filter(|wit_interface| {
+                    !served_within_workload(wit_interface, service.id(), &world, &component_worlds)
+                })
                 .cloned()
                 .collect();
 
@@ -2084,12 +2097,14 @@ impl UnresolvedWorkload {
             }
         }
 
-        for (id, workload_component) in &self.components {
-            let world = workload_component.world();
+        for (id, world) in &component_worlds {
             trace!(?world, "comparing component world to host interfaces");
             let required_interfaces: HashSet<WitInterface> = host_interfaces
                 .iter()
                 .filter(|wit_interface| world.includes_bidirectional(wit_interface))
+                .filter(|wit_interface| {
+                    !served_within_workload(wit_interface, id, world, &component_worlds)
+                })
                 .cloned()
                 .collect();
 
@@ -2580,6 +2595,61 @@ fn build_export_map(
     (interface_map, ambiguous)
 }
 
+/// Whether the workload answers `entry` for `item_id` out of its own
+/// components, so the host is never asked for it: `item_id` imports every one of
+/// the entry's interfaces, and each is exported by exactly one *other* component
+/// of the same workload.
+///
+/// Such an import is wired component-to-component by
+/// [`ResolvedWorkload::link_components`]. Keeping it away from plugin matching
+/// is what makes the workload's own component win, because whoever matches first
+/// installs the shim: plugins bind before components are linked, and a plugin
+/// that claimed the interface leaves the intra-workload link with nowhere to go
+/// — the linker instance is already defined, the link is skipped, and calls
+/// silently leave the workload for the plugin.
+///
+/// Only the *importing* side is filtered. A component that exports the interface
+/// keeps the entry, because an export is also how the host reaches into a
+/// workload — a `wasi:http` handler, a messaging handler, an interface a host
+/// component plugin calls — and where an import points is a separate question
+/// from whether the host may call an export.
+///
+/// Exactly one other exporter, not at least one: two exporters are the ambiguity
+/// [`build_export_map`] declines to resolve, and leaving those to a plugin keeps
+/// a workload that deploys today deploying.
+fn served_within_workload(
+    entry: &WitInterface,
+    item_id: &str,
+    item_world: &WitWorld,
+    component_worlds: &[(Arc<str>, WitWorld)],
+) -> bool {
+    // An entry naming no interface matches every interface of its package, so
+    // there is nothing specific to have found a provider for.
+    if entry.interfaces.is_empty() {
+        return false;
+    }
+    entry.interfaces.iter().all(|interface| {
+        let imported = item_world
+            .imports
+            .iter()
+            .any(|im| entry.same_package(im) && im.interfaces.contains(interface));
+        if !imported {
+            return false;
+        }
+        let exporters = component_worlds
+            .iter()
+            .filter(|(id, world)| {
+                id.as_ref() != item_id
+                    && world
+                        .exports
+                        .iter()
+                        .any(|ex| entry.same_package(ex) && ex.interfaces.contains(interface))
+            })
+            .count();
+        exporters == 1
+    })
+}
+
 /// Returns whether some *other* registered plugin (not `self_id`) with
 /// `supports_named_instances() == want_named` can serve `iface`.
 /// Used to determine whether a plugin can defer an `(implements ..)`
@@ -2877,6 +2947,141 @@ mod tests {
             Arc::default(),
             InstancePolicy::Ephemeral,
         )
+    }
+
+    /// A component built from WAT, so a test can state an exact import/export
+    /// shape rather than take whatever a fixture happens to have.
+    fn component_from_wat(id: &str, wat: &str) -> WorkloadComponent {
+        let engine = wasmtime::Engine::default();
+        let linker = Linker::new(&engine);
+        let wasm = wat::parse_str(wat).expect("failed to parse WAT");
+        let component = Component::new(&engine, &wasm).expect("failed to compile");
+
+        WorkloadComponent::new(
+            "workload-local-first".to_string(),
+            "test-workload".to_string(),
+            "test-namespace".to_string(),
+            id.to_string(),
+            component,
+            linker,
+            Vec::new(),
+            LocalResources::default(),
+            Arc::default(),
+            InstancePolicy::Ephemeral,
+        )
+    }
+
+    const MARKER: &str = "test:probe/marker@0.1.0";
+
+    fn marker_importer(id: &str) -> WorkloadComponent {
+        component_from_wat(
+            id,
+            &format!(r#"(component (import "{MARKER}" (instance)))"#),
+        )
+    }
+
+    fn marker_exporter(id: &str) -> WorkloadComponent {
+        component_from_wat(
+            id,
+            &format!(r#"(component (instance $marker) (export "{MARKER}" (instance $marker)))"#),
+        )
+    }
+
+    fn marker_workload(components: Vec<WorkloadComponent>) -> UnresolvedWorkload {
+        UnresolvedWorkload::new(
+            "local-first".to_string(),
+            "local-first".to_string(),
+            "test-namespace".to_string(),
+            None,
+            components,
+            vec![WitInterface::from(MARKER)],
+        )
+    }
+
+    fn marker_plugin() -> HashMap<&'static str, Arc<dyn HostPlugin>> {
+        let plugin = Arc::new(MockPlugin::new(
+            "marker-plugin",
+            vec![],
+            vec![WitInterface::from(MARKER)],
+        ));
+        HashMap::from([(plugin.id(), plugin as Arc<dyn HostPlugin>)])
+    }
+
+    /// Every component id `bind_plugins` reported as bound. Ids are fresh
+    /// UUIDs, so a test compares against the ones it captured, not the names it
+    /// gave.
+    fn bound_component_ids(
+        bound: &[(Arc<dyn HostPlugin + 'static>, Vec<String>)],
+    ) -> HashSet<String> {
+        bound
+            .iter()
+            .flat_map(|(_, ids)| ids.iter().cloned())
+            .collect()
+    }
+
+    /// A workload serves itself first: an interface one component imports and
+    /// another exports is linked component-to-component, so the importer is not
+    /// bound to the plugin that also offers it. Whoever matches installs the
+    /// shim, and plugins match before components are linked — so without this
+    /// the plugin would take the import and the sibling's export would go
+    /// unused, silently.
+    #[tokio::test]
+    async fn a_sibling_export_wins_over_a_plugin() {
+        let importer = marker_importer("importer");
+        let exporter = marker_exporter("exporter");
+        let importer_id = importer.id().to_string();
+        let exporter_id = exporter.id().to_string();
+
+        let mut workload = marker_workload(vec![importer, exporter]);
+        let bound = workload.bind_plugins(&marker_plugin()).await.unwrap();
+        let bound_ids = bound_component_ids(&bound);
+
+        assert!(
+            !bound_ids.contains(&importer_id),
+            "the importer should link to its sibling, not bind the plugin"
+        );
+        assert!(
+            bound_ids.contains(&exporter_id),
+            "the exporter still binds, because an export is how a host reaches into a workload"
+        );
+    }
+
+    /// The control: with no sibling exporting it, the same import binds the
+    /// plugin as before. Without this the test above would pass for a workload
+    /// that simply never matched anything.
+    #[tokio::test]
+    async fn a_lone_importer_still_binds_the_plugin() {
+        let importer = marker_importer("importer");
+        let importer_id = importer.id().to_string();
+
+        let mut workload = marker_workload(vec![importer]);
+        let bound = workload.bind_plugins(&marker_plugin()).await.unwrap();
+
+        assert!(
+            bound_component_ids(&bound).contains(&importer_id),
+            "with nothing in the workload exporting it, the plugin serves the import"
+        );
+    }
+
+    /// Two components exporting the same interface is the ambiguity
+    /// `build_export_map` declines to resolve, so the import is left to the
+    /// plugin rather than failing a workload that deploys today.
+    #[tokio::test]
+    async fn two_sibling_exporters_leave_the_import_to_the_plugin() {
+        let importer = marker_importer("importer");
+        let importer_id = importer.id().to_string();
+
+        let mut workload = marker_workload(vec![
+            importer,
+            marker_exporter("exporter-a"),
+            marker_exporter("exporter-b"),
+        ]);
+        let bound = workload.bind_plugins(&marker_plugin()).await.unwrap();
+
+        assert!(
+            bound_component_ids(&bound).contains(&importer_id),
+            "an ambiguous sibling export is not a provider, so the plugin keeps the import"
+        );
     }
 
     /// A host-dispatched export (like the `wasi:http` entrypoint) must go to

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -48,6 +48,35 @@ pub(crate) struct ExternalCallFunc<'a> {
     pub(crate) result_tys: &'a [wasmtime::component::types::Type],
 }
 
+/// What [`ResolvedWorkload::item_exporting`] found about the one item it was
+/// asked about: whether that item exports an interface a host component plugin
+/// imports, and — for a component, the only kind a plugin can call — how to
+/// address the export.
+#[cfg(feature = "host-component-plugins")]
+pub(crate) enum ItemExport {
+    /// A component exports it.
+    Component {
+        /// The component's manifest name, for the tie-break when two of them
+        /// export the same interface.
+        name: Arc<str>,
+        /// The component's own name for the export, which is what addresses it
+        /// on the instance. Not necessarily the plugin's name for the import:
+        /// matching tolerates one side omitting the version, so a plugin whose
+        /// package is unversioned can be satisfied by a versioned export. The
+        /// matched name has to travel with the answer, or looking the export up
+        /// by the plugin's name misses it.
+        export: Arc<str>,
+    },
+    /// The workload's long-lived service exports it. A plugin cannot call it:
+    /// reaching the *running* service means routing into its live instance, the
+    /// way inbound messaging does, and a call built like a component's would
+    /// instead instantiate a second copy whose state is not the one the service
+    /// has been accumulating.
+    Service,
+    /// Neither — this item bound to the plugin for a capability it imports.
+    None,
+}
+
 /// Type alias for tracking bound plugins with their matched interfaces during binding.
 /// Tuple: (plugin, matched_interfaces, component_ids)
 type BoundPluginWithInterfaces = (
@@ -1591,24 +1620,52 @@ impl ResolvedWorkload {
         Ok(pre)
     }
 
-    /// Whether `component_id` exports `interface`, and its manifest name — what
-    /// a host component plugin checks before claiming the component as the one
-    /// serving an interface the plugin imports, and the tie-break when two
-    /// components of the workload export the same one.
+    /// Which item of the workload exports `interface` — what a host component
+    /// plugin checks before claiming one as the item serving an interface it
+    /// imports.
     #[cfg(feature = "host-component-plugins")]
-    pub(crate) async fn component_exporting(
+    pub(crate) async fn item_exporting(
         &self,
-        component_id: &str,
+        item_id: &str,
         interface: &WitInterface,
-    ) -> Option<Arc<str>> {
+    ) -> ItemExport {
+        let exports = |world: &WitWorld| world.exports.iter().any(|e| e.contains(interface));
+        // A workload's long-lived service is bound as an item like any
+        // component, and `bind_plugins` hands its id here the same way, but it
+        // lives outside the component map — so check it explicitly rather than
+        // letting the lookup below miss and read as "exports nothing".
+        if let Some(service) = &self.service
+            && service.id() == item_id
+        {
+            return if exports(&service.world()) {
+                ItemExport::Service
+            } else {
+                ItemExport::None
+            };
+        }
         let components = self.components.read().await;
-        let component = components.get(component_id)?;
-        component
-            .world()
-            .exports
-            .iter()
-            .any(|exported| exported.contains(interface))
-            .then(|| Arc::from(component.name()))
+        let Some(component) = components.get(item_id) else {
+            return ItemExport::None;
+        };
+        // The export's own name, not the plugin's name for the import: the two
+        // agree except where matching tolerated a version on one side only, and
+        // addressing the instance needs the name the component actually used.
+        let Some(export) = component
+            .component_exports()
+            .ok()
+            .and_then(|exports| {
+                exports
+                    .into_iter()
+                    .find(|(name, _)| WitInterface::from(name.as_str()).contains(interface))
+            })
+            .map(|(name, _)| Arc::from(name))
+        else {
+            return ItemExport::None;
+        };
+        ItemExport::Component {
+            name: Arc::from(component.name()),
+            export,
+        }
     }
 
     /// Build the invocations a host component plugin uses to call `interface`
@@ -1618,10 +1675,17 @@ impl ResolvedWorkload {
     /// A plugin runs in a store of its own, so such a call can never share one
     /// with the callee: every invocation returned takes the ephemeral path,
     /// which builds a store for the callee per call (or reuses one of its warm
-    /// instances) and moves arguments and results across the boundary. A
-    /// signature carrying a `resource` or `error-context` handle cannot cross
-    /// that boundary and is rejected here, when the workload deploys, rather
-    /// than on the call.
+    /// instances) and moves arguments and results across the boundary.
+    ///
+    /// A function the callee does not export, or whose signature carries a
+    /// `resource` or `error-context` handle that cannot cross, fails the
+    /// workload's deploy. The alternative — installing a partial route and
+    /// letting the omitted function error when called — moves the failure onto
+    /// the plugin's call path, where an error has nowhere to go: a
+    /// workload-exported import has no error result, so the host returning one
+    /// traps the plugin guest and restarts the store every tenant shares. One
+    /// workload failing to deploy over a WIT its plugin disagrees with is the
+    /// contained outcome.
     #[cfg(feature = "host-component-plugins")]
     pub(crate) async fn external_export_invocations(
         &self,
@@ -1660,7 +1724,9 @@ impl ResolvedWorkload {
                 component.get_export(Some(&instance_idx), func.name)
             else {
                 bail!(
-                    "{interface} of component '{component_id}' does not export {}",
+                    "component '{component_id}' exports {interface} but not {}, which a host \
+                     component plugin imports; the workload's copy of the interface disagrees \
+                     with the plugin's",
                     func.name
                 );
             };
@@ -1677,9 +1743,9 @@ impl ResolvedWorkload {
                 }
             } else {
                 bail!(
-                    "{interface}#{} carries a handle that cannot cross a store boundary; a host \
-                     component plugin can call a workload export only when its parameters and \
-                     results are plain values, `stream<T>`, or `future<T>`",
+                    "{interface}#{} carries a handle that cannot cross the boundary between a \
+                     plugin's store and a workload's; only plain values, `stream<T>`, and \
+                     `future<T>` can",
                     func.name
                 );
             };
@@ -2034,8 +2100,17 @@ impl UnresolvedWorkload {
 
         trace!(?unmatched_interfaces, "resolving unmatched interfaces");
 
-        // Iterate through each plugin first, then check every component for matching worlds
-        for (plugin_id, p) in plugins.iter() {
+        // Iterate through each plugin first, then check every component for matching worlds.
+        //
+        // In plugin-id order, not `HashMap` order: where two plugins both match
+        // an interface the first one reached claims it, because a matched
+        // interface leaves `unmatched_interfaces` once its item bind succeeds.
+        // Leaving that to hash iteration makes the same manifest bind
+        // differently across process restarts — and with a plugin that *calls*
+        // an interface rather than serving it, one of those outcomes fails the
+        // deploy. A deterministic order at least makes the result reproducible.
+        let plugins_in_order: BTreeMap<_, _> = plugins.iter().collect();
+        for (plugin_id, p) in plugins_in_order {
             let plugin_interfaces = p.world();
             trace!(plugin_id = plugin_id, plugin_interfaces = ?plugin_interfaces, "checking plugin interfaces");
 

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -19,6 +19,8 @@ use wasmtime_wasi::p2::bindings::CommandPre;
 
 #[cfg(feature = "wasi-tls")]
 use crate::engine::ctx::SharedTlsProvider;
+#[cfg(feature = "host-component-plugins")]
+use crate::engine::linked_call::{types_are_bridge_safe, types_are_ephemeral_safe};
 use crate::{
     engine::{
         ctx::SharedCtx,
@@ -34,6 +36,17 @@ use crate::{
     types::{LocalResources, VolumeMount},
     wit::{WitInterface, WitWorld},
 };
+
+/// One function of an interface a host component plugin imports, named and
+/// typed as the plugin's own component type declares it. The types are what
+/// [`ResolvedWorkload::external_export_invocations`] classifies to decide how a
+/// call's arguments and results cross the store boundary.
+#[cfg(feature = "host-component-plugins")]
+pub(crate) struct ExternalCallFunc<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) param_tys: &'a [wasmtime::component::types::Type],
+    pub(crate) result_tys: &'a [wasmtime::component::types::Type],
+}
 
 /// Type alias for tracking bound plugins with their matched interfaces during binding.
 /// Tuple: (plugin, matched_interfaces, component_ids)
@@ -1576,6 +1589,123 @@ impl ResolvedWorkload {
         let pre = linker.instantiate_pre(&wasmtime_component)?;
 
         Ok(pre)
+    }
+
+    /// Whether `component_id` exports `interface`, and its manifest name — what
+    /// a host component plugin checks before claiming the component as the one
+    /// serving an interface the plugin imports, and the tie-break when two
+    /// components of the workload export the same one.
+    #[cfg(feature = "host-component-plugins")]
+    pub(crate) async fn component_exporting(
+        &self,
+        component_id: &str,
+        interface: &WitInterface,
+    ) -> Option<Arc<str>> {
+        let components = self.components.read().await;
+        let component = components.get(component_id)?;
+        component
+            .world()
+            .exports
+            .iter()
+            .any(|exported| exported.contains(interface))
+            .then(|| Arc::from(component.name()))
+    }
+
+    /// Build the invocations a host component plugin uses to call `interface`
+    /// on `component_id`'s export — the reverse of the capability direction,
+    /// where the plugin serves what a workload imports.
+    ///
+    /// A plugin runs in a store of its own, so such a call can never share one
+    /// with the callee: every invocation returned takes the ephemeral path,
+    /// which builds a store for the callee per call (or reuses one of its warm
+    /// instances) and moves arguments and results across the boundary. A
+    /// signature carrying a `resource` or `error-context` handle cannot cross
+    /// that boundary and is rejected here, when the workload deploys, rather
+    /// than on the call.
+    #[cfg(feature = "host-component-plugins")]
+    pub(crate) async fn external_export_invocations(
+        &self,
+        component_id: &str,
+        interface: &str,
+        funcs: &[ExternalCallFunc<'_>],
+    ) -> anyhow::Result<BTreeMap<Arc<str>, LinkedExportInvocation>> {
+        let (component, engine, linked_component_ids) = {
+            let components = self.components.read().await;
+            let component = components
+                .get(component_id)
+                .context("component ID not found in workload")?;
+            (
+                component.metadata.component.clone(),
+                component.metadata.engine().clone(),
+                component
+                    .metadata
+                    .linked_components
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            )
+        };
+        let Some((ComponentItem::ComponentInstance(_), instance_idx)) =
+            component.get_export(None, interface)
+        else {
+            bail!("component '{component_id}' does not export {interface}");
+        };
+        // Taken after the read guard above is dropped: this needs the write lock.
+        let pre = self.instantiate_pre(component_id).await?;
+        let component_id: Arc<str> = Arc::from(component_id);
+
+        let mut invocations = BTreeMap::new();
+        for func in funcs {
+            let Some((ComponentItem::ComponentFunc(_), func_idx)) =
+                component.get_export(Some(&instance_idx), func.name)
+            else {
+                bail!(
+                    "{interface} of component '{component_id}' does not export {}",
+                    func.name
+                );
+            };
+            let mode = if types_are_ephemeral_safe(func.param_tys)
+                && types_are_ephemeral_safe(func.result_tys)
+            {
+                EphemeralCallMode::PlainValue
+            } else if types_are_bridge_safe(func.param_tys)
+                && types_are_bridge_safe(func.result_tys)
+            {
+                EphemeralCallMode::Relocated {
+                    param_tys: func.param_tys.into(),
+                    result_tys: func.result_tys.into(),
+                }
+            } else {
+                bail!(
+                    "{interface}#{} carries a handle that cannot cross a store boundary; a host \
+                     component plugin can call a workload export only when its parameters and \
+                     results are plain values, `stream<T>`, or `future<T>`",
+                    func.name
+                );
+            };
+            invocations.insert(
+                Arc::from(func.name),
+                LinkedExportInvocation {
+                    import_name: Arc::from(interface),
+                    export_name: Arc::from(func.name),
+                    pre: pre.clone(),
+                    plugin_component_id: Arc::clone(&component_id),
+                    func_idx,
+                    param_tys: Arc::default(),
+                    ephemeral_call: Some(Arc::new(EphemeralLinkedCall {
+                        engine: engine.clone(),
+                        http_handler: self.http_handler.clone(),
+                        components: self.components.clone(),
+                        active_component_id: Arc::clone(&component_id),
+                        linked_component_ids: linked_component_ids.clone(),
+                        #[cfg(feature = "wasi-tls")]
+                        tls_provider: self.tls_provider.clone(),
+                        mode,
+                    })),
+                },
+            );
+        }
+        Ok(invocations)
     }
 
     /// Unbind all plugins from all components in this workload.

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -154,25 +154,80 @@ impl<T: HostApi> HostApi for Arc<T> {
     }
 }
 
+/// A claim on one workload id, minted whenever a task takes responsibility for
+/// that id and never reused within a host.
+///
+/// Both states a task has to leave behind while it works outside the map's lock
+/// carry one, so the task can tell its own slot from a slot a *later* workload
+/// claimed under the same id: a start reserves the id before building anything,
+/// and a teardown marks the id while it releases. Every write back into the map
+/// is conditional on the slot still holding the writer's own reservation.
+pub type Reservation = u64;
+
 /// Internal representation of a workload's state within the host.
 ///
 /// This enum tracks the lifecycle stages of a workload from starting
 /// through running to stopping or error states.
 #[derive(Debug, Clone)]
 pub enum HostWorkload {
-    Starting,
+    /// A start holds the id and is building the workload. The [`Reservation`]
+    /// is that start's.
+    Starting(Reservation),
     // Boxed to reduce size of the enum
     Running(Box<ResolvedWorkload>),
-    Stopping,
+    /// The workload is being torn down, and the id stays reserved until whoever
+    /// owns that teardown finishes it. The [`Reservation`] names the owner: the
+    /// stop or failure that took the workload out of the map, or — when a stop
+    /// arrived while the workload was still starting — the start that has yet
+    /// to hand its work over.
+    Stopping(Reservation),
     Error(String),
+}
+
+/// Give back everything binding a workload allocated: its service, then its
+/// plugins.
+///
+/// Every path that lets go of a bound workload goes through here — a start that
+/// failed after binding, a start that lost its slot to a concurrent stop, a
+/// plugin failing a running workload, and an ordinary stop. Tolerates a
+/// workload that never fully started: both steps have nothing to do when there
+/// is nothing to undo.
+///
+/// Which slot in the workload map may be written, and by whom, is what keeps
+/// this safe to run outside the map's lock: `unbind_all_plugins` is keyed by
+/// workload id, so the id must stay reserved until this returns or a new
+/// workload could claim it and be torn down by someone else's teardown. Every
+/// caller therefore leaves a [`HostWorkload::Stopping`] carrying its own
+/// [`Reservation`] over the whole call. See [`HostApi::workload_stop`] for the
+/// ownership rules that guarantee it.
+async fn release(workload_id: &str, resolved: &ResolvedWorkload) {
+    resolved.stop_service();
+    if let Err(e) = resolved.unbind_all_plugins().await {
+        warn!(
+            workload_id,
+            error = ?e,
+            "error unbinding plugins during teardown, continuing"
+        );
+    }
+}
+
+/// What a stop does to the slot it found, decided before anything is written.
+enum StopAction {
+    /// Mark the id `Stopping` under this reservation, holding it for the
+    /// teardown that follows.
+    Mark(Reservation),
+    /// Leave the slot to whoever already owns it.
+    Leave,
+    /// Drop the id: there is nothing bound behind it.
+    Drop,
 }
 
 impl std::fmt::Display for HostWorkload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            HostWorkload::Starting => write!(f, "Starting"),
+            HostWorkload::Starting(_) => write!(f, "Starting"),
             HostWorkload::Running(_) => write!(f, "Running"),
-            HostWorkload::Stopping => write!(f, "Stopping"),
+            HostWorkload::Stopping(_) => write!(f, "Stopping"),
             HostWorkload::Error(err) => write!(f, "Error: {err}"),
         }
     }
@@ -181,9 +236,9 @@ impl std::fmt::Display for HostWorkload {
 impl From<&HostWorkload> for WorkloadState {
     fn from(hw: &HostWorkload) -> Self {
         match hw {
-            HostWorkload::Starting => WorkloadState::Starting,
+            HostWorkload::Starting(_) => WorkloadState::Starting,
             HostWorkload::Running(_) => WorkloadState::Running,
-            HostWorkload::Stopping => WorkloadState::Stopping,
+            HostWorkload::Stopping(_) => WorkloadState::Stopping,
             HostWorkload::Error(_) => WorkloadState::Error,
         }
     }
@@ -200,6 +255,10 @@ pub struct Host {
     engine: Engine,
     /// Workloads mapped from ID to the workload and its current state
     workloads: Arc<RwLock<HashMap<String, HostWorkload>>>,
+    /// Source of the [`Reservation`] a start or a teardown stamps on the slot it
+    /// owns. Monotonic for the life of the host, so a reservation identifies one
+    /// occupant of a workload id and never a later one.
+    reservations: std::sync::atomic::AtomicU64,
     /// Plugins in a map from their ID to the plugin itself
     plugins: HashMap<&'static str, Arc<dyn HostPlugin>>,
     /// Host metadata
@@ -364,31 +423,85 @@ impl Host {
         Ok(host)
     }
 
+    /// Mint a fresh [`Reservation`] for a slot this host is about to claim.
+    fn reserve(&self) -> Reservation {
+        self.reservations
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Close out a teardown that marked `workload_id` as
+    /// `Stopping(reservation)`: drop the id, or leave `Some(reason)` behind as
+    /// the workload's `Error` for a later stop to collect.
+    ///
+    /// Conditional on the marker still being this teardown's, because a
+    /// teardown runs outside the map's lock. If the slot holds anything else —
+    /// most of all a *different* workload that claimed the id in the meantime —
+    /// it is not this teardown's to write, and removing it would leave that
+    /// workload running with nothing tracking it.
+    async fn finish_teardown(
+        &self,
+        workload_id: &str,
+        reservation: Reservation,
+        reason: Option<String>,
+    ) {
+        let mut workloads = self.workloads.write().await;
+        if !matches!(workloads.get(workload_id), Some(HostWorkload::Stopping(held)) if *held == reservation)
+        {
+            return;
+        }
+        match reason {
+            Some(reason) => {
+                workloads.insert(workload_id.to_string(), HostWorkload::Error(reason));
+            }
+            None => {
+                workloads.remove(workload_id);
+            }
+        }
+    }
+
     /// Transition a running workload to a failed state on a plugin's report
     /// (e.g. an evicted crash-looping bind): swap it to `Error`, so its status
     /// reports failed, and tear down its resources like a stop would. A workload
     /// that is already gone or not running is left as-is.
     async fn fail_workload(&self, workload_id: &str, reason: String) {
+        // Mark `Stopping` under a reservation of this failure's own rather than
+        // writing `Error` straight away. `Error` is a state a stop frees the id
+        // from, and freeing it here would let a redeploy claim the same id while
+        // `release` — keyed by workload id — is still unbinding, tearing down
+        // the new workload's bindings instead. The reservation is what makes the
+        // marker this failure's: nobody else writes over it, and the `Error`
+        // below lands only if it is still there.
+        let reservation = self.reserve();
         let resolved = {
             let mut workloads = self.workloads.write().await;
             match workloads.get_mut(workload_id) {
-                Some(slot) => {
-                    let previous = std::mem::replace(slot, HostWorkload::Error(reason.clone()));
-                    match previous {
+                Some(slot @ HostWorkload::Running(_)) => {
+                    match std::mem::replace(slot, HostWorkload::Stopping(reservation)) {
                         HostWorkload::Running(rw) => Some(*rw),
-                        // Not running (starting/stopping/already error): leave the
-                        // Error we just wrote, nothing to tear down.
+                        // Just matched on it.
                         _ => None,
                     }
                 }
-                None => None,
+                // Still starting: no teardown follows here, because the start
+                // owns everything it has built. Recording the failure now is
+                // what tells it its slot is gone, so it releases what it bound
+                // and leaves this `Error` for a stop to collect.
+                Some(slot @ HostWorkload::Starting(_)) => {
+                    *slot = HostWorkload::Error(reason.clone());
+                    None
+                }
+                // Already being torn down, already failed, or gone: the workload
+                // is on its way out either way, and the slot belongs to whoever
+                // is finishing it.
+                Some(HostWorkload::Stopping(_) | HostWorkload::Error(_)) | None => None,
             }
         };
         if let Some(resolved) = resolved {
-            resolved.stop_service();
-            if let Err(e) = resolved.unbind_all_plugins().await {
-                warn!(workload_id, error = ?e, "error unbinding plugins while failing workload");
-            }
+            release(workload_id, &resolved).await;
+            // The id was held as `Stopping` for the teardown; publish the
+            // failure now that letting a stop free it is safe.
+            self.finish_teardown(workload_id, reservation, Some(reason.clone()))
+                .await;
         }
         warn!(
             workload_id,
@@ -617,26 +730,46 @@ impl Host {
         request: WorkloadStartRequest,
     ) -> anyhow::Result<ResolvedWorkload> {
         let service_present = request.workload.service.is_some();
+        let workload_id = request.workload_id.clone();
 
         // Initialize the workload using the engine, receiving the unresolved workload
         let unresolved_workload = self
             .engine
             .initialize_workload(&request.workload_id, request.workload)?;
 
+        // `resolve` binds the workload's plugins, and gives back whatever it
+        // bound if any part of that fails.
         let mut resolved_workload = unresolved_workload
             .resolve(Some(&self.plugins), self.http_handler.clone())
             .await?;
 
-        // If the service didn't run and we had one, warn
-        if service_present && resolved_workload.execute_service().await?.is_none() {
-            warn!(
-                workload_id = request.workload_id,
-                "service did not properly execute"
-            );
+        // Past this point the plugins are bound, so every exit either hands the
+        // workload to the caller to commit or gives the binding back. The rest
+        // of starting lives in one function rather than inline, so a step added
+        // to it is covered by this rollback instead of needing its own.
+        if let Err(e) = start_resolved(&workload_id, &mut resolved_workload, service_present).await
+        {
+            release(&workload_id, &resolved_workload).await;
+            return Err(e);
         }
 
         Ok(resolved_workload)
     }
+}
+
+/// Everything after plugin binding that can still fail while starting a
+/// workload. Kept together so [`Host::workload_start_inner`] has exactly one
+/// failure path to roll back.
+async fn start_resolved(
+    workload_id: &str,
+    resolved: &mut ResolvedWorkload,
+    service_present: bool,
+) -> anyhow::Result<()> {
+    // If the service didn't run and we had one, warn
+    if service_present && resolved.execute_service().await?.is_none() {
+        warn!(workload_id, "service did not properly execute");
+    }
+    Ok(())
 }
 
 impl HostApi for Host {
@@ -711,7 +844,10 @@ impl HostApi for Host {
     ) -> anyhow::Result<WorkloadStartResponse> {
         // Reserve the workload ID while holding the write lock so concurrent
         // starts cannot both observe it as available. An ID remains reserved
-        // in every lifecycle state until workload_stop removes it.
+        // in every lifecycle state until workload_stop removes it. The
+        // reservation stamped on the slot is what lets the commit below tell
+        // this start's slot from one a later start claimed.
+        let reservation = self.reserve();
         {
             let mut workloads = self.workloads.write().await;
             if workloads.contains_key(&request.workload_id) {
@@ -726,32 +862,74 @@ impl HostApi for Host {
                     },
                 });
             }
-            workloads.insert(request.workload_id.clone(), HostWorkload::Starting);
+            workloads.insert(
+                request.workload_id.clone(),
+                HostWorkload::Starting(reservation),
+            );
         }
 
         let workload_id = request.workload_id.clone();
-        let resolved_workload = self.workload_start_inner(request).await;
+        let started = self.workload_start_inner(request).await;
 
-        let (workload_state, message) = if let Err(ref err) = resolved_workload {
-            (WorkloadState::Error, err.to_string())
-        } else {
-            (
-                WorkloadState::Running,
-                "Workload started successfully".to_string(),
-            )
+        // Commit under the same lock the id was reserved under, and only into
+        // the slot this start reserved. Anything else in that slot means the
+        // workload was stopped or failed while this was still starting: writing
+        // `Running` over it would resurrect a workload nobody is tracking, and
+        // simply dropping the result — which is what an `and_modify` that finds
+        // no entry does — would leave its plugins bound and its service running
+        // detached.
+        let (workload_state, message, orphaned) = {
+            let mut workloads = self.workloads.write().await;
+            let slot = workloads.get(&workload_id);
+            let mine = matches!(slot, Some(HostWorkload::Starting(held)) if *held == reservation);
+            // A stop that arrived mid-start handed the teardown back by marking
+            // the slot `Stopping` under this start's own reservation.
+            let handed_back =
+                matches!(slot, Some(HostWorkload::Stopping(held)) if *held == reservation);
+            match started {
+                Ok(resolved) if mine => {
+                    workloads.insert(
+                        workload_id.clone(),
+                        HostWorkload::Running(Box::new(resolved)),
+                    );
+                    (
+                        WorkloadState::Running,
+                        "Workload started successfully".to_string(),
+                        None,
+                    )
+                }
+                // Stopped (or failed) while starting. The stop could not tear
+                // this down because it did not exist yet, so that falls to us.
+                // The `Stopping` marker is left in place for the whole teardown:
+                // it keeps the id reserved, so a new start cannot claim it and
+                // then be unbound by our teardown.
+                Ok(resolved) => (
+                    WorkloadState::Stopping,
+                    "Workload was stopped while starting".to_string(),
+                    Some(resolved),
+                ),
+                Err(err) => {
+                    let message = err.to_string();
+                    if mine {
+                        workloads.insert(workload_id.clone(), HostWorkload::Error(message.clone()));
+                    } else if handed_back {
+                        // A stop is waiting on this start to finish. Nothing is
+                        // bound — `workload_start_inner` released it before
+                        // returning — so the id can go now.
+                        workloads.remove(&workload_id);
+                    }
+                    (WorkloadState::Error, message, None)
+                }
+            }
         };
 
-        // Update the workload state to `Running`
-        self.workloads
-            .write()
-            .await
-            .entry(workload_id.clone())
-            .and_modify(|workload| match resolved_workload {
-                Ok(resolved_workload) => {
-                    *workload = HostWorkload::Running(Box::new(resolved_workload))
-                }
-                Err(err) => *workload = HostWorkload::Error(err.to_string()),
-            });
+        if let Some(resolved) = orphaned {
+            release(&workload_id, &resolved).await;
+            // Only if the `Stopping` marker is still this start's. It may not be
+            // — a failure reported mid-start writes `Error` over it — and then
+            // the slot is not ours to drop.
+            self.finish_teardown(&workload_id, reservation, None).await;
+        }
 
         Ok(WorkloadStartResponse {
             workload_status: WorkloadStatus {
@@ -800,49 +978,80 @@ impl HostApi for Host {
             .contains_key(&request.workload_id);
 
         let (workload_state, message) = if has_workload {
-            // Update state to stopping
+            // What a stop can do depends on what it finds, because a workload's
+            // map slot is what owns its teardown, and only the owner may write
+            // it — otherwise the id frees up mid-teardown and a new workload
+            // claiming it is unbound by the old one's `unbind_all_plugins`,
+            // which is keyed by workload id.
+            //
+            // - `Running`: this stop owns it. Mark it under a reservation of
+            //   this stop's, tear down, and drop the id.
+            // - `Starting`: the start owns it and has not produced a workload
+            //   yet. Leave a `Stopping` marker carrying the start's own
+            //   reservation; the start sees it, tears down what it built, and
+            //   drops the id.
+            // - `Stopping`: a teardown is already under way and the id stays
+            //   reserved until it finishes. Repeating the stop cannot help and
+            //   freeing the id would hand it to a new workload that the running
+            //   teardown would then unbind, so this stop reports the state and
+            //   leaves the slot alone.
+            // - `Error`: nothing is bound (every failure path releases before
+            //   recording the error), so the slot can just go.
+            let reservation = self.reserve();
             let resolved_workload = {
                 let mut workloads = self.workloads.write().await;
                 trace!(
                     workload_id = request.workload_id,
                     "updating workload state to stopping"
                 );
-                // Insert Stopping state, extract the running workload if it was running
-                workloads
-                    .insert(request.workload_id.clone(), HostWorkload::Stopping)
-                    .and_then(|hw| match hw {
-                        HostWorkload::Running(rw) => Some(*rw),
-                        _ => None,
-                    })
+                // Read what the slot holds before writing it, so the whole
+                // decision is one exhaustive match rather than a mutation with
+                // an unreachable branch in it.
+                let outcome = match workloads.get(&request.workload_id) {
+                    // This stop owns the teardown, under a reservation of its
+                    // own.
+                    Some(HostWorkload::Running(_)) => StopAction::Mark(reservation),
+                    // The start owns it. Mark the id under the reservation the
+                    // start itself holds, so it recognises the marker as its to
+                    // finish.
+                    Some(HostWorkload::Starting(held)) => StopAction::Mark(*held),
+                    // A teardown is already under way, holding the id until it
+                    // is done; nothing here is this stop's to write.
+                    Some(HostWorkload::Stopping(_)) => StopAction::Leave,
+                    // Nothing is bound, so the slot can just go.
+                    Some(HostWorkload::Error(_)) | None => StopAction::Drop,
+                };
+                match outcome {
+                    StopAction::Mark(held) => {
+                        match workloads
+                            .insert(request.workload_id.clone(), HostWorkload::Stopping(held))
+                        {
+                            // Only a stop that found the workload running has
+                            // anything to tear down here.
+                            Some(HostWorkload::Running(rw)) => Some(*rw),
+                            _ => None,
+                        }
+                    }
+                    StopAction::Leave => None,
+                    StopAction::Drop => {
+                        workloads.remove(&request.workload_id);
+                        None
+                    }
+                }
             };
 
-            // Stop the workload:
-            // 1. Unbind from all plugins
-            // 2. Clean up resources (drop will handle wasmtime cleanup)
-            // 3. Remove from active workloads
             if let Some(resolved_workload) = resolved_workload {
                 debug!(
                     workload_id = request.workload_id,
                     workload_name = resolved_workload.name(),
                     "stopping workload"
                 );
-
-                // Stop the service if running
-                resolved_workload.stop_service();
-
-                // Unbind all plugins from the workload
-                if let Err(e) = resolved_workload.unbind_all_plugins().await {
-                    warn!(
-                        workload_id = request.workload_id,
-                        error = ?e,
-                        "error unbinding plugins during workload stop, continuing"
-                    );
-                }
+                release(&request.workload_id, &resolved_workload).await;
+                // Dropped only now, so the id stays reserved for the whole
+                // teardown.
+                self.finish_teardown(&request.workload_id, reservation, None)
+                    .await;
             }
-
-            // Remove the workload from the active workloads map
-            // This will drop the workload and clean up wasmtime resources
-            self.workloads.write().await.remove(&request.workload_id);
 
             debug!(
                 workload_id = request.workload_id,
@@ -1142,6 +1351,7 @@ impl HostBuilder {
         Ok(Host {
             engine,
             workloads: Arc::default(),
+            reservations: std::sync::atomic::AtomicU64::default(),
             plugins: self.plugins,
             id: self.id,
             hostname,
@@ -1370,6 +1580,338 @@ mod tests {
                 }
             })
         ));
+    }
+
+    /// Records which workloads it was bound to and unbound from, so a test can
+    /// assert that a workload which never finished starting still gave its
+    /// binding back. `bind_delay` holds a start open long enough for a stop to
+    /// race it, and `unbind_delay` does the same for a teardown.
+    #[derive(Default)]
+    struct BindRecordingPlugin {
+        bound: std::sync::Mutex<Vec<String>>,
+        unbound: std::sync::Mutex<Vec<String>>,
+        bind_delay: Duration,
+        unbind_delay: Duration,
+    }
+
+    impl BindRecordingPlugin {
+        fn unbound(&self) -> Vec<String> {
+            self.unbound
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        }
+
+        fn bound(&self) -> Vec<String> {
+            self.bound
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl HostPlugin for BindRecordingPlugin {
+        fn id(&self) -> &'static str {
+            "bind-recording"
+        }
+
+        fn world(&self) -> WitWorld {
+            WitWorld {
+                imports: HashSet::from([WitInterface::from("test:probe/marker@0.1.0")]),
+                exports: HashSet::new(),
+            }
+        }
+
+        async fn on_workload_bind(
+            &self,
+            workload: &crate::engine::workload::UnresolvedWorkload,
+            _interfaces: crate::plugin::WitInterfaces<'_>,
+        ) -> anyhow::Result<()> {
+            if !self.bind_delay.is_zero() {
+                tokio::time::sleep(self.bind_delay).await;
+            }
+            self.bound
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(workload.id().to_string());
+            Ok(())
+        }
+
+        async fn on_workload_unbind(
+            &self,
+            workload_id: &str,
+            _interfaces: crate::plugin::WitInterfaces<'_>,
+        ) -> anyhow::Result<()> {
+            if !self.unbind_delay.is_zero() {
+                tokio::time::sleep(self.unbind_delay).await;
+            }
+            self.unbound
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(workload_id.to_string());
+            Ok(())
+        }
+    }
+
+    /// A component whose only import is the interface `BindRecordingPlugin`
+    /// serves, so a workload carrying it binds that plugin.
+    fn marker_component_wasm() -> Vec<u8> {
+        wat::parse_str(r#"(component (import "test:probe/marker@0.1.0" (instance)))"#)
+            .expect("failed to parse WAT")
+    }
+
+    /// The same, plus a single exported interface — enough to pass the
+    /// service's export validation, but not `wasi:cli/run`, so building a
+    /// command from it fails. That failure lands *after* `resolve` has bound
+    /// the workload's plugins, which is the window these tests exercise.
+    fn marker_service_wasm() -> Vec<u8> {
+        wat::parse_str(
+            r#"(component
+                  (import "test:probe/marker@0.1.0" (instance))
+                  (instance $empty)
+                  (export "test:probe/runner@0.1.0" (instance $empty))
+               )"#,
+        )
+        .expect("failed to parse WAT")
+    }
+
+    fn marker_interfaces() -> Vec<WitInterface> {
+        vec![WitInterface::from("test:probe/marker@0.1.0")]
+    }
+
+    /// A workload whose service binds the plugin and then fails to start: the
+    /// component is valid and resolves, so plugins bind, but it exports no
+    /// `wasi:cli/run` for the service driver to call.
+    fn service_fails_after_bind_request(workload_id: &str) -> WorkloadStartRequest {
+        WorkloadStartRequest {
+            workload_id: workload_id.to_string(),
+            workload: Workload {
+                namespace: "wasmcloud".to_string(),
+                name: "binds-then-fails".to_string(),
+                annotations: Default::default(),
+                service: Some(crate::types::Service {
+                    bytes: marker_service_wasm().into(),
+                    digest: None,
+                    local_resources: Default::default(),
+                    max_restarts: 0,
+                }),
+                components: vec![],
+                host_interfaces: marker_interfaces(),
+                volumes: vec![],
+            },
+        }
+    }
+
+    /// A workload of one plain component that binds the plugin and reaches
+    /// `Running` — what a stop finds when it owns the teardown itself.
+    fn marker_request(workload_id: &str) -> WorkloadStartRequest {
+        WorkloadStartRequest {
+            workload_id: workload_id.to_string(),
+            workload: Workload {
+                namespace: "wasmcloud".to_string(),
+                name: workload_id.to_string(),
+                annotations: Default::default(),
+                service: None,
+                components: vec![Component {
+                    name: "marker".to_string(),
+                    digest: None,
+                    bytes: marker_component_wasm().into(),
+                    local_resources: Default::default(),
+                    pool_size: 1,
+                    max_invocations: 100,
+                    max_concurrency: 1,
+                }],
+                host_interfaces: marker_interfaces(),
+                volumes: vec![],
+            },
+        }
+    }
+
+    fn host_with(plugin: Arc<BindRecordingPlugin>) -> Host {
+        Host::builder()
+            .with_plugin(plugin)
+            .expect("failed to register plugin")
+            .build()
+            .expect("failed to build host")
+    }
+
+    /// A start that fails *after* its plugins bound must give the binding back.
+    /// `resolve` rolls back its own failures; anything failing later has to be
+    /// released by the start itself, or every plugin is left holding
+    /// per-workload state for a workload that never ran — and, for a plugin
+    /// that can call into workloads, still able to reach it.
+    #[tokio::test]
+    async fn test_start_failing_after_bind_unbinds_plugins() {
+        let plugin = Arc::new(BindRecordingPlugin::default());
+        let host = host_with(Arc::clone(&plugin));
+
+        let response = host
+            .workload_start(service_fails_after_bind_request("late-failure"))
+            .await
+            .expect("workload_start should report rather than error");
+
+        assert_eq!(
+            response.workload_status.workload_state,
+            WorkloadState::Error,
+            "the service cannot start, so the workload is in error"
+        );
+        assert_eq!(
+            plugin.bound(),
+            vec!["late-failure".to_string()],
+            "the plugin should have been bound before the failure; start said: {}",
+            response.workload_status.message
+        );
+        assert_eq!(
+            plugin.unbound(),
+            vec!["late-failure".to_string()],
+            "a start that fails after binding must unbind"
+        );
+    }
+
+    /// Stopping a workload that failed to start is a no-op beyond dropping the
+    /// id: the failure path already released it. In particular the plugin must
+    /// not be unbound a second time.
+    #[tokio::test]
+    async fn test_stopping_an_errored_workload_does_not_unbind_twice() {
+        let plugin = Arc::new(BindRecordingPlugin::default());
+        let host = host_with(Arc::clone(&plugin));
+
+        host.workload_start(service_fails_after_bind_request("errored"))
+            .await
+            .expect("workload_start should report rather than error");
+        host.workload_stop(WorkloadStopRequest {
+            workload_id: "errored".to_string(),
+        })
+        .await
+        .expect("stopping an errored workload should succeed");
+
+        assert_eq!(
+            plugin.unbound(),
+            vec!["errored".to_string()],
+            "the errored workload was already released; stop must not unbind again"
+        );
+        assert!(
+            host.workloads.read().await.is_empty(),
+            "stopping should drop the id"
+        );
+    }
+
+    /// A stop that arrives while a workload is still starting cannot tear it
+    /// down — there is nothing built yet — so it leaves a `Stopping` marker and
+    /// the start owns the cleanup: it finds its slot taken, releases what it
+    /// built, and drops the id itself. Without that the workload's plugins stay
+    /// bound and its service keeps running with no record of either.
+    #[tokio::test]
+    async fn test_stop_racing_a_start_releases_the_workload() {
+        let plugin = Arc::new(BindRecordingPlugin {
+            bind_delay: Duration::from_millis(300),
+            ..Default::default()
+        });
+        let host = Arc::new(host_with(Arc::clone(&plugin)));
+
+        let starting = {
+            let host = Arc::clone(&host);
+            tokio::spawn(async move { host.workload_start(marker_request("raced")).await })
+        };
+
+        // Stop while the plugin's bind is still sleeping.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let stopped = host
+            .workload_stop(WorkloadStopRequest {
+                workload_id: "raced".to_string(),
+            })
+            .await
+            .expect("stopping a starting workload should succeed");
+        assert_eq!(
+            stopped.workload_status.workload_state,
+            WorkloadState::Stopping
+        );
+
+        let started = starting
+            .await
+            .expect("the start task should not panic")
+            .expect("workload_start should report rather than error");
+        assert_eq!(
+            started.workload_status.workload_state,
+            WorkloadState::Stopping,
+            "a start whose slot was taken by a stop reports that, not Running"
+        );
+
+        assert_eq!(
+            plugin.unbound(),
+            vec!["raced".to_string()],
+            "the start must release what it bound once it finds its slot stopped"
+        );
+        assert!(
+            host.workloads.read().await.is_empty(),
+            "the id is dropped only once the start has released the workload"
+        );
+    }
+
+    /// A teardown holds its workload id for as long as it runs, so a second
+    /// stop arriving mid-teardown cannot free the id. Were it able to, a start
+    /// could claim the id while the first teardown is still unbinding — and
+    /// `unbind_all_plugins` is keyed by workload id, so the newcomer would be
+    /// unbound by its predecessor's teardown and then dropped from the map
+    /// entirely, left running with nothing tracking it.
+    #[tokio::test]
+    async fn test_a_second_stop_does_not_free_an_in_flight_teardown() {
+        let plugin = Arc::new(BindRecordingPlugin {
+            unbind_delay: Duration::from_millis(300),
+            ..Default::default()
+        });
+        let host = Arc::new(host_with(Arc::clone(&plugin)));
+        host.workload_start(marker_request("held"))
+            .await
+            .expect("workload_start should report rather than error");
+
+        let stopping = {
+            let host = Arc::clone(&host);
+            tokio::spawn(async move {
+                host.workload_stop(WorkloadStopRequest {
+                    workload_id: "held".to_string(),
+                })
+                .await
+            })
+        };
+
+        // A retried stop, while the first one's unbind is still sleeping.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        host.workload_stop(WorkloadStopRequest {
+            workload_id: "held".to_string(),
+        })
+        .await
+        .expect("a second stop should report rather than error");
+        assert!(
+            host.workloads.read().await.contains_key("held"),
+            "the id stays reserved while the first stop is still tearing down"
+        );
+
+        // ...so a redeploy under the same id cannot slip in behind it.
+        let redeployed = host
+            .workload_start(marker_request("held"))
+            .await
+            .expect("workload_start should report rather than error");
+        assert_eq!(
+            redeployed.workload_status.workload_state,
+            WorkloadState::Error,
+            "the id is still taken, so a start under it is refused rather than racing the teardown"
+        );
+
+        stopping
+            .await
+            .expect("the stop task should not panic")
+            .expect("stopping should succeed");
+        assert_eq!(
+            plugin.unbound(),
+            vec!["held".to_string()],
+            "the workload is unbound exactly once, by the stop that owned it"
+        );
+        assert!(
+            host.workloads.read().await.is_empty(),
+            "the id is dropped once its teardown finishes"
+        );
     }
 
     #[test]

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -47,10 +47,13 @@
 //! submodule; this module drives it from `ComponentHostPlugin`'s `HostPlugin`
 //! impl.
 //!
-//! Calls also run the other way. A plugin may *import* an interface no host
-//! built-in provides, in which case a workload that exports it satisfies it —
-//! the arrangement `wasi:http` and `wasmcloud:messaging` already have, where the
-//! host both serves a workload's imports and calls the handler it exports.
+//! Calls also run the other way. A plugin that imports `wasmcloud:host/workload`
+//! may *import* an interface no host built-in provides, in which case a workload
+//! that exports it satisfies it — the arrangement `wasi:http` and
+//! `wasmcloud:messaging` already have, where the host both serves a workload's
+//! imports and calls the handler it exports. Such an interface must be
+//! `async func` throughout, because the shim the host installs for it is
+//! concurrent and a sync-typed import cannot bind to one.
 //! [`classify_workload_imports`] decides which imports those are, and the
 //! `workload_call` submodule holds the rest: the per-workload routes (claimed in
 //! `on_workload_resolved`, exactly as a native plugin claims them), the
@@ -114,7 +117,7 @@ const CAPABILITY_CHANNEL_CAPACITY: usize = 256;
 /// a restart story is required rather than optional.
 const DEFAULT_MAX_RESTARTS: u32 = 3;
 
-type CapabilitySender = tokio::sync::mpsc::Sender<CapabilityJob>;
+pub(super) type CapabilitySender = tokio::sync::mpsc::Sender<CapabilityJob>;
 
 /// One exported capability function, introspected from the plugin component's
 /// type at construction. The param/result types drive the relocation pass that
@@ -123,6 +126,13 @@ struct ExportedFunc {
     name: Arc<str>,
     param_tys: Arc<[Type]>,
     result_tys: Arc<[Type]>,
+    /// Whether the function is declared `async func`. Every shim the host
+    /// installs is concurrent, and async-ness is part of a function's type
+    /// identity — a concurrent definition against a sync-typed import fails to
+    /// link with "type mismatch with async" — so a workload-facing import is
+    /// refused unless it is declared `async`
+    /// ([`workload_call::add_workload_calls_to_linker`]).
+    is_async: bool,
 }
 
 /// One interface, with the functions and resource types it carries, as
@@ -456,6 +466,55 @@ impl ComponentHostPlugin {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .contains_key(workload_id)
     }
+
+    /// Wire one workload item against the interfaces it matched this plugin on:
+    /// check the ones this plugin *calls*, and install shims for the ones it
+    /// *serves*. Every failure is returned rather than handled, so
+    /// [`HostPlugin::on_workload_item_bind`] can roll the workload's bind back
+    /// on any of them from one place.
+    fn wire_workload_item<'a>(
+        &self,
+        item: &mut WorkloadItem<'a>,
+        interfaces: WitInterfaces<'_>,
+    ) -> anyhow::Result<()> {
+        // An interface this plugin calls puts nothing on the item's linker —
+        // the item provides it rather than consuming it. But a match on such an
+        // interface only means the item's world mentions the package, so check
+        // here that it really exports it: an item that imports it instead has
+        // nobody to serve it, and would otherwise fail later as an unresolved
+        // wasmtime import with no mention of this plugin.
+        for called in self.state.workload_calls.imports() {
+            let iface_names: Vec<&str> = called.wit.interfaces.iter().map(String::as_str).collect();
+            if !interfaces.contains(&called.wit.namespace, &called.wit.package, &iface_names) {
+                continue;
+            }
+            anyhow::ensure!(
+                item.world()
+                    .exports
+                    .iter()
+                    .any(|exported| exported.contains(&called.wit)),
+                "host component plugin '{}' calls {} rather than serving it, and no host built-in \
+                 serves it either, so '{}' must export it — but component '{}' imports it instead",
+                self.id,
+                called.name,
+                item.workload_id(),
+                item.id(),
+            );
+        }
+
+        let linker = item.linker();
+        for exported in self.exports.iter() {
+            let iface_names: Vec<&str> =
+                exported.wit.interfaces.iter().map(String::as_str).collect();
+            // Only wire interfaces this workload was actually matched on.
+            if !interfaces.contains(&exported.wit.namespace, &exported.wit.package, &iface_names) {
+                continue;
+            }
+            add_capabilities_to_linker(linker, &self.state, exported)?;
+            debug!(id = self.id, interface = %exported.name, "wired host component capability");
+        }
+        Ok(())
+    }
 }
 
 /// Filters `plugins` down to the natives — every entry that is not itself a
@@ -694,64 +753,27 @@ impl HostPlugin for ComponentHostPlugin {
         interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         let workload_id: Arc<str> = Arc::from(item.workload_id());
-
-        // An interface this plugin *calls* puts nothing on the item's linker —
-        // the item provides it rather than consuming it. But a match on such an
-        // interface only means the item's world mentions the package, so check
-        // here that it really exports it: an item that imports it instead has
-        // nobody to serve it, and would otherwise fail later as an unresolved
-        // wasmtime import with no mention of this plugin.
-        for called in self.state.workload_calls.imports() {
-            let iface_names: Vec<&str> = called.wit.interfaces.iter().map(String::as_str).collect();
-            if !interfaces.contains(&called.wit.namespace, &called.wit.package, &iface_names) {
-                continue;
-            }
-            anyhow::ensure!(
-                item.world()
-                    .exports
-                    .iter()
-                    .any(|exported| exported.contains(&called.wit)),
-                "host component plugin '{}' calls {} rather than serving it, so '{}' must export \
-                 it, but '{}' does not",
-                self.id,
-                called.name,
-                item.workload_id(),
-                item.id(),
+        let Err(e) = self.wire_workload_item(item, interfaces) else {
+            return Ok(());
+        };
+        // However this item bind failed, the bind delivered in
+        // `on_workload_bind` has to come back off: the engine's bind-failure
+        // cleanup only unbinds plugins whose item binds ALL succeeded, and a
+        // plugin failing its own item bind is not yet on that list. Left
+        // undone, the workload stays in the replay set and its bind is
+        // re-delivered to every later incarnation of a plugin it never
+        // deployed against.
+        if let Some(lifecycle) = &self.lifecycle
+            && let Err(unbind_err) = remove_and_unbind(&self.state, lifecycle, &workload_id).await
+        {
+            warn!(
+                id = self.id,
+                %workload_id,
+                err = %unbind_err,
+                "item-bind rollback unbind not delivered"
             );
         }
-
-        let linker = item.linker();
-
-        for exported in self.exports.iter() {
-            let iface_names: Vec<&str> =
-                exported.wit.interfaces.iter().map(String::as_str).collect();
-            // Only wire interfaces this workload was actually matched on.
-            if !interfaces.contains(&exported.wit.namespace, &exported.wit.package, &iface_names) {
-                continue;
-            }
-
-            if let Err(e) = add_capabilities_to_linker(linker, &self.state, exported) {
-                // The engine's bind-failure cleanup only unbinds plugins whose
-                // item binds ALL succeeded — a plugin failing its own item bind
-                // is not yet on that list — so roll back the bind delivered in
-                // `on_workload_bind` ourselves.
-                if let Some(lifecycle) = &self.lifecycle
-                    && let Err(unbind_err) =
-                        remove_and_unbind(&self.state, lifecycle, &workload_id).await
-                {
-                    warn!(
-                        id = self.id,
-                        %workload_id,
-                        err = %unbind_err,
-                        "item-bind rollback unbind not delivered"
-                    );
-                }
-                return Err(e);
-            }
-            debug!(id = self.id, interface = %exported.name, "wired host component capability");
-        }
-
-        Ok(())
+        Err(e)
     }
 
     async fn on_workload_resolved(
@@ -762,10 +784,6 @@ impl HostPlugin for ComponentHostPlugin {
         if self.state.workload_calls.is_empty() {
             return Ok(());
         }
-        // The workload is running now, so its components can be instantiated
-        // and called. Claiming them here — rather than at bind — is what a
-        // native plugin does too, and is why `callable` reports a workload only
-        // once it is up.
         self.state
             .workload_calls
             .register(workload, component_id)
@@ -996,20 +1014,40 @@ fn is_self_satisfied(imported: &ExportedInterface, exports: &[ExportedInterface]
         || is_base_wasi(&imported.wit)
 }
 
+/// Whether the plugin declares that it calls workloads, by importing
+/// `wasmcloud:host/workload`.
+///
+/// This is what opens its import surface: only a plugin that says it calls
+/// workloads may have an otherwise-unsatisfiable import answered by a workload
+/// export. Without it every import must resolve to the plugin's own exports,
+/// the WASI base, or a native — and one that does not fails the load in
+/// [`link_native_imports`], naming the missing built-in.
+///
+/// Matched on the interface name within the reserved package rather than the
+/// exact import string, so a `wasmcloud:host` patch bump does not change what a
+/// plugin built against the previous one declares.
+fn declares_workload_calls(imports: &[ExportedInterface]) -> bool {
+    imports
+        .iter()
+        .any(|imported| is_reserved(&imported.wit) && imported.wit.interfaces.contains("workload"))
+}
+
 /// The plugin's imports that a *workload* must export, in the order the
 /// component declares them.
 ///
-/// An import lands here only when nothing else can satisfy it: it is not
-/// [`is_self_satisfied`], and no registered native plugin serves its package.
-/// Natives are checked first, and on the merged package view
-/// [`link_native_imports`] uses, so an interface a built-in provides never
-/// quietly turns into a call out to a workload.
+/// An import lands here only when the plugin [`declares_workload_calls`] and
+/// nothing else can satisfy it: it is not [`is_self_satisfied`], and no native
+/// plugin *provides* it. Natives win, so a built-in's interface is never handed
+/// to a workload instead.
 ///
-/// This is where a plugin's import surface stops being closed. Before, an
-/// import no native served failed the load; now it is published in the plugin's
-/// [`WitWorld`] and a workload that both declares and exports it satisfies it.
-/// An import nothing ever exports therefore loads fine and traps on the call
-/// that needs it, with a message naming the interface.
+/// The native check is per import and asks what a native provides (its world's
+/// imports), not what it mentions. That is what lets a plugin importing both
+/// `wasmcloud:messaging/consumer` and `handler` get `consumer` from the native
+/// and `handler` from a workload — the split the native messaging plugin itself
+/// has.
+///
+/// An import no workload ever exports traps on the call that needs it, naming
+/// the interface.
 fn classify_workload_imports(
     id: &str,
     component: &Component,
@@ -1017,37 +1055,17 @@ fn classify_workload_imports(
     native_plugins: &HashMap<&'static str, Arc<dyn HostPlugin>>,
 ) -> anyhow::Result<Vec<ExportedInterface>> {
     let imports = introspect_imports(component)?;
-
-    // Merge by instance before asking the natives, exactly as
-    // `link_native_imports` does: `wasmcloud:secrets/store` and
-    // `wasmcloud:secrets/reveal` are two introspected imports but one binding,
-    // and a native declaring both together only matches the merged view.
-    let mut merged: HashMap<String, WitInterface> = HashMap::new();
-    for imported in &imports {
-        if is_self_satisfied(imported, exports) {
-            continue;
-        }
-        merged
-            .entry(imported.wit.instance())
-            .and_modify(|existing| {
-                existing.merge(&imported.wit);
-            })
-            .or_insert_with(|| imported.wit.clone());
+    if !declares_workload_calls(&imports) {
+        return Ok(Vec::new());
     }
     let native_worlds: Vec<WitWorld> = native_plugins.values().map(|p| p.world()).collect();
-    let native_served: std::collections::HashSet<String> = merged
-        .into_iter()
-        .filter(|(_, wit)| {
-            native_worlds
-                .iter()
-                .any(|world| world.includes_bidirectional(wit))
-        })
-        .map(|(instance, _)| instance)
-        .collect();
 
     let mut workload_imports = Vec::new();
     for imported in imports {
-        if is_self_satisfied(&imported, exports) || native_served.contains(&imported.wit.instance())
+        if is_self_satisfied(&imported, exports)
+            || native_worlds
+                .iter()
+                .any(|world| world.provides(&imported.wit))
         {
             continue;
         }
@@ -1065,6 +1083,23 @@ fn classify_workload_imports(
              and a workload's",
             imported.name
         );
+        // The interface may define no resource of its own and still name one in
+        // a signature — a `borrow<session>` from a sibling `types` interface, or
+        // a `wasi:io` stream. Classify every function the way the call itself
+        // will be classified, so an unbridgeable signature is one clear failure
+        // when the plugin loads rather than a deploy failure in every workload
+        // that exports the interface.
+        for func in &imported.funcs {
+            anyhow::ensure!(
+                crate::engine::linked_call::types_are_bridge_safe(&func.param_tys)
+                    && crate::engine::linked_call::types_are_bridge_safe(&func.result_tys),
+                "host component plugin '{id}' imports {}#{} for a workload to export, but its \
+                 signature carries a handle that cannot cross the boundary between a plugin's \
+                 store and a workload's; only plain values, `stream<T>`, and `future<T>` can",
+                imported.name,
+                func.name
+            );
+        }
         debug!(
             id,
             interface = %imported.name,
@@ -1763,6 +1798,7 @@ fn introspect_interfaces<'a>(
                     name: func_name.into(),
                     param_tys: func_ty.params().map(|(_, ty)| ty).collect(),
                     result_tys: func_ty.results().collect(),
+                    is_async: func_ty.async_(),
                 }),
                 ComponentItem::Resource(_) => resources.push(func_name.into()),
                 _ => {}
@@ -1847,23 +1883,72 @@ mod tests {
         )
     }
 
+    /// The `wasmcloud:host/workload` import every opted-in plugin declares, as
+    /// a WAT line to paste into a test component.
+    const DECLARES_WORKLOAD_CALLS: &str = r#"(import "wasmcloud:host/workload@0.1.2" (instance))"#;
+
     /// Only an import nothing else can satisfy becomes the workload's to
     /// export. A native serving the interface wins — so introducing a built-in
     /// never silently turns into a call out to a workload — and the WASI base
     /// is already linked.
     #[test]
     fn only_unsatisfiable_imports_are_left_to_a_workload() {
-        let wat = r#"
+        let wat = format!(
+            r#"
             (component
+                {DECLARES_WORKLOAD_CALLS}
                 (import "acme:events/handler@0.1.0" (instance))
                 (import "test:probe/marker@0.1.0" (instance))
                 (import "wasi:clocks/monotonic-clock@0.3.0" (instance))
             )
-        "#;
+        "#
+        );
         assert_eq!(
-            workload_facing(wat, &[]).expect("classification should succeed"),
+            workload_facing(&wat, &[]).expect("classification should succeed"),
             vec!["acme:events/handler@0.1.0"],
             "the native-served and base-WASI imports should not be left to a workload"
+        );
+    }
+
+    /// A plugin that never says it calls workloads keeps a closed import
+    /// surface: an import no native serves is not quietly answered by a
+    /// workload export, it stays unresolved for `link_native_imports` to fail
+    /// the load on, naming the missing built-in.
+    #[test]
+    fn a_plugin_that_does_not_declare_workload_calls_demotes_nothing() {
+        let wat = r#"
+            (component
+                (import "acme:events/handler@0.1.0" (instance))
+                (import "wasi:keyvalue/store@0.2.0-draft" (instance))
+            )
+        "#;
+        assert!(
+            workload_facing(wat, &[])
+                .expect("classification should succeed")
+                .is_empty(),
+            "without the wasmcloud:host/workload import nothing may be left to a workload"
+        );
+    }
+
+    /// A native covering part of a package wins for the part it covers, and
+    /// leaves the rest to a workload. Asking about the merged package instead
+    /// would find no native covering both and hand the whole package over,
+    /// including the half the built-in was serving.
+    #[test]
+    fn a_partly_native_package_splits_rather_than_demoting_whole() {
+        let wat = format!(
+            r#"
+            (component
+                {DECLARES_WORKLOAD_CALLS}
+                (import "test:probe/marker@0.1.0" (instance))
+                (import "test:probe/callback@0.1.0" (instance))
+            )
+        "#
+        );
+        assert_eq!(
+            workload_facing(&wat, &[]).expect("classification should succeed"),
+            vec!["test:probe/callback@0.1.0"],
+            "the interface the native serves must stay with the native"
         );
     }
 
@@ -1871,11 +1956,14 @@ mod tests {
     /// to its own capability channel rather than out to a workload.
     #[test]
     fn a_self_import_is_not_left_to_a_workload() {
-        let wat = r#"
+        let wat = format!(
+            r#"
             (component
+                {DECLARES_WORKLOAD_CALLS}
                 (import "acme:events/handler@0.1.0" (instance))
             )
-        "#;
+        "#
+        );
         let exports = vec![ExportedInterface {
             name: Arc::from("acme:events/handler@0.1.0"),
             wit: WitInterface::from("acme:events/handler@0.1.0"),
@@ -1883,7 +1971,7 @@ mod tests {
             resources: Vec::new(),
         }];
         assert!(
-            workload_facing(wat, &exports)
+            workload_facing(&wat, &exports)
                 .expect("classification should succeed")
                 .is_empty(),
             "an interface the plugin also exports is served by the plugin itself"
@@ -1895,17 +1983,108 @@ mod tests {
     /// when the plugin loads rather than trapping on a call much later.
     #[test]
     fn a_resource_carrying_import_is_refused() {
-        let wat = r#"
+        let wat = format!(
+            r#"
             (component
+                {DECLARES_WORKLOAD_CALLS}
                 (import "acme:events/handler@0.1.0" (instance
                     (export "session" (type (sub resource)))
                 ))
             )
-        "#;
-        let err = workload_facing(wat, &[]).expect_err("a resource import should be refused");
+        "#
+        );
+        let err = workload_facing(&wat, &[]).expect_err("a resource import should be refused");
         assert!(
             err.to_string().contains("resource types"),
             "the error should name the reason, got: {err}"
+        );
+    }
+
+    /// A resource the interface does not define itself but names in a
+    /// signature is refused too — the guard reads the functions, not just the
+    /// interface's own type definitions, so an unbridgeable signature is one
+    /// clear failure at load rather than a deploy failure in every workload
+    /// that exports the interface.
+    #[test]
+    fn an_imported_resource_in_a_signature_is_refused() {
+        let wat = format!(
+            r#"
+            (component
+                {DECLARES_WORKLOAD_CALLS}
+                (import "acme:events/types@0.1.0" (instance $types
+                    (export "session" (type (sub resource)))
+                ))
+                (alias export $types "session" (type $session))
+                (import "acme:events/handler@0.1.0" (instance
+                    (export "notify" (func (param "s" (own $session))))
+                ))
+            )
+        "#
+        );
+        let err = workload_facing(&wat, &[]).expect_err("a resource parameter should be refused");
+        assert!(
+            err.to_string().contains("cannot cross"),
+            "the error should name the reason, got: {err}"
+        );
+    }
+
+    /// A plugin's own state, with nothing running — enough to install linker
+    /// shims, which is all the workload-facing import tests need.
+    pub(super) fn idle_state(id: &'static str) -> Arc<ComponentHostPluginState> {
+        Arc::new(ComponentHostPluginState {
+            id,
+            tx: ArcSwapOption::empty(),
+            supervisor: Mutex::new(None),
+            registry: ArcSwapOption::empty(),
+            bound: Mutex::new(BTreeMap::new()),
+            poison: Mutex::new(BTreeMap::new()),
+            bind_trap_log: Mutex::new(Vec::new()),
+            failure_sink: ArcSwapOption::empty(),
+            lifecycle_timeout_ms: AtomicU64::new(1_000),
+            native_plugins: HashMap::new(),
+            workload_calls: WorkloadCalls::new(id, Vec::new()),
+        })
+    }
+
+    pub(super) fn one_func_interface(name: &str, func: &str, is_async: bool) -> ExportedInterface {
+        ExportedInterface {
+            name: Arc::from(name),
+            wit: WitInterface::from(name),
+            funcs: vec![ExportedFunc {
+                name: Arc::from(func),
+                param_tys: Arc::default(),
+                result_tys: Arc::default(),
+                is_async,
+            }],
+            resources: Vec::new(),
+        }
+    }
+
+    /// Async-ness is part of a function's type identity, and introspection is
+    /// where the host reads it. Getting it wrong lets a workload-facing import
+    /// declared without `async` past its guard, to surface much later as an
+    /// unhelpful "type mismatch with async".
+    #[test]
+    fn introspection_records_a_functions_declared_async_ness() {
+        let wat = r#"
+            (component
+                (import "acme:kv/store@0.1.0" (instance
+                    (export "get" (func (param "k" string)))
+                ))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("failed to parse WAT");
+        let engine = Engine::builder().build().expect("failed to build engine");
+        let component = Component::new(engine.inner(), &wasm).expect("failed to compile");
+
+        let ifaces = introspect_imports(&component).expect("introspection should succeed");
+        let store = ifaces
+            .iter()
+            .find(|i| &*i.name == "acme:kv/store@0.1.0")
+            .expect("the imported interface should be introspected");
+        assert!(
+            !store.funcs[0].is_async,
+            "a plain `func` must be recorded as sync, or the workload-facing guard lets it through"
         );
     }
 

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -47,17 +47,18 @@
 //! submodule; this module drives it from `ComponentHostPlugin`'s `HostPlugin`
 //! impl.
 //!
-//! Calls also run the other way. A plugin that imports `wasmcloud:host/workload`
-//! may *import* an interface no host built-in provides, in which case a workload
-//! that exports it satisfies it — the arrangement `wasi:http` and
-//! `wasmcloud:messaging` already have, where the host both serves a workload's
-//! imports and calls the handler it exports. Such an interface must be
-//! `async func` throughout, because the shim the host installs for it is
-//! concurrent and a sync-typed import cannot bind to one.
+//! Calls also run the other way. A plugin that imports
+//! `wasmcloud:host/workload-call` may *import* an interface no host built-in
+//! provides, in which case a workload that exports it satisfies it — the
+//! arrangement `wasi:http` and `wasmcloud:messaging` already have, where the
+//! host both serves a workload's imports and calls the handler it exports.
+//! Such an interface must be `async func` throughout, because the shim the
+//! host installs for it is concurrent and a sync-typed import cannot bind to
+//! one.
 //! [`classify_workload_imports`] decides which imports those are, and the
 //! `workload_call` submodule holds the rest: the per-workload routes (claimed in
 //! `on_workload_resolved`, exactly as a native plugin claims them), the
-//! `wasmcloud:host/workload` `target` handle a plugin uses to name which
+//! `wasmcloud:host/workload-call` `target` handle a plugin uses to name which
 //! workload a call goes to, and the fallback that sends an unaddressed call back
 //! to the workload whose capability call is being served.
 
@@ -1015,7 +1016,7 @@ fn is_self_satisfied(imported: &ExportedInterface, exports: &[ExportedInterface]
 }
 
 /// Whether the plugin declares that it calls workloads, by importing
-/// `wasmcloud:host/workload`.
+/// `wasmcloud:host/workload-call`.
 ///
 /// This is what opens its import surface: only a plugin that says it calls
 /// workloads may have an otherwise-unsatisfiable import answered by a workload
@@ -1027,9 +1028,9 @@ fn is_self_satisfied(imported: &ExportedInterface, exports: &[ExportedInterface]
 /// exact import string, so a `wasmcloud:host` patch bump does not change what a
 /// plugin built against the previous one declares.
 fn declares_workload_calls(imports: &[ExportedInterface]) -> bool {
-    imports
-        .iter()
-        .any(|imported| is_reserved(&imported.wit) && imported.wit.interfaces.contains("workload"))
+    imports.iter().any(|imported| {
+        is_reserved(&imported.wit) && imported.wit.interfaces.contains("workload-call")
+    })
 }
 
 /// The plugin's imports that a *workload* must export, in the order the
@@ -1883,9 +1884,10 @@ mod tests {
         )
     }
 
-    /// The `wasmcloud:host/workload` import every opted-in plugin declares, as
-    /// a WAT line to paste into a test component.
-    const DECLARES_WORKLOAD_CALLS: &str = r#"(import "wasmcloud:host/workload@0.1.2" (instance))"#;
+    /// The `wasmcloud:host/workload-call` import every opted-in plugin
+    /// declares, as a WAT line to paste into a test component.
+    const DECLARES_WORKLOAD_CALLS: &str =
+        r#"(import "wasmcloud:host/workload-call@0.1.2" (instance))"#;
 
     /// Only an import nothing else can satisfy becomes the workload's to
     /// export. A native serving the interface wins — so introducing a built-in
@@ -1926,7 +1928,7 @@ mod tests {
             workload_facing(wat, &[])
                 .expect("classification should succeed")
                 .is_empty(),
-            "without the wasmcloud:host/workload import nothing may be left to a workload"
+            "without the wasmcloud:host/workload-call import nothing may be left to a workload"
         );
     }
 

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -46,6 +46,17 @@
 //! delivery, post-restart replay, and quarantine — lives in the `lifecycle`
 //! submodule; this module drives it from `ComponentHostPlugin`'s `HostPlugin`
 //! impl.
+//!
+//! Calls also run the other way. A plugin may *import* an interface no host
+//! built-in provides, in which case a workload that exports it satisfies it —
+//! the arrangement `wasi:http` and `wasmcloud:messaging` already have, where the
+//! host both serves a workload's imports and calls the handler it exports.
+//! [`classify_workload_imports`] decides which imports those are, and the
+//! `workload_call` submodule holds the rest: the per-workload routes (claimed in
+//! `on_workload_resolved`, exactly as a native plugin claims them), the
+//! `wasmcloud:host/workload` `target` handle a plugin uses to name which
+//! workload a call goes to, and the fallback that sends an unaddressed call back
+//! to the workload whose capability call is being served.
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -68,7 +79,9 @@ use crate::engine::ctx::{CallerIdentity, Ctx, SharedCtx};
 use crate::engine::instance_pool::InstancePolicy;
 use crate::engine::store::relocate::{self, Relocated};
 use crate::engine::store::resource_bridge::{self, ProxyResource};
-use crate::engine::workload::{UnresolvedWorkload, WorkloadComponent, WorkloadItem};
+use crate::engine::workload::{
+    ResolvedWorkload, UnresolvedWorkload, WorkloadComponent, WorkloadItem,
+};
 use crate::host::job_registry::JobRegistry;
 use crate::host::trigger_service::{
     CapabilityCall, CapabilityFunc, CapabilityJob, Ingress, LifecycleReplay, TriggerService,
@@ -82,12 +95,14 @@ use crate::types::LocalResources;
 use crate::wit::{WitInterface, WitWorld};
 
 mod lifecycle;
+mod workload_call;
 
 use lifecycle::{
     BindReply, HOST_LIFECYCLE_EXPORT, LifecycleFuncs, POISON_EVICT_STRIKES, attribute_replay_fault,
     await_bind_reply, evict_workload, lifecycle_funcs, remove_and_unbind, replay_snapshot,
     report_workload_failed, send_lifecycle_job, spawn_deferred_unbind, workload_info_val,
 };
+use workload_call::{WorkloadCalls, add_workload_calls_to_linker, install_host_workload};
 
 /// Capacity of a plugin incarnation's capability-call channel. Bounds queued
 /// (not-yet-served) calls; in-flight (being-served) calls are separately capped
@@ -110,7 +125,13 @@ struct ExportedFunc {
     result_tys: Arc<[Type]>,
 }
 
-/// One exported capability interface the plugin provides.
+/// One interface, with the functions and resource types it carries, as
+/// introspected from a plugin component's type. Used for all three kinds the
+/// plugin deals in — a capability it exports, an interface it both imports and
+/// exports (a self-import), and an interface it imports for a *workload* to
+/// export ([`workload_call`]) — because the shape the host needs is the same
+/// for each: the instance name to address it by, its functions' names and
+/// types, and any resources it defines.
 struct ExportedInterface {
     /// Full component instance name, e.g. `acme:kv/store@0.1.0` — the exact
     /// string used to address the interface on both the plugin's own instance
@@ -182,6 +203,11 @@ struct ComponentHostPluginState {
     /// [`crate::engine::ctx::Ctx::try_get_plugin`] — finds it there the same
     /// way it would in a workload's store.
     native_plugins: HashMap<&'static str, Arc<dyn HostPlugin>>,
+    /// The other direction: the interfaces this plugin imports for a *workload*
+    /// to export, which workloads currently serve them, and which workload each
+    /// in-flight guest task is addressing. Empty for a plugin that only
+    /// provides capabilities. See [`workload_call`].
+    workload_calls: WorkloadCalls,
 }
 
 impl ComponentHostPluginState {
@@ -297,6 +323,21 @@ impl ComponentHostPlugin {
         // so this is a no-op today, but it makes the cycle-safety invariant
         // hold by construction here too, not just at the caller.
         let native_plugins = native_only(&native_plugins);
+        let (component, base_linker) = engine.prepare_host_component(wasm)?;
+        let (exports, lifecycle) = introspect_capability_exports(id, &component)?;
+        let workload_imports =
+            classify_workload_imports(id, &component, &exports, &native_plugins)?;
+        // A plugin has to participate in one direction or the other: serve a
+        // capability a workload imports, or call an interface a workload
+        // exports. A plugin doing only the latter is a legitimate shape — a
+        // trigger that dispatches from its own `wasi:cli/run` and exports no
+        // capability at all.
+        anyhow::ensure!(
+            exports.iter().any(|e| !e.funcs.is_empty()) || !workload_imports.is_empty(),
+            "host component plugin '{id}' exports no capability functions to serve and imports \
+             no interface for a workload to export"
+        );
+
         let state = Arc::new(ComponentHostPluginState {
             id,
             tx: ArcSwapOption::empty(),
@@ -310,13 +351,32 @@ impl ComponentHostPlugin {
                 crate::timeouts::plugin_lifecycle_call().as_millis() as u64,
             ),
             native_plugins: native_plugins.clone(),
+            workload_calls: WorkloadCalls::new(id, workload_imports),
         });
 
-        let (exports, lifecycle, pre) =
-            build_plugin_linker(&engine, id, wasm, &state, &native_plugins, &config).await?;
+        let pre = build_plugin_linker(
+            &engine,
+            id,
+            &component,
+            base_linker,
+            &exports,
+            &state,
+            &native_plugins,
+            &config,
+        )
+        .await?;
 
+        // A capability the plugin exports and an interface it calls on a
+        // workload are both entries in the world the host matches a workload
+        // against: `includes_bidirectional` already covers a workload that
+        // satisfies one by *exporting* it, so the two directions need no
+        // distinction here.
         let world = WitWorld {
-            imports: exports.iter().map(|e| e.wit.clone()).collect(),
+            imports: exports
+                .iter()
+                .chain(state.workload_calls.imports())
+                .map(|e| e.wit.clone())
+                .collect(),
             exports: Default::default(),
         };
         let mut capability_funcs: Vec<CapabilityFunc> = exports
@@ -634,6 +694,32 @@ impl HostPlugin for ComponentHostPlugin {
         interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         let workload_id: Arc<str> = Arc::from(item.workload_id());
+
+        // An interface this plugin *calls* puts nothing on the item's linker —
+        // the item provides it rather than consuming it. But a match on such an
+        // interface only means the item's world mentions the package, so check
+        // here that it really exports it: an item that imports it instead has
+        // nobody to serve it, and would otherwise fail later as an unresolved
+        // wasmtime import with no mention of this plugin.
+        for called in self.state.workload_calls.imports() {
+            let iface_names: Vec<&str> = called.wit.interfaces.iter().map(String::as_str).collect();
+            if !interfaces.contains(&called.wit.namespace, &called.wit.package, &iface_names) {
+                continue;
+            }
+            anyhow::ensure!(
+                item.world()
+                    .exports
+                    .iter()
+                    .any(|exported| exported.contains(&called.wit)),
+                "host component plugin '{}' calls {} rather than serving it, so '{}' must export \
+                 it, but '{}' does not",
+                self.id,
+                called.name,
+                item.workload_id(),
+                item.id(),
+            );
+        }
+
         let linker = item.linker();
 
         for exported in self.exports.iter() {
@@ -668,11 +754,34 @@ impl HostPlugin for ComponentHostPlugin {
         Ok(())
     }
 
+    async fn on_workload_resolved(
+        &self,
+        workload: &ResolvedWorkload,
+        component_id: &str,
+    ) -> anyhow::Result<()> {
+        if self.state.workload_calls.is_empty() {
+            return Ok(());
+        }
+        // The workload is running now, so its components can be instantiated
+        // and called. Claiming them here — rather than at bind — is what a
+        // native plugin does too, and is why `callable` reports a workload only
+        // once it is up.
+        self.state
+            .workload_calls
+            .register(workload, component_id)
+            .await
+    }
+
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
         _interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
+        // Drop the routes into this workload first: its stores and warm
+        // instances go away with it, and an unbind hook below may run for a
+        // while.
+        self.state.workload_calls.unregister(workload_id);
+
         let Some(lifecycle) = &self.lifecycle else {
             return Ok(());
         };
@@ -849,37 +958,16 @@ async fn link_native_imports(
     ))
 }
 
-/// Build the plugin store's linker and pre-instantiate the component against it.
-/// This is the single place that declares the plugin's whole import surface:
-///
-/// - the WASI (and `wasi:http`) base, from [`Engine::prepare_host_component`];
-/// - the `wasmcloud:host/identity` import (unused unless the plugin imports it);
-/// - a route back to the plugin's own capability channel for any interface it
-///   both imports and exports (a self-import);
-/// - every other capability import, resolved against the host's native
-///   plugins ([`link_native_imports`]) — never against another component
-///   plugin.
-///
-/// The introspected exports are partitioned: the reserved `wasmcloud:host`
+/// Partition a plugin component's exports: the reserved `wasmcloud:host`
 /// lifecycle interface is a host-invoked contract, while everything else is a
-/// capability workloads may import. Returns the capability exports and the
-/// lifecycle export (if any) alongside the [`InstancePre`].
-async fn build_plugin_linker(
-    engine: &Engine,
+/// capability workloads may import.
+fn introspect_capability_exports(
     id: &str,
-    wasm: &[u8],
-    state: &Arc<ComponentHostPluginState>,
-    native_plugins: &HashMap<&'static str, Arc<dyn HostPlugin>>,
-    config: &HashMap<String, String>,
-) -> anyhow::Result<(
-    Vec<ExportedInterface>,
-    Option<LifecycleFuncs>,
-    InstancePre<SharedCtx>,
-)> {
-    let (component, mut linker) = engine.prepare_host_component(wasm)?;
+    component: &Component,
+) -> anyhow::Result<(Vec<ExportedInterface>, Option<LifecycleFuncs>)> {
     let mut lifecycle = None;
     let mut exports = Vec::new();
-    for export in introspect_exports(&component)? {
+    for export in introspect_exports(component)? {
         if is_reserved(&export.wit) {
             // Matched by interface name, not the exact `export.name` string —
             // `wasmcloud:host` is versioned as one package, so a patch bump
@@ -896,18 +984,130 @@ async fn build_plugin_linker(
             exports.push(export);
         }
     }
-    anyhow::ensure!(
-        exports.iter().any(|e| !e.funcs.is_empty()),
-        "host component plugin '{id}' exports no capability functions to serve"
-    );
+    Ok((exports, lifecycle))
+}
 
+/// Whether an import is already accounted for by something other than a
+/// workload: an interface the plugin exports itself (a self-import), the WASI
+/// base, or the reserved `wasmcloud:host` package.
+fn is_self_satisfied(imported: &ExportedInterface, exports: &[ExportedInterface]) -> bool {
+    exports.iter().any(|e| e.name == imported.name)
+        || is_reserved(&imported.wit)
+        || is_base_wasi(&imported.wit)
+}
+
+/// The plugin's imports that a *workload* must export, in the order the
+/// component declares them.
+///
+/// An import lands here only when nothing else can satisfy it: it is not
+/// [`is_self_satisfied`], and no registered native plugin serves its package.
+/// Natives are checked first, and on the merged package view
+/// [`link_native_imports`] uses, so an interface a built-in provides never
+/// quietly turns into a call out to a workload.
+///
+/// This is where a plugin's import surface stops being closed. Before, an
+/// import no native served failed the load; now it is published in the plugin's
+/// [`WitWorld`] and a workload that both declares and exports it satisfies it.
+/// An import nothing ever exports therefore loads fine and traps on the call
+/// that needs it, with a message naming the interface.
+fn classify_workload_imports(
+    id: &str,
+    component: &Component,
+    exports: &[ExportedInterface],
+    native_plugins: &HashMap<&'static str, Arc<dyn HostPlugin>>,
+) -> anyhow::Result<Vec<ExportedInterface>> {
+    let imports = introspect_imports(component)?;
+
+    // Merge by instance before asking the natives, exactly as
+    // `link_native_imports` does: `wasmcloud:secrets/store` and
+    // `wasmcloud:secrets/reveal` are two introspected imports but one binding,
+    // and a native declaring both together only matches the merged view.
+    let mut merged: HashMap<String, WitInterface> = HashMap::new();
+    for imported in &imports {
+        if is_self_satisfied(imported, exports) {
+            continue;
+        }
+        merged
+            .entry(imported.wit.instance())
+            .and_modify(|existing| {
+                existing.merge(&imported.wit);
+            })
+            .or_insert_with(|| imported.wit.clone());
+    }
+    let native_worlds: Vec<WitWorld> = native_plugins.values().map(|p| p.world()).collect();
+    let native_served: std::collections::HashSet<String> = merged
+        .into_iter()
+        .filter(|(_, wit)| {
+            native_worlds
+                .iter()
+                .any(|world| world.includes_bidirectional(wit))
+        })
+        .map(|(instance, _)| instance)
+        .collect();
+
+    let mut workload_imports = Vec::new();
+    for imported in imports {
+        if is_self_satisfied(&imported, exports) || native_served.contains(&imported.wit.instance())
+        {
+            continue;
+        }
+        anyhow::ensure!(
+            imported.wit.name.is_none(),
+            "host component plugin '{id}' imports {} under an `(implements ..)` label, but no \
+             host built-in serves it, so a workload export would have to — and a workload's \
+             export carries no label to route by. Import the interface directly instead.",
+            imported.name
+        );
+        anyhow::ensure!(
+            imported.resources.is_empty(),
+            "host component plugin '{id}' imports {} for a workload to export, but the interface \
+             defines resource types, which cannot cross the boundary between a plugin's store \
+             and a workload's",
+            imported.name
+        );
+        debug!(
+            id,
+            interface = %imported.name,
+            "host component plugin import will be served by a workload export"
+        );
+        workload_imports.push(imported);
+    }
+    Ok(workload_imports)
+}
+
+/// Wire the plugin store's linker and pre-instantiate the component against it.
+/// This is the single place that declares the plugin's whole import surface:
+///
+/// - the WASI (and `wasi:http`) base, from [`Engine::prepare_host_component`];
+/// - the `wasmcloud:host` identity/cancel/workload imports (unused unless the
+///   plugin imports them);
+/// - a route back to the plugin's own capability channel for any interface it
+///   both imports and exports (a self-import);
+/// - a route out to a workload's export for every import
+///   [`classify_workload_imports`] found no other provider for;
+/// - every other capability import, resolved against the host's native
+///   plugins ([`link_native_imports`]) — never against another component
+///   plugin.
+#[allow(clippy::too_many_arguments)]
+async fn build_plugin_linker(
+    engine: &Engine,
+    id: &str,
+    component: &Component,
+    mut linker: Linker<SharedCtx>,
+    exports: &[ExportedInterface],
+    state: &Arc<ComponentHostPluginState>,
+    native_plugins: &HashMap<&'static str, Arc<dyn HostPlugin>>,
+    config: &HashMap<String, String>,
+) -> anyhow::Result<InstancePre<SharedCtx>> {
     install_host_identity(&mut linker, state)
         .with_context(|| format!("failed to install host identity on plugin '{id}'"))?;
     install_host_cancel(&mut linker, state)
         .with_context(|| format!("failed to install host cancel on plugin '{id}'"))?;
+    install_host_workload(&mut linker, state)
+        .with_context(|| format!("failed to install host workload targeting on plugin '{id}'"))?;
 
-    let mut self_linked = std::collections::HashSet::new();
-    for imported in introspect_imports(&component)? {
+    let mut linked = std::collections::HashSet::new();
+    for imported in introspect_imports(component)? {
         if exports.iter().any(|e| e.name == imported.name) {
             add_capabilities_to_linker(&mut linker, state, &imported).with_context(|| {
                 format!(
@@ -915,26 +1115,34 @@ async fn build_plugin_linker(
                     imported.name
                 )
             })?;
-            self_linked.insert(Arc::clone(&imported.name));
+            linked.insert(Arc::clone(&imported.name));
         }
+    }
+    for imported in state.workload_calls.imports() {
+        add_workload_calls_to_linker(&mut linker, state, imported).with_context(|| {
+            format!(
+                "failed to wire workload-served import {} on plugin '{id}'",
+                imported.name
+            )
+        })?;
+        linked.insert(Arc::clone(&imported.name));
     }
 
     let linker = link_native_imports(
         engine,
         id,
-        &component,
+        component,
         linker,
-        &self_linked,
+        &linked,
         native_plugins,
         config,
     )
     .await?;
 
     linker
-        .instantiate_pre(&component)
+        .instantiate_pre(component)
         .map_err(anyhow::Error::from)
         .context("failed to pre-instantiate host component plugin")
-        .map(|pre| (exports, lifecycle, pre))
 }
 
 /// Interface name of the host identity import a plugin may use to partition
@@ -1309,6 +1517,12 @@ async fn run_supervisor(
         // as the tasks drop).
         let registry = JobRegistry::new();
         state.registry.store(Some(Arc::clone(&registry)));
+        // Target handles are per-store, but the stacks recording them live on
+        // `state` and so outlive a faulted incarnation, whose guests never ran
+        // their destructors. Guest task ids are reused once their task ends, so
+        // a stranded entry would otherwise route some later task's unaddressed
+        // calls to a workload it never named.
+        state.workload_calls.clear_targets();
         // `replay` was snapshotted when this incarnation's channel was
         // published (in `start()` or the restart path below): the incarnation
         // rebuilds its per-workload state from it before serving any queued
@@ -1614,6 +1828,85 @@ mod tests {
             *self.seen_id.lock().unwrap() = Some(item.id().to_string());
             Ok(())
         }
+    }
+
+    /// Compile `wat` and classify its imports the way plugin construction
+    /// does, against a single native serving `test:probe/marker`.
+    fn workload_facing(wat: &str, exports: &[ExportedInterface]) -> anyhow::Result<Vec<String>> {
+        let wasm = wat::parse_str(wat).expect("failed to parse WAT");
+        let engine = Engine::builder().build().expect("failed to build engine");
+        let component = Component::new(engine.inner(), &wasm).expect("failed to compile");
+        let recorder = Arc::new(IdRecordingPlugin::default());
+        let native_plugins: HashMap<&'static str, Arc<dyn HostPlugin>> =
+            HashMap::from([(recorder.id(), recorder as Arc<dyn HostPlugin>)]);
+        Ok(
+            classify_workload_imports("test-plugin", &component, exports, &native_plugins)?
+                .into_iter()
+                .map(|imported| imported.name.to_string())
+                .collect(),
+        )
+    }
+
+    /// Only an import nothing else can satisfy becomes the workload's to
+    /// export. A native serving the interface wins — so introducing a built-in
+    /// never silently turns into a call out to a workload — and the WASI base
+    /// is already linked.
+    #[test]
+    fn only_unsatisfiable_imports_are_left_to_a_workload() {
+        let wat = r#"
+            (component
+                (import "acme:events/handler@0.1.0" (instance))
+                (import "test:probe/marker@0.1.0" (instance))
+                (import "wasi:clocks/monotonic-clock@0.3.0" (instance))
+            )
+        "#;
+        assert_eq!(
+            workload_facing(wat, &[]).expect("classification should succeed"),
+            vec!["acme:events/handler@0.1.0"],
+            "the native-served and base-WASI imports should not be left to a workload"
+        );
+    }
+
+    /// An interface the plugin exports itself stays a self-import, routed back
+    /// to its own capability channel rather than out to a workload.
+    #[test]
+    fn a_self_import_is_not_left_to_a_workload() {
+        let wat = r#"
+            (component
+                (import "acme:events/handler@0.1.0" (instance))
+            )
+        "#;
+        let exports = vec![ExportedInterface {
+            name: Arc::from("acme:events/handler@0.1.0"),
+            wit: WitInterface::from("acme:events/handler@0.1.0"),
+            funcs: Vec::new(),
+            resources: Vec::new(),
+        }];
+        assert!(
+            workload_facing(wat, &exports)
+                .expect("classification should succeed")
+                .is_empty(),
+            "an interface the plugin also exports is served by the plugin itself"
+        );
+    }
+
+    /// A resource handle has no representation on the far side of a
+    /// plugin/workload store boundary, so an interface defining one is refused
+    /// when the plugin loads rather than trapping on a call much later.
+    #[test]
+    fn a_resource_carrying_import_is_refused() {
+        let wat = r#"
+            (component
+                (import "acme:events/handler@0.1.0" (instance
+                    (export "session" (type (sub resource)))
+                ))
+            )
+        "#;
+        let err = workload_facing(wat, &[]).expect_err("a resource import should be refused");
+        assert!(
+            err.to_string().contains("resource types"),
+            "the error should name the reason, got: {err}"
+        );
     }
 
     /// Regression test for a synthetic bind component keyed by a fresh random

--- a/crates/wash-runtime/src/plugin/component_host/workload_call.rs
+++ b/crates/wash-runtime/src/plugin/component_host/workload_call.rs
@@ -17,8 +17,8 @@
 //!   workload is already known from the caller's root guest task (the same
 //!   resolution [`wasmcloud:host/identity`] uses), so a plugin calling back
 //!   into its own caller addresses nothing; and
-//! - **explicitly**, through a `wasmcloud:host/workload` `target` handle whose
-//!   *lifetime* is the routing scope, which is what lets a plugin's own
+//! - **explicitly**, through a `wasmcloud:host/workload-call` `target` handle
+//!   whose *lifetime* is the routing scope, which is what lets a plugin's own
 //!   `wasi:cli/run` dispatch to a workload with no inbound call to inherit.
 //!
 //! The call itself reuses the workload↔workload machinery unchanged: each
@@ -47,12 +47,12 @@ use crate::engine::workload::{ExternalCallFunc, ItemExport, ResolvedWorkload};
 
 use super::{ComponentHostPluginState, ExportedInterface, caller_root_task};
 
-/// Interface name of the host workload import a plugin uses to name the
+/// Interface name of the host workload-call import a plugin uses to name the
 /// workload its calls go to. Versioned at the release that introduced the
 /// interface: wasmtime resolves a plugin's import of a later, semver-compatible
 /// `wasmcloud:host` against this definition, so the constant does not move when
 /// the package version does.
-pub(super) const HOST_WORKLOAD_INTERFACE: &str = "wasmcloud:host/workload@0.1.2";
+pub(super) const HOST_WORKLOAD_CALL_INTERFACE: &str = "wasmcloud:host/workload-call@0.1.2";
 
 /// A live `target` handle, as the guest holds it: the workload it names and the
 /// task it was opened on. The routes it directs calls to live on that task's
@@ -534,7 +534,7 @@ async fn route_workload_call(
                     wasmtime::format_err!(
                         "host component plugin '{}' called {interface}#{func} with no workload to \
                          call: it is not serving a workload's capability call, and holds no \
-                         wasmcloud:host/workload target handle naming one",
+                         wasmcloud:host/workload-call target handle naming one",
                         state.id
                     )
                 })?;
@@ -593,17 +593,17 @@ async fn route_workload_call(
     invoke_linked_async_export(accessor, params, results, &invocation).await
 }
 
-/// Install the `wasmcloud:host/workload` import on the plugin's own linker: the
-/// `target` handle that names which workload this task's calls go to, and
-/// `callable` for a plugin's own background work to discover what it may
-/// dispatch to. A plugin that does not import the interface leaves these
+/// Install the `wasmcloud:host/workload-call` import on the plugin's own
+/// linker: the `target` handle that names which workload this task's calls go
+/// to, and `callable` for a plugin's own background work to discover what it
+/// may dispatch to. A plugin that does not import the interface leaves these
 /// definitions unused.
 pub(super) fn install_host_workload(
     linker: &mut Linker<SharedCtx>,
     state: &Arc<ComponentHostPluginState>,
 ) -> anyhow::Result<()> {
     let mut instance = linker
-        .instance(HOST_WORKLOAD_INTERFACE)
+        .instance(HOST_WORKLOAD_CALL_INTERFACE)
         .map_err(|e| e.context("failed to open the host workload linker instance"))?;
 
     let drop_state = Arc::clone(state);
@@ -628,7 +628,7 @@ pub(super) fn install_host_workload(
                 Ok(())
             },
         )
-        .map_err(|e| e.context("failed to register wasmcloud:host/workload target"))?;
+        .map_err(|e| e.context("failed to register wasmcloud:host/workload-call target"))?;
 
     let open_state = Arc::clone(state);
     instance
@@ -689,7 +689,9 @@ pub(super) fn install_host_workload(
                 Ok(())
             },
         )
-        .map_err(|e| e.context("failed to define wasmcloud:host/workload#[static]target.open"))?;
+        .map_err(|e| {
+            e.context("failed to define wasmcloud:host/workload-call#[static]target.open")
+        })?;
 
     instance
         .func_new(
@@ -707,7 +709,9 @@ pub(super) fn install_host_workload(
             },
         )
         .map_err(|e| {
-            e.context("failed to define wasmcloud:host/workload#[method]target.get-workload-id")
+            e.context(
+                "failed to define wasmcloud:host/workload-call#[method]target.get-workload-id",
+            )
         })?;
 
     let callable_state = Arc::clone(state);
@@ -728,7 +732,7 @@ pub(super) fn install_host_workload(
             }
             Ok(())
         })
-        .map_err(|e| e.context("failed to define wasmcloud:host/workload#callable"))?;
+        .map_err(|e| e.context("failed to define wasmcloud:host/workload-call#callable"))?;
 
     Ok(())
 }

--- a/crates/wash-runtime/src/plugin/component_host/workload_call.rs
+++ b/crates/wash-runtime/src/plugin/component_host/workload_call.rs
@@ -1,0 +1,564 @@
+//! The plugin → workload direction: a host component plugin *importing* an
+//! interface a workload exports, and calling into it.
+//!
+//! A host-native (Rust) plugin does this by holding a value. It learns at bind
+//! time which components export the interface it wants to call (`wasi:http`'s
+//! `exports_wasi_http`, messaging's `exports_messaging_handler`), captures
+//! `(ResolvedWorkload, InstancePre, component_id)` in
+//! [`HostPlugin::on_workload_resolved`], and invokes the export off whatever
+//! event it likes — a request, a broker message, a timer.
+//!
+//! A plugin that is itself a component cannot hold that value: its import is
+//! one static linker instance with one implementation and no parameter naming a
+//! target. [`WorkloadCalls`] is that value, kept host-side on the plugin's
+//! behalf, with two ways for the guest to say which entry it means:
+//!
+//! - **implicitly**, when the plugin is serving a capability call — the calling
+//!   workload is already known from the caller's root guest task (the same
+//!   resolution [`wasmcloud:host/identity`] uses), so a plugin calling back
+//!   into its own caller addresses nothing; and
+//! - **explicitly**, through a `wasmcloud:host/workload` `target` handle whose
+//!   *lifetime* is the routing scope, which is what lets a plugin's own
+//!   `wasi:cli/run` dispatch to a workload with no inbound call to inherit.
+//!
+//! The call itself reuses the workload↔workload machinery unchanged: each
+//! function resolves to a [`LinkedExportInvocation`] pinned to the ephemeral
+//! path, so a call runs on one of the callee's warm instances (or a store built
+//! for it alone) and its arguments and results cross the boundary through
+//! [`crate::engine::store::relocate`]. A `resource` handle cannot cross this
+//! way and is rejected when the workload deploys.
+//!
+//! [`HostPlugin::on_workload_resolved`]: crate::plugin::HostPlugin::on_workload_resolved
+//! [`wasmcloud:host/identity`]: super::install_host_identity
+
+use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
+use std::sync::{Arc, Mutex, PoisonError, RwLock};
+
+use anyhow::Context as _;
+use tracing::{debug, warn};
+use wasmtime::AsContextMut;
+use wasmtime::component::{Accessor, GuestTaskId, Linker, Resource, ResourceType, Val};
+
+use crate::engine::ctx::SharedCtx;
+use crate::engine::linked_call::{LinkedExportInvocation, invoke_linked_async_export};
+use crate::engine::workload::{ExternalCallFunc, ResolvedWorkload};
+
+use super::{ComponentHostPluginState, ExportedInterface, caller_root_task};
+
+/// Interface name of the host workload import a plugin uses to name the
+/// workload its calls go to. Versioned at the release that introduced the
+/// interface: wasmtime resolves a plugin's import of a later, semver-compatible
+/// `wasmcloud:host` against this definition, so the constant does not move when
+/// the package version does.
+pub(super) const HOST_WORKLOAD_INTERFACE: &str = "wasmcloud:host/workload@0.1.2";
+
+/// A live `target` handle: the workload it names and the guest task it was
+/// constructed on. The task is recorded here rather than read from the call
+/// stack at destruction, because a handle may be dropped from a context that no
+/// longer has the constructing task on its stack (store teardown, most of all).
+struct TargetHandle {
+    workload_id: Arc<str>,
+    task: Option<GuestTaskId>,
+}
+
+/// The one component of a workload serving an interface this plugin imports,
+/// with a resolved invocation per function of that interface.
+struct InterfaceRoute {
+    /// Manifest name of the serving component. The tie-break when several
+    /// components of one workload export the same interface — the host
+    /// dispatches to one, and picking by name keeps that choice stable across
+    /// deploys, where component ids (fresh UUIDs) would not.
+    component_name: Arc<str>,
+    funcs: BTreeMap<Arc<str>, Arc<LinkedExportInvocation>>,
+}
+
+/// Every interface of one workload this plugin can call, keyed by the plugin's
+/// own import instance name.
+type WorkloadRoutes = BTreeMap<Arc<str>, InterfaceRoute>;
+
+/// The `target` handles live on one guest task, innermost last. Each is paired
+/// with the resource-table rep that identifies it, so a handle dropped out of
+/// order removes its own entry rather than whichever is on top.
+type TargetStack = Vec<(u32, Arc<str>)>;
+
+/// The workload-facing half of a host component plugin: which interfaces it
+/// imports that a workload is expected to export, which workloads currently
+/// serve them, and which workload each in-flight guest task is addressing.
+pub(super) struct WorkloadCalls {
+    plugin_id: &'static str,
+    /// The plugin's imports that no host built-in satisfies, so a workload
+    /// export must. Empty for a plugin that only provides capabilities, which
+    /// makes every operation here a no-op.
+    imports: Vec<ExportedInterface>,
+    /// Workload id → the interfaces of it this plugin can call. Written when a
+    /// workload resolves and when it unbinds; read on every call, so the lock
+    /// is only ever held long enough to clone one `Arc` out.
+    routes: RwLock<BTreeMap<Arc<str>, WorkloadRoutes>>,
+    /// Guest task → its stack of live `target` handles, innermost last. A stack
+    /// rather than a single slot so handles nest: dropping one restores the
+    /// workload the handle it shadowed names.
+    targets: Mutex<BTreeMap<Option<GuestTaskId>, TargetStack>>,
+}
+
+impl WorkloadCalls {
+    pub(super) fn new(plugin_id: &'static str, imports: Vec<ExportedInterface>) -> Self {
+        Self {
+            plugin_id,
+            imports,
+            routes: RwLock::new(BTreeMap::new()),
+            targets: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Whether this plugin imports anything a workload must export. `false` for
+    /// a pure capability plugin, which never routes a call this way.
+    pub(super) fn is_empty(&self) -> bool {
+        self.imports.is_empty()
+    }
+
+    /// The interfaces a workload may satisfy by exporting them.
+    pub(super) fn imports(&self) -> &[ExportedInterface] {
+        &self.imports
+    }
+
+    /// Claim `component_id` as the component serving whichever of this plugin's
+    /// workload-facing imports it exports, resolving an invocation per function
+    /// up front so a call is a map lookup rather than an export search.
+    ///
+    /// A component that exports none of them is simply not claimed — it bound
+    /// to this plugin for a capability it imports instead.
+    pub(super) async fn register(
+        &self,
+        workload: &ResolvedWorkload,
+        component_id: &str,
+    ) -> anyhow::Result<()> {
+        for import in &self.imports {
+            let Some(component_name) = workload
+                .component_exporting(component_id, &import.wit)
+                .await
+            else {
+                continue;
+            };
+            let funcs: Vec<ExternalCallFunc<'_>> = import
+                .funcs
+                .iter()
+                .map(|func| ExternalCallFunc {
+                    name: &func.name,
+                    param_tys: &func.param_tys,
+                    result_tys: &func.result_tys,
+                })
+                .collect();
+            let invocations = workload
+                .external_export_invocations(component_id, &import.name, &funcs)
+                .await
+                .with_context(|| {
+                    format!(
+                        "component '{component_id}' cannot serve {} for host component plugin '{}'",
+                        import.name, self.plugin_id
+                    )
+                })?;
+            let route = InterfaceRoute {
+                component_name,
+                funcs: invocations
+                    .into_iter()
+                    .map(|(name, inv)| (name, Arc::new(inv)))
+                    .collect(),
+            };
+            self.insert_route(workload.id(), Arc::clone(&import.name), route);
+        }
+        Ok(())
+    }
+
+    /// Record `route` as the way to reach `interface` on `workload_id`, keeping
+    /// the earlier-named component when one is already claimed.
+    fn insert_route(&self, workload_id: &str, interface: Arc<str>, route: InterfaceRoute) {
+        let mut routes = self.routes.write().unwrap_or_else(PoisonError::into_inner);
+        let workload_routes = routes.entry(Arc::from(workload_id)).or_default();
+        match workload_routes.entry(interface) {
+            Entry::Vacant(slot) => {
+                debug!(
+                    id = self.plugin_id,
+                    %workload_id,
+                    interface = %slot.key(),
+                    component = %route.component_name,
+                    "host component plugin can call a workload export"
+                );
+                slot.insert(route);
+            }
+            Entry::Occupied(mut slot) => {
+                // The host dispatches this interface to one component per
+                // workload, so a second exporter is ignored — deterministically,
+                // by name, mirroring how the HTTP entrypoint picks among several
+                // components carrying the same export.
+                let (selected, ignored) = if route.component_name < slot.get().component_name {
+                    let ignored = Arc::clone(&slot.get().component_name);
+                    let selected = Arc::clone(&route.component_name);
+                    slot.insert(route);
+                    (selected, ignored)
+                } else {
+                    (
+                        Arc::clone(&slot.get().component_name),
+                        Arc::clone(&route.component_name),
+                    )
+                };
+                warn!(
+                    id = self.plugin_id,
+                    %workload_id,
+                    interface = %slot.key(),
+                    %selected,
+                    %ignored,
+                    "multiple components export an interface the plugin calls; routing to one and \
+                     ignoring the rest"
+                );
+            }
+        }
+    }
+
+    /// Forget every route into `workload_id` — it has stopped, so its stores
+    /// and warm instances are going away with it.
+    pub(super) fn unregister(&self, workload_id: &str) {
+        self.routes
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(workload_id);
+    }
+
+    /// Every workload this plugin can currently call, sorted by id.
+    fn callable(&self) -> Vec<String> {
+        self.routes
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .keys()
+            .map(|id| id.to_string())
+            .collect()
+    }
+
+    /// The invocation for `interface`'s `func` on `workload_id`, if that
+    /// workload is running and exports it.
+    fn route(
+        &self,
+        workload_id: &str,
+        interface: &str,
+        func: &str,
+    ) -> Option<Arc<LinkedExportInvocation>> {
+        self.routes
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(workload_id)?
+            .get(interface)?
+            .funcs
+            .get(func)
+            .map(Arc::clone)
+    }
+
+    /// Push a newly constructed `target` handle onto its task's stack.
+    fn push_target(&self, task: Option<GuestTaskId>, rep: u32, workload_id: Arc<str>) {
+        self.targets
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .entry(task)
+            .or_default()
+            .push((rep, workload_id));
+    }
+
+    /// Remove a dropped handle from its task's stack. Removes by `rep` rather
+    /// than popping, so handles dropped out of order still each remove their
+    /// own entry; the task's entry goes when its last handle does.
+    fn pop_target(&self, task: Option<GuestTaskId>, rep: u32) {
+        let mut targets = self.targets.lock().unwrap_or_else(PoisonError::into_inner);
+        let Entry::Occupied(mut stack) = targets.entry(task) else {
+            return;
+        };
+        stack.get_mut().retain(|(held, _)| *held != rep);
+        if stack.get().is_empty() {
+            stack.remove();
+        }
+    }
+
+    /// Forget every live handle, because the store holding them is gone. The
+    /// supervisor calls this as it builds each incarnation: a faulted store's
+    /// guests never ran their destructors, and guest task ids are reused once
+    /// their task ends, so a stranded stack would answer for an unrelated task
+    /// in the next incarnation.
+    pub(super) fn clear_targets(&self) {
+        self.targets
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clear();
+    }
+
+    /// The workload the innermost live handle on `task` names. A `task` of
+    /// `None` (the caller's async call stack was unavailable) never holds one:
+    /// the constructor refuses to mint a handle it could not scope.
+    fn current_target(&self, task: Option<GuestTaskId>) -> Option<Arc<str>> {
+        self.targets
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&task)?
+            .last()
+            .map(|(_, workload_id)| Arc::clone(workload_id))
+    }
+}
+
+/// Install this plugin's shims for `iface` — an interface it imports that a
+/// workload exports — on the plugin's own linker. Where
+/// [`super::add_capabilities_to_linker`] routes a *workload's* call into the
+/// plugin store, these route the plugin's call out to a workload's store.
+pub(super) fn add_workload_calls_to_linker(
+    linker: &mut Linker<SharedCtx>,
+    state: &Arc<ComponentHostPluginState>,
+    iface: &ExportedInterface,
+) -> anyhow::Result<()> {
+    let mut linker_instance = linker
+        .instance(&iface.name)
+        .map_err(|e| e.context(format!("failed to open linker instance {}", iface.name)))?;
+
+    for func in &iface.funcs {
+        let state = Arc::clone(state);
+        let interface = Arc::clone(&iface.name);
+        let func_name = Arc::clone(&func.name);
+        linker_instance
+            .func_new_concurrent(
+                func.name.as_ref(),
+                move |accessor, _func_ty, params: &[Val], results: &mut [Val]| {
+                    let state = Arc::clone(&state);
+                    let interface = Arc::clone(&interface);
+                    let func = Arc::clone(&func_name);
+                    Box::pin(async move {
+                        route_workload_call(accessor, &state, &interface, &func, params, results)
+                            .await
+                    })
+                },
+            )
+            .map_err(|e| {
+                e.context(format!(
+                    "failed to install workload-call shim for {}/{}",
+                    iface.name, func.name
+                ))
+            })?;
+    }
+    Ok(())
+}
+
+/// Route one call from the plugin store out to the workload component that
+/// exports it.
+///
+/// The target is the workload named by the innermost live `target` handle on
+/// this task, or — with none held — the workload whose capability call this
+/// task is serving. Both are resolved from the caller's root guest task, so
+/// they stay exact while calls from other workloads interleave on the same
+/// store.
+async fn route_workload_call(
+    accessor: &Accessor<SharedCtx>,
+    state: &ComponentHostPluginState,
+    interface: &str,
+    func: &str,
+    params: &[Val],
+    results: &mut [Val],
+) -> wasmtime::Result<()> {
+    let task = accessor.with(|mut access| {
+        let mut store = access.as_context_mut();
+        caller_root_task(&mut store)
+    });
+
+    let target = match state.workload_calls.current_target(task) {
+        Some(target) => target,
+        None => {
+            let caller = task
+                .and_then(|task| state.registry()?.caller_for_task(task))
+                .ok_or_else(|| {
+                    wasmtime::format_err!(
+                        "host component plugin '{}' called {interface}#{func} with no workload to \
+                         call: it is not serving a workload's capability call, and holds no \
+                         wasmcloud:host/workload target handle naming one",
+                        state.id
+                    )
+                })?;
+            caller.workload_id
+        }
+    };
+
+    let invocation = state
+        .workload_calls
+        .route(&target, interface, func)
+        .ok_or_else(|| {
+            wasmtime::format_err!(
+                "host component plugin '{}' cannot call {interface}#{func} on workload \
+                 '{target}': it is not running, or no component of it exports {interface}",
+                state.id
+            )
+        })?;
+
+    invoke_linked_async_export(accessor, params, results, &invocation).await
+}
+
+/// Install the `wasmcloud:host/workload` import on the plugin's own linker: the
+/// `target` handle that names which workload this task's calls go to, and
+/// `callable` for a plugin's own background work to discover what it may
+/// dispatch to. A plugin that does not import the interface leaves these
+/// definitions unused.
+pub(super) fn install_host_workload(
+    linker: &mut Linker<SharedCtx>,
+    state: &Arc<ComponentHostPluginState>,
+) -> anyhow::Result<()> {
+    let mut instance = linker
+        .instance(HOST_WORKLOAD_INTERFACE)
+        .map_err(|e| e.context("failed to open the host workload linker instance"))?;
+
+    let drop_state = Arc::clone(state);
+    instance
+        .resource(
+            "target",
+            ResourceType::host::<TargetHandle>(),
+            move |mut store, rep| {
+                // A handle whose table entry is already gone (store teardown
+                // racing the guest's own drop) has nothing left to unwind, and
+                // failing here would trap a guest that did nothing wrong.
+                match store
+                    .data_mut()
+                    .table
+                    .delete(Resource::<TargetHandle>::new_own(rep))
+                {
+                    Ok(handle) => drop_state.workload_calls.pop_target(handle.task, rep),
+                    Err(e) => {
+                        debug!(err = %e, "dropped a workload target handle that was already gone");
+                    }
+                }
+                Ok(())
+            },
+        )
+        .map_err(|e| e.context("failed to register wasmcloud:host/workload target"))?;
+
+    let new_state = Arc::clone(state);
+    instance
+        .func_new(
+            "[constructor]target",
+            move |mut store, _ty, params, results| {
+                let workload_id = match params.first() {
+                    Some(Val::String(id)) => Arc::<str>::from(id.as_str()),
+                    _ => wasmtime::bail!("target constructor expects a single string workload id"),
+                };
+                // A handle scopes routing to one guest task, so a caller whose
+                // task cannot be resolved gets no handle at all: minting one
+                // anyway would pool it with every other unresolvable caller and
+                // could send their calls to a workload they never named.
+                let Some(task) = caller_root_task(&mut store) else {
+                    wasmtime::bail!(
+                        "cannot name a workload target from here: the calling task is unknown, so \
+                         the handle would have no call to scope"
+                    );
+                };
+                let handle = store.data_mut().table.push(TargetHandle {
+                    workload_id: Arc::clone(&workload_id),
+                    task: Some(task),
+                })?;
+                let rep = handle.rep();
+                let any = handle.try_into_resource_any(store.as_context_mut())?;
+                // Recorded only once the handle exists in the table, so a
+                // failure above cannot leave a target routing calls with
+                // nothing left to ever drop it.
+                new_state
+                    .workload_calls
+                    .push_target(Some(task), rep, workload_id);
+                if let Some(slot) = results.first_mut() {
+                    *slot = Val::Resource(any);
+                }
+                Ok(())
+            },
+        )
+        .map_err(|e| e.context("failed to define wasmcloud:host/workload#[constructor]target"))?;
+
+    instance
+        .func_new(
+            "[method]target.id",
+            move |mut store, _ty, params, results| {
+                let Some(Val::Resource(any)) = params.first() else {
+                    wasmtime::bail!("target.id expects a target handle");
+                };
+                let handle = any.try_into_resource::<TargetHandle>(store.as_context_mut())?;
+                let workload_id = store.data().table.get(&handle)?.workload_id.to_string();
+                if let Some(slot) = results.first_mut() {
+                    *slot = Val::String(workload_id);
+                }
+                Ok(())
+            },
+        )
+        .map_err(|e| e.context("failed to define wasmcloud:host/workload#[method]target.id"))?;
+
+    let callable_state = Arc::clone(state);
+    instance
+        .func_new("callable", move |_store, _ty, _params, results| {
+            let callable = callable_state.workload_calls.callable();
+            if let Some(slot) = results.first_mut() {
+                *slot = Val::List(callable.into_iter().map(Val::String).collect());
+            }
+            Ok(())
+        })
+        .map_err(|e| e.context("failed to define wasmcloud:host/workload#callable"))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Handles nest: the innermost names the target, dropping it restores the
+    /// one it shadowed, and dropping the last leaves no target at all. Dropped
+    /// out of order, each still removes its own entry rather than whichever is
+    /// on top — a guest is free to drop them in any order.
+    #[test]
+    fn target_handles_nest_and_unwind() {
+        let calls = WorkloadCalls::new("test-plugin", Vec::new());
+        assert!(
+            calls.current_target(None).is_none(),
+            "no handle held means no target"
+        );
+
+        calls.push_target(None, 1, Arc::from("wl-outer"));
+        calls.push_target(None, 2, Arc::from("wl-inner"));
+        assert_eq!(
+            calls.current_target(None).as_deref(),
+            Some("wl-inner"),
+            "the innermost handle wins"
+        );
+
+        calls.pop_target(None, 2);
+        assert_eq!(
+            calls.current_target(None).as_deref(),
+            Some("wl-outer"),
+            "dropping the inner handle restores the one it shadowed"
+        );
+
+        calls.push_target(None, 3, Arc::from("wl-middle"));
+        calls.push_target(None, 4, Arc::from("wl-last"));
+        calls.pop_target(None, 3);
+        assert_eq!(
+            calls.current_target(None).as_deref(),
+            Some("wl-last"),
+            "dropping a shadowed handle should not disturb the innermost one"
+        );
+
+        calls.pop_target(None, 4);
+        calls.pop_target(None, 1);
+        assert!(
+            calls.current_target(None).is_none(),
+            "dropping every handle leaves no target"
+        );
+    }
+
+    /// A plugin with no workload-facing imports never routes a call this way,
+    /// and reports nothing callable.
+    #[test]
+    fn a_plugin_that_only_serves_has_nothing_to_call() {
+        let calls = WorkloadCalls::new("test-plugin", Vec::new());
+        assert!(calls.is_empty());
+        assert!(calls.callable().is_empty());
+        assert!(
+            calls
+                .route("wl-a", "acme:events/handler@0.1.0", "notify")
+                .is_none()
+        );
+    }
+}

--- a/crates/wash-runtime/src/plugin/component_host/workload_call.rs
+++ b/crates/wash-runtime/src/plugin/component_host/workload_call.rs
@@ -33,6 +33,7 @@
 
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
 use anyhow::Context as _;
@@ -42,7 +43,7 @@ use wasmtime::component::{Accessor, GuestTaskId, Linker, Resource, ResourceType,
 
 use crate::engine::ctx::SharedCtx;
 use crate::engine::linked_call::{LinkedExportInvocation, invoke_linked_async_export};
-use crate::engine::workload::{ExternalCallFunc, ResolvedWorkload};
+use crate::engine::workload::{ExternalCallFunc, ItemExport, ResolvedWorkload};
 
 use super::{ComponentHostPluginState, ExportedInterface, caller_root_task};
 
@@ -53,10 +54,13 @@ use super::{ComponentHostPluginState, ExportedInterface, caller_root_task};
 /// the package version does.
 pub(super) const HOST_WORKLOAD_INTERFACE: &str = "wasmcloud:host/workload@0.1.2";
 
-/// A live `target` handle: the workload it names and the guest task it was
-/// constructed on. The task is recorded here rather than read from the call
-/// stack at destruction, because a handle may be dropped from a context that no
-/// longer has the constructing task on its stack (store teardown, most of all).
+/// A live `target` handle, as the guest holds it: the workload it names and the
+/// task it was opened on. The routes it directs calls to live on that task's
+/// [`TargetFrame`], which is where routing reads them.
+///
+/// The task is recorded here rather than read from the call stack at
+/// destruction, because a handle may be dropped from a context that no longer
+/// has the opening task on its stack (store teardown, most of all).
 struct TargetHandle {
     workload_id: Arc<str>,
     task: Option<GuestTaskId>,
@@ -64,6 +68,7 @@ struct TargetHandle {
 
 /// The one component of a workload serving an interface this plugin imports,
 /// with a resolved invocation per function of that interface.
+#[derive(Clone)]
 struct InterfaceRoute {
     /// Manifest name of the serving component. The tie-break when several
     /// components of one workload export the same interface — the host
@@ -74,13 +79,53 @@ struct InterfaceRoute {
 }
 
 /// Every interface of one workload this plugin can call, keyed by the plugin's
-/// own import instance name.
+/// own import instance name. Behind an `Arc` so an open `target` handle can
+/// hold the set it resolved against.
 type WorkloadRoutes = BTreeMap<Arc<str>, InterfaceRoute>;
 
-/// The `target` handles live on one guest task, innermost last. Each is paired
-/// with the resource-table rep that identifies it, so a handle dropped out of
-/// order removes its own entry rather than whichever is on top.
-type TargetStack = Vec<(u32, Arc<str>)>;
+/// Distinguishes one deployment of a workload id from the next to claim it.
+/// Minted when a workload's first route is claimed and never reused.
+type Generation = u64;
+
+/// One deployment of a workload, as this plugin can call it.
+struct CallableWorkload {
+    /// Which deployment these routes belong to. A `target` handle records the
+    /// generation it resolved against, so a handle held across a stop and a
+    /// redeploy under the same id is refused rather than dispatched into the
+    /// deployment it captured — the routes it holds name components of a
+    /// workload that is gone.
+    generation: Generation,
+    routes: Arc<WorkloadRoutes>,
+}
+
+/// One live `target` handle on a task's stack: the resource-table rep that
+/// identifies it (so a handle dropped out of order removes its own entry rather
+/// than whichever is on top), and what it routes to.
+///
+/// Holding the routes pins *which* component serves each interface for this
+/// handle's lifetime, so a second exporter appearing cannot move a call
+/// mid-dispatch. It deliberately does not pin liveness: the `generation` beside
+/// it is rechecked on every call, so a handle that outlived the deployment it
+/// resolved against is refused rather than sent into components that are gone.
+struct TargetFrame {
+    rep: u32,
+    workload_id: Arc<str>,
+    generation: Generation,
+    routes: Arc<WorkloadRoutes>,
+    /// The registry job the opening call was running under, or `None` outside
+    /// one (the plugin's own `cli/run`, or a task it spawned).
+    ///
+    /// A guest task id is reused once its task ends, and a handle the guest
+    /// never drops — one it stashed to reuse — leaves its frame behind under
+    /// that id. Without this, an unrelated later call assigned the same id
+    /// would inherit the stale target and be delivered to a workload it never
+    /// named. Job ids are unique within an incarnation and never reused, so
+    /// comparing them tells a leaked frame from a live one.
+    job: Option<crate::host::job_registry::JobId>,
+}
+
+/// The `target` handles live on one guest task, innermost last.
+type TargetStack = Vec<TargetFrame>;
 
 /// The workload-facing half of a host component plugin: which interfaces it
 /// imports that a workload is expected to export, which workloads currently
@@ -94,10 +139,20 @@ pub(super) struct WorkloadCalls {
     /// Workload id → the interfaces of it this plugin can call. Written when a
     /// workload resolves and when it unbinds; read on every call, so the lock
     /// is only ever held long enough to clone one `Arc` out.
-    routes: RwLock<BTreeMap<Arc<str>, WorkloadRoutes>>,
+    routes: RwLock<BTreeMap<Arc<str>, CallableWorkload>>,
+    /// Source of the [`Generation`] stamped on each deployment. Monotonic for
+    /// the plugin's lifetime, so a generation names one deployment of a workload
+    /// id and never a later one.
+    generations: AtomicU64,
     /// Guest task → its stack of live `target` handles, innermost last. A stack
     /// rather than a single slot so handles nest: dropping one restores the
     /// workload the handle it shadowed names.
+    ///
+    /// The key is an `Option` only so the tests below can name a task: a
+    /// `GuestTaskId` is minted by wasmtime and cannot be constructed here.
+    /// Nothing ever stores a `None` key in production — `open` refuses to hand
+    /// out a handle whose task it could not resolve — so a `None` lookup is a
+    /// miss, which is the answer a caller with no resolvable task should get.
     targets: Mutex<BTreeMap<Option<GuestTaskId>, TargetStack>>,
 }
 
@@ -107,6 +162,7 @@ impl WorkloadCalls {
             plugin_id,
             imports,
             routes: RwLock::new(BTreeMap::new()),
+            generations: AtomicU64::new(0),
             targets: Mutex::new(BTreeMap::new()),
         }
     }
@@ -122,24 +178,40 @@ impl WorkloadCalls {
         &self.imports
     }
 
-    /// Claim `component_id` as the component serving whichever of this plugin's
+    /// Claim `item_id` as the component serving whichever of this plugin's
     /// workload-facing imports it exports, resolving an invocation per function
     /// up front so a call is a map lookup rather than an export search.
     ///
-    /// A component that exports none of them is simply not claimed — it bound
-    /// to this plugin for a capability it imports instead.
+    /// An item that exports none of them is simply not claimed — it bound to
+    /// this plugin for a capability it imports instead.
     pub(super) async fn register(
         &self,
         workload: &ResolvedWorkload,
-        component_id: &str,
+        item_id: &str,
     ) -> anyhow::Result<()> {
         for import in &self.imports {
-            let Some(component_name) = workload
-                .component_exporting(component_id, &import.wit)
-                .await
-            else {
-                continue;
-            };
+            let (component_name, export_name) =
+                match workload.item_exporting(item_id, &import.wit).await {
+                    ItemExport::Component { name, export } => (name, export),
+                    ItemExport::Service => {
+                        // Loudly, not silently: the workload deploys and reports
+                        // healthy either way, so without this the only symptom
+                        // is the plugin never seeing it in `callable` and every
+                        // call naming it failing, with nothing to connect that
+                        // to the service.
+                        warn!(
+                            id = self.plugin_id,
+                            workload_id = workload.id(),
+                            service = item_id,
+                            interface = %import.name,
+                            "a workload's long-lived service exports an interface this plugin \
+                             calls, but a service is not callable from a plugin yet; move the \
+                             export to a component to make it reachable"
+                        );
+                        continue;
+                    }
+                    ItemExport::None => continue,
+                };
             let funcs: Vec<ExternalCallFunc<'_>> = import
                 .funcs
                 .iter()
@@ -149,12 +221,14 @@ impl WorkloadCalls {
                     result_tys: &func.result_tys,
                 })
                 .collect();
+            // Addressed by the component's own export name, which matching may
+            // have accepted despite differing from the plugin's import name.
             let invocations = workload
-                .external_export_invocations(component_id, &import.name, &funcs)
+                .external_export_invocations(item_id, &export_name, &funcs)
                 .await
                 .with_context(|| {
                     format!(
-                        "component '{component_id}' cannot serve {} for host component plugin '{}'",
+                        "component '{item_id}' cannot serve {} for host component plugin '{}'",
                         import.name, self.plugin_id
                     )
                 })?;
@@ -174,7 +248,16 @@ impl WorkloadCalls {
     /// the earlier-named component when one is already claimed.
     fn insert_route(&self, workload_id: &str, interface: Arc<str>, route: InterfaceRoute) {
         let mut routes = self.routes.write().unwrap_or_else(PoisonError::into_inner);
-        let workload_routes = routes.entry(Arc::from(workload_id)).or_default();
+        let entry = routes
+            .entry(Arc::from(workload_id))
+            .or_insert_with(|| CallableWorkload {
+                generation: self.generations.fetch_add(1, Ordering::Relaxed),
+                routes: Arc::default(),
+            });
+        // Copy-on-write: an already-open `target` handle keeps the snapshot it
+        // resolved against rather than seeing this workload's routes change
+        // under it mid-dispatch.
+        let workload_routes = Arc::make_mut(&mut entry.routes);
         match workload_routes.entry(interface) {
             Entry::Vacant(slot) => {
                 debug!(
@@ -224,42 +307,63 @@ impl WorkloadCalls {
             .remove(workload_id);
     }
 
-    /// Every workload this plugin can currently call, sorted by id.
-    fn callable(&self) -> Vec<String> {
+    /// Every workload this plugin can currently call, each with the interfaces
+    /// of it that are callable. Sorted by id, and each entry's interfaces sorted
+    /// by name, both by `BTreeMap` iteration.
+    ///
+    /// The interfaces are per workload rather than per plugin because a plugin
+    /// may import several and a workload need only export some: calling one it
+    /// does not export has no error result to return, so the plugin has to be
+    /// told which are safe rather than left to find out by trapping.
+    fn callable(&self) -> Vec<(String, Vec<String>)> {
         self.routes
             .read()
             .unwrap_or_else(PoisonError::into_inner)
-            .keys()
-            .map(|id| id.to_string())
+            .iter()
+            .map(|(id, callable)| {
+                let interfaces = callable
+                    .routes
+                    .keys()
+                    .map(|interface| interface.to_string())
+                    .collect();
+                (id.to_string(), interfaces)
+            })
             .collect()
     }
 
-    /// The invocation for `interface`'s `func` on `workload_id`, if that
-    /// workload is running and exports it.
-    fn route(
-        &self,
-        workload_id: &str,
-        interface: &str,
-        func: &str,
-    ) -> Option<Arc<LinkedExportInvocation>> {
+    /// Whether the deployment of `workload_id` stamped `generation` is still the
+    /// one this plugin may call. A held `target` handle keeps its route
+    /// snapshot, so this is the only thing that notices the workload stopping
+    /// underneath it — and comparing the generation rather than the id alone is
+    /// what makes a redeploy under that id count as stopping too, since the
+    /// snapshot names components of the deployment that has gone.
+    fn is_current(&self, workload_id: &str, generation: Generation) -> bool {
         self.routes
             .read()
             .unwrap_or_else(PoisonError::into_inner)
-            .get(workload_id)?
-            .get(interface)?
-            .funcs
-            .get(func)
-            .map(Arc::clone)
+            .get(workload_id)
+            .is_some_and(|callable| callable.generation == generation)
     }
 
-    /// Push a newly constructed `target` handle onto its task's stack.
-    fn push_target(&self, task: Option<GuestTaskId>, rep: u32, workload_id: Arc<str>) {
+    /// The routes into `workload_id`, with the generation they belong to, if it
+    /// is currently callable. What `open` checks, and what the handle it returns
+    /// then holds.
+    fn routes_for(&self, workload_id: &str) -> Option<(Generation, Arc<WorkloadRoutes>)> {
+        self.routes
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(workload_id)
+            .map(|callable| (callable.generation, Arc::clone(&callable.routes)))
+    }
+
+    /// Push a newly opened `target` handle onto its task's stack.
+    fn push_target(&self, task: Option<GuestTaskId>, frame: TargetFrame) {
         self.targets
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .entry(task)
             .or_default()
-            .push((rep, workload_id));
+            .push(frame);
     }
 
     /// Remove a dropped handle from its task's stack. Removes by `rep` rather
@@ -270,7 +374,7 @@ impl WorkloadCalls {
         let Entry::Occupied(mut stack) = targets.entry(task) else {
             return;
         };
-        stack.get_mut().retain(|(held, _)| *held != rep);
+        stack.get_mut().retain(|frame| frame.rep != rep);
         if stack.get().is_empty() {
             stack.remove();
         }
@@ -288,23 +392,56 @@ impl WorkloadCalls {
             .clear();
     }
 
-    /// The workload the innermost live handle on `task` names. A `task` of
-    /// `None` (the caller's async call stack was unavailable) never holds one:
-    /// the constructor refuses to mint a handle it could not scope.
-    fn current_target(&self, task: Option<GuestTaskId>) -> Option<Arc<str>> {
+    /// The workload the innermost live handle on `task` names, with the routes
+    /// that handle holds. A `task` of `None` (the caller's async call stack was
+    /// unavailable) never holds one: `open` refuses to hand out a handle it
+    /// could not scope.
+    ///
+    /// `job` is the registry job the *reading* call runs under. A frame whose
+    /// job differs was opened by an earlier call that happened to be assigned
+    /// the same guest task id and never dropped its handle; it is not this
+    /// call's target and is ignored.
+    fn current_target(
+        &self,
+        task: Option<GuestTaskId>,
+        job: Option<crate::host::job_registry::JobId>,
+    ) -> Option<(Arc<str>, Generation, Arc<WorkloadRoutes>)> {
         self.targets
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .get(&task)?
-            .last()
-            .map(|(_, workload_id)| Arc::clone(workload_id))
+            .iter()
+            .rev()
+            .find(|frame| frame.job == job)
+            .map(|frame| {
+                (
+                    Arc::clone(&frame.workload_id),
+                    frame.generation,
+                    Arc::clone(&frame.routes),
+                )
+            })
     }
+}
+
+/// The invocation for `interface`'s `func` within one workload's routes.
+fn invocation_in(
+    routes: &WorkloadRoutes,
+    interface: &str,
+    func: &str,
+) -> Option<Arc<LinkedExportInvocation>> {
+    routes.get(interface)?.funcs.get(func).map(Arc::clone)
 }
 
 /// Install this plugin's shims for `iface` — an interface it imports that a
 /// workload exports — on the plugin's own linker. Where
 /// [`super::add_capabilities_to_linker`] routes a *workload's* call into the
 /// plugin store, these route the plugin's call out to a workload's store.
+///
+/// Every function has to be `async func`, because every shim the host installs
+/// is concurrent and async-ness is part of a function's type identity: a plain
+/// `func` would fail to link with "type mismatch with async". Refused here, with
+/// a message that names the fix, rather than surfacing as that error much later
+/// at the plugin's own instantiation.
 pub(super) fn add_workload_calls_to_linker(
     linker: &mut Linker<SharedCtx>,
     state: &Arc<ComponentHostPluginState>,
@@ -315,6 +452,14 @@ pub(super) fn add_workload_calls_to_linker(
         .map_err(|e| e.context(format!("failed to open linker instance {}", iface.name)))?;
 
     for func in &iface.funcs {
+        anyhow::ensure!(
+            func.is_async,
+            "host component plugin imports {}/{} for a workload to export, but it is declared \
+             without `async`. The host serves it with a concurrent shim, which a sync-typed \
+             import cannot bind to. Declare the interface's functions `async func`.",
+            iface.name,
+            func.name,
+        );
         let state = Arc::clone(state);
         let interface = Arc::clone(&iface.name);
         let func_name = Arc::clone(&func.name);
@@ -326,7 +471,7 @@ pub(super) fn add_workload_calls_to_linker(
                     let interface = Arc::clone(&interface);
                     let func = Arc::clone(&func_name);
                     Box::pin(async move {
-                        route_workload_call(accessor, &state, &interface, &func, params, results)
+                        route_workload_call(accessor, &state, interface, func, params, results)
                             .await
                     })
                 },
@@ -349,11 +494,25 @@ pub(super) fn add_workload_calls_to_linker(
 /// task is serving. Both are resolved from the caller's root guest task, so
 /// they stay exact while calls from other workloads interleave on the same
 /// store.
+///
+/// A handle carries the routes it resolved when it opened, so *which* component
+/// serves the interface cannot change under the call. Whether that deployment is
+/// still running is a separate question, rechecked here rather than taken from
+/// the snapshot: a handle held across a stop would otherwise keep instantiating
+/// the stopped workload's components, running its guest code after the host
+/// reported it gone. The recheck is by generation, not by workload id, so a
+/// redeploy under the same id does not make a handle from the previous
+/// deployment look live again — its routes still name the components that went
+/// away with it.
+///
+/// Every failure here surfaces as a trap, because a workload-exported import
+/// has no error result the host could return instead — which is why a plugin
+/// checks with `target.open` rather than calling blind.
 async fn route_workload_call(
     accessor: &Accessor<SharedCtx>,
     state: &ComponentHostPluginState,
-    interface: &str,
-    func: &str,
+    interface: Arc<str>,
+    func: Arc<str>,
     params: &[Val],
     results: &mut [Val],
 ) -> wasmtime::Result<()> {
@@ -361,10 +520,14 @@ async fn route_workload_call(
         let mut store = access.as_context_mut();
         caller_root_task(&mut store)
     });
+    let job = task.and_then(|task| state.registry()?.job_for_task(task));
 
-    let target = match state.workload_calls.current_target(task) {
-        Some(target) => target,
+    let (target, generation, routes) = match state.workload_calls.current_target(task, job) {
+        Some(held) => held,
         None => {
+            // No handle: this call belongs to whichever workload's capability
+            // call the task is serving. That workload is by definition running
+            // (it is mid-call), so its routes are looked up live.
             let caller = task
                 .and_then(|task| state.registry()?.caller_for_task(task))
                 .ok_or_else(|| {
@@ -375,20 +538,57 @@ async fn route_workload_call(
                         state.id
                     )
                 })?;
-            caller.workload_id
+            let (generation, routes) = state
+                .workload_calls
+                .routes_for(&caller.workload_id)
+                .ok_or_else(|| {
+                    // A lifecycle hook carries no component id: the host is
+                    // telling the plugin *about* a workload rather than running
+                    // one of that workload's calls. Worth saying so, because
+                    // the hook is the one context where the caller is a
+                    // workload that is deliberately not callable, and the
+                    // generic message would read as a misconfiguration.
+                    if caller.component_id.is_none() {
+                        wasmtime::format_err!(
+                            "host component plugin '{}' cannot call {interface}#{func} on workload \
+                             '{}' from a workload-lifecycle hook: a workload is callable only \
+                             while it is running, and a hook is delivered either side of that — \
+                             still deploying at on-workload-bind, already torn down at \
+                             on-workload-unbind. Reclaim per-workload state by id instead.",
+                            state.id,
+                            caller.workload_id
+                        )
+                    } else {
+                        wasmtime::format_err!(
+                            "host component plugin '{}' cannot call {interface}#{func} back on its \
+                             caller '{}': it is not running, or nothing in it exports {interface}",
+                            state.id,
+                            caller.workload_id
+                        )
+                    }
+                })?;
+            (caller.workload_id, generation, routes)
         }
     };
 
-    let invocation = state
-        .workload_calls
-        .route(&target, interface, func)
-        .ok_or_else(|| {
-            wasmtime::format_err!(
-                "host component plugin '{}' cannot call {interface}#{func} on workload \
-                 '{target}': it is not running, or no component of it exports {interface}",
-                state.id
-            )
-        })?;
+    // Liveness is a separate question from routing, and only routing is
+    // snapshotted: a deployment that stopped since the handle opened must not be
+    // instantiated again just because the handle still remembers how.
+    if !state.workload_calls.is_current(&target, generation) {
+        return Err(wasmtime::format_err!(
+            "host component plugin '{}' cannot call {interface}#{func} on workload '{target}': the \
+             deployment this call names is no longer running",
+            state.id
+        ));
+    }
+
+    let invocation = invocation_in(&routes, &interface, &func).ok_or_else(|| {
+        wasmtime::format_err!(
+            "host component plugin '{}' cannot call {interface}#{func} on workload '{target}': no \
+             component of it exports {interface}#{func}",
+            state.id
+        )
+    })?;
 
     invoke_linked_async_export(accessor, params, results, &invocation).await
 }
@@ -430,14 +630,14 @@ pub(super) fn install_host_workload(
         )
         .map_err(|e| e.context("failed to register wasmcloud:host/workload target"))?;
 
-    let new_state = Arc::clone(state);
+    let open_state = Arc::clone(state);
     instance
         .func_new(
-            "[constructor]target",
+            "[static]target.open",
             move |mut store, _ty, params, results| {
                 let workload_id = match params.first() {
                     Some(Val::String(id)) => Arc::<str>::from(id.as_str()),
-                    _ => wasmtime::bail!("target constructor expects a single string workload id"),
+                    _ => wasmtime::bail!("target.open expects a single string workload id"),
                 };
                 // A handle scopes routing to one guest task, so a caller whose
                 // task cannot be resolved gets no handle at all: minting one
@@ -449,6 +649,18 @@ pub(super) fn install_host_workload(
                          the handle would have no call to scope"
                     );
                 };
+                // Resolving here rather than on the call is the whole point:
+                // the handle holds this snapshot, so `none` is the plugin's one
+                // chance to notice a workload it can no longer reach, and
+                // *which* component serves the interface cannot move under a
+                // call the handle scopes.
+                let Some((generation, routes)) = open_state.workload_calls.routes_for(&workload_id)
+                else {
+                    if let Some(slot) = results.first_mut() {
+                        *slot = Val::Option(None);
+                    }
+                    return Ok(());
+                };
                 let handle = store.data_mut().table.push(TargetHandle {
                     workload_id: Arc::clone(&workload_id),
                     task: Some(task),
@@ -458,23 +670,33 @@ pub(super) fn install_host_workload(
                 // Recorded only once the handle exists in the table, so a
                 // failure above cannot leave a target routing calls with
                 // nothing left to ever drop it.
-                new_state
-                    .workload_calls
-                    .push_target(Some(task), rep, workload_id);
+                let job = open_state
+                    .registry()
+                    .and_then(|registry| registry.job_for_task(task));
+                open_state.workload_calls.push_target(
+                    Some(task),
+                    TargetFrame {
+                        rep,
+                        workload_id,
+                        generation,
+                        routes,
+                        job,
+                    },
+                );
                 if let Some(slot) = results.first_mut() {
-                    *slot = Val::Resource(any);
+                    *slot = Val::Option(Some(Box::new(Val::Resource(any))));
                 }
                 Ok(())
             },
         )
-        .map_err(|e| e.context("failed to define wasmcloud:host/workload#[constructor]target"))?;
+        .map_err(|e| e.context("failed to define wasmcloud:host/workload#[static]target.open"))?;
 
     instance
         .func_new(
-            "[method]target.id",
+            "[method]target.get-workload-id",
             move |mut store, _ty, params, results| {
                 let Some(Val::Resource(any)) = params.first() else {
-                    wasmtime::bail!("target.id expects a target handle");
+                    wasmtime::bail!("target.get-workload-id expects a target handle");
                 };
                 let handle = any.try_into_resource::<TargetHandle>(store.as_context_mut())?;
                 let workload_id = store.data().table.get(&handle)?.workload_id.to_string();
@@ -484,14 +706,25 @@ pub(super) fn install_host_workload(
                 Ok(())
             },
         )
-        .map_err(|e| e.context("failed to define wasmcloud:host/workload#[method]target.id"))?;
+        .map_err(|e| {
+            e.context("failed to define wasmcloud:host/workload#[method]target.get-workload-id")
+        })?;
 
     let callable_state = Arc::clone(state);
     instance
         .func_new("callable", move |_store, _ty, _params, results| {
             let callable = callable_state.workload_calls.callable();
             if let Some(slot) = results.first_mut() {
-                *slot = Val::List(callable.into_iter().map(Val::String).collect());
+                *slot = Val::Map(
+                    callable
+                        .into_iter()
+                        .map(|(workload_id, interfaces)| {
+                            let interfaces =
+                                interfaces.into_iter().map(Val::String).collect::<Vec<_>>();
+                            (Val::String(workload_id), Val::List(interfaces))
+                        })
+                        .collect(),
+                );
             }
             Ok(())
         })
@@ -511,31 +744,43 @@ mod tests {
     #[test]
     fn target_handles_nest_and_unwind() {
         let calls = WorkloadCalls::new("test-plugin", Vec::new());
+        let frame = |rep: u32, id: &str, job: Option<u64>| TargetFrame {
+            rep,
+            workload_id: Arc::from(id),
+            generation: 0,
+            routes: Arc::new(WorkloadRoutes::new()),
+            job,
+        };
+        let held = |calls: &WorkloadCalls, job: Option<u64>| {
+            calls
+                .current_target(None, job)
+                .map(|(workload_id, ..)| workload_id.to_string())
+        };
         assert!(
-            calls.current_target(None).is_none(),
+            held(&calls, Some(1)).is_none(),
             "no handle held means no target"
         );
 
-        calls.push_target(None, 1, Arc::from("wl-outer"));
-        calls.push_target(None, 2, Arc::from("wl-inner"));
+        calls.push_target(None, frame(1, "wl-outer", Some(1)));
+        calls.push_target(None, frame(2, "wl-inner", Some(1)));
         assert_eq!(
-            calls.current_target(None).as_deref(),
+            held(&calls, Some(1)).as_deref(),
             Some("wl-inner"),
             "the innermost handle wins"
         );
 
         calls.pop_target(None, 2);
         assert_eq!(
-            calls.current_target(None).as_deref(),
+            held(&calls, Some(1)).as_deref(),
             Some("wl-outer"),
             "dropping the inner handle restores the one it shadowed"
         );
 
-        calls.push_target(None, 3, Arc::from("wl-middle"));
-        calls.push_target(None, 4, Arc::from("wl-last"));
+        calls.push_target(None, frame(3, "wl-middle", Some(1)));
+        calls.push_target(None, frame(4, "wl-last", Some(1)));
         calls.pop_target(None, 3);
         assert_eq!(
-            calls.current_target(None).as_deref(),
+            held(&calls, Some(1)).as_deref(),
             Some("wl-last"),
             "dropping a shadowed handle should not disturb the innermost one"
         );
@@ -543,9 +788,122 @@ mod tests {
         calls.pop_target(None, 4);
         calls.pop_target(None, 1);
         assert!(
-            calls.current_target(None).is_none(),
+            held(&calls, Some(1)).is_none(),
             "dropping every handle leaves no target"
         );
+    }
+
+    /// A handle the guest never drops outlives its task, and wasmtime reuses a
+    /// guest task id once its task ends. The stale frame must not become the
+    /// target of whatever call is assigned that id next — it belongs to a job
+    /// that is over, and job ids are never reused.
+    #[test]
+    fn a_leaked_handle_is_not_inherited_by_a_later_call() {
+        let calls = WorkloadCalls::new("test-plugin", Vec::new());
+        // Job 1 opens a handle and never drops it; its task ends.
+        calls.push_target(
+            None,
+            TargetFrame {
+                rep: 1,
+                workload_id: Arc::from("wl-other"),
+                generation: 0,
+                routes: Arc::new(WorkloadRoutes::new()),
+                job: Some(1),
+            },
+        );
+
+        // Job 2 is assigned the same task id and holds no handle of its own.
+        assert!(
+            calls.current_target(None, Some(2)).is_none(),
+            "a later call must not inherit a leaked frame from an earlier job"
+        );
+        // The frame is still the target of its own job, which may still be
+        // running — only the task id was reused.
+        assert_eq!(
+            calls
+                .current_target(None, Some(1))
+                .map(|(workload_id, ..)| workload_id.to_string())
+                .as_deref(),
+            Some("wl-other")
+        );
+    }
+
+    /// A `target` handle names one *deployment*, not a workload id. Held across
+    /// a stop and a redeploy under the same id, its routes still name components
+    /// of the workload that went away, so the generation it captured has to read
+    /// as gone even though the id is callable again.
+    #[test]
+    fn a_redeploy_under_the_same_id_does_not_revive_a_held_target() {
+        let calls = WorkloadCalls::new("test-plugin", Vec::new());
+        let claim = || {
+            calls.insert_route(
+                "wl-a",
+                Arc::from("acme:events/handler@0.1.0"),
+                InterfaceRoute {
+                    component_name: Arc::from("events-caller"),
+                    funcs: BTreeMap::new(),
+                },
+            );
+        };
+
+        claim();
+        let (held, _routes) = calls.routes_for("wl-a").expect("the workload is callable");
+        assert!(calls.is_current("wl-a", held));
+
+        calls.unregister("wl-a");
+        assert!(
+            !calls.is_current("wl-a", held),
+            "a stopped workload is not callable"
+        );
+
+        claim();
+        assert!(
+            calls.routes_for("wl-a").is_some(),
+            "the new deployment is callable"
+        );
+        assert!(
+            !calls.is_current("wl-a", held),
+            "a handle opened against the previous deployment must not reach the new one"
+        );
+    }
+
+    /// A workload-facing import has to be `async func`: the host serves it with
+    /// a concurrent shim, which a sync-typed import cannot bind to. Refused at
+    /// load, where the message can name the fix, rather than surfacing as a
+    /// "type mismatch with async" at the plugin's own instantiation.
+    #[test]
+    fn a_sync_workload_facing_import_is_refused() {
+        use super::super::tests::{idle_state, one_func_interface};
+        use crate::engine::Engine;
+
+        let engine = Engine::builder().build().expect("failed to build engine");
+        let mut linker = Linker::new(engine.inner());
+        let state = idle_state("sync-workload-call-plugin");
+        let iface = one_func_interface("acme:events/handler@0.1.0", "notify", false);
+
+        let err = add_workload_calls_to_linker(&mut linker, &state, &iface)
+            .expect_err("a sync workload-facing import should be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("concurrent shim") && msg.contains("async func"),
+            "the error should name the hazard and the fix, got: {msg}"
+        );
+    }
+
+    /// The same interface declared `async func` installs, which is what the
+    /// `events-plugin` fixture and every real workload-facing import look like.
+    #[test]
+    fn an_async_workload_facing_import_installs() {
+        use super::super::tests::{idle_state, one_func_interface};
+        use crate::engine::Engine;
+
+        let engine = Engine::builder().build().expect("failed to build engine");
+        let mut linker = Linker::new(engine.inner());
+        let state = idle_state("async-workload-call-plugin");
+        let iface = one_func_interface("acme:events/handler@0.1.0", "notify", true);
+
+        add_workload_calls_to_linker(&mut linker, &state, &iface)
+            .expect("an async workload-facing import should install");
     }
 
     /// A plugin with no workload-facing imports never routes a call this way,
@@ -556,9 +914,8 @@ mod tests {
         assert!(calls.is_empty());
         assert!(calls.callable().is_empty());
         assert!(
-            calls
-                .route("wl-a", "acme:events/handler@0.1.0", "notify")
-                .is_none()
+            calls.routes_for("wl-a").is_none(),
+            "an unknown workload is not callable, so `open` hands out no handle"
         );
     }
 }

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -69,6 +69,28 @@ impl WitWorld {
         })
     }
 
+    /// Whether this world *provides* `interface` — covers every one of its
+    /// interfaces from this world's own imports.
+    ///
+    /// A plugin's world states what it provides in `imports`, by the convention
+    /// [`crate::plugin::HostPlugin::world`] follows: a plugin declaring
+    /// `wasi:keyvalue/store` there is offering to serve it. Its `exports` mean
+    /// the opposite direction — an interface the plugin *calls* on a workload,
+    /// as `wasmcloud:messaging` does with `handler`.
+    ///
+    /// [`WitWorld::includes_bidirectional`] deliberately ignores that
+    /// distinction, because a workload satisfies an interface by importing or
+    /// exporting it. Asking whether a *provider* exists is the opposite
+    /// question, and answering it with the bidirectional check would count a
+    /// plugin's own outbound calls as though it served them.
+    pub fn provides(&self, interface: &WitInterface) -> bool {
+        interface.interfaces.iter().all(|i| {
+            self.imports
+                .iter()
+                .any(|im| interface.same_package(im) && im.interfaces.contains(i))
+        })
+    }
+
     /// Checks if a guest world (imports) can be satisfied by a host world (exports).
     ///
     /// A host world satisfies a guest world if all interfaces required by the guest

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -137,6 +137,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "events-caller"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
+name = "events-plugin"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -151,6 +151,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "events-service"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -60,6 +60,8 @@ members = [
     "secrets-consumer-plugin-caller",
     "http-egress-plugin",
     "http-egress-plugin-caller",
+    "events-plugin",
+    "events-caller",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/acme-events/events.wit
+++ b/crates/wash-runtime/tests/fixtures/acme-events/events.wit
@@ -12,6 +12,16 @@ interface handler {
     notify: async func(message: string) -> string;
 }
 
+/// A second interface in the plugin's *calling* direction that the workload
+/// fixture deliberately does not export. A plugin importing two of these is
+/// what makes `callable`'s per-workload interface list load-bearing: it has to
+/// say that `handler` is reachable on a workload and `metrics` is not, because
+/// calling one a workload does not export can only trap.
+interface metrics {
+    /// Report a measurement. Nothing exports this, so nothing may call it.
+    report: async func(measurement: string) -> string;
+}
+
 interface control {
     /// Call `handler.notify` back on the CALLING workload, naming no target —
     /// the host routes it to whichever workload's capability call this is.
@@ -19,7 +29,10 @@ interface control {
 
     /// Call `handler.notify` on the workload `id`, named with a
     /// `wasmcloud:host/workload` target handle rather than inherited from the
-    /// caller.
+    /// caller. The message carries the id read back off the handle, so the
+    /// reply proves which workload the host scoped the call to. Answers
+    /// `"unroutable:{id}"` when no such workload is callable, which is what a
+    /// plugin does with a `target.open` that returns `none`.
     dispatch: async func(id: string, message: string) -> string;
 
     /// Call `handler.notify` on `id` from inside a nested target handle, and
@@ -28,6 +41,24 @@ interface control {
     /// goes back to the caller.
     nested: async func(id: string, message: string) -> string;
 
-    /// Every workload the plugin can currently call.
+    /// Every workload the plugin can currently call, one entry per workload as
+    /// `"{id}={interface},{interface}"` — flattened so an HTTP test can read
+    /// the map the host hands the plugin.
     callable: async func() -> list<string>;
+
+    /// Call `metrics.report` on the workload named by a target handle. Nothing
+    /// exports `metrics`, so this exists only to make the plugin genuinely
+    /// import a second workload-facing interface; calling it would trap.
+    report: async func(id: string, measurement: string) -> string;
+
+    /// What the plugin saw when it tried to open a target for `id` from inside
+    /// each `wasmcloud:host/workload-lifecycle` hook, as
+    /// `"bind:{seen}|unbind:{seen}"` where each `seen` is `some` or `none`.
+    /// Empty for a workload no hook has run for.
+    ///
+    /// Both should read `none`: a workload is callable only while it is
+    /// running, and a hook is delivered either side of that. The record lives
+    /// in the plugin instance's own memory, so a non-empty answer here is also
+    /// evidence the plugin never restarted.
+    lifecycle-probe: async func(id: string) -> string;
 }

--- a/crates/wash-runtime/tests/fixtures/acme-events/events.wit
+++ b/crates/wash-runtime/tests/fixtures/acme-events/events.wit
@@ -1,0 +1,33 @@
+package acme:events@0.1.0;
+
+/// A bespoke event package whose two interfaces run in opposite directions, the
+/// same shape `wasmcloud:messaging` has: the host component plugin *exports*
+/// `control` for workloads to call, and *imports* `handler` for workloads to
+/// serve. Everything is an `async func` over primitives, so both directions use
+/// the handle-free relocation fast path.
+interface handler {
+    /// Handle one event. Exported by a workload; called by the plugin across
+    /// the store boundary. The reply carries the handling workload's own tag,
+    /// so a caller can tell which workload actually ran it.
+    notify: async func(message: string) -> string;
+}
+
+interface control {
+    /// Call `handler.notify` back on the CALLING workload, naming no target —
+    /// the host routes it to whichever workload's capability call this is.
+    echo: async func(message: string) -> string;
+
+    /// Call `handler.notify` on the workload `id`, named with a
+    /// `wasmcloud:host/workload` target handle rather than inherited from the
+    /// caller.
+    dispatch: async func(id: string, message: string) -> string;
+
+    /// Call `handler.notify` on `id` from inside a nested target handle, and
+    /// again once that handle is dropped, returning both replies joined by
+    /// `"|"`. Proves a target's scope is its handle's lifetime: the second call
+    /// goes back to the caller.
+    nested: async func(id: string, message: string) -> string;
+
+    /// Every workload the plugin can currently call.
+    callable: async func() -> list<string>;
+}

--- a/crates/wash-runtime/tests/fixtures/acme-events/events.wit
+++ b/crates/wash-runtime/tests/fixtures/acme-events/events.wit
@@ -28,8 +28,8 @@ interface control {
     echo: async func(message: string) -> string;
 
     /// Call `handler.notify` on the workload `id`, named with a
-    /// `wasmcloud:host/workload` target handle rather than inherited from the
-    /// caller. The message carries the id read back off the handle, so the
+    /// `wasmcloud:host/workload-call` target handle rather than inherited from
+    /// the caller. The message carries the id read back off the handle, so the
     /// reply proves which workload the host scoped the call to. Answers
     /// `"unroutable:{id}"` when no such workload is callable, which is what a
     /// plugin does with a `target.open` that returns `none`.

--- a/crates/wash-runtime/tests/fixtures/events-caller/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/events-caller/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/events_caller.wasm

--- a/crates/wash-runtime/tests/fixtures/events-caller/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/events-caller/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "events-caller"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/events-caller/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/events-caller/src/lib.rs
@@ -8,9 +8,10 @@
 //! one did:
 //!
 //! - `GET /echo?msg=M`           -> `control.echo(M)`          -> handling tag
-//! - `GET /dispatch?id=W&msg=M`  -> `control.dispatch(W, M)`   -> W's tag
+//! - `GET /dispatch?id=W&msg=M`  -> `control.dispatch(W, M)`   -> W's tag + W
 //! - `GET /nested?id=W&msg=M`    -> `control.nested(W, M)`     -> `W|self`
-//! - `GET /callable`             -> `control.callable()`       -> ids, one per line
+//! - `GET /callable`             -> `control.callable()`       -> `id=iface,…` a line
+//! - `GET /probe?id=W`           -> `control.lifecycle-probe(W)` -> what W's hooks saw
 //! - `GET /tag`                  -> this workload's own tag
 
 mod bindings {
@@ -69,6 +70,11 @@ impl HttpGuest for Component {
         if route.starts_with("/callable") {
             let ids = control::callable().await;
             return Ok(make_response(200, ids.join("\n").into_bytes()));
+        }
+        if route.starts_with("/probe") {
+            let id = query_get(query, "id").unwrap_or_default();
+            let seen = control::lifecycle_probe(id).await;
+            return Ok(make_response(200, seen.into_bytes()));
         }
         if route.starts_with("/tag") {
             return Ok(make_response(200, tag().into_bytes()));

--- a/crates/wash-runtime/tests/fixtures/events-caller/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/events-caller/src/lib.rs
@@ -1,0 +1,110 @@
+//! Workload component sitting on both sides of `acme:events`: it imports
+//! `control` (served by the host component plugin, the usual capability
+//! direction) and exports `handler` (which the plugin calls back into, the
+//! direction this fixture exists to exercise).
+//!
+//! Every reply from `notify` is prefixed with this workload's `EVENT_TAG`, so a
+//! test can tell WHICH workload actually ran the callback rather than only that
+//! one did:
+//!
+//! - `GET /echo?msg=M`           -> `control.echo(M)`          -> handling tag
+//! - `GET /dispatch?id=W&msg=M`  -> `control.dispatch(W, M)`   -> W's tag
+//! - `GET /nested?id=W&msg=M`    -> `control.nested(W, M)`     -> `W|self`
+//! - `GET /callable`             -> `control.callable()`       -> ids, one per line
+//! - `GET /tag`                  -> this workload's own tag
+
+mod bindings {
+    #![allow(unsafe_code)]
+    wit_bindgen::generate!({ world: "caller", generate_all });
+}
+
+use bindings::acme::events::control;
+use bindings::exports::acme::events::handler::Guest as HandlerGuest;
+use bindings::exports::wasi::http::handler::Guest as HttpGuest;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+
+struct Component;
+
+/// This workload's own name, from its manifest environment. Lets two deploys of
+/// this same wasm be told apart in a callback's reply.
+fn tag() -> String {
+    std::env::var("EVENT_TAG").unwrap_or_else(|_| "untagged".to_string())
+}
+
+impl HandlerGuest for Component {
+    /// Called by the plugin across the store boundary. Reports which workload
+    /// handled it, and what it was handed.
+    async fn notify(message: String) -> String {
+        format!("{}:{message}", tag())
+    }
+}
+
+impl HttpGuest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        let path = request
+            .get_path_with_query()
+            .unwrap_or_else(|| "/".to_string());
+        let (route, query) = match path.split_once('?') {
+            Some((r, q)) => (r, q),
+            None => (path.as_str(), ""),
+        };
+
+        if route.starts_with("/echo") {
+            let msg = query_get(query, "msg").unwrap_or_default();
+            let reply = control::echo(msg).await;
+            return Ok(make_response(200, reply.into_bytes()));
+        }
+        if route.starts_with("/dispatch") {
+            let id = query_get(query, "id").unwrap_or_default();
+            let msg = query_get(query, "msg").unwrap_or_default();
+            let reply = control::dispatch(id, msg).await;
+            return Ok(make_response(200, reply.into_bytes()));
+        }
+        if route.starts_with("/nested") {
+            let id = query_get(query, "id").unwrap_or_default();
+            let msg = query_get(query, "msg").unwrap_or_default();
+            let reply = control::nested(id, msg).await;
+            return Ok(make_response(200, reply.into_bytes()));
+        }
+        if route.starts_with("/callable") {
+            let ids = control::callable().await;
+            return Ok(make_response(200, ids.join("\n").into_bytes()));
+        }
+        if route.starts_with("/tag") {
+            return Ok(make_response(200, tag().into_bytes()));
+        }
+
+        Ok(make_response(404, Vec::new()))
+    }
+}
+
+fn query_get(query: &str, name: &str) -> Option<String> {
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k == name).then(|| v.to_string())
+    })
+}
+
+fn make_response(status: u16, body: Vec<u8>) -> Response {
+    let headers = Fields::new();
+    let _ = headers.set(
+        &"content-type".to_string(),
+        &[b"application/octet-stream".to_vec()],
+    );
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    let _ = response.set_status_code(status);
+    response
+}
+
+mod export {
+    #![allow(unsafe_code)]
+    use super::{bindings, Component};
+    bindings::export!(Component with_types_in bindings);
+}

--- a/crates/wash-runtime/tests/fixtures/events-caller/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/events-caller/wit/world.wit
@@ -4,8 +4,14 @@ package acme:eventscaller@0.1.0;
 /// workload is: it *imports* `acme:events/control` (the plugin's capability)
 /// and *exports* `acme:events/handler` (which the plugin calls back into).
 ///
-/// A single manifest entry for `acme:events` covers both, since interface
-/// matching already looks at a workload's exports as well as its imports.
+/// One manifest entry naming both interfaces covers this component, because
+/// interface matching looks at a component's exports as well as its imports —
+/// but it is matched against ONE component at a time, and every interface in
+/// the entry has to be in that component's world. A workload that splits the
+/// two across components needs an entry per component, each naming only the
+/// interfaces that component itself imports or exports; a combined entry
+/// matches neither of them, and the deploy fails at instantiation on an
+/// unresolved import instead.
 world caller {
     import wasi:http/types@0.3.0;
     import acme:events/control@0.1.0;

--- a/crates/wash-runtime/tests/fixtures/events-caller/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/events-caller/wit/world.wit
@@ -1,0 +1,14 @@
+package acme:eventscaller@0.1.0;
+
+/// Workload component on both sides of one package, the way a messaging
+/// workload is: it *imports* `acme:events/control` (the plugin's capability)
+/// and *exports* `acme:events/handler` (which the plugin calls back into).
+///
+/// A single manifest entry for `acme:events` covers both, since interface
+/// matching already looks at a workload's exports as well as its imports.
+world caller {
+    import wasi:http/types@0.3.0;
+    import acme:events/control@0.1.0;
+    export acme:events/handler@0.1.0;
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/events-caller/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/events-caller/wkg.toml
@@ -1,0 +1,8 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:http" = { path = "../p3-wit-deps/wasi-http-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }
+"acme:events" = { path = "../acme-events" }

--- a/crates/wash-runtime/tests/fixtures/events-plugin/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/events_plugin.wasm

--- a/crates/wash-runtime/tests/fixtures/events-plugin/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "events-plugin"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/events-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/src/lib.rs
@@ -4,8 +4,8 @@
 //!
 //! The exported ops cover the two ways a call finds its workload: `echo` names
 //! none and inherits the caller, `dispatch` names one with a
-//! `wasmcloud:host/workload` target handle, and `nested` shows the handle's
-//! lifetime is the scope by calling once inside it and once after.
+//! `wasmcloud:host/workload-call` target handle, and `nested` shows the
+//! handle's lifetime is the scope by calling once inside it and once after.
 //!
 //! It imports a *second* workload-facing interface, `acme:events/metrics`, that
 //! no workload exports, so `callable` has to report per workload which of the
@@ -33,7 +33,7 @@ use bindings::exports::acme::events::control::Guest;
 use bindings::exports::wasmcloud::host::workload_lifecycle::{
     Guest as LifecycleGuest, WorkloadInfo,
 };
-use bindings::wasmcloud::host::workload::{self, Target};
+use bindings::wasmcloud::host::workload_call::{self, Target};
 
 /// Workload id -> what each lifecycle hook saw when it tried to open a target
 /// for that workload. Instance memory, so it is empty again after a restart.
@@ -105,7 +105,7 @@ impl Guest for EventsPlugin {
     /// interfaces are what make it worth a map: this plugin imports two, and a
     /// workload exporting only one must be reported that way.
     async fn callable() -> Vec<String> {
-        workload::callable()
+        workload_call::callable()
             .into_iter()
             .map(|(id, interfaces)| format!("{id}={}", interfaces.join(",")))
             .collect()

--- a/crates/wash-runtime/tests/fixtures/events-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/src/lib.rs
@@ -1,0 +1,51 @@
+//! Host component plugin that CALLS its workloads rather than only serving
+//! them: it imports `acme:events/handler`, which no host built-in provides, so
+//! the host routes each call to the export of a bound workload.
+//!
+//! The three exported ops cover the two ways a call finds its workload:
+//! `echo` names none and inherits the caller, `dispatch` names one with a
+//! `wasmcloud:host/workload` target handle, and `nested` shows the handle's
+//! lifetime is the scope by calling once inside it and once after.
+
+mod bindings {
+    #![allow(unsafe_code)]
+    wit_bindgen::generate!({ world: "events-plugin", generate_all });
+}
+
+use bindings::acme::events::handler;
+use bindings::exports::acme::events::control::Guest;
+use bindings::wasmcloud::host::workload::{self, Target};
+
+struct EventsPlugin;
+
+impl Guest for EventsPlugin {
+    /// No target handle is held, so the host sends this to the workload whose
+    /// `control` call is running — the plugin calling back into its own caller.
+    async fn echo(message: String) -> String {
+        handler::notify(format!("echo:{message}")).await
+    }
+
+    /// The handle names the workload for as long as it is alive, so this
+    /// reaches `id` even though the calling workload is someone else.
+    async fn dispatch(id: String, message: String) -> String {
+        let _target = Target::new(&id);
+        handler::notify(format!("dispatch:{message}")).await
+    }
+
+    /// Held only for the inner block, so the second call falls back to the
+    /// caller — the difference a scoped handle is supposed to make.
+    async fn nested(id: String, message: String) -> String {
+        let targeted = {
+            let _target = Target::new(&id);
+            handler::notify(format!("inner:{message}")).await
+        };
+        let untargeted = handler::notify(format!("outer:{message}")).await;
+        format!("{targeted}|{untargeted}")
+    }
+
+    async fn callable() -> Vec<String> {
+        workload::callable()
+    }
+}
+
+bindings::export!(EventsPlugin with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/events-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/src/lib.rs
@@ -2,21 +2,71 @@
 //! them: it imports `acme:events/handler`, which no host built-in provides, so
 //! the host routes each call to the export of a bound workload.
 //!
-//! The three exported ops cover the two ways a call finds its workload:
-//! `echo` names none and inherits the caller, `dispatch` names one with a
+//! The exported ops cover the two ways a call finds its workload: `echo` names
+//! none and inherits the caller, `dispatch` names one with a
 //! `wasmcloud:host/workload` target handle, and `nested` shows the handle's
 //! lifetime is the scope by calling once inside it and once after.
+//!
+//! It imports a *second* workload-facing interface, `acme:events/metrics`, that
+//! no workload exports, so `callable` has to report per workload which of the
+//! two is reachable rather than just naming the workload.
+//!
+//! It also exports the lifecycle hooks, purely to record what a hook can
+//! reach. A workload is callable only while it is running, so neither hook can
+//! call the workload it is about — `on-workload-bind` arrives while it is
+//! still deploying and `on-workload-unbind` after it has been torn down. The
+//! hooks check with `target.open` rather than calling blind, which is the
+//! pattern that keeps a plugin from trapping: a workload-exported import has no
+//! error result, so a call that cannot be routed takes the plugin's store down
+//! with it.
 
 mod bindings {
     #![allow(unsafe_code)]
     wit_bindgen::generate!({ world: "events-plugin", generate_all });
 }
 
-use bindings::acme::events::handler;
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use bindings::acme::events::{handler, metrics};
 use bindings::exports::acme::events::control::Guest;
+use bindings::exports::wasmcloud::host::workload_lifecycle::{
+    Guest as LifecycleGuest, WorkloadInfo,
+};
 use bindings::wasmcloud::host::workload::{self, Target};
 
+/// Workload id -> what each lifecycle hook saw when it tried to open a target
+/// for that workload. Instance memory, so it is empty again after a restart.
+static PROBE: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());
+
+/// Try to open a target for `id` from inside a hook and append what happened.
+fn probe(id: &str, phase: &str) {
+    let seen = match Target::open(id) {
+        Some(_) => "some",
+        None => "none",
+    };
+    let mut probe = PROBE.lock().unwrap();
+    let entry = probe.entry(id.to_string()).or_default();
+    if !entry.is_empty() {
+        entry.push('|');
+    }
+    entry.push_str(phase);
+    entry.push(':');
+    entry.push_str(seen);
+}
+
 struct EventsPlugin;
+
+impl LifecycleGuest for EventsPlugin {
+    async fn on_workload_bind(workload: WorkloadInfo) -> Result<(), String> {
+        probe(&workload.id, "bind");
+        Ok(())
+    }
+
+    async fn on_workload_unbind(id: String) {
+        probe(&id, "unbind");
+    }
+}
 
 impl Guest for EventsPlugin {
     /// No target handle is held, so the host sends this to the workload whose
@@ -26,25 +76,53 @@ impl Guest for EventsPlugin {
     }
 
     /// The handle names the workload for as long as it is alive, so this
-    /// reaches `id` even though the calling workload is someone else.
+    /// reaches `id` even though the calling workload is someone else. `open`
+    /// answering `none` is the ordinary way a dispatch loop learns a workload
+    /// went away — the plugin reports it and carries on rather than calling
+    /// into nothing and trapping.
     async fn dispatch(id: String, message: String) -> String {
-        let _target = Target::new(&id);
-        handler::notify(format!("dispatch:{message}")).await
+        let Some(target) = Target::open(&id) else {
+            return format!("unroutable:{id}");
+        };
+        // Read the handle back rather than reuse `id`, so the reply carries the
+        // workload the *host* thinks this call is scoped to.
+        let named = target.get_workload_id();
+        handler::notify(format!("dispatch:{named}:{message}")).await
     }
 
     /// Held only for the inner block, so the second call falls back to the
     /// caller — the difference a scoped handle is supposed to make.
     async fn nested(id: String, message: String) -> String {
-        let targeted = {
-            let _target = Target::new(&id);
-            handler::notify(format!("inner:{message}")).await
+        let targeted = match Target::open(&id) {
+            Some(_target) => handler::notify(format!("inner:{message}")).await,
+            None => format!("unroutable:{id}"),
         };
         let untargeted = handler::notify(format!("outer:{message}")).await;
         format!("{targeted}|{untargeted}")
     }
 
+    /// Flatten the map the host hands back so an HTTP test can read it. The
+    /// interfaces are what make it worth a map: this plugin imports two, and a
+    /// workload exporting only one must be reported that way.
     async fn callable() -> Vec<String> {
         workload::callable()
+            .into_iter()
+            .map(|(id, interfaces)| format!("{id}={}", interfaces.join(",")))
+            .collect()
+    }
+
+    /// Never called by a test — calling `metrics` on a workload that does not
+    /// export it traps. It exists so the plugin genuinely imports a second
+    /// workload-facing interface.
+    async fn report(id: String, measurement: String) -> String {
+        let Some(_target) = Target::open(&id) else {
+            return format!("unroutable:{id}");
+        };
+        metrics::report(measurement).await
+    }
+
+    async fn lifecycle_probe(id: String) -> String {
+        PROBE.lock().unwrap().get(&id).cloned().unwrap_or_default()
     }
 }
 

--- a/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
@@ -11,8 +11,15 @@ world events-plugin {
     // The reverse direction: a workload exports this and the host routes the
     // plugin's calls on it to whichever workload the call is for.
     import acme:events/handler@0.1.0;
+    // A second interface in the same direction that no workload exports, so
+    // `callable` has to report per workload which of the two is reachable.
+    import acme:events/metrics@0.1.0;
     // Names which workload a call goes to, and lists the ones that can be
     // called at all. Unused for `echo`, which inherits its caller.
     import wasmcloud:host/workload@0.1.2;
     export acme:events/control@0.1.0;
+    // Lifecycle hooks, used here only to probe what a hook can reach: a
+    // workload is callable exactly while it is running, and both hooks land
+    // outside that window.
+    export wasmcloud:host/workload-lifecycle@0.1.2;
 }

--- a/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
@@ -1,0 +1,18 @@
+package acme:eventsplugin@0.1.0;
+
+/// Host component plugin exercising the plugin → workload direction: it
+/// *imports* `acme:events/handler`, which no host built-in provides, so the
+/// host resolves it to the export of a workload bound to this plugin.
+///
+/// It also exports `acme:events/control` so a test can drive both routing
+/// modes from an ordinary request rather than needing background work of its
+/// own — the plugin is otherwise a pure caller.
+world events-plugin {
+    // The reverse direction: a workload exports this and the host routes the
+    // plugin's calls on it to whichever workload the call is for.
+    import acme:events/handler@0.1.0;
+    // Names which workload a call goes to, and lists the ones that can be
+    // called at all. Unused for `echo`, which inherits its caller.
+    import wasmcloud:host/workload@0.1.2;
+    export acme:events/control@0.1.0;
+}

--- a/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
@@ -16,7 +16,7 @@ world events-plugin {
     import acme:events/metrics@0.1.0;
     // Names which workload a call goes to, and lists the ones that can be
     // called at all. Unused for `echo`, which inherits its caller.
-    import wasmcloud:host/workload@0.1.2;
+    import wasmcloud:host/workload-call@0.1.2;
     export acme:events/control@0.1.0;
     // Lifecycle hooks, used here only to probe what a hook can reach: a
     // workload is callable exactly while it is running, and both hooks land

--- a/crates/wash-runtime/tests/fixtures/events-plugin/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/wkg.toml
@@ -1,0 +1,11 @@
+[overrides]
+# `wasmcloud:host` is defined and installed by the runtime itself, so its
+# interfaces resolve from the repo's own copy rather than a registry.
+"wasmcloud:host" = { path = "../../../../../wit/host/wit" }
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:http" = { path = "../p3-wit-deps/wasi-http-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }
+"acme:events" = { path = "../acme-events" }

--- a/crates/wash-runtime/tests/fixtures/kv-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin/wit/world.wit
@@ -15,10 +15,10 @@ world kv-plugin {
     import wasi:clocks/system-clock@0.3.0;
     // Host identity import: lets the plugin partition state by the calling
     // workload (the host answers based on the in-flight capability call).
-    import wasmcloud:host/identity@0.1.1;
+    import wasmcloud:host/identity@0.1.2;
     // Host cancel import: lets the plugin cancel one of its own in-flight
     // invocations by the host-minted job id, exercised by `begin`/`cancel-job`.
-    import wasmcloud:host/cancel@0.1.1;
+    import wasmcloud:host/cancel@0.1.2;
     // Self-import: the plugin depends on its own capability so `recurse` can
     // re-enter across the store boundary. The host wires this back to the
     // plugin itself.
@@ -27,5 +27,5 @@ world kv-plugin {
     // Lifecycle export: the host calls these as workloads bind/unbind, letting
     // the plugin capture per-workload manifest config eagerly (observed through
     // the store interface's `bound-config`/`bind-info`/`lifecycle-log`).
-    export wasmcloud:host/workload-lifecycle@0.1.1;
+    export wasmcloud:host/workload-lifecycle@0.1.2;
 }

--- a/crates/wash-runtime/tests/integration_plugin_calls_workload.rs
+++ b/crates/wash-runtime/tests/integration_plugin_calls_workload.rs
@@ -1,0 +1,193 @@
+//! Integration tests for the plugin → workload direction: a host component
+//! plugin that *imports* `acme:events/handler`, which no host built-in
+//! provides, so the host routes each call to the export of a bound workload.
+//!
+//! The `events-plugin` component also exports `acme:events/control`, so both
+//! ways of choosing a target are drivable from an ordinary request:
+//!   - a call with no target handle held goes back to the calling workload;
+//!   - a call under a `wasmcloud:host/workload` target handle goes to the
+//!     workload that handle names, for as long as it is alive;
+//!   - `callable` reports the workloads that are up and export the interface.
+
+#![cfg(feature = "host-component-plugins")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use wash_runtime::host::HostApi;
+use wash_runtime::types::{
+    Component, LocalResources, Workload, WorkloadStartRequest, WorkloadStopRequest,
+};
+use wash_runtime::wit::WitInterface;
+
+mod common;
+use common::{http_incoming_handler_interface, req, start_host_with_component_plugin_by_host};
+
+const EVENTS_PLUGIN_WASM: &[u8] = include_bytes!("wasm/events_plugin.wasm");
+const EVENTS_CALLER_WASM: &[u8] = include_bytes!("wasm/events_caller.wasm");
+const PLUGIN_ID: &str = "acme-events-plugin";
+
+/// The `acme:events` binding: `control` the plugin serves, `handler` the
+/// workload serves. One manifest entry covers both directions, since interface
+/// matching already looks at a workload's exports as well as its imports.
+fn acme_events_interface() -> WitInterface {
+    WitInterface {
+        namespace: "acme".to_string(),
+        package: "events".to_string(),
+        interfaces: ["control".to_string(), "handler".to_string()]
+            .into_iter()
+            .collect(),
+        version: Some(semver::Version::parse("0.1.0").unwrap()),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+/// An `events-caller` workload with a caller-chosen id (so a test can name it
+/// as a dispatch target) and a `tag` it stamps on every callback reply (so a
+/// test can tell which workload actually handled one).
+fn events_workload(workload_id: &str, host: &str, tag: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: workload_id.to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: host.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "events-caller".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(EVENTS_CALLER_WASM),
+                local_resources: LocalResources {
+                    environment: HashMap::from([("EVENT_TAG".to_string(), tag.to_string())]),
+                    ..LocalResources::default()
+                },
+                pool_size: 1,
+                max_invocations: 100,
+                max_concurrency: 4,
+            }],
+            host_interfaces: vec![
+                http_incoming_handler_interface(host, None),
+                acme_events_interface(),
+            ],
+            volumes: vec![],
+        },
+    }
+}
+
+/// A plugin call that names no target goes back to the workload whose
+/// capability call it is serving — the callback shape, where the plugin never
+/// has to address anyone.
+#[tokio::test]
+async fn test_plugin_calls_back_into_its_caller() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "alpha", "/echo?msg=hi").await?;
+    assert_eq!(status.as_u16(), 200, "/echo should succeed");
+    assert_eq!(
+        body, "alpha:echo:hi",
+        "the plugin's unaddressed call should reach the calling workload's own handler export"
+    );
+
+    Ok(())
+}
+
+/// A plugin call under a target handle goes to the workload that handle names,
+/// not to the one that called in — the trigger shape, where the plugin picks.
+#[tokio::test]
+async fn test_plugin_dispatches_to_a_named_workload() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    h.workload_start(events_workload("wl-beta", "beta", "beta"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-beta&msg=hi").await?;
+    assert_eq!(status.as_u16(), 200, "/dispatch should succeed");
+    assert_eq!(
+        body, "beta:dispatch:hi",
+        "a named target should override the calling workload, reaching beta from alpha's request"
+    );
+
+    // ...and the reverse, so the result cannot be an artifact of which workload
+    // happened to deploy last.
+    let (status, body) = req(&client, &addr, "beta", "/dispatch?id=wl-alpha&msg=yo").await?;
+    assert_eq!(status.as_u16(), 200, "/dispatch should succeed");
+    assert_eq!(body, "alpha:dispatch:yo", "dispatch should route both ways");
+
+    Ok(())
+}
+
+/// A target's scope is its handle's lifetime: a call inside the handle goes to
+/// the workload it names, and the next call — after it is dropped — falls back
+/// to the caller.
+#[tokio::test]
+async fn test_target_scope_ends_with_the_handle() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    h.workload_start(events_workload("wl-beta", "beta", "beta"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "alpha", "/nested?id=wl-beta&msg=hi").await?;
+    assert_eq!(status.as_u16(), 200, "/nested should succeed");
+    assert_eq!(
+        body, "beta:inner:hi|alpha:outer:hi",
+        "the call inside the handle should reach beta and the one after it should fall back to \
+         the calling workload"
+    );
+
+    Ok(())
+}
+
+/// `callable` reports the workloads that are running and export an interface
+/// the plugin imports — appearing when they deploy and going when they stop.
+#[tokio::test]
+async fn test_callable_tracks_running_workloads() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "alpha", "/callable").await?;
+    assert_eq!(status.as_u16(), 200, "/callable should succeed");
+    assert_eq!(
+        body, "wl-alpha",
+        "only the deployed workload should be callable"
+    );
+
+    h.workload_start(events_workload("wl-beta", "beta", "beta"))
+        .await?;
+    let (_status, body) = req(&client, &addr, "alpha", "/callable").await?;
+    assert_eq!(
+        body, "wl-alpha\nwl-beta",
+        "a second workload should become callable once it is running, sorted by id"
+    );
+
+    h.workload_stop(WorkloadStopRequest {
+        workload_id: "wl-beta".to_string(),
+    })
+    .await?;
+    let (_status, body) = req(&client, &addr, "alpha", "/callable").await?;
+    assert_eq!(
+        body, "wl-alpha",
+        "a stopped workload should no longer be callable"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_plugin_calls_workload.rs
+++ b/crates/wash-runtime/tests/integration_plugin_calls_workload.rs
@@ -7,7 +7,8 @@
 //!   - a call with no target handle held goes back to the calling workload;
 //!   - a call under a `wasmcloud:host/workload` target handle goes to the
 //!     workload that handle names, for as long as it is alive;
-//!   - `callable` reports the workloads that are up and export the interface.
+//!   - `callable` reports the workloads that are up, each with the interfaces
+//!     of it the plugin may actually call.
 
 #![cfg(feature = "host-component-plugins")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
@@ -77,6 +78,64 @@ fn events_workload(workload_id: &str, host: &str, tag: &str) -> WorkloadStartReq
     }
 }
 
+/// Neither `workload-lifecycle` hook can call the workload it is about. A
+/// workload is callable exactly while it is running, and a hook lands either
+/// side of that: still deploying at `on-workload-bind`, already torn down at
+/// `on-workload-unbind` — its service aborted and its warm instances dropped
+/// before the hook runs. The plugin checks with `target.open` and gets `none`
+/// both times.
+///
+/// The probe record lives in the plugin instance's own memory, so reading it
+/// back after the workload has gone is also evidence the plugin never
+/// restarted: a hook that called blind would trap, faulting the shared store
+/// and clearing this.
+#[tokio::test]
+async fn test_a_lifecycle_hook_cannot_call_its_workload() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    h.workload_start(events_workload("wl-beta", "beta", "beta"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    // Beta is callable while it runs, which is what makes the hooks' `none`
+    // meaningful rather than just "this plugin can never call anything".
+    let (_status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-beta&msg=up").await?;
+    assert_eq!(
+        body, "beta:dispatch:wl-beta:up",
+        "beta is callable while running"
+    );
+
+    let (status, body) = req(&client, &addr, "alpha", "/probe?id=wl-beta").await?;
+    assert_eq!(status.as_u16(), 200, "/probe should succeed");
+    assert_eq!(
+        body, "bind:none",
+        "a workload is still deploying when its bind hook runs, so it is not callable there"
+    );
+
+    h.workload_stop(WorkloadStopRequest {
+        workload_id: "wl-beta".to_string(),
+    })
+    .await?;
+
+    let (status, body) = req(&client, &addr, "alpha", "/probe?id=wl-beta").await?;
+    assert_eq!(status.as_u16(), 200, "/probe should succeed");
+    assert_eq!(
+        body, "bind:none|unbind:none",
+        "a workload is already torn down when its unbind hook runs, so it is not callable there \
+         either — and the bind record surviving means the plugin did not restart"
+    );
+
+    // The plugin is the same live instance, still serving.
+    let (status, body) = req(&client, &addr, "alpha", "/echo?msg=alive").await?;
+    assert_eq!(status.as_u16(), 200, "the plugin should still be serving");
+    assert_eq!(body, "alpha:echo:alive");
+
+    Ok(())
+}
+
 /// A plugin call that names no target goes back to the workload whose
 /// capability call it is serving — the callback shape, where the plugin never
 /// has to address anyone.
@@ -115,7 +174,7 @@ async fn test_plugin_dispatches_to_a_named_workload() -> Result<()> {
     let (status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-beta&msg=hi").await?;
     assert_eq!(status.as_u16(), 200, "/dispatch should succeed");
     assert_eq!(
-        body, "beta:dispatch:hi",
+        body, "beta:dispatch:wl-beta:hi",
         "a named target should override the calling workload, reaching beta from alpha's request"
     );
 
@@ -123,7 +182,10 @@ async fn test_plugin_dispatches_to_a_named_workload() -> Result<()> {
     // happened to deploy last.
     let (status, body) = req(&client, &addr, "beta", "/dispatch?id=wl-alpha&msg=yo").await?;
     assert_eq!(status.as_u16(), 200, "/dispatch should succeed");
-    assert_eq!(body, "alpha:dispatch:yo", "dispatch should route both ways");
+    assert_eq!(
+        body, "alpha:dispatch:wl-alpha:yo",
+        "dispatch should route both ways"
+    );
 
     Ok(())
 }
@@ -153,10 +215,67 @@ async fn test_target_scope_ends_with_the_handle() -> Result<()> {
     Ok(())
 }
 
+/// A target for a workload that is not callable is reported to the plugin as
+/// `none` rather than trapping it. The plugin stays up and keeps serving, which
+/// is what makes a `callable`-then-dispatch loop safe against a workload
+/// stopping in between — a trap there would take the driver down and spend a
+/// supervised restart every time a workload was undeployed.
+#[tokio::test]
+async fn test_unroutable_target_is_reported_not_trapped() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-gone&msg=hi").await?;
+    assert_eq!(status.as_u16(), 200, "an unroutable target is not an error");
+    assert_eq!(
+        body, "unroutable:wl-gone",
+        "the plugin should observe `none` from target.open rather than trapping"
+    );
+
+    // The plugin is still the same live instance serving the same store: a
+    // restart would have been observable as a failed or slow call here.
+    let (status, body) = req(&client, &addr, "alpha", "/echo?msg=still-here").await?;
+    assert_eq!(status.as_u16(), 200, "the plugin should still be serving");
+    assert_eq!(body, "alpha:echo:still-here");
+
+    // Same again for a workload that WAS callable and then stopped — the race a
+    // dispatch loop actually hits.
+    h.workload_start(events_workload("wl-beta", "beta", "beta"))
+        .await?;
+    let (_status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-beta&msg=hi").await?;
+    assert_eq!(
+        body, "beta:dispatch:wl-beta:hi",
+        "beta should be reachable first"
+    );
+    h.workload_stop(WorkloadStopRequest {
+        workload_id: "wl-beta".to_string(),
+    })
+    .await?;
+    let (status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-beta&msg=hi").await?;
+    assert_eq!(status.as_u16(), 200, "a stopped target is not an error");
+    assert_eq!(
+        body, "unroutable:wl-beta",
+        "a workload that stopped should read as not callable, not trap the plugin"
+    );
+
+    Ok(())
+}
+
 /// `callable` reports the workloads that are running and export an interface
 /// the plugin imports — appearing when they deploy and going when they stop.
+///
+/// Each is reported with the interfaces of it that are callable, which is the
+/// part a plugin cannot work out for itself. `events-plugin` imports two
+/// workload-facing interfaces and `events-caller` exports only `handler`, so
+/// `metrics` must be absent from every entry: calling an interface a workload
+/// does not export has no error result to return, so the host could only trap
+/// and take the shared plugin store down with it.
 #[tokio::test]
-async fn test_callable_tracks_running_workloads() -> Result<()> {
+async fn test_callable_reports_each_workloads_callable_interfaces() -> Result<()> {
     let (addr, h) =
         start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
             .await?;
@@ -167,15 +286,16 @@ async fn test_callable_tracks_running_workloads() -> Result<()> {
     let (status, body) = req(&client, &addr, "alpha", "/callable").await?;
     assert_eq!(status.as_u16(), 200, "/callable should succeed");
     assert_eq!(
-        body, "wl-alpha",
-        "only the deployed workload should be callable"
+        body, "wl-alpha=acme:events/handler@0.1.0",
+        "the deployed workload is callable on the one interface it exports, and the interface the \
+         plugin imports but nothing exports is not reported as callable on it"
     );
 
     h.workload_start(events_workload("wl-beta", "beta", "beta"))
         .await?;
     let (_status, body) = req(&client, &addr, "alpha", "/callable").await?;
     assert_eq!(
-        body, "wl-alpha\nwl-beta",
+        body, "wl-alpha=acme:events/handler@0.1.0\nwl-beta=acme:events/handler@0.1.0",
         "a second workload should become callable once it is running, sorted by id"
     );
 
@@ -185,7 +305,7 @@ async fn test_callable_tracks_running_workloads() -> Result<()> {
     .await?;
     let (_status, body) = req(&client, &addr, "alpha", "/callable").await?;
     assert_eq!(
-        body, "wl-alpha",
+        body, "wl-alpha=acme:events/handler@0.1.0",
         "a stopped workload should no longer be callable"
     );
 

--- a/crates/wash-runtime/tests/integration_plugin_calls_workload.rs
+++ b/crates/wash-runtime/tests/integration_plugin_calls_workload.rs
@@ -5,7 +5,7 @@
 //! The `events-plugin` component also exports `acme:events/control`, so both
 //! ways of choosing a target are drivable from an ordinary request:
 //!   - a call with no target handle held goes back to the calling workload;
-//!   - a call under a `wasmcloud:host/workload` target handle goes to the
+//!   - a call under a `wasmcloud:host/workload-call` target handle goes to the
 //!     workload that handle names, for as long as it is alive;
 //!   - `callable` reports the workloads that are up, each with the interfaces
 //!     of it the plugin may actually call.

--- a/wit/host/wit/cancel.wit
+++ b/wit/host/wit/cancel.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.1;
+package wasmcloud:host@0.1.2;
 
 /// Host-provided so a component plugin can cooperatively cancel one of its own
 /// in-flight invocations. Job ids are host-minted and opaque. `request-cancel`

--- a/wit/host/wit/identity.wit
+++ b/wit/host/wit/identity.wit
@@ -5,8 +5,10 @@ package wasmcloud:host@0.1.2;
 /// capability call, resolved from the caller's own guest task, so it is exact
 /// under concurrency no matter when in the call the plugin reads it.
 interface identity {
+    use types.{workload-id, component-id};
+
     /// The workload id of the caller currently invoking this plugin.
-    get-workload-id: func() -> string;
+    get-workload-id: func() -> workload-id;
     /// The component id of the caller currently invoking this plugin.
-    get-component-id: func() -> string;
+    get-component-id: func() -> component-id;
 }

--- a/wit/host/wit/identity.wit
+++ b/wit/host/wit/identity.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.1;
+package wasmcloud:host@0.1.2;
 
 /// Provided by the host to a component plugin so it can partition state by the
 /// workload currently calling it. The host answers based on the in-flight

--- a/wit/host/wit/lifecycle.wit
+++ b/wit/host/wit/lifecycle.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.1;
+package wasmcloud:host@0.1.2;
 
 /// Optionally exported by a host component plugin. The host calls these as
 /// workloads that import the plugin's capabilities are bound and unbound,

--- a/wit/host/wit/lifecycle.wit
+++ b/wit/host/wit/lifecycle.wit
@@ -44,9 +44,9 @@ package wasmcloud:host@0.1.2;
 ///
 /// Calls the plugin already had in flight when the unbind arrived are not
 /// interrupted, the same way an in-flight request finishes rather than failing
-/// halfway. A `wasmcloud:host/workload` target handle opened before the stop
-/// does not extend that to *new* calls: the workload it names is gone, so the
-/// next call through the handle traps.
+/// halfway. A `wasmcloud:host/workload-call` target handle opened before the
+/// stop does not extend that to *new* calls: the workload it names is gone, so
+/// the next call through the handle traps.
 interface workload-lifecycle {
     use types.{workload-id, component-id};
 

--- a/wit/host/wit/lifecycle.wit
+++ b/wit/host/wit/lifecycle.wit
@@ -27,14 +27,28 @@ package wasmcloud:host@0.1.2;
 /// bind still running past the host's timeout may also observe the same
 /// workload's unbind delivered concurrently; state it provisions after that
 /// is reclaimed only by a later unbind or a plugin restart.
+///
+/// Nor can a hook *call* the workload it is about, on an interface the
+/// workload exports and the plugin imports. A workload is callable only while
+/// it is running, and a hook is delivered either side of that: it is still
+/// deploying when `on-workload-bind` arrives, and already being torn down when
+/// `on-workload-unbind` does — its service is aborted and its warm instances
+/// dropped before the hook runs, so there is nothing left to answer.
+///
+/// This costs a hook nothing, because the cleanup a plugin owes is its own.
+/// Everything it provisioned for a workload it keyed by that workload's id, and
+/// the id is what `on-workload-unbind` is handed — so reclaiming it needs no
+/// cooperation from the workload, which by then has none to give. A plugin that
+/// wants a workload to know it is going away should tell it while it is still
+/// running, not at teardown.
+///
+/// Calls the plugin already had in flight when the unbind arrived are not
+/// interrupted, the same way an in-flight request finishes rather than failing
+/// halfway. A `wasmcloud:host/workload` target handle opened before the stop
+/// does not extend that to *new* calls: the workload it names is gone, so the
+/// next call through the handle traps.
 interface workload-lifecycle {
-    /// Identifier of a workload; matches `identity.get-workload-id` for
-    /// capability calls made by the same workload.
-    type workload-id = string;
-
-    /// Identifier of a single component within a workload; matches
-    /// `identity.get-component-id`.
-    type component-id = string;
+    use types.{workload-id, component-id};
 
     /// Semantic version of an interface instance (e.g. `0.2.0-draft`).
     record version {

--- a/wit/host/wit/types.wit
+++ b/wit/host/wit/types.wit
@@ -3,7 +3,7 @@ package wasmcloud:host@0.1.2;
 /// The identifiers every other `wasmcloud:host` interface names a workload and
 /// its components by, defined once so they mean the same thing in all of them:
 /// the id `identity` reports for the caller of a capability call is the id
-/// `workload-lifecycle` binds and unbinds, and the id `workload` routes a
+/// `workload-lifecycle` binds and unbinds, and the id `workload-call` routes a
 /// plugin's outbound call to.
 interface types {
     /// Identifier of a workload. Host-minted, opaque, and stable for as long as

--- a/wit/host/wit/types.wit
+++ b/wit/host/wit/types.wit
@@ -1,0 +1,17 @@
+package wasmcloud:host@0.1.2;
+
+/// The identifiers every other `wasmcloud:host` interface names a workload and
+/// its components by, defined once so they mean the same thing in all of them:
+/// the id `identity` reports for the caller of a capability call is the id
+/// `workload-lifecycle` binds and unbinds, and the id `workload` routes a
+/// plugin's outbound call to.
+interface types {
+    /// Identifier of a workload. Host-minted, opaque, and stable for as long as
+    /// that deployment of the workload is running — a workload redeployed under
+    /// the same id is a new one as far as a live handle is concerned.
+    type workload-id = string;
+
+    /// Identifier of one component within a workload. Fresh per deploy, so it
+    /// identifies a running component rather than a manifest entry.
+    type component-id = string;
+}

--- a/wit/host/wit/workload.wit
+++ b/wit/host/wit/workload.wit
@@ -9,14 +9,20 @@ package wasmcloud:host@0.1.2;
 /// off any event of its own. This interface is that handle, for a plugin that
 /// is itself a component and so cannot hold a Rust value.
 ///
+/// Importing this interface is also what declares the intent: a plugin that
+/// does not is held to a closed import surface, where an import no host
+/// built-in provides fails the plugin's load rather than waiting for a workload
+/// that may never appear.
+///
 /// Only interfaces the plugin imports that no host built-in provides are routed
 /// this way. They are matched to a workload exactly as a capability is: the
 /// workload must both declare the interface among the ones it needs from the
-/// host and export it.
+/// host and export it. Every function on such an interface must be an
+/// `async func`: the host serves it concurrently, so that a call out to a
+/// workload never holds the plugin's store — shared by every workload it serves
+/// — for the round trip. A plain `func` is refused when the plugin loads.
 interface workload {
-    /// Identifier of a workload. The same id `identity.get-workload-id`
-    /// reports, and the one `workload-lifecycle` binds and unbinds.
-    type workload-id = string;
+    use types.{workload-id};
 
     /// Directs this task's calls on workload-exported imports to one workload,
     /// for as long as the handle is alive.
@@ -26,24 +32,45 @@ interface workload {
     /// workload whose capability call this task is serving — so a plugin
     /// calling back into its own caller needs no handle at all.
     ///
-    /// Construction never fails. A workload that never bound, or that stops
-    /// while a handle names it, is reported on the *call*, so a plugin sees one
-    /// error for "gone" and "never there" rather than having to race the
-    /// difference.
+    /// A handle pins *which* component of that workload serves each interface,
+    /// so a call it scopes cannot be moved to another one mid-dispatch. It does
+    /// not pin the workload itself: a handle held past the workload's stop — or
+    /// past a redeploy under the same id, which is a different workload as far
+    /// as this interface is concerned — traps on the next call through it. Open
+    /// a handle for the work at hand rather than stashing one.
     resource target {
-        /// Direct this task's calls to `id`.
-        constructor(id: workload-id);
+        /// Direct this task's calls to `id`, or `none` when no workload of that
+        /// id is callable.
+        ///
+        /// Check this rather than assuming: the list `callable` returns is a
+        /// snapshot, and a workload can stop between reading it and acting on
+        /// it. A plugin's own `wasi:cli/run` dispatch loop races exactly that
+        /// way every time a workload is undeployed.
+        open: static func(id: workload-id) -> option<target>;
 
         /// The workload this handle names.
-        id: func() -> workload-id;
+        get-workload-id: func() -> workload-id;
     }
 
-    /// Every workload currently bound to this plugin that exports at least one
-    /// interface the plugin imports, sorted by id. What a plugin's own
-    /// background work — its `wasi:cli/run` — iterates to dispatch.
+    /// Every running workload this plugin can call, mapped to the interfaces of
+    /// it that are callable — what a plugin's own background work (its
+    /// `wasi:cli/run`) iterates to dispatch. Keys are `workload-id`s; the type
+    /// is spelled `string` only because a map key cannot be a named alias.
     ///
-    /// A workload appears only once it is running: a workload is still
-    /// deploying when `workload-lifecycle.on-workload-bind` is delivered for
-    /// it, so it is not callable from inside that hook.
-    callable: func() -> list<workload-id>;
+    /// The interfaces matter for a plugin that imports more than one, because
+    /// calling one a workload does not export is not a recoverable error: a
+    /// workload-exported import has no error result, so the host can only trap,
+    /// taking down the store every workload shares. Check this list rather than
+    /// assume a workload serves everything the plugin imports.
+    ///
+    /// Running is the whole rule: a workload appears when it starts and goes
+    /// when it stops. Both `workload-lifecycle` hooks land outside that window
+    /// — still deploying at `on-workload-bind`, already torn down at
+    /// `on-workload-unbind` — so neither can call the workload it is about;
+    /// reclaim per-workload state from the id the hook is handed instead.
+    ///
+    /// A workload's long-lived service is left out even when it exports such an
+    /// interface, and the host says so at deploy: a call built like a
+    /// component's would start a second copy rather than reach the running one.
+    callable: func() -> map<string, list<string>>;
 }

--- a/wit/host/wit/workload.wit
+++ b/wit/host/wit/workload.wit
@@ -1,0 +1,49 @@
+package wasmcloud:host@0.1.2;
+
+/// Provided by the host to a component plugin that *imports* an interface a
+/// workload exports, so the plugin can call into that workload — the reverse of
+/// the capability direction, where a workload imports what the plugin exports.
+///
+/// A host-native (Rust) plugin does this by holding a handle: it captures the
+/// workload when the workload deploys and invokes the export whenever it likes,
+/// off any event of its own. This interface is that handle, for a plugin that
+/// is itself a component and so cannot hold a Rust value.
+///
+/// Only interfaces the plugin imports that no host built-in provides are routed
+/// this way. They are matched to a workload exactly as a capability is: the
+/// workload must both declare the interface among the ones it needs from the
+/// host and export it.
+interface workload {
+    /// Identifier of a workload. The same id `identity.get-workload-id`
+    /// reports, and the one `workload-lifecycle` binds and unbinds.
+    type workload-id = string;
+
+    /// Directs this task's calls on workload-exported imports to one workload,
+    /// for as long as the handle is alive.
+    ///
+    /// Handles nest: the innermost live handle on the task wins, and dropping
+    /// it restores the one it shadowed. With no handle held, calls go to the
+    /// workload whose capability call this task is serving — so a plugin
+    /// calling back into its own caller needs no handle at all.
+    ///
+    /// Construction never fails. A workload that never bound, or that stops
+    /// while a handle names it, is reported on the *call*, so a plugin sees one
+    /// error for "gone" and "never there" rather than having to race the
+    /// difference.
+    resource target {
+        /// Direct this task's calls to `id`.
+        constructor(id: workload-id);
+
+        /// The workload this handle names.
+        id: func() -> workload-id;
+    }
+
+    /// Every workload currently bound to this plugin that exports at least one
+    /// interface the plugin imports, sorted by id. What a plugin's own
+    /// background work — its `wasi:cli/run` — iterates to dispatch.
+    ///
+    /// A workload appears only once it is running: a workload is still
+    /// deploying when `workload-lifecycle.on-workload-bind` is delivered for
+    /// it, so it is not callable from inside that hook.
+    callable: func() -> list<workload-id>;
+}

--- a/wit/host/wit/workload.wit
+++ b/wit/host/wit/workload.wit
@@ -9,6 +9,10 @@ package wasmcloud:host@0.1.2;
 /// off any event of its own. This interface is that handle, for a plugin that
 /// is itself a component and so cannot hold a Rust value.
 ///
+/// No call goes through this interface. The plugin invokes a workload's export
+/// through its own import of that interface; this one only names which workload
+/// those calls land on, and lists the workloads callable at all.
+///
 /// Importing this interface is also what declares the intent: a plugin that
 /// does not is held to a closed import surface, where an import no host
 /// built-in provides fails the plugin's load rather than waiting for a workload
@@ -21,7 +25,7 @@ package wasmcloud:host@0.1.2;
 /// `async func`: the host serves it concurrently, so that a call out to a
 /// workload never holds the plugin's store — shared by every workload it serves
 /// — for the round trip. A plain `func` is refused when the plugin loads.
-interface workload {
+interface workload-call {
     use types.{workload-id};
 
     /// Directs this task's calls on workload-exported imports to one workload,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -137,6 +137,8 @@ const P3_FIXTURES: &[&str] = &[
     "secrets-consumer-plugin-caller",
     "http-egress-plugin",
     "http-egress-plugin-caller",
+    "events-plugin",
+    "events-caller",
 ];
 
 fn build_fixtures(workspace: &Path) -> Result<()> {


### PR DESCRIPTION
A host component plugin could only be called over the host component plugin's exports. Its imports resolved against the WASI base and the host's native plugins, and anything left over failed to load. The host component could not invoke workload component APIs.

Host-native plugins have always done both. `wasi:http` and`wasmcloud:messaging` declare a package, notice at bind time which components export the handler they want to call, and capture(ResolvedWorkload, InstancePre, component_id) in `on_workload_resolved` in order to invoke a workload component.

A plugin that is itself a component cannot hold that value, its importis one static linker instance with no parameter naming a target so thehost keeps it on the plugin's behalf, and `wasmcloud:host/workload` handsthe guest a handle into it whose lifetime is the routing scope. A callwith no handle held goes back to the workload whose capability call isbeing served, resolved from the caller's root guest task exactly as`wasmcloud:host/identity` is, so a plugin calling back into its owncaller addresses nothing.

Matching needed no change: `includes_bidirectional` already covers aworkload that satisfies an interface by exporting it, so publishing theplugin's workload-facing imports in its world is enough. Neither did thecall path `EphemeralLinkedCall` already crosses a store boundary withwarm-instance pooling and stream/future relocation, so each functionresolves to a `LinkedExportInvocation` pinned to it. `resource` and`error-context` handles cannot cross, and are refused when the pluginloads or the workload deploys rather than on the call.

| | native (`wasi:http`, `wasmcloud:messaging`) | host component plugin |
|---|---|---|
| declares | the package in `world()` | same |
| finds exporters | `exports_wasi_http` / `exports_messaging_handler` on the component's world at bind | same, per workload-facing import |
| holds the target | `(ResolvedWorkload, InstancePre, component_id)` in a Rust map | the same map, host-side |
| names the target | picks out of its own map | `wasmcloud:host/workload` `target` handle |

The last row is the only real gap: a wasm guest can't hold a Rust value, and its import is one static linker instance with no parameter naming a target. So the handle is a resource whose **lifetime** is the routing scope, and a call with no handle held falls back to the workload whose capability call is being served which is the resolution `wasmcloud:host/identity` already performs.
A plugin may now export no capability at all, which makes a pure trigger, one that only dispatches, from its own `wasi:cli/run`.

A plugin import that nothing satisfies used to fail at load. It now loads and traps on the call that needs it, with an error naming the interface. That is inherent to resolving these against workload exports without a new declaration list in ComponentPluginSpec; the plugin's world still has to match a workload that both declares and exports the interface for anything to bind.