### PR TITLE
release: v2.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bench-tools"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "wash-runtime"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7721,7 +7721,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xtask"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 [workspace.package]
 authors = ["The wasmCloud Team"]
 edition = "2024"
-version = "2.6.1"
+version = "2.6.2"
 rust-version = "1.94.0"
 
 [workspace.lints.rust]

--- a/charts/runtime-operator/Chart.yaml
+++ b/charts/runtime-operator/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # every release, so the two always match. Don't bump it in feature PRs — chart
 # changes ride out with the next release. (ct does not enforce a per-PR bump;
 # see .github/ct.yaml.)
-version: 2.6.1
+version: 2.6.2
 
 # The version of the application being deployed (the operator image tag default).
 # This tracks the release-train tag rather than this file: at release time
 # `helm-publish` overrides it with the pushed `vX.Y.Z` tag. The value here is the
 # local/dev default used by `helm template` and canary builds.
-appVersion: "2.6.1"
+appVersion: "2.6.2"


### PR DESCRIPTION
Automated release-train PR for **v2.6.2**.

**Action required:** a maintainer needs to approve this PR. Once required checks pass and approval is recorded, auto-merge fires. After merge, `release-tag.yml` waits for canary builds on `main` to pass and then pushes the immutable `v2.6.2` tag, which the existing tag-triggered workflows pick up.

If CI fails: fix forward and push to this branch, or close this PR. The train does not skip — patch releases out-of-cycle can be triggered via `workflow_dispatch` on `release-train.yml`.
