### PR TITLE
fix(wash-runtime): don't panic or poison the instance pool under concurrent load

### DIFF
--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -362,7 +362,7 @@ impl InstanceDriver {
     /// gone. A plain compare-and-swap rather than a semaphore: admission has to
     /// be non-blocking so a saturated instance falls through to the next one
     /// instead of making the caller wait.
-    fn try_admit(&self) -> Option<InFlightGuard> {
+    pub(crate) fn try_admit(&self) -> Option<InFlightGuard> {
         if self.is_retired() || self.is_gone() {
             return None;
         }
@@ -410,7 +410,7 @@ impl InstanceDriver {
     /// receiver stands in for the run loop: kept alive so the channel is open,
     /// never drained.
     #[cfg(test)]
-    fn stub(
+    pub(crate) fn stub(
         max_concurrency: usize,
         max_invocations: Option<usize>,
     ) -> (

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -45,7 +45,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use wasmtime::component::Instance;
 
@@ -220,6 +220,29 @@ impl InstancePool {
         }
     }
 
+    /// Lock the driver list, recovering it if a panic poisoned the lock.
+    ///
+    /// Treating a poisoned lock as "no pool" would disable pooling for the
+    /// rest of the workload's life: every later lock would fail, and every
+    /// call would quietly fall through to the cold path — still serving 200s,
+    /// at unpooled throughput, with nothing surfaced to the operator. An
+    /// unwind cannot leave the list logically inconsistent — a panicking sort
+    /// still leaves a valid permutation, and the other critical sections only
+    /// push, retain or take the `Vec` — so the state is safe to keep using:
+    /// clear the poison and keep serving warm instances.
+    fn lock_drivers(&self) -> MutexGuard<'_, Vec<Arc<InstanceDriver>>> {
+        match self.drivers.lock() {
+            Ok(drivers) => drivers,
+            Err(poisoned) => {
+                self.drivers.clear_poison();
+                tracing::warn!(
+                    "a panic poisoned the instance pool's lock; recovering the warm pool"
+                );
+                poisoned.into_inner()
+            }
+        }
+    }
+
     /// Guest calls this component may have in flight at once. See
     /// [`InstancePolicy::call_concurrency`].
     pub(crate) fn call_concurrency(&self) -> usize {
@@ -253,9 +276,7 @@ impl InstancePool {
         let Some((pool_size, _, _)) = self.limits() else {
             return Dispatch::Saturated(job);
         };
-        let Ok(mut drivers) = self.drivers.lock() else {
-            return Dispatch::Saturated(job);
-        };
+        let mut drivers = self.lock_drivers();
 
         // Reap instances that have drained or whose store faulted, so a
         // retired one frees its place in the pool.
@@ -265,7 +286,7 @@ impl InstancePool {
         // a trap takes down as little as possible. Sorted in place, since the
         // pool's order carries no meaning and leaving it sorted is what keeps
         // the next offer's sort near-linear.
-        drivers.sort_by_key(|d| d.in_flight());
+        sort_least_busy(&mut drivers);
 
         let mut job = job;
         for driver in drivers.iter() {
@@ -293,9 +314,7 @@ impl InstancePool {
         let Some((pool_size, max_invocations, max_concurrency)) = self.limits() else {
             return Err(job);
         };
-        let Ok(mut drivers) = self.drivers.lock() else {
-            return Err(job);
-        };
+        let mut drivers = self.lock_drivers();
         if drivers.len() >= pool_size {
             drop(drivers);
             return match self.offer(job) {
@@ -323,15 +342,33 @@ impl InstancePool {
     /// run loop. This does not wait for a drain: calls still in flight on
     /// those instances end with the store they were running on.
     pub(crate) fn clear(&self) {
-        if let Ok(mut drivers) = self.drivers.lock() {
-            drop(std::mem::take(&mut *drivers));
-        }
+        let mut drivers = self.lock_drivers();
+        drop(std::mem::take(&mut *drivers));
     }
+}
+
+/// Order drivers least-busy first, comparing a snapshot of each driver's
+/// in-flight count rather than the live counter.
+///
+/// Calls start and finish on other threads throughout the sort, so a
+/// comparator that re-read [`InstanceDriver::in_flight`] per comparison can
+/// observe the same driver under different keys within one pass. That violates
+/// the strict weak ordering the sort requires, which Rust's sort detects by
+/// panicking ("user-provided comparison function does not correctly implement
+/// a total order") — and the unwind then poisons the pool's lock.
+/// `sort_by_cached_key` computes every key exactly once, up front, so the
+/// ordering it compares cannot shift mid-sort.
+fn sort_least_busy(drivers: &mut [Arc<InstanceDriver>]) {
+    drivers.sort_by_cached_key(|d| d.in_flight());
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{InstancePolicy, NonZeroUsize};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::{InstancePolicy, InstancePool, NonZeroUsize, sort_least_busy};
+    use crate::engine::instance_driver::InstanceDriver;
 
     /// Zero, and the `-1` that `wash dev` and the operator send for "not
     /// configured", both mean instances are not kept.
@@ -373,6 +410,97 @@ mod tests {
                 max_invocations: NonZeroUsize::new(50),
                 max_concurrency: NonZeroUsize::MIN,
             }
+        );
+    }
+
+    /// Ordering the pool least-busy first must tolerate in-flight counts
+    /// moving under it: calls start and finish on other threads for the whole
+    /// time `offer` sorts. When the comparator re-read the live counter per
+    /// comparison, that churn made the ordering inconsistent within a single
+    /// pass, and Rust's sort raised "user-provided comparison function does
+    /// not correctly implement a total order" — poisoning the pool's lock and
+    /// silently disabling pooling. The keys are snapshotted now; this drives
+    /// the old race, which panicked here before the fix.
+    #[test]
+    fn sorting_survives_concurrent_in_flight_churn() {
+        let mut drivers = Vec::new();
+        let mut channels = Vec::new();
+        for _ in 0..32 {
+            let (driver, rx) = InstanceDriver::stub(64, None);
+            drivers.push(Arc::new(driver));
+            // Keep the receivers so the drivers stay live for the whole test.
+            channels.push(rx);
+        }
+
+        // Ends the churn threads however the sorting ends: a panicking sort
+        // must fail the test, not leave the threads spinning on a flag the
+        // unwound closure can no longer set.
+        struct StopOnDrop<'a>(&'a AtomicBool);
+        impl Drop for StopOnDrop<'_> {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Relaxed);
+            }
+        }
+
+        let stop = AtomicBool::new(false);
+        std::thread::scope(|scope| {
+            let stop = &stop;
+            for chunk in drivers.chunks(8) {
+                scope.spawn(move || {
+                    let mut guards = Vec::new();
+                    while !stop.load(Ordering::Relaxed) {
+                        for driver in chunk {
+                            guards.extend(driver.try_admit());
+                        }
+                        guards.clear();
+                    }
+                });
+            }
+
+            let _stop = StopOnDrop(stop);
+            let mut pool: Vec<_> = drivers.iter().map(Arc::clone).collect();
+            for _ in 0..50_000 {
+                sort_least_busy(&mut pool);
+            }
+        });
+    }
+
+    /// A panic while the pool's lock is held must not disable pooling. It
+    /// used to: the poisoned lock made every later offer and install fall
+    /// through to the cold path — still serving 200s, at unpooled throughput,
+    /// until the workload was restarted.
+    #[test]
+    fn a_panic_under_the_lock_does_not_disable_the_pool() {
+        let pool = InstancePool::new(InstancePolicy::from_limits(4, 0, 0));
+
+        // Panic while holding the lock, as the key-rereading sort in `offer`
+        // did. The hook is silenced so the intended panic does not land in
+        // the test output as a failure's would.
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _drivers = pool.drivers.lock().expect("lock is not yet poisoned");
+            panic!("simulated panic while holding the pool's lock");
+        }));
+        std::panic::set_hook(hook);
+        assert!(
+            pool.drivers.is_poisoned(),
+            "the panic must have poisoned the lock for this test to mean anything"
+        );
+
+        // The pool must recover the lock and keep working, not fall through
+        // to the cold path forever.
+        let (driver, _rx) = InstanceDriver::stub(1, None);
+        pool.lock_drivers().push(Arc::new(driver));
+        assert_eq!(
+            pool.lock_drivers().len(),
+            1,
+            "a recovered pool must still hold and serve its warm instances"
+        );
+        pool.clear();
+        assert!(
+            pool.lock_drivers().is_empty(),
+            "a recovered pool must still clear"
         );
     }
 }


### PR DESCRIPTION
Fixes #5487.

## What was happening

`InstancePool::offer` picks the least-busy warm instance by sorting the driver list:

```rust
drivers.sort_by_key(|d| d.in_flight());
```

`in_flight()` reads a live `AtomicUsize` that driver tasks on other threads increment on admission and decrement as calls finish. `sort_by_key` re-reads the key on every comparison, so under concurrent load the same driver can be observed under different keys within a single sort pass. That violates the strict weak ordering the sort requires, and Rust's driftsort/ipnsort detects it and panics with exactly the message in the report:

```
user-provided comparison function does not correctly implement a total order
  at library/core/src/slice/sort/shared/smallsort.rs:854
```

The panic unwinds while `offer` holds `self.drivers.lock()`, poisoning the `std::sync::Mutex`. Both `offer` and `install` treated a poisoned lock as "no pool" (`let Ok(...) else { fall through to the cold path }`), so from that point on every request was served by a fresh one-shot store: still 200s, at unpooled throughput, with nothing surfaced, until the workload was restarted. That is the "pooling silently disengages" half of the report.

## The fix

1. **Snapshot the sort keys** — `sort_by_cached_key` computes each driver's `in_flight` exactly once, up front, so the ordering being compared cannot shift mid-sort. The sort is factored into `sort_least_busy` with a comment explaining the constraint.
2. **Recover a poisoned pool lock** — defense in depth for any future panic under the lock. A panicking sort still leaves a valid permutation, and the other critical sections only push/retain/take the `Vec`, so an unwind cannot leave the list logically inconsistent. `lock_drivers()` clears the poison, logs a warning, and keeps serving warm instances instead of silently disabling pooling for the rest of the workload's life.

## Tests

- `sorting_survives_concurrent_in_flight_churn` — 32 stub drivers, 4 threads churning admissions while the pool sorts 50,000 times. Against the old `sort_by_key` this reproduces the reporter's panic in ~40ms; with the fix it always passes.
- `a_panic_under_the_lock_does_not_disable_the_pool` — poisons the lock the way the panicking sort did and asserts the pool keeps holding, serving, and clearing warm instances.

Also audited the rest of `wash-runtime` for sorts keyed on shared-mutable state; this was the only one (all others key on owned strings or immutable values).

## Verification

- `cargo test -p wash-runtime --features wasi-tls,host-component-plugins` — green
- `cargo clippy --workspace --features wasi-tls,host-component-plugins` — clean
- `cargo +nightly fmt -- --check` — clean
- anyhow context-casing grep — clean