### PR TITLE
style: fix two lints on main

### DIFF
--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -350,7 +350,7 @@ impl Engine {
     pub fn host_memory(&self) -> host_memory::HostMemoryBudgets {
         self.host_memory
     }
-    
+
     /// Core instances the pooling allocator was configured to admit, captured
     /// from the [`PoolingAllocationConfig`] actually installed — so it reflects
     /// the `WASMTIME_POOLING_TOTAL_CORE_INSTANCES` override and a

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -1368,6 +1368,48 @@ fn check_url_scheme(field: &str, value: &str, expected: &[&str], errors: &mut Ve
     }
 }
 
+/// Resolve the host's memory budget, per-memory ceiling and instance count.
+///
+/// # Errors
+///
+/// Rejects an unparseable size and a zero for any of the three. A zero would
+/// mean "this host runs nothing", which is never what an operator meant, and
+/// two of the three would misbehave inside wasmtime rather than saying so.
+pub fn host_memory(
+    max_guest_memory: Option<&str>,
+    default_heap_memory: Option<&str>,
+    core_instances: Option<u32>,
+) -> anyhow::Result<wash_runtime::engine::host_memory::HostMemoryBudgets> {
+    use wash_runtime::engine::host_memory::{HostMemoryBudgets, parse_bytes, render_bytes};
+
+    let max_guest_memory = max_guest_memory
+        .map(|raw| parse_bytes(raw).map_err(|e| anyhow::anyhow!("invalid --max-guest-memory: {e}")))
+        .transpose()?;
+    let default_heap_memory = default_heap_memory
+        .map(|raw| {
+            parse_bytes(raw).map_err(|e| anyhow::anyhow!("invalid --default-heap-memory: {e}"))
+        })
+        .transpose()?;
+
+    let resolved =
+        HostMemoryBudgets::resolve(max_guest_memory, default_heap_memory, core_instances)
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+    // Every one of these varies by host — the cgroup it landed in, the flags it
+    // was given — so an operator cannot read them off the docs. The reservation
+    // in particular is a product of two knobs set independently, and is the
+    // number behind an instantiation failure nobody can otherwise explain.
+    tracing::info!(
+        max_guest_memory = %render_bytes(resolved.max_guest_memory),
+        default_heap_memory = %render_bytes(resolved.default_heap_memory),
+        core_instances = resolved.core_instances,
+        pool_reservation = %render_bytes(resolved.pool_reservation()),
+        "host memory resolved"
+    );
+
+    Ok(resolved)
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -2170,46 +2212,4 @@ secrets:
         let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
         assert!(config.dev().environment.is_empty());
     }
-}
-
-/// Resolve the host's memory budget, per-memory ceiling and instance count.
-///
-/// # Errors
-///
-/// Rejects an unparseable size and a zero for any of the three. A zero would
-/// mean "this host runs nothing", which is never what an operator meant, and
-/// two of the three would misbehave inside wasmtime rather than saying so.
-pub fn host_memory(
-    max_guest_memory: Option<&str>,
-    default_heap_memory: Option<&str>,
-    core_instances: Option<u32>,
-) -> anyhow::Result<wash_runtime::engine::host_memory::HostMemoryBudgets> {
-    use wash_runtime::engine::host_memory::{HostMemoryBudgets, parse_bytes, render_bytes};
-
-    let max_guest_memory = max_guest_memory
-        .map(|raw| parse_bytes(raw).map_err(|e| anyhow::anyhow!("invalid --max-guest-memory: {e}")))
-        .transpose()?;
-    let default_heap_memory = default_heap_memory
-        .map(|raw| {
-            parse_bytes(raw).map_err(|e| anyhow::anyhow!("invalid --default-heap-memory: {e}"))
-        })
-        .transpose()?;
-
-    let resolved =
-        HostMemoryBudgets::resolve(max_guest_memory, default_heap_memory, core_instances)
-            .map_err(|e| anyhow::anyhow!(e))?;
-
-    // Every one of these varies by host — the cgroup it landed in, the flags it
-    // was given — so an operator cannot read them off the docs. The reservation
-    // in particular is a product of two knobs set independently, and is the
-    // number behind an instantiation failure nobody can otherwise explain.
-    tracing::info!(
-        max_guest_memory = %render_bytes(resolved.max_guest_memory),
-        default_heap_memory = %render_bytes(resolved.default_heap_memory),
-        core_instances = resolved.core_instances,
-        pool_reservation = %render_bytes(resolved.pool_reservation()),
-        "host memory resolved"
-    );
-
-    Ok(resolved)
 }


### PR DESCRIPTION
`cargo clippy --all-targets` and `cargo fmt --check` both fail on main:

* `config.rs` defines `host_memory` after the test module, which trips clippy's `items_after_test_module` (#5483 added it at the end of the file). Moved above the tests; the function itself is unchanged.
* A trailing-whitespace line in `engine/mod.rs` that `cargo fmt --check` rejects.

Found while rebasing a branch onto main, so this is only the fix, nothing else.
