### PR TITLE
(bugfix) rollback partially-bound plugins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-target/
+**/target/

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -2253,6 +2253,24 @@ impl UnresolvedWorkload {
                         err = ?e,
                         "failed to bind plugin to workload"
                     );
+                    // The plugin that just failed goes first: a bind can get
+                    // partway through before it errors, and wasmcloud:nats for
+                    // one has a live connection registered by then. Nothing
+                    // else ever unbinds it, so the connection outlives the
+                    // failed deploy and wedges the next one under the same id.
+                    if let Err(cleanup_err) = p
+                        .on_workload_unbind(
+                            self.id(),
+                            WitInterfaces::new(&plugin_matched_interfaces),
+                        )
+                        .await
+                    {
+                        warn!(
+                            plugin_id = plugin_id,
+                            error = ?cleanup_err,
+                            "failed to cleanup partially bound plugin after bind failure"
+                        );
+                    }
                     // Clean up all previously bound plugins in reverse order
                     for (bound_plugin, bound_interfaces, _) in
                         bound_plugins_with_interfaces.iter().rev()
@@ -2319,6 +2337,24 @@ impl UnresolvedWorkload {
                             err = ?e,
                             "failed to bind workload item to plugin"
                         );
+                        // This plugin's own on_workload_bind succeeded, so it
+                        // holds state nobody else will release — it is not in
+                        // `bound_plugins_with_interfaces` until every one of
+                        // its items binds. Unbind it before the plugins that
+                        // completed.
+                        if let Err(cleanup_err) = p
+                            .on_workload_unbind(
+                                self.id(),
+                                WitInterfaces::new(&plugin_matched_interfaces),
+                            )
+                            .await
+                        {
+                            warn!(
+                                plugin_id = plugin_id,
+                                error = ?cleanup_err,
+                                "failed to cleanup partially bound plugin after item bind failure"
+                            );
+                        }
                         // Clean up all previously bound plugins in reverse order
                         for (bound_plugin, bound_interfaces, _) in
                             bound_plugins_with_interfaces.iter().rev()
@@ -2490,9 +2526,21 @@ impl UnresolvedWorkload {
             .keys()
             .cloned()
             .collect();
-        resolved_workload
+        if let Err(e) = resolved_workload
             .resolve_component_volume_mounts(&all_component_ids)
-            .await?;
+            .await
+        {
+            // Same rollback as the linking failure above: plugins are already
+            // bound at this point, so a bad hostPath would otherwise leave
+            // their state — a live NATS connection among it — registered
+            // against a workload that never deploys.
+            warn!(
+                error = ?e,
+                "failed to resolve component volume mounts, unbinding all plugins"
+            );
+            let _ = resolved_workload.unbind_all_plugins().await;
+            bail!(e);
+        }
 
         // Notify plugins of the resolved workload
         for (plugin, component_ids) in bound_plugins.iter() {
@@ -3118,6 +3166,159 @@ mod tests {
         assert!(
             bound_component_ids(&bound).contains(&importer_id),
             "an ambiguous sibling export is not a provider, so the plugin keeps the import"
+        );
+    }
+
+    /// Which half of the bind a [`RollbackPlugin`] refuses.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum FailAt {
+        WorkloadBind,
+        ItemBind,
+    }
+
+    /// A plugin that counts its own `on_workload_unbind` and can refuse either
+    /// half of the bind. Whatever a real plugin opened on the way in — for
+    /// wasmcloud:nats, a live connection registered under the workload id — is
+    /// released through that callback and nowhere else, so the count is what
+    /// says whether a failure rolled itself back.
+    struct RollbackPlugin {
+        fail_at: Option<FailAt>,
+        unbinds: Arc<AtomicUsize>,
+    }
+
+    impl RollbackPlugin {
+        fn new(fail_at: Option<FailAt>) -> Self {
+            Self {
+                fail_at,
+                unbinds: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn unbind_count(&self) -> usize {
+            self.unbinds.load(Ordering::SeqCst)
+        }
+
+        fn registered(self: &Arc<Self>) -> HashMap<&'static str, Arc<dyn HostPlugin>> {
+            HashMap::from([(self.id(), self.clone() as Arc<dyn HostPlugin>)])
+        }
+    }
+
+    #[async_trait]
+    impl HostPlugin for RollbackPlugin {
+        fn id(&self) -> &'static str {
+            "rollback-plugin"
+        }
+
+        fn world(&self) -> WitWorld {
+            WitWorld {
+                imports: HashSet::new(),
+                exports: HashSet::from([WitInterface::from(MARKER)]),
+            }
+        }
+
+        async fn on_workload_bind(
+            &self,
+            _workload: &UnresolvedWorkload,
+            _interfaces: WitInterfaces<'_>,
+        ) -> anyhow::Result<()> {
+            match self.fail_at {
+                Some(FailAt::WorkloadBind) => bail!("refusing the workload bind"),
+                _ => Ok(()),
+            }
+        }
+
+        async fn on_workload_item_bind<'a>(
+            &self,
+            _item: &mut WorkloadItem<'a>,
+            _interfaces: WitInterfaces<'_>,
+        ) -> anyhow::Result<()> {
+            match self.fail_at {
+                Some(FailAt::ItemBind) => bail!("refusing the item bind"),
+                _ => Ok(()),
+            }
+        }
+
+        async fn on_workload_unbind(
+            &self,
+            _workload_id: &str,
+            _interfaces: WitInterfaces<'_>,
+        ) -> anyhow::Result<()> {
+            self.unbinds.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// A bind can get partway through before it errors, and the plugin that
+    /// failed is in no rollback list — it is added only once every one of its
+    /// items is bound. So the failure path unbinds it itself, or a connection
+    /// opened on the way in outlives the deploy that never happened.
+    #[tokio::test]
+    async fn a_failed_workload_bind_rolls_itself_back() {
+        let plugin = Arc::new(RollbackPlugin::new(Some(FailAt::WorkloadBind)));
+        let mut workload = marker_workload(vec![marker_importer("importer")]);
+
+        assert!(
+            workload.bind_plugins(&plugin.registered()).await.is_err(),
+            "the plugin refused its bind"
+        );
+
+        assert_eq!(
+            plugin.unbind_count(),
+            1,
+            "the plugin that failed its bind must be unbound exactly once"
+        );
+    }
+
+    /// The item bind is worse still: `on_workload_bind` already succeeded, so
+    /// the plugin is certainly holding state by the time an item is refused.
+    #[tokio::test]
+    async fn a_failed_item_bind_rolls_itself_back() {
+        let plugin = Arc::new(RollbackPlugin::new(Some(FailAt::ItemBind)));
+        let mut workload = marker_workload(vec![marker_importer("importer")]);
+
+        assert!(
+            workload.bind_plugins(&plugin.registered()).await.is_err(),
+            "the plugin refused its item bind"
+        );
+
+        assert_eq!(
+            plugin.unbind_count(),
+            1,
+            "the plugin that failed its item bind must be unbound exactly once"
+        );
+    }
+
+    /// Every step of `resolve` after the plugins are bound owes them a
+    /// rollback, volume-mount canonicalization included: a hostPath that does
+    /// not exist is a deploy-time failure like any other, and the plugins it
+    /// leaves behind keep tracking a workload that never runs.
+    #[tokio::test]
+    async fn a_bad_volume_mount_unbinds_the_plugins() {
+        let mut importer = marker_importer("importer");
+        importer.metadata.volume_mounts = vec![(
+            PathBuf::from("/definitely/not/a/directory/on/this/host"),
+            VolumeMount {
+                name: "data".to_string(),
+                mount_path: "/data".to_string(),
+                read_only: true,
+            },
+        )];
+
+        let plugin = Arc::new(RollbackPlugin::new(None));
+        let workload = marker_workload(vec![importer]);
+
+        workload
+            .resolve(
+                Some(&plugin.registered()),
+                Arc::new(crate::host::http::NullServer::default()),
+            )
+            .await
+            .expect_err("the volume mount cannot be canonicalized");
+
+        assert_eq!(
+            plugin.unbind_count(),
+            1,
+            "a plugin bound before the failing step must be unbound"
         );
     }
 

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -2253,11 +2253,7 @@ impl UnresolvedWorkload {
                         err = ?e,
                         "failed to bind plugin to workload"
                     );
-                    // The plugin that just failed goes first: a bind can get
-                    // partway through before it errors, and wasmcloud:nats for
-                    // one has a live connection registered by then. Nothing
-                    // else ever unbinds it, so the connection outlives the
-                    // failed deploy and wedges the next one under the same id.
+                    // Clean up plugin that just failed first.
                     if let Err(cleanup_err) = p
                         .on_workload_unbind(
                             self.id(),
@@ -2337,11 +2333,8 @@ impl UnresolvedWorkload {
                             err = ?e,
                             "failed to bind workload item to plugin"
                         );
-                        // This plugin's own on_workload_bind succeeded, so it
-                        // holds state nobody else will release — it is not in
-                        // `bound_plugins_with_interfaces` until every one of
-                        // its items binds. Unbind it before the plugins that
-                        // completed.
+                        // This plugin's own on_workload_bind succeeded, so it can hold a state until unbind.
+                        // Go ahead and unbind immediately before the completed plugins.
                         if let Err(cleanup_err) = p
                             .on_workload_unbind(
                                 self.id(),
@@ -3176,11 +3169,8 @@ mod tests {
         ItemBind,
     }
 
-    /// A plugin that counts its own `on_workload_unbind` and can refuse either
-    /// half of the bind. Whatever a real plugin opened on the way in — for
-    /// wasmcloud:nats, a live connection registered under the workload id — is
-    /// released through that callback and nowhere else, so the count is what
-    /// says whether a failure rolled itself back.
+    /// A plugin that counts its own `on_workload_unbind` and can refuse either half of the bind. Whatever
+    /// a real plugin opened on the way in is released through that callback, so the count is what says whether a failure rolled itself back.
     struct RollbackPlugin {
         fail_at: Option<FailAt>,
         unbinds: Arc<AtomicUsize>,

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -329,6 +329,14 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
     /// the workload. This can be called during binding failures (before resolution)
     /// or during normal workload shutdown (after resolution).
     ///
+    /// Implementations must be idempotent, and must tolerate a workload they
+    /// never finished binding: a failed [`HostPlugin::on_workload_bind`] or
+    /// [`HostPlugin::on_workload_item_bind`] is rolled back by unbinding the
+    /// plugin that failed, so this runs over whatever half of the bind managed
+    /// to execute — and it may run again when the workload stops. Release what
+    /// is there and treat what is not as already released, rather than
+    /// erroring.
+    ///
     /// The default implementation does nothing.
     ///
     /// # Arguments


### PR DESCRIPTION
While working on a nats host plugin one issues found, and one minor docker change:

1. A plugin is appended to the rollback list only once every one of its items has bound, so the plugin whose `on_workload_bind` or `on_workload_item_bind` actually failed is in no list and nothing ever unbinds it. This means that a connection, task etc. can outlive a workload that never started since nothing cleans it up. `resolve_component_volume_mounts` also runs after plugins are bound, so if there is a bad `hostPath`, this would result in the same scenario.
- Fix: failed plugins are now unbounded and cleaned up before the rolling back of completed plugins.

2. Adds `**/target/` to the .dockerignore so that example and fixture build directories are not pulled into the container image (may not be an issue with CI/CD, but does have an impact with local development)

