### PR TITLE
Fix/abandoned call deregistration

### DIFF
--- a/crates/wash-runtime/src/engine/abandon.rs
+++ b/crates/wash-runtime/src/engine/abandon.rs
@@ -22,12 +22,21 @@
 //! and the guest has since run through a grace's worth of execution.
 //! Execution is credited from the callback's own fires (`ExecutionCredit`):
 //! each fire proves the guest was running and is worth at most one sampling
-//! window, and only a pause too long to be scheduler delay clears the credit
-//! — so a guest waiting in a host call accrues nothing, while a pinned one
-//! keeps accruing even when a loaded scheduler spreads its fires out.
+//! window, and only a pause too long to be scheduler delay clears the credit.
 //! Abandonment alone would not do: dropping the dispatcher arms the flag, so
 //! an ordinary client disconnect would condemn a store whose guest is healthy
 //! and merely slow.
+//!
+//! Registration, not the sampling above, is what keeps a healthy guest out of
+//! this. Every ingress onto a store that outlives its call (a service
+//! singleton, a pooled instance, a plugin) runs it through
+//! [`watch_until_abandoned`], which deregisters the call once it has been
+//! abandoned for the grace and the guest has yielded. A new ingress onto such a
+//! store must go through it, or a merely slow guest there will be trapped.
+//!
+//! A store built to serve one call and be discarded (a cold one-shot HTTP
+//! store, an ephemeral linked call, a per-message store) does not need it:
+//! trapping it ends only the call that was already abandoned.
 //!
 //! The all-abandoned condition is what keeps the per-store blast radius safe:
 //! inside one sampling window a burst-then-await guest (frames, tokens, short
@@ -61,18 +70,51 @@ fn now_millis() -> u64 {
 /// When a call's dispatcher stopped wanting its result, or nothing if it still
 /// does. Minted only by [`DispatchedCall`], which is what makes a job type's
 /// `abandoned` field proof that its dispatcher actually enforces a deadline.
-pub struct AbandonFlag(AtomicU64);
+pub struct AbandonFlag {
+    armed_at: AtomicU64,
+    /// Wakes [`Self::abandoned_for`] when arming happens.
+    armed: tokio::sync::Notify,
+}
 
 impl AbandonFlag {
     fn new() -> Arc<Self> {
-        Arc::new(Self(AtomicU64::new(0)))
+        Arc::new(Self {
+            armed_at: AtomicU64::new(0),
+            armed: tokio::sync::Notify::new(),
+        })
     }
 
     /// Record the abandonment instant; only the first arming counts.
     pub(crate) fn arm(&self) {
-        let _ = self
-            .0
-            .compare_exchange(0, now_millis(), Ordering::Relaxed, Ordering::Relaxed);
+        if self
+            .armed_at
+            .compare_exchange(0, now_millis(), Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            self.armed.notify_waiters();
+        }
+    }
+
+    /// Resolves once this call has been abandoned for `grace`.
+    ///
+    /// Awaited from inside the store the call runs in, where it shares a task
+    /// with the guest call and so resolves only if the guest yields. See
+    /// [`watch_until_abandoned`].
+    async fn abandoned_for(&self, grace: Duration) {
+        loop {
+            // Registered before the check. `notify_waiters` stores no permit,
+            // so an arming in between would otherwise be missed.
+            let armed = self.armed.notified();
+            let Some(at) = self.armed_at() else {
+                armed.await;
+                continue;
+            };
+            let elapsed = Duration::from_millis(now_millis().saturating_sub(at));
+            if let Some(left) = grace.checked_sub(elapsed) {
+                tokio::time::sleep(left).await;
+            }
+            return;
+        }
     }
 
     /// Arm this flag when `deadline` elapses. For re-bounding a call that
@@ -93,7 +135,7 @@ impl AbandonFlag {
     }
 
     fn armed_at(&self) -> Option<u64> {
-        match self.0.load(Ordering::Relaxed) {
+        match self.armed_at.load(Ordering::Relaxed) {
             0 => None,
             at => Some(at),
         }
@@ -102,6 +144,44 @@ impl AbandonFlag {
 
 /// Cancels a pending [`AbandonFlag::arm_after`] timer when dropped.
 pub(crate) struct ArmTimer(#[expect(dead_code)] tokio_util::task::AbortOnDropHandle<()>);
+
+/// Run `call`, keeping it registered on its store's [`AbandonedCalls`] only
+/// while the epoch callback could usefully act on it.
+///
+/// The call is deregistered once it has been abandoned for `grace` and the
+/// guest has yielded. The grace timer shares a task with the guest call, so a
+/// guest awaiting anything lets it run and a guest pinned in compiled code
+/// cannot: reaching the timer is itself proof the guest is not wedged.
+///
+/// The call keeps running either way, and its result is still delivered. A
+/// `wasmcloud:host/workload-lifecycle` bind is uncancellable, and the host
+/// defers a rollback unbind until it completes so that whatever it provisioned
+/// late is still reclaimed.
+///
+/// A guest that yields once after being abandoned and only then starts spinning
+/// is no longer visible here, the same blind spot as a guest that spins after
+/// delivering its response.
+pub(crate) async fn watch_until_abandoned<F: Future>(
+    calls: &Arc<AbandonedCalls>,
+    flag: Arc<AbandonFlag>,
+    call: F,
+) -> F::Output {
+    let grace = crate::timeouts::abandoned_call_grace();
+    let mut registration = Some(calls.watch(Arc::clone(&flag)));
+    let mut call = std::pin::pin!(call);
+    let deregister = flag.abandoned_for(grace);
+    let mut deregister = std::pin::pin!(deregister);
+    loop {
+        tokio::select! {
+            output = &mut call => return output,
+            // Disabled once it has fired; a completed future must not be
+            // polled again.
+            () = &mut deregister, if registration.is_some() => {
+                registration = None;
+            }
+        }
+    }
+}
 
 /// The in-flight calls on one store, so the store's epoch callback can see
 /// which of them have been abandoned. One per store, on [`SharedCtx`].
@@ -119,35 +199,51 @@ impl AbandonedCalls {
         }
     }
 
-    /// Whether any watched call has been abandoned for longer than `grace`.
-    fn any_abandoned_longer_than(&self, grace: Duration) -> bool {
+    /// What the epoch callback needs to know about this store's calls.
+    ///
+    /// Answers every question under one lock, so the callback always acts on a
+    /// state that held at a single instant. Reading them separately lets a call
+    /// deregister in between, which can leave an empty list looking like
+    /// "everything is abandoned" and trap a store with nothing outstanding.
+    fn survey(&self, grace: Duration) -> CallSurvey {
         let list = self.lock();
+        let grace = u64::try_from(grace.as_millis()).unwrap_or(u64::MAX);
         // `now` is only worth computing once a flag is actually armed; the
         // common case (none are) stays free of clock reads.
         let mut now = None;
-        let grace = u64::try_from(grace.as_millis()).unwrap_or(u64::MAX);
-        list.iter().any(|f| match f.armed_at() {
-            None => false,
-            Some(at) => {
-                let now = *now.get_or_insert_with(now_millis);
-                now.saturating_sub(at) >= grace
-            }
-        })
-    }
-
-    /// Whether nothing watched is abandoned, which re-arms the warning.
-    fn none_abandoned(&self) -> bool {
-        self.lock().iter().all(|f| f.armed_at().is_none())
-    }
-
-    /// Whether every watched call has been abandoned, so trapping the store
-    /// would end nothing still wanted.
-    fn all_abandoned(&self) -> bool {
-        self.lock().iter().all(|f| f.armed_at().is_some())
+        let mut survey = CallSurvey {
+            watched: list.len(),
+            armed: 0,
+            any_past_grace: false,
+        };
+        for flag in list.iter() {
+            let Some(at) = flag.armed_at() else { continue };
+            survey.armed += 1;
+            let now = *now.get_or_insert_with(now_millis);
+            survey.any_past_grace |= now.saturating_sub(at) >= grace;
+        }
+        survey
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Vec<Arc<AbandonFlag>>> {
         self.0.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// One consistent look at a store's registered calls.
+#[derive(Clone, Copy)]
+struct CallSurvey {
+    watched: usize,
+    armed: usize,
+    /// Whether any armed call has been abandoned for longer than the grace.
+    any_past_grace: bool,
+}
+
+impl CallSurvey {
+    /// There is at least one registered call and every one of them is
+    /// abandoned, so trapping the store would end nothing still wanted.
+    fn all_abandoned(self) -> bool {
+        self.watched > 0 && self.armed == self.watched
     }
 }
 
@@ -157,12 +253,17 @@ impl AbandonedCalls {
 /// The callback runs only while guest code does, so each fire proves the
 /// guest was executing at that instant — and is worth at most one sampling
 /// window ([`EXECUTION_WINDOW_MS`]) of credit, however wide the gap before it.
-/// The per-fire cap is what keeps both failure directions out: a brief await
-/// between fires donates one window rather than its whole off-CPU length, and
-/// a pinned guest whose fires land late under scheduler load keeps
-/// accumulating instead of having its record wiped by the delay. Only a gap
-/// no scheduler could plausibly cause ([`RESET_THRESHOLD_MS`]) proves a real
-/// pause and clears the credit.
+/// The per-fire cap keeps a long await from donating its whole off-CPU length,
+/// and crediting the gap rather than resetting on it keeps a pinned guest whose
+/// fires land late under scheduler load accumulating instead of having its
+/// record wiped. Only a gap no scheduler could plausibly cause
+/// ([`reset_threshold_millis`]) proves a real pause and clears the credit.
+///
+/// This is not a measure of CPU. A gap under one window is credited whole, and
+/// the gap between fires never falls below one window however idle the store
+/// is, so a guest awaiting in sub-window hops banks credit as fast as a pinned
+/// one. [`watch_until_abandoned`] is what separates the two; this is only a
+/// backstop for a call still registered after it.
 ///
 /// Measured here rather than from the host side because the callback forces a
 /// yield on every fire, which would refresh any host-side liveness signal and
@@ -179,7 +280,7 @@ impl ExecutionCredit {
     /// milliseconds.
     fn observe(&mut self, now: u64) -> u64 {
         let gap = self.last_fire.map_or(0, |last| now.saturating_sub(last));
-        if gap > RESET_THRESHOLD_MS {
+        if gap > reset_threshold_millis() {
             self.credited_millis = 0;
         } else {
             self.credited_millis = self
@@ -204,9 +305,12 @@ const EXECUTION_WINDOW_MS: u64 =
 
 /// A gap between fires that only a real pause can explain — the guest waiting
 /// on host I/O measured in seconds, or going idle — never scheduler delay or
-/// a brief await. A fixed order-of-seconds invariant on purpose, not derived
-/// from the window: it models what schedulers do, not how often we sample.
-const RESET_THRESHOLD_MS: u64 = 3_000;
+/// a brief await. Not derived from the window: it models what schedulers do,
+/// not how often we sample, which is why it is tunable on its own
+/// ([`crate::timeouts::abandoned_call_pause_threshold`]).
+fn reset_threshold_millis() -> u64 {
+    u64::try_from(crate::timeouts::abandoned_call_pause_threshold().as_millis()).unwrap_or(u64::MAX)
+}
 
 /// Stops watching a call's flag when dropped, so a completed call leaves
 /// nothing behind — and so an abandoned flag whose call has ended is invisible
@@ -420,7 +524,8 @@ pub(crate) fn arm_epoch_deadline(
     let grace_millis = u64::try_from(grace.as_millis()).unwrap_or(u64::MAX);
     let escalation_millis = u64::try_from(escalation.as_millis()).unwrap_or(u64::MAX);
     let mut credit = ExecutionCredit::default();
-    // Reset below once nothing is abandoned, so a later wedge warns again.
+    // Reset below whenever the warned-about condition stops holding, so every
+    // episode is logged.
     let mut warned = false;
 
     store.set_epoch_deadline(EPOCH_DEADLINE_TICKS);
@@ -434,9 +539,11 @@ pub(crate) fn arm_epoch_deadline(
         // tokio's time driver, *no timer on the runtime fires*, including the
         // very deadline whose expiry would abandon this call.
         let keep_running = |warned: &mut bool, credit: &mut ExecutionCredit| {
-            if abandoned.none_abandoned() {
-                *warned = false;
-            }
+            // Every path through here means the warned-about condition no
+            // longer holds, so the next episode warns again. Waiting for zero
+            // armed calls instead would rarely fire on a busy plugin store,
+            // where every dispatcher drop arms one.
+            *warned = false;
             // Execution only counts against a store the host wants back:
             // otherwise a service's own background wakes (a run loop ticking
             // faster than the reset threshold) would bank credit for the
@@ -446,13 +553,16 @@ pub(crate) fn arm_epoch_deadline(
             Ok(wasmtime::UpdateDeadline::Yield(EPOCH_DEADLINE_TICKS))
         };
 
-        if !abandoned.any_abandoned_longer_than(grace) {
+        // The conditions below must all hold at the same instant to justify
+        // trapping, so read them once.
+        let survey = abandoned.survey(grace);
+        if !survey.any_past_grace {
             return keep_running(&mut warned, &mut credit);
         }
         // A call is still wanted: trapping the store would take it too — and
         // this is what keeps a yielding guest's store alive however its wakes
         // land relative to the sampling window.
-        if !abandoned.all_abandoned() {
+        if !survey.all_abandoned() {
             return keep_running(&mut warned, &mut credit);
         }
         // Wanted back, but the guest has not yet run through a grace's worth
@@ -496,11 +606,11 @@ mod tests {
         // Keep `call` alive: dropping it would arm the flag itself.
         let guard = calls.watch(Arc::clone(&flag));
 
-        assert!(!calls.any_abandoned_longer_than(Duration::ZERO));
+        assert!(!calls.survey(Duration::ZERO).any_past_grace);
         flag.arm();
-        assert!(calls.any_abandoned_longer_than(Duration::ZERO));
+        assert!(calls.survey(Duration::ZERO).any_past_grace);
         drop(guard);
-        assert!(!calls.any_abandoned_longer_than(Duration::ZERO));
+        assert!(!calls.survey(Duration::ZERO).any_past_grace);
     }
 
     #[test]
@@ -512,12 +622,12 @@ mod tests {
         let wanted_guard = calls.watch(wanted.flag());
 
         given_up.flag().arm();
-        assert!(calls.any_abandoned_longer_than(Duration::ZERO));
-        assert!(!calls.all_abandoned());
+        assert!(calls.survey(Duration::ZERO).any_past_grace);
+        assert!(!calls.survey(Duration::ZERO).all_abandoned());
         // The wanted call ends (or is abandoned in turn); nothing on the
         // store is wanted any more.
         drop(wanted_guard);
-        assert!(calls.all_abandoned());
+        assert!(calls.survey(Duration::ZERO).all_abandoned());
     }
 
     /// The grace holds the callback off a freshly abandoned call, and only the
@@ -530,10 +640,10 @@ mod tests {
         let _guard = calls.watch(Arc::clone(&flag));
 
         flag.arm();
-        assert!(!calls.any_abandoned_longer_than(Duration::from_secs(3600)));
+        assert!(!calls.survey(Duration::from_secs(3600)).any_past_grace);
         // Re-arming must not push the abandonment instant forward.
         flag.arm();
-        assert!(calls.any_abandoned_longer_than(Duration::ZERO));
+        assert!(calls.survey(Duration::ZERO).any_past_grace);
     }
 
     /// One fire proves at most one window of execution however wide the gap
@@ -552,12 +662,59 @@ mod tests {
         assert_eq!(c.observe(1_000 + W + 900), 2 * W);
         assert_eq!(c.observe(1_000 + W + 900 + W), 3 * W);
         // A gap past the reset threshold is a real pause: credit cleared.
-        let after_pause = 1_000 + W + 900 + W + RESET_THRESHOLD_MS + 1;
+        let after_pause = 1_000 + W + 900 + W + reset_threshold_millis() + 1;
         assert_eq!(c.observe(after_pause), 0);
         assert_eq!(c.observe(after_pause + W), W);
         // And the callback clears it whenever the store is not wanted back.
         c.reset();
         assert_eq!(c.observe(after_pause + 2 * W), W);
+    }
+
+    /// A call is deregistered a grace after being abandoned, but only because
+    /// the future measuring that grace got to run, which is the whole test.
+    #[tokio::test(start_paused = true)]
+    async fn a_yielding_call_is_deregistered_a_grace_after_abandonment() {
+        let calls = Arc::new(AbandonedCalls::default());
+        let call = DispatchedCall::new("test", Duration::from_secs(1));
+        let flag = call.flag();
+        let grace = crate::timeouts::abandoned_call_grace();
+
+        // A guest that yields: it awaits, so the deregistration timer runs.
+        let yielding = watch_until_abandoned(&calls, Arc::clone(&flag), async {
+            tokio::time::sleep(grace * 10).await;
+            7u32
+        });
+        let mut yielding = std::pin::pin!(yielding);
+
+        // Registered while the call is wanted, however long it runs.
+        tokio::time::timeout(grace * 2, &mut yielding)
+            .await
+            .unwrap_err();
+        assert_eq!(calls.survey(Duration::ZERO).watched, 1);
+
+        // Abandoned: still registered until the grace is out...
+        drop(call);
+        assert!(flag.armed_at().is_some());
+        tokio::time::timeout(grace / 2, &mut yielding)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            calls.survey(Duration::ZERO).watched,
+            1,
+            "deregistered before the grace was out"
+        );
+
+        // ...and gone once it is, with the call still running and still
+        // delivering its result afterwards.
+        tokio::time::timeout(grace, &mut yielding)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            calls.survey(Duration::ZERO).watched,
+            0,
+            "a yielding call must stop being visible to the epoch callback"
+        );
+        assert_eq!(yielding.await, 7, "the call must still run to completion");
     }
 
     /// `await_reply` disarms on delivery and arms on deadline or drop.

--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -156,12 +156,11 @@ impl AccessorTask<SharedCtx> for LinkedTask {
         } = *self.job;
         let instance = self.instance;
 
-        // Watch this call for the rest of its life. The guard deregisters on
-        // drop, however the call ends; the deadline is re-armed for it here.
-        let _abandoned = accessor.with(|mut access| {
+        // The epoch deadline measures this call's own execution, so re-arm it
+        // here. `watch_until_abandoned` below owns the registration.
+        let calls = accessor.with(|mut access| {
             crate::engine::abandon::rearm_for_call(&mut access);
-            let calls = Arc::clone(&access.get().abandoned);
-            calls.watch(abandoned)
+            Arc::clone(&access.get().abandoned)
         });
 
         let func = accessor.with(|mut access| {
@@ -179,9 +178,15 @@ impl AccessorTask<SharedCtx> for LinkedTask {
 
         let mut results = vec![Val::Bool(false); results_len];
         let call_timeout = crate::timeouts::ephemeral_call();
+        // This bound ends the caller's wait. Keeping a slow guest out of the
+        // epoch callback's reach is `watch_until_abandoned`'s job.
         let outcome = match tokio::time::timeout(
             call_timeout,
-            func.call_concurrent(accessor, &params, &mut results),
+            crate::engine::abandon::watch_until_abandoned(
+                &calls,
+                abandoned,
+                func.call_concurrent(accessor, &params, &mut results),
+            ),
         )
         .await
         {

--- a/crates/wash-runtime/src/host/trigger_service/capability.rs
+++ b/crates/wash-runtime/src/host/trigger_service/capability.rs
@@ -282,12 +282,11 @@ impl AccessorTask<SharedCtx> for CapabilityTask {
             abandoned,
         } = call;
 
-        // Watch this call for the rest of its life. The guard deregisters on
-        // drop, however the call ends; the deadline is re-armed for it here.
-        let _abandoned = accessor.with(|mut access| {
+        // The epoch deadline measures this call's own execution, so re-arm it
+        // here. `watch_until_abandoned` below owns the registration.
+        let calls = accessor.with(|mut access| {
             crate::engine::abandon::rearm_for_call(&mut access);
-            let calls = Arc::clone(&access.get().abandoned);
-            calls.watch(abandoned)
+            Arc::clone(&access.get().abandoned)
         });
 
         // Look up the export and inject the relocated arguments — in one discrete
@@ -333,7 +332,20 @@ impl AccessorTask<SharedCtx> for CapabilityTask {
             }
         };
         job_guard.set_task(task_id, caller);
-        let call_result = func_handle.finish_call_concurrent(accessor, call).await;
+        // Runs to completion however long it takes, because callers here need
+        // the result even after giving up. A `wasmcloud:host/workload-lifecycle`
+        // bind is uncancellable, and an over-budget one has its deploy failed
+        // while the host defers a rollback unbind until the hook completes, so
+        // ending the wait early would strand whatever it provisions
+        // (`test_bind_timeout_defers_rollback_unbind`). This bounds only how
+        // long the call stays visible to the epoch callback, whose trap would
+        // take the singleton every tenant shares.
+        let call_result = crate::engine::abandon::watch_until_abandoned(
+            &calls,
+            abandoned,
+            func_handle.finish_call_concurrent(accessor, call),
+        )
+        .await;
         if let Err(e) = call_result {
             let _ = reply.send(Err(
                 e.context(format!("capability call {interface}/{func} trapped"))

--- a/crates/wash-runtime/src/host/trigger_service/http.rs
+++ b/crates/wash-runtime/src/host/trigger_service/http.rs
@@ -82,12 +82,11 @@ impl AccessorTask<SharedCtx> for HttpTask {
             pool_slot,
         } = self;
 
-        // Watch this call for the rest of its life. The guard deregisters on
-        // drop, however the call ends; the deadline is re-armed for it here.
-        let _abandoned = accessor.with(|mut access| {
+        // The epoch deadline measures this call's own execution, so re-arm it
+        // here. `watch_until_abandoned` below owns the registration.
+        let calls = accessor.with(|mut access| {
             crate::engine::abandon::rearm_for_call(&mut access);
-            let calls = std::sync::Arc::clone(&access.get().abandoned);
-            calls.watch(abandoned)
+            std::sync::Arc::clone(&access.get().abandoned)
         });
 
         let (parts, body) = req.into_parts();
@@ -179,9 +178,17 @@ impl AccessorTask<SharedCtx> for HttpTask {
         // Bound the whole exchange so a stalled client (connected but not reading)
         // can't park this task on `frame_tx.send` for the life of the connection.
         // A response still streaming past this bound is truncated.
+        //
+        // That bound is far longer than the abandonment grace, so keeping a
+        // slow guest away from the epoch callback is `watch_until_abandoned`'s
+        // job, not this one's.
         match tokio::time::timeout(
             crate::timeouts::http_response(),
-            futures::future::join(handler_fut, io_fut),
+            crate::engine::abandon::watch_until_abandoned(
+                &calls,
+                abandoned,
+                futures::future::join(handler_fut, io_fut),
+            ),
         )
         .await
         {

--- a/crates/wash-runtime/src/host/trigger_service/messaging.rs
+++ b/crates/wash-runtime/src/host/trigger_service/messaging.rs
@@ -134,15 +134,14 @@ impl AccessorTask<SharedCtx> for MessagingTask {
             abandoned,
         } = self;
 
-        // Watch this call for the rest of its life. The guard deregisters on
-        // drop, however the call ends; the deadline is re-armed for it here.
-        let _abandoned = accessor.with(|mut access| {
+        // The epoch deadline measures this call's own execution, so re-arm it
+        // here. `watch_until_abandoned` below owns the registration.
+        let calls = accessor.with(|mut access| {
             crate::engine::abandon::rearm_for_call(&mut access);
-            let calls = Arc::clone(&access.get().abandoned);
-            calls.watch(abandoned)
+            Arc::clone(&access.get().abandoned)
         });
 
-        let outcome = async {
+        let deliver = async {
             // The `@0.3.0` body is a native `stream<u8>`; mint one carrying the
             // delivered bytes for the guest to drain.
             let body = accessor.with(|mut a| StreamReader::new(&mut a, msg.body))?;
@@ -155,8 +154,15 @@ impl AccessorTask<SharedCtx> for MessagingTask {
                 .wasmcloud_messaging0_3_0_handler()
                 .call_handle_message(accessor, wit_msg)
                 .await
-        }
-        .await;
+        };
+
+        // Unbounded from in here: the dispatcher enforces the deadline the
+        // caller waits out, and a handler that overruns it is slow rather than
+        // wedged. This bounds only how long an overrunning delivery stays
+        // visible to the epoch callback, whose trap would take the service
+        // singleton every other subject shares.
+        let outcome =
+            crate::engine::abandon::watch_until_abandoned(&calls, abandoned, deliver).await;
 
         match outcome {
             Ok(result) => {

--- a/crates/wash-runtime/src/timeouts.rs
+++ b/crates/wash-runtime/src/timeouts.rs
@@ -29,6 +29,27 @@ fn env_secs(var: &str, default_secs: u64) -> Duration {
     Duration::from_secs(secs)
 }
 
+/// Parse `var` as whole milliseconds, falling back to `default_millis` if it is
+/// unset. Unparseable values fall back with a warning, as in [`env_secs`].
+fn env_millis(var: &str, default_millis: u64) -> Duration {
+    let millis = match std::env::var(var) {
+        Ok(v) => match v.parse::<u64>() {
+            Ok(millis) => millis,
+            Err(_) => {
+                tracing::warn!(
+                    var,
+                    value = %v,
+                    default_millis,
+                    "ignoring unparseable timeout override (want whole milliseconds)"
+                );
+                default_millis
+            }
+        },
+        Err(_) => default_millis,
+    };
+    Duration::from_millis(millis)
+}
+
 /// Declare the runtime-tunable timeouts, one `name = ("ENV_VAR", default_secs)`
 /// entry per line (separated by `;`). Each entry generates a
 /// `pub(crate) fn name() -> Duration` accessor: on first call it reads the named
@@ -96,4 +117,16 @@ declare_timeouts! {
     /// Max wall-clock for one capability call into a host component plugin.
     #[cfg(feature = "host-component-plugins")]
     plugin_capability_call = ("WASH_PLUGIN_CAPABILITY_CALL_TIMEOUT_SECS", 600);
+}
+
+/// The gap between epoch fires past which a store's guest counts as having
+/// paused rather than having been held up (see [`crate::engine::abandon`]).
+///
+/// Raise it on a host loaded enough that a pinned guest's fires land further
+/// apart than the default, where the gaps read as pauses, execution never
+/// accumulates and a wedged store is never trapped.
+pub(crate) fn abandoned_call_pause_threshold() -> Duration {
+    static VALUE: LazyLock<Duration> =
+        LazyLock::new(|| env_millis("WASH_ABANDONED_CALL_PAUSE_THRESHOLD_MS", 3_000));
+    *VALUE
 }

--- a/crates/wash-runtime/tests/fixtures/kv-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin/src/lib.rs
@@ -29,6 +29,16 @@ use wit_bindgen::{FutureReader, StreamReader, StreamResult};
 /// lets a test prove a caller's proxy drop frees the real resource here.
 static DROPPED_BUCKETS: AtomicU64 = AtomicU64::new(0);
 
+/// How the `__chatter__` key spends its time.
+///
+/// Hops shorter than the epoch sampling window (100ms) on purpose, so the
+/// callback fires at the window's own rate and banks execution credit as fast
+/// as a pinned guest, clearing every sampling-based gate. The total must also
+/// outlast the deadline, grace and escalation combined, or the activation
+/// finishes before it could be trapped and the test proves nothing.
+const CHATTER_HOPS: u32 = 240;
+const CHATTER_HOP_MS: u64 = 50;
+
 /// A guest-owned key-value partition behind the exported `bucket` resource.
 struct BucketState {
     data: Mutex<BTreeMap<String, Vec<u8>>>,
@@ -96,6 +106,16 @@ impl Guest for Component {
             let mut x: u64 = 0;
             loop {
                 x = std::hint::black_box(x.wrapping_add(1));
+            }
+        }
+        // The `__chatter__` key is the counterpart: just as slow, but spending
+        // all of it awaiting. Each hop wakes onto an expired epoch deadline, so
+        // it fires exactly as `__spin__` does and banks the same execution
+        // credit. Only the fact that it yields tells them apart. Nothing here
+        // may cost the shared plugin store its state.
+        if key == "__chatter__" {
+            for _ in 0..CHATTER_HOPS {
+                monotonic_clock::wait_for(CHATTER_HOP_MS * 1_000_000).await;
             }
         }
         STORE.lock().unwrap().get(&key).cloned()

--- a/crates/wash-runtime/tests/fixtures/msg-counter/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/msg-counter/src/lib.rs
@@ -24,6 +24,12 @@ use bindings::wasmcloud::messaging::types::{BrokerMessage, HandleMessageError};
 
 static MSG_COUNT: AtomicU64 = AtomicU64::new(0);
 
+/// How the `chatter` subject spends its time: long enough to outlive a test's
+/// delivery deadline and grace several times over, in hops short enough that a
+/// detector reading only the gaps between wakes cannot see them.
+const CHATTER_HOPS: u32 = 16;
+const CHATTER_HOP_MS: u64 = 400;
+
 struct Component;
 
 impl RunGuest for Component {
@@ -56,6 +62,17 @@ impl MsgGuest for Component {
             let mut x: u64 = 0;
             loop {
                 x = std::hint::black_box(x.wrapping_add(1));
+            }
+        }
+        // A `chatter` subject is the opposite of `spin`: healthy, but slower
+        // than any delivery deadline and spending all of it awaiting. Each hop
+        // wakes onto an expired epoch deadline, so its fires land exactly as a
+        // pinned guest's do. Only the fact that it yields tells them apart.
+        // Nothing here may be trapped.
+        if msg.subject == "chatter" {
+            use bindings::wasi::clocks::monotonic_clock;
+            for _ in 0..CHATTER_HOPS {
+                monotonic_clock::wait_for(CHATTER_HOP_MS * 1_000_000).await;
             }
         }
         let n = MSG_COUNT.fetch_add(1, Ordering::SeqCst) + 1;

--- a/crates/wash-runtime/tests/integration_abandoned_calls.rs
+++ b/crates/wash-runtime/tests/integration_abandoned_calls.rs
@@ -43,6 +43,11 @@
 // the environment, which is the soundness condition it needs.
 #![allow(unsafe_code)]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
+// Every test holds `abandonment_env`'s serial guard across its awaits by
+// design: they pin CPUs and assert on timing, so they must not overlap. An
+// async mutex cannot serialise whole `#[tokio::test]` bodies, each on its own
+// runtime. Nothing contends the lock from inside an await.
+#![allow(clippy::await_holding_lock)]
 
 use std::collections::HashMap;
 use std::sync::Once;
@@ -95,7 +100,7 @@ fn abandonment_env() -> std::sync::MutexGuard<'static, ()> {
         std::env::set_var("WASH_EPHEMERAL_CALL_TIMEOUT_SECS", &deadline);
         std::env::set_var("WASH_MESSAGING_DELIVER_TIMEOUT_SECS", &deadline);
         std::env::set_var("WASH_PLUGIN_CAPABILITY_CALL_TIMEOUT_SECS", &deadline);
-        std::env::set_var("WASH_ABANDONED_CALL_GRACE_SECS", &GRACE_SECS.to_string());
+        std::env::set_var("WASH_ABANDONED_CALL_GRACE_SECS", GRACE_SECS.to_string());
         std::env::set_var("WASH_ABANDONED_CALL_ESCALATION_SECS", "3");
     });
     SERIAL
@@ -404,13 +409,13 @@ async fn a_component_wedged_by_its_input_is_trapped_and_replaced() -> Result<()>
         elapsed < SPIN_BOUND,
         "the wedged requests must be ended by abandonment, took {elapsed:?}"
     );
-    for outcome in &outcomes {
-        if let Ok(status) = outcome {
-            assert!(
-                (500..600).contains(status),
-                "a request wedged by its input must fail, got {status}"
-            );
-        }
+    // A transport error is a pass; the assertion is that the request failed.
+    // Only a request that came back has a status to check.
+    for status in outcomes.iter().flatten() {
+        assert!(
+            (500..600).contains(status),
+            "a request wedged by its input must fail, got {status}"
+        );
     }
 
     // The instance was reaped, so the component still serves: a fresh instance
@@ -606,6 +611,94 @@ async fn an_abandoned_message_delivery_traps_and_restarts_the_service() -> Resul
     Ok(())
 }
 
+/// A **healthy** handler that outruns its delivery deadline must keep its
+/// service, however long it goes on.
+///
+/// The counterweight to the test above. What separates the two is whether the
+/// guest yields.
+///
+/// The `chatter` subject spends all its time awaiting, in hops short enough that
+/// each wakes onto an expired epoch deadline, so its fires land exactly as a
+/// pinned guest's do and bank the same credit. It is also the only call on the
+/// store, so the wanted-call gate does not apply. `watch_until_abandoned`
+/// deregisters it because the handler yields; the `spin` subject can never let
+/// that happen.
+///
+/// A delivery runs unbounded from inside the store, on the service singleton
+/// every other subject shares, so without deregistration a slow handler stays
+/// visible to the epoch callback for as long as it runs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_chatty_messaging_handler_survives_being_abandoned() -> Result<()> {
+    let _serial = abandonment_env();
+    let (_addr, host, ingress) = common::start_host_with_p3_handler("127.0.0.1:0").await?;
+    let workload_id = uuid::Uuid::new_v4().to_string();
+    host.workload_start(WorkloadStartRequest {
+        workload_id: workload_id.clone(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "msg-chatter".to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(MSG_COUNTER_WASM),
+                local_resources: LocalResources::default(),
+                max_restarts: 2,
+            }),
+            components: vec![],
+            host_interfaces: vec![],
+            volumes: vec![],
+        },
+    })
+    .await
+    .context("msg-counter service should start")?;
+
+    assert_eq!(
+        deliver(&ingress, &workload_id, "first").await?,
+        Err("other: 1:first".to_string())
+    );
+
+    // Abandoned at its deadline: the handler is slower than any caller will
+    // wait, which is not itself an offence. All that matters here is that the
+    // delivery does not succeed.
+    let outcome = deliver(&ingress, &workload_id, "chatter").await;
+    assert!(
+        !matches!(outcome, Ok(Ok(()))),
+        "a delivery slower than its deadline must not report success, got {outcome:?}"
+    );
+
+    // Stay quiet while the handler hops: a delivery in this window would re-arm
+    // the epoch deadline and shield the hops from firing at all, and an
+    // otherwise-idle store is precisely the scenario. `CHATTER` covers the
+    // fixture's hops with room to spare.
+    // The fixture hops for ~6.4s (16 x 400ms), and a trap needs only the
+    // deadline plus the grace, so waiting ~2x the hop budget leaves the count
+    // below unambiguous.
+    //
+    // One delivery and one exact assertion rather than a poll: every delivery
+    // increments the counter, so a retry loop would walk a restarted handler up
+    // to the expected count and pass on the failure it exists to catch.
+    tokio::time::sleep(Duration::from_secs(12)).await;
+
+    // Untouched, the handler counted its own delivery, making this the third on
+    // the same instance.
+    let echoed = deliver(&ingress, &workload_id, "after")
+        .await?
+        .err()
+        .context("handler echoes via the err arm")?;
+    anyhow::ensure!(
+        echoed != "other: 1:after",
+        "a healthy chatty handler was trapped over its abandoned delivery: the \
+         service restarted and is counting from one"
+    );
+    anyhow::ensure!(
+        echoed == "other: 3:after",
+        "expected the third delivery on an undisturbed instance, got {echoed}; \
+         if this is `2:after` the chatter had not finished yet and the wait \
+         above is too short for this runner"
+    );
+    Ok(())
+}
+
 /// A capability call wedged in a host component plugin is warned about at the
 /// grace and **escalated to a trap**: a non-yielding activation holds the
 /// store's guest execution, so no other tenant's call can enter and the
@@ -682,6 +775,81 @@ async fn an_abandoned_capability_call_escalates_to_a_plugin_restart() -> Result<
         404,
         "the seeded state must be gone after the supervised restart"
     );
+    Ok(())
+}
+
+/// A healthy plugin activation that outruns its deadline must not cost every
+/// tenant the shared store.
+///
+/// `__chatter__` is as slow as `__spin__` and just as invisible to the sampling:
+/// same fire pattern, same execution credit, and the only call on the store, so
+/// the wanted-call gate does not apply. It survives because it yields, which
+/// lets `watch_until_abandoned` deregister it a grace after the dispatcher gives
+/// up.
+///
+/// The seeded key is the assertion. It lives in the plugin's in-memory store, so
+/// it survives only if there was no supervised restart.
+#[cfg(feature = "host-component-plugins")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_chatty_capability_call_does_not_restart_the_plugin() -> Result<()> {
+    use common::{
+        component_workload_request, kv_plugin_caller_host_interfaces,
+        start_host_with_component_plugin,
+    };
+
+    let _serial = abandonment_env();
+    let (addr, host) =
+        start_host_with_component_plugin("127.0.0.1:0", "kv-plugin", KV_PLUGIN_WASM).await?;
+    host.workload_start(component_workload_request(
+        "kv-caller",
+        "kv-caller",
+        KV_PLUGIN_CALLER_WASM,
+        LocalResources::default(),
+        kv_plugin_caller_host_interfaces("kv-caller"),
+    ))
+    .await
+    .context("kv caller workload should start")?;
+    let client = client()?;
+
+    // State in the plugin's singleton store, which a restart would destroy.
+    let (status, _) = get(&client, addr, "kv-caller", "/set?key=a&value=before").await?;
+    assert!(status.is_success(), "seed set failed: {status}");
+
+    // The caller gives up at its deadline. Being slower than any caller will
+    // wait is not itself an offence.
+    let outcome = client
+        .get(format!("http://{addr}/get?key=__chatter__"))
+        .header("HOST", "kv-caller")
+        .send()
+        .await;
+    if let Ok(resp) = outcome {
+        assert!(
+            !resp.status().is_success(),
+            "a call slower than its deadline must not report success, got {}",
+            resp.status()
+        );
+    }
+
+    // The fixture hops for ~12s, outlasting the deadline (2s), grace (1s) and
+    // escalation (3s) combined, so a trap has every opportunity to land. Wait
+    // it out so the plugin is idle again before asking.
+    tokio::time::sleep(Duration::from_secs(16)).await;
+
+    // Untouched: the same incarnation still serves, and still remembers.
+    let (status, body) = get(&client, addr, "kv-caller", "/get?key=a").await?;
+    anyhow::ensure!(
+        status.is_success() && body == "before",
+        "a healthy chatty activation restarted the shared plugin: /get?key=a returned \
+         {status} {body:?}, wanted 200 \"before\"; the seeded state only survives if the \
+         store was never trapped"
+    );
+
+    // Still usable for new work, not merely alive.
+    let (status, _) = get(&client, addr, "kv-caller", "/set?key=b&value=after").await?;
+    assert!(status.is_success(), "post-chatter set failed: {status}");
+    let (status, body) = get(&client, addr, "kv-caller", "/get?key=b").await?;
+    assert!(status.is_success(), "post-chatter get failed: {status}");
+    assert_eq!(body, "after", "the plugin must keep serving new calls");
     Ok(())
 }
 
@@ -861,11 +1029,11 @@ async fn an_abandoned_co_tenant_does_not_trap_a_chatty_healthy_stream() -> Resul
 ///
 /// Each hop wakes onto an expired epoch deadline, so the store's fires land
 /// one hop apart — a wake pattern that wall-clock sampling cannot tell from a
-/// pinned guest inside any single window. What protects it is the per-fire
-/// credit cap: its only call is abandoned (so the wanted-call gate does not
-/// apply), but each fire can only prove one sampling window of execution, so
-/// the credit stays far below the grace for as long as the guest actually
-/// spends its time awaiting.
+/// pinned guest inside any single window.
+///
+/// The guest yields, so `watch_until_abandoned` deregisters the call a grace
+/// after the client disconnects, and a store with nothing registered is never
+/// acted on.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_guest_awaiting_in_short_hops_survives_being_abandoned() -> Result<()> {
     let _serial = abandonment_env();

--- a/crates/wash-runtime/tests/integration_abandonment_grace_ratio.rs
+++ b/crates/wash-runtime/tests/integration_abandonment_grace_ratio.rs
@@ -1,0 +1,124 @@
+//! Abandonment when the ingress deadline is much longer than the grace, which
+//! is the shipping configuration.
+//!
+//! `integration_abandoned_calls` sets every ingress deadline to 2s against a 1s
+//! grace so its traps land quickly. The defaults are the other way round by a
+//! factor of sixty: 600s deadlines against a 10s grace. Deadlines are cached
+//! process-wide on first read, so a second ratio needs a second binary.
+//!
+//! The gap matters because dropping a dispatcher arms the flag, so an ordinary
+//! client disconnect abandons a call with most of its ingress deadline left to
+//! run. For all of that window the epoch callback is free to trap the store as
+//! soon as its conditions line up, which for a service with a `wasi:cli/run`
+//! tick loop takes only a grace's worth of fires. `watch_until_abandoned` is
+//! what deregisters the call, and this covers that it does so regardless of how
+//! long the ingress deadline is.
+
+#![allow(unsafe_code)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+use wash_runtime::host::HostApi;
+use wash_runtime::types::{LocalResources, Service, Workload, WorkloadStartRequest};
+
+mod common;
+use common::{http_only_host_interfaces, json_u64_field, start_host_with_dynamic_router};
+
+const HTTP_SLEEPER_WASM: &[u8] = include_bytes!("wasm/http_sleeper.wasm");
+
+/// The shipping shape, scaled down: an in-store bound thirty times the grace.
+const RESPONSE_TIMEOUT_SECS: u64 = 30;
+const GRACE_SECS: u64 = 1;
+
+/// A client disconnect must not cost a healthy guest its service, however much
+/// of the ingress deadline is left to run.
+///
+/// The guest hops 200 x 50ms, pure awaiting with no CPU at all, and its client
+/// walks away 300ms in, arming the flag on the spot. Every trap condition then
+/// lines up within a couple of seconds: it is the only call on the store, the
+/// grace passes, and the hops wake often enough that the epoch callback fires
+/// every sampling window and reads as continuous execution. Deregistration is
+/// the only thing that saves it, and the guest yields, so the grace timer
+/// sharing its task gets to run.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_disconnect_does_not_trap_a_healthy_guest_when_the_deadline_outlives_the_grace()
+-> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+    // Runs before any host starts and before anything reads the environment,
+    // and this binary holds exactly one test.
+    unsafe {
+        std::env::set_var(
+            "WASH_HTTP_RESPONSE_TIMEOUT_SECS",
+            RESPONSE_TIMEOUT_SECS.to_string(),
+        );
+        std::env::set_var("WASH_ABANDONED_CALL_GRACE_SECS", GRACE_SECS.to_string());
+    }
+
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+    host.workload_start(WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "healthy".to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_SLEEPER_WASM),
+                local_resources: LocalResources::default(),
+                // A restart is the failure this test looks for; allow it so it
+                // reads as a count restarting at one rather than a dead host.
+                max_restarts: 2,
+            }),
+            components: vec![],
+            host_interfaces: http_only_host_interfaces("healthy"),
+            volumes: vec![],
+        },
+    })
+    .await
+    .context("sleeper service should start")?;
+
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .timeout(Duration::from_secs(30))
+        .build()?;
+    let served = async |c: &reqwest::Client| -> Result<u64> {
+        let resp = c
+            .get(format!("http://{addr}/"))
+            .header("HOST", "healthy")
+            .send()
+            .await?;
+        anyhow::ensure!(resp.status().is_success(), "status {}", resp.status());
+        Ok(json_u64_field(&resp.text().await?, "served"))
+    };
+
+    let before = served(&client).await?;
+
+    let mut gone = Box::pin(
+        client
+            .get(format!("http://{addr}/chatter?hops=200&hop_ms=50"))
+            .header("HOST", "healthy")
+            .send(),
+    );
+    tokio::select! {
+        _ = &mut gone => anyhow::bail!("the chatter answered before the client gave up"),
+        () = tokio::time::sleep(Duration::from_millis(300)) => {}
+    }
+    drop(gone);
+
+    // Several times the grace and the credit the callback needs, while barely a
+    // third of the way into the 30s ingress deadline.
+    tokio::time::sleep(Duration::from_secs(8)).await;
+
+    let after = served(&client).await?;
+    anyhow::ensure!(
+        after > before,
+        "a disconnect trapped a healthy guest's service: served {before} -> {after}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Changes our epoch handling to deregister an abandoned call once its guest yields.

This fixes an issue where a client disconnect remained registered for the entire ingress deadline (~20 seconds).

```
ERROR wash_runtime::engine::abandon: an abandoned call has wedged this store
      past its grace; trapping it store_id=583fb4fe… executed_ms=1000
served before = 1, served after = 1     ← trapped and restarted
```

In every protective test in `integration_abandoned_calls`, it sets its deadline to 2s, so the in-store bound always expired first and nothing in the suite could see this.

This adds `watch_until_abandoned` which drops the call's `AbandonedGuard` after arming so a yielding guest stops being visible to the epoch callback.

This PR adds three tests, each verified to fail without the fix. 
Both fixture `chatter` branches hop in steps *shorter* than the sampling window.

| test | unfixed |
|---|---|
| `a_disconnect_does_not_trap_a_healthy_guest_when_the_deadline_outlives_the_grace` | `served 1 -> 1` |
| `a_chatty_messaging_handler_survives_being_abandoned` | traps at `executed_ms=1000` |
| `a_chatty_capability_call_does_not_restart_the_plugin` | escalates at `executed_ms=3000` |
