### PR TITLE
feat(wash-runtime): avoid trapping the plugin

### DIFF
--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -52,9 +52,12 @@
 //! provides, in which case a workload that exports it satisfies it — the
 //! arrangement `wasi:http` and `wasmcloud:messaging` already have, where the
 //! host both serves a workload's imports and calls the handler it exports.
-//! Such an interface must be `async func` throughout, because the shim the
-//! host installs for it is concurrent and a sync-typed import cannot bind to
-//! one.
+//! Such an interface must be `async func` throughout, because the shim the host
+//! installs for it is concurrent and a sync-typed import cannot bind to one,
+//! and every function of it must return a `result` the host can build an error
+//! into — a call out to another workload's guest can trap or stop mid-call, and
+//! the plugin's store is shared by every workload it serves, so the host
+//! answers with a value instead of faulting it.
 //! [`classify_workload_imports`] decides which imports those are, and the
 //! `workload_call` submodule holds the rest: the per-workload routes (claimed in
 //! `on_workload_resolved`, exactly as a native plugin claims them), the
@@ -1089,8 +1092,8 @@ fn declares_workload_calls(imports: &[ExportedInterface]) -> bool {
 /// and `handler` from a workload — the split the native messaging plugin itself
 /// has.
 ///
-/// An import no workload ever exports traps on the call that needs it, naming
-/// the interface.
+/// An import no workload ever exports is reported to the plugin as
+/// `not-exported` on the call that needs it, naming the interface.
 fn classify_workload_imports(
     id: &str,
     component: &Component,
@@ -1139,6 +1142,19 @@ fn classify_workload_imports(
                 "host component plugin '{id}' imports {}#{} for a workload to export, but its \
                  signature carries a handle that cannot cross the boundary between a plugin's \
                  store and a workload's; only plain values, `stream<T>`, and `future<T>` can",
+                imported.name,
+                func.name
+            );
+            anyhow::ensure!(
+                workload_call::error_shape(&func.result_tys).is_some(),
+                "host component plugin '{id}' imports {}#{} for a workload to export, but it \
+                 returns nothing the host can report a failure through. Such a call reaches \
+                 another workload's guest, which can trap or stop mid-call, and the host will \
+                 not take the plugin down for it — so the signature has to be able to say so. \
+                 Return a `result` whose error arm the host can build: \
+                 `wasmcloud:host/types.{{call-error}}` for the structured form (recommended), a \
+                 plain `string`, or the interface's own error type so long as one of its cases \
+                 carries nothing, a `string`, or an `option<string>`.",
                 imported.name,
                 func.name
             );
@@ -1957,7 +1973,7 @@ mod tests {
     /// The `wasmcloud:host/workload-call` import every opted-in plugin
     /// declares, as a WAT line to paste into a test component.
     const DECLARES_WORKLOAD_CALLS: &str =
-        r#"(import "wasmcloud:host/workload-call@0.1.2" (instance))"#;
+        r#"(import "wasmcloud:host/workload-call@0.1.3" (instance))"#;
 
     /// Only an import nothing else can satisfy becomes the workload's to
     /// export. A native serving the interface wins — so introducing a built-in
@@ -2100,6 +2116,51 @@ mod tests {
         );
     }
 
+    /// A workload-facing import must be able to say a call failed, because the
+    /// host answers a failed call with a value rather than trapping the plugin.
+    /// A function with no such result is refused when the plugin loads.
+    #[test]
+    fn a_workload_facing_import_that_cannot_report_failure_is_refused() {
+        let wat = format!(
+            r#"
+            (component
+                {DECLARES_WORKLOAD_CALLS}
+                (import "acme:events/handler@0.1.0" (instance
+                    (export "notify" (func async (param "m" string) (result string)))
+                ))
+            )
+        "#
+        );
+        let err =
+            workload_facing(&wat, &[]).expect_err("an import with no error arm should be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("error arm") && msg.contains("call-error"),
+            "the error should name the fix, got: {msg}"
+        );
+    }
+
+    /// `result<_, string>` is accepted, which is what an off-the-shelf interface
+    /// like `wasmcloud:messaging/handler` already declares.
+    #[test]
+    fn a_workload_facing_import_returning_a_string_error_is_accepted() {
+        let wat = format!(
+            r#"
+            (component
+                {DECLARES_WORKLOAD_CALLS}
+                (import "acme:events/handler@0.1.0" (instance
+                    (export "notify" (func async (param "m" string)
+                        (result (result string (error string)))))
+                ))
+            )
+        "#
+        );
+        assert_eq!(
+            workload_facing(&wat, &[]).expect("classification should succeed"),
+            vec!["acme:events/handler@0.1.0"],
+        );
+    }
+
     /// A plugin's own state, with nothing running — enough to install linker
     /// shims, which is all the workload-facing import tests need.
     pub(super) fn idle_state(id: &'static str) -> Arc<ComponentHostPluginState> {
@@ -2116,6 +2177,20 @@ mod tests {
             native_plugins: HashMap::new(),
             workload_calls: WorkloadCalls::new(id, Vec::new()),
         })
+    }
+
+    /// The one interface `wat` declares, introspected. Written as an import
+    /// because WAT can state an import's type without implementing it, and
+    /// introspection produces the same [`ExportedInterface`] either way. The way
+    /// to get a real [`Type`] into a test: wasmtime mints them, nothing else can.
+    pub(super) fn introspected_interface(wat: &str) -> ExportedInterface {
+        let wasm = wat::parse_str(wat).expect("failed to parse WAT");
+        let engine = Engine::builder().build().expect("failed to build engine");
+        let component = Component::new(engine.inner(), &wasm).expect("failed to compile");
+        introspect_imports(&component)
+            .expect("introspection should succeed")
+            .pop()
+            .expect("the WAT should declare one interface")
     }
 
     pub(super) fn one_func_interface(name: &str, func: &str, is_async: bool) -> ExportedInterface {

--- a/crates/wash-runtime/src/plugin/component_host/workload_call.rs
+++ b/crates/wash-runtime/src/plugin/component_host/workload_call.rs
@@ -39,6 +39,7 @@ use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use anyhow::Context as _;
 use tracing::{debug, warn};
 use wasmtime::AsContextMut;
+use wasmtime::component::types::Type;
 use wasmtime::component::{Accessor, GuestTaskId, Linker, Resource, ResourceType, Val};
 
 use crate::engine::ctx::SharedCtx;
@@ -63,6 +64,7 @@ pub(super) const HOST_WORKLOAD_CALL_INTERFACE: &str = "wasmcloud:host/workload-c
 /// has the opening task on its stack (store teardown, most of all).
 struct TargetHandle {
     workload_id: Arc<str>,
+    interface: Arc<str>,
     task: Option<GuestTaskId>,
 }
 
@@ -79,9 +81,10 @@ struct InterfaceRoute {
 }
 
 /// Every interface of one workload this plugin can call, keyed by the plugin's
-/// own import instance name. Behind an `Arc` so an open `target` handle can
-/// hold the set it resolved against.
-type WorkloadRoutes = BTreeMap<Arc<str>, InterfaceRoute>;
+/// own import instance name. Each route is behind its own `Arc` so a handle —
+/// and every call through one — takes a pointer to it rather than a copy of its
+/// function map.
+type WorkloadRoutes = BTreeMap<Arc<str>, Arc<InterfaceRoute>>;
 
 /// Distinguishes one deployment of a workload id from the next to claim it.
 /// Minted when a workload's first route is claimed and never reused.
@@ -102,16 +105,22 @@ struct CallableWorkload {
 /// identifies it (so a handle dropped out of order removes its own entry rather
 /// than whichever is on top), and what it routes to.
 ///
-/// Holding the routes pins *which* component serves each interface for this
-/// handle's lifetime, so a second exporter appearing cannot move a call
-/// mid-dispatch. It deliberately does not pin liveness: the `generation` beside
-/// it is rechecked on every call, so a handle that outlived the deployment it
-/// resolved against is refused rather than sent into components that are gone.
+/// A frame binds a workload *and* one of its interfaces, resolved together when
+/// the handle opened. That pairing is what makes a held handle proof the call
+/// can be routed: the route below exists, so there is no "does this workload
+/// export it" left to fail on at call time.
+///
+/// Holding the route also pins *which* component serves the interface, so a
+/// second exporter appearing cannot move the call mid-dispatch. It deliberately
+/// does not pin liveness: the `generation` beside it is rechecked on every call,
+/// so a handle that outlived the deployment it resolved against is refused
+/// rather than sent into components that are gone.
 struct TargetFrame {
     rep: u32,
     workload_id: Arc<str>,
+    interface: Arc<str>,
     generation: Generation,
-    routes: Arc<WorkloadRoutes>,
+    route: Arc<InterfaceRoute>,
     /// The registry job the opening call was running under, or `None` outside
     /// one (the plugin's own `cli/run`, or a task it spawned).
     ///
@@ -267,7 +276,7 @@ impl WorkloadCalls {
                     component = %route.component_name,
                     "host component plugin can call a workload export"
                 );
-                slot.insert(route);
+                slot.insert(Arc::new(route));
             }
             Entry::Occupied(mut slot) => {
                 // The host dispatches this interface to one component per
@@ -277,7 +286,7 @@ impl WorkloadCalls {
                 let (selected, ignored) = if route.component_name < slot.get().component_name {
                     let ignored = Arc::clone(&slot.get().component_name);
                     let selected = Arc::clone(&route.component_name);
-                    slot.insert(route);
+                    slot.insert(Arc::new(route));
                     (selected, ignored)
                 } else {
                     (
@@ -346,14 +355,28 @@ impl WorkloadCalls {
     }
 
     /// The routes into `workload_id`, with the generation they belong to, if it
-    /// is currently callable. What `open` checks, and what the handle it returns
-    /// then holds.
+    /// is currently callable.
     fn routes_for(&self, workload_id: &str) -> Option<(Generation, Arc<WorkloadRoutes>)> {
         self.routes
             .read()
             .unwrap_or_else(PoisonError::into_inner)
             .get(workload_id)
             .map(|callable| (callable.generation, Arc::clone(&callable.routes)))
+    }
+
+    /// The route to `interface` on `workload_id`, if that workload is running
+    /// and serves it. What `open` resolves, and what the handle it returns then
+    /// holds — so a handle that exists is a pairing the host has already agreed
+    /// to, not a request to be checked later.
+    fn route_for(
+        &self,
+        workload_id: &str,
+        interface: &str,
+    ) -> Option<(Generation, Arc<InterfaceRoute>)> {
+        let routes = self.routes.read().unwrap_or_else(PoisonError::into_inner);
+        let callable = routes.get(workload_id)?;
+        let route = callable.routes.get(interface)?;
+        Some((callable.generation, Arc::clone(route)))
     }
 
     /// Push a newly opened `target` handle onto its task's stack.
@@ -392,8 +415,10 @@ impl WorkloadCalls {
             .clear();
     }
 
-    /// The workload the innermost live handle on `task` names, with the routes
-    /// that handle holds. A `task` of `None` (the caller's async call stack was
+    /// The workload the innermost live handle on `task` for `interface` names,
+    /// with the route that handle holds. A handle opened for a different
+    /// interface does not answer here — it redirects only what it was opened
+    /// for, so anything else falls back to the caller. A `task` of `None` (the caller's async call stack was
     /// unavailable) never holds one: `open` refuses to hand out a handle it
     /// could not scope.
     ///
@@ -405,31 +430,243 @@ impl WorkloadCalls {
         &self,
         task: Option<GuestTaskId>,
         job: Option<crate::host::job_registry::JobId>,
-    ) -> Option<(Arc<str>, Generation, Arc<WorkloadRoutes>)> {
+        interface: &str,
+    ) -> Option<(Arc<str>, Generation, Arc<InterfaceRoute>)> {
         self.targets
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .get(&task)?
             .iter()
             .rev()
-            .find(|frame| frame.job == job)
+            .find(|frame| frame.job == job && &*frame.interface == interface)
             .map(|frame| {
                 (
                     Arc::clone(&frame.workload_id),
                     frame.generation,
-                    Arc::clone(&frame.routes),
+                    Arc::clone(&frame.route),
                 )
             })
     }
 }
 
-/// The invocation for `interface`'s `func` within one workload's routes.
-fn invocation_in(
-    routes: &WorkloadRoutes,
-    interface: &str,
-    func: &str,
-) -> Option<Arc<LinkedExportInvocation>> {
-    routes.get(interface)?.funcs.get(func).map(Arc::clone)
+/// Which failure a `call-error` case names, so the host picks one rather than
+/// only ever saying "something went wrong".
+#[derive(Clone, Copy)]
+enum CallFailure {
+    NoTarget,
+    NotRunning,
+    NotExported,
+    Failed,
+    /// A failure the host has no dedicated case for. Reached only by defensive
+    /// branches whose condition the deploy-time checks already rule out, which
+    /// is exactly what `other` is for — and keeps the case exercised rather
+    /// than dead until the host grows a use for it.
+    Other,
+}
+
+impl CallFailure {
+    /// The `wasmcloud:host/types.call-error` case this failure is reported as.
+    fn case(self) -> &'static str {
+        match self {
+            Self::NoTarget => "no-target",
+            Self::NotRunning => "not-running",
+            Self::NotExported => "not-exported",
+            Self::Failed => "failed",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// How a workload-facing function is able to carry a failure back to the
+/// plugin. Decided when the plugin loads, from the function's declared result,
+/// and captured by its shim so the failure path never has to look it up.
+#[derive(Clone)]
+pub(super) enum ErrorShape {
+    /// `result<_, string>` — the failure is flattened to its message. What an
+    /// off-the-shelf interface like `wasmcloud:messaging/handler` already has.
+    Message,
+    /// `result<_, call-error>` — the recommended form. The failure keeps its
+    /// case, so a plugin can tell "this workload is gone" from "this call
+    /// trapped" without parsing, and tell either from an error the *workload*
+    /// meant to return.
+    Structured,
+    /// The interface's own error type, with the one case the host picked to
+    /// build. Lets an interface the plugin does not own — a `wasi:sockets`-style
+    /// `error-code`, say — still be answerable.
+    ///
+    /// The cost is that the plugin cannot tell a host failure from one the
+    /// workload meant, because both arrive as the same case. Where the case has
+    /// somewhere to put text the detail is prefixed with
+    /// [`HOST_FAILURE_PREFIX`] so it is at least sniffable; where it has not,
+    /// the reason is simply lost. Prefer `call-error` when you own the
+    /// interface.
+    Borrowed(BorrowedCase),
+}
+
+/// The case of an interface's own error type the host builds, and how.
+#[derive(Clone)]
+pub(super) struct BorrowedCase {
+    case: Arc<str>,
+    build: CaseBuild,
+}
+
+/// What a case needs to become a value.
+#[derive(Clone, Copy)]
+enum CaseBuild {
+    /// An `enum` case: no payload anywhere in the type.
+    Enum,
+    /// A `variant` case carrying nothing.
+    Unit,
+    /// A `variant` case carrying `string`.
+    Str,
+    /// A `variant` case carrying `option<string>`.
+    OptStr,
+}
+
+/// Marks a failure the *host* produced, for the shapes whose type cannot say so
+/// on its own. A plugin matching on a borrowed case can look for this to tell
+/// the two apart; `call-error` needs no such convention.
+const HOST_FAILURE_PREFIX: &str = "wasmcloud:host: ";
+
+/// Cases the host prefers when it has to pick one of an interface's own, in
+/// order. Each names "something went wrong in a way this interface did not
+/// enumerate", which is exactly what a host failure is — `wasi:http`'s
+/// `internal-error` is the case in point. Anything constructible will do if none
+/// of these are present, but a named one carries closer to the right meaning.
+const PREFERRED_BORROWED_CASES: &[&str] = &["internal-error", "internal", "unknown", "other"];
+
+/// Whether `result_tys` can carry a host failure, and in which form.
+///
+/// A workload-facing import must return exactly one `result` whose error arm the
+/// host can build a value of, because the host answers a failed call with a
+/// value rather than a trap. Three ways that holds, in descending order of how
+/// much the plugin learns:
+///
+/// 1. the `call-error` variant, recognised structurally — by its case names and
+///    their `option<string>` payloads — so a plugin may `use` the host's
+///    definition or restate it and either links;
+/// 2. a plain `string`; or
+/// 3. the interface's own error type, if any one of its cases is something the
+///    host knows how to construct ([`borrowed_case`]).
+pub(super) fn error_shape(result_tys: &[Type]) -> Option<ErrorShape> {
+    let [Type::Result(result)] = result_tys else {
+        return None;
+    };
+    match result.err()? {
+        Type::String => Some(ErrorShape::Message),
+        Type::Variant(variant) => {
+            let cases: Vec<(&str, Option<Type>)> =
+                variant.cases().map(|case| (case.name, case.ty)).collect();
+            if is_call_error(&cases) {
+                return Some(ErrorShape::Structured);
+            }
+            borrowed_case(cases.into_iter().map(|(name, ty)| {
+                let build = match ty {
+                    None => Some(CaseBuild::Unit),
+                    Some(Type::String) => Some(CaseBuild::Str),
+                    Some(Type::Option(inner)) if inner.ty() == Type::String => {
+                        Some(CaseBuild::OptStr)
+                    }
+                    Some(_) => None,
+                };
+                (name, build)
+            }))
+        }
+        // An `enum` is all payload-less cases, so every one is constructible and
+        // the detail has nowhere to go.
+        Type::Enum(names) => borrowed_case(names.names().map(|n| (n, Some(CaseBuild::Enum)))),
+        _ => None,
+    }
+}
+
+/// Whether these cases are `wasmcloud:host/types.call-error`.
+fn is_call_error(cases: &[(&str, Option<Type>)]) -> bool {
+    cases.len() == CALL_ERROR_CASES.len()
+        && CALL_ERROR_CASES
+            .iter()
+            .all(|name| cases.iter().any(|(case, _)| case == name))
+        && cases
+            .iter()
+            .all(|(_, ty)| matches!(ty, Some(Type::Option(inner)) if inner.ty() == Type::String))
+}
+
+/// Pick the case the host will build, preferring one whose name already means
+/// "unenumerated failure" and otherwise taking the first it can construct in
+/// declaration order. `None` when the type offers nothing constructible — every
+/// case carries a record or a resource — which is where load refuses the import.
+fn borrowed_case<'a>(
+    cases: impl Iterator<Item = (&'a str, Option<CaseBuild>)>,
+) -> Option<ErrorShape> {
+    let constructible: Vec<(&str, CaseBuild)> = cases
+        .filter_map(|(name, build)| build.map(|build| (name, build)))
+        .collect();
+    let chosen = PREFERRED_BORROWED_CASES
+        .iter()
+        .find_map(|preferred| {
+            constructible
+                .iter()
+                .find(|(name, _)| name == preferred)
+                .copied()
+        })
+        .or_else(|| constructible.first().copied())?;
+    Some(ErrorShape::Borrowed(BorrowedCase {
+        case: Arc::from(chosen.0),
+        build: chosen.1,
+    }))
+}
+
+/// Every case of `wasmcloud:host/types.call-error`, which is what
+/// [`error_shape`] matches a plugin's declared error type against. `other` is
+/// among them: a plugin has to be able to receive it.
+const CALL_ERROR_CASES: &[&str] = &[
+    "no-target",
+    "not-running",
+    "not-exported",
+    "failed",
+    "other",
+];
+
+/// Write `failure` into the call's result slot, so the plugin receives an error
+/// value rather than a trap.
+///
+/// This is the whole of the no-trap contract: a workload-facing call reaches
+/// another workload's guest, which can trap, stop, or run long, and none of that
+/// is the plugin's fault — so none of it faults the store the plugin shares with
+/// every other workload it serves.
+fn report_failure(
+    results: &mut [Val],
+    shape: &ErrorShape,
+    failure: CallFailure,
+    detail: String,
+) -> wasmtime::Result<()> {
+    let err = match shape {
+        ErrorShape::Message => Val::String(format!("{HOST_FAILURE_PREFIX}{detail}")),
+        ErrorShape::Structured => Val::Variant(
+            failure.case().to_string(),
+            Some(Box::new(Val::Option(Some(Box::new(Val::String(detail)))))),
+        ),
+        ErrorShape::Borrowed(BorrowedCase { case, build }) => {
+            let case = case.to_string();
+            // The prefix is built only for a case with room for it; the others
+            // drop the reason entirely, which is the cost of borrowing a type
+            // that never meant to carry one.
+            let detail = || format!("{HOST_FAILURE_PREFIX}{detail}");
+            match build {
+                CaseBuild::Enum => Val::Enum(case),
+                CaseBuild::Unit => Val::Variant(case, None),
+                CaseBuild::Str => Val::Variant(case, Some(Box::new(Val::String(detail())))),
+                CaseBuild::OptStr => Val::Variant(
+                    case,
+                    Some(Box::new(Val::Option(Some(Box::new(Val::String(detail())))))),
+                ),
+            }
+        }
+    };
+    let slot = results.first_mut().ok_or_else(|| {
+        wasmtime::format_err!("workload-facing call has no result slot to report a failure through")
+    })?;
+    *slot = Val::Result(Err(Some(Box::new(err))));
+    Ok(())
 }
 
 /// Install this plugin's shims for `iface` — an interface it imports that a
@@ -460,6 +697,16 @@ pub(super) fn add_workload_calls_to_linker(
             iface.name,
             func.name,
         );
+        // Decided here and captured, so the failure path never has to work out
+        // how to say so. Load refuses a function without one
+        // ([`super::classify_workload_imports`]), which is what makes every exit
+        // below a value rather than a trap.
+        let shape = error_shape(&func.result_tys).with_context(|| {
+            format!(
+                "workload-facing import {}/{} cannot carry a failure",
+                iface.name, func.name
+            )
+        })?;
         let state = Arc::clone(state);
         let interface = Arc::clone(&iface.name);
         let func_name = Arc::clone(&func.name);
@@ -470,9 +717,12 @@ pub(super) fn add_workload_calls_to_linker(
                     let state = Arc::clone(&state);
                     let interface = Arc::clone(&interface);
                     let func = Arc::clone(&func_name);
+                    let shape = shape.clone();
                     Box::pin(async move {
-                        route_workload_call(accessor, &state, interface, func, params, results)
-                            .await
+                        route_workload_call(
+                            accessor, &state, interface, func, &shape, params, results,
+                        )
+                        .await
                     })
                 },
             )
@@ -505,14 +755,17 @@ pub(super) fn add_workload_calls_to_linker(
 /// deployment look live again — its routes still name the components that went
 /// away with it.
 ///
-/// Every failure here surfaces as a trap, because a workload-exported import
-/// has no error result the host could return instead — which is why a plugin
-/// checks with `target.open` rather than calling blind.
+/// No failure here traps the plugin. Every exit either returns the callee's own
+/// answer or writes a failure into the call's result slot ([`report_failure`]),
+/// because none of what can go wrong — another workload's guest trapping,
+/// stopping mid-call, or never exporting the interface — is the plugin's fault,
+/// and the store it would fault is shared by every workload the plugin serves.
 async fn route_workload_call(
     accessor: &Accessor<SharedCtx>,
     state: &ComponentHostPluginState,
     interface: Arc<str>,
     func: Arc<str>,
+    shape: &ErrorShape,
     params: &[Val],
     results: &mut [Val],
 ) -> wasmtime::Result<()> {
@@ -522,75 +775,123 @@ async fn route_workload_call(
     });
     let job = task.and_then(|task| state.registry()?.job_for_task(task));
 
-    let (target, generation, routes) = match state.workload_calls.current_target(task, job) {
-        Some(held) => held,
-        None => {
-            // No handle: this call belongs to whichever workload's capability
-            // call the task is serving. That workload is by definition running
-            // (it is mid-call), so its routes are looked up live.
-            let caller = task
-                .and_then(|task| state.registry()?.caller_for_task(task))
-                .ok_or_else(|| {
-                    wasmtime::format_err!(
-                        "host component plugin '{}' called {interface}#{func} with no workload to \
-                         call: it is not serving a workload's capability call, and holds no \
-                         wasmcloud:host/workload-call target handle naming one",
-                        state.id
-                    )
-                })?;
-            let (generation, routes) = state
-                .workload_calls
-                .routes_for(&caller.workload_id)
-                .ok_or_else(|| {
-                    // A lifecycle hook carries no component id: the host is
-                    // telling the plugin *about* a workload rather than running
-                    // one of that workload's calls. Worth saying so, because
-                    // the hook is the one context where the caller is a
-                    // workload that is deliberately not callable, and the
-                    // generic message would read as a misconfiguration.
-                    if caller.component_id.is_none() {
-                        wasmtime::format_err!(
-                            "host component plugin '{}' cannot call {interface}#{func} on workload \
-                             '{}' from a workload-lifecycle hook: a workload is callable only \
-                             while it is running, and a hook is delivered either side of that — \
-                             still deploying at on-workload-bind, already torn down at \
-                             on-workload-unbind. Reclaim per-workload state by id instead.",
-                            state.id,
-                            caller.workload_id
-                        )
-                    } else {
-                        wasmtime::format_err!(
+    let held = match state.workload_calls.current_target(task, job, &interface) {
+        Some(held) => Ok(held),
+        // No handle for this interface: the call belongs to whichever workload's
+        // capability call the task is serving. That workload is by definition
+        // running (it is mid-call), but it need not export what the plugin is
+        // calling — the one path on which that is still an open question.
+        None => match task.and_then(|task| state.registry()?.caller_for_task(task)) {
+            None => Err((
+                CallFailure::NoTarget,
+                format!(
+                    "host component plugin '{}' called {interface}#{func} with no workload to \
+                     call: it is not serving a workload's capability call, and holds no \
+                     wasmcloud:host/workload-call target handle for {interface}",
+                    state.id
+                ),
+            )),
+            Some(caller) => match state.workload_calls.routes_for(&caller.workload_id) {
+                // A lifecycle hook carries no component id: the host is telling
+                // the plugin *about* a workload rather than running one of that
+                // workload's calls. Worth saying so, because the hook is the one
+                // context where the caller is a workload that is deliberately
+                // not callable, and the generic message would read as a
+                // misconfiguration.
+                None if caller.component_id.is_none() => Err((
+                    CallFailure::NotRunning,
+                    format!(
+                        "host component plugin '{}' cannot call {interface}#{func} on workload \
+                         '{}' from a workload-lifecycle hook: a workload is callable only while \
+                         it is running, and a hook is delivered either side of that — still \
+                         deploying at on-workload-bind, already torn down at on-workload-unbind. \
+                         Reclaim per-workload state by id instead.",
+                        state.id, caller.workload_id
+                    ),
+                )),
+                None => Err((
+                    CallFailure::NotRunning,
+                    format!(
+                        "host component plugin '{}' cannot call {interface}#{func} back on its \
+                         caller '{}': it is not running",
+                        state.id, caller.workload_id
+                    ),
+                )),
+                Some((generation, routes)) => match routes.get(&*interface) {
+                    Some(route) => Ok((caller.workload_id, generation, Arc::clone(route))),
+                    None => Err((
+                        CallFailure::NotExported,
+                        format!(
                             "host component plugin '{}' cannot call {interface}#{func} back on its \
-                             caller '{}': it is not running, or nothing in it exports {interface}",
-                            state.id,
-                            caller.workload_id
-                        )
-                    }
-                })?;
-            (caller.workload_id, generation, routes)
-        }
+                             caller '{}': that workload does not export {interface}. Open a \
+                             wasmcloud:host/workload-call target for a workload that does — `callable` \
+                             reports which serve it.",
+                            state.id, caller.workload_id
+                        ),
+                    )),
+                },
+            },
+        },
+    };
+
+    let (target, generation, route) = match held {
+        Ok(held) => held,
+        Err((failure, detail)) => return report_failure(results, shape, failure, detail),
     };
 
     // Liveness is a separate question from routing, and only routing is
     // snapshotted: a deployment that stopped since the handle opened must not be
     // instantiated again just because the handle still remembers how.
     if !state.workload_calls.is_current(&target, generation) {
-        return Err(wasmtime::format_err!(
-            "host component plugin '{}' cannot call {interface}#{func} on workload '{target}': the \
-             deployment this call names is no longer running",
-            state.id
-        ));
+        return report_failure(
+            results,
+            shape,
+            CallFailure::NotRunning,
+            format!(
+                "host component plugin '{}' cannot call {interface}#{func} on workload '{target}': \
+                 the deployment this call names is no longer running",
+                state.id
+            ),
+        );
     }
 
-    let invocation = invocation_in(&routes, &interface, &func).ok_or_else(|| {
-        wasmtime::format_err!(
-            "host component plugin '{}' cannot call {interface}#{func} on workload '{target}': no \
-             component of it exports {interface}#{func}",
-            state.id
-        )
-    })?;
+    // The interface is settled — a handle only exists for one the workload
+    // serves, and the fallback above resolved it — so only the function can
+    // still be missing, and a workload exporting the interface without every
+    // function the plugin imports never deploys.
+    let Some(invocation) = route.funcs.get(&*func).map(Arc::clone) else {
+        return report_failure(
+            results,
+            shape,
+            CallFailure::Other,
+            format!(
+                "host component plugin '{}' cannot call {interface}#{func} on workload '{target}': \
+                 the interface is served but the function is not",
+                state.id
+            ),
+        );
+    };
 
-    invoke_linked_async_export(accessor, params, results, &invocation).await
+    if let Err(e) = invoke_linked_async_export(accessor, params, results, &invocation).await {
+        // The callee's own failure — a guest trap, a store that could not be
+        // built, a call past the host's ceiling. Reported rather than
+        // propagated: this is the case the whole no-trap contract exists for.
+        warn!(
+            id = state.id,
+            %target,
+            %interface,
+            %func,
+            err = ?e,
+            "call into a workload failed; reporting it to the plugin"
+        );
+        return report_failure(
+            results,
+            shape,
+            CallFailure::Failed,
+            format!("call to {interface}#{func} on workload '{target}' failed: {e:#}"),
+        );
+    }
+    Ok(())
 }
 
 /// Install the `wasmcloud:host/workload-call` import on the plugin's own
@@ -635,9 +936,12 @@ pub(super) fn install_host_workload(
         .func_new(
             "[static]target.open",
             move |mut store, _ty, params, results| {
-                let workload_id = match params.first() {
-                    Some(Val::String(id)) => Arc::<str>::from(id.as_str()),
-                    _ => wasmtime::bail!("target.open expects a single string workload id"),
+                let (workload_id, interface) = match params {
+                    [Val::String(id), Val::String(interface)] => (
+                        Arc::<str>::from(id.as_str()),
+                        Arc::<str>::from(interface.as_str()),
+                    ),
+                    _ => wasmtime::bail!("target.open expects a workload id and an interface"),
                 };
                 // A handle scopes routing to one guest task, so a caller whose
                 // task cannot be resolved gets no handle at all: minting one
@@ -649,12 +953,15 @@ pub(super) fn install_host_workload(
                          the handle would have no call to scope"
                     );
                 };
-                // Resolving here rather than on the call is the whole point:
-                // the handle holds this snapshot, so `none` is the plugin's one
-                // chance to notice a workload it can no longer reach, and
-                // *which* component serves the interface cannot move under a
-                // call the handle scopes.
-                let Some((generation, routes)) = open_state.workload_calls.routes_for(&workload_id)
+                // Resolving the pair here rather than on the call is the whole
+                // point: a handle exists only if this workload serves this
+                // interface, so holding one is proof the call can be routed and
+                // `none` is where a plugin finds out otherwise. It also pins
+                // *which* component serves it, so that cannot move under a call
+                // the handle scopes.
+                let Some((generation, route)) = open_state
+                    .workload_calls
+                    .route_for(&workload_id, &interface)
                 else {
                     if let Some(slot) = results.first_mut() {
                         *slot = Val::Option(None);
@@ -663,6 +970,7 @@ pub(super) fn install_host_workload(
                 };
                 let handle = store.data_mut().table.push(TargetHandle {
                     workload_id: Arc::clone(&workload_id),
+                    interface: Arc::clone(&interface),
                     task: Some(task),
                 })?;
                 let rep = handle.rep();
@@ -678,8 +986,9 @@ pub(super) fn install_host_workload(
                     TargetFrame {
                         rep,
                         workload_id,
+                        interface,
                         generation,
-                        routes,
+                        route,
                         job,
                     },
                 );
@@ -714,6 +1023,25 @@ pub(super) fn install_host_workload(
             )
         })?;
 
+    instance
+        .func_new(
+            "[method]target.get-interface",
+            move |mut store, _ty, params, results| {
+                let Some(Val::Resource(any)) = params.first() else {
+                    wasmtime::bail!("target.get-interface expects a target handle");
+                };
+                let handle = any.try_into_resource::<TargetHandle>(store.as_context_mut())?;
+                let interface = store.data().table.get(&handle)?.interface.to_string();
+                if let Some(slot) = results.first_mut() {
+                    *slot = Val::String(interface);
+                }
+                Ok(())
+            },
+        )
+        .map_err(|e| {
+            e.context("failed to define wasmcloud:host/workload-call#[method]target.get-interface")
+        })?;
+
     let callable_state = Arc::clone(state);
     instance
         .func_new("callable", move |_store, _ty, _params, results| {
@@ -745,19 +1073,30 @@ mod tests {
     /// one it shadowed, and dropping the last leaves no target at all. Dropped
     /// out of order, each still removes its own entry rather than whichever is
     /// on top — a guest is free to drop them in any order.
+    /// A frame for `IFACE`, which is what every handle in these tests routes.
+    fn test_frame(rep: u32, id: &str, job: Option<u64>) -> TargetFrame {
+        TargetFrame {
+            rep,
+            workload_id: Arc::from(id),
+            interface: Arc::from(IFACE),
+            generation: 0,
+            route: Arc::new(InterfaceRoute {
+                component_name: Arc::from("test-component"),
+                funcs: BTreeMap::new(),
+            }),
+            job,
+        }
+    }
+
+    const IFACE: &str = "acme:events/handler@0.1.0";
+
     #[test]
     fn target_handles_nest_and_unwind() {
         let calls = WorkloadCalls::new("test-plugin", Vec::new());
-        let frame = |rep: u32, id: &str, job: Option<u64>| TargetFrame {
-            rep,
-            workload_id: Arc::from(id),
-            generation: 0,
-            routes: Arc::new(WorkloadRoutes::new()),
-            job,
-        };
+        let frame = test_frame;
         let held = |calls: &WorkloadCalls, job: Option<u64>| {
             calls
-                .current_target(None, job)
+                .current_target(None, job, IFACE)
                 .map(|(workload_id, ..)| workload_id.to_string())
         };
         assert!(
@@ -805,30 +1144,74 @@ mod tests {
     fn a_leaked_handle_is_not_inherited_by_a_later_call() {
         let calls = WorkloadCalls::new("test-plugin", Vec::new());
         // Job 1 opens a handle and never drops it; its task ends.
-        calls.push_target(
-            None,
-            TargetFrame {
-                rep: 1,
-                workload_id: Arc::from("wl-other"),
-                generation: 0,
-                routes: Arc::new(WorkloadRoutes::new()),
-                job: Some(1),
-            },
-        );
+        calls.push_target(None, test_frame(1, "wl-other", Some(1)));
 
         // Job 2 is assigned the same task id and holds no handle of its own.
         assert!(
-            calls.current_target(None, Some(2)).is_none(),
+            calls.current_target(None, Some(2), IFACE).is_none(),
             "a later call must not inherit a leaked frame from an earlier job"
         );
         // The frame is still the target of its own job, which may still be
         // running — only the task id was reused.
         assert_eq!(
             calls
-                .current_target(None, Some(1))
+                .current_target(None, Some(1), IFACE)
                 .map(|(workload_id, ..)| workload_id.to_string())
                 .as_deref(),
             Some("wl-other")
+        );
+    }
+
+    /// A handle routes the interface it was opened for and nothing else. A call
+    /// on another interface falls back to the caller, exactly as if no handle
+    /// were held — which is what keeps a handle from silently redirecting a
+    /// call the workload it names cannot serve.
+    #[test]
+    fn a_handle_routes_only_the_interface_it_was_opened_for() {
+        let calls = WorkloadCalls::new("test-plugin", Vec::new());
+        calls.push_target(None, test_frame(1, "wl-a", Some(1)));
+
+        assert!(
+            calls.current_target(None, Some(1), IFACE).is_some(),
+            "the interface the handle was opened for routes through it"
+        );
+        assert!(
+            calls
+                .current_target(None, Some(1), "acme:events/metrics@0.1.0")
+                .is_none(),
+            "another interface does not, so it falls back to the caller"
+        );
+    }
+
+    /// `open` resolves a workload *and* an interface together, so a handle only
+    /// exists for a pair the host has agreed to. Asking for an interface the
+    /// workload does not serve hands back nothing, rather than a handle that
+    /// fails later on the call.
+    #[test]
+    fn a_target_resolves_the_workload_and_interface_together() {
+        let calls = WorkloadCalls::new("test-plugin", Vec::new());
+        calls.insert_route(
+            "wl-a",
+            Arc::from(IFACE),
+            InterfaceRoute {
+                component_name: Arc::from("events-caller"),
+                funcs: BTreeMap::new(),
+            },
+        );
+
+        assert!(
+            calls.route_for("wl-a", IFACE).is_some(),
+            "the pair the workload serves resolves"
+        );
+        assert!(
+            calls
+                .route_for("wl-a", "acme:events/metrics@0.1.0")
+                .is_none(),
+            "an interface it does not export has no route to open a handle on"
+        );
+        assert!(
+            calls.route_for("wl-gone", IFACE).is_none(),
+            "nor has a workload that is not callable at all"
         );
     }
 
@@ -894,20 +1277,72 @@ mod tests {
         );
     }
 
-    /// The same interface declared `async func` installs, which is what the
-    /// `events-plugin` fixture and every real workload-facing import look like.
+    /// An `async func` returning a result the host can fail into installs —
+    /// what the `events-plugin` fixture and every real workload-facing import
+    /// look like. The shim captures that shape, so it needs a genuine result
+    /// type rather than a hand-built one.
     #[test]
     fn an_async_workload_facing_import_installs() {
-        use super::super::tests::{idle_state, one_func_interface};
+        use super::super::tests::{idle_state, introspected_interface};
         use crate::engine::Engine;
 
         let engine = Engine::builder().build().expect("failed to build engine");
         let mut linker = Linker::new(engine.inner());
         let state = idle_state("async-workload-call-plugin");
-        let iface = one_func_interface("acme:events/handler@0.1.0", "notify", true);
+        let iface = introspected_interface(
+            r#"
+            (component
+                (import "acme:events/handler@0.1.0" (instance
+                    (export "notify" (func async (param "m" string)
+                        (result (result string (error string)))))
+                ))
+            )
+        "#,
+        );
 
         add_workload_calls_to_linker(&mut linker, &state, &iface)
             .expect("an async workload-facing import should install");
+    }
+
+    /// The two error shapes the host accepts, and the ones it does not. A
+    /// function that cannot carry a failure has no place to put the answer when
+    /// the callee traps, which is the whole reason load refuses it.
+    #[test]
+    fn error_shape_accepts_a_string_or_the_call_error_variant() {
+        use super::super::tests::introspected_interface;
+
+        let shape_of = |result: &str| {
+            let iface = introspected_interface(&format!(
+                r#"
+                (component
+                    (import "acme:events/handler@0.1.0" (instance
+                        (export "notify" (func async (param "m" string) {result}))
+                    ))
+                )
+            "#
+            ));
+            error_shape(&iface.funcs[0].result_tys)
+        };
+
+        assert!(
+            matches!(
+                shape_of("(result (result string (error string)))"),
+                Some(ErrorShape::Message)
+            ),
+            "result<_, string> is the flattened form"
+        );
+        assert!(
+            shape_of("(result string)").is_none(),
+            "a bare value has nowhere to report a failure"
+        );
+        assert!(
+            shape_of("").is_none(),
+            "nor has a function returning nothing"
+        );
+        assert!(
+            shape_of("(result (result string (error u32)))").is_none(),
+            "the host cannot synthesise an error type it does not know how to build"
+        );
     }
 
     /// A plugin with no workload-facing imports never routes a call this way,

--- a/crates/wash-runtime/tests/fixtures/acme-events/events.wit
+++ b/crates/wash-runtime/tests/fixtures/acme-events/events.wit
@@ -6,20 +6,35 @@ package acme:events@0.1.0;
 /// serve. Everything is an `async func` over primitives, so both directions use
 /// the handle-free relocation fast path.
 interface handler {
+    /// The host's failure type, so a call it could not complete comes back as a
+    /// value rather than trapping the plugin that made it.
+    use wasmcloud:host/types@0.1.3.{call-error};
+
     /// Handle one event. Exported by a workload; called by the plugin across
     /// the store boundary. The reply carries the handling workload's own tag,
     /// so a caller can tell which workload actually ran it.
-    notify: async func(message: string) -> string;
+    notify: async func(message: string) -> result<string, call-error>;
 }
 
 /// A second interface in the plugin's *calling* direction that the workload
 /// fixture deliberately does not export. A plugin importing two of these is
 /// what makes `callable`'s per-workload interface list load-bearing: it has to
-/// say that `handler` is reachable on a workload and `metrics` is not, because
-/// calling one a workload does not export can only trap.
+/// say that `handler` is reachable on a workload and `metrics` is not. Reports
+/// failure as a plain `string`, the other shape the host accepts.
 interface metrics {
+    /// This interface's own failure type, owing nothing to wasmCloud — the
+    /// shape a `wasi:sockets` or `wasi:http` error-code has. The host cannot
+    /// name a case that means what `call-error` would, so it borrows the one
+    /// closest to "something went wrong we did not enumerate".
+    variant metrics-error {
+        /// The measurement was refused.
+        rejected(option<string>),
+        /// Anything else.
+        internal-error(option<string>),
+    }
+
     /// Report a measurement. Nothing exports this, so nothing may call it.
-    report: async func(measurement: string) -> string;
+    report: async func(measurement: string) -> result<string, metrics-error>;
 }
 
 interface control {
@@ -47,9 +62,14 @@ interface control {
     callable: async func() -> list<string>;
 
     /// Call `metrics.report` on the workload named by a target handle. Nothing
-    /// exports `metrics`, so this exists only to make the plugin genuinely
-    /// import a second workload-facing interface; calling it would trap.
+    /// exports `metrics`, so opening one answers `none` and no call is made.
     report: async func(id: string, measurement: string) -> string;
+
+    /// Call `metrics.report` with no target held, so it falls back to the
+    /// calling workload — which does not export `metrics` either. The one path
+    /// where the host still has to report `not-exported`, and it has to say so
+    /// through this interface's own error type.
+    report-inherited: async func(measurement: string) -> string;
 
     /// What the plugin saw when it tried to open a target for `id` from inside
     /// each `wasmcloud:host/workload-lifecycle` hook, as

--- a/crates/wash-runtime/tests/fixtures/events-caller/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/events-caller/src/lib.rs
@@ -11,6 +11,8 @@
 //! - `GET /dispatch?id=W&msg=M`  -> `control.dispatch(W, M)`   -> W's tag + W
 //! - `GET /nested?id=W&msg=M`    -> `control.nested(W, M)`     -> `W|self`
 //! - `GET /callable`             -> `control.callable()`       -> `id=iface,…` a line
+//! - `GET /report?id=W&m=M`      -> `control.report(W, M)`     -> no target for it
+//! - `GET /report-inherited?m=M` -> `control.report-inherited(M)` -> borrowed error case
 //! - `GET /probe?id=W`           -> `control.lifecycle-probe(W)` -> what W's hooks saw
 //! - `GET /tag`                  -> this workload's own tag
 
@@ -20,7 +22,7 @@ mod bindings {
 }
 
 use bindings::acme::events::control;
-use bindings::exports::acme::events::handler::Guest as HandlerGuest;
+use bindings::exports::acme::events::handler::{CallError, Guest as HandlerGuest};
 use bindings::exports::wasi::http::handler::Guest as HttpGuest;
 use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
 
@@ -35,8 +37,12 @@ fn tag() -> String {
 impl HandlerGuest for Component {
     /// Called by the plugin across the store boundary. Reports which workload
     /// handled it, and what it was handed.
-    async fn notify(message: String) -> String {
-        format!("{}:{message}", tag())
+    async fn notify(message: String) -> Result<String, CallError> {
+        // A workload tagged `poison` traps instead of answering, so a test can
+        // prove the host reports that to the plugin rather than faulting the
+        // store the plugin shares with every other workload.
+        assert!(tag() != "poison", "deliberate trap for the no-trap test");
+        Ok(format!("{}:{message}", tag()))
     }
 }
 
@@ -70,6 +76,17 @@ impl HttpGuest for Component {
         if route.starts_with("/callable") {
             let ids = control::callable().await;
             return Ok(make_response(200, ids.join("\n").into_bytes()));
+        }
+        if route.starts_with("/report-inherited") {
+            let m = query_get(query, "m").unwrap_or_default();
+            let reply = control::report_inherited(m).await;
+            return Ok(make_response(200, reply.into_bytes()));
+        }
+        if route.starts_with("/report") {
+            let id = query_get(query, "id").unwrap_or_default();
+            let m = query_get(query, "m").unwrap_or_default();
+            let reply = control::report(id, m).await;
+            return Ok(make_response(200, reply.into_bytes()));
         }
         if route.starts_with("/probe") {
             let id = query_get(query, "id").unwrap_or_default();

--- a/crates/wash-runtime/tests/fixtures/events-caller/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/events-caller/wkg.toml
@@ -1,4 +1,7 @@
 [overrides]
+# `acme:events/handler` reports a failed call with the host's own `call-error`,
+# so the workload exporting it resolves `wasmcloud:host` too.
+"wasmcloud:host" = { path = "../../../../../wit/host/wit" }
 "wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
 "wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
 "wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }

--- a/crates/wash-runtime/tests/fixtures/events-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/src/lib.rs
@@ -29,6 +29,7 @@ use std::collections::BTreeMap;
 use std::sync::Mutex;
 
 use bindings::acme::events::{handler, metrics};
+use bindings::wasmcloud::host::types::CallError;
 use bindings::exports::acme::events::control::Guest;
 use bindings::exports::wasmcloud::host::workload_lifecycle::{
     Guest as LifecycleGuest, WorkloadInfo,
@@ -39,9 +40,15 @@ use bindings::wasmcloud::host::workload_call::{self, Target};
 /// for that workload. Instance memory, so it is empty again after a restart.
 static PROBE: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());
 
+/// The interfaces this plugin imports for a workload to export, spelled as
+/// `callable` reports them. A `target` is opened for one of these, not for a
+/// workload alone — the pairing is what makes a handle proof the call routes.
+const HANDLER: &str = "acme:events/handler@0.1.0";
+const METRICS: &str = "acme:events/metrics@0.1.0";
+
 /// Try to open a target for `id` from inside a hook and append what happened.
 fn probe(id: &str, phase: &str) {
-    let seen = match Target::open(id) {
+    let seen = match Target::open(id, HANDLER) {
         Some(_) => "some",
         None => "none",
     };
@@ -68,36 +75,70 @@ impl LifecycleGuest for EventsPlugin {
     }
 }
 
+/// Render a failed call the way a plugin would log it, so a test can read which
+/// case the host chose. Every one of these is a value the plugin *received* —
+/// none of them trapped it.
+fn failed(err: CallError) -> String {
+    let (case, detail) = match err {
+        CallError::NoTarget(detail) => ("no-target", detail),
+        CallError::NotRunning(detail) => ("not-running", detail),
+        CallError::NotExported(detail) => ("not-exported", detail),
+        CallError::Failed(detail) => ("failed", detail),
+        // Matched because the host may grow into it; the set is not closed.
+        CallError::Other(detail) => ("other", detail),
+    };
+    let _ = detail;
+    format!("error:{case}")
+}
+
+/// Render a `metrics` failure. The case is this interface's own, so the host
+/// picked the nearest thing it had — which is why the detail, where a case has
+/// room for one, is prefixed to say the host produced it.
+fn metrics_failure(err: metrics::MetricsError) -> String {
+    match err {
+        metrics::MetricsError::Rejected(_) => "metrics-error:rejected".to_string(),
+        metrics::MetricsError::InternalError(_) => "metrics-error:internal-error".to_string(),
+    }
+}
+
+/// Call `handler.notify` and flatten either outcome into one string.
+async fn notify(message: String) -> String {
+    match handler::notify(message).await {
+        Ok(reply) => reply,
+        Err(err) => failed(err),
+    }
+}
+
 impl Guest for EventsPlugin {
     /// No target handle is held, so the host sends this to the workload whose
     /// `control` call is running — the plugin calling back into its own caller.
     async fn echo(message: String) -> String {
-        handler::notify(format!("echo:{message}")).await
+        notify(format!("echo:{message}")).await
     }
 
     /// The handle names the workload for as long as it is alive, so this
     /// reaches `id` even though the calling workload is someone else. `open`
     /// answering `none` is the ordinary way a dispatch loop learns a workload
-    /// went away — the plugin reports it and carries on rather than calling
-    /// into nothing and trapping.
+    /// went away, and a call it did make coming back `Err` is the other — both
+    /// are values, neither takes the plugin down.
     async fn dispatch(id: String, message: String) -> String {
-        let Some(target) = Target::open(&id) else {
+        let Some(target) = Target::open(&id, HANDLER) else {
             return format!("unroutable:{id}");
         };
         // Read the handle back rather than reuse `id`, so the reply carries the
         // workload the *host* thinks this call is scoped to.
         let named = target.get_workload_id();
-        handler::notify(format!("dispatch:{named}:{message}")).await
+        notify(format!("dispatch:{named}:{message}")).await
     }
 
     /// Held only for the inner block, so the second call falls back to the
     /// caller — the difference a scoped handle is supposed to make.
     async fn nested(id: String, message: String) -> String {
-        let targeted = match Target::open(&id) {
-            Some(_target) => handler::notify(format!("inner:{message}")).await,
+        let targeted = match Target::open(&id, HANDLER) {
+            Some(_target) => notify(format!("inner:{message}")).await,
             None => format!("unroutable:{id}"),
         };
-        let untargeted = handler::notify(format!("outer:{message}")).await;
+        let untargeted = notify(format!("outer:{message}")).await;
         format!("{targeted}|{untargeted}")
     }
 
@@ -111,14 +152,29 @@ impl Guest for EventsPlugin {
             .collect()
     }
 
-    /// Never called by a test — calling `metrics` on a workload that does not
-    /// export it traps. It exists so the plugin genuinely imports a second
-    /// workload-facing interface.
+    /// Calls `metrics` on a workload that does not export it, which the host
+    /// answers with `not-exported` rather than a trap. Also what makes the
+    /// plugin genuinely import a second workload-facing interface.
     async fn report(id: String, measurement: String) -> String {
-        let Some(_target) = Target::open(&id) else {
+        let Some(_target) = Target::open(&id, METRICS) else {
+            // No workload exports `metrics`, so this is where a plugin finds
+            // out — before the call, not from its failure.
             return format!("unroutable:{id}");
         };
-        metrics::report(measurement).await
+        match metrics::report(measurement).await {
+            Ok(reply) => reply,
+            Err(err) => metrics_failure(err),
+        }
+    }
+
+    /// No handle, so this inherits the caller — which does not export `metrics`.
+    /// The host reports that through `metrics`'s own error type, having no case
+    /// of its own to use.
+    async fn report_inherited(measurement: String) -> String {
+        match metrics::report(measurement).await {
+            Ok(reply) => reply,
+            Err(err) => metrics_failure(err),
+        }
     }
 
     async fn lifecycle_probe(id: String) -> String {

--- a/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
@@ -16,10 +16,10 @@ world events-plugin {
     import acme:events/metrics@0.1.0;
     // Names which workload a call goes to, and lists the ones that can be
     // called at all. Unused for `echo`, which inherits its caller.
-    import wasmcloud:host/workload-call@0.1.2;
+    import wasmcloud:host/workload-call@0.1.3;
     export acme:events/control@0.1.0;
     // Lifecycle hooks, used here only to probe what a hook can reach: a
     // workload is callable exactly while it is running, and both hooks land
     // outside that window.
-    export wasmcloud:host/workload-lifecycle@0.1.2;
+    export wasmcloud:host/workload-lifecycle@0.1.3;
 }

--- a/crates/wash-runtime/tests/fixtures/kv-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin/wit/world.wit
@@ -15,10 +15,10 @@ world kv-plugin {
     import wasi:clocks/system-clock@0.3.0;
     // Host identity import: lets the plugin partition state by the calling
     // workload (the host answers based on the in-flight capability call).
-    import wasmcloud:host/identity@0.1.2;
+    import wasmcloud:host/identity@0.1.3;
     // Host cancel import: lets the plugin cancel one of its own in-flight
     // invocations by the host-minted job id, exercised by `begin`/`cancel-job`.
-    import wasmcloud:host/cancel@0.1.2;
+    import wasmcloud:host/cancel@0.1.3;
     // Self-import: the plugin depends on its own capability so `recurse` can
     // re-enter across the store boundary. The host wires this back to the
     // plugin itself.
@@ -27,5 +27,5 @@ world kv-plugin {
     // Lifecycle export: the host calls these as workloads bind/unbind, letting
     // the plugin capture per-workload manifest config eagerly (observed through
     // the store interface's `bound-config`/`bind-info`/`lifecycle-log`).
-    export wasmcloud:host/workload-lifecycle@0.1.2;
+    export wasmcloud:host/workload-lifecycle@0.1.3;
 }

--- a/crates/wash-runtime/tests/integration_plugin_calls_workload.rs
+++ b/crates/wash-runtime/tests/integration_plugin_calls_workload.rs
@@ -215,6 +215,117 @@ async fn test_target_scope_ends_with_the_handle() -> Result<()> {
     Ok(())
 }
 
+/// A workload whose export traps is reported to the plugin as a `call-error`,
+/// and the plugin keeps serving.
+///
+/// This is what the error arm on every workload-facing import buys. Without it
+/// the callee's trap propagates out of the host shim and faults the plugin's
+/// store — shared by every workload it serves — and a workload that traps every
+/// time exhausts the plugin's restart budget in three dispatches, taking every
+/// tenant with it. Nothing the plugin could do would help: its own strike
+/// counter lives in instance memory, which the fault it would be counting wipes.
+#[tokio::test]
+async fn test_a_trapping_workload_is_reported_not_fatal() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    // Tagged `poison`, so its `handler.notify` traps instead of answering.
+    h.workload_start(events_workload("wl-poison", "poison", "poison"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    for attempt in 0..4 {
+        let (status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-poison&msg=hi").await?;
+        assert_eq!(status.as_u16(), 200, "dispatch {attempt} should succeed");
+        assert_eq!(
+            body, "error:failed",
+            "the callee's trap should reach the plugin as the `failed` case, not take it down"
+        );
+    }
+
+    // Four dispatches is past the plugin's restart budget, so a propagating
+    // trap would have given up by now. The plugin is still the same live
+    // instance, still serving every other workload.
+    let (status, body) = req(&client, &addr, "alpha", "/echo?msg=alive").await?;
+    assert_eq!(status.as_u16(), 200, "the plugin should still be serving");
+    assert_eq!(body, "alpha:echo:alive");
+
+    // ...and the poison workload is still deployed and still callable: a failed
+    // call is the workload's problem to fix, not grounds for the host to evict.
+    let (_status, body) = req(&client, &addr, "alpha", "/callable").await?;
+    assert!(
+        body.contains("wl-poison="),
+        "a workload that fails a call stays callable; got: {body}"
+    );
+
+    Ok(())
+}
+
+/// A `target` binds a workload *and* an interface, so one cannot be opened for
+/// an interface that workload does not export.
+///
+/// `events-plugin` imports two workload-facing interfaces and `events-caller`
+/// exports only `handler`, so opening a `metrics` target for it answers `none`
+/// — the plugin learns before the call rather than from its failure. That is
+/// what makes a held handle proof the call routes: the pairing was checked when
+/// it was made.
+#[tokio::test]
+async fn test_a_target_for_an_unexported_interface_is_refused() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "alpha", "/report?id=wl-alpha&m=x").await?;
+    assert_eq!(status.as_u16(), 200, "/report should succeed");
+    assert_eq!(
+        body, "unroutable:wl-alpha",
+        "a workload that does not export the interface yields no target for it"
+    );
+
+    let (status, body) = req(&client, &addr, "alpha", "/echo?msg=alive").await?;
+    assert_eq!(status.as_u16(), 200, "the plugin should still be serving");
+    assert_eq!(body, "alpha:echo:alive");
+
+    Ok(())
+}
+
+/// An interface that brings its own error type is answerable too: the host
+/// borrows a case of it.
+///
+/// `acme:events/metrics` declares `metrics-error`, owing nothing to wasmCloud —
+/// the shape a `wasi:sockets` or `wasi:http` `error-code` has. Calling it with
+/// no target inherits the caller, which does not export `metrics`, so the host
+/// has to report `not-exported` through a type that has no such case. It picks
+/// `internal-error`: the case whose name means "something we did not
+/// enumerate", preferred over `rejected` which appears first.
+#[tokio::test]
+async fn test_a_failure_is_reported_through_an_interfaces_own_error_type() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "alpha", "/report-inherited?m=x").await?;
+    assert_eq!(status.as_u16(), 200, "/report-inherited should succeed");
+    assert_eq!(
+        body, "metrics-error:internal-error",
+        "the host should borrow the case closest to an unenumerated failure"
+    );
+
+    let (status, body) = req(&client, &addr, "alpha", "/echo?msg=alive").await?;
+    assert_eq!(status.as_u16(), 200, "the plugin should still be serving");
+    assert_eq!(body, "alpha:echo:alive");
+
+    Ok(())
+}
+
 /// A target for a workload that is not callable is reported to the plugin as
 /// `none` rather than trapping it. The plugin stays up and keeps serving, which
 /// is what makes a `callable`-then-dispatch loop safe against a workload

--- a/wit/host/wit/cancel.wit
+++ b/wit/host/wit/cancel.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.2;
+package wasmcloud:host@0.1.3;
 
 /// Host-provided so a component plugin can cooperatively cancel one of its own
 /// in-flight invocations. Job ids are host-minted and opaque. `request-cancel`

--- a/wit/host/wit/identity.wit
+++ b/wit/host/wit/identity.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.2;
+package wasmcloud:host@0.1.3;
 
 /// Provided by the host to a component plugin so it can partition state by the
 /// workload currently calling it. The host answers based on the in-flight

--- a/wit/host/wit/lifecycle.wit
+++ b/wit/host/wit/lifecycle.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.2;
+package wasmcloud:host@0.1.3;
 
 /// Optionally exported by a host component plugin. The host calls these as
 /// workloads that import the plugin's capabilities are bound and unbound,
@@ -46,7 +46,7 @@ package wasmcloud:host@0.1.2;
 /// interrupted, the same way an in-flight request finishes rather than failing
 /// halfway. A `wasmcloud:host/workload-call` target handle opened before the
 /// stop does not extend that to *new* calls: the workload it names is gone, so
-/// the next call through the handle traps.
+/// the next call through the handle comes back `not-running`.
 interface workload-lifecycle {
     use types.{workload-id, component-id};
 

--- a/wit/host/wit/types.wit
+++ b/wit/host/wit/types.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.2;
+package wasmcloud:host@0.1.3;
 
 /// The identifiers every other `wasmcloud:host` interface names a workload and
 /// its components by, defined once so they mean the same thing in all of them:
@@ -14,4 +14,58 @@ interface types {
     /// Identifier of one component within a workload. Fresh per deploy, so it
     /// identifies a running component rather than a manifest entry.
     type component-id = string;
+
+    /// Why the host could not complete a plugin's call into a workload.
+    ///
+    /// The recommended error arm for an interface a plugin imports for a
+    /// workload to export, and the only one that says a failure came from the
+    /// *host* rather than from the workload.
+    ///
+    /// Every function of such an interface must return a `result` the host can
+    /// build an error into, or the plugin does not load. Three ways that holds:
+    /// this variant; a plain `string`; or the interface's own error type, if any
+    /// of its cases carries nothing, a `string`, or an `option<string>` — which
+    /// is what lets an interface nobody here owns, a `wasi:sockets`-style
+    /// `error-code` say, still be answerable. The last two cannot distinguish a
+    /// host failure from one the workload meant, so where there is room for text
+    /// the host prefixes its detail with `wasmcloud:host: `. Use this variant
+    /// when the interface is yours.
+    ///
+    /// There is no fourth outcome: a call either returns the callee's own answer
+    /// or an error, and the plugin is never trapped for it.
+    ///
+    /// Treat the set as open. WIT gives no way to add a case without breaking
+    /// guests built against the old set, so `other` is where the host puts any
+    /// failure it has no dedicated case for — which is what keeps a new failure
+    /// mode from forcing a package version bump. Match `other` and the cases you
+    /// act on differently; do not assume the list is closed.
+    ///
+    /// Each case carries optional detail meant for a log, not for matching on.
+    variant call-error {
+        /// Nothing to call: the plugin is not serving a workload's capability
+        /// call and holds no `workload.target` handle naming one.
+        no-target(option<string>),
+        /// The workload named is not callable. It never bound, it has stopped,
+        /// or a redeploy under the same id replaced the deployment this call
+        /// names.
+        not-running(option<string>),
+        /// The workload is running but does not export this interface.
+        ///
+        /// Only reachable on an unaddressed call — a plugin calling back into
+        /// whichever workload's capability call it happens to be serving, which
+        /// need not export everything the plugin imports. A call through a
+        /// `workload.target` cannot land here: a handle is opened for one
+        /// interface and exists only if that workload serves it. Not a
+        /// disagreement over the interface's *functions* either: a workload
+        /// exporting an interface without every function the plugin imports
+        /// fails to deploy at all.
+        not-exported(option<string>),
+        /// The workload was reached and the call did not finish: its guest
+        /// trapped, it could not be instantiated, or it ran past the host's
+        /// ceiling for one call.
+        failed(option<string>),
+        /// A failure with no dedicated case, including any the host grows into
+        /// later. Carries whatever detail there is.
+        other(option<string>),
+    }
 }

--- a/wit/host/wit/workload.wit
+++ b/wit/host/wit/workload.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.2;
+package wasmcloud:host@0.1.3;
 
 /// Provided by the host to a component plugin that *imports* an interface a
 /// workload exports, so the plugin can call into that workload — the reverse of
@@ -28,32 +28,45 @@ package wasmcloud:host@0.1.2;
 interface workload-call {
     use types.{workload-id};
 
-    /// Directs this task's calls on workload-exported imports to one workload,
-    /// for as long as the handle is alive.
+    /// One workload, on one interface of it, that this task's calls go to for as
+    /// long as the handle is alive.
     ///
-    /// Handles nest: the innermost live handle on the task wins, and dropping
-    /// it restores the one it shadowed. With no handle held, calls go to the
-    /// workload whose capability call this task is serving — so a plugin
-    /// calling back into its own caller needs no handle at all.
+    /// A handle is per interface, not per workload, because a workload need only
+    /// export some of what a plugin imports. Binding both together is what makes
+    /// the pairing checkable when it is made rather than when it is used: a
+    /// handle exists only if that workload really serves that interface, so
+    /// holding one is proof the call can be routed.
     ///
-    /// A handle pins *which* component of that workload serves each interface,
-    /// so a call it scopes cannot be moved to another one mid-dispatch. It does
-    /// not pin the workload itself: a handle held past the workload's stop — or
-    /// past a redeploy under the same id, which is a different workload as far
-    /// as this interface is concerned — traps on the next call through it. Open
-    /// a handle for the work at hand rather than stashing one.
+    /// Handles nest per interface: the innermost live handle *for the interface
+    /// being called* wins, and dropping it restores the one it shadowed. A
+    /// handle for one interface does not redirect calls on another — those fall
+    /// back to the workload whose capability call this task is serving, the same
+    /// as if no handle were held, so a plugin calling back into its own caller
+    /// needs no handle at all.
+    ///
+    /// A handle also pins *which* component serves the interface, so a call it
+    /// scopes cannot be moved to another mid-dispatch. It does not pin the
+    /// workload: one held past the workload's stop — or past a redeploy under
+    /// the same id, which is a different workload as far as this interface is
+    /// concerned — answers `not-running` on the next call through it. Open a
+    /// handle for the work at hand rather than stashing one.
     resource target {
-        /// Direct this task's calls to `id`, or `none` when no workload of that
-        /// id is callable.
+        /// Direct this task's calls on `interface` to `id`, or `none` when that
+        /// workload is not currently callable on it — it is not running, or it
+        /// does not export that interface. `%interface` is spelled as it appears
+        /// in `callable`, which is where the pairs come from.
         ///
-        /// Check this rather than assuming: the list `callable` returns is a
+        /// Check this rather than assuming: what `callable` returns is a
         /// snapshot, and a workload can stop between reading it and acting on
         /// it. A plugin's own `wasi:cli/run` dispatch loop races exactly that
         /// way every time a workload is undeployed.
-        open: static func(id: workload-id) -> option<target>;
+        open: static func(id: workload-id, %interface: string) -> option<target>;
 
         /// The workload this handle names.
         get-workload-id: func() -> workload-id;
+
+        /// The interface this handle routes.
+        get-interface: func() -> string;
     }
 
     /// Every running workload this plugin can call, mapped to the interfaces of
@@ -61,11 +74,10 @@ interface workload-call {
     /// `wasi:cli/run`) iterates to dispatch. Keys are `workload-id`s; the type
     /// is spelled `string` only because a map key cannot be a named alias.
     ///
-    /// The interfaces matter for a plugin that imports more than one, because
-    /// calling one a workload does not export is not a recoverable error: a
-    /// workload-exported import has no error result, so the host can only trap,
-    /// taking down the store every workload shares. Check this list rather than
-    /// assume a workload serves everything the plugin imports.
+    /// The interfaces matter for a plugin that imports more than one, because a
+    /// workload may serve some and not others. They are the pairs `target.open`
+    /// accepts: opening one this list does not name answers `none`, so a
+    /// dispatch loop reading it never has to handle that case at all.
     ///
     /// Running is the whole rule: a workload appears when it starts and goes
     /// when it stops. Both `workload-lifecycle` hooks land outside that window


### PR DESCRIPTION
Follow-up to #5442, which landed the plugin → workload call direction. That direction had a failure mode it could not survive, and this closes it.

## Why

A host component plugin's call out to a workload reaches *another workload's* guest, which can trap, stop mid-call, or run long. None of that is the plugin's fault, but all of it surfaced as a trap: the failure propagated out of the host shim, faulted the plugin's store shared by every workload it serves and the supervisor restarted it. Unattributed faults are charged to the restart budget, so a workload that failed every dispatch exhausted `DEFAULT_MAX_RESTARTS` in three calls and took the plugin down for every tenant.

A plugin could not defend itself. Counting strikes in guest memory does not work, because the fault being counted wipes that memory. The same property `integration_component_plugin_lifecycle` relies on to prove a plugin *didn't* restart.

## What changed

**Every workload-facing import must be able to carry a failure**, checked when the plugin loads. `route_workload_call` no longer has an `Err` exit: nothing to call, workload stopped, deployment replaced, interface not exported, callee trapped, call timed out, each writes an error value into the result slot and returns `Ok`.

Three error shapes qualify, in descending order of what the plugin learns:

1. `wasmcloud:host/types.call-error` — new variant, **recommended**. Distinguishes a host failure from one the workload meant, and says which failure it was. Matched structurally, so a plugin may `use` the host's definition or restate it.
2. `result<_, string>` — what `wasmcloud:messaging/handler` already declares.
3. **The interface's own error type**, so long as the host can construct one of its cases (a payload-less one, or one taking `string`/`option<string>`). This is what lets a custom interface with `wasi:sockets`-style `error-code` still be answerable. The host picks the case whose name means "unenumerated failure", preferring `internal-error`.

Shapes 2 and 3 cannot distinguish a host failure from one the workload meant, so where a case has room for text the detail is prefixed `wasmcloud:host: `. Where it has not, the reason is lost. This is why we doc a preference for `call-error` when you own the interface.

`call-error` is deliberately open-ended: WIT gives no way to add a case without breaking guests built against the old set, so `other` is where the host puts anything it grows into later.

**A `target` handle now binds a workload *and* one of its interfaces.** A workload need only export some of what a plugin imports, so pairing them makes the pairing checkable when it is made rather than when it is used: `open(id, interface)` answers `none` unless that workload serves that interface, and a handle that exists is proof the call routes. `not-exported` is no longer reachable through one — only on an unaddressed call, where a plugin calls back into whichever workload's capability call it happens to be serving. Handles nest per interface; one opened for `handler` does not redirect a `metrics` call.

## Consequences worth knowing

- **A workload-facing function can no longer return nothing.** A void function has nowhere to be told the call failed, so it is refused at load. Fire-and-forget signatures need a `result`.
- **`wasi:http/handler` still cannot be a workload-facing import**, and this does not change that. Its `request`/`response` are resources, which the bridge-safety check refuses; the plugin → workload direction has no resource bridge. Its *error* type would have been fine.
- This makes a dispatch-side poison quarantine unnecessary since there is no crash loop left to contain. The `on-workload-bind` quarantine (`POISON_EVICT_STRIKES`) is a separate path and is unchanged.

## Testing

`events-plugin` grows a second workload-facing interface with its own error type, and `events-caller` grows a workload whose export traps on demand.

- `test_a_trapping_workload_is_reported_not_fatal` dispatches to a trapping workload **four times** past the plugin's restart budget and asserts every call returns `failed`, that the plugin still serves afterwards, and that the workload stays callable.
- `test_a_failure_is_reported_through_an_interfaces_own_error_type` proves the borrowed shape end to end, including that `internal-error` is preferred over the case declared first.
- `test_a_target_for_an_unexported_interface_is_refused` pins that the check moved to open time.
- Unit tests cover which result shapes are accepted and rejected, and that a handle routes only its own interface.
