### PR TITLE
WIP feat(otel): thread per-target host/workload OTel endpoints

### DIFF
--- a/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
@@ -33,11 +33,15 @@ use crate::wit::{WitInterface, WitWorld};
 
 const WASI_OTEL_ID: &str = "wasi-otel";
 
-/// OTel gRPC default per the OTLP/gRPC spec. Matches what
-/// `opentelemetry_otlp::SpanExporter::builder().with_tonic()` falls back to
-/// when no `OTEL_EXPORTER_OTLP_*_ENDPOINT` is set; duplicated here only so
-/// the log line at plugin start reflects what the exporter actually used.
+/// OTel gRPC default per the OTLP/gRPC spec.
 const DEFAULT_OTLP_GRPC_ENDPOINT: &str = "http://localhost:4317";
+
+/// OTel HTTP default per the OTLP/HTTP spec.
+const DEFAULT_OTLP_HTTP_ENDPOINT: &str = "http://localhost:4318";
+
+/// TODO: This message is temporary. His only purpose is to allow compilation and test while http
+/// protocol not supported. Must be removed before merge on main branch.
+const UNSUPPORTED_HTTP_MSG: &str = "OTLP protocol 'http/protobuf' is not yet supported; use 'grpc'";
 
 mod bindings {
     wasmtime::component::bindgen!({
@@ -48,6 +52,39 @@ mod bindings {
 
 use bindings::wasi::otel::tracing::{SpanContext as WitSpanContext, TraceFlags as WitTraceFlags};
 
+/// OTLP wire protocol used to reach an [`OtelTarget`].
+///
+/// This selects the exporter *transport* config in builder (`.with_tonic()` vs `.with_http()`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OtelProtocol {
+    /// OTLP over gRPC.
+    #[default]
+    Grpc,
+    /// OTLP over HTTP with protobuf-encoded bodies.
+    /// Not yet implemented.
+    HttpProtobuf,
+}
+
+impl std::fmt::Display for OtelProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Grpc => write!(f, "grpc"),
+            Self::HttpProtobuf => write!(f, "http/protobuf"),
+        }
+    }
+}
+
+impl OtelProtocol {
+    /// The OTLP spec's conventional default endpoint for this protocol.
+    fn default_endpoint(self) -> String {
+        match self {
+            Self::Grpc => DEFAULT_OTLP_GRPC_ENDPOINT.to_string(),
+            Self::HttpProtobuf => DEFAULT_OTLP_HTTP_ENDPOINT.to_string(),
+        }
+    }
+}
+
 /// A single OTLP destination.
 ///
 /// Construct via [`OtelTarget::builder`].
@@ -57,6 +94,8 @@ pub struct OtelTarget {
     /// OTLP endpoint, e.g. `http://localhost:4317`.
     #[builder(into)]
     pub endpoint: String,
+    /// OTLP wire protocol for this target.
+    pub protocol: Option<OtelProtocol>,
 }
 
 /// Configuration for the [`WasiOtel`] plugin.
@@ -83,12 +122,8 @@ pub struct WasiOtelConfig {
     pub service_name: String,
 
     /// Host/platform telemetry target. When unset, falls back to
-    /// `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT`,
-    /// then [`DEFAULT_OTLP_GRPC_ENDPOINT`] — preserves prior behavior.
-    ///
-    /// No host-originated signal flows through this plugin yet, so today
-    /// this only matters as the default `workload` falls back to.
-    /// TODO: Handle protocol and backward compatibility in following commit
+    /// `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` /
+    /// `OTEL_EXPORTER_OTLP_PROTOCOL`. Preserves prior behavior for deployments that only set the standard env vars.
     pub host: Option<OtelTarget>,
 
     /// Workload/application telemetry target, used for all spans, logs, and
@@ -103,17 +138,56 @@ impl Default for WasiOtelConfig {
     }
 }
 
+/// A fully-resolved OTLP destination — a concrete endpoint and protocol.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedTarget {
+    endpoint: String,
+    protocol: OtelProtocol,
+}
+
+#[derive(Clone, Debug, Default)]
+struct EnvDefaults {
+    /// From `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT`.
+    endpoint: Option<String>,
+    /// From `OTEL_EXPORTER_OTLP_PROTOCOL`.
+    protocol: Option<OtelProtocol>,
+}
+
 impl WasiOtelConfig {
-    /// Resolves the effective `(host_endpoint, workload_endpoint)` pair.
-    fn resolve_endpoints(&self, env_default_host_endpoint: String) -> (String, String) {
-        let host = self
+    /// Resolves the effective `(host, workload)` target pair.
+    fn resolve_targets(&self, env: &EnvDefaults) -> (ResolvedTarget, ResolvedTarget) {
+        let host_protocol = self
             .host
             .as_ref()
-            .map_or(env_default_host_endpoint, |t| t.endpoint.clone());
-        let workload = self
+            .and_then(|t| t.protocol)
+            .or(env.protocol)
+            .unwrap_or_default();
+        let host_endpoint = self
+            .host
+            .as_ref()
+            .map(|t| t.endpoint.clone())
+            .or_else(|| env.endpoint.clone())
+            .unwrap_or_else(|| host_protocol.default_endpoint());
+        let host = ResolvedTarget {
+            endpoint: host_endpoint,
+            protocol: host_protocol,
+        };
+
+        let workload_protocol = self
             .workload
             .as_ref()
-            .map_or_else(|| host.clone(), |t| t.endpoint.clone());
+            .and_then(|t| t.protocol)
+            .unwrap_or(host.protocol);
+        let workload_endpoint = self
+            .workload
+            .as_ref()
+            .map(|t| t.endpoint.clone())
+            .unwrap_or_else(|| host.endpoint.clone());
+        let workload = ResolvedTarget {
+            endpoint: workload_endpoint,
+            protocol: workload_protocol,
+        };
+
         (host, workload)
     }
 }
@@ -172,47 +246,46 @@ impl HostPlugin for WasiOtel {
     }
 
     async fn start(&self) -> anyhow::Result<()> {
-        // Absent an explicit `host` target, fall back to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`,
-        // then `OTEL_EXPORTER_OTLP_ENDPOINT`, then the OTel gRPC default
-        // ([`DEFAULT_OTLP_GRPC_ENDPOINT`]) — preserves prior behavior for
-        // deployments that only set the standard env vars.
-        let env_default_host_endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+        // Absent explicit config, fall back to the standard `OTEL_EXPORTER_OTLP_*`
+        // env vars, then a protocol-dependent default — preserves prior behavior
+        // for deployments that only set the standard env vars.
+        let env_endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
             .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT"))
-            .unwrap_or_else(|_| DEFAULT_OTLP_GRPC_ENDPOINT.to_string());
-        let (host_endpoint, workload_endpoint) =
-            self.config.resolve_endpoints(env_default_host_endpoint);
+            .ok();
+        let env_protocol = match std::env::var("OTEL_EXPORTER_OTLP_PROTOCOL") {
+            Ok(v) if v == "grpc" => Some(OtelProtocol::Grpc),
+            Ok(v) if v == "http/protobuf" => Some(OtelProtocol::HttpProtobuf),
+            Ok(v) => {
+                // An unparseable value shouldn't stop the host from booting;
+                // fall through to the next link in the chain instead.
+                tracing::warn!(
+                    value = %v,
+                    "Unrecognized OTEL_EXPORTER_OTLP_PROTOCOL value, ignoring"
+                );
+                None
+            }
+            Err(_) => None,
+        };
+        let (host, workload) = self.config.resolve_targets(&EnvDefaults {
+            endpoint: env_endpoint,
+            protocol: env_protocol,
+        });
 
         tracing::info!(
-            host_endpoint = %host_endpoint,
-            workload_endpoint = %workload_endpoint,
-            protocol = "grpc",
+            host_endpoint = %host.endpoint,
+            host_protocol = %host.protocol,
+            workload_endpoint = %workload.endpoint,
+            workload_protocol = %workload.protocol,
             "Starting WASI OTel plugin"
         );
 
         // Every signal this plugin currently exports (span/log/metric handlers
         // below) is workload-originated, so all three exporters target
-        // `workload_endpoint`. `host_endpoint` has no traffic of its own yet;
-        // it only matters as the default `workload_endpoint` falls back to.
-
-        // set up the grpc span exporter
-        let span_exporter = SpanExporter::builder()
-            .with_tonic()
-            .with_endpoint(&workload_endpoint)
-            .build()
-            .map_err(|e| anyhow::anyhow!("Failed to create span exporter: {e}"))?;
-
-        // set up the grpc log exporter
-        let log_exporter = LogExporter::builder()
-            .with_tonic()
-            .with_endpoint(&workload_endpoint)
-            .build()?;
-
-        // set up metric exporter
-        let metric_exporter = MetricExporter::builder()
-            .with_tonic()
-            .with_endpoint(&workload_endpoint)
-            .build()
-            .map_err(|e| anyhow::anyhow!("Failed to create metric exporter: {e}"))?;
+        // `workload`. `host` has no traffic of its own yet; it only matters as
+        // the default `workload` falls back to.
+        let span_exporter = build_span_exporter(&workload)?;
+        let log_exporter = build_log_exporter(&workload)?;
+        let metric_exporter = build_metric_exporter(&workload)?;
 
         // processor
         let processor = BatchLogProcessor::builder(log_exporter).build();
@@ -337,6 +410,42 @@ impl HostPlugin for WasiOtel {
 
         tracing::info!("WASI OTel plugin stopped");
         Ok(())
+    }
+}
+
+/// NOTE: Could be impl in `ResolvedTarget` instead of root level functions
+/// But the returned types SpanExporter, LogExporter, MetricExporter are not
+/// related to ResolvedTarget.
+fn build_span_exporter(target: &ResolvedTarget) -> anyhow::Result<SpanExporter> {
+    match target.protocol {
+        OtelProtocol::Grpc => SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(&target.endpoint)
+            .build()
+            .map_err(|e| anyhow::anyhow!("Failed to create span exporter: {e}")),
+        OtelProtocol::HttpProtobuf => anyhow::bail!("{UNSUPPORTED_HTTP_MSG}"),
+    }
+}
+
+fn build_log_exporter(target: &ResolvedTarget) -> anyhow::Result<LogExporter> {
+    match target.protocol {
+        OtelProtocol::Grpc => LogExporter::builder()
+            .with_tonic()
+            .with_endpoint(&target.endpoint)
+            .build()
+            .map_err(|e| anyhow::anyhow!("Failed to create log exporter: {e}")),
+        OtelProtocol::HttpProtobuf => anyhow::bail!("{UNSUPPORTED_HTTP_MSG}"),
+    }
+}
+
+fn build_metric_exporter(target: &ResolvedTarget) -> anyhow::Result<MetricExporter> {
+    match target.protocol {
+        OtelProtocol::Grpc => MetricExporter::builder()
+            .with_tonic()
+            .with_endpoint(&target.endpoint)
+            .build()
+            .map_err(|e| anyhow::anyhow!("Failed to create metric exporter: {e}")),
+        OtelProtocol::HttpProtobuf => anyhow::bail!("{UNSUPPORTED_HTTP_MSG}"),
     }
 }
 
@@ -551,22 +660,31 @@ impl<'a> bindings::wasi::otel::types::Host for ActiveCtx<'a> {}
 mod tests {
     use super::*;
 
+    fn env(endpoint: Option<&str>, protocol: Option<OtelProtocol>) -> EnvDefaults {
+        EnvDefaults {
+            endpoint: endpoint.map(str::to_string),
+            protocol,
+        }
+    }
+
     #[test]
     fn workload_falls_back_to_explicit_host() {
         let config = WasiOtelConfig::builder()
             .host(OtelTarget::builder().endpoint("http://host:4317").build())
             .build();
-        let (host, workload) = config.resolve_endpoints("http://env-default:4317".to_string());
-        assert_eq!(host, "http://host:4317");
-        assert_eq!(workload, "http://host:4317");
+        let (host, workload) = config.resolve_targets(&env(Some("http://env-default:4317"), None));
+        assert_eq!(host.endpoint, "http://host:4317");
+        assert_eq!(workload.endpoint, "http://host:4317");
+        assert_eq!(host.protocol, OtelProtocol::Grpc);
+        assert_eq!(workload.protocol, OtelProtocol::Grpc);
     }
 
     #[test]
     fn workload_falls_back_to_env_default_host() {
         let config = WasiOtelConfig::builder().build();
-        let (host, workload) = config.resolve_endpoints("http://env-default:4317".to_string());
-        assert_eq!(host, "http://env-default:4317");
-        assert_eq!(workload, "http://env-default:4317");
+        let (host, workload) = config.resolve_targets(&env(Some("http://env-default:4317"), None));
+        assert_eq!(host.endpoint, "http://env-default:4317");
+        assert_eq!(workload.endpoint, "http://env-default:4317");
     }
 
     #[test]
@@ -579,9 +697,9 @@ mod tests {
             )
             .workload(OtelTarget::builder().endpoint("http://app:4317").build())
             .build();
-        let (host, workload) = config.resolve_endpoints("http://env-default:4317".to_string());
-        assert_eq!(host, "http://platform:4317");
-        assert_eq!(workload, "http://app:4317");
+        let (host, workload) = config.resolve_targets(&env(Some("http://env-default:4317"), None));
+        assert_eq!(host.endpoint, "http://platform:4317");
+        assert_eq!(workload.endpoint, "http://app:4317");
     }
 
     #[test]
@@ -589,8 +707,109 @@ mod tests {
         let config = WasiOtelConfig::builder()
             .workload(OtelTarget::builder().endpoint("http://app:4317").build())
             .build();
-        let (host, workload) = config.resolve_endpoints("http://env-default:4317".to_string());
-        assert_eq!(host, "http://env-default:4317");
-        assert_eq!(workload, "http://app:4317");
+        let (host, workload) = config.resolve_targets(&env(Some("http://env-default:4317"), None));
+        assert_eq!(host.endpoint, "http://env-default:4317");
+        assert_eq!(workload.endpoint, "http://app:4317");
+    }
+
+    #[test]
+    fn protocol_inherits_workload_from_host() {
+        let config = WasiOtelConfig::builder()
+            .host(
+                OtelTarget::builder()
+                    .endpoint("http://platform:4318")
+                    .protocol(OtelProtocol::HttpProtobuf)
+                    .build(),
+            )
+            // Sets only an endpoint, so its protocol should inherit from `host`.
+            .workload(OtelTarget::builder().endpoint("http://app:4317").build())
+            .build();
+        let (host, workload) = config.resolve_targets(&env(None, None));
+        assert_eq!(host.protocol, OtelProtocol::HttpProtobuf);
+        assert_eq!(workload.protocol, OtelProtocol::HttpProtobuf);
+        // The endpoint itself is NOT inherited, since workload set its own.
+        assert_eq!(workload.endpoint, "http://app:4317");
+    }
+
+    #[test]
+    fn protocol_falls_back_to_env_then_default() {
+        let config = WasiOtelConfig::builder().build();
+
+        let (host, workload) = config.resolve_targets(&env(None, Some(OtelProtocol::HttpProtobuf)));
+        assert_eq!(host.protocol, OtelProtocol::HttpProtobuf);
+        assert_eq!(workload.protocol, OtelProtocol::HttpProtobuf);
+
+        let (host, workload) = config.resolve_targets(&env(None, None));
+        assert_eq!(host.protocol, OtelProtocol::Grpc);
+        assert_eq!(workload.protocol, OtelProtocol::Grpc);
+    }
+
+    #[test]
+    fn split_protocols_resolve_independently() {
+        // This is the case the host/workload split exists for: two collectors
+        // that don't even speak the same OTLP transport.
+        let config = WasiOtelConfig::builder()
+            .host(
+                OtelTarget::builder()
+                    .endpoint("http://platform:4317")
+                    .protocol(OtelProtocol::Grpc)
+                    .build(),
+            )
+            .workload(
+                OtelTarget::builder()
+                    .endpoint("http://app:4318")
+                    .protocol(OtelProtocol::HttpProtobuf)
+                    .build(),
+            )
+            .build();
+        let (host, workload) = config.resolve_targets(&env(None, None));
+        assert_eq!(host.protocol, OtelProtocol::Grpc);
+        assert_eq!(workload.protocol, OtelProtocol::HttpProtobuf);
+    }
+
+    #[test]
+    fn protocol_dependent_default_endpoint() {
+        let config = WasiOtelConfig::builder().build();
+
+        let (host, workload) = config.resolve_targets(&env(None, None));
+        assert_eq!(host.endpoint, DEFAULT_OTLP_GRPC_ENDPOINT);
+        assert_eq!(workload.endpoint, DEFAULT_OTLP_GRPC_ENDPOINT);
+
+        let (host, workload) = config.resolve_targets(&env(None, Some(OtelProtocol::HttpProtobuf)));
+        assert_eq!(host.endpoint, DEFAULT_OTLP_HTTP_ENDPOINT);
+        assert_eq!(workload.endpoint, DEFAULT_OTLP_HTTP_ENDPOINT);
+    }
+
+    #[test]
+    fn explicit_endpoint_wins_over_protocol_dependent_default() {
+        // A non-default collector port is a legitimate choice; an explicit
+        // endpoint is honored even when it doesn't match the protocol's
+        // conventional port.
+        let config = WasiOtelConfig::builder()
+            .host(
+                OtelTarget::builder()
+                    .endpoint("http://collector:4317")
+                    .protocol(OtelProtocol::HttpProtobuf)
+                    .build(),
+            )
+            .build();
+        let (host, _workload) = config.resolve_targets(&env(None, None));
+        assert_eq!(host.endpoint, "http://collector:4317");
+        assert_eq!(host.protocol, OtelProtocol::HttpProtobuf);
+    }
+
+    #[test]
+    fn http_protobuf_exporter_construction_is_not_yet_supported() {
+        let target = ResolvedTarget {
+            endpoint: "http://localhost:4318".to_string(),
+            protocol: OtelProtocol::HttpProtobuf,
+        };
+        for err in [
+            build_span_exporter(&target).unwrap_err(),
+            build_log_exporter(&target).unwrap_err(),
+            build_metric_exporter(&target).unwrap_err(),
+        ] {
+            assert!(err.to_string().contains("not yet supported"));
+        }
     }
 }

--- a/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_otel/mod.rs
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use opentelemetry_otlp::{LogExporter, MetricExporter, SpanExporter};
+use opentelemetry_otlp::{LogExporter, MetricExporter, SpanExporter, WithExportConfig};
 
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::plugin::{HostPlugin, WitInterfaces, WorkloadItem, WorkloadTracker};
@@ -47,6 +47,17 @@ mod bindings {
 }
 
 use bindings::wasi::otel::tracing::{SpanContext as WitSpanContext, TraceFlags as WitTraceFlags};
+
+/// A single OTLP destination.
+///
+/// Construct via [`OtelTarget::builder`].
+#[derive(Clone, Debug, bon::Builder)]
+#[non_exhaustive]
+pub struct OtelTarget {
+    /// OTLP endpoint, e.g. `http://localhost:4317`.
+    #[builder(into)]
+    pub endpoint: String,
+}
 
 /// Configuration for the [`WasiOtel`] plugin.
 ///
@@ -70,11 +81,40 @@ pub struct WasiOtelConfig {
     /// metrics, and logs. Defaults to the plugin id (`wasi-otel`).
     #[builder(default = WASI_OTEL_ID.to_string(), into)]
     pub service_name: String,
+
+    /// Host/platform telemetry target. When unset, falls back to
+    /// `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT`,
+    /// then [`DEFAULT_OTLP_GRPC_ENDPOINT`] — preserves prior behavior.
+    ///
+    /// No host-originated signal flows through this plugin yet, so today
+    /// this only matters as the default `workload` falls back to.
+    /// TODO: Handle protocol and backward compatibility in following commit
+    pub host: Option<OtelTarget>,
+
+    /// Workload/application telemetry target, used for all spans, logs, and
+    /// metrics emitted by components through `wasi:otel`. When unset, falls
+    /// back to `host`.
+    pub workload: Option<OtelTarget>,
 }
 
 impl Default for WasiOtelConfig {
     fn default() -> Self {
         Self::builder().build()
+    }
+}
+
+impl WasiOtelConfig {
+    /// Resolves the effective `(host_endpoint, workload_endpoint)` pair.
+    fn resolve_endpoints(&self, env_default_host_endpoint: String) -> (String, String) {
+        let host = self
+            .host
+            .as_ref()
+            .map_or(env_default_host_endpoint, |t| t.endpoint.clone());
+        let workload = self
+            .workload
+            .as_ref()
+            .map_or_else(|| host.clone(), |t| t.endpoint.clone());
+        (host, workload)
     }
 }
 
@@ -99,8 +139,15 @@ pub struct WasiOtel {
 
 impl Default for WasiOtel {
     fn default() -> Self {
+        Self::new(WasiOtelConfig::default())
+    }
+}
+
+impl WasiOtel {
+    /// Construct the plugin with the given configuration.
+    pub fn new(config: WasiOtelConfig) -> Self {
         Self {
-            config: WasiOtelConfig::default(),
+            config,
             tracker: Arc::new(RwLock::new(WorkloadTracker::default())),
             meter_provider: Arc::new(RwLock::new(None)),
             tracer_provider: Arc::new(RwLock::new(None)),
@@ -125,41 +172,45 @@ impl HostPlugin for WasiOtel {
     }
 
     async fn start(&self) -> anyhow::Result<()> {
-        // The exporter resolves its endpoint from `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`,
-        // then `OTEL_EXPORTER_OTLP_ENDPOINT`, falling back to the OTel gRPC default
-        // ([`DEFAULT_OTLP_GRPC_ENDPOINT`]). Protocol is fixed to gRPC because we use
-        // `with_tonic()` below; tracking richer per-target endpoint configuration as a
-        // follow-up to this PR (see TODO below).
-        let endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+        // Absent an explicit `host` target, fall back to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`,
+        // then `OTEL_EXPORTER_OTLP_ENDPOINT`, then the OTel gRPC default
+        // ([`DEFAULT_OTLP_GRPC_ENDPOINT`]) — preserves prior behavior for
+        // deployments that only set the standard env vars.
+        let env_default_host_endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
             .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT"))
             .unwrap_or_else(|_| DEFAULT_OTLP_GRPC_ENDPOINT.to_string());
+        let (host_endpoint, workload_endpoint) =
+            self.config.resolve_endpoints(env_default_host_endpoint);
+
         tracing::info!(
-            endpoint = %endpoint,
+            host_endpoint = %host_endpoint,
+            workload_endpoint = %workload_endpoint,
             protocol = "grpc",
             "Starting WASI OTel plugin"
         );
 
-        // TODO: thread per-target endpoints (host vs workload) through `WasiOtelConfig`
-        // so platform telemetry and application telemetry can ship to different backends.
+        // Every signal this plugin currently exports (span/log/metric handlers
+        // below) is workload-originated, so all three exporters target
+        // `workload_endpoint`. `host_endpoint` has no traffic of its own yet;
+        // it only matters as the default `workload_endpoint` falls back to.
 
         // set up the grpc span exporter
         let span_exporter = SpanExporter::builder()
             .with_tonic()
+            .with_endpoint(&workload_endpoint)
             .build()
             .map_err(|e| anyhow::anyhow!("Failed to create span exporter: {e}"))?;
 
         // set up the grpc log exporter
         let log_exporter = LogExporter::builder()
             .with_tonic()
-            //.with_endpoint("http://localhost:5318")
-            //.with_protocol(opentelemetry_otlp::Protocol::Grpc)
+            .with_endpoint(&workload_endpoint)
             .build()?;
 
         // set up metric exporter
         let metric_exporter = MetricExporter::builder()
             .with_tonic()
-            //.with_endpoint("http://localhost:5318")
-            //.with_protocol(opentelemetry_otlp::Protocol::Grpc)
+            .with_endpoint(&workload_endpoint)
             .build()
             .map_err(|e| anyhow::anyhow!("Failed to create metric exporter: {e}"))?;
 
@@ -495,3 +546,51 @@ impl<'a> bindings::wasi::otel::tracing::Host for ActiveCtx<'a> {
 }
 
 impl<'a> bindings::wasi::otel::types::Host for ActiveCtx<'a> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workload_falls_back_to_explicit_host() {
+        let config = WasiOtelConfig::builder()
+            .host(OtelTarget::builder().endpoint("http://host:4317").build())
+            .build();
+        let (host, workload) = config.resolve_endpoints("http://env-default:4317".to_string());
+        assert_eq!(host, "http://host:4317");
+        assert_eq!(workload, "http://host:4317");
+    }
+
+    #[test]
+    fn workload_falls_back_to_env_default_host() {
+        let config = WasiOtelConfig::builder().build();
+        let (host, workload) = config.resolve_endpoints("http://env-default:4317".to_string());
+        assert_eq!(host, "http://env-default:4317");
+        assert_eq!(workload, "http://env-default:4317");
+    }
+
+    #[test]
+    fn split_endpoints_resolve_independently() {
+        let config = WasiOtelConfig::builder()
+            .host(
+                OtelTarget::builder()
+                    .endpoint("http://platform:4317")
+                    .build(),
+            )
+            .workload(OtelTarget::builder().endpoint("http://app:4317").build())
+            .build();
+        let (host, workload) = config.resolve_endpoints("http://env-default:4317".to_string());
+        assert_eq!(host, "http://platform:4317");
+        assert_eq!(workload, "http://app:4317");
+    }
+
+    #[test]
+    fn workload_only_leaves_host_at_env_default() {
+        let config = WasiOtelConfig::builder()
+            .workload(OtelTarget::builder().endpoint("http://app:4317").build())
+            .build();
+        let (host, workload) = config.resolve_endpoints("http://env-default:4317".to_string());
+        assert_eq!(host, "http://env-default:4317");
+        assert_eq!(workload, "http://app:4317");
+    }
+}

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -309,10 +309,24 @@ impl CliCommand for DevCommand {
             }
         }
 
-        // Add otel plugin
+        // Add otel plugin if configured
         if dev_config.wasi_otel {
-            host_builder =
-                host_builder.with_plugin(Arc::new(plugin::wasi_otel::WasiOtel::default()))?;
+            let otel_config = plugin::wasi_otel::WasiOtelConfig::builder()
+                .maybe_host(
+                    dev_config
+                        .otel_host_endpoint
+                        .as_ref()
+                        .map(|e| plugin::wasi_otel::OtelTarget::builder().endpoint(e).build()),
+                )
+                .maybe_workload(
+                    dev_config
+                        .otel_workload_endpoint
+                        .as_ref()
+                        .map(|e| plugin::wasi_otel::OtelTarget::builder().endpoint(e).build()),
+                )
+                .build();
+            host_builder = host_builder
+                .with_plugin(Arc::new(plugin::wasi_otel::WasiOtel::new(otel_config)))?;
             debug!("WASI OpenTelemetry plugin registered");
         }
 

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -311,20 +311,12 @@ impl CliCommand for DevCommand {
 
         // Add otel plugin if configured
         if dev_config.wasi_otel {
-            let otel_config = plugin::wasi_otel::WasiOtelConfig::builder()
-                .maybe_host(
-                    dev_config
-                        .otel_host_endpoint
-                        .as_ref()
-                        .map(|e| plugin::wasi_otel::OtelTarget::builder().endpoint(e).build()),
-                )
-                .maybe_workload(
-                    dev_config
-                        .otel_workload_endpoint
-                        .as_ref()
-                        .map(|e| plugin::wasi_otel::OtelTarget::builder().endpoint(e).build()),
-                )
-                .build();
+            let otel_config = crate::config::wasi_otel_config(
+                dev_config.otel_host_endpoint.as_deref(),
+                dev_config.otel_host_protocol,
+                dev_config.otel_workload_endpoint.as_deref(),
+                dev_config.otel_workload_protocol,
+            );
             host_builder = host_builder
                 .with_plugin(Arc::new(plugin::wasi_otel::WasiOtel::new(otel_config)))?;
             debug!("WASI OpenTelemetry plugin registered");

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -262,6 +262,16 @@ pub struct HostCommand {
     #[arg(long = "wasi-otel", default_value_t = false)]
     pub wasi_otel: bool,
 
+    /// OTLP endpoint for host/platform telemetry.
+    /// Only takes effect with --wasi-otel.
+    #[arg(long = "otel-host-endpoint", env = "WASH_OTEL_HOST_ENDPOINT")]
+    pub otel_host_endpoint: Option<String>,
+
+    /// OTLP endpoint for workload/application telemetry emitted by components via wasi:otel.
+    /// Only takes effect with --wasi-otel.
+    #[arg(long = "otel-workload-endpoint", env = "WASH_OTEL_WORKLOAD_ENDPOINT")]
+    pub otel_workload_endpoint: Option<String>,
+
     /// Let workloads and plugins reach the machine's own loopback through
     /// `host.wasmcloud.internal`.
     ///
@@ -570,8 +580,20 @@ impl CliCommand for HostCommand {
 
         // Enable otel plugin
         if self.wasi_otel {
+            let otel_config = plugin::wasi_otel::WasiOtelConfig::builder()
+                .maybe_host(
+                    self.otel_host_endpoint
+                        .as_ref()
+                        .map(|e| plugin::wasi_otel::OtelTarget::builder().endpoint(e).build()),
+                )
+                .maybe_workload(
+                    self.otel_workload_endpoint
+                        .as_ref()
+                        .map(|e| plugin::wasi_otel::OtelTarget::builder().endpoint(e).build()),
+                )
+                .build();
             cluster_host_builder = cluster_host_builder
-                .with_plugin(Arc::new(plugin::wasi_otel::WasiOtel::default()))?;
+                .with_plugin(Arc::new(plugin::wasi_otel::WasiOtel::new(otel_config)))?;
         }
 
         // Enable WASI WebGPU if requested

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -10,7 +10,7 @@ use wash_runtime::{
 };
 
 use crate::cli::{CliCommand, CliContext, CommandOutput};
-use crate::config::{HttpClientTrustRoots, load_config};
+use crate::config::{HttpClientTrustRoots, OtelProtocol, load_config};
 
 #[derive(Debug, Clone, Args)]
 pub struct HostCommand {
@@ -264,6 +264,7 @@ pub struct HostCommand {
 
     /// OTLP endpoint for host/platform telemetry.
     /// Only takes effect with --wasi-otel.
+    /// NOTE: Should we add value_parser with local function (like what is done for parse_host_plugin_spec)?
     #[arg(long = "otel-host-endpoint", env = "WASH_OTEL_HOST_ENDPOINT")]
     pub otel_host_endpoint: Option<String>,
 
@@ -271,6 +272,27 @@ pub struct HostCommand {
     /// Only takes effect with --wasi-otel.
     #[arg(long = "otel-workload-endpoint", env = "WASH_OTEL_WORKLOAD_ENDPOINT")]
     pub otel_workload_endpoint: Option<String>,
+
+    /// OTLP protocol for host/platform telemetry. Unset inherits the
+    /// OTEL_EXPORTER_OTLP_PROTOCOL env var, then defaults to grpc.
+    /// Only takes effect with --wasi-otel, and only when --otel-host-endpoint is
+    /// also set.
+    #[arg(
+        long = "otel-host-protocol",
+        env = "WASH_OTEL_HOST_PROTOCOL",
+        value_enum
+    )]
+    pub otel_host_protocol: Option<OtelProtocol>,
+
+    /// OTLP protocol for workload/application telemetry. Unset inherits
+    /// --otel-host-protocol. Only takes effect with --wasi-otel, and only when
+    /// --otel-workload-endpoint is also set.
+    #[arg(
+        long = "otel-workload-protocol",
+        env = "WASH_OTEL_WORKLOAD_PROTOCOL",
+        value_enum
+    )]
+    pub otel_workload_protocol: Option<OtelProtocol>,
 
     /// Let workloads and plugins reach the machine's own loopback through
     /// `host.wasmcloud.internal`.
@@ -580,18 +602,12 @@ impl CliCommand for HostCommand {
 
         // Enable otel plugin
         if self.wasi_otel {
-            let otel_config = plugin::wasi_otel::WasiOtelConfig::builder()
-                .maybe_host(
-                    self.otel_host_endpoint
-                        .as_ref()
-                        .map(|e| plugin::wasi_otel::OtelTarget::builder().endpoint(e).build()),
-                )
-                .maybe_workload(
-                    self.otel_workload_endpoint
-                        .as_ref()
-                        .map(|e| plugin::wasi_otel::OtelTarget::builder().endpoint(e).build()),
-                )
-                .build();
+            let otel_config = crate::config::wasi_otel_config(
+                self.otel_host_endpoint.as_deref(),
+                self.otel_host_protocol,
+                self.otel_workload_endpoint.as_deref(),
+                self.otel_workload_protocol,
+            );
             cluster_host_builder = cluster_host_builder
                 .with_plugin(Arc::new(plugin::wasi_otel::WasiOtel::new(otel_config)))?;
         }

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -599,6 +599,55 @@ impl From<HttpClientTrustRoots> for wash_runtime::host::http_client::TrustRoots 
     }
 }
 
+/// OTLP wire protocol for a `wasi:otel` target. CLI/config mirror of
+/// [`wash_runtime::plugin::wasi_otel::OtelProtocol`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
+pub enum OtelProtocol {
+    /// OTLP over gRPC.
+    #[serde(rename = "grpc")]
+    #[value(name = "grpc")]
+    Grpc,
+    /// OTLP over HTTP with protobuf-encoded bodies.
+    /// TODO: add support for http config. Should decide for an http lib to use first.
+    #[serde(rename = "http/protobuf", alias = "http-protobuf")]
+    #[value(name = "http/protobuf", alias = "http-protobuf")]
+    HttpProtobuf,
+}
+
+impl From<OtelProtocol> for wash_runtime::plugin::wasi_otel::OtelProtocol {
+    fn from(protocol: OtelProtocol) -> Self {
+        match protocol {
+            OtelProtocol::Grpc => Self::Grpc,
+            OtelProtocol::HttpProtobuf => Self::HttpProtobuf,
+        }
+    }
+}
+
+/// Builds a [`wash_runtime::plugin::wasi_otel::WasiOtelConfig`] from the four
+/// optional CLI/config host_endpoint, workload_endpoint, host_protocol, workload_protocol.
+pub fn wasi_otel_config(
+    host_endpoint: Option<&str>,
+    host_protocol: Option<OtelProtocol>,
+    workload_endpoint: Option<&str>,
+    workload_protocol: Option<OtelProtocol>,
+) -> wash_runtime::plugin::wasi_otel::WasiOtelConfig {
+    use wash_runtime::plugin::wasi_otel::{OtelTarget, WasiOtelConfig};
+
+    let target = |endpoint: Option<&str>, protocol: Option<OtelProtocol>| {
+        endpoint.map(|e| {
+            OtelTarget::builder()
+                .endpoint(e)
+                .maybe_protocol(protocol.map(Into::into))
+                .build()
+        })
+    };
+
+    WasiOtelConfig::builder()
+        .maybe_host(target(host_endpoint, host_protocol))
+        .maybe_workload(target(workload_endpoint, workload_protocol))
+        .build()
+}
+
 /// Build the host's [`QuotaRegistry`] from optional config/CLI overrides.
 ///
 /// One registry governs every surface a guest can hold a connection on, so
@@ -940,6 +989,16 @@ pub struct DevConfig {
     /// Example: http://app-collector:4317
     #[serde(skip_serializing_if = "Option::is_none")]
     pub otel_workload_endpoint: Option<String>,
+
+    /// OTLP protocol for host/platform telemetry: `grpc` or `http/protobuf`.
+    /// If not set, falls back to OTEL_EXPORTER_OTLP_PROTOCOL env var, then `grpc`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub otel_host_protocol: Option<OtelProtocol>,
+
+    /// OTLP protocol for workload/application telemetry: `grpc` or `http/protobuf`.
+    /// If not set, falls back to otel_host_protocol.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub otel_workload_protocol: Option<OtelProtocol>,
 
     /// Additional wasm proposals to enable on the engine, by name. Accepted
     /// names match `wash_runtime`'s `WasmProposal`: component-model-async,
@@ -1667,6 +1726,48 @@ dev:
                 .to_string()
                 .contains("dev.otel_workload_endpoint")
         );
+    }
+
+    #[test]
+    fn dev_otel_protocols_deserialize_from_yaml() {
+        let yaml = r#"
+dev:
+  wasi_otel: true
+  otel_host_protocol: grpc
+  otel_workload_protocol: http/protobuf
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let dev = config.dev();
+        assert_eq!(dev.otel_host_protocol, Some(OtelProtocol::Grpc));
+        assert_eq!(dev.otel_workload_protocol, Some(OtelProtocol::HttpProtobuf));
+        assert!(dev.validate().is_ok());
+    }
+
+    #[test]
+    fn dev_otel_protocol_accepts_kebab_case_alias() {
+        let yaml = r#"
+dev:
+  otel_workload_protocol: http-protobuf
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(
+            config.dev().otel_workload_protocol,
+            Some(OtelProtocol::HttpProtobuf)
+        );
+    }
+
+    #[test]
+    fn dev_otel_protocols_absent_deserialize_to_none() {
+        // Unset must stay `None`, not a default variant — that's what lets
+        // `wasi_otel::OtelTarget::protocol` inherit rather than pin gRPC.
+        let yaml = r#"
+dev:
+  wasi_otel: true
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let dev = config.dev();
+        assert_eq!(dev.otel_host_protocol, None);
+        assert_eq!(dev.otel_workload_protocol, None);
     }
 
     #[test]

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -929,6 +929,18 @@ pub struct DevConfig {
     #[serde(default)]
     pub wasi_otel: bool,
 
+    /// Optional OTEL collector endpoint for host/platform Spans, Logs, Metrics.
+    /// If not set, falls back to OTEL_EXPORTER_OTLP_TRACES_ENDPOINT or OTEL_EXPORTER_OTLP_ENDPOINT env var.
+    /// Example: http://platform-collector:4317
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub otel_host_endpoint: Option<String>,
+
+    /// Optional OTEL collector endpoint for workload/application Spans, Logs, Metrics.
+    /// If not set, falls back to otel_host_endpoint.
+    /// Example: http://app-collector:4317
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub otel_workload_endpoint: Option<String>,
+
     /// Additional wasm proposals to enable on the engine, by name. Accepted
     /// names match `wash_runtime`'s `WasmProposal`: component-model-async,
     /// component-model-map, gc, exception-handling, wide-arithmetic, threads,
@@ -1029,6 +1041,22 @@ impl DevConfig {
                 "dev.postgres_url",
                 url,
                 &["postgres", "postgresql"],
+                &mut errors,
+            );
+        }
+        if let Some(url) = &self.otel_host_endpoint {
+            check_url_scheme(
+                "dev.otel_host_endpoint",
+                url,
+                &["http", "https"],
+                &mut errors,
+            );
+        }
+        if let Some(url) = &self.otel_workload_endpoint {
+            check_url_scheme(
+                "dev.otel_workload_endpoint",
+                url,
+                &["http", "https"],
                 &mut errors,
             );
         }
@@ -1588,6 +1616,56 @@ dev:
         assert_eq!(
             env.get("OTEL_EXPORTER_OTLP_ENDPOINT").map(String::as_str),
             Some("http://localhost:4317")
+        );
+    }
+
+    #[test]
+    fn dev_otel_endpoints_deserialize_from_yaml() {
+        let yaml = r#"
+dev:
+  wasi_otel: true
+  otel_host_endpoint: http://platform-collector:4317
+  otel_workload_endpoint: http://app-collector:4317
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let dev = config.dev();
+        assert!(dev.wasi_otel);
+        assert_eq!(
+            dev.otel_host_endpoint.as_deref(),
+            Some("http://platform-collector:4317")
+        );
+        assert_eq!(
+            dev.otel_workload_endpoint.as_deref(),
+            Some("http://app-collector:4317")
+        );
+        assert!(dev.validate().is_ok());
+    }
+
+    #[test]
+    fn dev_otel_host_endpoint_bad_scheme_is_err() {
+        let cfg = DevConfig {
+            otel_host_endpoint: Some("nats://localhost:4317".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            cfg.validate()
+                .unwrap_err()
+                .to_string()
+                .contains("dev.otel_host_endpoint")
+        );
+    }
+
+    #[test]
+    fn dev_otel_workload_endpoint_bad_scheme_is_err() {
+        let cfg = DevConfig {
+            otel_workload_endpoint: Some("nats://localhost:4317".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            cfg.validate()
+                .unwrap_err()
+                .to_string()
+                .contains("dev.otel_workload_endpoint")
         );
     }
 

--- a/examples/otel-config/README.md
+++ b/examples/otel-config/README.md
@@ -172,6 +172,32 @@ Open the dashboard at [http://localhost:18888](http://localhost:18888). You shou
   `http.server.response_body.size` gauge, both labelled by the Resource attributes from
   `workload.config`.
 
+## Routing host vs. workload telemetry to different backends
+
+By default all telemetry from this plugin — including every span, log, and metric this
+component emits via `wasi:otel` — goes to one OTLP endpoint (`OTEL_EXPORTER_OTLP_ENDPOINT`
+above). To split platform/host telemetry from application/workload telemetry, set
+`dev.otel_host_endpoint` and `dev.otel_workload_endpoint` in `.wash/config.yaml` instead:
+
+```yaml
+dev:
+  wasi_otel: true
+  otel_host_endpoint: http://localhost:28889     # platform-engineering collector
+  otel_workload_endpoint: http://localhost:18889 # app-team collector
+```
+
+Equivalent `wash host` flags: `--otel-host-endpoint` / `--otel-workload-endpoint` (or
+`WASH_OTEL_HOST_ENDPOINT` / `WASH_OTEL_WORKLOAD_ENDPOINT`).
+
+- Everything this component emits through `wasi:otel` is workload telemetry, so it all ships
+  to `otel_workload_endpoint`.
+- Omitting `otel_workload_endpoint` falls back to `otel_host_endpoint`.
+- Omitting both falls back to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` /
+  `OTEL_EXPORTER_OTLP_ENDPOINT` / `http://localhost:4317`, i.e. today's single-endpoint
+  behavior is unchanged.
+- `otel_host_endpoint` has no plugin-emitted traffic of its own yet — it only matters as the
+  default `otel_workload_endpoint` falls back to.
+
 ## Multi-workload trace roll-up
 
 The single workload above already shows the two ingredients of a distributed

--- a/examples/otel-config/README.md
+++ b/examples/otel-config/README.md
@@ -193,10 +193,42 @@ Equivalent `wash host` flags: `--otel-host-endpoint` / `--otel-workload-endpoint
   to `otel_workload_endpoint`.
 - Omitting `otel_workload_endpoint` falls back to `otel_host_endpoint`.
 - Omitting both falls back to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` /
-  `OTEL_EXPORTER_OTLP_ENDPOINT` / `http://localhost:4317`, i.e. today's single-endpoint
-  behavior is unchanged.
+  `OTEL_EXPORTER_OTLP_ENDPOINT` / a protocol-dependent default (see below), i.e. today's
+  single-endpoint behavior is unchanged.
 - `otel_host_endpoint` has no plugin-emitted traffic of its own yet — it only matters as the
   default `otel_workload_endpoint` falls back to.
+
+### Choosing a protocol per target
+
+Each target also takes an OTLP protocol, independent of its counterpart:
+
+```yaml
+dev:
+  wasi_otel: true
+  otel_host_endpoint: http://localhost:28889
+  otel_host_protocol: grpc
+  otel_workload_endpoint: http://localhost:18889
+  otel_workload_protocol: http/protobuf
+```
+
+Equivalent `wash host` flags: `--otel-host-protocol` / `--otel-workload-protocol` (or
+`WASH_OTEL_HOST_PROTOCOL` / `WASH_OTEL_WORKLOAD_PROTOCOL`).
+
+- Accepted values are `grpc` (default) and `http/protobuf`.
+- A `*_protocol` key only takes effect when its matching `*_endpoint` is also set — a target
+  needs a concrete endpoint to exist at all, so a protocol override with no endpoint is
+  dropped and that target falls all the way back to inheritance/env/default, as if neither
+  had been set.
+- Omitting `otel_workload_protocol` falls back to `otel_host_protocol`, then to the
+  `OTEL_EXPORTER_OTLP_PROTOCOL` env var, then to `grpc` — the same inheritance shape as the
+  endpoints.
+- The default endpoint (when no endpoint is configured at all) depends on the resolved
+  protocol: `http://localhost:4317` for `grpc`, `http://localhost:4318` for `http/protobuf`,
+  matching the OTLP spec's per-transport conventions.
+- **`http/protobuf` is not yet functional.** It's accepted by config/CLI validation, but the
+  host will fail to start with an explanatory error (`OTLP protocol 'http/protobuf' is not
+  yet supported; use 'grpc'`) if it's the protocol actually resolved for a target. Use `grpc`
+  (the default) until HTTP transport support lands.
 
 ## Multi-workload trace roll-up
 


### PR DESCRIPTION
Splits `WasiOtelConfig`'s single OTLP destination into independent `host` and `workload` targets, so platform and application telemetry can route to different collectors.
`workload` falls back to `host`, which falls back to the existing
`OTEL_EXPORTER_OTLP_*` env vars, so single-endpoint deployments are unaffected.

Exposes the new targets through `wash dev` (`.wash/config.yaml`) and `wash host` (`--otel-host-endpoint` / `--otel-workload-endpoint`).

Per-target protocol and actual host-originated signal export are left as follow-up (see TODO in `wasi_otel/mod.rs`).

Part of #5162

---
Start implementation for otel config protocol in commit 86c3f4c