### PR TITLE
fix/embedder oci and socket defaults

### DIFF
--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -856,14 +856,25 @@ impl HostApi for Host {
         {
             let mut workloads = self.workloads.write().await;
             if workloads.contains_key(&request.workload_id) {
+                let message = format!(
+                    "Workload ID [{}] already exists (the exising workload must be stopped to reuse the ID)",
+                    request.workload_id
+                );
+                // Logged here rather than at the single site below, because
+                // this refusal returns before the start ever begins. At `warn`,
+                // not `error`: this is the guard that makes a replayed start
+                // request idempotent, and a scheduler retrying one is not a
+                // host malfunction.
+                tracing::warn!(
+                    workload_id = request.workload_id,
+                    reason = message,
+                    "refused to start workload"
+                );
                 return Ok(WorkloadStartResponse {
                     workload_status: WorkloadStatus {
                         workload_id: request.workload_id.clone(),
                         workload_state: WorkloadState::Error,
-                        message: format!(
-                            "Workload ID [{}] already exists (the exising workload must be stopped to reuse the ID)",
-                            request.workload_id
-                        ),
+                        message,
                     },
                 });
             }
@@ -914,7 +925,10 @@ impl HostApi for Host {
                     Some(resolved),
                 ),
                 Err(err) => {
-                    let message = err.to_string();
+                    // `{:#}` so the whole context chain reaches the caller and
+                    // the log below: the outer layer alone ("failed to pull
+                    // image for component 'x'") never names the cause.
+                    let message = format!("{err:#}");
                     if mine {
                         workloads.insert(workload_id.clone(), HostWorkload::Error(message.clone()));
                     } else if handed_back {
@@ -927,6 +941,17 @@ impl HostApi for Host {
                 }
             }
         };
+
+        // A start that failed is reported to whoever asked and nowhere else.
+        // Say so locally too: the operator diagnosing it — a pull against a
+        // registry this host does not trust, a plugin that would not bind — is
+        // reading the host's log, and without this the host has nothing to say.
+        if workload_state == WorkloadState::Error {
+            // `reason`, not `message`: `message` is the field tracing gives
+            // the event's own text, and a second one under that name displaces
+            // it.
+            tracing::error!(workload_id, reason = message, "failed to start workload");
+        }
 
         if let Some(resolved) = orphaned {
             release(&workload_id, &resolved).await;
@@ -1125,6 +1150,21 @@ pub struct HostConfig {
     pub allow_oci_insecure: bool,
     pub oci_pull_timeout: Option<Duration>,
     pub oci_cache_dir: Option<PathBuf>,
+    /// PEM CA bundles to trust for OCI pulls, on top of the compiled-in webpki
+    /// roots. Needed to reach a registry behind a private CA — an in-cluster
+    /// one, or a corporate mirror.
+    ///
+    /// Applied by [`HostBuilder::build`] to the process-wide trust store, so an
+    /// embedder that fills in this struct configures registry trust the same
+    /// way it configures every other OCI setting. `wash oci pull`/`push`, which
+    /// build no host at all, reach that store through
+    /// [`oci::set_extra_ca_certificates`](crate::oci::set_extra_ca_certificates)
+    /// directly.
+    ///
+    /// That store holds one set for the whole process. Two hosts in one process
+    /// may name the same bundles; a second host naming *different* ones fails
+    /// to build, rather than running on trust it did not ask for.
+    pub oci_ca_paths: Vec<PathBuf>,
 }
 
 impl Default for HostConfig {
@@ -1133,6 +1173,7 @@ impl Default for HostConfig {
             allow_oci_insecure: false,
             oci_pull_timeout: Duration::from_secs(30).into(),
             oci_cache_dir: None,
+            oci_ca_paths: Vec::new(),
         }
     }
 }
@@ -1323,8 +1364,20 @@ impl HostBuilder {
     /// A new `Host` instance ready to be started.
     ///
     /// # Errors
-    /// Returns an error if the default engine cannot be created (when no engine is provided).
+    /// Returns an error if the default engine cannot be created (when no engine
+    /// is provided), if a CA bundle named by [`HostConfig::oci_ca_paths`]
+    /// cannot be read or does not parse, or if a different set of bundles is
+    /// already configured for this process.
     pub fn build(self) -> anyhow::Result<Host> {
+        let config = self.config.unwrap_or_default();
+
+        // Trust roots first, before anything this host builds can pull: the
+        // host pulls on behalf of every workload, and a bundle that cannot be
+        // read is a startup failure rather than a registry that rejects every
+        // pull much later.
+        crate::oci::set_extra_ca_certificates(&config.oci_ca_paths)
+            .context("failed to load the OCI CA certificates in the host config")?;
+
         let engine = if let Some(engine) = self.engine {
             engine
         } else {
@@ -1367,7 +1420,7 @@ impl HostBuilder {
             started_at: chrono::Utc::now(),
             system_monitor: Arc::new(RwLock::new(SystemMonitor::new())),
             http_handler,
-            config: self.config.unwrap_or_default(),
+            config,
             meters: self.meters,
         })
     }
@@ -1377,6 +1430,26 @@ impl HostBuilder {
 mod tests {
     use super::*;
     use crate::types::Component;
+
+    /// An unreadable CA bundle has to stop the host being built. Trust is
+    /// configured once and used much later, so accepting it here would surface
+    /// as every pull from that registry failing to verify, far from the typo
+    /// that caused it.
+    #[test]
+    fn an_unreadable_oci_ca_bundle_fails_the_build() {
+        let err = Host::builder()
+            .with_config(HostConfig {
+                oci_ca_paths: vec![PathBuf::from("/definitely/not/a/ca.pem")],
+                ..Default::default()
+            })
+            .build()
+            .expect_err("a host must not build around a CA bundle it cannot read");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("/definitely/not/a/ca.pem"),
+            "the error should name the bundle it could not read: {msg}"
+        );
+    }
 
     fn empty_workload_start_request(workload_id: &str) -> WorkloadStartRequest {
         WorkloadStartRequest {

--- a/crates/wash-runtime/src/oci.rs
+++ b/crates/wash-runtime/src/oci.rs
@@ -108,7 +108,7 @@ fn install_ca_certificates(store: &OnceLock<InstalledTrust>, paths: &[PathBuf]) 
         // this caller asked for the compiled-in roots and is not getting them.
         if let Some(installed) = store.get() {
             warn!(
-                paths = ?installed.paths,
+                paths = %display_paths(&installed.paths),
                 "no OCI CA certificates requested, but extra trust roots configured earlier in \
                  this process apply to every OCI client in it"
             );
@@ -143,9 +143,23 @@ fn conflicting_trust(installed: &BTreeSet<PathBuf>, requested: &BTreeSet<PathBuf
         return Ok(());
     }
     bail!(
-        "different OCI CA certificates are already configured for this process ({installed:?}); \
-         the trust store holds one set, so {requested:?} would not take effect"
+        "different OCI CA certificates are already configured for this process ({}); the trust \
+         store holds one set, so {} would not take effect",
+        display_paths(installed),
+        display_paths(requested)
     )
+}
+
+/// Paths as an operator wrote them, for an error they have to compare by eye.
+///
+/// `{:?}` on a `Path` escapes its separators, which turns a Windows path into
+/// something that does not match what is in the config it came from.
+fn display_paths(paths: &BTreeSet<PathBuf>) -> String {
+    paths
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Read and parse PEM CA bundles from disk. Split from
@@ -928,7 +942,9 @@ mod tests {
         let err = install_ca_certificates(&store, std::slice::from_ref(&second))
             .expect_err("different bundles must not be silently dropped");
         let msg = err.to_string();
-        // Both halves, because the operator's next move is to compare them.
+        // Both halves, because the operator's next move is to compare them —
+        // spelled as they are on disk, which is what a Windows path escaped by
+        // `{:?}` would not be.
         for named in [&first, &second] {
             assert!(
                 msg.contains(named.to_str().unwrap()),
@@ -938,6 +954,19 @@ mod tests {
         }
         // The first bundle is what is trusted, and it is intact.
         assert_eq!(store.get().map(|t| t.certs.len()), Some(1));
+    }
+
+    /// A path in an error has to read as it does in the configuration it came
+    /// from. `{:?}` escapes separators, so a Windows path came out doubled and
+    /// matched nothing an operator could search for. Asserted with a
+    /// backslash-bearing path, which is an ordinary filename on Unix, so the
+    /// property holds on every platform this runs on.
+    #[test]
+    fn paths_in_errors_are_not_debug_escaped() {
+        let windows_ish = PathBuf::from(r"C:\etc\pki\ca.pem");
+        let rendered = display_paths(&BTreeSet::from([windows_ish.clone()]));
+        assert_eq!(rendered, windows_ish.display().to_string());
+        assert!(!rendered.contains(r"\\"), "separators must not be doubled");
     }
 
     /// A self-signed certificate written to `name` under `dir`.

--- a/crates/wash-runtime/src/oci.rs
+++ b/crates/wash-runtime/src/oci.rs
@@ -38,7 +38,7 @@ use oci_client::{
 use oci_wasm::{ToConfig, WASM_LAYER_MEDIA_TYPE, WasmConfig};
 use sha2::{Digest, Sha256};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     path::{Path, PathBuf},
     sync::OnceLock,
     time::Duration,
@@ -55,7 +55,23 @@ use tracing::{debug, instrument, warn};
 ///
 /// Empty unless [`set_extra_ca_certificates`] is called, which keeps the
 /// default behavior exactly as it was: the roots `oci-client` compiles in.
-static EXTRA_CA_CERTIFICATES: OnceLock<Vec<Certificate>> = OnceLock::new();
+static EXTRA_CA_CERTIFICATES: OnceLock<InstalledTrust> = OnceLock::new();
+
+/// The one set of extra trust roots a process runs with, and the configuration
+/// that asked for it.
+///
+/// Keyed by the paths rather than by the bytes read from them, because a bundle
+/// on disk is not immutable: cert-manager and projected Kubernetes secrets
+/// rewrite one in place, and the two calls that install a host's trust — the
+/// CLI before it pulls its host component plugins, the host it then builds —
+/// are separated by exactly those pulls. Comparing content would turn a
+/// rotation landing in that window into a startup failure.
+struct InstalledTrust {
+    /// A set, so the same bundles listed in a different order are the same
+    /// configuration.
+    paths: BTreeSet<PathBuf>,
+    certs: Vec<Certificate>,
+}
 
 /// Trust the PEM CA bundles at `paths` for every subsequent OCI pull or push.
 ///
@@ -66,13 +82,70 @@ static EXTRA_CA_CERTIFICATES: OnceLock<Vec<Certificate>> = OnceLock::new();
 ///
 /// Fails when a bundle cannot be read or does not parse, rather than starting
 /// a host that will reject every pull from the registry it was pointed at.
+///
+/// Naming the same bundles twice is a no-op, and does not re-read them: a
+/// `wash host` installs its CA paths before pulling its host component plugins,
+/// then the host it builds applies the same
+/// [`HostConfig::oci_ca_paths`](crate::host::HostConfig) again. *Different*
+/// paths arriving second fail, because the store holds one set for the whole
+/// process and that caller would otherwise be told its trust was configured
+/// when it was not.
 pub fn set_extra_ca_certificates(paths: &[PathBuf]) -> Result<()> {
+    install_ca_certificates(&EXTRA_CA_CERTIFICATES, paths)
+}
+
+/// [`set_extra_ca_certificates`] against a given store.
+///
+/// Split out to take the store as an argument: the real one can only be written
+/// once per process, so a test that exercised it would own it for the whole
+/// test binary.
+fn install_ca_certificates(store: &OnceLock<InstalledTrust>, paths: &[PathBuf]) -> Result<()> {
+    let requested: BTreeSet<PathBuf> = paths.iter().cloned().collect();
+    if requested.is_empty() {
+        // Claiming the store with nothing would lock out the caller that does
+        // have trust roots — and tell it that it succeeded. Say so when trust
+        // configured elsewhere in this process is in force regardless, because
+        // this caller asked for the compiled-in roots and is not getting them.
+        if let Some(installed) = store.get() {
+            warn!(
+                paths = ?installed.paths,
+                "no OCI CA certificates requested, but extra trust roots configured earlier in \
+                 this process apply to every OCI client in it"
+            );
+        }
+        return Ok(());
+    }
+    // Already installed by an earlier caller naming the same bundles. Returning
+    // here rather than re-reading is what keeps a rotation landing between the
+    // two calls from failing the second one.
+    if let Some(installed) = store.get() {
+        return conflicting_trust(&installed.paths, &requested);
+    }
     let certs = load_ca_certificates(paths)?;
     debug!(count = certs.len(), "trusting extra OCI CA certificates");
-    if EXTRA_CA_CERTIFICATES.set(certs).is_err() {
-        warn!("extra OCI CA certificates were already set; keeping the first set");
+    match store.set(InstalledTrust {
+        paths: requested,
+        certs,
+    }) {
+        Ok(()) => Ok(()),
+        // Lost a race to another caller; the winner decides. `set` failing
+        // means the store is claimed, so `get` is `Some`.
+        Err(rejected) => match store.get() {
+            Some(installed) => conflicting_trust(&installed.paths, &rejected.paths),
+            None => Ok(()),
+        },
     }
-    Ok(())
+}
+
+/// Whether trust already installed covers what a caller asked for.
+fn conflicting_trust(installed: &BTreeSet<PathBuf>, requested: &BTreeSet<PathBuf>) -> Result<()> {
+    if installed == requested {
+        return Ok(());
+    }
+    bail!(
+        "different OCI CA certificates are already configured for this process ({installed:?}); \
+         the trust store holds one set, so {requested:?} would not take effect"
+    )
 }
 
 /// Read and parse PEM CA bundles from disk. Split from
@@ -128,7 +201,10 @@ fn validate_ca_bundle(data: &[u8]) -> Result<()> {
 
 /// The extra CA certificates configured for this process, for a `ClientConfig`.
 fn extra_ca_certificates() -> Vec<Certificate> {
-    EXTRA_CA_CERTIFICATES.get().cloned().unwrap_or_default()
+    EXTRA_CA_CERTIFICATES
+        .get()
+        .map(|trust| trust.certs.clone())
+        .unwrap_or_default()
 }
 
 #[allow(deprecated)]
@@ -789,6 +865,86 @@ mod tests {
             err.to_string().contains("CA bundle"),
             "the error should name what it failed to read, got: {err}"
         );
+    }
+
+    /// An empty configuration must leave the store unclaimed. It can only be
+    /// written once, so an empty set taking it would lock out the caller that
+    /// does have trust roots — and that caller would be told it succeeded.
+    #[test]
+    fn no_ca_paths_leaves_the_trust_store_unclaimed() {
+        set_extra_ca_certificates(&[]).expect("an empty set is not a failure");
+        assert!(
+            extra_ca_certificates().is_empty(),
+            "nothing to install must install nothing"
+        );
+    }
+
+    /// The ordinary double-apply: `wash host start` installs its CA paths
+    /// before pulling its host component plugins, then the host it builds
+    /// applies the same [`HostConfig::oci_ca_paths`] again. In any order — the
+    /// two callers hold the same configuration, not the same `Vec`.
+    #[test]
+    fn the_same_bundles_installed_twice_are_a_no_op() {
+        let dir = TempDir::new().unwrap();
+        let paths = [written_bundle(&dir, "a.pem"), written_bundle(&dir, "b.pem")];
+        let store = OnceLock::new();
+
+        install_ca_certificates(&store, &paths).expect("the first configuration installs");
+        let reversed = [paths[1].clone(), paths[0].clone()];
+        install_ca_certificates(&store, &reversed).expect("the same bundles are not a conflict");
+        assert_eq!(store.get().map(|t| t.certs.len()), Some(2));
+    }
+
+    /// The window between those two calls is a network pull of every host
+    /// component plugin, and the bundle on disk is not immutable: cert-manager
+    /// and projected Kubernetes secrets rewrite one in place. A rotation
+    /// landing in that window must not fail the host's startup.
+    #[test]
+    fn a_bundle_rewritten_between_two_installs_is_still_the_same_configuration() {
+        let dir = TempDir::new().unwrap();
+        let path = written_bundle(&dir, "ca.pem");
+        let store = OnceLock::new();
+
+        install_ca_certificates(&store, std::slice::from_ref(&path)).expect("the first install");
+        std::fs::write(&path, test_certificate_pem("rotated.test")).unwrap();
+        install_ca_certificates(&store, std::slice::from_ref(&path))
+            .expect("a rotated bundle at the same path is the same configuration");
+    }
+
+    /// Different bundles cannot be honored — the store holds one set for the
+    /// whole process — so the caller has to hear that, rather than be told its
+    /// trust was configured and watch every pull fail verification.
+    #[test]
+    fn conflicting_trust_is_an_error_not_a_silent_first_wins() {
+        let dir = TempDir::new().unwrap();
+        let (first, second) = (
+            written_bundle(&dir, "first.pem"),
+            written_bundle(&dir, "second.pem"),
+        );
+        let store = OnceLock::new();
+
+        install_ca_certificates(&store, std::slice::from_ref(&first))
+            .expect("the first bundle installs");
+        let err = install_ca_certificates(&store, std::slice::from_ref(&second))
+            .expect_err("different bundles must not be silently dropped");
+        let msg = err.to_string();
+        // Both halves, because the operator's next move is to compare them.
+        for named in [&first, &second] {
+            assert!(
+                msg.contains(named.to_str().unwrap()),
+                "the error should name {}: {msg}",
+                named.display()
+            );
+        }
+        // The first bundle is what is trusted, and it is intact.
+        assert_eq!(store.get().map(|t| t.certs.len()), Some(1));
+    }
+
+    /// A self-signed certificate written to `name` under `dir`.
+    fn written_bundle(dir: &TempDir, name: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, test_certificate_pem(name)).unwrap();
+        path
     }
 
     /// A self-signed certificate, PEM encoded, for the bundles below.

--- a/crates/wash-runtime/src/sockets/policy.rs
+++ b/crates/wash-runtime/src/sockets/policy.rs
@@ -119,13 +119,18 @@ pub struct SocketPolicy {
 }
 
 impl Default for SocketPolicy {
+    /// The same policy the `wash` CLI builds when an operator passes no socket
+    /// flags: range filtering on, egress gate counting rather than enforcing,
+    /// host loopback closed. An embedder that installs no policy of its own
+    /// gets what an operator running the host would get, rather than a
+    /// permissive one nobody chose.
     fn default() -> Self {
         Self {
             kind: GuestKind::Component,
             allowed_hosts: Arc::from([]),
             host_loopback: Arc::from([]),
             host_loopback_enabled: false,
-            egress_addrs: EgressAddressPolicy::permissive(),
+            egress_addrs: EgressAddressPolicy::default(),
             host_owned_ports: None,
             egress_mode: EgressMode::Count,
             quota: None,
@@ -768,5 +773,21 @@ mod tests {
             denied(&policy.decide(SocketAddrUse::TcpConnect, addr("127.255.255.254:5432"))),
             Some(DenyReason::HostLoopbackNotPermitted)
         );
+    }
+
+    /// An embedder that installs no policy of its own takes this default, so
+    /// it has to be the policy `wash host start` builds from its own flag
+    /// defaults. Otherwise the library is the weaker of the two and nobody
+    /// chose that.
+    #[test]
+    fn the_default_matches_the_cli_flag_defaults() {
+        let policy = SocketPolicy::default();
+        // `--deny-special-ranges` defaults on, `--deny-private-ranges` off.
+        assert_eq!(policy.egress_addrs, EgressAddressPolicy::default());
+        assert!(policy.egress_addrs.deny_special);
+        assert!(policy.egress_addrs.allow_private);
+        // `--socket-egress count`, `--allow-host-loopback` off.
+        assert_eq!(policy.egress_mode, EgressMode::Count);
+        assert!(!policy.host_loopback_enabled);
     }
 }

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -443,6 +443,26 @@ async fn host_heartbeat(host: &impl HostApi) -> anyhow::Result<types::v2::HostHe
     Ok(hb.into())
 }
 
+/// A workload that could not be started, reported to the scheduler and to this
+/// host's own log.
+///
+/// The response travels back to whoever asked, and nothing else here would say
+/// why: an image the host cannot pull — a registry behind a CA it does not
+/// trust, a reference that does not exist — otherwise leaves no trace on the
+/// machine that failed to pull it.
+fn workload_start_error(workload_id: &str, message: String) -> types::v2::WorkloadStartResponse {
+    // `reason`, not `message`: `message` is the field tracing gives the event's
+    // own text, and a second one under that name displaces it.
+    error!(workload_id, reason = message, "failed to start workload");
+    types::v2::WorkloadStartResponse {
+        workload_status: Some(types::v2::WorkloadStatus {
+            workload_id: workload_id.to_string(),
+            workload_state: types::v2::WorkloadState::Error.into(),
+            message,
+        }),
+    }
+}
+
 #[instrument(skip_all, fields(
     workload_id = %req.workload_id,
     workload.name=?req.workload.as_ref().map(|w| &w.name).unwrap_or(&"<none>".to_string()),
@@ -486,30 +506,19 @@ async fn workload_start(
                     format!("failed to pull image for component '{}'", component.name)
                 }) {
                     Ok(loaded) => loaded,
-                    Err(e) => {
-                        return Ok(types::v2::WorkloadStartResponse {
-                            workload_status: Some(types::v2::WorkloadStatus {
-                                workload_id: workload_id.clone(),
-                                workload_state: types::v2::WorkloadState::Error.into(),
-                                message: format!("{e:#}"),
-                            }),
-                        });
-                    }
+                    Err(e) => return Ok(workload_start_error(&workload_id, format!("{e:#}"))),
                 };
             let local_resources = match component.local_resources.clone() {
                 Some(lr) => match crate::types::LocalResources::try_from(lr) {
                     Ok(lr) => lr,
                     Err(e) => {
-                        return Ok(types::v2::WorkloadStartResponse {
-                            workload_status: Some(types::v2::WorkloadStatus {
-                                workload_id: workload_id.clone(),
-                                workload_state: types::v2::WorkloadState::Error.into(),
-                                message: format!(
-                                    "invalid local_resources for component {}: {e:#}",
-                                    component.name
-                                ),
-                            }),
-                        });
+                        return Ok(workload_start_error(
+                            &workload_id,
+                            format!(
+                                "invalid local_resources for component {}: {e:#}",
+                                component.name
+                            ),
+                        ));
                     }
                 },
                 None => crate::types::LocalResources::default(),
@@ -542,27 +551,16 @@ async fn workload_start(
             .context("failed to pull image for the workload service")
         {
             Ok(loaded) => loaded,
-            Err(e) => {
-                return Ok(types::v2::WorkloadStartResponse {
-                    workload_status: Some(types::v2::WorkloadStatus {
-                        workload_id: workload_id.clone(),
-                        workload_state: types::v2::WorkloadState::Error.into(),
-                        message: format!("{e:#}"),
-                    }),
-                });
-            }
+            Err(e) => return Ok(workload_start_error(&workload_id, format!("{e:#}"))),
         };
         let local_resources = match service.local_resources.clone() {
             Some(lr) => match crate::types::LocalResources::try_from(lr) {
                 Ok(lr) => lr,
                 Err(e) => {
-                    return Ok(types::v2::WorkloadStartResponse {
-                        workload_status: Some(types::v2::WorkloadStatus {
-                            workload_id: workload_id.clone(),
-                            workload_state: types::v2::WorkloadState::Error.into(),
-                            message: format!("invalid local_resources for service: {e:#}"),
-                        }),
-                    });
+                    return Ok(workload_start_error(
+                        &workload_id,
+                        format!("invalid local_resources for service: {e:#}"),
+                    ));
                 }
             },
             None => crate::types::LocalResources::default(),

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -417,18 +417,18 @@ impl CliCommand for HostCommand {
         .context("failed to connect to NATS")?;
         let data_nats_client = Arc::new(data_nats_client);
 
-        // Parse the CA bundles before anything pulls, and fail if any is
-        // invalid.
-        if !self.oci_ca_paths.is_empty() {
-            wash_runtime::oci::set_extra_ca_certificates(&self.oci_ca_paths)
-                .context("failed to load --oci-ca-path CA certificates")?;
-        }
-
         let host_config = wash_runtime::host::HostConfig {
             allow_oci_insecure: self.allow_insecure_registries,
             oci_pull_timeout: Some(self.registry_pull_timeout),
             oci_cache_dir: self.oci_cache_dir.clone(),
+            oci_ca_paths: self.oci_ca_paths.clone(),
         };
+
+        // The host applies these itself when it is built, but host component
+        // plugins are pulled before that. Install them here too — the same
+        // bundles a second time are a no-op — and fail now if any is invalid.
+        wash_runtime::oci::set_extra_ca_certificates(&host_config.oci_ca_paths)
+            .context("failed to load --oci-ca-path CA certificates")?;
 
         let mut engine_builder = Engine::builder()
             .with_pooling_allocator(true)

--- a/crates/wash/src/cli/oci.rs
+++ b/crates/wash/src/cli/oci.rs
@@ -44,10 +44,8 @@ impl RegistryArgs {
         // at startup. Fails rather than falling back to the public roots, which
         // would surface as a verification error against the registry the
         // bundle was meant to cover.
-        if !self.ca_paths.is_empty() {
-            wash_runtime::oci::set_extra_ca_certificates(&self.ca_paths)
-                .context("failed to load --ca-path CA certificates")?;
-        }
+        wash_runtime::oci::set_extra_ca_certificates(&self.ca_paths)
+            .context("failed to load --ca-path CA certificates")?;
 
         let mut oci_config = OciConfig::new_with_cache(ctx.cache_dir().join(OCI_CACHE_DIR));
         oci_config.insecure = self.insecure;


### PR DESCRIPTION
Three fixes for host embedders.

Closes #5477

### `SocketPolicy::default()`

`egress_addrs` defaulted to `EgressAddressPolicy::permissive()`, while `wash host start` with no socket flags builds `deny_special: true, allow_private: true`. An embedder that installed no policy with the `Engine::builder()` without `with_socket_policy` ran with range filtering off. The default is now EgressAddressPolicy::default().

### oci_ca_paths on HostConfig (#5477)

Extra CA trust was the only OCI setting an embedder could not see while constructing HostConfig.

### Workload-start failures are logged (#5477, "Related")

A failed start was returned as WorkloadState::Error with a message and not logged.
