### PR TITLE
feat(wash-runtime): timeout hardening for guest code that spins CPU forever

### DIFF
--- a/crates/wash-runtime/benches/http_invoke.rs
+++ b/crates/wash-runtime/benches/http_invoke.rs
@@ -56,6 +56,13 @@ struct WarmHost {
 }
 
 async fn start_warm_host(flavor: Flavor) -> anyhow::Result<WarmHost> {
+    // No instance reuse: a store is built, instantiated and dropped per
+    // request. That is the default, and it is the baseline the pooled groups
+    // below are measured against.
+    start_warm_host_with_pool(flavor, 0).await
+}
+
+async fn start_warm_host_with_pool(flavor: Flavor, pool_size: i32) -> anyhow::Result<WarmHost> {
     let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
     let addr = ingress.addr();
 
@@ -78,10 +85,7 @@ async fn start_warm_host(flavor: Flavor) -> anyhow::Result<WarmHost> {
                 digest: None,
                 bytes: bytes::Bytes::from_static(flavor.wasm()),
                 local_resources: LocalResources::default(),
-                // No instance reuse: a store is built, instantiated and
-                // dropped per request. That is the default, and it is the
-                // baseline the pooled groups below are measured against.
-                pool_size: 0,
+                pool_size,
                 max_invocations: 0,
                 max_concurrency: 1,
             }],
@@ -146,6 +150,52 @@ async fn hot_invocation(warm: &WarmHost) -> anyhow::Result<()> {
     // Consume body so the server-side stream completes before timing stops.
     let _ = resp.bytes().await?;
     Ok(())
+}
+
+/// Paced invocation: request latency on a **pooled** instance whose store sat
+/// idle since the previous request, so the engine's epoch advanced while
+/// nothing ran on it.
+///
+/// This is the low-rps shape [`hot_invocation`] cannot produce: back-to-back
+/// requests never leave the store idle, and an unpooled host builds a fresh
+/// store per request, so neither ever holds a store whose epoch state has
+/// gone stale. P3 only — the pool path is p3-only, and p2 has no persistent
+/// request store for the idle gap to age.
+///
+/// The gap is slept **off the clock** (`iter_custom`); only the request is
+/// timed, so a per-request entry cost is not buried under the gap.
+fn bench_paced_latency(c: &mut Criterion) {
+    /// Longer than the epoch deadline a store arms, so each request finds the
+    /// idle store's deadline already expired.
+    const IDLE_GAP: Duration = Duration::from_millis(200);
+
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("paced_invocation");
+    group.throughput(Throughput::Elements(1));
+    // Each iteration costs the idle gap before the timed request starts.
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(30));
+
+    let warm = rt
+        .block_on(start_warm_host_with_pool(Flavor::P3, 1))
+        .expect("warm pooled host");
+    group.bench_function(BenchmarkId::from_parameter("p3_pooled"), |b| {
+        b.to_async(&rt).iter_custom(|iters| {
+            let warm = &warm;
+            async move {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    tokio::time::sleep(IDLE_GAP).await;
+                    let started = Instant::now();
+                    hot_invocation(warm).await.unwrap();
+                    total += started.elapsed();
+                }
+                total
+            }
+        });
+    });
+    drop(warm);
+    group.finish();
 }
 
 fn bench_cold(c: &mut Criterion) {
@@ -384,6 +434,7 @@ criterion_group!(
     benches,
     bench_cold,
     bench_hot_latency,
+    bench_paced_latency,
     bench_throughput,
     bench_pooled_throughput
 );

--- a/crates/wash-runtime/src/engine/abandon.rs
+++ b/crates/wash-runtime/src/engine/abandon.rs
@@ -1,0 +1,419 @@
+//! Teardown for guest work whose caller has given up on it — even when the
+//! guest never yields.
+//!
+//! Every other teardown the host owns (`tokio::time::timeout`, task aborts,
+//! pool retirement) is a future on the very task a non-yielding guest is
+//! blocking, so none of them can fire against the one failure mode that
+//! matters most: a guest spinning in compiled code. The pieces here close that
+//! hole, split across the only two places that can act:
+//!
+//! - **Outside the store**, a dispatcher hands its call a [`DispatchedCall`]:
+//!   the deadline, and a flag ([`AbandonFlag`]) it arms once the result is no
+//!   longer wanted — the deadline passed, or whoever asked went away.
+//! - **Inside the store**, the task serving the call registers that flag with
+//!   the store's [`AbandonedCalls`] for exactly as long as the call runs, and
+//!   [`arm_epoch_deadline`] wires wasmtime's epoch callback — compiled into
+//!   the guest's own loop back-edges, the only host code a non-yielding guest
+//!   cannot block — to read it.
+//!
+//! The callback acts only on a call that has stayed abandoned *and still
+//! registered* for longer than [`crate::timeouts::abandoned_call_grace`]. The
+//! grace is what makes abandonment safe to signal eagerly: a healthy guest
+//! finishes the abandoned call and deregisters it well inside the grace, so a
+//! client disconnect costs nothing, while a wedged call is still there when
+//! the grace runs out. Without it, every mid-call disconnect would condemn a
+//! store that was serving other callers perfectly well.
+//!
+//! No judgement of the guest is made anywhere here. The epoch advances on wall
+//! clock, so it can report whether guest code is running, never whether it is
+//! getting anywhere: a store pegged at 100% CPU serving calls its callers
+//! still want is left alone. The one decision — "nobody wants this any more" —
+//! is the dispatcher's, and it is one the host already makes today by dropping
+//! futures; this module only makes it stick against a guest that never yields.
+//!
+//! What this cannot see: a guest burning CPU with *no* call outstanding
+//! against it — one that delivered its response and then kept spinning.
+//! Abandonment is keyed on calls, and there is no call left to abandon.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock, Mutex, PoisonError};
+use std::time::{Duration, Instant};
+
+use crate::engine::ctx::SharedCtx;
+
+/// Milliseconds since the first flag was minted, biased by +1 so that `0` can
+/// mean "not armed" inside an [`AbandonFlag`].
+fn now_millis() -> u64 {
+    static ANCHOR: LazyLock<Instant> = LazyLock::new(Instant::now);
+    u64::try_from(ANCHOR.elapsed().as_millis()).unwrap_or(u64::MAX - 1) + 1
+}
+
+/// When a call's dispatcher stopped wanting its result, or nothing if it still
+/// does. Minted only by [`DispatchedCall`], which is what makes a job type's
+/// `abandoned` field proof that its dispatcher actually enforces a deadline.
+pub struct AbandonFlag(AtomicU64);
+
+impl AbandonFlag {
+    fn new() -> Arc<Self> {
+        Arc::new(Self(AtomicU64::new(0)))
+    }
+
+    /// Record the abandonment instant; only the first arming counts.
+    pub(crate) fn arm(&self) {
+        let _ = self
+            .0
+            .compare_exchange(0, now_millis(), Ordering::Relaxed, Ordering::Relaxed);
+    }
+
+    /// Arm this flag when `deadline` elapses, from a detached timer. For
+    /// re-bounding a call that outlives its reply (a post-reply stream drain),
+    /// and for waiters that themselves live inside the dispatched-to store. A
+    /// call already deregistered by then makes the arming invisible.
+    pub(crate) fn arm_after(self: Arc<Self>, deadline: Duration) {
+        tokio::spawn(async move {
+            tokio::time::sleep(deadline).await;
+            self.arm();
+        });
+    }
+
+    fn armed_at(&self) -> Option<u64> {
+        match self.0.load(Ordering::Relaxed) {
+            0 => None,
+            at => Some(at),
+        }
+    }
+}
+
+/// The in-flight calls on one store, so the store's epoch callback can see
+/// which of them have been abandoned. One per store, on [`SharedCtx`].
+#[derive(Default)]
+pub struct AbandonedCalls(Mutex<Vec<Arc<AbandonFlag>>>);
+
+impl AbandonedCalls {
+    /// Watch `flag` until the returned guard drops — held by the task serving
+    /// the call, for exactly as long as the call runs.
+    pub fn watch(self: &Arc<Self>, flag: Arc<AbandonFlag>) -> AbandonedGuard {
+        self.lock().push(Arc::clone(&flag));
+        AbandonedGuard {
+            calls: Arc::clone(self),
+            flag,
+        }
+    }
+
+    /// Whether any watched call has been abandoned for longer than `grace`.
+    fn any_abandoned_longer_than(&self, grace: Duration) -> bool {
+        let list = self.lock();
+        // `now` is only worth computing once a flag is actually armed; the
+        // common case (none are) stays free of clock reads.
+        let mut now = None;
+        let grace = u64::try_from(grace.as_millis()).unwrap_or(u64::MAX);
+        list.iter().any(|f| match f.armed_at() {
+            None => false,
+            Some(at) => {
+                let now = *now.get_or_insert_with(now_millis);
+                now.saturating_sub(at) >= grace
+            }
+        })
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<Arc<AbandonFlag>>> {
+        self.0.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Stops watching a call's flag when dropped, so a completed call leaves
+/// nothing behind — and so an abandoned flag whose call has ended is invisible
+/// to the epoch callback, which is what makes arming safe on every path.
+pub struct AbandonedGuard {
+    calls: Arc<AbandonedCalls>,
+    flag: Arc<AbandonFlag>,
+}
+
+impl Drop for AbandonedGuard {
+    fn drop(&mut self) {
+        self.calls.lock().retain(|f| !Arc::ptr_eq(f, &self.flag));
+    }
+}
+
+/// Arms a dispatched call's flag when dropped, unless the reply arrived first.
+///
+/// Drop-armed rather than only timeout-armed so that a dispatcher future
+/// cancelled outright — a client disconnect drops it without running any of
+/// its code — counts the same as its deadline passing.
+pub(crate) struct AbandonOnDrop {
+    flag: Arc<AbandonFlag>,
+    arm_on_drop: bool,
+}
+
+impl AbandonOnDrop {
+    fn new(flag: Arc<AbandonFlag>) -> Self {
+        Self {
+            flag,
+            arm_on_drop: true,
+        }
+    }
+
+    /// The reply arrived and is wanted; leave the call alone.
+    pub(crate) fn disarm(mut self) {
+        self.arm_on_drop = false;
+    }
+
+    fn flag(&self) -> Arc<AbandonFlag> {
+        Arc::clone(&self.flag)
+    }
+}
+
+impl Drop for AbandonOnDrop {
+    fn drop(&mut self) {
+        if self.arm_on_drop {
+            self.flag.arm();
+        }
+    }
+}
+
+/// One call handed to a store the dispatcher does not drive: the deadline the
+/// dispatcher will enforce, and the flag the store-side task must register.
+///
+/// This is the only source of [`AbandonFlag`]s, and every job type carries one
+/// as a required field — so a new ingress cannot be wired up without deciding
+/// its deadline, and cannot compile with the waiting accidentally placed
+/// inside the store it is waiting on.
+///
+/// Owns an [`AbandonOnDrop`] rather than a bare flag so that dropping it on
+/// *any* path — including an `await_reply` future cancelled before its first
+/// poll, after the job was already sent — abandons the call rather than
+/// leaving the store to serve it forever.
+pub(crate) struct DispatchedCall {
+    watch: AbandonOnDrop,
+    deadline: Duration,
+    /// Names the ingress in the timeout log line.
+    what: &'static str,
+}
+
+impl DispatchedCall {
+    pub(crate) fn new(what: &'static str, deadline: Duration) -> Self {
+        Self {
+            watch: AbandonOnDrop::new(AbandonFlag::new()),
+            deadline,
+            what,
+        }
+    }
+
+    /// The flag to carry in the job; the store-side task registers it with
+    /// [`AbandonedCalls::watch`] for the life of the call.
+    pub(crate) fn flag(&self) -> Arc<AbandonFlag> {
+        self.watch.flag()
+    }
+
+    /// Await the call's reply, abandoning the call if the deadline passes or
+    /// this future is dropped. `None` means no reply is coming.
+    pub(crate) async fn await_reply<F: Future>(self, reply: F) -> Option<F::Output> {
+        let (output, watch) = self.await_head(reply).await?;
+        watch.disarm();
+        Some(output)
+    }
+
+    /// For a dispatcher that must await from *inside* the store it dispatched
+    /// to (a lifecycle replay, whose serve loop shares the plugin store): its
+    /// own timeout can be starved by the very guest it bounds, so consume the
+    /// call and arm the flag from a detached timer at the deadline instead.
+    #[cfg_attr(not(feature = "host-component-plugins"), allow(dead_code))]
+    pub(crate) fn arm_detached(self) {
+        let Self {
+            watch, deadline, ..
+        } = self;
+        watch.flag().arm_after(deadline);
+        watch.disarm();
+    }
+
+    /// Like [`await_reply`], but the reply is only the *head* of the exchange:
+    /// on delivery the returned [`AbandonOnDrop`] keeps the call condemned-on-
+    /// drop, for a dispatcher that goes on streaming (an HTTP response body)
+    /// after the reply arrives.
+    ///
+    /// [`await_reply`]: Self::await_reply
+    pub(crate) async fn await_head<F: Future>(
+        self,
+        reply: F,
+    ) -> Option<(F::Output, AbandonOnDrop)> {
+        let Self {
+            watch,
+            deadline,
+            what,
+        } = self;
+        match tokio::time::timeout(deadline, reply).await {
+            Ok(output) => Some((output, watch)),
+            Err(_) => {
+                tracing::error!(
+                    ingress = what,
+                    timeout = ?deadline,
+                    "dispatched call produced no reply within its deadline; abandoning it so its \
+                     store can end it"
+                );
+                // `watch` drops here, arming the flag.
+                None
+            }
+        }
+    }
+}
+
+/// How many epoch ticks between deadline checks — how promptly an abandoned
+/// call is noticed once its grace runs out, and how often a busy guest yields
+/// its worker thread back to the executor.
+///
+/// Neither purpose wants this fine. Noticing an armed flag within ~100ms is
+/// ample against deadlines measured in seconds, and yielding every ~100ms of
+/// continuous guest execution is enough to keep a spinning guest from
+/// starving the executor (and tokio's time driver) for longer than that. What
+/// rules out a *finer* setting is the yield itself: it requeues the store's
+/// task through the executor, and paying that on every 10ms tick showed up as
+/// a measurable per-request cost on the p3 request path — ~2% of requests
+/// cross a tick mid-guest and eat a ~1ms reschedule.
+const EPOCH_DEADLINE_TICKS: u64 = 10;
+
+/// What a store does about a call abandoned past its grace; see
+/// [`arm_epoch_deadline`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AbandonedCallPolicy {
+    /// Trap the store at the grace. For a store that can be replaced: an
+    /// ephemeral store serves one call, a pooled instance is reaped and
+    /// rebuilt on the next call, and a trapped service is restarted by its
+    /// supervisor. Everything sharing the store goes down with it — the same
+    /// blast radius as a guest trap, bounded the same way.
+    Trap,
+    /// Warn at the grace, trap only at
+    /// [`crate::timeouts::abandoned_call_escalation`]. For a host component
+    /// plugin's store, which serves every tenant at once: the long runway lets
+    /// an abandoned call that still *yields* finish harmlessly, costing no one
+    /// anything. A call that never yields, though, holds the store's guest
+    /// execution for as long as it lives — no other tenant's call can enter —
+    /// so a store still carrying it at the escalation is already down for
+    /// everyone, and trapping it is what brings it back (the supervisor
+    /// rebuilds it and replays binds, the same path an organic plugin trap
+    /// takes). Per-task cancellation (bytecodealliance/wasmtime#11833) is what
+    /// would end the one call instead.
+    WarnThenTrap,
+}
+
+/// Let the host end guest work whose caller has abandoned it, even if the
+/// guest never yields.
+///
+/// Every store needs this call whether or not anything will ever abandon a
+/// call on it — a store that never sets a deadline traps the moment it runs
+/// any guest code, and the host cannot install one later.
+///
+/// The callback is the enforcement point because it is the only one left: a
+/// guest that never yields never returns from its poll, so every host future
+/// on that store — timeouts included — is stuck behind it. wasmtime compiles
+/// the deadline check into the guest's own loop back-edges, which is the one
+/// place a spinning guest cannot avoid. The module docs
+/// ([`crate::engine::abandon`]) cover the model.
+pub(crate) fn arm_epoch_deadline(
+    store: &mut wasmtime::Store<SharedCtx>,
+    policy: AbandonedCallPolicy,
+) {
+    let abandoned = Arc::clone(&store.data().abandoned);
+    let store_id = Arc::clone(&store.data().active_ctx.store_id);
+    let grace = crate::timeouts::abandoned_call_grace();
+    let escalation = crate::timeouts::abandoned_call_escalation();
+    let mut warned = false;
+
+    store.set_epoch_deadline(EPOCH_DEADLINE_TICKS);
+    store.epoch_deadline_callback(move |_| {
+        if !abandoned.any_abandoned_longer_than(grace) {
+            // Yield, never merely continue: this callback is the only point at
+            // which a non-yielding guest hands the host back its thread. Ridden
+            // straight through, the guest keeps the worker — and if that worker
+            // holds tokio's time driver, *no timer on the runtime fires*,
+            // including the very deadline whose expiry would abandon this call.
+            // The yield is what keeps the enforcement loop closed.
+            return Ok(wasmtime::UpdateDeadline::Yield(EPOCH_DEADLINE_TICKS));
+        }
+        if policy == AbandonedCallPolicy::WarnThenTrap
+            && !abandoned.any_abandoned_longer_than(escalation)
+        {
+            if !warned {
+                warned = true;
+                tracing::warn!(
+                    store_id = %store_id,
+                    escalation = ?escalation,
+                    "a call on this store was abandoned past its grace but its guest is still \
+                     running; the store is shared, so it is not trapped before the escalation"
+                );
+            }
+            return Ok(wasmtime::UpdateDeadline::Yield(EPOCH_DEADLINE_TICKS));
+        }
+        tracing::error!(
+            store_id = %store_id,
+            "a call on this store was abandoned but its guest is still running; trapping the store"
+        );
+        Ok(wasmtime::UpdateDeadline::Interrupt)
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A flag armed and then deregistered must be invisible: this is what makes
+    /// arming safe on every completion path (disconnects included) rather than
+    /// only on timeouts.
+    #[test]
+    fn deregistered_flags_are_invisible() {
+        let calls = Arc::new(AbandonedCalls::default());
+        let call = DispatchedCall::new("test", Duration::ZERO);
+        let flag = call.flag();
+        // Keep `call` alive: dropping it would arm the flag itself.
+        let guard = calls.watch(Arc::clone(&flag));
+
+        assert!(!calls.any_abandoned_longer_than(Duration::ZERO));
+        flag.arm();
+        assert!(calls.any_abandoned_longer_than(Duration::ZERO));
+        drop(guard);
+        assert!(!calls.any_abandoned_longer_than(Duration::ZERO));
+    }
+
+    /// The grace holds the callback off a freshly abandoned call, and only the
+    /// first arming sets the clock.
+    #[test]
+    fn grace_is_measured_from_first_arming() {
+        let calls = Arc::new(AbandonedCalls::default());
+        let call = DispatchedCall::new("test", Duration::ZERO);
+        let flag = call.flag();
+        let _guard = calls.watch(Arc::clone(&flag));
+
+        flag.arm();
+        assert!(!calls.any_abandoned_longer_than(Duration::from_secs(3600)));
+        // Re-arming must not push the abandonment instant forward.
+        flag.arm();
+        assert!(calls.any_abandoned_longer_than(Duration::ZERO));
+    }
+
+    /// `await_reply` disarms on delivery and arms on deadline or drop.
+    #[tokio::test(start_paused = true)]
+    async fn await_reply_arms_on_deadline_and_drop_only() {
+        // Delivered: no arming.
+        let call = DispatchedCall::new("test", Duration::from_secs(1));
+        let flag = call.flag();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tx.send(7u32).unwrap();
+        assert_eq!(call.await_reply(rx).await, Some(Ok(7)));
+        assert!(flag.armed_at().is_none());
+
+        // Deadline passed: armed.
+        let call = DispatchedCall::new("test", Duration::from_secs(1));
+        let flag = call.flag();
+        let (_tx, rx) = tokio::sync::oneshot::channel::<u32>();
+        assert_eq!(call.await_reply(rx).await, None);
+        assert!(flag.armed_at().is_some());
+
+        // Future dropped without ever being polled (a disconnect can cancel
+        // the dispatcher at its previous await, after the job was sent): the
+        // call travels inside the future, so this must still arm.
+        let call = DispatchedCall::new("test", Duration::from_secs(1));
+        let flag = call.flag();
+        let (_tx, rx) = tokio::sync::oneshot::channel::<u32>();
+        drop(call.await_reply(rx));
+        assert!(flag.armed_at().is_some());
+    }
+}

--- a/crates/wash-runtime/src/engine/abandon.rs
+++ b/crates/wash-runtime/src/engine/abandon.rs
@@ -16,20 +16,23 @@
 //!   the guest's own loop back-edges, the only host code a non-yielding guest
 //!   cannot block — to read it.
 //!
-//! The callback acts only on a call that has stayed abandoned *and still
-//! registered* for longer than [`crate::timeouts::abandoned_call_grace`]. The
-//! grace is what makes abandonment safe to signal eagerly: a healthy guest
-//! finishes the abandoned call and deregisters it well inside the grace, so a
-//! client disconnect costs nothing, while a wedged call is still there when
-//! the grace runs out. Without it, every mid-call disconnect would condemn a
-//! store that was serving other callers perfectly well.
+//! A store is acted on only when two things hold for longer than
+//! [`crate::timeouts::abandoned_call_grace`]: a call on it is abandoned and
+//! still registered, and `Continuity` shows guest code running without a
+//! pause. The second is what separates the two kinds of stuck call — a guest
+//! waiting in a host call stops executing, so the stretch resets, while a
+//! pinned one never does. Abandonment alone would not do: dropping the
+//! dispatcher arms the flag, so an ordinary client disconnect would condemn a
+//! store whose guest is healthy and merely slow.
 //!
-//! No judgement of the guest is made anywhere here. The epoch advances on wall
+//! The two are scoped differently — abandonment per call, continuity per store
+//! — so they can be satisfied by different calls. That is intended: a call
+//! pinning the store wedges every other call on it, abandoned or not.
+//!
+//! No judgement of *speed* is made anywhere here. The epoch advances on wall
 //! clock, so it can report whether guest code is running, never whether it is
 //! getting anywhere: a store pegged at 100% CPU serving calls its callers
-//! still want is left alone. The one decision — "nobody wants this any more" —
-//! is the dispatcher's, and it is one the host already makes today by dropping
-//! futures; this module only makes it stick against a guest that never yields.
+//! still want is left alone.
 //!
 //! What this cannot see: a guest burning CPU with *no* call outstanding
 //! against it — one that delivered its response and then kept spinning.
@@ -65,15 +68,21 @@ impl AbandonFlag {
             .compare_exchange(0, now_millis(), Ordering::Relaxed, Ordering::Relaxed);
     }
 
-    /// Arm this flag when `deadline` elapses, from a detached timer. For
-    /// re-bounding a call that outlives its reply (a post-reply stream drain),
-    /// and for waiters that themselves live inside the dispatched-to store. A
-    /// call already deregistered by then makes the arming invisible.
-    pub(crate) fn arm_after(self: Arc<Self>, deadline: Duration) {
-        tokio::spawn(async move {
-            tokio::time::sleep(deadline).await;
-            self.arm();
-        });
+    /// Arm this flag when `deadline` elapses. For re-bounding a call that
+    /// outlives its reply (a post-reply stream drain), and for waiters that
+    /// themselves live inside the dispatched-to store.
+    ///
+    /// The timer sleeps the whole deadline, so the handle must be held by the
+    /// work it bounds and dropped when that work ends; detaching one per call
+    /// accumulates a task and a timer entry per call on healthy traffic.
+    #[must_use = "dropping the handle immediately cancels the timer; bind it to the work it bounds"]
+    pub(crate) fn arm_after(self: Arc<Self>, deadline: Duration) -> ArmTimer {
+        ArmTimer(tokio_util::task::AbortOnDropHandle::new(tokio::spawn(
+            async move {
+                tokio::time::sleep(deadline).await;
+                self.arm();
+            },
+        )))
     }
 
     fn armed_at(&self) -> Option<u64> {
@@ -83,6 +92,9 @@ impl AbandonFlag {
         }
     }
 }
+
+/// Cancels a pending [`AbandonFlag::arm_after`] timer when dropped.
+pub(crate) struct ArmTimer(#[expect(dead_code)] tokio_util::task::AbortOnDropHandle<()>);
 
 /// The in-flight calls on one store, so the store's epoch callback can see
 /// which of them have been abandoned. One per store, on [`SharedCtx`].
@@ -116,9 +128,66 @@ impl AbandonedCalls {
         })
     }
 
+    /// Whether nothing watched is abandoned, which re-arms the warning.
+    fn none_abandoned(&self) -> bool {
+        self.lock().iter().all(|f| f.armed_at().is_none())
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, Vec<Arc<AbandonFlag>>> {
         self.0.lock().unwrap_or_else(PoisonError::into_inner)
     }
+}
+
+/// How long guest code has been executing on one store without pausing.
+///
+/// The callback runs only while guest code does, so consecutive fires stay
+/// about one sampling interval apart while a guest keeps executing, and a
+/// wider gap means it stopped to wait for something. Measured here rather than
+/// from the host side because the callback forces a yield on every fire, which
+/// would refresh any host-side liveness signal and make a pinned guest look
+/// healthy.
+#[derive(Default)]
+struct Continuity {
+    /// When the current unbroken stretch of guest execution began.
+    stretch_start: Option<u64>,
+    /// When this callback last fired.
+    last_fire: Option<u64>,
+}
+
+impl Continuity {
+    /// Record a fire and return how long the guest has now been executing
+    /// without a pause, in milliseconds.
+    fn observe(&mut self, now: u64, pause_threshold_millis: u64) -> u64 {
+        // A gap wider than the threshold means guest code stopped running in
+        // between, so this starts a new stretch.
+        let broken = self
+            .last_fire
+            .is_none_or(|last| now.saturating_sub(last) > pause_threshold_millis);
+        if broken {
+            self.stretch_start = Some(now);
+        }
+        self.last_fire = Some(now);
+        now.saturating_sub(self.stretch_start.unwrap_or(now))
+    }
+}
+
+/// How many sampling intervals a gap must exceed to count as a pause. Fires
+/// are one interval apart while a guest runs straight through, so this leaves
+/// room for scheduler jitter while staying well below any real wait.
+const PAUSE_FACTOR: u32 = 5;
+
+/// How long a gap between fires counts as the guest having paused, derived
+/// from the sampling interval so it follows if that changes.
+///
+/// `WASH_ABANDONED_CALL_PAUSE_THRESHOLD_MS` overrides it, for a host loaded
+/// enough that a pinned guest's fires land further apart than this — which
+/// reads as a pause and stops anything from being trapped.
+pub(crate) fn pause_threshold() -> Duration {
+    static VALUE: LazyLock<Duration> = LazyLock::new(|| {
+        let derived = crate::engine::EPOCH_TICK * (EPOCH_DEADLINE_TICKS as u32) * PAUSE_FACTOR;
+        crate::timeouts::env_millis("WASH_ABANDONED_CALL_PAUSE_THRESHOLD_MS", derived)
+    });
+    *VALUE
 }
 
 /// Stops watching a call's flag when dropped, so a completed call leaves
@@ -216,14 +285,20 @@ impl DispatchedCall {
     /// For a dispatcher that must await from *inside* the store it dispatched
     /// to (a lifecycle replay, whose serve loop shares the plugin store): its
     /// own timeout can be starved by the very guest it bounds, so consume the
-    /// call and arm the flag from a detached timer at the deadline instead.
+    /// call and arm the flag from a timer instead.
+    ///
+    /// The returned [`ArmTimer`] must be held for as long as the call it
+    /// bounds — dropping it cancels the arming, and dropping it once the call
+    /// has finished is exactly the point.
     #[cfg_attr(not(feature = "host-component-plugins"), allow(dead_code))]
-    pub(crate) fn arm_detached(self) {
+    #[must_use = "hold the timer for the life of the call; dropping it cancels the arming"]
+    pub(crate) fn arm_on_timer(self) -> ArmTimer {
         let Self {
             watch, deadline, ..
         } = self;
-        watch.flag().arm_after(deadline);
+        let timer = watch.flag().arm_after(deadline);
         watch.disarm();
+        timer
     }
 
     /// Like [`await_reply`], but the reply is only the *head* of the exchange:
@@ -257,46 +332,52 @@ impl DispatchedCall {
     }
 }
 
-/// How many epoch ticks between deadline checks — how promptly an abandoned
-/// call is noticed once its grace runs out, and how often a busy guest yields
-/// its worker thread back to the executor.
+/// How many epoch ticks of *continuous guest execution* between deadline
+/// checks — how promptly an abandoned call is noticed once its grace runs out,
+/// and how often a busy guest yields its worker thread back to the executor.
 ///
-/// Neither purpose wants this fine. Noticing an armed flag within ~100ms is
-/// ample against deadlines measured in seconds, and yielding every ~100ms of
-/// continuous guest execution is enough to keep a spinning guest from
-/// starving the executor (and tokio's time driver) for longer than that. What
-/// rules out a *finer* setting is the yield itself: it requeues the store's
-/// task through the executor, and paying that on every 10ms tick showed up as
-/// a measurable per-request cost on the p3 request path — ~2% of requests
-/// cross a tick mid-guest and eat a ~1ms reschedule.
+/// Neither purpose wants this fine. Noticing within ~100ms is ample against
+/// deadlines measured in seconds, and yielding every ~100ms of unbroken guest
+/// execution is enough to keep a pinned guest from starving the executor (and
+/// tokio's time driver) for longer than that. What rules out a *finer* setting
+/// is the yield itself, which requeues the store's task through the executor.
+///
+/// The epoch advances on wall clock whether or not a guest is running, so this
+/// counts continuous execution only because [`rearm_for_call`] restarts it per
+/// call; left armed at construction, an idle store is already past its deadline
+/// when its next call arrives.
 const EPOCH_DEADLINE_TICKS: u64 = 10;
 
-/// What a store does about a call abandoned past its grace; see
+/// Re-arm the epoch deadline at the start of a call, so its countdown measures
+/// that call's own execution. See [`EPOCH_DEADLINE_TICKS`].
+pub(crate) fn rearm_for_call(store: &mut impl wasmtime::AsContextMut<Data = SharedCtx>) {
+    store
+        .as_context_mut()
+        .set_epoch_deadline(EPOCH_DEADLINE_TICKS);
+}
+
+/// What a store does about a call that is both abandoned and wedged; see
 /// [`arm_epoch_deadline`].
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AbandonedCallPolicy {
-    /// Trap the store at the grace. For a store that can be replaced: an
-    /// ephemeral store serves one call, a pooled instance is reaped and
-    /// rebuilt on the next call, and a trapped service is restarted by its
-    /// supervisor. Everything sharing the store goes down with it — the same
-    /// blast radius as a guest trap, bounded the same way.
+    /// Trap the store. For a store that can be replaced: an ephemeral store
+    /// serves one call, a pooled instance is reaped and rebuilt on the next
+    /// call, and a trapped service is restarted by its supervisor. Everything
+    /// sharing the store goes down with it, and by this point was already
+    /// stuck behind the pinned guest anyway.
     Trap,
-    /// Warn at the grace, trap only at
+    /// Warn first, trap only once the same conditions have held for
     /// [`crate::timeouts::abandoned_call_escalation`]. For a host component
-    /// plugin's store, which serves every tenant at once: the long runway lets
-    /// an abandoned call that still *yields* finish harmlessly, costing no one
-    /// anything. A call that never yields, though, holds the store's guest
-    /// execution for as long as it lives — no other tenant's call can enter —
-    /// so a store still carrying it at the escalation is already down for
-    /// everyone, and trapping it is what brings it back (the supervisor
-    /// rebuilds it and replays binds, the same path an organic plugin trap
-    /// takes). Per-task cancellation (bytecodealliance/wasmtime#11833) is what
-    /// would end the one call instead.
+    /// plugin's store, which serves every tenant at once, so the restart it
+    /// costs is worth delaying while there is any chance the guest frees the
+    /// store on its own. Per-task cancellation
+    /// (bytecodealliance/wasmtime#11833) is what would end the one call
+    /// instead.
     WarnThenTrap,
 }
 
-/// Let the host end guest work whose caller has abandoned it, even if the
-/// guest never yields.
+/// Let the host end guest work that has been abandoned *and* has wedged its
+/// store, even though the guest never yields.
 ///
 /// Every store needs this call whether or not anything will ever abandon a
 /// call on it — a store that never sets a deadline traps the moment it runs
@@ -306,8 +387,9 @@ pub(crate) enum AbandonedCallPolicy {
 /// guest that never yields never returns from its poll, so every host future
 /// on that store — timeouts included — is stuck behind it. wasmtime compiles
 /// the deadline check into the guest's own loop back-edges, which is the one
-/// place a spinning guest cannot avoid. The module docs
-/// ([`crate::engine::abandon`]) cover the model.
+/// place a pinned guest cannot avoid. Both conditions are required — an armed
+/// flag alone only says nobody wants the result, which a client disconnect is
+/// enough to cause. The module docs ([`crate::engine::abandon`]) cover it.
 pub(crate) fn arm_epoch_deadline(
     store: &mut wasmtime::Store<SharedCtx>,
     policy: AbandonedCallPolicy,
@@ -316,36 +398,53 @@ pub(crate) fn arm_epoch_deadline(
     let store_id = Arc::clone(&store.data().active_ctx.store_id);
     let grace = crate::timeouts::abandoned_call_grace();
     let escalation = crate::timeouts::abandoned_call_escalation();
+    let grace_millis = u64::try_from(grace.as_millis()).unwrap_or(u64::MAX);
+    let escalation_millis = u64::try_from(escalation.as_millis()).unwrap_or(u64::MAX);
+    let pause_millis = u64::try_from(pause_threshold().as_millis()).unwrap_or(u64::MAX);
+    let mut continuity = Continuity::default();
+    // Reset below once nothing is abandoned, so a later wedge warns again.
     let mut warned = false;
 
     store.set_epoch_deadline(EPOCH_DEADLINE_TICKS);
     store.epoch_deadline_callback(move |_| {
+        // Every fire counts, or the pattern means nothing.
+        let pinned_for = continuity.observe(now_millis(), pause_millis);
+
+        // Yield, never merely continue: this callback is the only point at
+        // which a pinned guest hands the host back its thread. Ridden straight
+        // through, the guest keeps the worker — and if that worker holds
+        // tokio's time driver, *no timer on the runtime fires*, including the
+        // very deadline whose expiry would abandon this call.
+        let keep_running = |warned: &mut bool| {
+            if abandoned.none_abandoned() {
+                *warned = false;
+            }
+            Ok(wasmtime::UpdateDeadline::Yield(EPOCH_DEADLINE_TICKS))
+        };
+
         if !abandoned.any_abandoned_longer_than(grace) {
-            // Yield, never merely continue: this callback is the only point at
-            // which a non-yielding guest hands the host back its thread. Ridden
-            // straight through, the guest keeps the worker — and if that worker
-            // holds tokio's time driver, *no timer on the runtime fires*,
-            // including the very deadline whose expiry would abandon this call.
-            // The yield is what keeps the enforcement loop closed.
-            return Ok(wasmtime::UpdateDeadline::Yield(EPOCH_DEADLINE_TICKS));
+            return keep_running(&mut warned);
         }
-        if policy == AbandonedCallPolicy::WarnThenTrap
-            && !abandoned.any_abandoned_longer_than(escalation)
-        {
+        // Abandoned, but the guest is still pausing to wait: slow, not wedged.
+        if pinned_for < grace_millis {
+            return keep_running(&mut warned);
+        }
+        if policy == AbandonedCallPolicy::WarnThenTrap && pinned_for < escalation_millis {
             if !warned {
                 warned = true;
                 tracing::warn!(
                     store_id = %store_id,
                     escalation = ?escalation,
-                    "a call on this store was abandoned past its grace but its guest is still \
-                     running; the store is shared, so it is not trapped before the escalation"
+                    "an abandoned call has wedged this store; it is shared, so it is not trapped \
+                     before the escalation"
                 );
             }
             return Ok(wasmtime::UpdateDeadline::Yield(EPOCH_DEADLINE_TICKS));
         }
         tracing::error!(
             store_id = %store_id,
-            "a call on this store was abandoned but its guest is still running; trapping the store"
+            pinned_for_ms = pinned_for,
+            "an abandoned call has wedged this store past its grace; trapping it"
         );
         Ok(wasmtime::UpdateDeadline::Interrupt)
     });
@@ -387,6 +486,26 @@ mod tests {
         // Re-arming must not push the abandonment instant forward.
         flag.arm();
         assert!(calls.any_abandoned_longer_than(Duration::ZERO));
+    }
+
+    /// A pause between fires starts a new stretch; unbroken fires accumulate.
+    #[test]
+    fn continuity_resets_on_a_pause_and_accumulates_otherwise() {
+        const T: u64 = 500;
+        let mut c = Continuity::default();
+        // A run of fires one sampling interval apart: one unbroken stretch.
+        assert_eq!(c.observe(1_000, T), 0);
+        assert_eq!(c.observe(1_100, T), 100);
+        assert_eq!(c.observe(1_200, T), 200);
+        // A gap past the threshold — the guest stopped running and waited, so
+        // the next fire begins a fresh stretch however long the last one was.
+        let after_pause = 1_200 + T + 1;
+        assert_eq!(c.observe(after_pause, T), 0);
+        assert_eq!(c.observe(after_pause + 100, T), 100);
+        // A gap *at* the threshold is still the same stretch: only a wider one
+        // counts as a pause, so scheduler jitter cannot reset it.
+        let jittered = after_pause + 100 + T;
+        assert_eq!(c.observe(jittered, T), jittered - after_pause);
     }
 
     /// `await_reply` disarms on delivery and arms on deadline or drop.

--- a/crates/wash-runtime/src/engine/abandon.rs
+++ b/crates/wash-runtime/src/engine/abandon.rs
@@ -16,18 +16,23 @@
 //!   the guest's own loop back-edges, the only host code a non-yielding guest
 //!   cannot block — to read it.
 //!
-//! A store is acted on only when two things hold for longer than
-//! [`crate::timeouts::abandoned_call_grace`]: a call on it is abandoned and
-//! still registered, and `Continuity` shows guest code running without a
-//! pause. The second is what separates the two kinds of stuck call — a guest
-//! waiting in a host call stops executing, so the stretch resets, while a
-//! pinned one never does. Abandonment alone would not do: dropping the
-//! dispatcher arms the flag, so an ordinary client disconnect would condemn a
-//! store whose guest is healthy and merely slow.
+//! A store is acted on only when three things hold: a call on it has been
+//! abandoned longer than [`crate::timeouts::abandoned_call_grace`] and is
+//! still registered, *every* other registered call has been abandoned too,
+//! and `Continuity` shows guest code running without a pause. The last
+//! separates the two kinds of stuck call — a guest waiting in a host call
+//! stops executing, so the stretch resets, while a pinned one never does.
+//! Abandonment alone would not do: dropping the dispatcher arms the flag, so
+//! an ordinary client disconnect would condemn a store whose guest is healthy
+//! and merely slow.
 //!
-//! The two are scoped differently — abandonment per call, continuity per store
-//! — so they can be satisfied by different calls. That is intended: a call
-//! pinning the store wedges every other call on it, abandoned or not.
+//! The all-abandoned condition is what keeps the per-store blast radius safe:
+//! continuity cannot tell a guest that yields every few hundred milliseconds
+//! from a pinned one whose fires are spread that far by scheduler jitter, so
+//! the trap waits until it would end nothing still wanted. Teardown of a
+//! really pinned store is delayed by that, not lost — such a guest admits no
+//! new calls, and the calls already on it are abandoned by their own
+//! deadlines in turn.
 //!
 //! No judgement of *speed* is made anywhere here. The epoch advances on wall
 //! clock, so it can report whether guest code is running, never whether it is
@@ -131,6 +136,12 @@ impl AbandonedCalls {
     /// Whether nothing watched is abandoned, which re-arms the warning.
     fn none_abandoned(&self) -> bool {
         self.lock().iter().all(|f| f.armed_at().is_none())
+    }
+
+    /// Whether every watched call has been abandoned, so trapping the store
+    /// would end nothing still wanted.
+    fn all_abandoned(&self) -> bool {
+        self.lock().iter().all(|f| f.armed_at().is_some())
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Vec<Arc<AbandonFlag>>> {
@@ -425,6 +436,13 @@ pub(crate) fn arm_epoch_deadline(
         if !abandoned.any_abandoned_longer_than(grace) {
             return keep_running(&mut warned);
         }
+        // A call is still wanted: trapping the store would take it too. This
+        // also protects a yielding guest whose wakes land closer together
+        // than the pause threshold and so read as one pinned stretch — its
+        // own wanted call is what keeps its store alive.
+        if !abandoned.all_abandoned() {
+            return keep_running(&mut warned);
+        }
         // Abandoned, but the guest is still pausing to wait: slow, not wedged.
         if pinned_for < grace_millis {
             return keep_running(&mut warned);
@@ -470,6 +488,23 @@ mod tests {
         assert!(calls.any_abandoned_longer_than(Duration::ZERO));
         drop(guard);
         assert!(!calls.any_abandoned_longer_than(Duration::ZERO));
+    }
+
+    #[test]
+    fn a_wanted_call_blocks_all_abandoned() {
+        let calls = Arc::new(AbandonedCalls::default());
+        let given_up = DispatchedCall::new("test", Duration::ZERO);
+        let wanted = DispatchedCall::new("test", Duration::ZERO);
+        let _given_up_guard = calls.watch(given_up.flag());
+        let wanted_guard = calls.watch(wanted.flag());
+
+        given_up.flag().arm();
+        assert!(calls.any_abandoned_longer_than(Duration::ZERO));
+        assert!(!calls.all_abandoned());
+        // The wanted call ends (or is abandoned in turn); nothing on the
+        // store is wanted any more.
+        drop(wanted_guard);
+        assert!(calls.all_abandoned());
     }
 
     /// The grace holds the callback off a freshly abandoned call, and only the

--- a/crates/wash-runtime/src/engine/abandon.rs
+++ b/crates/wash-runtime/src/engine/abandon.rs
@@ -19,20 +19,22 @@
 //! A store is acted on only when three things hold: a call on it has been
 //! abandoned longer than [`crate::timeouts::abandoned_call_grace`] and is
 //! still registered, *every* other registered call has been abandoned too,
-//! and `Continuity` shows guest code running without a pause. The last
-//! separates the two kinds of stuck call — a guest waiting in a host call
-//! stops executing, so the stretch resets, while a pinned one never does.
+//! and the guest has since run through a grace's worth of execution.
+//! Execution is credited from the callback's own fires (`ExecutionCredit`):
+//! each fire proves the guest was running and is worth at most one sampling
+//! window, and only a pause too long to be scheduler delay clears the credit
+//! — so a guest waiting in a host call accrues nothing, while a pinned one
+//! keeps accruing even when a loaded scheduler spreads its fires out.
 //! Abandonment alone would not do: dropping the dispatcher arms the flag, so
 //! an ordinary client disconnect would condemn a store whose guest is healthy
 //! and merely slow.
 //!
 //! The all-abandoned condition is what keeps the per-store blast radius safe:
-//! continuity cannot tell a guest that yields every few hundred milliseconds
-//! from a pinned one whose fires are spread that far by scheduler jitter, so
-//! the trap waits until it would end nothing still wanted. Teardown of a
-//! really pinned store is delayed by that, not lost — such a guest admits no
-//! new calls, and the calls already on it are abandoned by their own
-//! deadlines in turn.
+//! inside one sampling window a burst-then-await guest (frames, tokens, short
+//! outbound calls) is indistinguishable from a pinned one, so the trap waits
+//! until it would end nothing still wanted. Teardown of a really pinned store
+//! is delayed by that, not lost — such a guest admits no new calls, and the
+//! calls already on it are abandoned by their own deadlines in turn.
 //!
 //! No judgement of *speed* is made anywhere here. The epoch advances on wall
 //! clock, so it can report whether guest code is running, never whether it is
@@ -149,57 +151,62 @@ impl AbandonedCalls {
     }
 }
 
-/// How long guest code has been executing on one store without pausing.
+/// Guest execution credited against one store, accumulated from the epoch
+/// callback's own fires while the host wants the store back.
 ///
-/// The callback runs only while guest code does, so consecutive fires stay
-/// about one sampling interval apart while a guest keeps executing, and a
-/// wider gap means it stopped to wait for something. Measured here rather than
-/// from the host side because the callback forces a yield on every fire, which
-/// would refresh any host-side liveness signal and make a pinned guest look
-/// healthy.
+/// The callback runs only while guest code does, so each fire proves the
+/// guest was executing at that instant — and is worth at most one sampling
+/// window ([`EXECUTION_WINDOW_MS`]) of credit, however wide the gap before it.
+/// The per-fire cap is what keeps both failure directions out: a brief await
+/// between fires donates one window rather than its whole off-CPU length, and
+/// a pinned guest whose fires land late under scheduler load keeps
+/// accumulating instead of having its record wiped by the delay. Only a gap
+/// no scheduler could plausibly cause ([`RESET_THRESHOLD_MS`]) proves a real
+/// pause and clears the credit.
+///
+/// Measured here rather than from the host side because the callback forces a
+/// yield on every fire, which would refresh any host-side liveness signal and
+/// make a pinned guest look healthy.
 #[derive(Default)]
-struct Continuity {
-    /// When the current unbroken stretch of guest execution began.
-    stretch_start: Option<u64>,
+struct ExecutionCredit {
+    credited_millis: u64,
     /// When this callback last fired.
     last_fire: Option<u64>,
 }
 
-impl Continuity {
-    /// Record a fire and return how long the guest has now been executing
-    /// without a pause, in milliseconds.
-    fn observe(&mut self, now: u64, pause_threshold_millis: u64) -> u64 {
-        // A gap wider than the threshold means guest code stopped running in
-        // between, so this starts a new stretch.
-        let broken = self
-            .last_fire
-            .is_none_or(|last| now.saturating_sub(last) > pause_threshold_millis);
-        if broken {
-            self.stretch_start = Some(now);
+impl ExecutionCredit {
+    /// Record a fire and return the credit accumulated so far, in
+    /// milliseconds.
+    fn observe(&mut self, now: u64) -> u64 {
+        let gap = self.last_fire.map_or(0, |last| now.saturating_sub(last));
+        if gap > RESET_THRESHOLD_MS {
+            self.credited_millis = 0;
+        } else {
+            self.credited_millis = self
+                .credited_millis
+                .saturating_add(gap.min(EXECUTION_WINDOW_MS));
         }
         self.last_fire = Some(now);
-        now.saturating_sub(self.stretch_start.unwrap_or(now))
+        self.credited_millis
+    }
+
+    /// Clear the credit: the store is not wanted back right now, so whatever
+    /// its guest is doing is not held against it.
+    fn reset(&mut self) {
+        self.credited_millis = 0;
     }
 }
 
-/// How many sampling intervals a gap must exceed to count as a pause. Fires
-/// are one interval apart while a guest runs straight through, so this leaves
-/// room for scheduler jitter while staying well below any real wait.
-const PAUSE_FACTOR: u32 = 5;
+/// The most execution one fire-to-fire gap can prove: fires land one sampling
+/// window apart while a guest runs straight through.
+const EXECUTION_WINDOW_MS: u64 =
+    crate::engine::EPOCH_TICK.as_millis() as u64 * EPOCH_DEADLINE_TICKS;
 
-/// How long a gap between fires counts as the guest having paused, derived
-/// from the sampling interval so it follows if that changes.
-///
-/// `WASH_ABANDONED_CALL_PAUSE_THRESHOLD_MS` overrides it, for a host loaded
-/// enough that a pinned guest's fires land further apart than this — which
-/// reads as a pause and stops anything from being trapped.
-pub(crate) fn pause_threshold() -> Duration {
-    static VALUE: LazyLock<Duration> = LazyLock::new(|| {
-        let derived = crate::engine::EPOCH_TICK * (EPOCH_DEADLINE_TICKS as u32) * PAUSE_FACTOR;
-        crate::timeouts::env_millis("WASH_ABANDONED_CALL_PAUSE_THRESHOLD_MS", derived)
-    });
-    *VALUE
-}
+/// A gap between fires that only a real pause can explain — the guest waiting
+/// on host I/O measured in seconds, or going idle — never scheduler delay or
+/// a brief await. A fixed order-of-seconds invariant on purpose, not derived
+/// from the window: it models what schedulers do, not how often we sample.
+const RESET_THRESHOLD_MS: u64 = 3_000;
 
 /// Stops watching a call's flag when dropped, so a completed call leaves
 /// nothing behind — and so an abandoned flag whose call has ended is invisible
@@ -398,9 +405,10 @@ pub(crate) enum AbandonedCallPolicy {
 /// guest that never yields never returns from its poll, so every host future
 /// on that store — timeouts included — is stuck behind it. wasmtime compiles
 /// the deadline check into the guest's own loop back-edges, which is the one
-/// place a pinned guest cannot avoid. Both conditions are required — an armed
-/// flag alone only says nobody wants the result, which a client disconnect is
-/// enough to cause. The module docs ([`crate::engine::abandon`]) cover it.
+/// place a pinned guest cannot avoid. All three conditions are required — an
+/// armed flag alone only says nobody wants the result, which a client
+/// disconnect is enough to cause. The module docs ([`crate::engine::abandon`])
+/// cover it.
 pub(crate) fn arm_epoch_deadline(
     store: &mut wasmtime::Store<SharedCtx>,
     policy: AbandonedCallPolicy,
@@ -411,43 +419,48 @@ pub(crate) fn arm_epoch_deadline(
     let escalation = crate::timeouts::abandoned_call_escalation();
     let grace_millis = u64::try_from(grace.as_millis()).unwrap_or(u64::MAX);
     let escalation_millis = u64::try_from(escalation.as_millis()).unwrap_or(u64::MAX);
-    let pause_millis = u64::try_from(pause_threshold().as_millis()).unwrap_or(u64::MAX);
-    let mut continuity = Continuity::default();
+    let mut credit = ExecutionCredit::default();
     // Reset below once nothing is abandoned, so a later wedge warns again.
     let mut warned = false;
 
     store.set_epoch_deadline(EPOCH_DEADLINE_TICKS);
     store.epoch_deadline_callback(move |_| {
-        // Every fire counts, or the pattern means nothing.
-        let pinned_for = continuity.observe(now_millis(), pause_millis);
+        // Every fire counts, or the credit means nothing.
+        let executed_for = credit.observe(now_millis());
 
         // Yield, never merely continue: this callback is the only point at
         // which a pinned guest hands the host back its thread. Ridden straight
         // through, the guest keeps the worker — and if that worker holds
         // tokio's time driver, *no timer on the runtime fires*, including the
         // very deadline whose expiry would abandon this call.
-        let keep_running = |warned: &mut bool| {
+        let keep_running = |warned: &mut bool, credit: &mut ExecutionCredit| {
             if abandoned.none_abandoned() {
                 *warned = false;
             }
+            // Execution only counts against a store the host wants back:
+            // otherwise a service's own background wakes (a run loop ticking
+            // faster than the reset threshold) would bank credit for the
+            // store's whole lifetime and any later abandonment would trap at
+            // the grace with no execution since.
+            credit.reset();
             Ok(wasmtime::UpdateDeadline::Yield(EPOCH_DEADLINE_TICKS))
         };
 
         if !abandoned.any_abandoned_longer_than(grace) {
-            return keep_running(&mut warned);
+            return keep_running(&mut warned, &mut credit);
         }
-        // A call is still wanted: trapping the store would take it too. This
-        // also protects a yielding guest whose wakes land closer together
-        // than the pause threshold and so read as one pinned stretch — its
-        // own wanted call is what keeps its store alive.
+        // A call is still wanted: trapping the store would take it too — and
+        // this is what keeps a yielding guest's store alive however its wakes
+        // land relative to the sampling window.
         if !abandoned.all_abandoned() {
-            return keep_running(&mut warned);
+            return keep_running(&mut warned, &mut credit);
         }
-        // Abandoned, but the guest is still pausing to wait: slow, not wedged.
-        if pinned_for < grace_millis {
-            return keep_running(&mut warned);
+        // Wanted back, but the guest has not yet run through a grace's worth
+        // of execution since then: it is waiting, or finishing.
+        if executed_for < grace_millis {
+            return Ok(wasmtime::UpdateDeadline::Yield(EPOCH_DEADLINE_TICKS));
         }
-        if policy == AbandonedCallPolicy::WarnThenTrap && pinned_for < escalation_millis {
+        if policy == AbandonedCallPolicy::WarnThenTrap && executed_for < escalation_millis {
             if !warned {
                 warned = true;
                 tracing::warn!(
@@ -461,7 +474,7 @@ pub(crate) fn arm_epoch_deadline(
         }
         tracing::error!(
             store_id = %store_id,
-            pinned_for_ms = pinned_for,
+            executed_ms = executed_for,
             "an abandoned call has wedged this store past its grace; trapping it"
         );
         Ok(wasmtime::UpdateDeadline::Interrupt)
@@ -523,24 +536,28 @@ mod tests {
         assert!(calls.any_abandoned_longer_than(Duration::ZERO));
     }
 
-    /// A pause between fires starts a new stretch; unbroken fires accumulate.
+    /// One fire proves at most one window of execution however wide the gap
+    /// before it, sub-reset gaps (scheduler delay included) never wipe what a
+    /// pinned guest accrued, and only a real pause clears the credit.
     #[test]
-    fn continuity_resets_on_a_pause_and_accumulates_otherwise() {
-        const T: u64 = 500;
-        let mut c = Continuity::default();
-        // A run of fires one sampling interval apart: one unbroken stretch.
-        assert_eq!(c.observe(1_000, T), 0);
-        assert_eq!(c.observe(1_100, T), 100);
-        assert_eq!(c.observe(1_200, T), 200);
-        // A gap past the threshold — the guest stopped running and waited, so
-        // the next fire begins a fresh stretch however long the last one was.
-        let after_pause = 1_200 + T + 1;
-        assert_eq!(c.observe(after_pause, T), 0);
-        assert_eq!(c.observe(after_pause + 100, T), 100);
-        // A gap *at* the threshold is still the same stretch: only a wider one
-        // counts as a pause, so scheduler jitter cannot reset it.
-        let jittered = after_pause + 100 + T;
-        assert_eq!(c.observe(jittered, T), jittered - after_pause);
+    fn execution_credit_caps_each_gap_and_resets_only_on_a_real_pause() {
+        const W: u64 = EXECUTION_WINDOW_MS;
+        let mut c = ExecutionCredit::default();
+        // First fire: nothing before it to credit.
+        assert_eq!(c.observe(1_000), 0);
+        // Straight-through execution: every window fully credited.
+        assert_eq!(c.observe(1_000 + W), W);
+        // A wide-but-sub-reset gap — a brief await, or a slow requeue under
+        // load — donates one window, and does not wipe the accrual.
+        assert_eq!(c.observe(1_000 + W + 900), 2 * W);
+        assert_eq!(c.observe(1_000 + W + 900 + W), 3 * W);
+        // A gap past the reset threshold is a real pause: credit cleared.
+        let after_pause = 1_000 + W + 900 + W + RESET_THRESHOLD_MS + 1;
+        assert_eq!(c.observe(after_pause), 0);
+        assert_eq!(c.observe(after_pause + W), W);
+        // And the callback clears it whenever the store is not wanted back.
+        c.reset();
+        assert_eq!(c.observe(after_pause + 2 * W), W);
     }
 
     /// `await_reply` disarms on delivery and arms on deadline or drop.

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -77,6 +77,9 @@ pub struct SharedCtx {
     /// a caller store leaves it `None` and holds opaque proxies instead. See
     /// [`crate::engine::store::resource_bridge`].
     pub resource_registry: Option<crate::engine::store::resource_bridge::ResourceRegistry>,
+    /// The in-flight calls on this store whose dispatchers may abandon them;
+    /// read by the store's epoch callback. See [`crate::engine::abandon`].
+    pub abandoned: Arc<crate::engine::abandon::AbandonedCalls>,
 }
 
 /// The identity of whoever is invoking a host component plugin, used to
@@ -101,6 +104,7 @@ impl SharedCtx {
             contexts: Default::default(),
             exporter_instances: Default::default(),
             resource_registry: None,
+            abandoned: Arc::default(),
         }
     }
 

--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -63,6 +63,9 @@ pub(crate) struct LinkedJob {
     pub(crate) import_name: Arc<str>,
     pub(crate) export_name: Arc<str>,
     pub(crate) reply: tokio::sync::oneshot::Sender<wasmtime::Result<Vec<Val>>>,
+    /// The abandonment flag of the dispatched call enforcing this job's
+    /// deadline (see [`crate::engine::abandon`]).
+    pub(crate) abandoned: Arc<crate::engine::abandon::AbandonFlag>,
 }
 
 /// Work an instance can be given. Both shapes run as concurrent tasks on the
@@ -116,6 +119,11 @@ impl PoolSlot {
     /// Stop this instance admitting: it drains what it took, ends its run loop,
     /// and its store's teardown ends any guest work still running on it.
     ///
+    /// Only as far as the last call returning, though: every path to `drained`
+    /// runs through a call's task ending, so a guest that never yields holds the
+    /// store open regardless. That one is ended by its abandoned call instead
+    /// (see [`crate::engine::abandon`]).
+    ///
     /// TODO: retirement is a stand-in for cancelling the one bad call. The
     /// host cannot cancel a guest `call_concurrent` subtask
     /// (bytecodealliance/wasmtime#11833), so ending a wedged call's work means
@@ -144,8 +152,16 @@ impl AccessorTask<SharedCtx> for LinkedTask {
             import_name,
             export_name,
             reply,
+            abandoned,
         } = *self.job;
         let instance = self.instance;
+
+        // Watch this call for the rest of its life. The guard deregisters on
+        // drop, however the call ends.
+        let _abandoned = accessor.with(|mut access| {
+            let calls = Arc::clone(&access.get().abandoned);
+            calls.watch(abandoned)
+        });
 
         let func = accessor.with(|mut access| {
             instance
@@ -287,7 +303,11 @@ impl InstanceDriver {
                         };
                         let spawned = match job {
                             InstanceJob::Http(job) => {
-                                let (req, resp_tx) = *job;
+                                let ServiceHttpJob {
+                                    req,
+                                    resp_tx,
+                                    abandoned,
+                                } = *job;
                                 let Some(service) = service.as_ref().map(Arc::clone) else {
                                     // Admission declines HTTP for an instance
                                     // without the export, so this is not
@@ -302,6 +322,7 @@ impl InstanceDriver {
                                     service,
                                     req,
                                     resp_tx,
+                                    abandoned,
                                     pool_slot: Some(PoolSlot {
                                         state: Arc::clone(&task_state),
                                         _in_flight: guard,

--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -157,8 +157,9 @@ impl AccessorTask<SharedCtx> for LinkedTask {
         let instance = self.instance;
 
         // Watch this call for the rest of its life. The guard deregisters on
-        // drop, however the call ends.
+        // drop, however the call ends; the deadline is re-armed for it here.
         let _abandoned = accessor.with(|mut access| {
+            crate::engine::abandon::rearm_for_call(&mut access);
             let calls = Arc::clone(&access.get().abandoned);
             calls.watch(abandoned)
         });

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -593,6 +593,7 @@ async fn invoke_ephemeral_relocated(
         };
         // Watched for the store's whole run, the post-reply stream drain
         // included.
+        let drain_flag = Arc::clone(&call_flag);
         let _abandoned = store.data().abandoned.watch(call_flag);
         let instance = match callee_pre.instantiate_async(&mut store).await {
             Ok(i) => i,
@@ -655,6 +656,12 @@ async fn invoke_ephemeral_relocated(
                         // stream would otherwise pin this ephemeral store — and its
                         // core-instance slots — indefinitely. A transfer still making
                         // progress past this bound is truncated when the store drops.
+                        // The `timeout` below is a future on this store, so it
+                        // cannot fire if the guest stops yielding mid-drain.
+                        // This timer runs off-store, and is cancelled when the
+                        // drain ends.
+                        let _drain_timer =
+                            Arc::clone(&drain_flag).arm_after(crate::timeouts::stream_drain());
                         let drain = async {
                             for done in dones {
                                 let _ = done.await;
@@ -676,7 +683,6 @@ async fn invoke_ephemeral_relocated(
             .await;
     }));
 
-    let drain_flag = call.flag();
     let relocated = call
         .await_reply(ready_rx)
         .await
@@ -685,14 +691,9 @@ async fn invoke_ephemeral_relocated(
 
     // Results are in hand; the task must keep running to feed any result streams,
     // so detach it (cancellation past this point is handled by the result-stream
-    // consumers closing their pump channels).
+    // consumers closing their pump channels). The drain is bounded from inside
+    // that task.
     std::mem::forget(task);
-
-    // The detached store bounds its own stream drain, but that bound is a
-    // future on the store and cannot fire against a guest that never yields.
-    // Re-abandon the call when the drain budget expires: a store already done
-    // by then has deregistered the flag, so this only ever ends a wedged drain.
-    drain_flag.arm_after(crate::timeouts::stream_drain());
 
     // Inject results into the caller store; result-stream producers pull from
     // the still-draining ephemeral store.

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -31,6 +31,7 @@ use wasmtime::error::Context as _;
 use wasmtime::{AsContext, AsContextMut, StoreContextMut};
 use wasmtime_wasi::WasiCtxBuilder;
 
+use crate::engine::abandon::{AbandonedCallPolicy, arm_epoch_deadline};
 #[cfg(feature = "wasi-tls")]
 use crate::engine::ctx::SharedTlsProvider;
 use crate::engine::ctx::{AccessorActiveCtxGuard, Ctx, SharedCtx, StoreActiveCtxGuard};
@@ -352,6 +353,9 @@ pub(crate) async fn new_store_from_templates(
     }
 
     let mut store = wasmtime::Store::new(engine, shared_ctx);
+    // Trap for every store built here, services included: trapping a service
+    // means a supervisor restart, which beats carrying a wedged call forever.
+    arm_epoch_deadline(&mut store, AbandonedCallPolicy::Trap);
 
     let active_id = active.component_id.clone();
     for (linked_id, linked_pre) in linked_instances {
@@ -560,6 +564,14 @@ async fn invoke_ephemeral_relocated(
     let import_name = inv.import_name.clone();
     let export_name = inv.export_name.clone();
 
+    // Deadline enforced from out here (see `crate::engine::abandon`); the flag
+    // travels into the task, which registers it once the store exists.
+    let call = crate::engine::abandon::DispatchedCall::new(
+        "linked (relocated ephemeral store)",
+        crate::timeouts::ephemeral_call(),
+    );
+    let call_flag = call.flag();
+
     trace!(
         name = %inv.import_name,
         fn_name = %inv.export_name,
@@ -579,6 +591,9 @@ async fn invoke_ephemeral_relocated(
                 return;
             }
         };
+        // Watched for the store's whole run, the post-reply stream drain
+        // included.
+        let _abandoned = store.data().abandoned.watch(call_flag);
         let instance = match callee_pre.instantiate_async(&mut store).await {
             Ok(i) => i,
             Err(e) => {
@@ -661,14 +676,23 @@ async fn invoke_ephemeral_relocated(
             .await;
     }));
 
-    let relocated = ready_rx
+    let drain_flag = call.flag();
+    let relocated = call
+        .await_reply(ready_rx)
         .await
+        .ok_or_else(|| wasmtime::format_err!("ephemeral store produced no results in time"))?
         .map_err(|_| wasmtime::format_err!("ephemeral store dropped before producing results"))??;
 
     // Results are in hand; the task must keep running to feed any result streams,
     // so detach it (cancellation past this point is handled by the result-stream
     // consumers closing their pump channels).
     std::mem::forget(task);
+
+    // The detached store bounds its own stream drain, but that bound is a
+    // future on the store and cannot fire against a guest that never yields.
+    // Re-abandon the call when the drain budget expires: a store already done
+    // by then has deregistered the flag, so this only ever ends a wedged drain.
+    drain_flag.arm_after(crate::timeouts::stream_drain());
 
     // Inject results into the caller store; result-stream producers pull from
     // the still-draining ephemeral store.
@@ -719,6 +743,13 @@ async fn invoke_ephemeral_plain(
 
     if let Some(pool) = pool.as_ref() {
         let (reply, reply_rx) = tokio::sync::oneshot::channel();
+        // Deadline enforced here, in the caller's task, outside the callee's
+        // store — where a non-yielding callee cannot block it (see
+        // `crate::engine::abandon`).
+        let call = crate::engine::abandon::DispatchedCall::new(
+            "linked (pooled)",
+            crate::timeouts::ephemeral_call(),
+        );
         let job = InstanceJob::Linked(Box::new(LinkedJob {
             func_idx: inv.func_idx,
             params: params.to_vec(),
@@ -726,6 +757,7 @@ async fn invoke_ephemeral_plain(
             import_name: inv.import_name.clone(),
             export_name: inv.export_name.clone(),
             reply,
+            abandoned: call.flag(),
         }));
         let outcome = match pool.offer(job) {
             Dispatch::Sent => Ok(()),
@@ -744,8 +776,12 @@ async fn invoke_ephemeral_plain(
         };
         match outcome {
             Ok(()) => {
-                let vals = reply_rx
+                let vals = call
+                    .await_reply(reply_rx)
                     .await
+                    .ok_or_else(|| {
+                        wasmtime::format_err!("pooled instance produced no reply in time")
+                    })?
                     .map_err(|_| wasmtime::format_err!("pooled instance dropped the call"))??;
                 write_results(vals, results)?;
                 trace!(
@@ -781,9 +817,18 @@ async fn invoke_ephemeral_plain(
     let call_export_name = inv.export_name.clone();
     let func_idx = inv.func_idx;
 
+    // Deadline enforced from out here (see `crate::engine::abandon`); the
+    // watch guard travels into the task to cover the call for its whole run.
+    let call = crate::engine::abandon::DispatchedCall::new(
+        "linked (ephemeral store)",
+        crate::timeouts::ephemeral_call(),
+    );
+    let watch_guard = store.data().abandoned.watch(call.flag());
+
     // The store travels into the task, so a caller cancelled mid-call drops it
     // with the task rather than leaving it running.
     let mut task = AbortOnDrop(tokio::task::spawn(async move {
+        let _abandoned = watch_guard;
         store
             .run_concurrent(async move |accessor| {
                 let func = accessor.with(|mut access| -> wasmtime::Result<_> {
@@ -808,8 +853,10 @@ async fn invoke_ephemeral_plain(
             .map_err(|e| wasmtime::format_err!("{e:#}"))
             .and_then(|inner| inner)
     }));
-    let vals = (&mut task.0)
+    let vals = call
+        .await_reply(&mut task.0)
         .await
+        .ok_or_else(|| wasmtime::format_err!("ephemeral linked call produced no result in time"))?
         .map_err(|e| wasmtime::format_err!("ephemeral linked call task failed: {e}"))??;
     write_results(vals, results)?;
 

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -217,6 +217,7 @@ pub fn targets_wasip3_http(component: &Component) -> bool {
             .any(|(name, _)| name.starts_with("wasi:http") && name.contains("@0.3"))
 }
 
+pub mod abandon;
 pub mod ctx;
 pub(crate) mod instance_driver;
 pub(crate) mod instance_pool;
@@ -226,6 +227,39 @@ pub(crate) mod store;
 mod value;
 mod volumes;
 pub mod workload;
+
+/// How often the engine's epoch advances.
+///
+/// This is the resolution of the deadline checks compiled into every guest, not
+/// how often any store is interrupted: what a store does when its deadline
+/// passes is [`crate::engine::abandon::arm_epoch_deadline`]'s decision. It
+/// bounds how promptly an abandoned call can be noticed.
+pub(crate) const EPOCH_TICK: Duration = Duration::from_millis(10);
+
+/// Start the thread that advances `engine`'s epoch every [`EPOCH_TICK`].
+///
+/// Holds a [`wasmtime::Engine::weak`] handle rather than the engine itself, so
+/// the ticker does not keep a dropped engine alive: the next tick after the last
+/// strong reference goes away fails to upgrade and the thread ends. One ticker
+/// per engine, started at construction — an engine built with
+/// `epoch_interruption` whose epoch never advances would hang any store that
+/// armed a deadline.
+fn spawn_epoch_ticker(engine: &wasmtime::Engine) -> anyhow::Result<()> {
+    let weak = engine.weak();
+    std::thread::Builder::new()
+        .name("wasmtime-epoch-ticker".to_string())
+        .spawn(move || {
+            while let Some(engine) = weak.upgrade() {
+                engine.increment_epoch();
+                // Drop the strong reference before sleeping, so a dropped
+                // engine is not kept alive for a whole tick.
+                drop(engine);
+                std::thread::sleep(EPOCH_TICK);
+            }
+        })
+        .context("failed to spawn the epoch ticker thread")?;
+    Ok(())
+}
 
 /// The core WebAssembly engine for executing components and workloads.
 ///
@@ -1011,11 +1045,18 @@ impl EngineBuilder {
         self.proposals
             .insert(WasmProposal::WasmComponentModelImplements);
 
+        // Compile a deadline check into every guest's loop back-edges, so guest
+        // work that never yields can still be ended. Every store must then set a
+        // deadline of its own — see [`crate::engine::abandon::arm_epoch_deadline`],
+        // which is what decides when one is acted on.
+        config.epoch_interruption(true);
+
         for proposal in &self.proposals {
             proposal.apply(&mut config);
         }
 
         let inner = wasmtime::Engine::new(&config)?;
+        spawn_epoch_ticker(&inner)?;
         let cache = Cache::builder()
             .max_capacity(self.compilation_cache_size.unwrap_or(100))
             .time_to_idle(

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -28,6 +28,7 @@ use std::{
 
 use arc_swap::ArcSwap;
 
+use crate::engine::abandon::{AbandonFlag, AbandonOnDrop, DispatchedCall};
 use crate::host::allowed_hosts::AllowedHost;
 use crate::host::trigger_service::{BrokerMessage, MessagingJob};
 use crate::{engine::ctx::SharedCtx, observability::Meters};
@@ -918,16 +919,71 @@ impl HostHandler for NullServer {
     }
 }
 
+/// An HTTP response body that keeps its dispatched call condemned-on-drop while
+/// it streams: dropped mid-stream (the client disconnected), the wrapped
+/// [`AbandonOnDrop`] abandons the call; ended cleanly, it disarms. Extends the
+/// deadline enforcement of [`DispatchedCall::await_head`] across the body phase,
+/// so a guest that produces a response head and then wedges mid-body is still
+/// reachable.
+struct WatchedBody<B> {
+    inner: B,
+    /// `None` once end-of-stream disarmed it.
+    watch: Option<AbandonOnDrop>,
+}
+
+impl<B: hyper::body::Body + Unpin> hyper::body::Body for WatchedBody<B> {
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        let poll = std::pin::Pin::new(&mut this.inner).poll_frame(cx);
+        // Clean end of stream: the response was delivered whole, so nothing is
+        // abandoned. An *error* frame deliberately does not disarm — the
+        // exchange broke off, and if the guest is wedged behind it, the armed
+        // flag is what ends it (a completed call deregisters, so arming a
+        // healthy one is harmless).
+        if let std::task::Poll::Ready(None) = poll
+            && let Some(watch) = this.watch.take()
+        {
+            watch.disarm();
+        }
+        poll
+    }
+}
+
+/// Wrap `resp`'s body so the dispatched call behind it stays condemned-on-drop
+/// until the body finishes streaming.
+fn watch_body(
+    resp: hyper::Response<HyperOutgoingBody>,
+    watch: AbandonOnDrop,
+) -> hyper::Response<HyperOutgoingBody> {
+    resp.map(|inner| {
+        HyperOutgoingBody::new(
+            WatchedBody {
+                inner,
+                watch: Some(watch),
+            }
+            .boxed_unsync(),
+        )
+    })
+}
+
 /// A map from host header to resolved workload handles and their associated component id
 pub type WorkloadHandles =
     Arc<RwLock<HashMap<String, (ResolvedWorkload, InstancePre<SharedCtx>, String)>>>;
 
 /// An inbound HTTP request routed to a long-lived service instance, paired with
-/// a oneshot for its response.
-pub type ServiceHttpJob = (
-    hyper::Request<hyper::body::Incoming>,
-    tokio::sync::oneshot::Sender<anyhow::Result<hyper::Response<HyperOutgoingBody>>>,
-);
+/// a oneshot for its response and the abandonment flag of the [`DispatchedCall`]
+/// enforcing its deadline (see [`crate::engine::abandon`]).
+pub struct ServiceHttpJob {
+    pub req: hyper::Request<hyper::body::Incoming>,
+    pub resp_tx: tokio::sync::oneshot::Sender<anyhow::Result<hyper::Response<HyperOutgoingBody>>>,
+    pub abandoned: Arc<AbandonFlag>,
+}
 
 /// A map from workload id to the channel of its HTTP-serving service instance.
 /// Empty unless a workload's service opts into HTTP ingress (a p3 feature).
@@ -1328,11 +1384,20 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
                 )
             })?;
         let (tx, rx) = tokio::sync::oneshot::channel();
+        // Deadline enforced here, outside the service's store, where a
+        // non-yielding guest cannot block it (see `crate::engine::abandon`).
+        let call = DispatchedCall::new("messaging (service)", crate::timeouts::messaging_deliver());
         sender
-            .send((msg, tx))
+            .send(MessagingJob {
+                msg,
+                result_tx: tx,
+                abandoned: call.flag(),
+            })
             .await
             .map_err(|_| anyhow::anyhow!("trigger service messaging instance is not running"))?;
-        rx.await
+        call.await_reply(rx)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("trigger service produced no message response in time"))?
             .map_err(|_| anyhow::anyhow!("trigger service dropped the message response"))
     }
 
@@ -1611,18 +1676,31 @@ async fn handle_http_request<T: Router>(
     let service_sender = service_handlers.read().await.get(&workload_id).cloned();
     if let Some(sender) = service_sender {
         let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-        let response = if sender.send((req, resp_tx)).await.is_err() {
+        // The deadline is enforced here, outside the service's store: a guest
+        // that never yields blocks every host future on its own store, so only
+        // a waiter out here can abandon the call (see `crate::engine::abandon`).
+        let call = DispatchedCall::new("HTTP (service)", crate::timeouts::http_response());
+        let job = ServiceHttpJob {
+            req,
+            resp_tx,
+            abandoned: call.flag(),
+        };
+        let response = if sender.send(job).await.is_err() {
             error!(host = %workload_id, "service HTTP instance is not running");
             error_response(503)
         } else {
-            match resp_rx.await {
-                Ok(Ok(resp)) => resp,
-                Ok(Err(e)) => {
+            match call.await_head(resp_rx).await {
+                Some((Ok(Ok(resp)), watch)) => watch_body(resp, watch),
+                Some((Ok(Err(e)), _)) => {
                     error!(err = ?e, "service HTTP handler failed");
                     error_response(500)
                 }
-                Err(_) => {
+                Some((Err(_), _)) => {
                     error!("service HTTP instance dropped the response");
+                    error_response(500)
+                }
+                None => {
+                    error!("service HTTP instance produced no response");
                     error_response(500)
                 }
             }
@@ -1878,7 +1956,12 @@ async fn invoke_component_handler(
             use crate::engine::instance_driver::InstanceJob;
             use crate::engine::instance_pool::Dispatch;
             let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-            let outcome = match pool.offer(InstanceJob::Http(Box::new((req, resp_tx)))) {
+            let call = DispatchedCall::new("HTTP (pooled)", crate::timeouts::http_response());
+            let outcome = match pool.offer(InstanceJob::Http(Box::new(ServiceHttpJob {
+                req,
+                resp_tx,
+                abandoned: call.flag(),
+            }))) {
                 Dispatch::Sent => Ok(()),
                 // The pool has room. Build and instantiate the store out here,
                 // where awaiting is allowed and where a component that fails
@@ -1896,12 +1979,16 @@ async fn invoke_component_handler(
             };
             match outcome {
                 Ok(()) => {
-                    return resp_rx
+                    let (resp, watch) = call
+                        .await_head(resp_rx)
                         .await
-                        .map_err(|_| anyhow::anyhow!("pooled instance dropped the request"))?;
+                        .ok_or_else(|| anyhow::anyhow!("pooled instance produced no response"))?;
+                    let resp =
+                        resp.map_err(|_| anyhow::anyhow!("pooled instance dropped the request"))??;
+                    return Ok(watch_body(resp, watch));
                 }
                 // Every warm instance was busy; serve it cold below.
-                Err(InstanceJob::Http(job)) => job.0,
+                Err(InstanceJob::Http(job)) => job.req,
                 // A job comes back as the variant it went in as, so this is
                 // unreachable — but not worth a panic on a request path.
                 Err(InstanceJob::Linked(_)) => {
@@ -1916,8 +2003,15 @@ async fn invoke_component_handler(
         let mut store = workload_handle.new_store(component_id).await?;
         let instance = instance_pre.instantiate_async(&mut store).await?;
         let cold = crate::engine::instance_pool::ComponentInstance { store, instance };
-        let resp = crate::host::http_p3::handle_component_request_p3(cold, req, fuel_meter).await?;
-        let (parts, body) = resp.into_parts();
+        let call = DispatchedCall::new("HTTP (cold store)", crate::timeouts::http_response());
+        let flag = call.flag();
+        let (resp, watch) = call
+            .await_head(crate::host::http_p3::handle_component_request_p3(
+                cold, req, flag, fuel_meter,
+            ))
+            .await
+            .ok_or_else(|| anyhow::anyhow!("cold instance produced no response"))?;
+        let (parts, body) = resp?.into_parts();
         let body = HyperOutgoingBody::new(
             body.map_err(|e| {
                 wasmtime_wasi_http::p2::bindings::http::types::ErrorCode::InternalError(Some(
@@ -1926,7 +2020,7 @@ async fn invoke_component_handler(
             })
             .boxed_unsync(),
         );
-        return Ok(hyper::Response::from_parts(parts, body));
+        return Ok(watch_body(hyper::Response::from_parts(parts, body), watch));
     }
 
     // The p2 path still builds and instantiates per request: its store is
@@ -1967,11 +2061,18 @@ pub async fn handle_component_request(
         .map_err(anyhow::Error::from)
         .context("failed to instantiate proxy pre")?;
 
+    // The deadline is enforced below, outside the store, where a non-yielding
+    // guest cannot block it (see `crate::engine::abandon`).
+    let call = DispatchedCall::new("HTTP (p2 cold store)", crate::timeouts::http_response());
+    let watch_guard = store.data().abandoned.watch(call.flag());
+
     // Run the http request itself in a separate task so the task can
     // optionally continue to execute beyond after the initial
     // headers/response code are sent.
     let task: JoinHandle<anyhow::Result<()>> = tokio::task::spawn(
         async move {
+            // Watched for as long as the store runs guest code.
+            let _abandoned = watch_guard;
             // Run the http request itself by instantiating and calling the component
             let proxy = pre.instantiate_async(&mut store).await?;
 
@@ -2000,15 +2101,15 @@ pub async fn handle_component_request(
         .in_current_span(),
     );
 
-    match receiver.await {
+    match call.await_head(receiver).await {
         // If the client calls `response-outparam::set` then one of these
         // methods will be called.
-        Ok(Ok(resp)) => Ok(resp),
-        Ok(Err(e)) => Err(e.into()),
+        Some((Ok(Ok(resp)), watch)) => Ok(watch_body(resp, watch)),
+        Some((Ok(Err(e)), _)) => Err(e.into()),
 
         // Otherwise the `sender` will get dropped along with the `Store`
         // meaning that the oneshot will get disconnected
-        Err(e) => {
+        Some((Err(e), _)) => {
             if let Err(task_error) = task.await {
                 error!(err = ?task_error, "error receiving http response");
                 Err(anyhow::anyhow!(
@@ -2021,6 +2122,10 @@ pub async fn handle_component_request(
                 ))
             }
         }
+
+        // No response within the deadline; the call is abandoned, and the
+        // store's epoch callback ends the guest work behind it.
+        None => Err(anyhow::anyhow!("component produced no response in time")),
     }
 }
 

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -946,21 +946,41 @@ impl<B: hyper::body::Body + Unpin> hyper::body::Body for WatchedBody<B> {
         // exchange broke off, and if the guest is wedged behind it, the armed
         // flag is what ends it (a completed call deregisters, so arming a
         // healthy one is harmless).
-        if let std::task::Poll::Ready(None) = poll
-            && let Some(watch) = this.watch.take()
-        {
+        // `is_end_stream` too, since hyper stops polling once a declared
+        // `content-length` is written and never delivers that final `None`.
+        let ended = matches!(poll, std::task::Poll::Ready(None)) || this.inner.is_end_stream();
+        if ended && let Some(watch) = this.watch.take() {
             watch.disarm();
         }
         poll
+    }
+
+    // Forwarded, not defaulted: hyper frames the response from these, so
+    // defaulting them sends a fixed-length body chunked and close-delimits a
+    // HEAD or 204/304 that would otherwise keep its connection alive.
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.inner.size_hint()
     }
 }
 
 /// Wrap `resp`'s body so the dispatched call behind it stays condemned-on-drop
 /// until the body finishes streaming.
+///
+/// An already-complete body is left unwrapped and disarmed: hyper never polls
+/// one, so a wrapper would be dropped un-disarmed and arm the flag on a
+/// response that was delivered whole.
 fn watch_body(
     resp: hyper::Response<HyperOutgoingBody>,
     watch: AbandonOnDrop,
 ) -> hyper::Response<HyperOutgoingBody> {
+    if hyper::body::Body::is_end_stream(resp.body()) {
+        watch.disarm();
+        return resp;
+    }
     resp.map(|inner| {
         HyperOutgoingBody::new(
             WatchedBody {

--- a/crates/wash-runtime/src/host/http_p3.rs
+++ b/crates/wash-runtime/src/host/http_p3.rs
@@ -39,10 +39,10 @@ pub type P3SendFuture = Box<dyn std::future::Future<Output = P3SendResult> + Sen
 struct ChannelBody {
     rx: tokio::sync::mpsc::Receiver<Result<hyper::body::Frame<bytes::Bytes>, ErrorCode>>,
     /// Aborts the component task when this body is dropped before the stream
-    /// completes (e.g. the client disconnects). Without this, a guest that is
-    /// busy computing — rather than parked on a frame send — would keep running
-    /// until its next send; there is no epoch/wall-clock backstop. Held only
-    /// for its `Drop`.
+    /// completes (e.g. the client disconnects). The abort lands at the guest's
+    /// next await, reclaiming a yielding guest at once; a guest that never
+    /// yields is unreachable by it and is ended by its abandoned call instead
+    /// (see [`crate::engine::abandon`]). Held only for its `Drop`.
     _task: tokio_util::task::AbortOnDropHandle<()>,
 }
 
@@ -72,6 +72,7 @@ impl hyper::body::Body for ChannelBody {
 pub(crate) async fn handle_component_request_p3(
     warm: ComponentInstance,
     req: hyper::Request<hyper::body::Incoming>,
+    abandoned: std::sync::Arc<crate::engine::abandon::AbandonFlag>,
     fuel_meter: FuelConsumptionMeter,
 ) -> anyhow::Result<hyper::Response<P3Body>> {
     let _ = &fuel_meter; // fuel metering integration deferred to match P2's observe() pattern
@@ -106,6 +107,9 @@ pub(crate) async fn handle_component_request_p3(
                 mut store,
                 instance,
             } = warm;
+            // Watched for the life of the store's run: the dispatcher enforces
+            // the deadline out where a non-yielding guest cannot block it.
+            let _abandoned = store.data().abandoned.watch(abandoned);
             // A binding view over the instance, rebuilt per request. Cheap
             // (export lookups); the expensive part -- the store and the
             // instantiation -- is what a warm instance carries over.

--- a/crates/wash-runtime/src/host/http_p3.rs
+++ b/crates/wash-runtime/src/host/http_p3.rs
@@ -56,6 +56,18 @@ impl hyper::body::Body for ChannelBody {
     ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
         self.rx.poll_recv(cx)
     }
+
+    fn is_end_stream(&self) -> bool {
+        self.rx.is_closed() && self.rx.is_empty()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        if self.is_end_stream() {
+            hyper::body::SizeHint::with_exact(0)
+        } else {
+            hyper::body::SizeHint::default()
+        }
+    }
 }
 
 /// Handle an HTTP request using the WASIP3 `wasi:http/handler` interface.
@@ -249,6 +261,38 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use hyper::body::Frame;
+
+    /// `ChannelBody` must report end-of-stream **at rest** — closed sender,
+    /// drained buffer — not only through a terminal poll: hyper stops polling
+    /// a fixed-length body early, and `WatchedBody` reads this to tell a
+    /// delivered response from an abandoned one.
+    #[tokio::test]
+    async fn channel_body_reports_end_of_stream_at_rest() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<Frame<Bytes>, ErrorCode>>(4);
+        let mut body = ChannelBody {
+            rx,
+            _task: tokio_util::task::AbortOnDropHandle::new(tokio::spawn(async {})),
+        };
+        assert!(!hyper::body::Body::is_end_stream(&body));
+
+        tx.send(Ok(Frame::data(Bytes::from_static(b"data"))))
+            .await
+            .expect("send");
+        drop(tx);
+        // Closed but not yet drained: the last frame is still deliverable.
+        assert!(!hyper::body::Body::is_end_stream(&body));
+
+        let frame = std::future::poll_fn(|cx| {
+            hyper::body::Body::poll_frame(std::pin::Pin::new(&mut body), cx)
+        })
+        .await
+        .expect("a frame")
+        .expect("not an error");
+        assert!(frame.is_data());
+        // Closed and drained: ended, with an exact size of zero.
+        assert!(hyper::body::Body::is_end_stream(&body));
+        assert_eq!(hyper::body::Body::size_hint(&body).exact(), Some(0));
+    }
 
     /// `ChannelBody` must forward frames **incrementally**, a consumer should
     /// receive a frame while the producer is still parked, not only after the

--- a/crates/wash-runtime/src/host/trigger_service/capability.rs
+++ b/crates/wash-runtime/src/host/trigger_service/capability.rs
@@ -64,6 +64,11 @@ pub struct CapabilityCall {
     /// Carries the call's relocated results (or a trap/routing error) back to
     /// the shim.
     pub reply: tokio::sync::oneshot::Sender<wasmtime::Result<Vec<Relocated>>>,
+    /// The abandonment flag of the dispatched call enforcing this job's
+    /// deadline (see [`crate::engine::abandon`]). The plugin store is
+    /// `WarnThenTrap`, so an abandoned call here is logged at the grace and
+    /// only traps the shared store at the escalation.
+    pub abandoned: Arc<crate::engine::abandon::AbandonFlag>,
 }
 
 /// A `wasmcloud:host/workload-lifecycle` bind a fresh plugin incarnation must
@@ -274,7 +279,15 @@ impl AccessorTask<SharedCtx> for CapabilityTask {
             args,
             result_tys,
             reply,
+            abandoned,
         } = call;
+
+        // Watch this call for the rest of its life. The guard deregisters on
+        // drop, however the call ends.
+        let _abandoned = accessor.with(|mut access| {
+            let calls = Arc::clone(&access.get().abandoned);
+            calls.watch(abandoned)
+        });
 
         // Look up the export and inject the relocated arguments — in one discrete
         // sync block, never holding the borrow across the await below.

--- a/crates/wash-runtime/src/host/trigger_service/capability.rs
+++ b/crates/wash-runtime/src/host/trigger_service/capability.rs
@@ -283,8 +283,9 @@ impl AccessorTask<SharedCtx> for CapabilityTask {
         } = call;
 
         // Watch this call for the rest of its life. The guard deregisters on
-        // drop, however the call ends.
+        // drop, however the call ends; the deadline is re-armed for it here.
         let _abandoned = accessor.with(|mut access| {
+            crate::engine::abandon::rearm_for_call(&mut access);
             let calls = Arc::clone(&access.get().abandoned);
             calls.watch(abandoned)
         });

--- a/crates/wash-runtime/src/host/trigger_service/http.rs
+++ b/crates/wash-runtime/src/host/trigger_service/http.rs
@@ -34,6 +34,18 @@ impl hyper::body::Body for ChannelBody {
     ) -> Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
         self.rx.poll_recv(cx)
     }
+
+    fn is_end_stream(&self) -> bool {
+        self.rx.is_closed() && self.rx.is_empty()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        if self.is_end_stream() {
+            hyper::body::SizeHint::with_exact(0)
+        } else {
+            hyper::body::SizeHint::default()
+        }
+    }
 }
 
 /// Handles one inbound HTTP request on a shared instance: the workload's
@@ -209,6 +221,35 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use hyper::body::Frame;
+
+    /// [`ChannelBody`] must report end-of-stream **at rest** — closed sender,
+    /// drained buffer — not only through a terminal poll: hyper stops polling
+    /// a fixed-length body early, and `WatchedBody` reads this to tell a
+    /// delivered response from an abandoned one.
+    #[tokio::test]
+    async fn channel_body_reports_end_of_stream_at_rest() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<Frame<Bytes>, P2ErrorCode>>(4);
+        let mut body = ChannelBody { rx };
+        assert!(!hyper::body::Body::is_end_stream(&body));
+
+        tx.send(Ok(Frame::data(Bytes::from_static(b"data"))))
+            .await
+            .expect("send");
+        drop(tx);
+        // Closed but not yet drained: the last frame is still deliverable.
+        assert!(!hyper::body::Body::is_end_stream(&body));
+
+        let frame = std::future::poll_fn(|cx| {
+            hyper::body::Body::poll_frame(std::pin::Pin::new(&mut body), cx)
+        })
+        .await
+        .expect("a frame")
+        .expect("not an error");
+        assert!(frame.is_data());
+        // Closed and drained: ended, with an exact size of zero.
+        assert!(hyper::body::Body::is_end_stream(&body));
+        assert_eq!(hyper::body::Body::size_hint(&body).exact(), Some(0));
+    }
 
     /// [`ChannelBody`] must forward frames **incrementally** — a consumer
     /// receives a frame while the producer is still parked — so a service

--- a/crates/wash-runtime/src/host/trigger_service/http.rs
+++ b/crates/wash-runtime/src/host/trigger_service/http.rs
@@ -71,8 +71,9 @@ impl AccessorTask<SharedCtx> for HttpTask {
         } = self;
 
         // Watch this call for the rest of its life. The guard deregisters on
-        // drop, however the call ends.
+        // drop, however the call ends; the deadline is re-armed for it here.
         let _abandoned = accessor.with(|mut access| {
+            crate::engine::abandon::rearm_for_call(&mut access);
             let calls = std::sync::Arc::clone(&access.get().abandoned);
             calls.watch(abandoned)
         });

--- a/crates/wash-runtime/src/host/trigger_service/http.rs
+++ b/crates/wash-runtime/src/host/trigger_service/http.rs
@@ -50,6 +50,10 @@ pub(crate) struct HttpTask {
     pub(crate) req: hyper::Request<hyper::body::Incoming>,
     pub(crate) resp_tx:
         tokio::sync::oneshot::Sender<anyhow::Result<hyper::Response<HyperOutgoingBody>>>,
+    /// Armed by the dispatcher once it has stopped waiting for this response.
+    /// It is registered on the store for the life of the call so the epoch
+    /// callback can see it — the only way to end a guest that never yields.
+    pub(crate) abandoned: std::sync::Arc<crate::engine::abandon::AbandonFlag>,
     /// This call's tether to a pooled instance: holds its in-flight slot and
     /// can retire the instance. `None` for a service, whose singleton instance
     /// is not the pool's to retire.
@@ -62,8 +66,16 @@ impl AccessorTask<SharedCtx> for HttpTask {
             service,
             req,
             resp_tx,
+            abandoned,
             pool_slot,
         } = self;
+
+        // Watch this call for the rest of its life. The guard deregisters on
+        // drop, however the call ends.
+        let _abandoned = accessor.with(|mut access| {
+            let calls = std::sync::Arc::clone(&access.get().abandoned);
+            calls.watch(abandoned)
+        });
 
         let (parts, body) = req.into_parts();
         let body = body

--- a/crates/wash-runtime/src/host/trigger_service/messaging.rs
+++ b/crates/wash-runtime/src/host/trigger_service/messaging.rs
@@ -11,8 +11,11 @@
 //!
 //! [`Ingress::Messaging`]: super::Ingress::Messaging
 
+use std::sync::Arc;
+
 use wasmtime::component::{Accessor, AccessorTask, Instance, StreamReader};
 
+use crate::engine::abandon::AbandonFlag;
 use crate::engine::ctx::SharedCtx;
 
 mod bindings {
@@ -44,13 +47,15 @@ pub struct BrokerMessage {
     pub reply_to: Option<String>,
 }
 
-/// A messaging invocation: the message plus a oneshot carrying the handler's
-/// outcome back to the host-side ingress (to ack/log), its disposition rendered
-/// to a string.
-pub type MessagingJob = (
-    BrokerMessage,
-    tokio::sync::oneshot::Sender<Result<(), String>>,
-);
+/// A messaging invocation: the message, a oneshot carrying the handler's
+/// outcome back to the host-side ingress (to ack/log, its disposition rendered
+/// to a string), and the abandonment flag of the dispatched call enforcing its
+/// deadline (see [`crate::engine::abandon`]).
+pub struct MessagingJob {
+    pub msg: BrokerMessage,
+    pub result_tx: tokio::sync::oneshot::Sender<Result<(), String>>,
+    pub abandoned: Arc<AbandonFlag>,
+}
 
 /// The messaging handler export a trigger service must provide.
 ///
@@ -117,6 +122,7 @@ pub(super) struct MessagingTask {
     pub(super) handler: std::sync::Arc<AsyncMessaging>,
     pub(super) msg: BrokerMessage,
     pub(super) result_tx: tokio::sync::oneshot::Sender<Result<(), String>>,
+    pub(super) abandoned: Arc<AbandonFlag>,
 }
 
 impl AccessorTask<SharedCtx> for MessagingTask {
@@ -125,7 +131,15 @@ impl AccessorTask<SharedCtx> for MessagingTask {
             handler,
             msg,
             result_tx,
+            abandoned,
         } = self;
+
+        // Watch this call for the rest of its life. The guard deregisters on
+        // drop, however the call ends.
+        let _abandoned = accessor.with(|mut access| {
+            let calls = Arc::clone(&access.get().abandoned);
+            calls.watch(abandoned)
+        });
 
         let outcome = async {
             // The `@0.3.0` body is a native `stream<u8>`; mint one carrying the

--- a/crates/wash-runtime/src/host/trigger_service/messaging.rs
+++ b/crates/wash-runtime/src/host/trigger_service/messaging.rs
@@ -135,8 +135,9 @@ impl AccessorTask<SharedCtx> for MessagingTask {
         } = self;
 
         // Watch this call for the rest of its life. The guard deregisters on
-        // drop, however the call ends.
+        // drop, however the call ends; the deadline is re-armed for it here.
         let _abandoned = accessor.with(|mut access| {
+            crate::engine::abandon::rearm_for_call(&mut access);
             let calls = Arc::clone(&access.get().abandoned);
             calls.watch(abandoned)
         });

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -280,7 +280,8 @@ impl PreparedIngress {
                         crate::timeouts::plugin_lifecycle_call(),
                     );
                     let abandoned = call.flag();
-                    call.arm_detached();
+                    // Dropped once the outcome is in, cancelling the arming.
+                    let _replay_timer = call.arm_on_timer();
                     admit_and_spawn_call(
                         accessor,
                         *instance,

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -200,11 +200,17 @@ impl PreparedIngress {
     async fn serve(&mut self, accessor: &Accessor<SharedCtx>) -> ServeOutcome {
         match self {
             PreparedIngress::Http { service, rx } => {
-                while let Some((req, resp_tx)) = rx.recv().await {
+                while let Some(ServiceHttpJob {
+                    req,
+                    resp_tx,
+                    abandoned,
+                }) = rx.recv().await
+                {
                     if let Err(e) = accessor.spawn(HttpTask {
                         service: Arc::clone(service),
                         req,
                         resp_tx,
+                        abandoned,
                         pool_slot: None,
                     }) {
                         tracing::error!(err = %e, "failed to spawn HTTP invocation task");
@@ -213,11 +219,17 @@ impl PreparedIngress {
                 ServeOutcome::Shutdown
             }
             PreparedIngress::Messaging { handler, rx } => {
-                while let Some((msg, result_tx)) = rx.recv().await {
+                while let Some(MessagingJob {
+                    msg,
+                    result_tx,
+                    abandoned,
+                }) = rx.recv().await
+                {
                     if let Err(e) = accessor.spawn(MessagingTask {
                         handler: Arc::clone(handler),
                         msg,
                         result_tx,
+                        abandoned,
                     }) {
                         tracing::error!(err = %e, "failed to spawn messaging invocation task");
                     }
@@ -260,6 +272,15 @@ impl PreparedIngress {
                     let workload_id = Arc::clone(&caller.workload_id);
                     registry.replay_begin(caller.clone());
                     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+                    // This waiter lives inside the plugin's own store, where a
+                    // non-yielding bind would starve its timeout — so the
+                    // abandonment deadline is armed from a detached timer.
+                    let call = crate::engine::abandon::DispatchedCall::new(
+                        "workload-bind replay (plugin)",
+                        crate::timeouts::plugin_lifecycle_call(),
+                    );
+                    let abandoned = call.flag();
+                    call.arm_detached();
                     admit_and_spawn_call(
                         accessor,
                         *instance,
@@ -273,6 +294,7 @@ impl PreparedIngress {
                             args,
                             result_tys,
                             reply: reply_tx,
+                            abandoned,
                         },
                     );
                     await_replay_outcome(workload_id, reply_rx).await;

--- a/crates/wash-runtime/src/plugin/component_host/lifecycle.rs
+++ b/crates/wash-runtime/src/plugin/component_host/lifecycle.rs
@@ -38,6 +38,7 @@ use tracing::{debug, error, warn};
 use wasmtime::component::Val;
 use wasmtime::component::types::Type;
 
+use crate::engine::abandon::DispatchedCall;
 use crate::engine::ctx::CallerIdentity;
 use crate::engine::store::relocate::Relocated;
 use crate::engine::workload::UnresolvedWorkload;
@@ -279,12 +280,14 @@ pub(super) enum BindReply {
 }
 
 /// Enqueue one lifecycle call on `sender` and return its pending reply
-/// receiver. Bounded by [`crate::timeouts::plugin_lifecycle_call`] so a full
-/// channel cannot park a deploy or a stop; a send that times out (or hits a
-/// closed channel) leaves the job un-enqueued — tokio's bounded send only
-/// enqueues on completion — so the caller knows no hook is running. The call
-/// runs under the workload's identity (empty component id) so
-/// `wasmcloud:host/identity` answers consistently inside the hook.
+/// receiver, paired with the [`DispatchedCall`] whose deadline the caller must
+/// enforce when awaiting it. Bounded by
+/// [`crate::timeouts::plugin_lifecycle_call`] so a full channel cannot park a
+/// deploy or a stop; a send that times out (or hits a closed channel) leaves
+/// the job un-enqueued — tokio's bounded send only enqueues on completion — so
+/// the caller knows no hook is running. The call runs under the workload's
+/// identity (empty component id) so `wasmcloud:host/identity` answers
+/// consistently inside the hook.
 pub(super) async fn send_lifecycle_job(
     sender: &CapabilitySender,
     state: &ComponentHostPluginState,
@@ -292,8 +295,9 @@ pub(super) async fn send_lifecycle_job(
     func: &ExportedFunc,
     arg: Val,
     workload_id: &Arc<str>,
-) -> anyhow::Result<LifecycleReplyRx> {
+) -> anyhow::Result<(LifecycleReplyRx, DispatchedCall)> {
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    let call = DispatchedCall::new("workload-lifecycle (plugin)", state.lifecycle_timeout());
     let job = CapabilityJob::Call(CapabilityCall {
         interface: Arc::clone(&lifecycle.interface),
         func: Arc::clone(&func.name),
@@ -304,6 +308,7 @@ pub(super) async fn send_lifecycle_job(
         args: vec![Relocated::Val(arg)],
         result_tys: Arc::clone(&func.result_tys),
         reply: reply_tx,
+        abandoned: call.flag(),
     });
     tokio::time::timeout(state.lifecycle_timeout(), sender.send(job))
         .await
@@ -314,7 +319,7 @@ pub(super) async fn send_lifecycle_job(
             )
         })?
         .map_err(|_| anyhow::anyhow!("host component plugin '{}' channel closed", state.id))?;
-    Ok(reply_rx)
+    Ok((reply_rx, call))
 }
 
 /// Interpret a resolved lifecycle reply receiver value into relocated results
@@ -334,16 +339,20 @@ fn interpret_reply(
 }
 
 /// Await a bind reply, keeping the receiver if the budget elapses first so the
-/// caller can defer cleanup until the still-running hook returns.
+/// caller can defer cleanup until the still-running hook returns. A timeout
+/// also abandons the call (the [`DispatchedCall`] arms its flag), so a hook
+/// wedged in non-yielding guest code is at least detected and logged.
 pub(super) async fn await_bind_reply(
     mut reply_rx: LifecycleReplyRx,
+    call: DispatchedCall,
     state: &ComponentHostPluginState,
 ) -> BindReply {
-    let deadline = tokio::time::sleep(state.lifecycle_timeout());
-    tokio::pin!(deadline);
-    tokio::select! {
-        reply = &mut reply_rx => BindReply::Completed(interpret_reply(reply, state)),
-        () = &mut deadline => BindReply::TimedOut(reply_rx),
+    match call.await_head(&mut reply_rx).await {
+        Some((reply, watch)) => {
+            watch.disarm();
+            BindReply::Completed(interpret_reply(reply, state))
+        }
+        None => BindReply::TimedOut(reply_rx),
     }
 }
 
@@ -359,10 +368,11 @@ async fn call_lifecycle(
     arg: Val,
     workload_id: &Arc<str>,
 ) -> anyhow::Result<Vec<Relocated>> {
-    let reply_rx = send_lifecycle_job(sender, state, lifecycle, func, arg, workload_id).await?;
-    match tokio::time::timeout(state.lifecycle_timeout(), reply_rx).await {
-        Ok(reply) => interpret_reply(reply, state),
-        Err(_) => Err(anyhow::anyhow!(
+    let (reply_rx, call) =
+        send_lifecycle_job(sender, state, lifecycle, func, arg, workload_id).await?;
+    match call.await_reply(reply_rx).await {
+        Some(reply) => interpret_reply(reply, state),
+        None => Err(anyhow::anyhow!(
             "lifecycle call to host component plugin '{}' timed out",
             state.id
         )),

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -722,7 +722,7 @@ impl HostPlugin for ComponentHostPlugin {
         // reached the guest (tokio's bounded send does not enqueue a dropped
         // send), so no hook is running — forget the workload and fail, no
         // unbind needed.
-        let reply_rx = match send_lifecycle_job(
+        let (reply_rx, call) = match send_lifecycle_job(
             &sender_arc,
             &self.state,
             lifecycle,
@@ -732,7 +732,7 @@ impl HostPlugin for ComponentHostPlugin {
         )
         .await
         {
-            Ok(reply_rx) => reply_rx,
+            Ok(sent) => sent,
             Err(e) => {
                 self.state.forget_workload(&workload_id);
                 return Err(e.context(format!(
@@ -748,7 +748,7 @@ impl HostPlugin for ComponentHostPlugin {
         // hook actually returns — guaranteeing bind-then-unbind ordering so
         // whatever it provisions late is still reclaimed (see
         // [`spawn_deferred_unbind`]).
-        let failure = match await_bind_reply(reply_rx, &self.state).await {
+        let failure = match await_bind_reply(reply_rx, call, &self.state).await {
             BindReply::Completed(Ok(results)) => match decode_bind_reply(&results) {
                 Ok(Ok(())) => {
                     debug!(id = self.id, %workload_id, "workload bound to host component plugin");
@@ -1550,6 +1550,14 @@ async fn route_capability_call(
     })?;
 
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    // Deadline enforced here, in the calling workload's task, outside the
+    // plugin's store (see `crate::engine::abandon`). The plugin store is
+    // `WarnThenTrap`: an abandoned call is logged at the grace and only traps
+    // the shared store at the escalation.
+    let call = crate::engine::abandon::DispatchedCall::new(
+        "capability (plugin)",
+        crate::timeouts::plugin_capability_call(),
+    );
     sender
         .send(CapabilityJob::Call(CapabilityCall {
             interface,
@@ -1558,15 +1566,25 @@ async fn route_capability_call(
             args,
             result_tys,
             reply: reply_tx,
+            abandoned: call.flag(),
         }))
         .await
         .map_err(|_| {
             wasmtime::format_err!("host component plugin '{}' channel closed", state.id)
         })?;
 
-    let produced = reply_rx.await.map_err(|_| {
-        wasmtime::format_err!("host component plugin '{}' dropped the reply", state.id)
-    })??;
+    let produced = call
+        .await_reply(reply_rx)
+        .await
+        .ok_or_else(|| {
+            wasmtime::format_err!(
+                "host component plugin '{}' produced no reply in time",
+                state.id
+            )
+        })?
+        .map_err(|_| {
+            wasmtime::format_err!("host component plugin '{}' dropped the reply", state.id)
+        })??;
 
     // Inject the relocated results into the caller store.
     accessor.with(|mut access| -> wasmtime::Result<()> {
@@ -1834,7 +1852,17 @@ fn build_plugin_store(
     let ctx = ctx_builder.build();
     // The registry marks this as the plugin (real) side of the resource bridge
     // and keeps the resources it hands out across the boundary alive.
-    Store::new(engine.inner(), SharedCtx::new(ctx).with_resource_registry())
+    let mut store = Store::new(engine.inner(), SharedCtx::new(ctx).with_resource_registry());
+    // Required, not optional: the engine enables `epoch_interruption`, and a
+    // store that never sets a deadline traps the moment it runs any guest code.
+    // `WarnThenTrap` because this one store serves every workload that imports
+    // the plugin's capability: an abandoned call gets a long runway to finish
+    // on its own before ending it costs every tenant a supervised restart.
+    crate::engine::abandon::arm_epoch_deadline(
+        &mut store,
+        crate::engine::abandon::AbandonedCallPolicy::WarnThenTrap,
+    );
+    store
 }
 
 /// Introspect a plugin component's exported interfaces and their functions from

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -786,10 +786,21 @@ impl HostPlugin for InMemoryMessaging {
 
                         let fuel_meter = fuel_meter.clone();
 
+                        // As in the NATS backend: nothing awaits this call, so
+                        // its deadline is a timer outliving the store's task.
+                        let call = crate::engine::abandon::DispatchedCall::new(
+                            "messaging (per-message store)",
+                            crate::timeouts::messaging_deliver(),
+                        );
+                        let abandoned = store.data().abandoned.watch(call.flag());
+                        let deadline = call.arm_on_timer();
+
                         tokio::spawn(async move {
                             // Released on completion, trap or not — which is
                             // what frees the instance slot this message holds.
                             let _permit = permit;
+                            let _abandoned = abandoned;
+                            let _deadline = deadline;
                             let result = fuel_meter.observe(
                                 &[
                                     KeyValue::new("plugin", PLUGIN_MESSAGING_MEMORY_ID),

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -722,10 +722,24 @@ impl HostPlugin for NatsMessaging {
 
                         let fuel_meter = fuel_meter.clone();
 
+                        // Nothing awaits this call, so its deadline is a timer
+                        // outliving the store's own task; without it a guest
+                        // pinned on a poison message holds this store, and its
+                        // instance slot, for the life of the host.
+                        let call = crate::engine::abandon::DispatchedCall::new(
+                            "messaging (per-message store)",
+                            crate::timeouts::messaging_deliver(),
+                        );
+                        let abandoned = store.data().abandoned.watch(call.flag());
+                        let deadline = call.arm_on_timer();
+
                         tokio::spawn(async move {
                             // Released on completion, trap or not — which is
                             // what frees the instance slot this message holds.
                             let _permit = permit;
+                            // Dropped when the call ends, however it ends.
+                            let _abandoned = abandoned;
+                            let _deadline = deadline;
                             let result = fuel_meter.observe(
                                 &[
                                     KeyValue::new("plugin", PLUGIN_MESSAGING_ID),

--- a/crates/wash-runtime/src/timeouts.rs
+++ b/crates/wash-runtime/src/timeouts.rs
@@ -3,34 +3,9 @@
 //! Every timeout is declared in the single [`declare_timeouts!`] invocation
 //! below and read through a generated accessor. Add a new timeout by adding one
 //! line there.
-//!
-//! [`crate::engine::abandon::pause_threshold`] is the exception: a sampling
-//! tolerance whose default is derived rather than declared, reading its
-//! override through [`env_millis`].
 
 use std::sync::LazyLock;
 use std::time::Duration;
-
-/// Parse `var` as whole milliseconds, falling back to `default` if it is unset
-/// or unparseable (with a warning, so a typo is not swallowed). Anything
-/// expressible in seconds belongs in [`declare_timeouts!`] instead.
-pub(crate) fn env_millis(var: &str, default: Duration) -> Duration {
-    match std::env::var(var) {
-        Ok(v) => match v.parse::<u64>() {
-            Ok(millis) => Duration::from_millis(millis),
-            Err(_) => {
-                tracing::warn!(
-                    var,
-                    value = %v,
-                    default_millis = default.as_millis() as u64,
-                    "ignoring unparseable override (want whole milliseconds)"
-                );
-                default
-            }
-        },
-        Err(_) => default,
-    }
-}
 
 /// Parse `var` as whole seconds, falling back to `default_secs` if it is unset.
 /// A set-but-unparseable value also falls back, with a warning — silently

--- a/crates/wash-runtime/src/timeouts.rs
+++ b/crates/wash-runtime/src/timeouts.rs
@@ -62,6 +62,19 @@ declare_timeouts! {
     shared_store_call = ("WASH_SHARED_STORE_CALL_TIMEOUT_SECS", 30);
     /// Max wall-clock for a trigger service to produce an HTTP response.
     http_response = ("WASH_HTTP_RESPONSE_TIMEOUT_SECS", 600);
+    /// Max wall-clock for a trigger service to acknowledge a delivered message.
+    messaging_deliver = ("WASH_MESSAGING_DELIVER_TIMEOUT_SECS", 600);
+    /// How long an abandoned call may keep running before its store acts on the
+    /// abandonment (see [`crate::engine::abandon`]). This is what makes
+    /// abandonment safe to signal on every disconnect: a healthy guest finishes
+    /// the call well inside the grace, while a wedged one is still running —
+    /// and still registered — when it runs out.
+    abandoned_call_grace = ("WASH_ABANDONED_CALL_GRACE_SECS", 10);
+    /// How long a `WarnThenTrap` store carries an abandoned call before
+    /// trapping anyway. The long runway lets a yielding call finish harmlessly;
+    /// a call still running at the end of it has the store wedged for every
+    /// tenant, and the supervised restart is what restores service.
+    abandoned_call_escalation = ("WASH_ABANDONED_CALL_ESCALATION_SECS", 60);
     /// The per-plugin stop budget. A host component plugin's `stop()` waits
     /// this long for its supervisor to exit before aborting it; `Host::stop`
     /// caps every plugin's `stop()` at this budget plus a one-second grace so
@@ -80,4 +93,7 @@ declare_timeouts! {
     /// Upper bound on a host component plugin's pre-restart backoff.
     #[cfg(feature = "host-component-plugins")]
     plugin_restart_backoff_max = ("WASH_PLUGIN_RESTART_BACKOFF_MAX_SECS", 5);
+    /// Max wall-clock for one capability call into a host component plugin.
+    #[cfg(feature = "host-component-plugins")]
+    plugin_capability_call = ("WASH_PLUGIN_CAPABILITY_CALL_TIMEOUT_SECS", 600);
 }

--- a/crates/wash-runtime/src/timeouts.rs
+++ b/crates/wash-runtime/src/timeouts.rs
@@ -3,9 +3,34 @@
 //! Every timeout is declared in the single [`declare_timeouts!`] invocation
 //! below and read through a generated accessor. Add a new timeout by adding one
 //! line there.
+//!
+//! [`crate::engine::abandon::pause_threshold`] is the exception: a sampling
+//! tolerance whose default is derived rather than declared, reading its
+//! override through [`env_millis`].
 
 use std::sync::LazyLock;
 use std::time::Duration;
+
+/// Parse `var` as whole milliseconds, falling back to `default` if it is unset
+/// or unparseable (with a warning, so a typo is not swallowed). Anything
+/// expressible in seconds belongs in [`declare_timeouts!`] instead.
+pub(crate) fn env_millis(var: &str, default: Duration) -> Duration {
+    match std::env::var(var) {
+        Ok(v) => match v.parse::<u64>() {
+            Ok(millis) => Duration::from_millis(millis),
+            Err(_) => {
+                tracing::warn!(
+                    var,
+                    value = %v,
+                    default_millis = default.as_millis() as u64,
+                    "ignoring unparseable override (want whole milliseconds)"
+                );
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
 
 /// Parse `var` as whole seconds, falling back to `default_secs` if it is unset.
 /// A set-but-unparseable value also falls back, with a warning — silently

--- a/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-callee-p3/src/lib.rs
@@ -25,6 +25,17 @@ struct Component;
 
 impl Guest for Component {
     async fn run(n: u32) -> u32 {
+        // `run(0)` wedges: a loop that never yields, unreachable by any
+        // host-side timeout (those are futures on this store, and this poll
+        // never returns). Only the epoch deadline compiled into the loop's
+        // back-edge can end it. A magic argument rather than a separate
+        // function so the WIT (vendored into both fixtures) stays unchanged.
+        if n == 0 {
+            let mut x: u64 = 0;
+            loop {
+                x = std::hint::black_box(x.wrapping_add(1));
+            }
+        }
         n.wrapping_mul(2).wrapping_add(1)
     }
 

--- a/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/ephemeral-caller-p3/src/lib.rs
@@ -26,11 +26,14 @@ impl Handler for Component {
     async fn handle(request: Request) -> Result<Response, ErrorCode> {
         // Plain-value async cross-component call -> ephemeral-store path.
         // `/calls` reports how many calls the callee instance has served, so a
-        // caller can tell a reused instance from a fresh one; anything else is
-        // run(21) = 21 * 2 + 1 = 43.
+        // caller can tell a reused instance from a fresh one; `/spin` drives
+        // the callee into a non-yielding loop (`run(0)` wedges by contract);
+        // anything else is run(21) = 21 * 2 + 1 = 43.
         let path = request.get_path_with_query().unwrap_or_default();
         let result = if path.starts_with("/calls") {
             compute::calls().await
+        } else if path.starts_with("/spin") {
+            compute::run(0).await
         } else {
             compute::run(21).await
         };

--- a/crates/wash-runtime/tests/fixtures/http-sleeper/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/http-sleeper/src/lib.rs
@@ -78,6 +78,19 @@ impl HttpGuest for Component {
             monotonic_clock::wait_for(ms.saturating_mul(1_000_000)).await;
         }
 
+        // Chatty but healthy: `/chatter?hops=N&hop_ms=M` computes briefly,
+        // awaits M ms, and repeats N times before answering — a guest that
+        // yields constantly but never pauses for long. Each wake lands on an
+        // expired epoch deadline, so this is the wake pattern that a sampled
+        // view cannot tell from a pinned guest within a single window.
+        if path.starts_with("/chatter") {
+            let hops = query_u64(&path, "hops=").unwrap_or(4);
+            let hop_ms = query_u64(&path, "hop_ms=").unwrap_or(200);
+            for _ in 0..hops {
+                monotonic_clock::wait_for(hop_ms.saturating_mul(1_000_000)).await;
+            }
+        }
+
         // Spinning: never yields, so it is unreachable by every host-side
         // timeout — those are futures, and this call's poll never returns for
         // one to be polled. Only the epoch deadline compiled into this loop's

--- a/crates/wash-runtime/tests/fixtures/http-sleeper/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/http-sleeper/src/lib.rs
@@ -61,6 +61,23 @@ impl HttpGuest for Component {
             monotonic_clock::wait_for(3_600_000_000_000).await; // one hour
         }
 
+        // `/sse?frames=N&gap_ms=M` answers at once, then emits N frames M ms
+        // apart. A client disconnecting mid-stream is not noticed until the
+        // next write, so with a long gap the response is abandoned while the
+        // guest is asleep — healthy, and its store must be left alone.
+        if path.starts_with("/sse") {
+            let frames = query_u64(&path, "frames=").unwrap_or(10);
+            let gap_ms = query_u64(&path, "gap_ms=").unwrap_or(1_000);
+            return Ok(make_sse_response(frames, gap_ms));
+        }
+
+        // Slow but healthy: `/slow?ms=N` sleeps N ms and then answers. It
+        // yields the whole time, however large N is.
+        if path.starts_with("/slow") {
+            let ms = query_u64(&path, "ms=").unwrap_or(1_000);
+            monotonic_clock::wait_for(ms.saturating_mul(1_000_000)).await;
+        }
+
         // Spinning: never yields, so it is unreachable by every host-side
         // timeout — those are futures, and this call's poll never returns for
         // one to be polled. Only the epoch deadline compiled into this loop's
@@ -169,6 +186,26 @@ fn redos_match(subject: &[u8], at: usize) -> bool {
         }
     }
     false
+}
+
+/// A `text/event-stream` response whose frames are produced `gap_ms` apart,
+/// awaiting the clock in between.
+fn make_sse_response(frames: u64, gap_ms: u64) -> Response {
+    let headers = Fields::new();
+    let _ = headers.set(&"content-type".to_string(), &[b"text/event-stream".to_vec()]);
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        for n in 0..frames {
+            monotonic_clock::wait_for(gap_ms.saturating_mul(1_000_000)).await;
+            tx.write_all(format!("data: {n}\n\n").into_bytes()).await;
+        }
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    let _ = response.set_status_code(200);
+    response
 }
 
 fn make_response(status: u16, body: Vec<u8>) -> Response {

--- a/crates/wash-runtime/tests/fixtures/http-sleeper/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/http-sleeper/src/lib.rs
@@ -61,6 +61,53 @@ impl HttpGuest for Component {
             monotonic_clock::wait_for(3_600_000_000_000).await; // one hour
         }
 
+        // Spinning: never yields, so it is unreachable by every host-side
+        // timeout — those are futures, and this call's poll never returns for
+        // one to be polled. Only the epoch deadline compiled into this loop's
+        // back-edge can end it. `black_box` keeps the loop from being optimised
+        // away; the counter is never read.
+        //
+        // `/spin` runs forever. `/spin?ms=N` runs for N milliseconds and then
+        // replies normally, which is how a test tells "trapped" from "measured
+        // and left alone" — the bounded spin exceeds the budget either way, but
+        // only a store that is never trapped lives to answer.
+        //
+        // `monotonic_clock::now()` is a plain host call, not an await: it
+        // returns on the same fiber without suspending the guest, so this loop
+        // still never yields to the executor.
+        if path.starts_with("/spin") {
+            // `0` means "forever": no bound was asked for.
+            let deadline = spin_deadline_nanos(&path);
+            let mut n: u64 = 0;
+            loop {
+                n = std::hint::black_box(n.wrapping_add(1));
+                if deadline != 0 && monotonic_clock::now() >= deadline {
+                    break;
+                }
+            }
+        }
+
+        // The realistic shape of the same failure: a component whose *input* —
+        // not its code — drives it into an unbounded loop. `/redos?n=N` matches
+        // a crafted string against `^(a+)+$` with the naive backtracking a JS or
+        // PCRE engine uses, which is exponential in `n`. No host calls, so the
+        // guest never yields, exactly as with `/spin` — but here nothing is
+        // deliberately looping and nothing looks wrong in review.
+        if path.starts_with("/redos") {
+            // 2^n backtracks. The default is far past "slow" and into "never
+            // finishes": ~10^15 steps, months of CPU.
+            let n = query_u64(&path, "n=").unwrap_or(50) as usize;
+            // `n` 'a's then a byte the pattern cannot match, so every one of the
+            // 2^(n-1) ways to split the run is tried before the match fails.
+            let mut subject = vec![b'a'; n];
+            subject.push(b'!');
+            let matched = redos_match(&subject, 0);
+            return Ok(make_response(
+                200,
+                format!("{{\"matched\":{matched}}}").into_bytes(),
+            ));
+        }
+
         let now = IN_FLIGHT.fetch_add(1, Ordering::SeqCst) + 1;
         PEAK_IN_FLIGHT.fetch_max(now, Ordering::SeqCst);
 
@@ -84,6 +131,44 @@ impl HttpGuest for Component {
         let body = format!("{{\"peak_in_flight\":{peak},\"served\":{served}}}");
         Ok(make_response(200, body.into_bytes()))
     }
+}
+
+/// The monotonic instant `/spin?ms=N` should stop at, or `0` for "run forever"
+/// when the path carries no `ms=`.
+fn spin_deadline_nanos(path: &str) -> u64 {
+    match query_u64(path, "ms=") {
+        Some(ms) => monotonic_clock::now().saturating_add(ms.saturating_mul(1_000_000)),
+        None => 0,
+    }
+}
+
+/// The digits following `key` in `path`, if it carries that key.
+fn query_u64(path: &str, key: &str) -> Option<u64> {
+    let (_, rest) = path.split_once(key)?;
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+/// `^(a+)+$` matched against `subject` from `at`, the way a backtracking engine
+/// does it: the inner `a+` takes one or more, the outer `+` repeats, and every
+/// split is retried on failure. Exponential when the subject ends in a byte the
+/// pattern cannot match — the classic ReDoS.
+///
+/// Recursion depth is bounded by the subject length; it is the *breadth* that
+/// explodes, so this cannot overflow the stack before the epoch deadline sees
+/// it.
+fn redos_match(subject: &[u8], at: usize) -> bool {
+    if at == subject.len() {
+        return true; // matched `$`
+    }
+    let mut end = at;
+    while end < subject.len() && subject[end] == b'a' {
+        end += 1;
+        if redos_match(subject, end) {
+            return true;
+        }
+    }
+    false
 }
 
 fn make_response(status: u16, body: Vec<u8>) -> Response {

--- a/crates/wash-runtime/tests/fixtures/kv-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin/src/lib.rs
@@ -86,6 +86,18 @@ impl Guest for Component {
     }
 
     async fn get(key: String) -> Option<Vec<u8>> {
+        // The `__spin__` key wedges this call in a loop that never yields,
+        // unreachable by any host-side timeout — and, because a non-yielding
+        // activation holds the store's guest execution, it wedges every other
+        // caller's calls with it. The plugin store's policy is WarnThenTrap,
+        // so a test can prove the wedge is escalated into a supervised restart
+        // that restores service.
+        if key == "__spin__" {
+            let mut x: u64 = 0;
+            loop {
+                x = std::hint::black_box(x.wrapping_add(1));
+            }
+        }
         STORE.lock().unwrap().get(&key).cloned()
     }
 

--- a/crates/wash-runtime/tests/fixtures/msg-counter/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/msg-counter/src/lib.rs
@@ -49,6 +49,15 @@ impl MsgGuest for Component {
         if msg.subject == "boom" {
             panic!("msg-counter boom: deliberate handler trap for the restart test");
         }
+        // A `spin` subject wedges the handler in a loop that never yields,
+        // unreachable by any host-side timeout; only the epoch deadline
+        // compiled into the loop's back-edge can end it.
+        if msg.subject == "spin" {
+            let mut x: u64 = 0;
+            loop {
+                x = std::hint::black_box(x.wrapping_add(1));
+            }
+        }
         let n = MSG_COUNT.fetch_add(1, Ordering::SeqCst) + 1;
         // Echo the running count + subject so the trigger service spike can
         // observe delivery and that the instance is long-lived. The disposition

--- a/crates/wash-runtime/tests/integration_abandoned_calls.rs
+++ b/crates/wash-runtime/tests/integration_abandoned_calls.rs
@@ -798,6 +798,71 @@ async fn an_sse_client_disconnecting_between_frames_does_not_trap_the_service() 
     Ok(())
 }
 
+/// A store with a call somebody still wants must not be trapped over a call
+/// somebody else gave up on.
+///
+/// The chatty stream here wakes every 150ms — closer together than the pause
+/// threshold, so its epoch fires chain into what continuity reads as one
+/// pinned stretch. When a co-tenant's client walks away and that call passes
+/// its grace, the first two trap conditions hold and the third looks like it
+/// does; the stream's own still-wanted call is what must keep the store
+/// alive. The frames all arriving is the assertion — a trap cuts the stream
+/// mid-flight and restarts the service.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_abandoned_co_tenant_does_not_trap_a_chatty_healthy_stream() -> Result<()> {
+    let _serial = abandonment_env();
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    start_sleeper(&host, "chatty-svc", true).await?;
+    let client = client()?;
+
+    assert_eq!(served(&client, addr, "chatty-svc").await?, 1);
+
+    // The co-tenant: a slow request whose client walks away, arming its flag
+    // at ~0.3s; it stays registered until its exchange bound ends its task.
+    let mut gone = Box::pin(
+        client
+            .get(format!("http://{addr}/slow?ms=8000"))
+            .header("HOST", "chatty-svc")
+            .send(),
+    );
+    tokio::select! {
+        _ = &mut gone => anyhow::bail!("the slow request answered before the client gave up"),
+        () = tokio::time::sleep(Duration::from_millis(300)) => {}
+    }
+    drop(gone);
+
+    // The wanted call: sub-threshold frames for 1.5s, spanning the whole
+    // window in which the abandoned co-tenant is past its grace.
+    let resp = client
+        .get(format!("http://{addr}/sse?frames=10&gap_ms=150"))
+        .header("HOST", "chatty-svc")
+        .send()
+        .await
+        .context("SSE response head should arrive immediately")?;
+    anyhow::ensure!(resp.status().is_success(), "sse head: {}", resp.status());
+    let body = resp
+        .bytes()
+        .await
+        .context("the chatty stream must survive an abandoned co-tenant")?;
+    let frames = String::from_utf8_lossy(&body).matches("data: ").count();
+    anyhow::ensure!(frames == 10, "stream cut short: {frames}/10 frames");
+
+    // And the same instance is still serving: a trap would have restarted it.
+    let mut previous = 1;
+    for _ in 0..3 {
+        let now = served(&client, addr, "chatty-svc")
+            .await
+            .context("the service must keep serving after the stream ends")?;
+        anyhow::ensure!(
+            now > previous,
+            "the service was restarted: served {previous} -> {now}"
+        );
+        previous = now;
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    }
+    Ok(())
+}
+
 /// A busy but *healthy* instance must never be touched, however long it lives.
 ///
 /// There is no CPU budget and no heuristic left to get wrong here: a store is

--- a/crates/wash-runtime/tests/integration_abandoned_calls.rs
+++ b/crates/wash-runtime/tests/integration_abandoned_calls.rs
@@ -566,7 +566,7 @@ async fn an_abandoned_message_delivery_traps_and_restarts_the_service() -> Resul
     // and this instance has served one message.
     assert_eq!(
         deliver(&ingress, &workload_id, "first").await?,
-        Err("1:first".to_string())
+        Err("other: 1:first".to_string())
     );
 
     // `spin` wedges the handler. The delivery must error at the deadline
@@ -593,7 +593,7 @@ async fn an_abandoned_message_delivery_traps_and_restarts_the_service() -> Resul
     })
     .await?;
     assert_eq!(
-        echoed, "1:after",
+        echoed, "other: 1:after",
         "the restarted service must count from one"
     );
     Ok(())
@@ -675,6 +675,112 @@ async fn an_abandoned_capability_call_escalates_to_a_plugin_restart() -> Result<
         404,
         "the seeded state must be gone after the supervised restart"
     );
+    Ok(())
+}
+
+/// A client that gives up must cost a healthy call nothing, even when the guest
+/// keeps working long past both the deadline and the grace.
+///
+/// A disconnect arms the flag, so acting on abandonment alone would condemn the
+/// store a grace later and take every co-tenant request with it. The guest here
+/// yields throughout, so its stretch keeps resetting and the store is left
+/// alone. The bystander requests are the assertion: same instance throughout,
+/// `served` climbing unbroken rather than restarting at 1.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_client_that_gives_up_does_not_disturb_a_healthy_slow_guest() -> Result<()> {
+    abandonment_env();
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    start_sleeper(&host, "slow-svc", true).await?;
+    let client = client()?;
+
+    assert_eq!(served(&client, addr, "slow-svc").await?, 1);
+
+    // A request the guest spends far longer on than deadline + grace, whose
+    // client walks away almost at once — dropping the future is a disconnect.
+    let abandon_ms = (DEADLINE_SECS + GRACE_SECS) * 1_000 + 4_000;
+    let mut gave_up = Box::pin(
+        client
+            .get(format!("http://{addr}/slow?ms={abandon_ms}"))
+            .header("HOST", "slow-svc")
+            .send(),
+    );
+    tokio::select! {
+        _ = &mut gave_up => anyhow::bail!("the slow request answered before the client gave up"),
+        () = tokio::time::sleep(Duration::from_millis(300)) => {}
+    }
+    drop(gave_up);
+
+    // Well past deadline + grace, the same instance must still be serving.
+    let until = Instant::now() + Duration::from_millis(abandon_ms);
+    let mut previous = 1;
+    while Instant::now() < until {
+        let now = served(&client, addr, "slow-svc")
+            .await
+            .context("a healthy service must keep serving after a client disconnects")?;
+        anyhow::ensure!(
+            now > previous,
+            "the service was restarted by an abandoned-but-healthy call: served {previous} -> {now}"
+        );
+        previous = now;
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    }
+    anyhow::ensure!(
+        previous > 5,
+        "expected the bystander traffic to keep flowing, only saw {previous}"
+    );
+    Ok(())
+}
+
+/// The streaming form of the same guarantee: an SSE / long-poll client that
+/// disconnects between heartbeats.
+///
+/// The head arrives at once, so the call rides on the body wrapper, which the
+/// disconnect drops and arms. The guest only finds out at its next frame write,
+/// so with a heartbeat longer than the grace it is always still holding the
+/// call when the grace expires — and only its pauses between frames distinguish
+/// it from a wedged guest.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_sse_client_disconnecting_between_frames_does_not_trap_the_service() -> Result<()> {
+    abandonment_env();
+    // Frames further apart than deadline + grace, so the guest is mid-sleep
+    // for the whole window in which a time-only trap would fire.
+    const GAP_MS: u64 = (DEADLINE_SECS + GRACE_SECS) * 1_000 + 2_000;
+
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    start_sleeper(&host, "sse-svc", true).await?;
+    let client = client()?;
+
+    assert_eq!(served(&client, addr, "sse-svc").await?, 1);
+
+    // Take the head, then walk away without reading the body: a closed tab.
+    let stream = client
+        .get(format!("http://{addr}/sse?frames=10&gap_ms={GAP_MS}"))
+        .header("HOST", "sse-svc")
+        .send()
+        .await
+        .context("SSE response head should arrive immediately")?;
+    assert!(
+        stream.status().is_success(),
+        "SSE head should be 2xx, got {}",
+        stream.status()
+    );
+    drop(stream);
+
+    // Past deadline + grace with the guest asleep between frames.
+    let until = Instant::now() + Duration::from_millis(GAP_MS);
+    let mut previous = 1;
+    while Instant::now() < until {
+        let now = served(&client, addr, "sse-svc")
+            .await
+            .context("a service must survive an SSE client disconnecting")?;
+        anyhow::ensure!(
+            now > previous,
+            "the service was restarted by an abandoned SSE stream: served {previous} -> {now}"
+        );
+        previous = now;
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    }
+    anyhow::ensure!(previous > 5, "expected steady traffic, only saw {previous}");
     Ok(())
 }
 

--- a/crates/wash-runtime/tests/integration_abandoned_calls.rs
+++ b/crates/wash-runtime/tests/integration_abandoned_calls.rs
@@ -1,0 +1,716 @@
+//! What ends a guest that never yields, at every ingress.
+//!
+//! Every other timeout in the runtime is a future the host awaits, which works
+//! for a guest parked in a host call — `integration_http_call_timeout`'s
+//! `/wedge` is suspended, so control is back in the executor and the timer
+//! fires. A guest that *spins* is the case none of them reach: its poll never
+//! returns, so no timer on that task is ever polled and no host code on that
+//! store runs again. What ends it is abandonment (`wash_runtime::engine::
+//! abandon`): the dispatcher enforcing the call's deadline runs *outside* the
+//! store, arms the call's flag when it stops wanting the result, and the epoch
+//! callback compiled into the guest's own loop back-edges — the only host code
+//! a spinning guest cannot block — acts once the call stays abandoned past its
+//! grace.
+//!
+//! What that costs depends on the store:
+//!
+//!  * A **pooled instance** or **ephemeral store** is trapped; the pool reaps
+//!    it and the next call gets a fresh one.
+//!  * A **service** is trapped too; its supervisor restarts it — a restart
+//!    beats carrying a wedged call for the rest of the singleton's life.
+//!  * A **host component plugin** is warned about at the grace and trapped
+//!    only at the escalation: its one store serves every tenant, so a
+//!    yielding abandoned call gets a long runway to finish harmlessly — but a
+//!    non-yielding one holds the store's guest execution, wedging every
+//!    tenant, and the supervised restart is what restores service.
+//!
+//! One test per ingress: HTTP to a pooled instance and to a service, a linked
+//! call to a cold ephemeral store and to a pooled instance, a message delivery,
+//! and a capability call into a plugin. The counterweight test at the bottom
+//! drives steady healthy traffic that must never be touched: with no CPU
+//! budget anywhere, a store is only ever acted on when a call on it is
+//! actually abandoned.
+//!
+//! These live in their own binary because every deadline here is cached
+//! process-wide on first read, and this file wants them all very short.
+//!
+//! Spin tests need a multi-threaded runtime: a spinning guest occupies the
+//! worker thread its store is driven on, so on the single-threaded default it
+//! would starve the HTTP server and the test itself.
+
+// `std::env::set_var` is unsafe on edition 2024. The override below runs once,
+// before any host is started and before anything else in this process reads
+// the environment, which is the soundness condition it needs.
+#![allow(unsafe_code)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+
+use wash_runtime::host::HostApi;
+use wash_runtime::types::{Component, LocalResources, Service, Workload, WorkloadStartRequest};
+
+mod common;
+use common::{http_only_host_interfaces, json_u64_field, start_host_with_dynamic_router};
+
+const HTTP_SLEEPER_WASM: &[u8] = include_bytes!("wasm/http_sleeper.wasm");
+const EPHEMERAL_CALLER_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_caller_p3.wasm");
+const EPHEMERAL_CALLEE_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_callee_p3.wasm");
+const MSG_COUNTER_WASM: &[u8] = include_bytes!("wasm/msg_counter.wasm");
+#[cfg(feature = "host-component-plugins")]
+const KV_PLUGIN_WASM: &[u8] = include_bytes!("wasm/kv_plugin.wasm");
+#[cfg(feature = "host-component-plugins")]
+const KV_PLUGIN_CALLER_WASM: &[u8] = include_bytes!("wasm/kv_plugin_caller.wasm");
+
+/// Every ingress deadline in this binary. Once it passes the dispatcher
+/// abandons the call.
+const DEADLINE_SECS: u64 = 2;
+/// How long an abandoned call may keep running before its store acts. Short,
+/// so traps land quickly; the default (10s) is tuned for production, where a
+/// disconnect must not condemn a call that was about to finish.
+const GRACE_SECS: u64 = 1;
+
+/// Deadline + grace + epoch ticks + unwind, with a wide margin. A wedged call
+/// must fail within this; without abandonment it hangs forever.
+const SPIN_BOUND: Duration = Duration::from_secs(20);
+
+/// Set this binary's deadlines and grace. All are cached process-wide on first
+/// read, so every test must want the same values and must call this before
+/// starting a host.
+fn abandonment_env() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+    static SET: Once = Once::new();
+    SET.call_once(|| unsafe {
+        let deadline = DEADLINE_SECS.to_string();
+        std::env::set_var("WASH_HTTP_RESPONSE_TIMEOUT_SECS", &deadline);
+        std::env::set_var("WASH_EPHEMERAL_CALL_TIMEOUT_SECS", &deadline);
+        std::env::set_var("WASH_MESSAGING_DELIVER_TIMEOUT_SECS", &deadline);
+        std::env::set_var("WASH_PLUGIN_CAPABILITY_CALL_TIMEOUT_SECS", &deadline);
+        std::env::set_var("WASH_ABANDONED_CALL_GRACE_SECS", &GRACE_SECS.to_string());
+        std::env::set_var("WASH_ABANDONED_CALL_ESCALATION_SECS", "3");
+    });
+}
+
+fn client() -> Result<reqwest::Client> {
+    Ok(reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .timeout(Duration::from_secs(30))
+        .build()?)
+}
+
+/// Retry `probe` every 250ms until it succeeds or `bound` passes — for the
+/// requests right after a trap, which race the pool reap or the service
+/// supervisor's restart.
+async fn eventually<T, F>(bound: Duration, mut probe: F) -> Result<T>
+where
+    F: AsyncFnMut() -> Result<T>,
+{
+    let started = Instant::now();
+    loop {
+        match probe().await {
+            Ok(v) => return Ok(v),
+            Err(e) if started.elapsed() > bound => {
+                return Err(e.context(format!("probe still failing after {bound:?}")));
+            }
+            Err(_) => tokio::time::sleep(Duration::from_millis(250)).await,
+        }
+    }
+}
+
+/// Start a `http-sleeper` workload, pooled or as a service, under `name`.
+async fn start_sleeper(host: &impl HostApi, name: &str, as_service: bool) -> Result<()> {
+    let (service, components) = if as_service {
+        (
+            Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_SLEEPER_WASM),
+                local_resources: LocalResources::default(),
+                // A trapped service must come back: that restart is half of
+                // what the service test asserts.
+                max_restarts: 2,
+            }),
+            vec![],
+        )
+    } else {
+        (
+            None,
+            vec![Component {
+                name: "sleeper".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_SLEEPER_WASM),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 0,
+                max_concurrency: 4,
+            }],
+        )
+    };
+    host.workload_start(WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: name.to_string(),
+            annotations: HashMap::new(),
+            service,
+            components,
+            host_interfaces: http_only_host_interfaces(name),
+            volumes: vec![],
+        },
+    })
+    .await
+    .with_context(|| format!("sleeper workload {name} should start"))?;
+    Ok(())
+}
+
+/// Start an `ephemeral-caller-p3` -> `ephemeral-callee-p3` workload under
+/// `name`. `callee_pool` picks the linked-call path a `/spin` wedges: `0`
+/// serves each call from a cold ephemeral store, `1` from a warm pooled
+/// instance.
+async fn start_linked(host: &impl HostApi, name: &str, callee_pool: i32) -> Result<()> {
+    host.workload_start(WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: name.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![
+                Component {
+                    name: "ephemeral-caller".to_string(),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(EPHEMERAL_CALLER_P3_WASM),
+                    local_resources: LocalResources::default(),
+                    pool_size: 1,
+                    max_invocations: 0,
+                    max_concurrency: 4,
+                },
+                Component {
+                    name: "ephemeral-callee".to_string(),
+                    digest: None,
+                    bytes: bytes::Bytes::from_static(EPHEMERAL_CALLEE_P3_WASM),
+                    local_resources: LocalResources::default(),
+                    pool_size: callee_pool,
+                    max_invocations: 0,
+                    max_concurrency: 4,
+                },
+            ],
+            host_interfaces: http_only_host_interfaces(name),
+            volumes: vec![],
+        },
+    })
+    .await
+    .with_context(|| format!("linked workload {name} should start"))?;
+    Ok(())
+}
+
+/// GET `path` and return `(status, body)`.
+async fn get(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host_header: &str,
+    path: &str,
+) -> Result<(reqwest::StatusCode, String)> {
+    let resp = client
+        .get(format!("http://{addr}{path}"))
+        .header("HOST", host_header)
+        .send()
+        .await?;
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    Ok((status, body))
+}
+
+/// GET `/` and return the instance's `served` count.
+async fn served(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host_header: &str,
+) -> Result<u64> {
+    let (status, body) = get(client, addr, host_header, "/").await?;
+    anyhow::ensure!(status.is_success(), "status {status}");
+    Ok(json_u64_field(&body, "served"))
+}
+
+/// A pooled guest that never yields is ended by abandonment and its instance
+/// replaced. No host-side timeout can reach this call — the fixture's `/spin`
+/// runs forever and never lets one be polled — so the request completing at all
+/// is the epoch deadline doing it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_spinning_pooled_instance_is_trapped_and_replaced() -> Result<()> {
+    abandonment_env();
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    start_sleeper(&host, "spin-pooled", false).await?;
+    let client = client()?;
+
+    // Warm the one instance; its own count reads 1.
+    assert_eq!(served(&client, addr, "spin-pooled").await?, 1);
+
+    let started = Instant::now();
+    let outcome = client
+        .get(format!("http://{addr}/spin"))
+        .header("HOST", "spin-pooled")
+        .send()
+        .await;
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < SPIN_BOUND,
+        "the spinning call must be ended by abandonment, took {elapsed:?}"
+    );
+    if let Ok(resp) = outcome {
+        assert!(
+            resp.status().is_server_error(),
+            "a trapped call must fail, got {}",
+            resp.status()
+        );
+    }
+
+    // The spun instance had served 2 requests; had it survived, this would read
+    // 3. A fresh instance reading 1 is the trap and reap, observed.
+    let count = eventually(SPIN_BOUND, async || {
+        served(&client, addr, "spin-pooled").await
+    })
+    .await?;
+    assert_eq!(
+        count, 1,
+        "the request after the spin must land on a fresh instance"
+    );
+    Ok(())
+}
+
+/// A service whose call is abandoned is trapped like anything else, and its
+/// supervisor restarts it: a restart beats carrying a wedged call — and the
+/// whole singleton with it — for the rest of the workload's life. A spin that
+/// finishes *inside* the deadline is never abandoned and so never touched,
+/// however hot it ran.
+///
+/// The `bystander` workload shows the trap stayed in its own store. Two
+/// workloads need the `DynamicRouter`; the `DevRouter` sends every request to
+/// whichever workload resolved last.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_spinning_service_is_trapped_and_restarted() -> Result<()> {
+    abandonment_env();
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    start_sleeper(&host, "spin-svc", true).await?;
+    start_sleeper(&host, "bystander", false).await?;
+    let client = client()?;
+
+    assert_eq!(served(&client, addr, "spin-svc").await?, 1);
+    assert_eq!(served(&client, addr, "bystander").await?, 1);
+
+    // Hot but bounded: the spin replies inside the deadline, so nothing is
+    // ever abandoned and the instance must survive it (`served` climbs on).
+    let (status, body) = get(&client, addr, "spin-svc", "/spin?ms=500").await?;
+    assert!(
+        status.is_success(),
+        "a spin that beats the deadline must not be touched, got {status}"
+    );
+    assert_eq!(
+        json_u64_field(&body, "served"),
+        2,
+        "the same service instance must answer a bounded spin"
+    );
+
+    // Unbounded: the deadline passes, the call is abandoned, and the store is
+    // trapped rather than carrying the wedged call forever.
+    let started = Instant::now();
+    let outcome = client
+        .get(format!("http://{addr}/spin"))
+        .header("HOST", "spin-svc")
+        .send()
+        .await;
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < SPIN_BOUND,
+        "the spinning service call must be ended by abandonment, took {elapsed:?}"
+    );
+    if let Ok(resp) = outcome {
+        assert!(
+            resp.status().is_server_error(),
+            "a trapped service call must fail, got {}",
+            resp.status()
+        );
+    }
+
+    // The supervisor restarts the service: a fresh instance answers, counting
+    // from one again (the wedged instance was at 3).
+    let count = eventually(SPIN_BOUND, async || served(&client, addr, "spin-svc").await).await?;
+    assert_eq!(
+        count, 1,
+        "the restarted service must answer on a fresh instance"
+    );
+
+    // And the trap stayed in its own store: the neighbour counts on.
+    assert_eq!(
+        served(&client, addr, "bystander").await?,
+        2,
+        "a trapped service must not disturb another workload's instance"
+    );
+    Ok(())
+}
+
+/// The same failure, arrived at the way it actually happens: a component driven
+/// into an unbounded loop by its *input*.
+///
+/// `/redos` matches a crafted string against `^(a+)+$` with the naive
+/// backtracking a JS or PCRE engine uses — 2^n steps, ~10^15 at the default `n`.
+/// Nothing about the component is looping on purpose, and the attacker controls
+/// only a query parameter. It makes no host calls, so it never yields, so no
+/// host-side timeout is ever polled: on a runtime without abandonment this
+/// request never returns and its instance is lost for the life of the process.
+///
+/// This also covers the amplification. `max_concurrency` is 4, so `try_send`
+/// admits three more requests onto the wedged instance and queues them for a run
+/// loop that is stuck mid-poll and will never read them. Trapping the store is
+/// what fails them; without it they hang until their clients give up.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_component_wedged_by_its_input_is_trapped_and_replaced() -> Result<()> {
+    abandonment_env();
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    start_sleeper(&host, "redos", false).await?;
+    let client = client()?;
+
+    assert_eq!(served(&client, addr, "redos").await?, 1);
+
+    // Three more alongside it, to fill `max_concurrency` on the same instance.
+    let started = Instant::now();
+    let mut inflight = tokio::task::JoinSet::new();
+    for _ in 0..4 {
+        let (client, addr) = (client.clone(), addr);
+        inflight.spawn(async move {
+            client
+                .get(format!("http://{addr}/redos"))
+                .header("HOST", "redos")
+                .send()
+                .await
+                .map(|r| r.status().as_u16())
+        });
+    }
+    let outcomes = inflight.join_all().await;
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < SPIN_BOUND,
+        "the wedged requests must be ended by abandonment, took {elapsed:?}"
+    );
+    for outcome in &outcomes {
+        if let Ok(status) = outcome {
+            assert!(
+                (500..600).contains(status),
+                "a request wedged by its input must fail, got {status}"
+            );
+        }
+    }
+
+    // The instance was reaped, so the component still serves: a fresh instance
+    // answers, counting from one.
+    let count = eventually(SPIN_BOUND, async || served(&client, addr, "redos").await).await?;
+    assert_eq!(count, 1, "the component must recover on a fresh instance");
+    Ok(())
+}
+
+/// A linked call served from a **cold ephemeral store** whose guest never
+/// yields is ended by abandonment. The wedge is two components deep: HTTP
+/// reaches the caller, the caller's imported `run(0)` wedges the callee, and
+/// the callee's store — built for this one call — is the one that must die.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_abandoned_linked_call_to_a_cold_ephemeral_store_is_ended() -> Result<()> {
+    abandonment_env();
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    start_linked(&host, "linked-cold", 0).await?;
+    let client = client()?;
+
+    let (status, body) = get(&client, addr, "linked-cold", "/").await?;
+    assert!(status.is_success(), "warmup failed: {status}");
+    assert_eq!(body, "43", "the linked call must round-trip");
+
+    // The callee spins in its own store; the caller's dispatcher abandons the
+    // call at the deadline and the epoch deadline ends the callee. The caller
+    // sees its import fail, so this request errors rather than hanging.
+    let started = Instant::now();
+    let outcome = client
+        .get(format!("http://{addr}/spin"))
+        .header("HOST", "linked-cold")
+        .send()
+        .await;
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < SPIN_BOUND,
+        "the wedged linked call must be ended by abandonment, took {elapsed:?}"
+    );
+    if let Ok(resp) = outcome {
+        assert!(
+            resp.status().is_server_error(),
+            "a wedged linked call must fail, got {}",
+            resp.status()
+        );
+    }
+
+    // The workload recovers whole: caller and callee both serve again.
+    let body = eventually(SPIN_BOUND, async || {
+        let (status, body) = get(&client, addr, "linked-cold", "/").await?;
+        anyhow::ensure!(status.is_success(), "status {status}");
+        Ok(body)
+    })
+    .await?;
+    assert_eq!(body, "43", "the linked path must recover after the trap");
+    Ok(())
+}
+
+/// A linked call served from a **pooled warm instance** whose guest never
+/// yields is ended by abandonment, and the pool replaces the instance. The
+/// callee's `calls` counter lives in its instance's linear memory, so a count
+/// that climbs and then restarts at one is the reap, observed from inside.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_abandoned_linked_call_to_a_pooled_instance_is_ended() -> Result<()> {
+    abandonment_env();
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    start_linked(&host, "linked-pooled", 1).await?;
+    let client = client()?;
+
+    // Two calls land on the same warm callee instance: its count climbs.
+    let (_, first) = get(&client, addr, "linked-pooled", "/calls").await?;
+    let (_, second) = get(&client, addr, "linked-pooled", "/calls").await?;
+    assert_eq!((first.as_str(), second.as_str()), ("1", "2"));
+
+    let started = Instant::now();
+    let outcome = client
+        .get(format!("http://{addr}/spin"))
+        .header("HOST", "linked-pooled")
+        .send()
+        .await;
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < SPIN_BOUND,
+        "the wedged pooled linked call must be ended by abandonment, took {elapsed:?}"
+    );
+    if let Ok(resp) = outcome {
+        assert!(
+            resp.status().is_server_error(),
+            "a wedged pooled linked call must fail, got {}",
+            resp.status()
+        );
+    }
+
+    // The wedged callee instance was reaped: a fresh one counts from one.
+    let body = eventually(SPIN_BOUND, async || {
+        let (status, body) = get(&client, addr, "linked-pooled", "/calls").await?;
+        anyhow::ensure!(status.is_success(), "status {status}");
+        Ok(body)
+    })
+    .await?;
+    assert_eq!(
+        body, "1",
+        "the call after the spin must land on a fresh callee instance"
+    );
+    Ok(())
+}
+
+/// Deliver one message to a trigger service, the way a messaging backend does.
+/// The outer `Result` is delivery (this is what abandonment bounds); the inner
+/// one is the handler's own `result<_, string>`, which `msg-counter` uses to
+/// echo its running count.
+async fn deliver(
+    ingress: &std::sync::Arc<
+        wash_runtime::host::http::Ingress<wash_runtime::host::http::DevRouter>,
+    >,
+    workload_id: &str,
+    subject: &str,
+) -> Result<Result<(), String>> {
+    use wash_runtime::host::http::HostHandler as _;
+    ingress
+        .deliver_trigger_service_message(
+            workload_id,
+            wash_runtime::host::trigger_service::BrokerMessage {
+                subject: subject.to_string(),
+                body: b"hi".to_vec(),
+                reply_to: None,
+            },
+        )
+        .await
+}
+
+/// A message delivery wedged in a non-yielding handler is ended by
+/// abandonment: the delivery errors at the deadline instead of hanging, and
+/// the service supervisor restarts the instance (its count resets).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_abandoned_message_delivery_traps_and_restarts_the_service() -> Result<()> {
+    abandonment_env();
+    let (_addr, host, ingress) = common::start_host_with_p3_handler("127.0.0.1:0").await?;
+    let workload_id = uuid::Uuid::new_v4().to_string();
+    host.workload_start(WorkloadStartRequest {
+        workload_id: workload_id.clone(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "msg-spin".to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(MSG_COUNTER_WASM),
+                local_resources: LocalResources::default(),
+                max_restarts: 2,
+            }),
+            components: vec![],
+            host_interfaces: vec![],
+            volumes: vec![],
+        },
+    })
+    .await
+    .context("msg-counter service should start")?;
+
+    // The handler echoes its running count as the error string: delivery works
+    // and this instance has served one message.
+    assert_eq!(
+        deliver(&ingress, &workload_id, "first").await?,
+        Err("1:first".to_string())
+    );
+
+    // `spin` wedges the handler. The delivery must error at the deadline
+    // rather than hang — on a runtime without abandonment this await never
+    // returns.
+    let started = Instant::now();
+    let outcome = deliver(&ingress, &workload_id, "spin").await;
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < SPIN_BOUND,
+        "the wedged delivery must be ended by abandonment, took {elapsed:?}"
+    );
+    assert!(
+        outcome.is_err(),
+        "a wedged delivery must error, got {outcome:?}"
+    );
+
+    // The supervisor restarts the service: a fresh instance counts from one.
+    let echoed = eventually(SPIN_BOUND, async || {
+        deliver(&ingress, &workload_id, "after")
+            .await?
+            .err()
+            .context("handler echoes via the err arm")
+    })
+    .await?;
+    assert_eq!(
+        echoed, "1:after",
+        "the restarted service must count from one"
+    );
+    Ok(())
+}
+
+/// A capability call wedged in a host component plugin is warned about at the
+/// grace and **escalated to a trap**: a non-yielding activation holds the
+/// store's guest execution, so no other tenant's call can enter and the
+/// singleton is already down for everyone. Trapping it at the escalation is
+/// what brings it back — the supervisor rebuilds the store and replays binds,
+/// the same path an organic plugin trap takes. The in-memory state dies with
+/// the store; that is the documented blast radius of the shared singleton,
+/// and per-task cancellation (bytecodealliance/wasmtime#11833) is what would
+/// shrink it to the one bad call.
+#[cfg(feature = "host-component-plugins")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_abandoned_capability_call_escalates_to_a_plugin_restart() -> Result<()> {
+    use common::{
+        component_workload_request, kv_plugin_caller_host_interfaces,
+        start_host_with_component_plugin,
+    };
+
+    abandonment_env();
+    let (addr, host) =
+        start_host_with_component_plugin("127.0.0.1:0", "kv-plugin", KV_PLUGIN_WASM).await?;
+    host.workload_start(component_workload_request(
+        "kv-caller",
+        "kv-caller",
+        KV_PLUGIN_CALLER_WASM,
+        LocalResources::default(),
+        kv_plugin_caller_host_interfaces("kv-caller"),
+    ))
+    .await
+    .context("kv caller workload should start")?;
+    let client = client()?;
+
+    // Seed state in the plugin's singleton store.
+    let (status, _) = get(&client, addr, "kv-caller", "/set?key=a&value=before").await?;
+    assert!(status.is_success(), "seed set failed: {status}");
+
+    // `__spin__` wedges the plugin-side call. The caller's request must fail
+    // at its deadline rather than hang.
+    let started = Instant::now();
+    let outcome = client
+        .get(format!("http://{addr}/get?key=__spin__"))
+        .header("HOST", "kv-caller")
+        .send()
+        .await;
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < SPIN_BOUND,
+        "the wedged capability call must be abandoned, took {elapsed:?}"
+    );
+    if let Ok(resp) = outcome {
+        assert!(
+            resp.status().is_server_error(),
+            "a wedged capability call must fail, got {}",
+            resp.status()
+        );
+    }
+
+    // The wedged plugin is trapped at the escalation and rebuilt under
+    // supervision: service comes back for everyone.
+    let body = eventually(SPIN_BOUND, async || {
+        let (status, body) = get(&client, addr, "kv-caller", "/set?key=b&value=after").await?;
+        anyhow::ensure!(status.is_success(), "set: status {status}, body: {body}");
+        let (status, body) = get(&client, addr, "kv-caller", "/get?key=b").await?;
+        anyhow::ensure!(status.is_success(), "get: status {status}, body: {body}");
+        Ok(body)
+    })
+    .await?;
+    assert_eq!(body, "after", "the rebuilt plugin must serve again");
+
+    // And it really is a fresh incarnation: the state seeded before the wedge
+    // died with the trapped store.
+    let (status, _) = get(&client, addr, "kv-caller", "/get?key=a").await?;
+    assert_eq!(
+        status.as_u16(),
+        404,
+        "the seeded state must be gone after the supervised restart"
+    );
+    Ok(())
+}
+
+/// A busy but *healthy* instance must never be touched, however long it lives.
+///
+/// There is no CPU budget and no heuristic left to get wrong here: a store is
+/// only ever acted on when a call on it is abandoned, and steady successful
+/// traffic abandons nothing. Driving many deadline-periods' worth of requests
+/// is what pins that down — each does ~5ms of guest work and yields, and the
+/// instance must survive with its `served` count climbing unbroken; a trap
+/// would show up as a failed request and a count restarting.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_healthy_instance_under_steady_traffic_is_never_trapped() -> Result<()> {
+    abandonment_env();
+    // Several deadline periods, so a spurious once-per-period trap cannot hide.
+    const DRIVE: Duration = Duration::from_secs(DEADLINE_SECS * 3);
+    const GAP: Duration = Duration::from_millis(200);
+
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    start_sleeper(&host, "healthy", false).await?;
+    let client = client()?;
+
+    let started = Instant::now();
+    let mut previous = 0;
+    while started.elapsed() < DRIVE {
+        let served = served(&client, addr, "healthy")
+            .await
+            .with_context(|| format!("request failed at t={:?}", started.elapsed()))?;
+        anyhow::ensure!(
+            served > previous,
+            "the instance was replaced at t={:?}: served went {previous} -> {served}",
+            started.elapsed()
+        );
+        previous = served;
+        tokio::time::sleep(GAP).await;
+    }
+    anyhow::ensure!(previous > 5, "expected steady traffic, only saw {previous}");
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_abandoned_calls.rs
+++ b/crates/wash-runtime/tests/integration_abandoned_calls.rs
@@ -80,7 +80,11 @@ const SPIN_BOUND: Duration = Duration::from_secs(20);
 /// Set this binary's deadlines and grace. All are cached process-wide on first
 /// read, so every test must want the same values and must call this before
 /// starting a host.
-fn abandonment_env() {
+/// Every test here pins or starves CPUs and then makes timing assertions, so
+/// two at once on a small CI runner can hold each other's guests off-core past
+/// the pause threshold. The returned guard runs them one at a time.
+fn abandonment_env() -> std::sync::MutexGuard<'static, ()> {
+    static SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init();
@@ -93,7 +97,17 @@ fn abandonment_env() {
         std::env::set_var("WASH_PLUGIN_CAPABILITY_CALL_TIMEOUT_SECS", &deadline);
         std::env::set_var("WASH_ABANDONED_CALL_GRACE_SECS", &GRACE_SECS.to_string());
         std::env::set_var("WASH_ABANDONED_CALL_ESCALATION_SECS", "3");
+        // CI runners are small and this binary's tests deliberately pin cores,
+        // so a pinned guest can go unscheduled long enough for the default
+        // 500ms pause threshold to read the gap as a yield and reset its
+        // stretch — postponing the escalation past the probes' patience. The
+        // tests that depend on real pauses being seen (slow guest, SSE) pause
+        // for 5s+ per await, so 2s keeps them intact.
+        std::env::set_var("WASH_ABANDONED_CALL_PAUSE_THRESHOLD_MS", "2000");
     });
+    SERIAL
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 fn client() -> Result<reqwest::Client> {
@@ -242,7 +256,7 @@ async fn served(
 /// is the epoch deadline doing it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_spinning_pooled_instance_is_trapped_and_replaced() -> Result<()> {
-    abandonment_env();
+    let _serial = abandonment_env();
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
     start_sleeper(&host, "spin-pooled", false).await?;
     let client = client()?;
@@ -293,7 +307,7 @@ async fn a_spinning_pooled_instance_is_trapped_and_replaced() -> Result<()> {
 /// whichever workload resolved last.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_spinning_service_is_trapped_and_restarted() -> Result<()> {
-    abandonment_env();
+    let _serial = abandonment_env();
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
     start_sleeper(&host, "spin-svc", true).await?;
     start_sleeper(&host, "bystander", false).await?;
@@ -369,7 +383,7 @@ async fn a_spinning_service_is_trapped_and_restarted() -> Result<()> {
 /// what fails them; without it they hang until their clients give up.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_component_wedged_by_its_input_is_trapped_and_replaced() -> Result<()> {
-    abandonment_env();
+    let _serial = abandonment_env();
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
     start_sleeper(&host, "redos", false).await?;
     let client = client()?;
@@ -419,7 +433,7 @@ async fn a_component_wedged_by_its_input_is_trapped_and_replaced() -> Result<()>
 /// the callee's store — built for this one call — is the one that must die.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn an_abandoned_linked_call_to_a_cold_ephemeral_store_is_ended() -> Result<()> {
-    abandonment_env();
+    let _serial = abandonment_env();
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
     start_linked(&host, "linked-cold", 0).await?;
     let client = client()?;
@@ -467,7 +481,7 @@ async fn an_abandoned_linked_call_to_a_cold_ephemeral_store_is_ended() -> Result
 /// that climbs and then restarts at one is the reap, observed from inside.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn an_abandoned_linked_call_to_a_pooled_instance_is_ended() -> Result<()> {
-    abandonment_env();
+    let _serial = abandonment_env();
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
     start_linked(&host, "linked-pooled", 1).await?;
     let client = client()?;
@@ -539,7 +553,7 @@ async fn deliver(
 /// the service supervisor restarts the instance (its count resets).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn an_abandoned_message_delivery_traps_and_restarts_the_service() -> Result<()> {
-    abandonment_env();
+    let _serial = abandonment_env();
     let (_addr, host, ingress) = common::start_host_with_p3_handler("127.0.0.1:0").await?;
     let workload_id = uuid::Uuid::new_v4().to_string();
     host.workload_start(WorkloadStartRequest {
@@ -616,7 +630,7 @@ async fn an_abandoned_capability_call_escalates_to_a_plugin_restart() -> Result<
         start_host_with_component_plugin,
     };
 
-    abandonment_env();
+    let _serial = abandonment_env();
     let (addr, host) =
         start_host_with_component_plugin("127.0.0.1:0", "kv-plugin", KV_PLUGIN_WASM).await?;
     host.workload_start(component_workload_request(
@@ -688,7 +702,7 @@ async fn an_abandoned_capability_call_escalates_to_a_plugin_restart() -> Result<
 /// `served` climbing unbroken rather than restarting at 1.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_client_that_gives_up_does_not_disturb_a_healthy_slow_guest() -> Result<()> {
-    abandonment_env();
+    let _serial = abandonment_env();
     let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
     start_sleeper(&host, "slow-svc", true).await?;
     let client = client()?;
@@ -741,7 +755,7 @@ async fn a_client_that_gives_up_does_not_disturb_a_healthy_slow_guest() -> Resul
 /// it from a wedged guest.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn an_sse_client_disconnecting_between_frames_does_not_trap_the_service() -> Result<()> {
-    abandonment_env();
+    let _serial = abandonment_env();
     // Frames further apart than deadline + grace, so the guest is mid-sleep
     // for the whole window in which a time-only trap would fire.
     const GAP_MS: u64 = (DEADLINE_SECS + GRACE_SECS) * 1_000 + 2_000;
@@ -794,7 +808,7 @@ async fn an_sse_client_disconnecting_between_frames_does_not_trap_the_service() 
 /// would show up as a failed request and a count restarting.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_healthy_instance_under_steady_traffic_is_never_trapped() -> Result<()> {
-    abandonment_env();
+    let _serial = abandonment_env();
     // Several deadline periods, so a spurious once-per-period trap cannot hide.
     const DRIVE: Duration = Duration::from_secs(DEADLINE_SECS * 3);
     const GAP: Duration = Duration::from_millis(200);

--- a/crates/wash-runtime/tests/integration_abandoned_calls.rs
+++ b/crates/wash-runtime/tests/integration_abandoned_calls.rs
@@ -81,8 +81,8 @@ const SPIN_BOUND: Duration = Duration::from_secs(20);
 /// read, so every test must want the same values and must call this before
 /// starting a host.
 /// Every test here pins or starves CPUs and then makes timing assertions, so
-/// two at once on a small CI runner can hold each other's guests off-core past
-/// the pause threshold. The returned guard runs them one at a time.
+/// two at once on a small CI runner distort the very timing the assertions
+/// depend on. The returned guard runs them one at a time.
 fn abandonment_env() -> std::sync::MutexGuard<'static, ()> {
     static SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
     let _ = tracing_subscriber::fmt()
@@ -97,13 +97,6 @@ fn abandonment_env() -> std::sync::MutexGuard<'static, ()> {
         std::env::set_var("WASH_PLUGIN_CAPABILITY_CALL_TIMEOUT_SECS", &deadline);
         std::env::set_var("WASH_ABANDONED_CALL_GRACE_SECS", &GRACE_SECS.to_string());
         std::env::set_var("WASH_ABANDONED_CALL_ESCALATION_SECS", "3");
-        // CI runners are small and this binary's tests deliberately pin cores,
-        // so a pinned guest can go unscheduled long enough for the default
-        // 500ms pause threshold to read the gap as a yield and reset its
-        // stretch — postponing the escalation past the probes' patience. The
-        // tests that depend on real pauses being seen (slow guest, SSE) pause
-        // for 5s+ per await, so 2s keeps them intact.
-        std::env::set_var("WASH_ABANDONED_CALL_PAUSE_THRESHOLD_MS", "2000");
     });
     SERIAL
         .lock()
@@ -859,6 +852,60 @@ async fn an_abandoned_co_tenant_does_not_trap_a_chatty_healthy_stream() -> Resul
         );
         previous = now;
         tokio::time::sleep(Duration::from_millis(400)).await;
+    }
+    Ok(())
+}
+
+/// A guest that awaits repeatedly in **short hops** must survive being
+/// abandoned, exactly like the single-long-await guest above.
+///
+/// Each hop wakes onto an expired epoch deadline, so the store's fires land
+/// one hop apart — a wake pattern that wall-clock sampling cannot tell from a
+/// pinned guest inside any single window. What protects it is the per-fire
+/// credit cap: its only call is abandoned (so the wanted-call gate does not
+/// apply), but each fire can only prove one sampling window of execution, so
+/// the credit stays far below the grace for as long as the guest actually
+/// spends its time awaiting.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_guest_awaiting_in_short_hops_survives_being_abandoned() -> Result<()> {
+    let _serial = abandonment_env();
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    start_sleeper(&host, "hoppy-svc", true).await?;
+    let client = client()?;
+
+    assert_eq!(served(&client, addr, "hoppy-svc").await?, 1);
+
+    // Eight 400ms hops ≈ 3.2s of constant short awaits, whose client walks
+    // away almost at once: the call is abandoned past its grace while the
+    // guest is still hopping, with no other call registered to shield it.
+    let mut gone = Box::pin(
+        client
+            .get(format!("http://{addr}/chatter?hops=8&hop_ms=400"))
+            .header("HOST", "hoppy-svc")
+            .send(),
+    );
+    tokio::select! {
+        _ = &mut gone => anyhow::bail!("the chatter answered before the client gave up"),
+        () = tokio::time::sleep(Duration::from_millis(300)) => {}
+    }
+    drop(gone);
+
+    // Stay quiet while the guest hops: a request in this window would re-arm
+    // the epoch deadline and shield the hops from firing at all, and the
+    // scenario is precisely an otherwise-idle store. Then the same instance
+    // must still be serving, its count climbing from where it left off.
+    tokio::time::sleep(Duration::from_millis(2_500)).await;
+    let mut previous = 1;
+    for _ in 0..4 {
+        let now = served(&client, addr, "hoppy-svc")
+            .await
+            .context("a hopping guest must not be trapped when abandoned")?;
+        anyhow::ensure!(
+            now > previous,
+            "the service was restarted over a short-hop awaiter: served {previous} -> {now}"
+        );
+        previous = now;
+        tokio::time::sleep(Duration::from_millis(300)).await;
     }
     Ok(())
 }


### PR DESCRIPTION
## The problem

When a wasm guest is executing compiled wasm and never yields, it is unreachable by every teardown the host owns.

Not "hard to reach" — unreachable by construction. The guest's poll never returns, so nothing else on that task is ever polled again, and every remedy we have is a future on exactly that task: `tokio::time::timeout`, `AbortOnDrop`, and pool retirement's drain (which waits for the call's task to end — the one thing that will never happen). No timeout value, however small, ever fires. The call runs until the process dies.

**This PR does not touch host-parked calls.** A guest awaiting something the host owns — a socket that never answers, a long clock wait — has yielded: its future is suspended, the executor has its thread back, and the existing timeouts tear it down correctly today. That path is already covered (`integration_http_call_timeout`, the `/wedge` fixture) and is unchanged here. The gap is only the non-yielding case.

It is also worse than one stuck request. A guest pinned to a worker thread can wedge the tokio worker holding the **time driver**, at which point no timer anywhere in the process fires — so a single non-yielding guest can take down the protection the parked case relies on, along with every other timeout in the host.

## Confirming the broken behaviour

Two experiments on `main`:

**A guest that loops on purpose.** A fixture route that spins with no host calls ran **232 seconds pinned at 100% CPU** and was still going when we killed the experiment. Nothing in the runtime was ever going to stop it; the client had long since given up, and the instance was lost for the life of the process.

**A guest driven into a boundless loop by its input** — the realistic shape, where nothing in the component looks wrong. `/redos?n=N` matches `a…a!` against `^(a+)+$` with the naive backtracking a JS or PCRE engine uses. It makes no host calls, so it never yields. At the default `n = 50` that is `2^49 ≈ 5.6 × 10^14` backtracks: even at an optimistic 10⁹ steps/second it would need **~6.5 days of continuous CPU**, and realistically weeks. It never returns.

The attacker controls only a query parameter. On `main` one such request permanently converts a core into a heater and wedges its instance — and with `max_concurrency: 4`, three further requests queue onto a run loop that is stuck mid-poll and will never read them, so they hang too.

## The solution

### The ingress surfaces

Work enters a wasm store from every place listed below, and each one has a dispatcher that lives **outside** the store it is sending into — a healthy task, whose timer still fires when the callee is pinned. That is the only leverage available, so every one of them is wired:

| # | Ingress | Deadline |
|---|---|---|
| 1 | HTTP → service store | `http_response` |
| 2 | HTTP → pooled instance | `http_response` |
| 3 | HTTP → cold one-shot store (p3) | `http_response` |
| 3b | HTTP → cold one-shot store (p2) | `http_response` |
| 4 | Linked call → ephemeral store (plain + relocated) | `ephemeral_call` |
| 5 | Linked call → pooled instance | `ephemeral_call` |
| 6 | Linked call → shared store | same store — covered transitively by its own ingress |
| 7 | Messaging delivery → service store | `messaging_deliver` *(new)* |
| 7b | Messaging delivery → per-message store | `messaging_deliver` *(new)* |
| 8 | Capability call → plugin store | `plugin_capability_call` *(new)* |
| 8b | Lifecycle call → plugin store | `plugin_lifecycle_call` |

`7`, `7b` and `8` had no bound at all before this PR. `7b` matters beyond the stuck call itself: a guest spinning on a poison message would hold its store's pooling-allocator instance slot forever, and redelivery would repeat that until instantiation failed host-wide.

### Abandonment

Each dispatcher creates a `DispatchedCall` (`engine/abandon.rs`) holding the deadline and a flag, and the flag travels with the job into the store:

```rust
let call = DispatchedCall::new("HTTP (service)", timeouts::http_response());
sender.send(ServiceHttpJob { req, resp_tx, abandoned: call.flag() }).await?;
call.await_reply(resp_rx).await          // waited out here, not in the store
```

The flag is **armed** when the dispatcher stops wanting the result — the deadline passes, or the dispatcher's future is dropped outright (a client disconnect). Inside the store, the task serving the call registers that flag on the store's `AbandonedCalls` for exactly as long as the call runs, deregistering on drop however the call ends. Waiters that cannot await a reply (per-message deliveries, lifecycle replay, post-reply stream drains) arm through a timer instead, held as a cancel-on-drop handle bound to the work it bounds — healthy traffic accumulates no timers.

That leaves one reader: the wasmtime **epoch deadline callback**, compiled into the guest's own loop back-edges — the only host code a non-yielding guest still executes. The deadline is re-armed at the start of every call, so its countdown measures that call's own execution rather than wall time since the store was built.

The callback traps a store only when **three things hold together**:

1. **A call on it is abandoned and still registered** past the grace (`WASH_ABANDONED_CALL_GRACE_SECS`, 10s): the host has said, from outside, that nobody wants this work any more.
2. **Every registered call on the store is abandoned.** Trapping ends the whole store, so it waits until it would end nothing still wanted. This delays teardown but never loses it: a pinned guest admits no new calls, and the calls already on it are abandoned by their own deadlines in turn.
3. **The guest is actually pinned.** `Continuity` shows guest code executing without a pause for at least the grace: the callback fires only while guest code runs, so fires land about one sampling interval apart while a guest runs unbroken, and a wider gap (`WASH_ABANDONED_CALL_PAUSE_THRESHOLD_MS`, default 5× the sampling interval) means it stopped to wait for something, which resets the stretch.

Condition 3 is measured from the callback's own fire pattern rather than a host-side liveness stamp, because a stamp measurably cannot work here: the callback forces a yield on every fire (see below), and that yield returns the store's driving future to the executor, refreshing any host-side signal — a fully pinned guest looks continuously healthy from the host side.

Together the three make abandonment safe to arm liberally. A client disconnect arms the flag — deliberately, since if the guest behind it is wedged this flag is the only thing that will ever end it — but arming is harmless: a slow guest that still yields fails condition 3 and finishes untouched, and a healthy chatty guest (a stream ticking faster than the pause threshold, indistinguishable from pinned by fire pattern alone) fails condition 2, because its own call is still wanted.

What acting means depends on what the store is:

| Store | Policy | Outcome |
|---|---|---|
| Ephemeral / pooled instance | `Trap` | Store trapped, pool reaps it, next call gets a fresh instance |
| Service singleton | `Trap` | Supervised restart — better than carrying a wedged call forever |
| Host component plugin | `WarnThenTrap` | Warn once all three conditions hold at the grace; trap only once the pinned stretch reaches `WASH_ABANDONED_CALL_ESCALATION_SECS` (60s). A yielding abandoned call gets the runway to finish harmlessly; a non-yielding one already blocks every tenant's guest execution, so the restart + bind replay is what restores service. The warning re-arms once the store returns to nothing-abandoned, so every episode is logged |

The callback always **yields** rather than continuing, every ~100ms of unbroken guest execution. That is what closes the time-driver hole: a busy guest periodically hands its worker back, so it can never silence the deadline that would abandon it.

The flag is a **required field on every job type** and can only be minted by `DispatchedCall`, so a new ingress cannot compile without choosing a deadline and threading the flag. Streaming HTTP responses stay condemned-on-drop until the body completes; relocated linked calls re-bound their post-reply stream drain.

### How this composes with per-task cancellation (wasmtime#11833)

The one thing wasmtime cannot do today is cancel a single guest `call_concurrent` subtask. That is why every outcome above is store-scoped: with no way to kill one call, ending it means condemning its store and whatever shares it. bytecodealliance/wasmtime#11833 is the upstream API that fixes exactly that.

**It will not replace this work — it plugs into it.** The framework has three layers, and #11833 only touches the last:

- **Deciding a call is unwanted** stays. Per-ingress deadlines, disconnect detection, the grace period, the registration — none of that comes from wasmtime. A `cancel(task)` API tells you *how* to stop a call, never *which* call or *when*; this PR is what answers that.
- **Reaching a non-yielding guest** stays. Cancellation is still cooperative at the runtime level: a guest spinning in compiled code can only be interrupted where the runtime regains control, which is the epoch check in its back-edges. Per-task cancellation of a pinned task rides the same mechanism underneath. The always-yield fairness fix is independent of cancellation entirely.
- **The blast radius shrinks.** Only `AbandonedCallPolicy` changes: `Trap` and `WarnThenTrap` become "cancel this one task", and stores stop being condemned over one bad call — which also retires the all-abandoned wait. That is a single enforcement point, deliberately kept in one place so adopting #11833 does not mean re-touching the ingresses.

So the timeout-based design here is the layer that survives; #11833 makes its response surgical.

## Testing

### Fixtures

Non-yielding branches added to four existing fixtures, each reachable by input so a test can wedge a specific ingress on demand. All of them loop with no host calls, which is what makes them unreachable by host timeouts:

- **`http-sleeper`** — `/spin` loops forever; `/spin?ms=N` loops for N ms and then answers normally (so a test can tell "trapped" from "ran hot and was left alone", since only an untrapped store lives to reply); `/redos?n=N` is the boundless-regex case above, wedged by input rather than by intent. For the protective tests it also gained `/slow?ms=N` (sleeps N ms, yielding the whole time) and `/sse?frames=N&gap_ms=M` (answers at once, then streams N frames M ms apart).
- **`ephemeral-callee-p3`** — `run(0)` wedges by contract, reached through `ephemeral-caller-p3`'s new `/spin` route. A magic argument rather than a new export, so the WIT vendored into both fixtures is untouched.
- **`msg-counter`** — a `spin` subject wedges the messaging handler, alongside the existing `boom` (trap) subject.
- **`kv-plugin`** — a `__spin__` key wedges a capability call inside the shared plugin store.

### `integration_abandoned_calls.rs`

One test per ingress, each asserting the same two things: the dispatcher returns an error within roughly its deadline (on `main` these hang until the harness kills the run), and service is restored afterwards.

- **`a_spinning_pooled_instance_is_trapped_and_replaced`** — warms one instance, hits `/spin`, and asserts the request ends within bound; then reads the fixture's own `served` counter, which lives in the instance's linear memory. A survivor would report `3`; a fresh instance reports `1`, which is the trap-and-reap observed from inside the guest.
- **`a_spinning_service_is_trapped_and_restarted`** — first proves a bounded spin that beats the deadline is *never touched* (`served` climbs 1→2, so running hot is not itself an offence), then wedges the singleton and asserts the supervisor brings back a fresh instance counting from one. A bystander workload confirms the trap stayed in its own store.
- **`a_component_wedged_by_its_input_is_trapped_and_replaced`** — the ReDoS case, with four concurrent requests to fill `max_concurrency` on the wedged instance. All four must fail (without the trap, the three queued behind hang until their clients give up), and the component must recover on a fresh instance.
- **`an_abandoned_linked_call_to_a_cold_ephemeral_store_is_ended`** — the wedge is two components deep: HTTP reaches the caller, the caller's imported `run(0)` wedges the callee in a store built for that one call. Asserts the caller's request fails and the whole linked path round-trips again afterwards.
- **`an_abandoned_linked_call_to_a_pooled_instance_is_ended`** — same, but the callee is warm. The callee's own `calls` counter climbing 1→2 and then restarting at 1 is the reap, observed from inside the callee.
- **`an_abandoned_message_delivery_traps_and_restarts_the_service`** — delivers through the host's messaging API; a `spin` subject must make the delivery error at its deadline instead of hanging, and the restarted handler must count from one.
- **`an_abandoned_capability_call_escalates_to_a_plugin_restart`** — seeds state in the shared plugin store, wedges it with `__spin__`, asserts the caller fails, then asserts the rebuilt plugin serves again *and* that the seeded key is gone — proving it really is a fresh incarnation rather than a survivor.

Three tests pin down what must **never** be touched — one per trap condition, and each fails if its condition is removed:

- **`a_client_that_gives_up_does_not_disturb_a_healthy_slow_guest`** — a client walks away 300ms into a request the guest legitimately spends far longer than deadline + grace serving. The disconnect arms the flag; the guest yields throughout, so the same instance must keep serving bystanders unbroken for the whole window.
- **`an_sse_client_disconnecting_between_frames_does_not_trap_the_service`** — the streaming form: head at once, frames further apart than deadline + grace, client takes the head and closes the tab. The guest only learns at its next frame write, so it is mid-sleep for the entire window a time-only trap would use — only its pauses distinguish it from a wedged guest.
- **`an_abandoned_co_tenant_does_not_trap_a_chatty_healthy_stream`** — a connected client reads a stream whose frames land *closer together* than the pause threshold, so its epoch fires read as one pinned stretch, while a co-tenant's abandoned call passes its grace. The stream's own still-wanted call is what must keep the store alive; every frame arriving is the assertion.
- **`a_healthy_instance_under_steady_traffic_is_never_trapped`** — the counterweight. Several deadline-periods of ordinary traffic with `served` required to climb unbroken. Nothing here is abandoned, so nothing may be touched; this is what would catch a design that guessed at "too busy" instead of waiting to be told.

Unit tests in `engine/abandon.rs` cover the semantics directly: a deregistered flag is invisible (so arming on every disconnect is safe), the grace is measured from first arming and re-arming cannot push it forward, a continuity stretch accumulates across sub-threshold gaps and resets on a pause, one still-wanted call blocks `all_abandoned`, and `await_reply` arms on deadline **and** on being dropped unpolled but never on delivery.

Full suite green; the cooperative `wasmcloud:host/cancel` tests are untouched and passing.

## Performance

Criterion, 30s runs, this branch vs `main`:

| Path | main | this PR | verdict |
|---|---|---|---|
| p2 request (hot) | 222 µs | 223 µs | no change (p = 0.29) |
| p3 request (hot) | ~203 µs | 177 µs | no change (p = 0.20) |
| p3 pooled request, paced (200ms idle gaps) | 591 µs | 590 µs | no change |
| guest loop epoch checks | — | ~0.03 ns/iter | interleaved A/B harness |

The paced row is the shape hot loops cannot produce: a pooled instance whose store sits idle between requests (the gap is slept off-clock; only the request is timed). Without the per-call re-arm, an idle store is past its deadline before its next call starts and pays the callback on that call's first back-edge — instrumentation confirms the callback fires once per idle return in that configuration — but the measured cost sits below the noise floor either way; the re-arm removes those fires entirely.

The first cut yielded on every 10ms tick and that *was* measurable — ~+20 µs on p3, from the ~2% of requests that cross a tick mid-guest and eat a fiber requeue. At 100ms granularity the cost is statistically indistinguishable from a runtime without epoch interruption at all, while a pinned guest still frees its worker every ≤100ms.

## Non-goals and known limits

- `wasmcloud:host/cancel` is unchanged — cooperative, guest-facing cancellation stays as is.
- Host-parked calls are unchanged; they were already torn down correctly.
- Teardown is store-scoped until wasmtime#11833. The wanted-call condition bounds the collateral — a store with any live call nobody has given up on is never trapped — at the price of delay: a wedged store with healthy co-tenant calls is only trapped once those calls are abandoned by their own deadlines. A plugin escalation still costs the plugin's in-memory state.
- Pinned-ness is sampled from the epoch callback's fire pattern on wall clock. On a host loaded enough that a pinned guest's fires land further apart than the pause threshold, the gaps read as pauses and the trap is postponed until the load lifts; `WASH_ABANDONED_CALL_PAUSE_THRESHOLD_MS` is the operational knob for that regime.
- A guest that spins *after* delivering its response has no outstanding call to abandon, so it is only reclaimed when the next call lands on its store.
