### PR TITLE
fix(wash): `wash wit` ergonomics and error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -100,7 +100,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -687,7 +687,7 @@ dependencies = [
  "cap-primitives 4.0.2",
  "cap-std 4.0.2",
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -734,7 +734,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -1717,7 +1717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2729,7 +2729,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3195,7 +3195,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4144,7 +4144,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4571,7 +4571,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4640,7 +4640,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5036,7 +5036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5224,7 +5224,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5243,7 +5243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6402,9 +6402,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-client"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7dae50579eae08cd8756d5ab0ea673d98dfe024567d31ee5f398a8c151914cd"
+checksum = "c39aa5033e60ecdd6c7015ef6450f3e3141c3a04c8bbeedbedb49119c7fc82d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6437,9 +6437,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-common"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "412cdb0ef8a3b68870019baf7b8fbeef435a6a3163572fed3e7a2bc996ba74d0"
+checksum = "e2c316a266be61c22568d7c3534046964535b44317c2f5ee8b5c0b8e0001b7e6"
 dependencies = [
  "anyhow",
  "base16ct",
@@ -6459,9 +6459,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-core"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca03eb9b4552ae25577f16a6ac74cd44d307d145fcf6387290856802cd1dd776"
+checksum = "bf5fffabf09201736a503c7233fe2ad05ae9d5dd98f697cee52de18b31465149"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -7188,7 +7188,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,8 +121,8 @@ tracing-opentelemetry = { version = "0.32", default-features = false }
 tracing-subscriber = { version = "0.3.19", default-features = false, features = ["env-filter", "ansi", "time", "json"] }
 url = { version = "2.5", default-features = false }
 uuid = { version = "1.17.0", default-features = false }
-wasm-pkg-client = { version = "0.16.0", default-features = false }
-wasm-pkg-core = { version = "0.16.0", default-features = false }
+wasm-pkg-client = { version = "0.16.1", default-features = false }
+wasm-pkg-core = { version = "0.16.1", default-features = false }
 wasm-metadata = { version = "0.254.0", default-features = false, features = ["oci"] }
 wasmcloud = { path = "crates/wasmcloud", default-features = false }
 wasmtime = { version = "47.0.3", default-features = false }

--- a/crates/wash/src/cli/mod.rs
+++ b/crates/wash/src/cli/mod.rs
@@ -271,6 +271,8 @@ pub struct CliContextBuilder {
     config: Option<PathBuf>,
     project_dir: Option<PathBuf>,
     enable_meters: bool,
+    #[cfg(test)]
+    keep_working_dir: bool,
 }
 
 impl CliContextBuilder {
@@ -291,6 +293,14 @@ impl CliContextBuilder {
 
     pub fn enable_meters(mut self, enable_meters: bool) -> Self {
         self.enable_meters = enable_meters;
+        self
+    }
+
+    /// Leave the process working directory where it is. Tests share one process, so a test that
+    /// moved it would move it under every other test running at the same time.
+    #[cfg(test)]
+    pub(crate) fn keep_working_dir(mut self) -> Self {
+        self.keep_working_dir = true;
         self
     }
 
@@ -361,7 +371,13 @@ impl CliContextBuilder {
         };
 
         // Change working directory to project path
-        std::env::set_current_dir(&project_dir).context("failed to open project directory")?;
+        #[cfg(test)]
+        let move_working_dir = !self.keep_working_dir;
+        #[cfg(not(test))]
+        let move_working_dir = true;
+        if move_working_dir {
+            std::env::set_current_dir(&project_dir).context("failed to open project directory")?;
+        }
 
         Ok(CliContext {
             app_strategy,

--- a/crates/wash/src/cli/wit.rs
+++ b/crates/wash/src/cli/wit.rs
@@ -36,12 +36,18 @@
 //!
 //! ## Add a new dependency
 //!
+//! A world imports interfaces, so an interface has to be named. Passing a package on its own
+//! lists the interfaces it defines instead of writing anything.
+//!
 //! ```bash
 //! # Add latest version
-//! wash wit add wasi:http
+//! wash wit add wasi:http/types
 //!
 //! # Add specific version
-//! wash wit add wasi:http@0.2.0
+//! wash wit add wasi:http/types@0.2.0
+//!
+//! # List the interfaces of a package
+//! wash wit add wasi:http
 //! ```
 //!
 //! ## Update dependencies
@@ -104,16 +110,16 @@
 //! - [WIT Language Specification](https://component-model.bytecodealliance.org/design/wit.html)
 //! - [wasm-pkg-tools Documentation](https://github.com/bytecodealliance/wasm-pkg-tools)
 
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
 use anyhow::{Context as _, Result, bail};
 use clap::{Parser, Subcommand};
-use tracing::{debug, info, instrument};
+use tracing::{debug, info, instrument, warn};
 
 use crate::{
     cli::{CliCommand, CliContext, CommandOutput},
     config::Config,
-    wit::{WkgFetcher, load_lock_file},
+    wit::{PackageContents, PackageLookup, WKG_LOCK_FILE_NAME, WkgFetcher, load_lock_file},
 };
 
 /// Manage WIT dependencies for wasmCloud components
@@ -147,15 +153,17 @@ pub enum WitCommand {
         package: Option<String>,
     },
 
-    /// Add a new WIT dependency
+    /// Add a WIT interface to the world's imports
     Add {
-        /// Package to add (e.g., wasi:keyvalue or wasi:keyvalue@0.2.0-draft)
+        /// Interface to import (e.g., wasi:keyvalue/store or wasi:keyvalue/store@0.2.0-draft).
+        /// Passing a package on its own (e.g., wasi:keyvalue) lists its interfaces
         package: String,
     },
 
     /// Remove a WIT dependency
     Remove {
-        /// Package to remove (e.g., wasi:keyvalue)
+        /// Interface (e.g., wasi:keyvalue/store) or package (e.g., wasi:keyvalue) to remove.
+        /// A package removes every import and include it contributes to the world
         package: String,
     },
 
@@ -188,27 +196,281 @@ impl CliCommand for WitCommand {
     }
 }
 
-/// Validate a WIT package reference follows the convention:
-/// `namespace:package` or `namespace:package/interface`, optionally with `@version`
-fn validate_interface_ref(package: &str) -> Result<()> {
-    let name_part = package.split('@').next().unwrap_or(package);
+/// A WIT reference as accepted on the command line: `namespace:package`, optionally with an
+/// `/interface` and an `@version`
+#[derive(Debug, PartialEq, Eq)]
+struct WitRef {
+    /// The `namespace:package` part of the reference
+    package: String,
+    /// The interface named after the package, if any
+    interface: Option<String>,
+    /// The version, if any
+    version: Option<String>,
+}
 
-    let Some((namespace, rest)) = name_part.split_once(':') else {
-        bail!(
-            "Invalid package format '{name_part}': must be in 'namespace:package' or 'namespace:package/interface' format (e.g., 'wasi:http' or 'wasi:http/types')"
-        );
-    };
+impl WitRef {
+    /// Parse a reference of the form `namespace:package[/interface][@version]`
+    fn parse(reference: &str) -> Result<Self> {
+        let (name_part, version) = match reference.split_once('@') {
+            Some((name, version)) => (name, Some(version.to_string())),
+            None => (reference, None),
+        };
 
-    // The package name is everything before an optional '/'
-    let pkg_name = rest.split('/').next().unwrap_or(rest);
+        let Some((namespace, rest)) = name_part.split_once(':') else {
+            bail!(
+                "Invalid package format '{name_part}': must be in 'namespace:package' or 'namespace:package/interface' format (e.g., 'wasi:http' or 'wasi:http/types')"
+            );
+        };
 
-    if namespace.is_empty() || pkg_name.is_empty() {
-        bail!(
-            "Invalid package format '{name_part}': namespace and package name must be non-empty (e.g., 'wasi:http' or 'wasi:http/types')"
-        );
+        let (pkg_name, interface) = match rest.split_once('/') {
+            Some((pkg_name, interface)) => (pkg_name, Some(interface.to_string())),
+            None => (rest, None),
+        };
+
+        if namespace.is_empty() || pkg_name.is_empty() {
+            bail!(
+                "Invalid package format '{name_part}': namespace and package name must be non-empty (e.g., 'wasi:http' or 'wasi:http/types')"
+            );
+        }
+
+        // A trailing slash names no interface, and `import wasi:http/@0.2.0;` is not WIT
+        if interface.as_deref().is_some_and(str::is_empty) {
+            bail!(
+                "Invalid package format '{name_part}': the interface after '/' is empty (e.g., 'wasi:http/types')"
+            );
+        }
+
+        Ok(Self {
+            package: format!("{namespace}:{pkg_name}"),
+            interface,
+            version,
+        })
     }
 
-    Ok(())
+    /// The path a world statement names, e.g. `wasi:http/types@0.2.0`, carrying `version`. A
+    /// world can only name an interface (or a world, via `include`), so this is `None` for a
+    /// package-only reference.
+    fn world_path(&self, version: Option<&str>) -> Option<String> {
+        let interface = self.interface.as_deref()?;
+        Some(match version {
+            Some(version) => format!("{}/{interface}@{version}", self.package),
+            None => format!("{}/{interface}", self.package),
+        })
+    }
+
+    /// Whether a path named by a world statement refers to this reference, ignoring versions. A
+    /// package-only reference matches everything the package contributes to the world.
+    fn matches_path(&self, path: &str) -> bool {
+        match self.interface.as_deref() {
+            Some(interface) => statement_package(path) == format!("{}/{interface}", self.package),
+            None => self.is_same_package(path),
+        }
+    }
+
+    /// Whether a path named by a world statement comes from this reference's package, whichever
+    /// interface or world of it the statement names
+    fn is_same_package(&self, path: &str) -> bool {
+        let path = statement_package(path);
+        path == self.package
+            || path
+                .strip_prefix(&self.package)
+                .is_some_and(|rest| rest.starts_with('/'))
+    }
+}
+
+/// A statement a world is built out of: `import wasi:http/types@0.2.0;`, the labelled form
+/// `import store-a: wasi:keyvalue/store@0.2.0-draft;` that the component model's `(implements ..)`
+/// mechanism uses, `include`, `export`, and the `use` an interface is written with.
+struct WorldStatement<'a> {
+    /// `import`, `include`, `export` or `use`
+    keyword: &'a str,
+    /// The label a multiplexed import is bound to, if any
+    label: Option<&'a str>,
+    /// The path the statement names, e.g. `wasi:http/types@0.2.0`
+    path: &'a str,
+}
+
+impl<'a> WorldStatement<'a> {
+    /// Whether this is the kind of statement `wash wit add` writes and `wash wit remove` takes
+    /// away. An `export` is something a component implements and a `use` belongs to an interface,
+    /// so neither is one of those, whatever package it names.
+    fn is_dependency(&self) -> bool {
+        matches!(self.keyword, "import" | "include")
+    }
+}
+
+/// Read a world statement, if the line is one
+fn world_statement(line: &str) -> Option<WorldStatement<'_>> {
+    let trimmed = line.trim();
+    let (keyword, rest) = ["import", "include", "export", "use"]
+        .into_iter()
+        .find_map(|keyword| Some((keyword, trimmed.strip_prefix(&format!("{keyword} "))?)))?;
+
+    // A trailing line comment sits outside the statement
+    let rest = rest.split("//").next().unwrap_or(rest).trim();
+    let rest = rest.strip_suffix(';').unwrap_or(rest).trim();
+
+    // `import <label>: <interface>` binds one interface to a label, and the path is what follows
+    // the label. A package path has no `:` outside its `namespace:package`, which comes after the
+    // label's, so the first `:` is the label's only when a second one follows it.
+    let (label, path) = match rest.split_once(':') {
+        Some((label, after)) if after.contains(':') => (Some(label.trim()), after.trim()),
+        _ => (None, rest),
+    };
+
+    Some(WorldStatement {
+        keyword,
+        label,
+        path,
+    })
+}
+
+/// The path of any statement that uses a package, which is what decides the version in use. An
+/// export uses its package just as an import does, and so does a labelled import.
+fn any_statement_path(line: &str) -> Option<&str> {
+    world_statement(line).map(|statement| statement.path)
+}
+
+/// The `namespace:package/name` part of a statement path, without its version. An
+/// `include ... with { ... }` carries more than the path, so the path ends at the first space.
+fn statement_package(path: &str) -> &str {
+    let path = path.split('@').next().unwrap_or(path).trim();
+    path.split_whitespace().next().unwrap_or(path)
+}
+
+/// The version a statement path carries, e.g. `0.2.0` from `wasi:http/types@0.2.0`. A `use` names
+/// what it takes after the version — `use wasi:clocks/wall-clock@0.2.0.{datetime};` — so what
+/// follows the `@` is only a version when it reads as one.
+fn statement_version(path: &str) -> Option<&str> {
+    let (_, after) = path.split_once('@')?;
+    let version = after.split_whitespace().next().unwrap_or(after);
+    // A `use` names what it takes from the interface after the version
+    let version = version
+        .split_once(".{")
+        .map_or(version, |(version, _)| version);
+    semver::Version::parse(version).ok()?;
+    Some(version)
+}
+
+/// A copy of the source with its comments blanked out, so that scanning never takes a
+/// commented-out statement for a real one or writes into the middle of a comment. Every comment
+/// character becomes a space, so lines and columns still line up with the original.
+///
+/// WIT block comments nest, which is what the depth counts.
+fn without_comments(content: &str) -> String {
+    let mut blanked = String::with_capacity(content.len());
+    let mut chars = content.chars().peekable();
+    let mut line_comment = false;
+    let mut depth = 0usize;
+
+    while let Some(c) = chars.next() {
+        if c == '\n' {
+            line_comment = false;
+            blanked.push(c);
+            continue;
+        }
+        if line_comment || depth > 0 {
+            // Nested block comments open and close inside one another
+            if depth > 0 && c == '/' && chars.peek() == Some(&'*') {
+                chars.next();
+                depth += 1;
+                blanked.push_str("  ");
+                continue;
+            }
+            if depth > 0 && c == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                depth -= 1;
+                blanked.push_str("  ");
+                continue;
+            }
+            blanked.push(' ');
+            continue;
+        }
+        match (c, chars.peek()) {
+            ('/', Some('/')) => {
+                chars.next();
+                line_comment = true;
+                blanked.push_str("  ");
+            }
+            ('/', Some('*')) => {
+                chars.next();
+                depth = 1;
+                blanked.push_str("  ");
+            }
+            _ => blanked.push(c),
+        }
+    }
+
+    blanked
+}
+
+/// The last line a statement occupies, given the line it starts on. A statement runs to its `;`,
+/// except for `include ... with { ... }`, which ends with the closing brace and takes no
+/// semicolon. A statement that ends neither way is treated as the one line, so that a file this
+/// does not understand loses nothing.
+fn statement_end(lines: &[&str], start: usize) -> usize {
+    let mut depth = 0usize;
+    let mut opened = false;
+
+    for (offset, line) in lines.iter().skip(start).enumerate() {
+        for c in line.chars() {
+            match c {
+                '{' => {
+                    depth += 1;
+                    opened = true;
+                }
+                '}' => {
+                    depth = depth.saturating_sub(1);
+                    if opened && depth == 0 {
+                        return start + offset;
+                    }
+                }
+                ';' if depth == 0 => return start + offset,
+                _ => {}
+            }
+        }
+    }
+
+    start
+}
+
+/// Whether a line is a doc comment, which belongs to the statement below it
+fn is_doc_comment(line: &str) -> bool {
+    line.trim_start().starts_with("///")
+}
+
+/// The version a new world statement should carry.
+///
+/// What was asked for wins: a whole version is written as typed, even when the world uses a
+/// different one for that package. A partial version like `0.3` asks for anything compatible
+/// with it, which is the version the world already uses when that one fits, and the newest
+/// `0.3.x` otherwise. Asking for nothing takes the world's version, then the newest.
+///
+/// The result carries a whole version whenever one can be worked out. WIT has no version ranges,
+/// and an import with no version at all does not resolve against a versioned package — `import
+/// wasi:clocks/monotonic-clock;` fails the fetch with "package 'wasi:clocks' not found. known
+/// packages: wasi:clocks@0.3.1" — so an unversioned statement is only ever written when nothing
+/// could be resolved to pin it to.
+fn version_to_write(
+    world_version: Option<&str>,
+    requested: Option<&str>,
+    resolved: Option<&semver::Version>,
+) -> Option<String> {
+    match (requested, world_version) {
+        // The version the world already uses satisfies what was asked for, so nothing moves
+        (Some(requested), Some(existing)) if version_matches(requested, existing) => {
+            Some(existing.to_string())
+        }
+        // A whole version is written as it was asked for
+        (Some(requested), _) if semver::Version::parse(requested).is_ok() => {
+            Some(requested.to_string())
+        }
+        // A partial version is not something a world statement can express, so it becomes the
+        // newest version compatible with it
+        (Some(_), _) => resolved.map(ToString::to_string),
+        (None, Some(existing)) => Some(existing.to_string()),
+        (None, None) => resolved.map(ToString::to_string),
+    }
 }
 
 /// Find the WIT file containing the world definition
@@ -281,8 +543,25 @@ async fn find_world_wit_file(wit_dir: &std::path::Path) -> Result<std::path::Pat
     )
 }
 
+/// The indentation to write a world's statements at, read from the first line inside it that has
+/// any. This reads the original rather than the blanked copy, where a comment is all spaces.
+fn indent_inside_world(original: &[&str], world_line: usize) -> String {
+    let indent = original
+        .iter()
+        .skip(world_line + 1)
+        .find(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .unwrap_or(4);
+    " ".repeat(indent.max(4))
+}
+
 fn insert_import_into_world(content: &str, import_line: &str) -> Result<String> {
-    let lines: Vec<&str> = content.lines().collect();
+    // The world block is located in a copy with the comments blanked out, so that a `world` or
+    // `import` inside a comment is not taken for the real thing and written into. Blanking keeps
+    // lines and columns, so an index into it is an index into the original.
+    let blanked = without_comments(content);
+    let original: Vec<&str> = content.lines().collect();
+    let lines: Vec<&str> = blanked.lines().collect();
     let mut new_lines = Vec::new();
     let mut inserted = false;
     let mut pending_world = false;
@@ -295,24 +574,16 @@ fn insert_import_into_world(content: &str, import_line: &str) -> Result<String> 
             pending_world = true;
             if trimmed.contains('{') {
                 pending_world = false;
-                let next_indent = lines
-                    .get(i + 1)
-                    .map(|next_line| next_line.len() - next_line.trim_start().len())
-                    .unwrap_or(4);
-                world_indent = " ".repeat(next_indent.max(4));
+                world_indent = indent_inside_world(&original, i);
             }
         } else if pending_world && trimmed.starts_with('{') {
             pending_world = false;
-            let next_indent = lines
-                .get(i + 1)
-                .map(|next_line| next_line.len() - next_line.trim_start().len())
-                .unwrap_or(4);
-            world_indent = " ".repeat(next_indent.max(4));
+            world_indent = indent_inside_world(&original, i);
         } else if pending_world && !trimmed.is_empty() && !trimmed.starts_with("//") {
             pending_world = false;
         }
 
-        new_lines.push((*line).to_string());
+        new_lines.push(original.get(i).copied().unwrap_or(line).to_string());
 
         if inserted || world_indent.is_empty() {
             continue;
@@ -361,6 +632,29 @@ fn insert_import_into_world(content: &str, import_line: &str) -> Result<String> 
 /// Handle `wash wit fetch`
 #[instrument(level = "debug", skip(ctx))]
 async fn handle_fetch(ctx: &CliContext, config: &Config, clean: bool) -> Result<CommandOutput> {
+    // Before building a fetcher, which applies the project's source overrides and so downloads
+    // and clones the sources they name
+    let wit_dir = config.wit_dir();
+    if !wit_dir.exists() {
+        return Ok(CommandOutput::error(
+            format!("WIT directory does not exist: {}", wit_dir.display()),
+            None,
+        ));
+    }
+
+    let fetcher = build_fetcher(ctx, config).await?;
+    fetch_with(&fetcher, ctx, config, clean).await
+}
+
+/// Fetch a project's WIT dependencies with a fetcher that is already built. Building one applies
+/// the project's source overrides, which downloads and clones the sources they name, so a command
+/// that already has one hands it on rather than paying for another.
+async fn fetch_with(
+    fetcher: &WkgFetcher,
+    ctx: &CliContext,
+    config: &Config,
+    clean: bool,
+) -> Result<CommandOutput> {
     let project_dir = ctx.project_dir();
     let wit_dir = config.wit_dir();
     // Check if WIT directory exists
@@ -391,17 +685,22 @@ async fn handle_fetch(ctx: &CliContext, config: &Config, clean: bool) -> Result<
     // Load or create lock file
     let mut lock_file = load_lock_file(&project_dir).await?;
 
-    // Setup package fetcher and apply the project's `[wit]` config
-    let mut fetcher =
-        WkgFetcher::for_project(ctx.cache_dir().join("package_cache"), project_dir).await?;
-    if let Some(wit_config) = &config.wit {
-        fetcher.apply_wit_config(wit_config, project_dir).await?;
-    }
-
     // Fetch dependencies
-    fetcher
+    if let Err(e) = fetcher
         .fetch_wit_dependencies(&wit_dir, &mut lock_file)
-        .await?;
+        .await
+    {
+        // Resolution reports only that it failed, so ask the sources what they have for each
+        // package the WIT names and report anything they do not. The underlying error goes with
+        // it, since the report is a reading of the WIT rather than of the failure itself.
+        if let Some(report) = fetch_failure_report(fetcher, &wit_dir).await {
+            return Ok(CommandOutput::error(
+                format!("{report}\n\nFetching failed with: {e:#}"),
+                None,
+            ));
+        }
+        return Err(e);
+    }
 
     // Write lock file
     lock_file
@@ -418,6 +717,33 @@ async fn handle_fetch(ctx: &CliContext, config: &Config, clean: bool) -> Result<
             "lock_file": project_dir.join("wkg.lock").display().to_string(),
         })),
     ))
+}
+
+/// Put the lock file back when an update's fetch does not land. `wash wit update` clears the lock
+/// to force re-resolution, so a fetch that fails would otherwise leave the project with nothing
+/// pinned and the next successful fetch free to take versions nobody chose.
+async fn restore_lock_on_failure(
+    lock_file_path: &std::path::Path,
+    lock_before: Option<Vec<u8>>,
+    fetched: Result<CommandOutput>,
+) -> Result<CommandOutput> {
+    let landed = matches!(&fetched, Ok(output) if output.is_success());
+    if landed {
+        return fetched;
+    }
+
+    let Some(lock_before) = lock_before else {
+        return fetched;
+    };
+    match tokio::fs::write(lock_file_path, lock_before).await {
+        Ok(()) => debug!("update did not land, put {} back", lock_file_path.display()),
+        Err(e) => warn!(
+            "update did not land and {} could not be put back: {e}",
+            lock_file_path.display()
+        ),
+    }
+
+    fetched
 }
 
 /// Handle `wash wit update`
@@ -448,23 +774,25 @@ async fn handle_update(
         "updating WIT dependencies"
     );
 
-    // For update, we need to clear the lock file (or specific package entries) to force re-resolution
-    let lock_file_path = project_dir.join("wkg.lock");
+    // For update, we need to clear the lock file (or specific package entries) to force
+    // re-resolution — and to put back what was there if the fetch that follows does not land, so
+    // that a failed update does not leave the project unpinned
+    let lock_file_path = project_dir.join(WKG_LOCK_FILE_NAME);
+    let versions_before = locked_versions(project_dir).await;
+    let lock_before = tokio::fs::read(&lock_file_path).await.ok();
 
     if let Some(package_name) = package {
-        // Selective package update: remove only the specified package from lock file
-        validate_interface_ref(package_name)?;
+        // Selective package update: remove only the specified package from lock file. The lock
+        // file records packages, so an interface reference updates the package it belongs to.
+        let wit_ref = WitRef::parse(package_name)?;
 
         // Load the existing lock file
         let mut lock_file = load_lock_file(&project_dir).await?;
 
-        // Parse the package name to get PackageRef
-        let package_ref: wasm_pkg_client::PackageRef = package_name
-            .split('@')
-            .next()
-            .unwrap_or(package_name)
+        let package_ref: wasm_pkg_client::PackageRef = wit_ref
+            .package
             .parse()
-            .context("failed to parse package name")?;
+            .with_context(|| format!("[{}] is not a valid package name", wit_ref.package))?;
 
         // Count packages before removal
         let before_count = lock_file.packages.len();
@@ -496,12 +824,21 @@ async fn handle_update(
         );
 
         // Now fetch to re-resolve just this package
-        handle_fetch(ctx, config, false).await?;
+        let fetched = handle_fetch(ctx, config, false).await;
+        let fetched = restore_lock_on_failure(&lock_file_path, lock_before, fetched).await?;
+        if !fetched.is_success() {
+            return Ok(fetched);
+        }
 
+        let changes = version_changes(&versions_before, &locked_versions(project_dir).await);
         Ok(CommandOutput::ok(
-            format!("Updated package: {package_name}"),
+            match changes.is_empty() {
+                true => format!("{package_name} is already at the version it resolves to"),
+                false => format!("Updated {package_name}\n{}", render_changes(&changes)),
+            },
             Some(serde_json::json!({
                 "package": package_name,
+                "changes": changes,
                 "wit_dir": wit_dir.display().to_string(),
             })),
         ))
@@ -516,15 +853,308 @@ async fn handle_update(
         }
 
         // Now fetch with the cleared lock file, which will resolve to latest versions
-        handle_fetch(ctx, config, false).await?;
+        let fetched = handle_fetch(ctx, config, false).await;
+        let fetched = restore_lock_on_failure(&lock_file_path, lock_before, fetched).await?;
+        if !fetched.is_success() {
+            return Ok(fetched);
+        }
 
+        let changes = version_changes(&versions_before, &locked_versions(project_dir).await);
         Ok(CommandOutput::ok(
-            "All WIT dependencies updated successfully".to_string(),
+            match changes.is_empty() {
+                true => {
+                    "All WIT dependencies are already at the versions they resolve to".to_string()
+                }
+                false => format!(
+                    "Updated WIT dependencies\n{changes}",
+                    changes = render_changes(&changes)
+                ),
+            },
             Some(serde_json::json!({
+                "changes": changes,
                 "wit_dir": wit_dir.display().to_string(),
             })),
         ))
     }
+}
+
+/// The versions a project's lock file pins, keyed by package. A package can be locked to more
+/// than one version when the WIT names more than one requirement for it.
+async fn locked_versions(project_dir: &std::path::Path) -> BTreeMap<String, Vec<String>> {
+    let lock_file = match load_lock_file(project_dir).await {
+        Ok(lock_file) => lock_file,
+        Err(e) => {
+            debug!("no lock file to compare against: {e:#}");
+            return BTreeMap::new();
+        }
+    };
+
+    let mut versions: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for package in &lock_file.packages {
+        versions
+            .entry(package.name.to_string())
+            .or_default()
+            .extend(
+                package
+                    .versions
+                    .iter()
+                    .map(|locked| locked.version.to_string()),
+            );
+    }
+    for locked in versions.values_mut() {
+        locked.sort();
+    }
+    versions
+}
+
+/// What moved between two sets of locked versions, in the shape `cargo update` reports
+fn version_changes(
+    before: &BTreeMap<String, Vec<String>>,
+    after: &BTreeMap<String, Vec<String>>,
+) -> Vec<String> {
+    let mut changes = Vec::new();
+    for (package, versions) in after {
+        match before.get(package) {
+            Some(previous) if previous == versions => {}
+            Some(previous) => changes.push(format!(
+                "Updating {package} {} -> {}",
+                previous.join(", "),
+                versions.join(", ")
+            )),
+            None => changes.push(format!("Adding {package} {}", versions.join(", "))),
+        }
+    }
+    for (package, versions) in before {
+        if !after.contains_key(package) {
+            changes.push(format!("Removing {package} {}", versions.join(", ")));
+        }
+    }
+    changes
+}
+
+/// Indent a list of changes under the line that introduces them
+fn render_changes(changes: &[String]) -> String {
+    changes
+        .iter()
+        .map(|change| format!("  {change}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Render the message for a package-only reference, listing what the package defines when it
+/// could be loaded
+fn package_reference_message(
+    wit_ref: &WitRef,
+    contents: Result<&PackageContents, &anyhow::Error>,
+) -> String {
+    let package = &wit_ref.package;
+    let mut message = format!(
+        "{package} is a package, and a world imports interfaces from a package rather than the package itself.\n"
+    );
+
+    let contents = match contents {
+        Ok(contents) => contents,
+        Err(e) => {
+            let version = wit_ref
+                .version
+                .as_deref()
+                .map(|v| format!("@{v}"))
+                .unwrap_or_default();
+            message.push_str(&format!(
+                "\nIts interfaces could not be listed: {e:#}\n\
+                 \n\
+                 Add one of them instead, for example:\n  wash wit add {package}/<interface>{version}\n"
+            ));
+            return message;
+        }
+    };
+
+    if contents.interfaces.is_empty() {
+        let version = package_version_suffix(contents);
+        message.push_str(&format!("\n{package}{version} defines no interfaces.\n"));
+    } else {
+        message.push_str(&interface_list(package, contents));
+        message.push_str(
+            "\nAn interface your component implements belongs in an `export` instead, which is written directly in wit/world.wit.\n",
+        );
+    }
+
+    if !contents.worlds.is_empty() {
+        let version = package_version_suffix(contents);
+        message.push_str(
+            "\nTo pull in every interface of a world at once, add an `include` to your own world in wit/world.wit:\n",
+        );
+        for world in &contents.worlds {
+            message.push_str(&format!("  include {package}/{world}{version};\n"));
+        }
+    }
+
+    message
+}
+
+/// Render the message for an interface the loaded package does not define, or `None` when it
+/// defines it
+fn undefined_interface_message(wit_ref: &WitRef, contents: &PackageContents) -> Option<String> {
+    let interface = wit_ref.interface.as_deref()?;
+    if contents
+        .interfaces
+        .iter()
+        .any(|defined| defined == interface)
+    {
+        return None;
+    }
+
+    let package = &wit_ref.package;
+    let version = package_version_suffix(contents);
+    let mut message =
+        format!("{package}{version} does not define an interface named `{interface}`.\n");
+    if contents.interfaces.is_empty() {
+        message.push_str(&format!("\n{package}{version} defines no interfaces.\n"));
+    } else {
+        message.push_str(&interface_list(package, contents));
+    }
+    Some(message)
+}
+
+/// The `@version` suffix to print for a loaded package, empty when it is unversioned
+fn package_version_suffix(contents: &PackageContents) -> String {
+    contents
+        .version
+        .as_ref()
+        .map(|version| format!("@{version}"))
+        .unwrap_or_default()
+}
+
+/// The `wash wit add` line for each interface a package defines
+fn interface_list(package: &str, contents: &PackageContents) -> String {
+    let version = package_version_suffix(contents);
+    let mut list = format!("\nInterfaces in {package}{version}:\n");
+    for interface in &contents.interfaces {
+        list.push_str(&format!("  wash wit add {package}/{interface}{version}\n"));
+    }
+    list
+}
+
+/// Load a package from the project's configured sources and report what it defines
+async fn load_package(
+    fetcher: &WkgFetcher,
+    wit_ref: &WitRef,
+    version: Option<&str>,
+    lock: Option<&wasm_pkg_core::lock::LockFile>,
+) -> PackageLookup {
+    match wit_ref.package.parse::<wasm_pkg_client::PackageRef>() {
+        Ok(package) => fetcher.load_package(&package, version, lock).await,
+        Err(e) => PackageLookup::Missing(format!(
+            "{} is not a valid package name: {e}",
+            wit_ref.package
+        )),
+    }
+}
+
+/// Whether two versions sit in the same major.minor line, which is the line WIT treats as one
+/// package: `0.2.3` and `0.2.6` are the same package at two versions, while `0.2.3` and `0.3.0`
+/// are separate packages that can both appear in a world
+fn same_version_line(one: &str, other: &str) -> bool {
+    match (semver::Version::parse(one), semver::Version::parse(other)) {
+        (Ok(one), Ok(other)) => (one.major, one.minor) == (other.major, other.minor),
+        _ => false,
+    }
+}
+
+/// Whether a requested version, which may be partial like `0.2`, is the version already in use
+fn version_matches(requested: &str, existing: &str) -> bool {
+    match (
+        semver::VersionReq::parse(&format!("={requested}")),
+        semver::Version::parse(existing),
+    ) {
+        (Ok(requirement), Ok(version)) => requirement.matches(&version),
+        // Whatever semver cannot read is compared as written
+        _ => requested == existing,
+    }
+}
+
+/// The report to show for a fetch that failed, when the WIT turns out to name something its
+/// sources do not have or to name one package twice. `None` when nothing is found, in which case
+/// the fetch failed for a reason its own error describes.
+async fn fetch_failure_report(fetcher: &WkgFetcher, wit_dir: &std::path::Path) -> Option<String> {
+    let problems = fetcher
+        .diagnose_wit(wit_dir)
+        .await
+        .inspect_err(|e| debug!("could not check the WIT directory's packages: {e:#}"))
+        .ok()?;
+
+    match problems.is_empty() {
+        true => None,
+        false => Some(problems.join("\n\n")),
+    }
+}
+
+/// Build a package fetcher for the project, with the project's `[wit]` configuration applied
+async fn build_fetcher(ctx: &CliContext, config: &Config) -> Result<WkgFetcher> {
+    let project_dir = ctx.project_dir();
+    let mut fetcher =
+        WkgFetcher::for_project(ctx.cache_dir().join("package_cache"), &project_dir).await?;
+    if let Some(wit_config) = &config.wit {
+        fetcher.apply_wit_config(wit_config, &project_dir).await?;
+    }
+    Ok(fetcher)
+}
+
+/// Put `content` in the world file, and take it back out again if that is what stops the WIT
+/// parsing. Returns the message to show when the edit was refused.
+///
+/// The check runs against the file in place rather than the new text on its own, because a world
+/// is parsed together with the rest of its package — an `interface` in a sibling file, a `use` of
+/// it — so the text alone says little. A WIT directory that did not parse before the edit is left
+/// to the edit: refusing there would stand in the way of the change that repairs it.
+async fn write_world_wit(
+    world_wit_path: &std::path::Path,
+    wit_dir: &std::path::Path,
+    previous: &str,
+    content: &str,
+) -> Result<Option<String>> {
+    let parsed_before = wit_parses(wit_dir).await;
+
+    tokio::fs::write(world_wit_path, content)
+        .await
+        .context("failed to write world.wit")?;
+
+    let Err(e) = parse_wit(wit_dir).await else {
+        return Ok(None);
+    };
+
+    if !parsed_before {
+        warn!(
+            "{} still does not parse, which it did not before this either: {e:#}",
+            wit_dir.display()
+        );
+        return Ok(None);
+    }
+
+    tokio::fs::write(world_wit_path, previous)
+        .await
+        .context("failed to put world.wit back")?;
+
+    Ok(Some(format!(
+        "{} was left as it was: the edit would have stopped it parsing.\n\
+         \n\
+         {e:#}",
+        world_wit_path.display()
+    )))
+}
+
+/// Parse a WIT directory, which is what every later `wash wit fetch` and `wash build` starts with
+async fn parse_wit(wit_dir: &std::path::Path) -> Result<()> {
+    let wit_dir = wit_dir.to_path_buf();
+    tokio::task::spawn_blocking(move || wasm_pkg_core::wit::get_packages(&wit_dir))
+        .await
+        .context("failed to parse the WIT directory")??;
+    Ok(())
+}
+
+/// Whether a WIT directory parses
+async fn wit_parses(wit_dir: &std::path::Path) -> bool {
+    parse_wit(wit_dir).await.is_ok()
 }
 
 /// Handle `wash wit add`
@@ -546,15 +1176,7 @@ async fn handle_add(ctx: &CliContext, package: &str, config: &Config) -> Result<
 
     debug!(wit_dir = %wit_dir.display(), package, "adding WIT dependency");
 
-    // Validate package reference format
-    validate_interface_ref(package)?;
-
-    // Parse package name and version
-    let (package_name, version) = if let Some((name, ver)) = package.split_once('@') {
-        (name, Some(ver))
-    } else {
-        (package, None)
-    };
+    let wit_ref = WitRef::parse(package)?;
 
     // Find the WIT file containing the world definition
     let world_wit_path = match find_world_wit_file(&wit_dir).await {
@@ -569,47 +1191,196 @@ async fn handle_add(ctx: &CliContext, package: &str, config: &Config) -> Result<
         .await
         .context("failed to read world WIT file")?;
 
-    // Check if the import already exists
-    let import_line = if let Some(ver) = version {
-        format!("import {package_name}@{ver};")
-    } else {
-        format!("import {package_name};")
-    };
+    // What the world says is read from a copy with the comments blanked out, so a commented-out
+    // import counts for nothing
+    let blanked = without_comments(&content);
 
-    if content.contains(&import_line) || content.contains(&format!("import {package_name}@")) {
+    // An interface already imported is answered from the file alone, before the package is looked
+    // up: the interface counts as imported whatever version it is pinned to
+    if wit_ref.interface.is_some()
+        && let Some(existing) = blanked
+            .lines()
+            .filter_map(world_statement)
+            // A labelled import binds one more copy of an interface, so it is not the plain
+            // import of it that is being asked for here
+            .filter(|statement| statement.is_dependency() && statement.label.is_none())
+            .map(|statement| statement.path)
+            .find(|path| wit_ref.matches_path(path))
+    {
         return Ok(CommandOutput::error(
-            format!("Package {package_name} is already imported in world.wit"),
+            format!("{existing} is already imported in world.wit"),
             None,
         ));
     }
 
+    // The version the world already uses for this package, which is what an unversioned or
+    // compatible reference resolves to. An export counts: a component that exports
+    // `wasi:http/incoming-handler@0.2.0` is using wasi:http at 0.2.0. Statements that name the
+    // package without a version say nothing about which one, so they are passed over rather than
+    // taken as an answer.
+    let world_version = blanked
+        .lines()
+        .filter_map(any_statement_path)
+        .filter(|path| wit_ref.is_same_package(path))
+        .find_map(statement_version)
+        .map(ToString::to_string);
+
+    // The version to look the package up at, which is the one that will be written when it can be
+    // pinned down before the lookup
+    let requested_version = match (wit_ref.version.as_deref(), world_version.as_deref()) {
+        (Some(requested), Some(existing)) if version_matches(requested, existing) => {
+            Some(existing.to_string())
+        }
+        (Some(requested), _) => Some(requested.to_string()),
+        (None, existing) => existing.map(ToString::to_string),
+    };
+
+    // The world statement is only written once the package is known to exist and to define the
+    // named interface: a world imports an interface rather than a whole package, and an import
+    // that names something the source does not have fails every later fetch and build.
+    //
+    // One fetcher for the lookup and the fetch that follows it: building one applies the project's
+    // source overrides, which downloads and clones the sources they name. The lock file goes into
+    // the lookup so it selects the version the fetch would, and is dropped before that fetch takes
+    // it for writing.
+    let fetcher = build_fetcher(ctx, config).await?;
+    let lookup = {
+        let lock = load_lock_file(&ctx.project_dir()).await?;
+        load_package(
+            &fetcher,
+            &wit_ref,
+            requested_version.as_deref(),
+            Some(&lock),
+        )
+        .await
+    };
+
+    let world_path = match lookup {
+        PackageLookup::Missing(message) => return Ok(CommandOutput::error(message, None)),
+        // Whatever went wrong, the source could not say whether this interface exists, and an
+        // import of something that does not is what this command is here to avoid writing
+        PackageLookup::Failed(e) => {
+            return Ok(CommandOutput::error(
+                match wit_ref.interface.is_some() {
+                    true => format!(
+                        "{package} could not be loaded, so it was not added to world.wit: {e:#}"
+                    ),
+                    false => package_reference_message(&wit_ref, Err(&e)),
+                },
+                None,
+            ));
+        }
+        PackageLookup::Found(contents) => {
+            let version = version_to_write(
+                world_version.as_deref(),
+                wit_ref.version.as_deref(),
+                contents.version.as_ref(),
+            );
+
+            // A version that was asked for is written as asked for, so a source that does not
+            // have it is said so rather than written down. On the registry path the version was
+            // already checked, so this is what catches a local or overridden source.
+            if let Some(requested) = wit_ref.version.as_deref()
+                && let Some(loaded) = contents.version.as_ref()
+                && !version_matches(requested, &loaded.to_string())
+            {
+                return Ok(CommandOutput::error(
+                    format!(
+                        "{} provides {loaded}, not the requested version [{requested}].",
+                        wit_ref.package
+                    ),
+                    None,
+                ));
+            }
+
+            match wit_ref.world_path(version.as_deref()) {
+                None => {
+                    return Ok(CommandOutput::error(
+                        package_reference_message(&wit_ref, Ok(&contents)),
+                        None,
+                    ));
+                }
+                Some(world_path) => {
+                    if let Some(message) = undefined_interface_message(&wit_ref, &contents) {
+                        return Ok(CommandOutput::error(message, None));
+                    }
+                    world_path
+                }
+            }
+        }
+    };
+
+    // A version that was asked for wins over the one the world uses, which leaves the world
+    // naming that package twice
+    if let Some(existing) = world_version.as_deref()
+        && let Some(written) = statement_version(&world_path)
+        && written != existing
+    {
+        let package = &wit_ref.package;
+        match same_version_line(written, existing) {
+            // Two versions in one major.minor line are the same package to WIT, and it cannot
+            // hold both
+            true => warn!(
+                "world.wit imports {package}@{existing} elsewhere, which cannot resolve alongside \
+                 {written}: move the other imports to {written} too, or add this one at {existing}"
+            ),
+            // Different major.minor versions are separate packages, which WIT resolves side by
+            // side — but a fetch only resolves one version per package name
+            false => warn!(
+                "world.wit imports {package}@{existing} elsewhere: a fetch resolves one version \
+                 per package name, so only one of {existing} and {written} will reach wit/deps"
+            ),
+        }
+    }
+
+    let import_line = format!("import {world_path};");
     let new_content = match insert_import_into_world(&content, &import_line) {
         Ok(content) => content,
         Err(e) => return Ok(CommandOutput::error(e.to_string(), None)),
     };
 
-    // Write the updated content
-    tokio::fs::write(&world_wit_path, &new_content)
+    // Write the updated content, and only keep it if the WIT still parses with it in place
+    if let Some(refused) =
+        write_world_wit(&world_wit_path, &wit_dir, &content, &new_content).await?
+    {
+        return Ok(CommandOutput::error(refused, None));
+    }
+
+    info!("Added {world_path} to world.wit");
+
+    // Now fetch the newly added dependency. The world has already been edited, so a fetch that
+    // fails is reported against that rather than hidden behind a success.
+    let fetch_context = || {
+        format!(
+            "`{import_line}` was added to {}, but fetching the WIT dependencies of the world it \
+             now describes failed",
+            world_wit_path.display()
+        )
+    };
+    let fetched = fetch_with(&fetcher, ctx, config, false)
         .await
-        .context("failed to write world.wit")?;
-
-    info!("Added {package} to world.wit");
-
-    // Now fetch the newly added dependency
-    handle_fetch(ctx, config, false).await?;
+        .with_context(fetch_context)?;
+    if !fetched.is_success() {
+        let (message, _) = fetched.render();
+        return Ok(CommandOutput::error(
+            format!("{}\n\n{message}", fetch_context()),
+            None,
+        ));
+    }
 
     Ok(CommandOutput::ok(
-        format!("Added WIT dependency: {package}"),
+        format!("Added WIT dependency: {world_path}"),
         Some(serde_json::json!({
             "package": package,
+            "import": world_path,
             "wit_dir": wit_dir.display().to_string(),
         })),
     ))
 }
 
 /// Handle `wash wit remove`
-#[instrument(level = "debug", skip(_ctx, config))]
-async fn handle_remove(_ctx: &CliContext, package: &str, config: &Config) -> Result<CommandOutput> {
+#[instrument(level = "debug", skip(ctx, config))]
+async fn handle_remove(ctx: &CliContext, package: &str, config: &Config) -> Result<CommandOutput> {
     let wit_dir = config.wit_dir();
 
     if !wit_dir.exists() {
@@ -626,8 +1397,7 @@ async fn handle_remove(_ctx: &CliContext, package: &str, config: &Config) -> Res
 
     debug!(wit_dir = %wit_dir.display(), package, "removing WIT dependency");
 
-    // Validate package reference format
-    validate_interface_ref(package)?;
+    let wit_ref = WitRef::parse(package)?;
 
     // Find the WIT file containing the world definition
     let world_wit_path = match find_world_wit_file(&wit_dir).await {
@@ -642,42 +1412,65 @@ async fn handle_remove(_ctx: &CliContext, package: &str, config: &Config) -> Res
         .await
         .context("failed to read world WIT file")?;
 
-    // Remove the import line
+    // Statements are found in a copy with the comments blanked out, so a commented-out import is
+    // not mistaken for a real one, and taken out of the original by line
+    let blanked = without_comments(&content);
+    let blanked: Vec<&str> = blanked.lines().collect();
     let lines: Vec<&str> = content.lines().collect();
-    let mut new_lines = Vec::new();
+
+    let mut new_lines: Vec<&str> = Vec::new();
     let mut removed = false;
+    let mut labelled = Vec::new();
+    let mut line_number = 0;
 
-    for line in lines {
-        let trimmed = line.trim();
-        // Check if this line imports the package we want to remove
-        if trimmed.starts_with("import ") && trimmed.contains(package) {
-            // Verify it's exactly the package (not a partial match)
-            // Extract the package name from "import wasi:cli@0.2.0;" or "import wasi:cli;"
-            if let Some(after_import) = trimmed.strip_prefix("import ") {
-                let package_part = after_import
-                    .trim()
-                    .split(';')
-                    .next()
-                    .unwrap_or(after_import)
-                    .split('@')
-                    .next()
-                    .unwrap_or(after_import)
-                    .trim();
+    while line_number < lines.len() {
+        let statement = blanked
+            .get(line_number)
+            .and_then(|line| world_statement(line))
+            .filter(|statement| statement.is_dependency() && wit_ref.matches_path(statement.path));
 
-                // Strip version from user input so "wasi:http@0.2.0" matches "import wasi:http@0.2.0;"
-                let package_name_only = package.split('@').next().unwrap_or(package);
-                if package_part == package_name_only {
-                    removed = true;
-                    continue; // Skip this line
-                }
-            }
+        let Some(statement) = statement else {
+            new_lines.extend(lines.get(line_number));
+            line_number += 1;
+            continue;
+        };
+
+        // A labelled import binds one more copy of an interface under a name the component's
+        // bindings use. It is not what `wash wit add` writes, so it is not what this takes
+        // away — it is reported instead.
+        if let Some(label) = statement.label {
+            labelled.push(format!("{label}: {}", statement.path));
+            new_lines.extend(lines.get(line_number));
+            line_number += 1;
+            continue;
         }
-        new_lines.push(line);
+
+        removed = true;
+        // A doc comment belongs to the statement below it, so it goes with the statement rather
+        // than staying behind to document whatever follows
+        while new_lines.last().is_some_and(|line| is_doc_comment(line)) {
+            new_lines.pop();
+        }
+        line_number = statement_end(&blanked, line_number) + 1;
     }
 
     if !removed {
         return Ok(CommandOutput::error(
-            format!("Package {package} not found in world.wit imports"),
+            match labelled.is_empty() {
+                true => format!("Package {package} not found in world.wit imports"),
+                false => format!(
+                    "{package} is only imported under a label in world.wit, which \
+                     `wash wit remove` leaves alone:\n{}\n\
+                     \n\
+                     Those bind interfaces to names the component's bindings use; take them out \
+                     of world.wit by hand.",
+                    labelled
+                        .iter()
+                        .map(|statement| format!("  import {statement};"))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                ),
+            },
             None,
         ));
     }
@@ -688,20 +1481,107 @@ async fn handle_remove(_ctx: &CliContext, package: &str, config: &Config) -> Res
         new_content.push('\n');
     }
 
-    // Write the updated content
-    tokio::fs::write(&world_wit_path, new_content)
-        .await
-        .context("failed to write world.wit")?;
+    // Write the updated content, and only keep it if the WIT still parses with it in place
+    if let Some(refused) =
+        write_world_wit(&world_wit_path, &wit_dir, &content, &new_content).await?
+    {
+        return Ok(CommandOutput::error(refused, None));
+    }
 
     info!("Removed {package} from world.wit");
 
-    Ok(CommandOutput::ok(
-        format!("Removed WIT dependency: {package}"),
-        Some(serde_json::json!({
-            "package": package,
-            "wit_dir": wit_dir.display().to_string(),
-        })),
-    ))
+    // Take the removed package out of `wit/deps` directly, so the removal holds even when the
+    // fetch below cannot run. The fetch rewrites `wit/deps` from the resolution and prunes it
+    // too, but only when it gets that far.
+    let deps_dir = wit_dir.join("deps");
+    let dropped = remove_package_deps(&deps_dir, &wit_ref.package).await;
+    if dropped > 0 {
+        debug!(
+            "removed {dropped} director(ies) from {}",
+            deps_dir.display()
+        );
+    }
+
+    // Re-fetch so the lock file stops pinning what the world no longer names, and so anything
+    // still named is back in place. A project that has never fetched has nothing to bring back.
+    let nothing_fetched =
+        !deps_dir.exists() && !ctx.project_dir().join(WKG_LOCK_FILE_NAME).exists();
+    let refetched = match nothing_fetched {
+        true => true,
+        false => match handle_fetch(ctx, config, false).await {
+            Ok(output) if output.is_success() => true,
+            // The world has already been edited, so the removal stands and the fetch failure is
+            // reported rather than hidden
+            Ok(output) => {
+                warn!(
+                    "removed {package}, but the re-fetch that follows it failed: {}",
+                    output.render().0
+                );
+                false
+            }
+            Err(e) => {
+                warn!("removed {package}, but the re-fetch that follows it failed: {e:#}");
+                false
+            }
+        },
+    };
+
+    let mut message = match refetched {
+        true => format!("Removed WIT dependency: {package}"),
+        false => format!(
+            "Removed WIT dependency: {package}\n\n\
+             The lock file still pins it; run `wash wit fetch` once world.wit resolves again."
+        ),
+    };
+    if !labelled.is_empty() {
+        message.push_str(&format!(
+            "\n\n{} labelled import(s) of it are still in world.wit, which this leaves alone.",
+            labelled.len()
+        ));
+    }
+
+    let data = serde_json::json!({
+        "package": package,
+        "refetched": refetched,
+        "labelled_kept": labelled,
+        "wit_dir": wit_dir.display().to_string(),
+    });
+
+    match refetched {
+        true => Ok(CommandOutput::ok(message, Some(data))),
+        // world.wit no longer agrees with wit/deps and the lock file, which a `&&` in a script
+        // needs to hear about
+        false => Ok(CommandOutput::error(message, Some(data))),
+    }
+}
+
+/// Remove a package's directories from `wit/deps`, which wkg names `<namespace>-<name>` with the
+/// version appended. Returns how many were removed.
+async fn remove_package_deps(deps_dir: &std::path::Path, package: &str) -> usize {
+    let prefix = package.replace(':', "-");
+    let Ok(mut entries) = tokio::fs::read_dir(deps_dir).await else {
+        return 0;
+    };
+
+    let mut removed = 0;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name().to_string_lossy().to_string();
+        // `wasi-http-0.2.0` belongs to wasi:http; `wasi-http-extra-0.2.0` does not, so whatever
+        // follows the name has to be a version
+        let belongs = name == prefix
+            || name
+                .strip_prefix(&format!("{prefix}-"))
+                .is_some_and(|rest| semver::Version::parse(rest).is_ok());
+        if !belongs {
+            continue;
+        }
+        if let Err(e) = tokio::fs::remove_dir_all(entry.path()).await {
+            warn!("failed to remove {}: {e}", entry.path().display());
+            continue;
+        }
+        removed += 1;
+    }
+    removed
 }
 
 /// Handle `wash wit clean`
@@ -841,7 +1721,9 @@ async fn handle_build(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::fs;
+    use std::path::Path;
     use tempfile::TempDir;
 
     /// Helper to create a temporary project directory with a basic WIT structure
@@ -868,9 +1750,49 @@ world example {
         (temp_dir, project_dir, wit_dir)
     }
 
+    /// The path of a statement `wash wit add` writes or `wash wit remove` takes away
+    fn dependency_path(line: &str) -> Option<&str> {
+        world_statement(line)
+            .filter(WorldStatement::is_dependency)
+            .map(|statement| statement.path)
+    }
+
+    /// A [`CliContext`] rooted in a test project, so that nothing a command does — a lock file,
+    /// a `deps` directory — lands outside its temporary directory. The process working directory
+    /// stays where it is, since every other test in this binary is using it.
+    async fn test_ctx(project_dir: &Path) -> CliContext {
+        CliContext::builder()
+            .non_interactive(true)
+            .project_dir(project_dir.to_path_buf())
+            .keep_working_dir()
+            .build()
+            .await
+            .expect("failed to build CLI context")
+    }
+
+    /// A [`Config`] pointing at a test project's WIT directory
+    fn test_config(wit_dir: &Path) -> Config {
+        Config {
+            wit: Some(crate::wit::WitConfig {
+                wit_dir: Some(wit_dir.to_path_buf()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Assert that a WIT file parses, which is what `wash wit fetch` and `wash wit build` do
+    /// before anything else
+    fn assert_parses(world_wit_path: &Path) {
+        if let Err(e) = wasm_pkg_core::wit::get_packages(world_wit_path) {
+            let content = fs::read_to_string(world_wit_path).unwrap_or_default();
+            panic!("WIT should parse but did not: {e:#}\n{content}");
+        }
+    }
+
     #[tokio::test]
     async fn test_clean_removes_deps_directory() {
-        let (_temp, _project_dir, wit_dir) = setup_test_project().await;
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
 
         // Create a deps directory with content
         let deps_dir = wit_dir.join("deps");
@@ -878,7 +1800,7 @@ world example {
         fs::write(deps_dir.join("test.wit"), "// test").expect("failed to write test file");
         assert!(deps_dir.exists());
 
-        let ctx = CliContext::builder().build().await.unwrap();
+        let ctx = test_ctx(&project_dir).await;
         let config = Config {
             wit: Some(crate::wit::WitConfig {
                 wit_dir: Some(wit_dir.clone()),
@@ -894,121 +1816,671 @@ world example {
 
     #[tokio::test]
     async fn test_remove_package_from_world_wit() {
-        let (_temp, _project_dir, wit_dir) = setup_test_project().await;
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
         let world_wit_path = wit_dir.join("world.wit");
 
-        // Add an import to the file first
         let content = r#"package test:component@0.1.0;
 
-import wasi:cli@0.2.0;
-
 world example {
-
+    import wasi:cli/stdout@0.2.0;
+    import wasi:http/types@0.2.0;
 }
 "#;
         fs::write(&world_wit_path, content).expect("failed to write world.wit");
 
-        // Read the file
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
+
+        let output = handle_remove(&ctx, "wasi:cli/stdout", &config)
+            .await
+            .expect("handle_remove should not return Err");
+        assert!(output.is_success());
+
         let content = tokio::fs::read_to_string(&world_wit_path)
             .await
             .expect("failed to read world.wit");
 
-        assert!(content.contains("import wasi:cli@0.2.0;"));
-
-        // Remove the import
-        let new_lines: Vec<&str> = content
-            .lines()
-            .filter(|line| {
-                let trimmed = line.trim();
-                !(trimmed.starts_with("import ") && trimmed.contains("wasi:cli"))
-            })
-            .collect();
-
-        let new_content = new_lines.join("\n");
-        tokio::fs::write(&world_wit_path, new_content)
-            .await
-            .expect("failed to write world.wit");
-
-        // Verify removal
-        let content = tokio::fs::read_to_string(&world_wit_path)
-            .await
-            .expect("failed to read world.wit");
-
-        assert!(!content.contains("import wasi:cli@0.2.0;"));
+        assert!(!content.contains("import wasi:cli/stdout@0.2.0;"));
+        assert!(content.contains("import wasi:http/types@0.2.0;"));
+        assert_parses(&world_wit_path);
     }
 
     #[tokio::test]
-    async fn test_add_package_to_world_wit() {
+    async fn test_remove_package_removes_every_interface_of_that_package() {
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
+        let world_wit_path = wit_dir.join("world.wit");
+
+        let content = r#"package test:component@0.1.0;
+
+world example {
+    import wasi:keyvalue/store@0.2.0-draft;
+    import wasi:keyvalue/atomics@0.2.0-draft;
+    import wasi:http/types@0.2.0;
+}
+"#;
+        fs::write(&world_wit_path, content).expect("failed to write world.wit");
+
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
+
+        let output = handle_remove(&ctx, "wasi:keyvalue", &config)
+            .await
+            .expect("handle_remove should not return Err");
+        assert!(output.is_success());
+
+        let content = tokio::fs::read_to_string(&world_wit_path)
+            .await
+            .expect("failed to read world.wit");
+
+        assert!(
+            !content.contains("wasi:keyvalue"),
+            "both wasi:keyvalue interfaces should be gone: {content}"
+        );
+        assert!(content.contains("import wasi:http/types@0.2.0;"));
+        assert_parses(&world_wit_path);
+    }
+
+    #[tokio::test]
+    async fn test_an_edit_that_would_not_parse_is_refused() {
         let (_temp, _project_dir, wit_dir) = setup_test_project().await;
         let world_wit_path = wit_dir.join("world.wit");
 
-        let original_content = r#"package test:component@0.1.0;
+        let content = r#"package test:component@0.1.0;
 
 world example {
-
+    import wasi:cli/stdout@0.2.0;
 }
 "#;
-        fs::write(&world_wit_path, original_content).expect("failed to write world.wit");
+        fs::write(&world_wit_path, content).expect("failed to write world.wit");
 
-        // Simulate adding a package inside the world block
-        let package = "wasi:http@0.2.0";
-        let import_line = format!("import {package};");
+        // The shape `wash wit add` used to write: a world imports interfaces, not packages
+        let broken = r#"package test:component@0.1.0;
+
+world example {
+    import wasi:cli/stdout@0.2.0;
+    import wasmcloud:messaging;
+}
+"#;
+        let refused = write_world_wit(&world_wit_path, &wit_dir, content, broken)
+            .await
+            .expect("the guard should not return Err")
+            .expect("WIT that does not parse should be refused");
+
+        assert!(refused.contains("was left as it was"), "{refused}");
+        assert!(
+            refused.contains("messaging"),
+            "the reason it does not parse comes with it: {refused}"
+        );
+
+        let after = fs::read_to_string(&world_wit_path).expect("failed to read world.wit");
+        assert_eq!(after, content, "world.wit should be back as it was");
+
+        // What does parse is kept
+        let valid = r#"package test:component@0.1.0;
+
+world example {
+    import wasi:cli/stdout@0.2.0;
+    import wasmcloud:messaging/consumer@0.2.0;
+}
+"#;
+        assert_eq!(
+            write_world_wit(&world_wit_path, &wit_dir, content, valid)
+                .await
+                .expect("the guard should not return Err"),
+            None
+        );
+        let after = fs::read_to_string(&world_wit_path).expect("failed to read world.wit");
+        assert_eq!(after, valid);
+    }
+
+    #[tokio::test]
+    async fn test_an_edit_to_wit_that_already_does_not_parse_is_kept() {
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
+        let world_wit_path = wit_dir.join("world.wit");
+
+        // The shape `wash wit add` used to write: a world cannot import a package, so this file
+        // does not parse before the edit either
+        let content = r#"package test:component@0.1.0;
+
+world example {
+    import wasmcloud:messaging;
+    import wasi:cli/stdout@0.2.0;
+}
+"#;
+        fs::write(&world_wit_path, content).expect("failed to write world.wit");
+
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
+
+        let output = handle_remove(&ctx, "wasmcloud:messaging", &config)
+            .await
+            .expect("handle_remove should not return Err");
+        assert!(output.is_success());
+
+        // Refusing here would stand in the way of the edit that repairs the file
+        let after = fs::read_to_string(&world_wit_path).expect("failed to read world.wit");
+        assert!(!after.contains("wasmcloud:messaging"), "{after}");
+        assert!(after.contains("import wasi:cli/stdout@0.2.0;"));
+    }
+
+    #[tokio::test]
+    async fn test_remove_prunes_stale_deps() {
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
+
+        // A local source keeps this off the network
+        let source_dir = project_dir.join("local-wit");
+        fs::create_dir_all(&source_dir).expect("failed to create local source dir");
+        fs::write(
+            source_dir.join("greet.wit"),
+            "package test:dep@0.1.0;\n\ninterface greet {\n  hello: func() -> string;\n}\n",
+        )
+        .expect("failed to write the local package");
+
+        fs::write(
+            wit_dir.join("world.wit"),
+            "package test:component@0.1.0;\n\nworld example {\n    import test:dep/greet@0.1.0;\n}\n",
+        )
+        .expect("failed to write world.wit");
+
+        let config = Config {
+            wit: Some(crate::wit::WitConfig {
+                wit_dir: Some(wit_dir.clone()),
+                sources: HashMap::from([("test:dep".to_string(), "local-wit".to_string())]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let ctx = test_ctx(&project_dir).await;
+
+        let output = handle_fetch(&ctx, &config, false)
+            .await
+            .expect("fetch should not return Err");
+        assert!(output.is_success(), "fetch from a local source should work");
+
+        // Something the world does not name, of the kind left behind by an earlier edit
+        let deps_dir = wit_dir.join("deps");
+        let stale_dir = deps_dir.join("stale-pkg-0.1.0");
+        fs::create_dir_all(&stale_dir).expect("failed to create the stale dep");
+        fs::write(
+            stale_dir.join("package.wit"),
+            "package stale:pkg@0.1.0;\n\ninterface gone {\n  ping: func();\n}\n",
+        )
+        .expect("failed to write the stale dep");
+
+        let output = handle_remove(&ctx, "test:dep", &config)
+            .await
+            .expect("handle_remove should not return Err");
+        assert!(output.is_success());
+
+        let content = fs::read_to_string(wit_dir.join("world.wit")).expect("failed to read world");
+        assert!(!content.contains("test:dep"), "the import should be gone");
+        assert!(
+            !stale_dir.exists(),
+            "wit/deps should no longer hold what the world does not name"
+        );
+    }
+
+    #[test]
+    fn test_version_changes_between_lock_files() {
+        let before = BTreeMap::from([
+            ("wasi:http".to_string(), vec!["0.2.0".to_string()]),
+            ("wasi:config".to_string(), vec!["0.2.0-draft".to_string()]),
+        ]);
+        let after = BTreeMap::from([
+            ("wasi:http".to_string(), vec!["0.2.6".to_string()]),
+            ("wasi:clocks".to_string(), vec!["0.2.12".to_string()]),
+        ]);
+
+        assert_eq!(
+            version_changes(&before, &after),
+            [
+                "Adding wasi:clocks 0.2.12",
+                "Updating wasi:http 0.2.0 -> 0.2.6",
+                "Removing wasi:config 0.2.0-draft",
+            ]
+        );
+
+        // A lock file that did not move reports nothing
+        assert!(version_changes(&after, &after).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_remove_takes_the_whole_include_statement() {
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
+        let world_wit_path = wit_dir.join("world.wit");
+
+        // `include ... with { ... }` runs past the line its path is on, and takes no semicolon
+        let content = r#"package test:component@0.1.0;
+
+world example {
+    include wasi:http/proxy@0.2.0 with {
+        handler as my-handler
+    }
+    import wasi:cli/stdout@0.2.0;
+}
+"#;
+        fs::write(&world_wit_path, content).expect("failed to write world.wit");
+
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
+
+        let output = handle_remove(&ctx, "wasi:http", &config)
+            .await
+            .expect("handle_remove should not return Err");
+        assert!(output.is_success());
 
         let content = tokio::fs::read_to_string(&world_wit_path)
             .await
             .expect("failed to read world.wit");
 
-        assert!(!content.contains(&import_line));
+        assert!(!content.contains("wasi:http/proxy"));
+        assert!(
+            !content.contains("my-handler"),
+            "the rest of the statement should go with it: {content}"
+        );
+        assert!(
+            content.contains("import wasi:cli/stdout@0.2.0;"),
+            "the statement after it stays: {content}"
+        );
+        assert!(content.contains('}'), "the world still closes: {content}");
+        assert_parses(&world_wit_path);
+    }
 
-        // Add the import inside the world block (correct WIT syntax)
-        let lines: Vec<&str> = content.lines().collect();
-        let mut new_lines = Vec::new();
-        let mut inserted = false;
+    #[test]
+    fn test_statements_inside_comments_are_not_statements() {
+        let content = r#"package test:component@0.1.0;
 
-        for line in lines.iter() {
-            new_lines.push(line.to_string());
+world example {
+    /*
+    import wasi:http/types@0.2.0;
+    /* a nested comment, which WIT allows */
+    */
+    import wasi:cli/stdout@0.2.0; // and a line comment
+}
+"#;
+        let blanked = without_comments(content);
 
-            if !inserted {
-                let trimmed = line.trim();
-                // Insert after the opening brace of the world block
-                if trimmed.starts_with("world ") && trimmed.ends_with('{') {
-                    new_lines.push(format!("   {import_line}")); // Indent inside world block
-                    inserted = true;
-                }
-            }
-        }
+        // Only the one real statement survives blanking
+        let statements: Vec<&str> = blanked.lines().filter_map(any_statement_path).collect();
+        assert_eq!(statements, ["wasi:cli/stdout@0.2.0"], "{blanked}");
 
-        let new_content = new_lines.join("\n");
-        tokio::fs::write(&world_wit_path, &new_content)
+        // Blanking keeps the shape of the file, so a line index into it is one into the original
+        assert_eq!(blanked.lines().count(), content.lines().count());
+
+        // ... and an import is not written into the middle of the comment
+        let updated = insert_import_into_world(content, "import wasi:clocks/wall-clock@0.2.0;")
+            .expect("should insert the import");
+        let position = updated
+            .lines()
+            .position(|line| line.contains("wasi:clocks/wall-clock"))
+            .expect("the import was written");
+        let last_comment = updated
+            .lines()
+            .position(|line| line.trim() == "*/")
+            .expect("the comment is still there");
+        assert!(position > last_comment, "{updated}");
+    }
+
+    #[test]
+    fn test_version_is_only_read_when_it_reads_as_one() {
+        // A `use` names what it takes after the version
+        assert_eq!(
+            statement_version("wasi:clocks/wall-clock@0.2.0.{datetime}"),
+            Some("0.2.0")
+        );
+        assert_eq!(statement_version("wasi:http/types@0.2.0"), Some("0.2.0"));
+        assert_eq!(
+            statement_version("wasmcloud:messaging/consumer@0.2.0-draft"),
+            Some("0.2.0-draft")
+        );
+        // An `include ... with` carries more than the path
+        assert_eq!(
+            statement_version("wasi:http/proxy@0.2.0 with {"),
+            Some("0.2.0")
+        );
+        assert_eq!(statement_version("wasi:http/types"), None);
+        assert_eq!(statement_version("wasi:http/types@nonsense"), None);
+
+        // The package is what comes before the version, and before anything else on the line
+        assert_eq!(
+            statement_package("wasi:http/proxy with { handler as my-handler }"),
+            "wasi:http/proxy"
+        );
+        assert_eq!(
+            statement_package("wasi:http/types@0.2.0"),
+            "wasi:http/types"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_leaves_other_packages_with_the_same_prefix() {
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
+        let world_wit_path = wit_dir.join("world.wit");
+
+        let content = r#"package test:component@0.1.0;
+
+world example {
+    import wasi:http/types@0.2.0;
+    import wasi:http-extra/types@0.2.0;
+}
+"#;
+        fs::write(&world_wit_path, content).expect("failed to write world.wit");
+
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
+
+        handle_remove(&ctx, "wasi:http", &config)
             .await
-            .expect("failed to write world.wit");
+            .expect("handle_remove should not return Err");
 
-        // Verify addition - import should be inside the world block
         let content = tokio::fs::read_to_string(&world_wit_path)
             .await
             .expect("failed to read world.wit");
 
+        assert!(!content.contains("import wasi:http/types@0.2.0;"));
+        assert!(content.contains("import wasi:http-extra/types@0.2.0;"));
+    }
+
+    #[test]
+    fn test_add_writes_a_parseable_import() {
+        let content = r#"package test:component@0.1.0;
+
+world example {
+}
+"#;
+        // The line `wash wit add` writes for a fully qualified interface reference
+        let wit_ref = WitRef::parse("wasi:http/types@0.2.0").expect("reference should parse");
+        let world_path = wit_ref
+            .world_path(wit_ref.version.as_deref())
+            .expect("interface reference has a path");
+        let updated = insert_import_into_world(content, &format!("import {world_path};"))
+            .expect("should insert the import");
+
+        assert!(updated.contains("    import wasi:http/types@0.2.0;"));
+
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let world_wit_path = temp.path().join("world.wit");
+        fs::write(&world_wit_path, &updated).expect("failed to write world.wit");
+        assert_parses(&world_wit_path);
+    }
+
+    #[test]
+    fn test_add_rejects_a_package_without_an_interface() {
+        // A world cannot import a package, so there is no line to write for one
+        let wit_ref = WitRef::parse("wasmcloud:messaging@0.3.0").expect("reference should parse");
+        assert_eq!(wit_ref.world_path(None), None);
+
+        let error = anyhow::anyhow!("no release matching version requirement `=0.3.0`");
+        let message = package_reference_message(&wit_ref, Err(&error));
         assert!(
-            content.contains(&import_line),
-            "Import should be added to world.wit"
+            message.contains("no release matching version requirement"),
+            "the reason the lookup failed is kept: {message}"
         );
-        // Verify it's inside the world block, not at top level
-        let lines: Vec<&str> = content.lines().collect();
-        let mut found_world = false;
-        let mut found_import_inside = false;
-        for line in lines {
-            if line.trim().starts_with("world ") {
-                found_world = true;
-            }
-            if found_world && line.trim().starts_with("import wasi:http") {
-                found_import_inside = true;
-                break;
-            }
-        }
         assert!(
-            found_import_inside,
-            "Import should be inside the world block"
+            message.contains("wash wit add wasmcloud:messaging/<interface>@0.3.0"),
+            "unresolvable packages still get a usable example: {message}"
         );
+
+        let contents = PackageContents {
+            version: Some(semver::Version::new(0, 3, 0)),
+            interfaces: vec!["types".to_string(), "consumer".to_string()],
+            worlds: vec!["imports".to_string()],
+        };
+        let message = package_reference_message(&wit_ref, Ok(&contents));
+        assert!(message.contains("wash wit add wasmcloud:messaging/consumer@0.3.0"));
+        assert!(message.contains("include wasmcloud:messaging/imports@0.3.0;"));
+    }
+
+    #[test]
+    fn test_version_written_into_the_world() {
+        let resolved = semver::Version::new(0, 3, 7);
+
+        // A whole version is written as it was asked for
+        assert_eq!(
+            version_to_write(None, Some("0.3.4"), Some(&resolved)).as_deref(),
+            Some("0.3.4")
+        );
+
+        // A partial version is not something a world statement can carry, so what gets written is
+        // the newest version compatible with it
+        assert_eq!(
+            version_to_write(None, Some("0.3"), Some(&resolved)).as_deref(),
+            Some("0.3.7")
+        );
+
+        // No version becomes the version that was selected: an unversioned statement does not
+        // resolve against a versioned package
+        assert_eq!(
+            version_to_write(None, None, Some(&resolved)).as_deref(),
+            Some("0.3.7")
+        );
+
+        // Only a package that could not be resolved at all is left unversioned
+        assert_eq!(version_to_write(None, None, None), None);
+
+        // The version the world already uses is what an unversioned reference takes
+        assert_eq!(
+            version_to_write(Some("0.3.1"), None, Some(&resolved)).as_deref(),
+            Some("0.3.1")
+        );
+
+        // ... and what a compatible partial version takes, rather than moving the world
+        assert_eq!(
+            version_to_write(Some("0.3.1"), Some("0.3"), Some(&resolved)).as_deref(),
+            Some("0.3.1")
+        );
+
+        // A whole version that was asked for wins over the world's
+        assert_eq!(
+            version_to_write(Some("0.3.1"), Some("0.3.4"), Some(&resolved)).as_deref(),
+            Some("0.3.4")
+        );
+        assert_eq!(
+            version_to_write(Some("0.2.0"), Some("0.3.4"), Some(&resolved)).as_deref(),
+            Some("0.3.4")
+        );
+
+        // A partial version the world cannot satisfy takes the newest compatible with it
+        assert_eq!(
+            version_to_write(Some("0.2.0"), Some("0.3"), Some(&resolved)).as_deref(),
+            Some("0.3.7")
+        );
+
+        let wit_ref = WitRef::parse("wasi:http/types@0.2").expect("reference should parse");
+        assert_eq!(
+            wit_ref.world_path(Some("0.2.3")).as_deref(),
+            Some("wasi:http/types@0.2.3")
+        );
+        assert_eq!(wit_ref.world_path(None).as_deref(), Some("wasi:http/types"));
+    }
+
+    #[test]
+    fn test_labelled_imports_are_read() {
+        // The `(implements ..)` form binds one interface to a label
+        let statement =
+            world_statement("    import team-a: wasi:keyvalue/store@0.2.0-draft;").unwrap();
+        assert_eq!(statement.keyword, "import");
+        assert_eq!(statement.label, Some("team-a"));
+        assert_eq!(statement.path, "wasi:keyvalue/store@0.2.0-draft");
+        assert_eq!(statement_version(statement.path), Some("0.2.0-draft"));
+
+        // An unlabelled import has a `:` of its own, which is the package's
+        let statement = world_statement("    import wasi:keyvalue/store@0.2.0-draft;").unwrap();
+        assert_eq!(statement.label, None);
+        assert_eq!(statement.path, "wasi:keyvalue/store@0.2.0-draft");
+
+        // A labelled import is one the world depends on, so it decides the version in use
+        let wit_ref = WitRef::parse("wasi:keyvalue").unwrap();
+        assert!(wit_ref.is_same_package(statement.path));
+    }
+
+    #[tokio::test]
+    async fn test_remove_leaves_labelled_imports_alone() {
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
+        let world_wit_path = wit_dir.join("world.wit");
+
+        let content = r#"package test:component@0.1.0;
+
+world example {
+    import team-a: wasi:keyvalue/store@0.2.0-draft;
+    import wasi:keyvalue/store@0.2.0-draft;
+}
+"#;
+        fs::write(&world_wit_path, content).expect("failed to write world.wit");
+
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
+
+        let output = handle_remove(&ctx, "wasi:keyvalue/store", &config)
+            .await
+            .expect("handle_remove should not return Err");
+        assert!(output.is_success());
+        let (message, _) = output.render();
+
+        let content = tokio::fs::read_to_string(&world_wit_path)
+            .await
+            .expect("failed to read world.wit");
+
+        // The plain import goes; the labelled binding the component's bindings are written
+        // against stays, and is reported
+        assert!(
+            !content.contains("    import wasi:keyvalue/store@0.2.0-draft;"),
+            "{content}"
+        );
+        assert!(content.contains("import team-a: wasi:keyvalue/store@0.2.0-draft;"));
+        assert!(message.contains("labelled import"), "{message}");
+        assert_parses(&world_wit_path);
+    }
+
+    #[tokio::test]
+    async fn test_remove_reports_when_only_labelled_imports_match() {
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
+        let world_wit_path = wit_dir.join("world.wit");
+
+        let content = r#"package test:component@0.1.0;
+
+world example {
+    import team-a: wasi:keyvalue/store@0.2.0-draft;
+}
+"#;
+        fs::write(&world_wit_path, content).expect("failed to write world.wit");
+
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
+
+        let output = handle_remove(&ctx, "wasi:keyvalue", &config)
+            .await
+            .expect("handle_remove should not return Err");
+        assert!(!output.is_success());
+        let (message, _) = output.render();
+        assert!(message.contains("only imported under a label"), "{message}");
+        assert!(
+            message.contains("import team-a: wasi:keyvalue/store@0.2.0-draft;"),
+            "{message}"
+        );
+
+        let after = tokio::fs::read_to_string(&world_wit_path)
+            .await
+            .expect("failed to read world.wit");
+        assert_eq!(after, content, "world.wit should be untouched");
+    }
+
+    #[tokio::test]
+    async fn test_remove_takes_the_doc_comment_with_it() {
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
+        let world_wit_path = wit_dir.join("world.wit");
+
+        let content = r#"package test:component@0.1.0;
+
+world example {
+    /// Wall-clock time, used for the cache expiry.
+    /// Two lines of it, even.
+    import wasi:clocks/wall-clock@0.2.0;
+    /// Monotonic time, used for the retry backoff.
+    import wasi:clocks/monotonic-clock@0.2.0;
+}
+"#;
+        fs::write(&world_wit_path, content).expect("failed to write world.wit");
+
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
+
+        handle_remove(&ctx, "wasi:clocks/wall-clock", &config)
+            .await
+            .expect("handle_remove should not return Err");
+
+        let content = tokio::fs::read_to_string(&world_wit_path)
+            .await
+            .expect("failed to read world.wit");
+
+        // The comment that documented the removed import goes with it, rather than staying to
+        // document the one below
+        assert!(!content.contains("cache expiry"), "{content}");
+        assert!(!content.contains("Two lines of it"), "{content}");
+        assert!(content.contains("/// Monotonic time, used for the retry backoff."));
+        assert!(content.contains("import wasi:clocks/monotonic-clock@0.2.0;"));
+        assert_parses(&world_wit_path);
+    }
+
+    #[test]
+    fn test_version_line_compatibility() {
+        // The same major.minor line is one package to WIT, which cannot hold two versions of it
+        assert!(same_version_line("0.2.3", "0.2.6"));
+        assert!(same_version_line("0.2.0", "0.2.0"));
+        // Different major.minor versions are separate packages, which can sit side by side
+        assert!(!same_version_line("0.2.3", "0.3.0"));
+        assert!(!same_version_line("1.0.0", "2.0.0"));
+        assert!(!same_version_line("0.2", "0.2.0"));
+    }
+
+    #[test]
+    fn test_export_pins_the_version_in_use() {
+        let world = "package test:component@0.1.0;\n\n\
+                     world example {\n    export wasi:http/incoming-handler@0.2.0;\n}\n";
+
+        // An export uses the package just as an import does, so it decides the version
+        let exported = world
+            .lines()
+            .filter_map(any_statement_path)
+            .next()
+            .expect("the export names a path");
+        assert_eq!(statement_version(exported), Some("0.2.0"));
+
+        // ... but it is not something `add` treats as already imported, or `remove` takes away
+        assert_eq!(world.lines().filter_map(dependency_path).count(), 0);
+    }
+
+    #[test]
+    fn test_requested_version_against_the_one_in_use() {
+        assert!(version_matches("0.2.0", "0.2.0"));
+        assert!(version_matches("0.2", "0.2.0"));
+        assert!(version_matches("0.2.0-draft", "0.2.0-draft"));
+        assert!(!version_matches("0.3.0", "0.2.0"));
+        assert!(!version_matches("0.2", "0.3.1"));
+    }
+
+    #[test]
+    fn test_add_rejects_an_interface_the_package_does_not_define() {
+        let contents = PackageContents {
+            version: Some(semver::Version::new(0, 2, 0)),
+            interfaces: vec!["types".to_string(), "consumer".to_string()],
+            worlds: Vec::new(),
+        };
+
+        let wit_ref = WitRef::parse("wasmcloud:messaging/consumr@0.2.0").expect("should parse");
+        let message = undefined_interface_message(&wit_ref, &contents)
+            .expect("a misspelled interface is rejected");
+        assert!(
+            message.contains("does not define an interface named `consumr`"),
+            "the message names the interface: {message}"
+        );
+        assert!(
+            message.contains("wash wit add wasmcloud:messaging/consumer@0.2.0"),
+            "the message lists what the package does define: {message}"
+        );
+
+        let wit_ref = WitRef::parse("wasmcloud:messaging/consumer@0.2.0").expect("should parse");
+        assert_eq!(undefined_interface_message(&wit_ref, &contents), None);
     }
 
     #[test]
@@ -1019,10 +2491,10 @@ world example {
 }
 "#;
 
-        let updated = insert_import_into_world(content, "import wasi:http@0.2.0;")
+        let updated = insert_import_into_world(content, "import wasi:http/types@0.2.0;")
             .expect("insert should succeed");
 
-        assert!(updated.contains("    import wasi:http@0.2.0;"));
+        assert!(updated.contains("    import wasi:http/types@0.2.0;"));
     }
 
     #[test]
@@ -1034,10 +2506,10 @@ world example
 }
 "#;
 
-        let updated = insert_import_into_world(content, "import wasi:http@0.2.0;")
+        let updated = insert_import_into_world(content, "import wasi:http/types@0.2.0;")
             .expect("insert should succeed");
 
-        assert!(updated.contains("{\n    import wasi:http@0.2.0;\n}"));
+        assert!(updated.contains("{\n    import wasi:http/types@0.2.0;\n}"));
     }
 
     #[test]
@@ -1050,40 +2522,46 @@ world example
 }
 "#;
 
-        let updated = insert_import_into_world(content, "import wasi:http@0.2.0;")
+        let updated = insert_import_into_world(content, "import wasi:http/types@0.2.0;")
             .expect("insert should succeed");
 
-        assert!(
-            updated.contains(
-                "    import wasi:config/store@0.2.0-draft;\n    import wasi:http@0.2.0;\n}"
-            )
-        );
+        assert!(updated.contains(
+            "    import wasi:config/store@0.2.0-draft;\n    import wasi:http/types@0.2.0;\n}"
+        ));
     }
 
     #[test]
     fn test_parse_package_with_version() {
-        let package = "wasi:http@0.2.0";
-        let (name, version) = if let Some((n, v)) = package.split_once('@') {
-            (n, Some(v))
-        } else {
-            (package, None)
-        };
-
-        assert_eq!(name, "wasi:http");
-        assert_eq!(version, Some("0.2.0"));
+        assert_eq!(
+            WitRef::parse("wasi:http@0.2.0").unwrap(),
+            WitRef {
+                package: "wasi:http".to_string(),
+                interface: None,
+                version: Some("0.2.0".to_string()),
+            }
+        );
+        assert_eq!(
+            WitRef::parse("wasi:keyvalue/store@0.2.0-draft").unwrap(),
+            WitRef {
+                package: "wasi:keyvalue".to_string(),
+                interface: Some("store".to_string()),
+                version: Some("0.2.0-draft".to_string()),
+            }
+        );
     }
 
     #[test]
     fn test_parse_package_without_version() {
-        let package = "wasi:http";
-        let (name, version) = if let Some((n, v)) = package.split_once('@') {
-            (n, Some(v))
-        } else {
-            (package, None)
-        };
-
-        assert_eq!(name, "wasi:http");
-        assert_eq!(version, None);
+        assert_eq!(
+            WitRef::parse("wasi:http").unwrap(),
+            WitRef {
+                package: "wasi:http".to_string(),
+                interface: None,
+                version: None,
+            }
+        );
+        let wit_ref = WitRef::parse("wasi:http/types").unwrap();
+        assert_eq!(wit_ref.world_path(None).as_deref(), Some("wasi:http/types"));
     }
 
     #[tokio::test]
@@ -1190,32 +2668,35 @@ world example
 
     #[test]
     fn test_import_line_detection() {
-        let content = r#"package test:component@0.1.0;
+        assert_eq!(
+            dependency_path("    import wasi:http/types@0.2.0;"),
+            Some("wasi:http/types@0.2.0")
+        );
+        assert_eq!(
+            dependency_path("  include wasi:http/proxy@0.2.0;"),
+            Some("wasi:http/proxy@0.2.0")
+        );
+        assert_eq!(dependency_path("export wasi:cli/run@0.2.0;"), None);
+        assert_eq!(dependency_path("world example {"), None);
 
-import wasi:cli@0.2.0;
-import wasi:http@0.2.0;
+        let wit_ref = WitRef::parse("wasi:http").unwrap();
+        assert!(wit_ref.matches_path("wasi:http/types@0.2.0"));
+        assert!(wit_ref.matches_path("wasi:http/proxy"));
+        assert!(!wit_ref.matches_path("wasi:http-extra/types@0.2.0"));
+        assert!(!wit_ref.matches_path("wasi:keyvalue/store"));
 
-world example {
-
-}
-"#;
-
-        let has_cli = content.contains("import wasi:cli");
-        let has_http = content.contains("import wasi:http");
-        let has_keyvalue = content.contains("import wasi:keyvalue");
-
-        assert!(has_cli);
-        assert!(has_http);
-        assert!(!has_keyvalue);
+        let wit_ref = WitRef::parse("wasi:http/types").unwrap();
+        assert!(wit_ref.matches_path("wasi:http/types@0.2.0"));
+        assert!(!wit_ref.matches_path("wasi:http/proxy@0.2.0"));
     }
 
     #[tokio::test]
     async fn test_clean_nonexistent_deps_directory() {
-        let (_temp, _project_dir, wit_dir) = setup_test_project().await;
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
         let deps_dir = wit_dir.join("deps");
         assert!(!deps_dir.exists());
 
-        let ctx = CliContext::builder().build().await.unwrap();
+        let ctx = test_ctx(&project_dir).await;
         let config = Config {
             wit: Some(crate::wit::WitConfig {
                 wit_dir: Some(wit_dir.clone()),
@@ -1242,93 +2723,61 @@ world example {
         assert!(content.contains("world example"));
     }
 
-    #[tokio::test]
-    async fn test_multiple_imports_in_world_wit() {
-        let (_temp, _project_dir, wit_dir) = setup_test_project().await;
-        let world_wit_path = wit_dir.join("world.wit");
+    #[test]
+    fn test_multiple_imports_in_world_wit() {
+        let mut content = "package test:component@0.1.0;\n\nworld example {\n}\n".to_string();
 
-        let content = r#"package test:component@0.1.0;
+        for reference in [
+            "wasi:cli/stdout@0.2.0",
+            "wasi:http/types@0.2.0",
+            "wasi:keyvalue/store@0.2.0-draft",
+        ] {
+            let wit_ref = WitRef::parse(reference).unwrap();
+            let world_path = wit_ref
+                .world_path(wit_ref.version.as_deref())
+                .expect("interface reference has a path");
+            content = insert_import_into_world(&content, &format!("import {world_path};"))
+                .expect("should insert the import");
+        }
 
-import wasi:cli@0.2.0;
-import wasi:http@0.2.0;
-import wasi:keyvalue@0.2.0-draft;
+        let imports: Vec<&str> = content.lines().filter_map(dependency_path).collect();
+        assert_eq!(
+            imports,
+            [
+                "wasi:cli/stdout@0.2.0",
+                "wasi:http/types@0.2.0",
+                "wasi:keyvalue/store@0.2.0-draft"
+            ]
+        );
 
-world example {
-
-}
-"#;
-        fs::write(&world_wit_path, content).expect("failed to write world.wit");
-
-        let read_content = tokio::fs::read_to_string(&world_wit_path)
-            .await
-            .expect("failed to read world.wit");
-
-        // Count imports
-        let import_count = read_content
-            .lines()
-            .filter(|line| line.trim().starts_with("import "))
-            .count();
-
-        assert_eq!(import_count, 3);
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let world_wit_path = temp.path().join("world.wit");
+        fs::write(&world_wit_path, &content).expect("failed to write world.wit");
+        assert_parses(&world_wit_path);
     }
 
     #[tokio::test]
     async fn test_remove_specific_import() {
-        let (_temp, _project_dir, wit_dir) = setup_test_project().await;
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
         let world_wit_path = wit_dir.join("world.wit");
 
         let content = r#"package test:component@0.1.0;
 
-import wasi:cli@0.2.0;
-import wasi:http@0.2.0;
-import wasi:keyvalue@0.2.0-draft;
-
 world example {
-
+    import wasi:cli/stdout@0.2.0;
+    import wasi:http/types@0.2.0;
+    import wasi:keyvalue/store@0.2.0-draft;
 }
 "#;
         fs::write(&world_wit_path, content).expect("failed to write world.wit");
 
-        // Remove wasi:http
-        let package_to_remove = "wasi:http";
-        let read_content = tokio::fs::read_to_string(&world_wit_path)
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
+
+        let output = handle_remove(&ctx, "wasi:http", &config)
             .await
-            .expect("failed to read world.wit");
-
-        let new_lines: Vec<&str> = read_content
-            .lines()
-            .filter(|line| {
-                let trimmed = line.trim();
-                if trimmed.starts_with("import ") {
-                    // Extract the package name from the import line
-                    // Format: import wasi:http@0.2.0;
-                    if let Some(rest) = trimmed.strip_prefix("import ") {
-                        // First remove the semicolon if present
-                        let rest = rest.trim_end_matches(';');
-                        // Then split by @ to get the package name without version
-                        let package_name = if let Some((pkg, _version)) = rest.split_once('@') {
-                            pkg.trim()
-                        } else {
-                            rest.trim()
-                        };
-                        // Keep the line only if it doesn't match the package to remove
-                        package_name != package_to_remove
-                    } else {
-                        // If we can't parse it, keep it
-                        true
-                    }
-                } else {
-                    // Keep all non-import lines
-                    true
-                }
-            })
-            .collect();
-
-        let new_content = new_lines.join("\n");
-
-        tokio::fs::write(&world_wit_path, &new_content)
-            .await
-            .expect("failed to write world.wit");
+            .expect("handle_remove should not return Err");
+        assert!(output.is_success());
 
         let final_content = tokio::fs::read_to_string(&world_wit_path)
             .await
@@ -1340,6 +2789,7 @@ world example {
         );
         assert!(final_content.contains("import wasi:cli"));
         assert!(final_content.contains("import wasi:keyvalue"));
+        assert_parses(&world_wit_path);
     }
 
     #[tokio::test]
@@ -1447,72 +2897,28 @@ digest = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456789
         );
     }
 
-    #[tokio::test]
-    async fn test_add_malformed_wit_file() {
-        use std::fs;
-
-        let (_temp, _project_dir, wit_dir) = setup_test_project().await;
-
-        // Create a malformed world.wit file (missing closing brace)
-        let world_wit_path = wit_dir.join("world.wit");
+    #[test]
+    fn test_add_malformed_wit_file() {
+        // A file that does not parse is still edited: the WIT syntax error is reported by the
+        // fetch that follows, and the import line itself lands where it belongs
         let malformed_content = r#"package test:component@0.1.0;
 
 world example {
     import wasi:http/types@0.2.0;
     // Missing closing brace!
 "#;
-        fs::write(&world_wit_path, malformed_content).expect("failed to write malformed world.wit");
 
-        // Try to add an import - our code should handle the malformed file gracefully
-        let content = tokio::fs::read_to_string(&world_wit_path)
-            .await
-            .expect("failed to read world.wit");
+        let updated = insert_import_into_world(malformed_content, "import wasi:cli/stdout@0.2.0;")
+            .expect("should insert the import");
 
-        // Verify we can still read and parse it line-by-line (our approach is resilient)
-        let lines: Vec<&str> = content.lines().collect();
-        assert!(lines.iter().any(|l| l.trim().starts_with("import ")));
-        assert!(lines.iter().any(|l| l.trim().starts_with("world ")));
-
-        // Our line-based approach will still add the import even though file is malformed
-        // The actual validation happens when wasm_pkg_core tries to parse it
-        let new_import = "import wasi:cli/stdout@0.2.0;";
-        let mut new_lines = Vec::new();
-        let mut inserted = false;
-
-        for (i, line) in lines.iter().enumerate() {
-            new_lines.push(line.to_string());
-
-            if !inserted {
-                let trimmed = line.trim();
-                if trimmed.starts_with("import ") {
-                    let remaining_lines = &lines[i + 1..];
-                    let has_more_imports = remaining_lines
-                        .iter()
-                        .any(|l| l.trim().starts_with("import "));
-                    if !has_more_imports {
-                        new_lines.push(new_import.to_string());
-                        inserted = true;
-                    }
-                }
-            }
-        }
-
-        // Verify import was added (though file is still malformed)
-        let new_content = new_lines.join("\n");
-        assert!(new_content.contains(new_import));
-
-        // Note: The malformed syntax will be caught by wasm_pkg_core when fetching
-        // Our responsibility is to add the import line correctly, not to validate WIT syntax
+        assert!(
+            updated
+                .contains("    import wasi:http/types@0.2.0;\n    import wasi:cli/stdout@0.2.0;")
+        );
     }
 
-    #[tokio::test]
-    async fn test_add_to_wit_file_with_comments() {
-        use std::fs;
-
-        let (_temp, _project_dir, wit_dir) = setup_test_project().await;
-
-        // Create a world.wit with comments
-        let world_wit_path = wit_dir.join("world.wit");
+    #[test]
+    fn test_add_to_wit_file_with_comments() {
         let content_with_comments = r#"package test:component@0.1.0;
 
 // This is a comment about imports
@@ -1522,39 +2928,31 @@ world example {
     // More comments
 }
 "#;
-        fs::write(&world_wit_path, content_with_comments)
-            .expect("failed to write world.wit with comments");
 
-        // Parse and add import
-        let content = tokio::fs::read_to_string(&world_wit_path)
-            .await
-            .expect("failed to read world.wit");
+        let updated =
+            insert_import_into_world(content_with_comments, "import wasi:cli/stdout@0.2.0;")
+                .expect("should insert the import");
 
-        let lines: Vec<&str> = content.lines().collect();
-
-        // Verify comments are preserved and not mistaken for imports
-        let comment_count = lines.iter().filter(|l| l.trim().starts_with("//")).count();
-        assert_eq!(comment_count, 3, "Should preserve all comment lines");
-
-        // Verify import detection works correctly (ignores comments)
-        let import_count = lines
-            .iter()
-            .filter(|l| l.trim().starts_with("import "))
-            .count();
         assert_eq!(
-            import_count, 1,
-            "Should find only actual import, not comments"
+            updated
+                .lines()
+                .filter(|l| l.trim().starts_with("//"))
+                .count(),
+            3,
+            "comments should be preserved: {updated}"
+        );
+        assert!(
+            updated
+                .contains("    import wasi:http/types@0.2.0;\n    import wasi:cli/stdout@0.2.0;"),
+            "{updated}"
         );
     }
 
     #[tokio::test]
     async fn test_remove_from_empty_world_wit() {
-        use std::fs;
-
-        let (_temp, _project_dir, wit_dir) = setup_test_project().await;
-
-        // Create an empty world.wit (only package declaration)
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
         let world_wit_path = wit_dir.join("world.wit");
+
         let empty_world = r#"package test:component@0.1.0;
 
 world example {
@@ -1562,114 +2960,93 @@ world example {
 "#;
         fs::write(&world_wit_path, empty_world).expect("failed to write empty world.wit");
 
-        let package_to_remove = "wasi:http";
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
 
-        // Try to remove a package that doesn't exist
+        let output = handle_remove(&ctx, "wasi:http", &config)
+            .await
+            .expect("handle_remove should not return Err");
+        assert!(!output.is_success(), "there is nothing to remove");
+
         let content = tokio::fs::read_to_string(&world_wit_path)
             .await
             .expect("failed to read world.wit");
-
-        let new_lines: Vec<&str> = content
-            .lines()
-            .filter(|line| {
-                let trimmed = line.trim();
-                if trimmed.starts_with("import ") {
-                    if let Some(rest) = trimmed.strip_prefix("import ") {
-                        let rest = rest.trim_end_matches(';');
-                        let package_name = if let Some((pkg, _version)) = rest.split_once('@') {
-                            pkg.trim()
-                        } else {
-                            rest.trim()
-                        };
-                        package_name != package_to_remove
-                    } else {
-                        true
-                    }
-                } else {
-                    true
-                }
-            })
-            .collect();
-
-        let new_content = new_lines.join("\n");
-
-        // Content should be unchanged (no imports to remove)
-        assert_eq!(content.trim(), new_content.trim());
+        assert_eq!(content, empty_world, "world.wit should be untouched");
     }
 
     #[tokio::test]
     async fn test_wit_file_with_inline_comments() {
-        use std::fs;
-
-        let (_temp, _project_dir, wit_dir) = setup_test_project().await;
-
-        // Create world.wit with inline comments (not on import lines, but nearby)
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
         let world_wit_path = wit_dir.join("world.wit");
+
         let content = r#"package test:component@0.1.0;
 
 world example {
     import wasi:http/types@0.2.0; // HTTP types
-    import wasi:cli/stdout@0.2.0; // CLI output
-    // import wasi:disabled@0.1.0; - This is commented out
+    import wasi:cli/stdout; // CLI output
+    // import wasi:keyvalue/store@0.2.0-draft; - This is commented out
 }
 "#;
         fs::write(&world_wit_path, content).expect("failed to write world.wit");
 
-        let read_content = tokio::fs::read_to_string(&world_wit_path)
+        let config = test_config(&wit_dir);
+        let ctx = test_ctx(&project_dir).await;
+
+        // A trailing comment does not hide the interface a line imports, versioned or not
+        for package in ["wasi:http", "wasi:cli/stdout"] {
+            let output = handle_remove(&ctx, package, &config)
+                .await
+                .expect("handle_remove should not return Err");
+            assert!(output.is_success(), "{package} should have been removed");
+        }
+
+        let content = tokio::fs::read_to_string(&world_wit_path)
             .await
             .expect("failed to read world.wit");
-
-        let lines: Vec<&str> = read_content.lines().collect();
-
-        // Count actual imports (should ignore the commented-out import)
-        let import_count = lines
-            .iter()
-            .filter(|l| {
-                let trimmed = l.trim();
-                trimmed.starts_with("import ") && !trimmed.starts_with("// import")
-            })
-            .count();
-
-        assert_eq!(
-            import_count, 2,
-            "Should find 2 imports, ignoring commented one"
+        assert!(!content.contains("import wasi:http"));
+        assert!(!content.contains("import wasi:cli"));
+        assert!(
+            content.contains("// import wasi:keyvalue/store@0.2.0-draft;"),
+            "a commented out import is left alone: {content}"
         );
     }
 
     #[test]
-    fn test_validate_interface_ref_package_only() {
+    fn test_wit_ref_package_only() {
         // Package-level references (no interface) must be accepted
-        assert!(validate_interface_ref("wasi:http").is_ok());
-        assert!(validate_interface_ref("wasi:http@0.2.0").is_ok());
-        assert!(validate_interface_ref("wasi:keyvalue").is_ok());
+        assert!(WitRef::parse("wasi:http").is_ok());
+        assert!(WitRef::parse("wasi:http@0.2.0").is_ok());
+        assert!(WitRef::parse("wasi:keyvalue").is_ok());
     }
 
     #[test]
-    fn test_validate_interface_ref_with_interface() {
+    fn test_wit_ref_with_interface() {
         // Interface-level references must still be accepted
-        assert!(validate_interface_ref("wasi:http/types").is_ok());
-        assert!(validate_interface_ref("wasi:http/types@0.2.0").is_ok());
-        assert!(validate_interface_ref("wasi:http/incoming-handler@0.2.0").is_ok());
+        assert!(WitRef::parse("wasi:http/types").is_ok());
+        assert!(WitRef::parse("wasi:http/types@0.2.0").is_ok());
+        assert!(WitRef::parse("wasi:http/incoming-handler@0.2.0").is_ok());
     }
 
     #[test]
-    fn test_validate_interface_ref_invalid() {
+    fn test_wit_ref_invalid() {
         // Missing namespace separator
-        assert!(validate_interface_ref("http").is_err());
-        assert!(validate_interface_ref("http/types").is_err());
+        assert!(WitRef::parse("http").is_err());
+        assert!(WitRef::parse("http/types").is_err());
         // Empty namespace or package name
-        assert!(validate_interface_ref(":http").is_err());
-        assert!(validate_interface_ref("wasi:").is_err());
-        assert!(validate_interface_ref(":/").is_err());
+        assert!(WitRef::parse(":http").is_err());
+        assert!(WitRef::parse("wasi:").is_err());
+        assert!(WitRef::parse(":/").is_err());
+        // A trailing slash names no interface
+        assert!(WitRef::parse("wasi:http/").is_err());
+        assert!(WitRef::parse("wasi:http/@0.2.0").is_err());
     }
 
     #[tokio::test]
     async fn test_remove_with_version_in_argument() {
-        let (_temp, _project_dir, wit_dir) = setup_test_project().await;
+        let (_temp, project_dir, wit_dir) = setup_test_project().await;
         let world_wit_path = wit_dir.join("world.wit");
 
-        let content =
-            "package test:component@0.1.0;\n\nworld example {\n    import wasi:http@0.2.0;\n}\n";
+        let content = "package test:component@0.1.0;\n\nworld example {\n    import wasi:http/types@0.2.0;\n}\n";
         fs::write(&world_wit_path, content).expect("failed to write world.wit");
 
         let config = Config {
@@ -1679,17 +3056,17 @@ world example {
             }),
             ..Default::default()
         };
-        let ctx = CliContext::builder().build().await.unwrap();
+        let ctx = test_ctx(&project_dir).await;
 
         // Removing with an explicit version should work: "wasi:http@0.2.0" matches
-        // "import wasi:http@0.2.0;" by stripping the version before comparing.
+        // "import wasi:http/types@0.2.0;" by stripping the version before comparing.
         let output = handle_remove(&ctx, "wasi:http@0.2.0", &config)
             .await
             .expect("handle_remove should not return Err");
 
         assert!(
             output.is_success(),
-            "removing wasi:http@0.2.0 should succeed when 'import wasi:http@0.2.0;' is present"
+            "removing wasi:http@0.2.0 should succeed when 'import wasi:http/types@0.2.0;' is present"
         );
 
         let new_content = tokio::fs::read_to_string(&world_wit_path)

--- a/crates/wash/src/wit.rs
+++ b/crates/wash/src/wit.rs
@@ -5,7 +5,7 @@
 //! fetching dependencies from registries and manages lock files for reproducible builds.
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
 };
 
@@ -472,15 +472,20 @@ impl WkgFetcher {
         Ok(())
     }
 
+    /// A caching client for this fetcher's registry configuration
+    fn client(&self) -> CachingClient<FileCache> {
+        CachingClient::new(
+            Some(wasm_pkg_client::Client::new(self.wkg_client_config.clone())),
+            self.cache.clone(),
+        )
+    }
+
     pub async fn fetch_wit_dependencies(
-        self,
+        &self,
         wit_dir: impl AsRef<Path>,
         lock: &mut LockFile,
     ) -> Result<()> {
-        let client = CachingClient::new(
-            Some(wasm_pkg_client::Client::new(self.wkg_client_config)),
-            self.cache,
-        );
+        let client = self.client();
 
         wasm_pkg_core::wit::fetch_dependencies(
             &self.wkg_config,
@@ -496,7 +501,7 @@ impl WkgFetcher {
 
     /// Build a WIT package into a Wasm binary
     pub async fn build_wit_package(
-        self,
+        &self,
         wit_dir: impl AsRef<Path>,
         lock: &mut LockFile,
     ) -> Result<(
@@ -504,13 +509,385 @@ impl WkgFetcher {
         Option<semver::Version>,
         Vec<u8>,
     )> {
-        let client = CachingClient::new(
-            Some(wasm_pkg_client::Client::new(self.wkg_client_config)),
-            self.cache,
-        );
+        let client = self.client();
 
         wasm_pkg_core::wit::build_package(&self.wkg_config, wit_dir.as_ref(), lock, client).await
     }
+
+    /// Work out what is wrong with a WIT directory that failed to fetch. Resolution reports only
+    /// that it failed, so this turns that into the two things it usually is: a package or version
+    /// the sources do not have, or one package named at two versions.
+    ///
+    /// Returns an empty list when nothing is found, which means the fetch failed for a reason its
+    /// own error already describes.
+    pub async fn diagnose_wit(&self, wit_dir: impl AsRef<Path>) -> Result<Vec<String>> {
+        let (_, packages) = wasm_pkg_core::wit::get_packages(wit_dir.as_ref())?;
+
+        // A HashSet has no order of its own, and the report should read the same every time
+        let mut required: BTreeMap<PackageRef, Vec<semver::VersionReq>> = BTreeMap::new();
+        for (package, requirement) in packages {
+            required.entry(package).or_default().push(requirement);
+        }
+        for requirements in required.values_mut() {
+            requirements.sort_by_key(ToString::to_string);
+        }
+
+        let overrides = self.wkg_config.overrides.clone().unwrap_or_default();
+        let client = self.client();
+
+        let mut problems = Vec::new();
+        for (package, requirements) in required {
+            // A fetch resolves one version per package name, so a package named at more than one
+            // version has no single version to ask the registry about either
+            if requirements.len() > 1 {
+                problems.push(multiple_versions_message(&package, &requirements));
+                continue;
+            }
+
+            // An overridden package does not come from the registry, so the registry has nothing
+            // to say about it
+            if overrides.contains_key(&package.to_string())
+                || overrides.contains_key(&package.namespace().to_string())
+            {
+                continue;
+            }
+
+            let Some(requirement) = requirements.first() else {
+                continue;
+            };
+            let version = requested_version(requirement);
+            match missing_from_registry(&client, &package, version.as_deref(), requirement).await {
+                Ok(Some(message)) => problems.push(message),
+                Ok(None) => {}
+                // A package that cannot be looked up is not a package that is known to be absent,
+                // and a registry that cannot answer for one will not answer for the rest either
+                Err(e) => {
+                    debug!("could not check [{package}] against its registry: {e:#}");
+                    break;
+                }
+            }
+        }
+
+        Ok(problems)
+    }
+
+    /// Load a single package from its source and report the interfaces and worlds it defines. A
+    /// world imports interfaces rather than whole packages, so this is what turns
+    /// `wasmcloud:messaging` into the set of names that can actually appear in a world.
+    ///
+    /// A package that the registry does not have comes back as [`PackageLookup::Missing`] with a
+    /// message naming what was searched; a lookup that could not be completed at all comes back
+    /// as [`PackageLookup::Failed`], so a caller can tell "there is no such package" apart from
+    /// "the registry could not be reached".
+    pub async fn load_package(
+        &self,
+        package: &PackageRef,
+        version: Option<&str>,
+        lock: Option<&LockFile>,
+    ) -> PackageLookup {
+        match self.try_load_package(package, version, lock).await {
+            Ok(lookup) => lookup,
+            Err(e) => PackageLookup::Failed(e),
+        }
+    }
+
+    async fn try_load_package(
+        &self,
+        package: &PackageRef,
+        version: Option<&str>,
+        lock: Option<&LockFile>,
+    ) -> Result<PackageLookup> {
+        let requirement = match version {
+            Some(version) => semver::VersionReq::parse(&format!("={version}"))
+                .map_err(|e| anyhow::anyhow!("invalid version [{version}]: {e}"))?,
+            None => semver::VersionReq::STAR,
+        };
+
+        // A `wkg.toml` override (which is also where a `wit.sources` local path lands) replaces
+        // the registry for this package, so the registry is only searched when there is none.
+        // Overrides are keyed by `namespace:package`, or by `namespace` alone for a whole
+        // namespace.
+        let package_override = self
+            .wkg_config
+            .overrides
+            .as_ref()
+            .and_then(|overrides| {
+                overrides
+                    .get(&package.to_string())
+                    .or_else(|| overrides.get(&package.namespace().to_string()))
+            })
+            .cloned();
+
+        let client = self.client();
+
+        // The lock file goes in so that a version it already pins is the one selected here, the
+        // same way the fetch that follows selects it
+        let mut resolver =
+            wasm_pkg_core::resolver::DependencyResolver::new_with_client(client.clone(), lock)
+                .context("failed to create dependency resolver")?;
+
+        match package_override {
+            Some(package_override) => {
+                // An override that pins a different version than the one asked for wins, the same
+                // way it does during a fetch, so say so rather than quietly resolving the other one
+                if let Some(pinned) = package_override.version.as_ref()
+                    && let Some(version) = version
+                    && semver::Version::parse(version)
+                        .is_ok_and(|requested| !pinned.matches(&requested))
+                {
+                    return Ok(PackageLookup::Missing(format!(
+                        "[{package}] is pinned to [{pinned}] by a source override, which does not \
+                         provide the requested version [{version}].\n\
+                         \n\
+                         Change the override under `wit.sources` in .wash/config.yaml (or in \
+                         wkg.toml), or ask for the pinned version."
+                    )));
+                }
+                let dependency = override_dependency(package, package_override, &requirement)
+                    .await
+                    .with_context(|| format!("failed to apply the override for [{package}]"))?;
+                resolver
+                    .add_dependency(package, &dependency)
+                    .await
+                    .with_context(|| format!("failed to load package [{package}]"))?;
+            }
+            None => {
+                if let Some(missing) =
+                    missing_from_registry(&client, package, version, &requirement).await?
+                {
+                    return Ok(PackageLookup::Missing(missing));
+                }
+                resolver
+                    .add_packages([(package.clone(), requirement)])
+                    .await
+                    .with_context(|| format!("failed to look up package [{package}]"))?;
+            }
+        }
+
+        let resolutions = resolver
+            .resolve()
+            .await
+            .with_context(|| format!("failed to resolve package [{package}]"))?;
+
+        let resolution = resolutions
+            .get(package)
+            .with_context(|| format!("package [{package}] resolved to nothing"))?;
+        let decoded = resolution
+            .decode()
+            .await
+            .with_context(|| format!("failed to decode package [{package}]"))?;
+        let (resolve, package_id, _) = decoded
+            .resolve()
+            .with_context(|| format!("failed to parse the WIT of package [{package}]"))?;
+        let resolved = resolve
+            .packages
+            .get(package_id)
+            .with_context(|| format!("package [{package}] is missing from its own WIT"))?;
+
+        Ok(PackageLookup::Found(PackageContents {
+            version: resolved.name.version.clone(),
+            interfaces: resolved.interfaces.keys().cloned().collect(),
+            worlds: resolved.worlds.keys().cloned().collect(),
+        }))
+    }
+}
+
+/// The outcome of loading one package, which separates a package the source does not have from a
+/// lookup that could not be completed
+pub enum PackageLookup {
+    /// The package was loaded, and this is what it defines
+    Found(PackageContents),
+    /// The source answered, and the package or the requested version is not in it. The message
+    /// says what was searched and, where the registry knows them, which versions do exist.
+    Missing(String),
+    /// The lookup could not be completed: the registry was unreachable, the credentials were
+    /// rejected, or the package was there but could not be read
+    Failed(anyhow::Error),
+}
+
+/// Turn a `wkg.toml` override into the dependency the resolver should load the package from
+async fn override_dependency(
+    package: &PackageRef,
+    package_override: wasm_pkg_core::manifest::Override,
+    requirement: &semver::VersionReq,
+) -> Result<wasm_pkg_core::resolver::Dependency> {
+    match (package_override.path, package_override.version) {
+        (Some(path), _) => {
+            let path = tokio::fs::canonicalize(&path)
+                .await
+                .with_context(|| format!("local path [{}] does not exist", path.display()))?;
+            Ok(wasm_pkg_core::resolver::Dependency::Local(path))
+        }
+        (None, version) => Ok(wasm_pkg_core::resolver::Dependency::Package(
+            wasm_pkg_core::resolver::RegistryPackage {
+                name: Some(package.clone()),
+                version: version.unwrap_or_else(|| requirement.clone()),
+                registry: None,
+            },
+        )),
+    }
+}
+
+/// The message for a package the WIT names at more than one version.
+///
+/// Versions in different major.minor lines are separate packages that WIT is happy to resolve
+/// side by side, but a fetch only resolves one version per package name, so `wit/deps` ends up
+/// with one of them and the imports of the other have nothing to resolve against. Two versions
+/// within one major.minor line cannot coexist at all.
+fn multiple_versions_message(package: &PackageRef, requirements: &[semver::VersionReq]) -> String {
+    let versions: Vec<String> = requirements
+        .iter()
+        .map(|requirement| requested_version(requirement).unwrap_or_else(|| NO_VERSION.to_string()))
+        .collect();
+    let listed = versions.join(", ");
+
+    let parsed: Vec<semver::Version> = requirements
+        .iter()
+        .filter_map(|requirement| semver::Version::parse(&requested_version(requirement)?).ok())
+        .collect();
+    let same_line = parsed.iter().enumerate().any(|(i, version)| {
+        parsed
+            .iter()
+            .skip(i + 1)
+            .any(|other| (version.major, version.minor) == (other.major, other.minor))
+    });
+
+    // An unversioned reference asks for `*`, which no versioned package satisfies
+    if let Some(named) = versions.iter().find(|version| *version != NO_VERSION)
+        && versions.iter().any(|version| version == NO_VERSION)
+    {
+        return format!(
+            "The WIT names [{package}] both with and without a version: {listed}.\n\
+             \n\
+             An unversioned statement does not resolve against a versioned package. Give the \
+             unversioned one a version — [{named}] is what the rest of the WIT uses."
+        );
+    }
+
+    match same_line {
+        true => format!(
+            "The WIT names [{package}] at more than one version in the same major.minor line: \
+             {listed}.\n\
+             \n\
+             Those cannot coexist; the imports have to agree on one of them."
+        ),
+        false => format!(
+            "The WIT names [{package}] at more than one version: {listed}.\n\
+             \n\
+             A fetch resolves one version per package name, so only one of those reaches \
+             wit/deps and the imports of the others have nothing to resolve against. The imports \
+             have to agree on one version."
+        ),
+    }
+}
+
+/// What the report calls a statement that names no version
+const NO_VERSION: &str = "no version";
+
+/// The version a requirement asks for, when it asks for exactly one. WIT carries a whole version
+/// or none, and that is what wkg turns into `=<version>` or `*`.
+fn requested_version(requirement: &semver::VersionReq) -> Option<String> {
+    let requirement = requirement.to_string();
+    requirement.strip_prefix('=').map(ToString::to_string)
+}
+
+/// Check the registry for a package before it is resolved, so that a package or version the
+/// registry does not have is reported as such rather than as a resolution failure. Returns the
+/// message to show, or `None` when the requirement can be satisfied.
+async fn missing_from_registry(
+    client: &CachingClient<FileCache>,
+    package: &PackageRef,
+    version: Option<&str>,
+    requirement: &semver::VersionReq,
+) -> Result<Option<String>> {
+    let registry = client
+        .client()
+        .ok()
+        .and_then(|client| client.config().resolve_registry(package))
+        .map(|registry| format!(" in registry [{registry}]"))
+        .unwrap_or_default();
+
+    let versions = match client.list_all_versions(package).await {
+        Ok(versions) => versions,
+        Err(wasm_pkg_client::Error::PackageNotFound) => {
+            return Ok(Some(format!(
+                "Package [{package}] was not found{registry}.\n\
+                 \n\
+                 Check the package name, and that the registry serving it is configured under \
+                 `wit.sources` in .wash/config.yaml."
+            )));
+        }
+        Err(wasm_pkg_client::Error::NoRegistryForNamespace(namespace)) => {
+            return Ok(Some(format!(
+                "No registry is configured for the [{namespace}] namespace, so [{package}] cannot be looked up.\n\
+                 \n\
+                 Map the namespace to a registry under `wit.sources` in .wash/config.yaml."
+            )));
+        }
+        Err(e) => bail!("failed to list versions of [{package}]{registry}: {e}"),
+    };
+
+    let mut published: Vec<semver::Version> = versions
+        .into_iter()
+        .filter(|version| !version.yanked)
+        .map(|version| version.version)
+        .collect();
+    published.sort();
+
+    if published.iter().any(|v| requirement.matches(v)) {
+        return Ok(None);
+    }
+
+    if published.is_empty() {
+        return Ok(Some(format!(
+            "Package [{package}] has no published versions{registry}."
+        )));
+    }
+
+    let listed = published
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    Ok(Some(match version {
+        Some(version) => format!(
+            "Package [{package}] has no version [{version}]{registry}.\n\
+             \n\
+             Published versions: {listed}"
+        ),
+        // Every version being a pre-release is the one case where a package with published
+        // versions still selects none of them, and naming one is the way out
+        None if published.iter().all(|version| !version.pre.is_empty()) => {
+            let newest = published
+                .last()
+                .map(ToString::to_string)
+                .unwrap_or_default();
+            format!(
+                "Every published version of [{package}]{registry} is a pre-release, and a \
+                 pre-release is only selected when it is named.\n\
+                 \n\
+                 Published versions: {listed}\n\
+                 \n\
+                 Name one, for example [{package}@{newest}]."
+            )
+        }
+        None => format!(
+            "No version of [{package}] could be selected{registry}.\n\
+             \n\
+             Published versions: {listed}"
+        ),
+    }))
+}
+
+/// What a WIT package defines, as resolved from a registry
+#[derive(Debug, Clone)]
+pub struct PackageContents {
+    /// The resolved version of the package, if it is versioned
+    pub version: Option<semver::Version>,
+    /// Names of the interfaces the package defines
+    pub interfaces: Vec<String>,
+    /// Names of the worlds the package defines
+    pub worlds: Vec<String>,
 }
 
 /// Detect source type from string format
@@ -519,8 +896,12 @@ fn detect_source_type(source: &str) -> RegistryPullSource {
         RegistryPullSource::RemoteGit(source.to_string())
     } else if source.starts_with("http://") || source.starts_with("https://") {
         RegistryPullSource::RemoteHttp(source.to_string())
-    } else if source.contains('/') && !source.starts_with('.') && !source.starts_with("file://") {
-        // Likely OCI reference (contains slash but not relative path)
+    } else if source.contains('/')
+        && !source.starts_with('.')
+        && !source.starts_with('/')
+        && !source.starts_with("file://")
+    {
+        // Likely OCI reference (contains slash but not a filesystem path)
         RegistryPullSource::RemoteOci(source.to_string())
     } else {
         // Default to local path
@@ -788,7 +1169,6 @@ pub async fn load_wkg_config(
     if tokio::fs::try_exists(&config_path).await.unwrap_or(false) {
         debug!(path = %config_path.display(), "loading wkg.toml overrides");
         wasm_pkg_core::manifest::Manifest::load_from_path(&config_path)
-            .await
             .with_context(|| format!("failed to load {}", config_path.display()))
     } else {
         Ok(wasm_pkg_core::manifest::Manifest::default())
@@ -820,6 +1200,10 @@ mod tests {
         ));
         assert!(matches!(
             detect_source_type("./local/path"),
+            RegistryPullSource::LocalPath(_)
+        ));
+        assert!(matches!(
+            detect_source_type("/absolute/path/wit"),
             RegistryPullSource::LocalPath(_)
         ));
         assert!(matches!(

--- a/crates/wash/tests/integration_wit.rs
+++ b/crates/wash/tests/integration_wit.rs
@@ -151,7 +151,7 @@ async fn test_update_selective_and_full() -> Result<()> {
 
 world example {
     import wasi:logging/logging@0.1.0-draft;
-    import wasi:config/store@0.2.0-draft;
+    import wasi:config/runtime@0.2.0-draft;
 }
 "#,
     )
@@ -209,7 +209,7 @@ async fn test_remove_workflow() -> Result<()> {
 
 world example {
     import wasi:logging/logging@0.1.0-draft;
-    import wasi:config/store@0.2.0-draft;
+    import wasi:config/runtime@0.2.0-draft;
 }
 "#,
     )
@@ -243,7 +243,7 @@ world example {
         "wasi:logging should be removed from world.wit"
     );
     assert!(
-        content.contains("import wasi:config/store"),
+        content.contains("import wasi:config/runtime"),
         "wasi:config should remain in world.wit"
     );
 


### PR DESCRIPTION
Bug fixes for `wash wit` commands as well has enhanced error handling.

`wash wit add wasmcloud:messaging@0.3.0` wrote `import wasmcloud:messaging@0.3.0;`
into world.wit, which is not valid WIT: a world imports interfaces, never a whole  package, and this is invalid wit grammar (fails on the `@`).

`wash wit add` now takes an interface reference and checks it before touching world.wit. A package on its own lists the interfaces it defines instead of writing anything, and a package, version, or interface the sources do not have is reported  as such with the versions that do exist, rather than as a resolution failure.

Alongside that:
- `wash wit fetch` diagnoses a failed resolution instead of passing the resolver error through: a missing package or version, or one package named at more than one version, which a fetch resolves one of per package name
- `wash wit update` reports what moved, in the shape `cargo update` reports
- `wash wit remove` drops the removed package from `wit/deps` and re-fetches, so the lock file stops pinning it
- `wash wit update` accepts the same interface references `add` and `remove` do
- `wit.sources` accepts an absolute local path instead of reading it as an OCI reference
- wasm-pkg-client/core 0.16.0 -> 0.16.1
- `WkgFetcher::load_package` returns a three-way `PackageLookup` (`Found`/`Missing`/`Failed`)

The tests in this module have been rewritten. They now call the real functions and run the result through `wasm_pkg_core::wit::get_packages`.